### PR TITLE
Support Filter Pushdown in Spark Structured Streaming

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.transforms.Transforms;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -268,6 +269,50 @@ public class ExpressionUtil {
     }
 
     throw new UnsupportedOperationException("Cannot unbind unsupported term: " + term);
+  }
+
+  public static Set<String> referencedColumns(Expression expr, boolean caseSensitive) {
+    return ExpressionVisitors.visit(
+        expr,
+        new ExpressionVisitors.ExpressionVisitor<Set<String>>() {
+          @Override
+          public Set<String> alwaysTrue() {
+            return Sets.newHashSet();
+          }
+
+          @Override
+          public Set<String> alwaysFalse() {
+            return Sets.newHashSet();
+          }
+
+          @Override
+          public Set<String> not(Set<String> result) {
+            return result;
+          }
+
+          @Override
+          public Set<String> and(Set<String> left, Set<String> right) {
+            return Sets.union(left, right);
+          }
+
+          @Override
+          public Set<String> or(Set<String> left, Set<String> right) {
+            return Sets.union(left, right);
+          }
+
+          @Override
+          public <T> Set<String> predicate(
+              org.apache.iceberg.expressions.UnboundPredicate<T> pred) {
+            return Sets.newHashSet(
+                caseSensitive ? pred.ref().name() : pred.ref().name().toLowerCase(Locale.ROOT));
+          }
+
+          @Override
+          public <T> Set<String> predicate(org.apache.iceberg.expressions.BoundPredicate<T> pred) {
+            return Sets.newHashSet(
+                caseSensitive ? pred.ref().name() : pred.ref().name().toLowerCase(Locale.ROOT));
+          }
+        });
   }
 
   private static class RetainPredicatesByFieldIdVisitor

--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -23,6 +23,9 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -30,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,11 +62,39 @@ public class MicroBatches {
       Snapshot snapshot,
       ManifestFile manifestFile,
       boolean scanAllFiles) {
+    return openManifestFileWithFilter(
+        io, specsById, caseSensitive, snapshot, manifestFile, scanAllFiles, Lists.newArrayList());
+  }
+
+  public static CloseableIterable<FileScanTask> openManifestFileWithFilter(
+      FileIO io,
+      Map<Integer, PartitionSpec> specsById,
+      boolean caseSensitive,
+      Snapshot snapshot,
+      ManifestFile manifestFile,
+      boolean scanAllFiles,
+      List<Expression> pushedFilters) {
+
+    // 1. Get the field IDs used in the partition spec
+    Expression partitionExpr = Expressions.alwaysTrue();
+    Expression dataExpr = Expressions.alwaysTrue();
+
+    for (Expression filter : pushedFilters) {
+      if (isPartitionOnly(
+          filter, specsById.values().iterator().next().partitionType(), caseSensitive)) {
+        partitionExpr = Expressions.and(partitionExpr, filter);
+      } else {
+        dataExpr = Expressions.and(dataExpr, filter);
+      }
+    }
 
     ManifestGroup manifestGroup =
         new ManifestGroup(io, ImmutableList.of(manifestFile))
             .specsById(specsById)
-            .caseSensitive(caseSensitive);
+            .caseSensitive(caseSensitive)
+            .filterPartitions(partitionExpr)
+            .filterData(dataExpr);
+
     if (!scanAllFiles) {
       manifestGroup =
           manifestGroup
@@ -74,6 +106,20 @@ public class MicroBatches {
     }
 
     return manifestGroup.planFiles();
+  }
+
+  // 2. The Helper Method using Iceberg's core Visitor
+  private static boolean isPartitionOnly(
+      Expression expr, Types.StructType partitionType, boolean caseSensitive) {
+    try {
+      // If this doesn't throw an error, it means the filter
+      // only uses columns present in the partition schema.
+      Binder.bind(partitionType, expr, caseSensitive);
+      return true;
+    } catch (org.apache.iceberg.exceptions.ValidationException e) {
+      // Filter references columns NOT in the partition spec
+      return false;
+    }
   }
 
   /**
@@ -209,11 +255,22 @@ public class MicroBatches {
           Iterables.size(
               SnapshotChanges.builderFor(snapshot, io, specsById).build().addedDataFiles()),
           targetSizeInBytes,
-          scanAllFiles);
+          scanAllFiles,
+          Lists.newArrayList());
     }
 
     public MicroBatch generate(
         long startFileIndex, long endFileIndex, long targetSizeInBytes, boolean scanAllFiles) {
+      return generate(
+          startFileIndex, endFileIndex, targetSizeInBytes, scanAllFiles, Lists.newArrayList());
+    }
+
+    public MicroBatch generate(
+        long startFileIndex,
+        long endFileIndex,
+        long targetSizeInBytes,
+        boolean scanAllFiles,
+        List<Expression> pushedFilters) {
       Preconditions.checkArgument(endFileIndex >= 0, "endFileIndex is unexpectedly smaller than 0");
       Preconditions.checkArgument(
           startFileIndex >= 0, "startFileIndex is unexpectedly smaller than 0");
@@ -225,7 +282,8 @@ public class MicroBatches {
           startFileIndex,
           endFileIndex,
           targetSizeInBytes,
-          scanAllFiles);
+          scanAllFiles,
+          pushedFilters);
     }
 
     /**
@@ -247,7 +305,8 @@ public class MicroBatches {
         long startFileIndex,
         long endFileIndex,
         long targetSizeInBytes,
-        boolean scanAllFiles) {
+        boolean scanAllFiles,
+        List<Expression> pushedFilters) {
       if (indexedManifests.isEmpty()) {
         return new MicroBatch(
             snapshot.snapshotId(), startFileIndex, endFileIndex, 0L, Collections.emptyList(), true);
@@ -262,13 +321,14 @@ public class MicroBatches {
         currentFileIndex = indexedManifests.get(idx).second();
 
         try (CloseableIterable<FileScanTask> taskIterable =
-                openManifestFile(
+                openManifestFileWithFilter(
                     io,
                     specsById,
                     caseSensitive,
                     snapshot,
                     indexedManifests.get(idx).first(),
-                    scanAllFiles);
+                    scanAllFiles,
+                    pushedFilters);
             CloseableIterator<FileScanTask> taskIter = taskIterable.iterator()) {
           while (taskIter.hasNext()) {
             FileScanTask task = taskIter.next();

--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -21,10 +21,12 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
-import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
@@ -33,12 +35,13 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class MicroBatches {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicroBatches.class);
+
   private MicroBatches() {}
 
   public static List<Pair<ManifestFile, Integer>> skippedManifestIndexesFromSnapshot(
@@ -74,20 +77,31 @@ public class MicroBatches {
       ManifestFile manifestFile,
       boolean scanAllFiles,
       List<Expression> pushedFilters) {
+    // find the correct spec from manifest
+    PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
+    Set<String> partitionNames =
+        spec.fields().stream()
+            .map(field -> caseSensitive ? field.name() : field.name().toLowerCase(Locale.ROOT))
+            .collect(java.util.stream.Collectors.toSet());
 
-    // 1. Get the field IDs used in the partition spec
     Expression partitionExpr = Expressions.alwaysTrue();
     Expression dataExpr = Expressions.alwaysTrue();
 
     for (Expression filter : pushedFilters) {
-      if (isPartitionOnly(
-          filter, specsById.values().iterator().next().partitionType(), caseSensitive)) {
+      // Extract all column names referenced in the filter
+      Set<String> referencedColumns = ExpressionUtil.referencedColumns(filter, caseSensitive);
+
+      // If all columns in the filter exist in the partition spec
+      if (!referencedColumns.isEmpty() && partitionNames.containsAll(referencedColumns)) {
         partitionExpr = Expressions.and(partitionExpr, filter);
       } else {
         dataExpr = Expressions.and(dataExpr, filter);
       }
     }
-
+    LOGGER.debug(
+        "pruning manifest group with partition filters={}, data filters={}",
+        partitionExpr,
+        dataExpr);
     ManifestGroup manifestGroup =
         new ManifestGroup(io, ImmutableList.of(manifestFile))
             .specsById(specsById)
@@ -106,20 +120,6 @@ public class MicroBatches {
     }
 
     return manifestGroup.planFiles();
-  }
-
-  // 2. The Helper Method using Iceberg's core Visitor
-  private static boolean isPartitionOnly(
-      Expression expr, Types.StructType partitionType, boolean caseSensitive) {
-    try {
-      // If this doesn't throw an error, it means the filter
-      // only uses columns present in the partition schema.
-      Binder.bind(partitionType, expr, caseSensitive);
-      return true;
-    } catch (org.apache.iceberg.exceptions.ValidationException e) {
-      // Filter references columns NOT in the partition spec
-      return false;
-    }
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -23,6 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.Collections;
 import java.util.List;
 import org.apache.iceberg.MicroBatches.MicroBatch;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,6 +142,53 @@ public class TestMicroBatchBuilder extends TestBase {
     assertThat(batch5.sizeInBytes()).isEqualTo(0);
     assertThat(batch5.tasks()).isEmpty();
     assertThat(batch5.lastIndexOfSnapshot()).isTrue();
+  }
+
+  @TestTemplate
+  public void testGenerateMicroBatchWithFilter() {
+    List<Expression> filters =
+        ImmutableList.of(Expressions.equal("data_bucket", 1), Expressions.equal("id", 1));
+    runMicroBatchWithTest(filters, true);
+  }
+
+  @TestTemplate
+  public void testGenerateMicroBatchWithFilterWithCaseInsensitive() {
+    List<Expression> filters =
+        ImmutableList.of(Expressions.equal("DATA_bucket", 1), Expressions.equal("Id", 1));
+    runMicroBatchWithTest(filters, false);
+  }
+
+  private void runMicroBatchWithTest(List<Expression> filters, boolean caseSensitive) {
+    // 1. Setup data across different partitions
+    DataFile fileA =
+        DataFiles.builder(table.spec())
+            .withPath("A.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .withPartitionPath("data_bucket=0")
+            .build();
+    DataFile fileB =
+        DataFiles.builder(table.spec())
+            .withPath("B.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .withPartitionPath("data_bucket=1")
+            .build();
+
+    table.newAppend().appendFile(fileA).appendFile(fileB).commit();
+
+    // 3. Generate batch with filters
+    // Note: You may need to update your MicroBatches.from() builder
+    // to accept .filter(filters) if you haven't exposed it yet.
+    MicroBatch batch =
+        MicroBatches.from(table.snapshot(1L), table.io())
+            .specsById(table.specs())
+            .caseSensitive(caseSensitive)
+            .generate(0, 2, Long.MAX_VALUE, true, filters);
+
+    // 4. Verify only File B is present despite the range covering both files
+    assertThat(batch.sizeInBytes()).isEqualTo(10);
+    filesMatch(Lists.newArrayList("B"), filesToScan(batch.tasks()));
   }
 
   private static DataFile file(String name) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -84,8 +85,9 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
       SparkReadConf readConf,
       StreamingOffset initialOffset,
       StreamingOffset maybeEndOffset,
-      StreamingOffset lastOffsetForTriggerAvailableNow) {
-    super(table, readConf);
+      StreamingOffset lastOffsetForTriggerAvailableNow,
+      List<Expression> pushedFilters) {
+    super(table, readConf, pushedFilters);
     this.minQueuedFiles = readConf().maxFilesPerMicroBatch();
     this.minQueuedRows = readConf().maxRecordsPerMicroBatch();
     this.lastOffsetForTriggerAvailableNow = lastOffsetForTriggerAvailableNow;
@@ -403,7 +405,12 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
         MicroBatches.from(snapshot, table().io())
             .caseSensitive(readConf().caseSensitive())
             .specsById(table().specs())
-            .generate(startFileIndex, endFileIndex, Long.MAX_VALUE, shouldScanAllFile);
+            .generate(
+                startFileIndex,
+                endFileIndex,
+                Long.MAX_VALUE,
+                shouldScanAllFile,
+                getPushedFilters());
 
     long position = startFileIndex;
     for (FileScanTask task : microBatch.tasks()) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkMicroBatchPlanner.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.spark.source;
 
+import java.util.List;
 import java.util.Locale;
 import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
@@ -37,10 +39,12 @@ abstract class BaseSparkMicroBatchPlanner implements SparkMicroBatchPlanner {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSparkMicroBatchPlanner.class);
   private final Table table;
   private final SparkReadConf readConf;
+  private final List<Expression> pushedFilters;
 
-  BaseSparkMicroBatchPlanner(Table table, SparkReadConf readConf) {
+  BaseSparkMicroBatchPlanner(Table table, SparkReadConf readConf, List<Expression> filters) {
     this.table = table;
     this.readConf = readConf;
+    this.pushedFilters = filters;
   }
 
   protected Table table() {
@@ -49,6 +53,10 @@ abstract class BaseSparkMicroBatchPlanner implements SparkMicroBatchPlanner {
 
   protected SparkReadConf readConf() {
     return readConf;
+  }
+
+  protected List<Expression> getPushedFilters() {
+    return pushedFilters;
   }
 
   protected boolean shouldProcess(Snapshot snapshot) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
@@ -57,6 +58,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerAvailableNow {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SparkMicroBatchStream.class);
   private static final Joiner SLASH = Joiner.on("/");
   private static final Logger LOG = LoggerFactory.getLogger(SparkMicroBatchStream.class);
   private static final Types.StructType EMPTY_GROUPING_KEY_TYPE = Types.StructType.of();
@@ -77,6 +79,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
   private final int maxFilesPerMicroBatch;
   private final int maxRecordsPerMicroBatch;
   private final boolean cacheDeleteFilesOnExecutors;
+  private final List<Expression> filters;
   private SparkMicroBatchPlanner planner;
   private StreamingOffset lastOffsetForTriggerAvailableNow;
 
@@ -86,6 +89,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
       Supplier<FileIO> fileIO,
       SparkReadConf readConf,
       Schema projection,
+      List<Expression> filters,
       String checkpointLocation) {
     this.table = table;
     this.fileIO = fileIO;
@@ -102,11 +106,13 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
     this.maxFilesPerMicroBatch = readConf.maxFilesPerMicroBatch();
     this.maxRecordsPerMicroBatch = readConf.maxRecordsPerMicroBatch();
     this.cacheDeleteFilesOnExecutors = readConf.cacheDeleteFilesOnExecutors();
+    this.filters = filters;
 
     InitialOffsetStore initialOffsetStore =
         new InitialOffsetStore(
             table, checkpointLocation, fromTimestamp, sparkContext.hadoopConfiguration());
     this.initialOffset = initialOffsetStore.initialOffset();
+    LOGGER.error("[jalpan] creating micro batch with filter {} ", filters);
   }
 
   @Override
@@ -128,6 +134,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
 
   @Override
   public InputPartition[] planInputPartitions(Offset start, Offset end) {
+    LOGGER.error("[jalpan] planning input partitions micro batch with filter {} ", filters);
     Preconditions.checkArgument(
         end instanceof StreamingOffset, "Invalid end offset: %s is not a StreamingOffset", end);
     Preconditions.checkArgument(
@@ -209,10 +216,11 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
     if (readConf.asyncMicroBatchPlanningEnabled()) {
       this.planner =
           new AsyncSparkMicroBatchPlanner(
-              table, readConf, startOffset, endOffset, lastOffsetForTriggerAvailableNow);
+              table, readConf, startOffset, endOffset, lastOffsetForTriggerAvailableNow, filters);
     } else {
       this.planner =
-          new SyncSparkMicroBatchPlanner(table, readConf, lastOffsetForTriggerAvailableNow);
+          new SyncSparkMicroBatchPlanner(
+              table, readConf, lastOffsetForTriggerAvailableNow, filters);
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -58,7 +58,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerAvailableNow {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SparkMicroBatchStream.class);
   private static final Joiner SLASH = Joiner.on("/");
   private static final Logger LOG = LoggerFactory.getLogger(SparkMicroBatchStream.class);
   private static final Types.StructType EMPTY_GROUPING_KEY_TYPE = Types.StructType.of();
@@ -112,7 +111,6 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
         new InitialOffsetStore(
             table, checkpointLocation, fromTimestamp, sparkContext.hadoopConfiguration());
     this.initialOffset = initialOffsetStore.initialOffset();
-    LOGGER.error("[jalpan] creating micro batch with filter {} ", filters);
   }
 
   @Override
@@ -134,7 +132,6 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
 
   @Override
   public InputPartition[] planInputPartitions(Offset start, Offset end) {
-    LOGGER.error("[jalpan] planning input partitions micro batch with filter {} ", filters);
     Preconditions.checkArgument(
         end instanceof StreamingOffset, "Invalid end offset: %s is not a StreamingOffset", end);
     Preconditions.checkArgument(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -185,7 +185,6 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
-    LOG.error("[jalpan] creating micro batch stream");
     return new SparkMicroBatchStream(
         sparkContext, table, fileIO, readConf, projection, filters, checkpointLocation);
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -185,8 +185,9 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
   @Override
   public MicroBatchStream toMicroBatchStream(String checkpointLocation) {
+    LOG.error("[jalpan] creating micro batch stream");
     return new SparkMicroBatchStream(
-        sparkContext, table, fileIO, readConf, projection, checkpointLocation);
+        sparkContext, table, fileIO, readConf, projection, filters, checkpointLocation);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.MicroBatches.MicroBatch;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -45,8 +46,11 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
   private final StreamingOffset lastOffsetForTriggerAvailableNow;
 
   SyncSparkMicroBatchPlanner(
-      Table table, SparkReadConf readConf, StreamingOffset lastOffsetForTriggerAvailableNow) {
-    super(table, readConf);
+      Table table,
+      SparkReadConf readConf,
+      StreamingOffset lastOffsetForTriggerAvailableNow,
+      List<Expression> pushedFilters) {
+    super(table, readConf, pushedFilters);
     this.caseSensitive = readConf().caseSensitive();
     this.fromTimestamp = readConf().streamFromTimestamp();
     this.lastOffsetForTriggerAvailableNow = lastOffsetForTriggerAvailableNow;
@@ -102,7 +106,8 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
                   currentOffset.position(),
                   endFileIndex,
                   Long.MAX_VALUE,
-                  currentOffset.shouldScanAllFiles());
+                  currentOffset.shouldScanAllFiles(),
+                  getPushedFilters());
 
       fileScanTasks.addAll(latestMicroBatch.tasks());
     } while (currentOffset.snapshotId() != endOffset.snapshotId());
@@ -163,13 +168,14 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
         // be rest assured curPos >= startFileIndex
         curPos = indexedManifests.get(idx).second();
         try (CloseableIterable<FileScanTask> taskIterable =
-                MicroBatches.openManifestFile(
+                MicroBatches.openManifestFileWithFilter(
                     table().io(),
                     table().specs(),
                     caseSensitive,
                     curSnapshot,
                     indexedManifests.get(idx).first(),
-                    scanAllFiles);
+                    scanAllFiles,
+                    getPushedFilters());
             CloseableIterator<FileScanTask> taskIter = taskIterable.iterator()) {
           while (taskIter.hasNext()) {
             FileScanTask task = taskIter.next();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -502,6 +502,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
                         SparkReadOptions.ASYNC_QUEUE_PRELOAD_ROW_LIMIT,
                         "10"))),
             table.schema(),
+            Lists.newArrayList(),
             temp.resolve("available-now-cap-checkpoint").toString());
 
     try {
@@ -1212,6 +1213,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         table::io,
         new SparkReadConf(spark, table, new CaseInsensitiveStringMap(allOptions)),
         table.schema(),
+        Lists.newArrayList(),
         temp.resolve(checkpointDirName).toString());
   }
 }


### PR DESCRIPTION
## Overview

This PR introduces the core Iceberg-side support for predicate pushdown within Spark Structured Streaming.

Currently, Spark streaming workloads on Iceberg tables lack the pruning efficiencies available in batch scans. This change bridges that gap by enabling the SparkScan to propagate filter expressions to the MicroBatchStream. By moving filter evaluation from the Spark executor level to the Iceberg metadata level (during partition planning), we significantly reduce:

1. **I/O Overhead**: Fewer manifests and data files are scanned.
2. **Driver Memory Pressure**: Reduced metadata processing during task planning.
3. **Compute Costs**: Lower scheduling overhead for micro-batches on high-cardinality partitioned tables.

> Note on Dependencies: This commit provides the necessary interface and implementation in the Iceberg connector. To fully leverage this, a corresponding PR will be raised in the Apache Spark repository to ensure the engine correctly passes these predicates to the V2 streaming source.

Spark changes - https://github.com/apache/spark/pull/55679


Fixes https://github.com/apache/iceberg/issues/15692

## Testing & Verification


```
scala> val streamingDF = spark.readStream
     |   .format("iceberg")
     |   .load("local.db.filtered_stream")
     |   .filter("part = 'active'") // This filter is currently NOT pushed down to Iceberg
     |
     | val query = streamingDF.writeStream
     |   .format("console")
     |   .option("checkpointLocation", s"/tmp/iceberg_stream_${System.currentTimeMillis()}")
     |   .start()

val streamingDF: org.apache.spark.sql.Dataset[org.apache.spark.sql.Row] = [id: bigint, part: string]
val query: org.apache.spark.sql.streaming.StreamingQuery = org.apache.spark.sql.execution.streaming.runtime.StreamingQueryWrapper@577c2d74

scala> 26/05/03 20:32:57 ERROR SparkScan: [jalpan] creating micro batch stream
26/05/03 20:32:57 ERROR SparkMicroBatchStream: [jalpan] creating micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:58 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:58 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:58 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:58 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:59 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
26/05/03 20:32:59 ERROR SparkMicroBatchStream: [jalpan] planning input partitions micro batch with filter [ref(name="part") == "active"]
-------------------------------------------
Batch: 0
-------------------------------------------
+---+------+
| id|  part|
+---+------+
|  1|active|
+---+------+
```
