### PR TITLE
Open-API: Stop publishing REST fixture runtime jar

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -166,7 +166,7 @@ jobs:
           scan-path: flink/v2.1/flink-runtime/build/libs
           unpack: false
         - distribution: open-api-test-fixtures-runtime
-          build-task: :iceberg-open-api:installRESTServer
+          build-task: :iceberg-open-api:stageRESTFixtureRuntime
           scan-path: open-api/build/iceberg-rest-server/libs
           unpack: false
           copy-all: true

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -166,9 +166,10 @@ jobs:
           scan-path: flink/v2.1/flink-runtime/build/libs
           unpack: false
         - distribution: open-api-test-fixtures-runtime
-          build-task: :iceberg-open-api:shadowJar
-          scan-path: open-api/build/libs
+          build-task: :iceberg-open-api:installRESTServer
+          scan-path: open-api/build/iceberg-rest-server/libs
           unpack: false
+          copy-all: true
     name: ${{ matrix.distribution }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -192,6 +193,8 @@ jobs:
         mkdir -p /tmp/cve-scan
         if [ "${{ matrix.unpack }}" = "true" ]; then
           unzip ${{ matrix.scan-path }}/*.zip -d /tmp/cve-scan
+        elif [ "${{ matrix.copy-all }}" = "true" ]; then
+          cp ${{ matrix.scan-path }}/*.jar /tmp/cve-scan/
         else
           cp ${{ matrix.scan-path }}/iceberg-${{ matrix.distribution }}-*.jar /tmp/cve-scan/
         fi

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -53,7 +53,7 @@ jobs:
         # Read-only: small job; restore opportunistically from other jobs' caches but never write.
         cache-read-only: true
     - name: Stage REST fixture image classpath
-      run: ./gradlew :iceberg-open-api:installRESTServer
+      run: ./gradlew :iceberg-open-api:stageRESTFixtureRuntime
     - name: Login to Docker Hub
       env:
         DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -52,8 +52,8 @@ jobs:
       with:
         # Read-only: small job; restore opportunistically from other jobs' caches but never write.
         cache-read-only: true
-    - name: Build Iceberg Open API project
-      run: ./gradlew :iceberg-open-api:shadowJar
+    - name: Stage REST fixture image classpath
+      run: ./gradlew :iceberg-open-api:installRESTServer
     - name: Login to Docker Hub
       env:
         DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}

--- a/build.gradle
+++ b/build.gradle
@@ -1162,7 +1162,7 @@ project(':iceberg-open-api') {
   check.dependsOn('validateRESTCatalogSpec')
 
   // REST server runtime as a dir of jars; consumed by docker/iceberg-rest-fixture.
-  tasks.register('installRESTServer', Sync) {
+  tasks.register('stageRESTFixtureRuntime', Sync) {
     into layout.buildDirectory.dir('iceberg-rest-server')
     from(projectDir) {
       include 'LICENSE'

--- a/build.gradle
+++ b/build.gradle
@@ -1077,9 +1077,6 @@ project(':iceberg-snowflake') {
 
 project(':iceberg-open-api') {
   apply plugin: 'java-test-fixtures'
-  apply plugin: 'com.gradleup.shadow'
-
-  build.dependsOn shadowJar
 
   dependencies {
     testImplementation project(':iceberg-api')
@@ -1164,23 +1161,19 @@ project(':iceberg-open-api') {
   }
   check.dependsOn('validateRESTCatalogSpec')
 
-  shadowJar {
-    archiveBaseName.set("iceberg-open-api-test-fixtures-runtime")
-    archiveClassifier.set(null)
-    configurations = [project.configurations.testFixturesRuntimeClasspath]
-    from sourceSets.testFixtures.output
-    zip64 true
-
-    // include the LICENSE and NOTICE files for the runtime Jar
+  // REST server runtime as a dir of jars; consumed by docker/iceberg-rest-fixture.
+  tasks.register('installRESTServer', Sync) {
+    into layout.buildDirectory.dir('iceberg-rest-server')
     from(projectDir) {
       include 'LICENSE'
       include 'NOTICE'
     }
-
-    manifest {
-      attributes 'Main-Class': 'org.apache.iceberg.rest.RESTCatalogServer'
+    into('libs') {
+      from configurations.testFixturesRuntimeClasspath
+      from tasks.testFixturesJar
     }
   }
+  build.dependsOn 'installRESTServer'
 
   jar {
     enabled = false

--- a/build.gradle
+++ b/build.gradle
@@ -1173,7 +1173,6 @@ project(':iceberg-open-api') {
       from tasks.testFixturesJar
     }
   }
-  build.dependsOn 'installRESTServer'
 
   jar {
     enabled = false

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -55,7 +55,11 @@ subprojects {
       }
 
       // add LICENSE and NOTICE
-      [jar, sourceJar, javadocJar, testJar].each { task ->
+      def archiveTasks = [jar, sourceJar, javadocJar, testJar]
+      if (isOpenApi) {
+        archiveTasks.add(testFixturesJar)
+      }
+      archiveTasks.each { task ->
         task.dependsOn rootProject.tasks.buildInfo
         task.from("${rootDir}/build") {
           include 'iceberg-build.properties'

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -54,12 +54,8 @@ subprojects {
         testArtifacts testJar
       }
 
-      // add LICENSE and NOTICE
-      def archiveTasks = [jar, sourceJar, javadocJar, testJar]
-      if (isOpenApi) {
-        archiveTasks.add(testFixturesJar)
-      }
-      archiveTasks.each { task ->
+      // add build info, LICENSE, and NOTICE
+      def addBuildInfoAndLicense = { task ->
         task.dependsOn rootProject.tasks.buildInfo
         task.from("${rootDir}/build") {
           include 'iceberg-build.properties'
@@ -68,6 +64,11 @@ subprojects {
           include 'LICENSE'
           include 'NOTICE'
         }
+      }
+      [jar, sourceJar, javadocJar, testJar].each(addBuildInfoAndLicense)
+      if (isOpenApi) {
+        // OpenAPI also publishes testFixturesJar for REST fixture consumers.
+        addBuildInfoAndLicense(testFixturesJar)
       }
     }
 

--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -30,8 +30,8 @@ RUN  set -xeu && \
 # Working directory for the application
 WORKDIR /usr/lib/iceberg-rest
 
-# Copy runtime files directly to the target location
-COPY --chown=iceberg:iceberg open-api/build/libs/iceberg-open-api-test-fixtures-runtime-*.jar /usr/lib/iceberg-rest/iceberg-rest-adapter.jar
+# Copy REST server libs and LICENSE/NOTICE
+COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ /usr/lib/iceberg-rest/
 COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh /usr/lib/iceberg-rest/entrypoint.sh
 
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog

--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -30,7 +30,7 @@ RUN  set -xeu && \
 # Working directory for the application
 WORKDIR /usr/lib/iceberg-rest
 
-# Copy REST server libs and LICENSE/NOTICE
+# Copy staged REST fixture runtime, including libs/ and LICENSE/NOTICE
 COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ /usr/lib/iceberg-rest/
 COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh /usr/lib/iceberg-rest/entrypoint.sh
 

--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -28,11 +28,12 @@ RUN  set -xeu && \
      rm -rf /var/lib/apt/lists/*
 
 # Working directory for the application
-WORKDIR /usr/lib/iceberg-rest
+ENV REST_SERVER_HOME=/usr/lib/iceberg-rest
+WORKDIR $REST_SERVER_HOME
 
 # Copy REST server libs and LICENSE/NOTICE
-COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ /usr/lib/iceberg-rest/
-COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh /usr/lib/iceberg-rest/entrypoint.sh
+COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ ./
+COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh ./entrypoint.sh
 
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db

--- a/docker/iceberg-rest-fixture/Dockerfile
+++ b/docker/iceberg-rest-fixture/Dockerfile
@@ -28,12 +28,11 @@ RUN  set -xeu && \
      rm -rf /var/lib/apt/lists/*
 
 # Working directory for the application
-ENV REST_SERVER_HOME=/usr/lib/iceberg-rest
-WORKDIR $REST_SERVER_HOME
+WORKDIR /usr/lib/iceberg-rest
 
 # Copy REST server libs and LICENSE/NOTICE
-COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ ./
-COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh ./entrypoint.sh
+COPY --chown=iceberg:iceberg open-api/build/iceberg-rest-server/ /usr/lib/iceberg-rest/
+COPY --chown=iceberg:iceberg docker/iceberg-rest-fixture/entrypoint.sh /usr/lib/iceberg-rest/entrypoint.sh
 
 ENV CATALOG_CATALOG__IMPL=org.apache.iceberg.jdbc.JdbcCatalog
 ENV CATALOG_URI=jdbc:sqlite:/tmp/iceberg_catalog.db

--- a/docker/iceberg-rest-fixture/README.md
+++ b/docker/iceberg-rest-fixture/README.md
@@ -86,7 +86,7 @@ When making changes to the local files and test them out, you can build the imag
 
 ```bash
 # Build the project from iceberg root directory
-./gradlew :iceberg-open-api:installRESTServer
+./gradlew :iceberg-open-api:stageRESTFixtureRuntime
 
 # Rebuild the docker image
 docker image rm -f apache/iceberg-rest-fixture && docker build -t apache/iceberg-rest-fixture -f docker/iceberg-rest-fixture/Dockerfile .

--- a/docker/iceberg-rest-fixture/README.md
+++ b/docker/iceberg-rest-fixture/README.md
@@ -86,7 +86,7 @@ When making changes to the local files and test them out, you can build the imag
 
 ```bash
 # Build the project from iceberg root directory
-./gradlew :iceberg-open-api:shadowJar
+./gradlew :iceberg-open-api:installRESTServer
 
 # Rebuild the docker image
 docker image rm -f apache/iceberg-rest-fixture && docker build -t apache/iceberg-rest-fixture -f docker/iceberg-rest-fixture/Dockerfile .

--- a/docker/iceberg-rest-fixture/entrypoint.sh
+++ b/docker/iceberg-rest-fixture/entrypoint.sh
@@ -20,8 +20,7 @@
 
 set -eu
 
-REST_SERVER_MAIN="org.apache.iceberg.rest.RESTCatalogServer"
-CLASSPATH="${REST_SERVER_HOME}/libs/*"
+CLASSPATH="libs/*"
 
 if [ -n "${LOG_CONFIG_DIR:-}" ]; then
   CLASSPATH="${LOG_CONFIG_DIR}:${CLASSPATH}"
@@ -33,4 +32,4 @@ if [ -n "${LOG_LEVEL:-}" ]; then
   set -- "$@" "-Dorg.slf4j.simpleLogger.defaultLogLevel=${LOG_LEVEL}"
 fi
 
-exec "$@" -cp "$CLASSPATH" "$REST_SERVER_MAIN"
+exec "$@" -cp "$CLASSPATH" org.apache.iceberg.rest.RESTCatalogServer

--- a/docker/iceberg-rest-fixture/entrypoint.sh
+++ b/docker/iceberg-rest-fixture/entrypoint.sh
@@ -20,6 +20,7 @@
 
 set -eu
 
+# The staged runtime puts all REST server jars under libs/; Java expands this wildcard.
 CLASSPATH="libs/*"
 
 if [ -n "${LOG_CONFIG_DIR:-}" ]; then

--- a/docker/iceberg-rest-fixture/entrypoint.sh
+++ b/docker/iceberg-rest-fixture/entrypoint.sh
@@ -20,7 +20,7 @@
 
 set -eu
 
-CLASSPATH="iceberg-rest-adapter.jar"
+CLASSPATH="libs/*"
 
 if [ -n "${LOG_CONFIG_DIR:-}" ]; then
   CLASSPATH="${LOG_CONFIG_DIR}:${CLASSPATH}"

--- a/docker/iceberg-rest-fixture/entrypoint.sh
+++ b/docker/iceberg-rest-fixture/entrypoint.sh
@@ -20,7 +20,8 @@
 
 set -eu
 
-CLASSPATH="libs/*"
+REST_SERVER_MAIN="org.apache.iceberg.rest.RESTCatalogServer"
+CLASSPATH="${REST_SERVER_HOME}/libs/*"
 
 if [ -n "${LOG_CONFIG_DIR:-}" ]; then
   CLASSPATH="${LOG_CONFIG_DIR}:${CLASSPATH}"
@@ -32,4 +33,4 @@ if [ -n "${LOG_LEVEL:-}" ]; then
   set -- "$@" "-Dorg.slf4j.simpleLogger.defaultLogLevel=${LOG_LEVEL}"
 fi
 
-exec "$@" -cp "$CLASSPATH" org.apache.iceberg.rest.RESTCatalogServer
+exec "$@" -cp "$CLASSPATH" "$REST_SERVER_MAIN"


### PR DESCRIPTION
## Summary

Stop publishing the OpenAPI REST fixture as a shaded runtime jar. Docker now uses `:iceberg-open-api:stageRESTFixtureRuntime` to stage the test-fixtures jar, runtime dependencies, `LICENSE`, and `NOTICE` under `open-api/build/iceberg-rest-server/`, then launches `RESTCatalogServer` with `java -cp`.

I'll follow up with another PR to fix the content of the LICENSE/NOTICE files 

## Changes

- Remove the OpenAPI Shadow plugin and runtime `shadowJar`.
- Keep Docker runtime staging out of normal `:iceberg-open-api:build`.
- Update Docker, CVE scan, and README references to the staged runtime task.
- Keep the published `testFixturesJar` for test consumers, with standard archive metadata.

## Testing

- `./gradlew :iceberg-open-api:stageRESTFixtureRuntime`
- `./gradlew :iceberg-open-api:build --dry-run`
- `docker build` + `docker run` smoke test: container became healthy and `/v1/config` returned endpoints.