### PR TITLE
Core, Spark: Fix invalid snapshot ID filtering in RewriteTablePath copy plan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -332,7 +332,9 @@ public class RewriteTablePathUtil {
    * Rewrite a data manifest, replacing path references.
    *
    * @param manifestFile source manifest file to rewrite
-   * @param snapshotIds snapshot ids for filtering returned data manifest entries
+   * @param snapshotIds snapshot ids for filtering copy-plan entries; live entries whose adding
+   *     snapshot is not in this set are written to the rewritten manifest but excluded from the
+   *     copy plan
    * @param outputFile output file to rewrite manifest file to
    * @param io file io
    * @param format format of the manifest file
@@ -365,10 +367,36 @@ public class RewriteTablePathUtil {
   }
 
   /**
+   * Rewrite a data manifest, replacing path references. All live entries are included in the copy
+   * plan regardless of the snapshot that added them.
+   *
+   * @param manifestFile source manifest file to rewrite
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @return a copy plan of content files in the manifest that was rewritten
+   */
+  public static RewriteResult<DataFile> rewriteDataManifest(
+      ManifestFile manifestFile,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
+    return rewriteDataManifest(
+        manifestFile, null, outputFile, io, format, specsById, sourcePrefix, targetPrefix);
+  }
+
+  /**
    * Rewrite a delete manifest, replacing path references.
    *
    * @param manifestFile source delete manifest to rewrite
-   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
+   * @param snapshotIds snapshot ids for filtering copy-plan entries
    * @param outputFile output file to rewrite manifest file to
    * @param io file io
    * @param format format of the manifest file
@@ -417,7 +445,7 @@ public class RewriteTablePathUtil {
    * file_size_in_bytes} stays consistent with the rewritten file on disk.
    *
    * @param manifestFile source delete manifest to rewrite
-   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
+   * @param snapshotIds snapshot ids for filtering copy-plan entries
    * @param outputFile output file to rewrite manifest file to
    * @param io file io
    * @param format format of the manifest file
@@ -463,6 +491,46 @@ public class RewriteTablePathUtil {
     }
   }
 
+  /**
+   * Rewrite a delete manifest, replacing path references. All live entries are included in the copy
+   * plan regardless of the snapshot that added them.
+   *
+   * @param manifestFile source delete manifest to rewrite
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @param stagingLocation staging location for rewritten position delete files
+   * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
+   *     the rewritten file; entries absent from the map keep their original size
+   * @return a copy plan of content files in the manifest that was rewritten
+   */
+  public static RewriteResult<DeleteFile> rewriteDeleteManifest(
+      ManifestFile manifestFile,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingLocation,
+      Map<String, Long> rewrittenDeleteFileSizes)
+      throws IOException {
+    return rewriteDeleteManifest(
+        manifestFile,
+        null,
+        outputFile,
+        io,
+        format,
+        specsById,
+        sourcePrefix,
+        targetPrefix,
+        stagingLocation,
+        rewrittenDeleteFileSizes);
+  }
+
   private static RewriteResult<DataFile> writeDataFileEntry(
       ManifestEntry<DataFile> entry,
       Set<Long> snapshotIds,
@@ -482,13 +550,20 @@ public class RewriteTablePathUtil {
     DataFile newDataFile =
         DataFiles.builder(spec).copy(entry.file()).withPath(targetDataFilePath).build();
     appendEntryWithFile(entry, writer, newDataFile);
-    // keep the following entries in metadata but exclude them from copyPlan
-    // 1) deleted data files
-    // 2) entries not changed by snapshotIds
-    if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
+    if (includeInCopyPlan(entry, snapshotIds)) {
       result.copyPlan().add(Pair.of(sourceDataFilePath, newDataFile.location()));
     }
     return result;
+  }
+
+  /**
+   * Whether a manifest entry should be added to the copy plan. Every live entry is included; when
+   * {@code snapshotIds} is non-null, inclusion is further restricted to entries added by one of
+   * those snapshots (legacy filtering). A {@code null} {@code snapshotIds} means all live entries
+   * are included.
+   */
+  private static boolean includeInCopyPlan(ManifestEntry<?> entry, Set<Long> snapshotIds) {
+    return entry.isLive() && (snapshotIds == null || snapshotIds.contains(entry.snapshotId()));
   }
 
   private static RewriteResult<DeleteFile> writeDeleteFileEntry(
@@ -513,10 +588,7 @@ public class RewriteTablePathUtil {
         DeleteFile posDeleteFile =
             newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix, fileSizeInBytes);
         appendEntryWithFile(entry, writer, posDeleteFile);
-        // keep the following entries in metadata but exclude them from copyPlan
-        // 1) deleted position delete files
-        // 2) entries not changed by snapshotIds
-        if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
+        if (includeInCopyPlan(entry, snapshotIds)) {
           result
               .copyPlan()
               .add(
@@ -529,11 +601,7 @@ public class RewriteTablePathUtil {
       case EQUALITY_DELETES:
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, eqDeleteFile);
-        // keep the following entries in metadata but exclude them from copyPlan
-        // 1) deleted equality delete files
-        // 2) entries not changed by snapshotIds
-        if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
-          // No need to rewrite equality delete files as they do not contain absolute file paths.
+        if (includeInCopyPlan(entry, snapshotIds)) {
           result.copyPlan().add(Pair.of(file.location(), eqDeleteFile.location()));
         }
         return result;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -329,10 +329,32 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     // rebuild manifest files
     RewriteContentFileResult rewriteManifestResult =
         rewriteManifests(
-            deltaSnapshots,
-            endMetadata,
-            manifestFiles,
-            sparkContext().broadcast(rewrittenDeleteFileSizes));
+            endMetadata, manifestFiles, sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // For incremental copies, filter out files that were already copied by a previous replication.
+    // Prefer the target copy of the start version (dedup by target path), which retains everything
+    // previously replicated even when source snapshots have since been expired. If the target is not
+    // readable (e.g. files were not physically copied), fall back to the start version on the source
+    // (dedup by source path).
+    if (startMetadata != null && !rewriteManifestResult.copyPlan().isEmpty()) {
+      try {
+        String targetStartVersion =
+            RewriteTablePathUtil.newPath(startVersionName, sourcePrefix, targetPrefix);
+        Set<String> targetPaths = readContentFilePaths(targetStartVersion);
+        rewriteManifestResult.copyPlan().removeIf(pair -> targetPaths.contains(pair.second()));
+      } catch (Exception fromTarget) {
+        try {
+          Set<String> sourcePaths = readContentFilePaths(startVersionName);
+          rewriteManifestResult.copyPlan().removeIf(pair -> sourcePaths.contains(pair.first()));
+        } catch (Exception fromSource) {
+          fromSource.addSuppressed(fromTarget);
+          LOG.warn(
+              "Unable to read content files from the start version on the target or source for "
+                  + "incremental filtering; falling back to full copy plan.",
+              fromSource);
+        }
+      }
+    }
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -352,6 +374,16 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     String fileListLocation = saveFileList(copyPlan);
 
     return builder.fileListLocation(fileListLocation).build();
+  }
+
+  /**
+   * Read the set of content file paths referenced by the given metadata version. Used to dedup
+   * incremental copies against files that were already replicated.
+   */
+  private Set<String> readContentFilePaths(String metadataFileLocation) {
+    Table startTable = newStaticTable(metadataFileLocation, table.io());
+    return Sets.newHashSet(
+        contentFileDS(startTable).select("path").as(Encoders.STRING()).collectAsList());
   }
 
   private String saveFileList(Set<Pair<String, String>> filesToMove) {
@@ -574,7 +606,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   /** Rewrite manifest files in a distributed manner and return rewritten data files path pairs. */
   private RewriteContentFileResult rewriteManifests(
-      Set<Snapshot> deltaSnapshots,
       TableMetadata tableMetadata,
       Set<ManifestFile> toRewrite,
       Broadcast<Map<String, Long>> rewrittenDeleteFileSizes) {
@@ -585,15 +616,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Encoder<ManifestFile> manifestFileEncoder = Encoders.javaSerialization(ManifestFile.class);
     Dataset<ManifestFile> manifestDS =
         spark().createDataset(Lists.newArrayList(toRewrite), manifestFileEncoder);
-    Set<Long> deltaSnapshotIds =
-        deltaSnapshots.stream().map(Snapshot::snapshotId).collect(Collectors.toSet());
 
     return manifestDS
         .repartition(toRewrite.size())
         .map(
             toManifests(
                 tableBroadcast(),
-                sparkContext().broadcast(deltaSnapshotIds),
                 stagingDir,
                 tableMetadata.formatVersion(),
                 sourcePrefix,
@@ -607,7 +635,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   private static MapFunction<ManifestFile, RewriteContentFileResult> toManifests(
       Broadcast<Table> table,
-      Broadcast<Set<Long>> deltaSnapshotIds,
       String stagingLocation,
       int format,
       String sourcePrefix,
@@ -620,20 +647,13 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
         case DATA:
           result.appendDataFile(
               writeDataManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix));
+                  manifestFile, table, stagingLocation, format, sourcePrefix, targetPrefix));
           break;
         case DELETES:
           result.appendDeleteFile(
               writeDeleteManifest(
                   manifestFile,
                   table,
-                  deltaSnapshotIds,
                   stagingLocation,
                   format,
                   sourcePrefix,
@@ -651,7 +671,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private static RewriteResult<DataFile> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
-      Broadcast<Set<Long>> snapshotIds,
       String stagingLocation,
       int format,
       String sourcePrefix,
@@ -662,16 +681,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
-      Set<Long> deltaSnapshotIds = snapshotIds.value();
       return RewriteTablePathUtil.rewriteDataManifest(
-          manifestFile,
-          deltaSnapshotIds,
-          outputFile,
-          io,
-          format,
-          specsById,
-          sourcePrefix,
-          targetPrefix);
+          manifestFile, outputFile, io, format, specsById, sourcePrefix, targetPrefix);
     } catch (IOException e) {
       throw new RuntimeIOException(e);
     }
@@ -680,7 +691,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private static RewriteResult<DeleteFile> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
-      Broadcast<Set<Long>> snapshotIds,
       String stagingLocation,
       int format,
       String sourcePrefix,
@@ -692,10 +702,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       FileIO io = table.getValue().io();
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
-      Set<Long> deltaSnapshotIds = snapshotIds.value();
       return RewriteTablePathUtil.rewriteDeleteManifest(
           manifestFile,
-          deltaSnapshotIds,
           outputFile,
           io,
           format,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -328,6 +328,114 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testIncrementalRewriteWithRewriteManifestsAndExpire() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable =
+        TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), Maps.newHashMap(), location);
+
+    // Write 2 initial snapshots
+    List<ThreeColumnRecord> recordsA =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    Dataset<Row> dfA = spark.createDataFrame(recordsA, ThreeColumnRecord.class).coalesce(1);
+    dfA.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+
+    List<ThreeColumnRecord> recordsB =
+        Lists.newArrayList(new ThreeColumnRecord(2, "BBBBBBBBBB", "BBBB"));
+    Dataset<Row> dfB = spark.createDataFrame(recordsB, ThreeColumnRecord.class).coalesce(1);
+    dfB.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    sourceTable.refresh();
+
+    // Full replication
+    RewriteTablePath.Result initialResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .stagingLocation(stagingLocation())
+            .execute();
+    copyTableFiles(initialResult);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .hasSize(2);
+
+    // Append new data
+    List<ThreeColumnRecord> recordsC =
+        Lists.newArrayList(new ThreeColumnRecord(3, "CCCCCCCCCC", "CCCC"));
+    Dataset<Row> dfC = spark.createDataFrame(recordsC, ThreeColumnRecord.class).coalesce(1);
+    dfC.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(location);
+    sourceTable.refresh();
+
+    // RewriteManifests merges all manifests
+    actions().rewriteManifests(sourceTable).execute();
+    sourceTable.refresh();
+
+    // Expire old snapshots including the one that added file C
+    actions()
+        .expireSnapshots(sourceTable)
+        .retainLast(1)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis() + 1)
+        .execute();
+    sourceTable.refresh();
+
+    // Incremental replication should still copy file C
+    Table targetTable = TABLES.load(targetTableLocation());
+    String startVersion = fileName(currentMetadata(targetTable).metadataFileLocation());
+    RewriteTablePath.Result incrementalResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .stagingLocation(stagingLocation())
+            .startVersion(startVersion)
+            .execute();
+    copyTableFiles(incrementalResult);
+
+    // Dedup check: files A and B were already replicated by the initial copy, so the incremental
+    // copy plan must contain only the newly appended data file (C).
+    List<Tuple2<String, String>> incrementalPaths =
+        readPathPairList(incrementalResult.fileListLocation());
+    assertThat(
+            incrementalPaths.stream()
+                .filter(p -> p._1().contains("/data/") && p._1().endsWith(".parquet")))
+        .as("Only the newly appended data file (C) should be copied incrementally")
+        .hasSize(1);
+
+    List<Object[]> actual = rowsSorted(targetTableLocation(), "c1");
+    List<Object[]> expected = rowsSorted(location, "c1");
+    assertEquals(
+        "Rows should match after incremental copy with expired snapshots", expected, actual);
+  }
+
+  @TestTemplate
+  public void testFullCopyWithRewriteManifestsAndExpire() throws Exception {
+    String location = newTableLocation();
+    Table sourceTable = createTableWithSnapshots(location, 2);
+
+    // RewriteManifests
+    actions().rewriteManifests(sourceTable).execute();
+    sourceTable.refresh();
+
+    // Expire all but the latest snapshot
+    actions()
+        .expireSnapshots(sourceTable)
+        .retainLast(1)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis() + 1)
+        .execute();
+    sourceTable.refresh();
+
+    // Full copy should include all live data files despite expired snapshot IDs
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .stagingLocation(stagingLocation())
+            .execute();
+    copyTableFiles(result);
+
+    List<Object[]> actual = rowsSorted(targetTableLocation(), "c1");
+    List<Object[]> expected = rowsSorted(location, "c1");
+    assertEquals(
+        "All rows should be present after full copy with expired snapshots", expected, actual);
+  }
+
+  @TestTemplate
   public void testTableWith3Snapshots(@TempDir Path location1, @TempDir Path location2)
       throws Exception {
     String location = newTableLocation();
@@ -1021,8 +1129,9 @@ public class TestRewriteTablePathsAction extends TestBase {
     // the first snapshot
     // from the version file history
     int missingVersionFile = 1;
-    // since first snapshot cannot be found, first data files will also be skipped
-    int missingDataFile = 1;
+    // the first snapshot was expired, but its data file is still live and
+    // included in the copy plan
+    int missingDataFile = 0;
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(sourceTable)


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/14458

## Summary

- Removes broken snapshotIds.contains(entry.snapshotId()) filter from RewriteTablePathUtil that silently dropped live, un replicated files when their adding snapshot was expired
- Replaces snapshot-ID-based entry filtering with entry.isLive() only — all live content files are included in the copy plan
- Adds anti-join dedup for incremental copies: filters out previously-replicated files by comparing against the start version's content files via contentFileDS
- Fixes both full copy (expired snapshot IDs missing from endMetadata.snapshots()) and incremental copy (expired snapshot IDs missing from deltaSnapshotIds after RewriteManifests + ExpireSnapshots)

## Problem

RewriteTablePathUtil.writeDataFileEntry filtered copy plan entries using snapshotIds.contains(entry.snapshotId()). This is fundamentally broken because entry.snapshotId() reflects the snapshot that originally added the file, which can be expired at any time by table maintenance. When RewriteManifests reorganizes entries from expired snapshots into new manifests, the manifest is correctly selected for processing but the entry-level filter drops the files — causing silent data loss at the target.

**Scenario**: 
Append (S3) → RewriteManifests (S4) → Expire S3 → Incremental replication builds deltaSnapshotIds = {S4}, but file C has entry.snapshotId() = S3 → {S4}.contains(S3) == false → file C excluded from copy plan.

## Approach
1. Entry level: Include all live entries in copy plan (no snapshot ID check)
2. Incremental dedup: Anti-join against start version's content files using contentFileDS from BaseSparkAction
3. Manifest selection: Unchanged — manifestsToRewrite still uses deltaSnapshotIds from version history

## Test plan

- Verify existing TestRewriteTablePathsAction tests pass (full copy, incremental, expire scenarios)
- Verify existing TestRewriteTablePathUtil tests pass
- Add integration test: incremental replication after append + RewriteManifests + ExpireSnapshots
- Verify incremental copy produces correct file counts (no duplicate copies of already-replicated files)
- Verify full copy after many snapshots with expired snapshot IDs includes all live data