### PR TITLE
Spark: Add compaction only benchmark - rewrite data files

### DIFF
--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
@@ -122,6 +122,10 @@ public abstract class IcebergCompactionBenchmark {
     return Map.of("type", "hadoop");
   }
 
+  protected String sparkMaster() {
+    return "local[*]";
+  }
+
   protected void setupSpark() {
     SparkSession.Builder builder =
         SparkSession.builder()
@@ -129,12 +133,11 @@ public abstract class IcebergCompactionBenchmark {
                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
             .config(TestBase.DISABLE_UI)
-            .master("local[*]");
+            .master(sparkMaster());
     extraCatalogProperties()
         .forEach((key, value) -> builder.config("spark.sql.catalog.spark_catalog." + key, value));
+    hadoopConf.forEach(entry -> builder.config("spark.hadoop." + entry.getKey(), entry.getValue()));
     spark = builder.getOrCreate();
-    Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
-    hadoopConf.forEach(entry -> sparkHadoopConf.set(entry.getKey(), entry.getValue()));
   }
 
   protected void tearDownSpark() {

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.action;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.concat;
+import static org.apache.spark.sql.functions.lit;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.SaveMode;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * A benchmark that evaluates the performance of the rewrite data files action in Spark.
+ *
+ * <p>To run this benchmark for spark-4.1: <code>
+ *   ./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh
+ *       -PjmhIncludeRegex=IcebergCompactionBenchmark.rewriteDataFiles
+ *       -PjmhOutputPath=benchmark/compaction-benchmark-1000files-2000rows-v3.txt
+ *       -PjmhJsonOutputPath=benchmark/compaction-benchmark-1000files-2000rows-v3.json
+ * </code>
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.SingleShotTime)
+@Timeout(time = 1000, timeUnit = TimeUnit.HOURS)
+public class IcebergCompactionBenchmark {
+
+  private static final String[] NAMESPACE = new String[] {"default"};
+  private static final String NAME = "compactbench";
+  private static final Identifier IDENT = Identifier.of(NAMESPACE, NAME);
+  private static final int NUM_FILES = 1000;
+  private static final long NUM_ROWS = 2000;
+
+  private final Configuration hadoopConf = initHadoopConf();
+  private SparkSession spark;
+
+  @Setup
+  public void setupBench() {
+    setupSpark();
+  }
+
+  @TearDown
+  public void teardownBench() {
+    tearDownSpark();
+  }
+
+  @Setup(Level.Iteration)
+  public void setupIteration() {
+    initTable();
+    appendData();
+  }
+
+  @TearDown(Level.Iteration)
+  public void cleanUpIteration() throws IOException {
+    cleanupFiles();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void rewriteDataFiles() {
+    SparkActions.get()
+        .rewriteDataFiles(table())
+        .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
+        .execute();
+  }
+
+  protected Configuration initHadoopConf() {
+    return new Configuration();
+  }
+
+  protected final void initTable() {
+    Schema schema =
+        new Schema(
+            required(1, "intCol", Types.IntegerType.get()),
+            required(2, "stringCol", Types.StringType.get()),
+            optional(3, "nullCol", Types.StringType.get()));
+
+    SparkSessionCatalog<?> catalog;
+    try {
+      catalog =
+          (SparkSessionCatalog<?>)
+              Spark3Util.catalogAndIdentifier(spark(), "spark_catalog").catalog();
+      catalog.dropTable(IDENT);
+      catalog.createTable(
+          IDENT, SparkSchemaUtil.convert(schema), new Transform[0], Collections.emptyMap());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void appendData() {
+    Dataset<Row> df =
+        spark()
+            .range(0, NUM_FILES * NUM_ROWS)
+            .withColumn("intCol", col("id").cast("int"))
+            .withColumn("stringCol", concat(lit("foo_"), col("id")))
+            .withColumn("nullCol", lit(null).cast("string"))
+            .drop("id")
+            .repartition(NUM_FILES);
+    writeData(df);
+  }
+
+  private void writeData(Dataset<Row> df) {
+    df.write().format("iceberg").mode(SaveMode.Append).save(NAME);
+  }
+
+  protected final Table table() {
+    try {
+      return Spark3Util.loadIcebergTable(spark(), NAME);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected final SparkSession spark() {
+    return spark;
+  }
+
+  protected String getCatalogWarehouse() {
+    try {
+      return Files.createTempDirectory("benchmark-").toAbsolutePath()
+          + "/"
+          + UUID.randomUUID()
+          + "/";
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  protected void cleanupFiles() throws IOException {
+    spark.sql("DROP TABLE IF EXISTS " + NAME);
+  }
+
+  protected void setupSpark() {
+    SparkSession.Builder builder =
+        SparkSession.builder()
+            .config(
+                "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
+            .config("spark.sql.catalog.spark_catalog.type", "hadoop")
+            .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
+            .config(TestBase.DISABLE_UI)
+            .master("local[*]");
+    spark = builder.getOrCreate();
+    Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
+    hadoopConf.forEach(entry -> sparkHadoopConf.set(entry.getKey(), entry.getValue()));
+  }
+
+  protected void tearDownSpark() {
+    spark.stop();
+  }
+}

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
@@ -45,7 +45,7 @@ import org.openjdk.jmh.annotations.Timeout;
 @Fork(1)
 @State(Scope.Benchmark)
 @BenchmarkMode(Mode.SingleShotTime)
-@Timeout(time = 1000, timeUnit = TimeUnit.HOURS)
+@Timeout(time = 1, timeUnit = TimeUnit.HOURS)
 public abstract class IcebergCompactionBenchmark {
 
   private final Configuration hadoopConf = initHadoopConf();

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergCompactionBenchmark.java
@@ -18,74 +18,44 @@
  */
 package org.apache.iceberg.spark.action;
 
-import static org.apache.iceberg.types.Types.NestedField.optional;
-import static org.apache.iceberg.types.Types.NestedField.required;
-import static org.apache.spark.sql.functions.col;
-import static org.apache.spark.sql.functions.concat;
-import static org.apache.spark.sql.functions.lit;
-
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.file.Files;
-import java.util.Collections;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.spark.Spark3Util;
-import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.spark.SparkSessionCatalog;
 import org.apache.iceberg.spark.TestBase;
-import org.apache.iceberg.spark.actions.SparkActions;
-import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SaveMode;
 import org.apache.spark.sql.SparkSession;
-import org.apache.spark.sql.connector.catalog.Identifier;
-import org.apache.spark.sql.connector.expressions.Transform;
-import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
-import org.openjdk.jmh.annotations.Measurement;
 import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
 import org.openjdk.jmh.annotations.TearDown;
-import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.annotations.Timeout;
-import org.openjdk.jmh.annotations.Warmup;
 
-/**
- * A benchmark that evaluates the performance of the rewrite data files action in Spark.
- *
- * <p>To run this benchmark for spark-4.1: <code>
- *   ./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh
- *       -PjmhIncludeRegex=IcebergCompactionBenchmark.rewriteDataFiles
- *       -PjmhOutputPath=benchmark/compaction-benchmark-1000files-2000rows-v3.txt
- *       -PjmhJsonOutputPath=benchmark/compaction-benchmark-1000files-2000rows-v3.json
- * </code>
- */
 @Fork(1)
 @State(Scope.Benchmark)
-@Warmup(iterations = 3)
-@Measurement(iterations = 10)
 @BenchmarkMode(Mode.SingleShotTime)
 @Timeout(time = 1000, timeUnit = TimeUnit.HOURS)
-public class IcebergCompactionBenchmark {
-
-  private static final String[] NAMESPACE = new String[] {"default"};
-  private static final String NAME = "compactbench";
-  private static final Identifier IDENT = Identifier.of(NAMESPACE, NAME);
-  private static final int NUM_FILES = 1000;
-  private static final long NUM_ROWS = 2000;
+public abstract class IcebergCompactionBenchmark {
 
   private final Configuration hadoopConf = initHadoopConf();
   private SparkSession spark;
+
+  protected abstract String tableName();
+
+  protected abstract void initTable();
+
+  protected abstract void appendData();
 
   @Setup
   public void setupBench() {
@@ -108,58 +78,13 @@ public class IcebergCompactionBenchmark {
     cleanupFiles();
   }
 
-  @Benchmark
-  @Threads(1)
-  public void rewriteDataFiles() {
-    SparkActions.get()
-        .rewriteDataFiles(table())
-        .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
-        .execute();
-  }
-
   protected Configuration initHadoopConf() {
     return new Configuration();
   }
 
-  protected final void initTable() {
-    Schema schema =
-        new Schema(
-            required(1, "intCol", Types.IntegerType.get()),
-            required(2, "stringCol", Types.StringType.get()),
-            optional(3, "nullCol", Types.StringType.get()));
-
-    SparkSessionCatalog<?> catalog;
-    try {
-      catalog =
-          (SparkSessionCatalog<?>)
-              Spark3Util.catalogAndIdentifier(spark(), "spark_catalog").catalog();
-      catalog.dropTable(IDENT);
-      catalog.createTable(
-          IDENT, SparkSchemaUtil.convert(schema), new Transform[0], Collections.emptyMap());
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  private void appendData() {
-    Dataset<Row> df =
-        spark()
-            .range(0, NUM_FILES * NUM_ROWS)
-            .withColumn("intCol", col("id").cast("int"))
-            .withColumn("stringCol", concat(lit("foo_"), col("id")))
-            .withColumn("nullCol", lit(null).cast("string"))
-            .drop("id")
-            .repartition(NUM_FILES);
-    writeData(df);
-  }
-
-  private void writeData(Dataset<Row> df) {
-    df.write().format("iceberg").mode(SaveMode.Append).save(NAME);
-  }
-
   protected final Table table() {
     try {
-      return Spark3Util.loadIcebergTable(spark(), NAME);
+      return Spark3Util.loadIcebergTable(spark(), tableName());
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -181,7 +106,20 @@ public class IcebergCompactionBenchmark {
   }
 
   protected void cleanupFiles() throws IOException {
-    spark.sql("DROP TABLE IF EXISTS " + NAME);
+    spark.sql("DROP TABLE IF EXISTS " + tableName());
+  }
+
+  /**
+   * Returns extra properties added to the Spark catalog during session setup.
+   *
+   * <p>The default implementation returns {@code type=hadoop} for a local Hadoop catalog. Override
+   * to switch the catalog implementation or FileIO, e.g., with {@code catalog-impl}, {@code
+   * io-impl}, and {@code warehouse} for an S3-backed run.
+   *
+   * @return a map of catalog properties to apply
+   */
+  protected Map<String, String> extraCatalogProperties() {
+    return Map.of("type", "hadoop");
   }
 
   protected void setupSpark() {
@@ -189,10 +127,11 @@ public class IcebergCompactionBenchmark {
         SparkSession.builder()
             .config(
                 "spark.sql.catalog.spark_catalog", "org.apache.iceberg.spark.SparkSessionCatalog")
-            .config("spark.sql.catalog.spark_catalog.type", "hadoop")
             .config("spark.sql.catalog.spark_catalog.warehouse", getCatalogWarehouse())
             .config(TestBase.DISABLE_UI)
             .master("local[*]");
+    extraCatalogProperties()
+        .forEach((key, value) -> builder.config("spark.sql.catalog.spark_catalog." + key, value));
     spark = builder.getOrCreate();
     Configuration sparkHadoopConf = spark.sessionState().newHadoopConf();
     hadoopConf.forEach(entry -> sparkHadoopConf.set(entry.getKey(), entry.getValue()));
@@ -200,5 +139,9 @@ public class IcebergCompactionBenchmark {
 
   protected void tearDownSpark() {
     spark.stop();
+  }
+
+  protected void writeData(Dataset<Row> df) {
+    df.write().format("iceberg").mode(SaveMode.Append).save(tableName());
   }
 }

--- a/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergDataCompactionBenchmark.java
+++ b/spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergDataCompactionBenchmark.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.action;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.spark.sql.functions.col;
+import static org.apache.spark.sql.functions.concat;
+import static org.apache.spark.sql.functions.lit;
+
+import java.util.Collections;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.spark.Spark3Util;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkSessionCatalog;
+import org.apache.iceberg.spark.actions.SparkActions;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+
+/**
+ * A benchmark that evaluates the performance of the rewrite data files action in Spark.
+ *
+ * <p>To run this benchmark for spark-4.1: <code>
+ *   ./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:jmh
+ *       -PjmhIncludeRegex=IcebergDataCompactionBenchmark.rewriteDataFiles
+ *       -PjmhOutputPath=benchmark/data-compaction-benchmark-results.txt
+ *       -PjmhJsonOutputPath=benchmark/data-compaction-benchmark-results.json
+ * </code>
+ */
+@Warmup(iterations = 3)
+@Measurement(iterations = 10)
+public class IcebergDataCompactionBenchmark extends IcebergCompactionBenchmark {
+
+  private static final String[] NAMESPACE = new String[] {"default"};
+  private static final String NAME = "compactbench";
+  private static final Identifier IDENT = Identifier.of(NAMESPACE, NAME);
+  private static final long TOTAL_ROWS = 2_000_000L;
+
+  @Param({"250", "500", "1000", "2000"})
+  private int numFiles;
+
+  @Override
+  protected String tableName() {
+    return NAME;
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void rewriteDataFiles() {
+    SparkActions.get()
+        .rewriteDataFiles(table())
+        .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
+        .execute();
+  }
+
+  @Override
+  protected final void initTable() {
+    Schema schema =
+        new Schema(
+            required(1, "intCol", Types.IntegerType.get()),
+            required(2, "stringCol", Types.StringType.get()),
+            optional(3, "nullCol", Types.StringType.get()));
+
+    SparkSessionCatalog<?> catalog;
+    try {
+      catalog =
+          (SparkSessionCatalog<?>)
+              Spark3Util.catalogAndIdentifier(spark(), "spark_catalog").catalog();
+      catalog.dropTable(IDENT);
+      catalog.createTable(
+          IDENT, SparkSchemaUtil.convert(schema), new Transform[0], Collections.emptyMap());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  protected void appendData() {
+    Dataset<Row> df =
+        spark()
+            .range(0, TOTAL_ROWS)
+            .withColumn("intCol", col("id").cast("int"))
+            .withColumn("stringCol", concat(lit("foo_"), col("id")))
+            .withColumn("nullCol", lit(null).cast("string"))
+            .drop("id")
+            .repartition(numFiles);
+    writeData(df);
+  }
+}


### PR DESCRIPTION
None of the existing benchmarks solely measure compaction (rewrite data files) time.
Closest reference is `spark/v4.1/spark/src/jmh/java/org/apache/iceberg/spark/action/IcebergSortCompactionBenchmark.java`but it still includes several other actions which add noise when trying to benchmark compaction performance itself.


Created a base class `action/IcebergCompactionBenchmark.java` which currently serves `action/IcebergDataCompactionBenchmark.java` and will also serve `action/IcebergSortCompactionBenchmark.java` when this PR gets merged 

Currently, benchmarking is done using local FS without latency injection. 
To benchmark under more realistic storage latency, there are two possible approaches: 
- latency injection
- Switch to S3FileIO

For switching to S3FileIO, two functions from the base class `action/IcebergCompactionBenchmark.java` can be overridden:  
Example (extraCatalogProperties) : 
```
@Override
  protected Map<String, String> extraCatalogProperties() {
    return Map.of(
        "catalog-impl", "org.apache.iceberg.jdbc.JdbcCatalog",
        "uri", "jdbc:sqlite:/tmp/iceberg-compaction-benchmark-catalog.db",
        "io-impl", "org.apache.iceberg.aws.s3.S3FileIO",
        "client.region", "ap-south-1");
  }
  
```
Example (getCatalogWarehouse) : 

```
@Override
  protected String getCatalogWarehouse() {
    return "s3a://location-to-bucket/path-to-destination/";
  }