### PR TITLE
Core: Add multi-snapshot support to SnapshotChanges

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,6 +28,6 @@ jobs:
   triage:
     runs-on: ubuntu-slim
     steps:
-    - uses: actions/labeler@f27b608878404679385c85cfa523b85ccb86e213 # v6.1.0
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
       with:
         sync-labels: true

--- a/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
+++ b/core/src/main/java/org/apache/iceberg/CherryPickOperation.java
@@ -22,19 +22,15 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
-import org.apache.iceberg.util.ThreadPools;
 import org.apache.iceberg.util.WapUtil;
 
 /**
@@ -227,17 +223,10 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
               SnapshotUtil.ancestorsBetween(
                   meta.currentSnapshot().snapshotId(), parentId, meta::snapshot));
       if (!snapshots.isEmpty()) {
-        Iterable<CloseableIterable<DataFile>> addedFileTasks =
-            Iterables.concat(
-                Iterables.transform(
-                    snapshots,
-                    snap ->
-                        Iterables.transform(
-                            manifestsCreatedBy(snap, io),
-                            manifest -> addedDataFiles(manifest, io, meta.specsById()))));
+        SnapshotChanges changes =
+            SnapshotChanges.builderFor(snapshots, io, meta.specsById()).build();
 
-        try (CloseableIterable<DataFile> newFiles =
-            new ParallelIterable<>(addedFileTasks, ThreadPools.getWorkerPool())) {
+        try (CloseableIterable<DataFile> newFiles = changes.readAddedDataFiles()) {
           for (DataFile newFile : newFiles) {
             ValidationException.check(
                 !replacedPartitions.contains(newFile.specId(), newFile.partition()),
@@ -249,20 +238,6 @@ class CherryPickOperation extends MergingSnapshotProducer<CherryPickOperation> {
         }
       }
     }
-  }
-
-  private static Iterable<ManifestFile> manifestsCreatedBy(Snapshot snapshot, FileIO io) {
-    return Iterables.filter(
-        snapshot.dataManifests(io), m -> Objects.equals(m.snapshotId(), snapshot.snapshotId()));
-  }
-
-  private static CloseableIterable<DataFile> addedDataFiles(
-      ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
-    CloseableIterable<ManifestEntry<DataFile>> entries =
-        ManifestFiles.read(manifest, io, specsById).entries();
-    CloseableIterable<ManifestEntry<DataFile>> added =
-        CloseableIterable.filter(entries, e -> e.status() == ManifestEntry.Status.ADDED);
-    return CloseableIterable.transform(added, e -> e.file().copy());
   }
 
   private static Long lookupAncestorBySourceSnapshot(TableMetadata meta, long snapshotId) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -35,11 +35,12 @@ import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.ThreadPools;
 
 /**
- * Helper class for retrieving file changes across one or more snapshots, with caching.
+ * Helper class for retrieving file changes across one or more snapshots.
  *
- * <p>This class caches the results of file change detection operations, making it efficient to
- * query multiple file change types for the same set of snapshots. The accessors return the union of
- * changes across all configured snapshots.
+ * <p>The {@code read*} accessors return streaming {@link CloseableIterable}s and must be closed by
+ * callers. The non-{@code read} accessors materialize and cache file changes, making it efficient
+ * to query multiple file change types for the same set of snapshots. All accessors return the union
+ * of changes across the configured snapshots.
  *
  * <p>By default, manifests are read single-threaded when only one snapshot is configured. When more
  * than one snapshot is configured the shared {@link ThreadPools#getWorkerPool()} is used so that
@@ -108,6 +109,11 @@ public class SnapshotChanges {
     return new Builder(io, specsById).snapshot(snapshot);
   }
 
+  static Builder builderFor(
+      Iterable<Snapshot> snapshots, FileIO io, Map<Integer, PartitionSpec> specsById) {
+    return new Builder(io, specsById).snapshots(snapshots);
+  }
+
   private <T> CloseableIterable<T> iterate(Iterable<CloseableIterable<T>> tasks) {
     if (executorService != null) {
       return new ParallelIterable<>(tasks, executorService);
@@ -119,6 +125,42 @@ public class SnapshotChanges {
     } else {
       return CloseableIterable.concat(tasks);
     }
+  }
+
+  /**
+   * Returns a closeable iterable of data files added across the configured snapshots.
+   *
+   * <p>Callers are responsible for closing the returned iterable.
+   */
+  public CloseableIterable<DataFile> readAddedDataFiles() {
+    return readDataFiles(ManifestEntry.Status.ADDED);
+  }
+
+  /**
+   * Returns a closeable iterable of data files removed across the configured snapshots.
+   *
+   * <p>Callers are responsible for closing the returned iterable.
+   */
+  public CloseableIterable<DataFile> readRemovedDataFiles() {
+    return readDataFiles(ManifestEntry.Status.DELETED);
+  }
+
+  /**
+   * Returns a closeable iterable of delete files added across the configured snapshots.
+   *
+   * <p>Callers are responsible for closing the returned iterable.
+   */
+  public CloseableIterable<DeleteFile> readAddedDeleteFiles() {
+    return readDeleteFiles(ManifestEntry.Status.ADDED);
+  }
+
+  /**
+   * Returns a closeable iterable of delete files removed across the configured snapshots.
+   *
+   * <p>Callers are responsible for closing the returned iterable.
+   */
+  public CloseableIterable<DeleteFile> readRemovedDeleteFiles() {
+    return readDeleteFiles(ManifestEntry.Status.DELETED);
   }
 
   /** Returns all data files added across the configured snapshots. */
@@ -161,20 +203,8 @@ public class SnapshotChanges {
     ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
 
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DataFile>>> manifestReadTasks =
-        Iterables.concat(
-            Iterables.transform(
-                snapshots,
-                snapshot ->
-                    Iterables.transform(
-                        Iterables.filter(
-                            snapshot.dataManifests(io),
-                            manifest ->
-                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
-                        this::readDataManifest)));
-
     try (CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changedDataFiles =
-        iterate(manifestReadTasks)) {
+        readDataFileChanges()) {
       for (Pair<ManifestEntry.Status, DataFile> pair : changedDataFiles) {
         switch (pair.first()) {
           case ADDED:
@@ -191,6 +221,29 @@ public class SnapshotChanges {
 
     this.addedDataFiles = adds.build();
     this.removedDataFiles = deletes.build();
+  }
+
+  private CloseableIterable<DataFile> readDataFiles(ManifestEntry.Status status) {
+    CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changes = readDataFileChanges();
+    CloseableIterable<Pair<ManifestEntry.Status, DataFile>> matching =
+        CloseableIterable.filter(changes, pair -> pair.first() == status);
+    return CloseableIterable.transform(matching, Pair::second);
+  }
+
+  private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> readDataFileChanges() {
+    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DataFile>>> manifestReadTasks =
+        Iterables.concat(
+            Iterables.transform(
+                snapshots,
+                snapshot ->
+                    Iterables.transform(
+                        Iterables.filter(
+                            snapshot.dataManifests(io),
+                            manifest ->
+                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
+                        this::readDataManifest)));
+
+    return iterate(manifestReadTasks);
   }
 
   private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> readDataManifest(
@@ -216,20 +269,8 @@ public class SnapshotChanges {
     ImmutableList.Builder<DeleteFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> deletes = ImmutableList.builder();
 
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>>> manifestReadTasks =
-        Iterables.concat(
-            Iterables.transform(
-                snapshots,
-                snapshot ->
-                    Iterables.transform(
-                        Iterables.filter(
-                            snapshot.deleteManifests(io),
-                            manifest ->
-                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
-                        this::readDeleteManifest)));
-
     try (CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changedDeleteFiles =
-        iterate(manifestReadTasks)) {
+        readDeleteFileChanges()) {
       for (Pair<ManifestEntry.Status, DeleteFile> pair : changedDeleteFiles) {
         switch (pair.first()) {
           case ADDED:
@@ -246,6 +287,29 @@ public class SnapshotChanges {
 
     this.addedDeleteFiles = adds.build();
     this.removedDeleteFiles = deletes.build();
+  }
+
+  private CloseableIterable<DeleteFile> readDeleteFiles(ManifestEntry.Status status) {
+    CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changes = readDeleteFileChanges();
+    CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> matching =
+        CloseableIterable.filter(changes, pair -> pair.first() == status);
+    return CloseableIterable.transform(matching, Pair::second);
+  }
+
+  private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> readDeleteFileChanges() {
+    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>>> manifestReadTasks =
+        Iterables.concat(
+            Iterables.transform(
+                snapshots,
+                snapshot ->
+                    Iterables.transform(
+                        Iterables.filter(
+                            snapshot.deleteManifests(io),
+                            manifest ->
+                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
+                        this::readDeleteManifest)));
+
+    return iterate(manifestReadTasks);
   }
 
   private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> readDeleteManifest(

--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -29,19 +29,29 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.ParallelIterable;
+import org.apache.iceberg.util.ThreadPools;
 
 /**
- * Helper class for retrieving file changes in a snapshot with caching.
+ * Helper class for retrieving file changes across one or more snapshots, with caching.
  *
  * <p>This class caches the results of file change detection operations, making it efficient to
- * query multiple file change types for the same snapshot. By default, manifests are read
- * single-threaded. Use {@link Builder#executeWith(ExecutorService)} to enable parallel manifest
- * reading.
+ * query multiple file change types for the same set of snapshots. The accessors return the union of
+ * changes across all configured snapshots.
+ *
+ * <p>By default, manifests are read single-threaded when only one snapshot is configured. When more
+ * than one snapshot is configured the shared {@link ThreadPools#getWorkerPool()} is used so that
+ * manifest reads are parallelised across snapshot boundaries. Use {@link
+ * Builder#executeWith(ExecutorService)} to supply a custom executor in either case.
+ *
+ * <p>Each manifest is attributed to exactly one snapshot via {@link ManifestFile#snapshotId()}, so
+ * the multi-snapshot path never reads the same manifest twice even when the configured snapshots
+ * share an ancestor chain.
  */
 public class SnapshotChanges {
-  private final Snapshot snapshot;
+  private final List<Snapshot> snapshots;
   private final FileIO io;
   private final Map<Integer, PartitionSpec> specsById;
   private final ExecutorService executorService;
@@ -52,14 +62,18 @@ public class SnapshotChanges {
   private List<DeleteFile> removedDeleteFiles = null;
 
   private SnapshotChanges(
-      Snapshot snapshot,
+      List<Snapshot> snapshots,
       FileIO io,
       Map<Integer, PartitionSpec> specsById,
       ExecutorService executorService) {
-    Preconditions.checkArgument(snapshot != null, "Snapshot cannot be null");
+    Preconditions.checkArgument(snapshots != null, "Snapshots cannot be null");
+    Preconditions.checkArgument(!snapshots.isEmpty(), "Snapshots cannot be empty");
     Preconditions.checkArgument(io != null, "FileIO cannot be null");
     Preconditions.checkArgument(specsById != null, "Partition specs cannot be null");
-    this.snapshot = snapshot;
+    for (Snapshot snapshot : snapshots) {
+      Preconditions.checkArgument(snapshot != null, "Snapshot cannot be null");
+    }
+    this.snapshots = ImmutableList.copyOf(snapshots);
     this.io = io;
     this.specsById = specsById;
     this.executorService = executorService;
@@ -72,22 +86,42 @@ public class SnapshotChanges {
    * @return a new Builder
    */
   public static Builder builderFor(Table table) {
-    return new Builder(table.currentSnapshot(), table.io(), table.specs());
+    Builder builder = new Builder(table.io(), table.specs());
+    if (table.currentSnapshot() != null) {
+      builder.snapshot(table.currentSnapshot());
+    }
+    return builder;
+  }
+
+  /**
+   * Create a builder for SnapshotChanges over a fixed set of snapshots.
+   *
+   * @param table the table the snapshots belong to (used for {@link FileIO} and partition specs)
+   * @param snapshots the snapshots to detect file changes for; must be non-empty
+   * @return a new Builder
+   */
+  public static Builder builderFor(Table table, Iterable<Snapshot> snapshots) {
+    return new Builder(table.io(), table.specs()).snapshots(snapshots);
   }
 
   static Builder builderFor(Snapshot snapshot, FileIO io, Map<Integer, PartitionSpec> specsById) {
-    return new Builder(snapshot, io, specsById);
+    return new Builder(io, specsById).snapshot(snapshot);
   }
 
   private <T> CloseableIterable<T> iterate(Iterable<CloseableIterable<T>> tasks) {
     if (executorService != null) {
       return new ParallelIterable<>(tasks, executorService);
+    } else if (snapshots.size() > 1) {
+      // Multi-snapshot mode defaults to the shared worker pool to keep manifest reads
+      // saturated across snapshot boundaries. Single-snapshot mode keeps the historical
+      // serial-by-default behaviour to avoid surprising existing callers.
+      return new ParallelIterable<>(tasks, ThreadPools.getWorkerPool());
     } else {
       return CloseableIterable.concat(tasks);
     }
   }
 
-  /** Returns all data files added to the table in this snapshot */
+  /** Returns all data files added across the configured snapshots. */
   public Iterable<DataFile> addedDataFiles() {
     if (addedDataFiles == null) {
       cacheDataFileChanges();
@@ -96,7 +130,7 @@ public class SnapshotChanges {
     return addedDataFiles;
   }
 
-  /** Returns all data files removed from the table in this snapshot. */
+  /** Returns all data files removed across the configured snapshots. */
   public Iterable<DataFile> removedDataFiles() {
     if (removedDataFiles == null) {
       cacheDataFileChanges();
@@ -105,7 +139,7 @@ public class SnapshotChanges {
     return removedDataFiles;
   }
 
-  /** Returns all delete files added to the table in this snapshot. */
+  /** Returns all delete files added across the configured snapshots. */
   public Iterable<DeleteFile> addedDeleteFiles() {
     if (addedDeleteFiles == null) {
       cacheDeleteFileChanges();
@@ -114,7 +148,7 @@ public class SnapshotChanges {
     return addedDeleteFiles;
   }
 
-  /** Returns all delete files removed from the table in this snapshot. */
+  /** Returns all delete files removed across the configured snapshots. */
   public Iterable<DeleteFile> removedDeleteFiles() {
     if (removedDeleteFiles == null) {
       cacheDeleteFileChanges();
@@ -127,13 +161,17 @@ public class SnapshotChanges {
     ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
 
-    Iterable<ManifestFile> relevantDataManifests =
-        Iterables.filter(
-            snapshot.dataManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
     Iterable<CloseableIterable<Pair<ManifestEntry.Status, DataFile>>> manifestReadTasks =
-        Iterables.transform(relevantDataManifests, this::readDataManifest);
+        Iterables.concat(
+            Iterables.transform(
+                snapshots,
+                snapshot ->
+                    Iterables.transform(
+                        Iterables.filter(
+                            snapshot.dataManifests(io),
+                            manifest ->
+                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
+                        this::readDataManifest)));
 
     try (CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changedDataFiles =
         iterate(manifestReadTasks)) {
@@ -178,13 +216,17 @@ public class SnapshotChanges {
     ImmutableList.Builder<DeleteFile> adds = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> deletes = ImmutableList.builder();
 
-    Iterable<ManifestFile> relevantDeleteManifests =
-        Iterables.filter(
-            snapshot.deleteManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
     Iterable<CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>>> manifestReadTasks =
-        Iterables.transform(relevantDeleteManifests, this::readDeleteManifest);
+        Iterables.concat(
+            Iterables.transform(
+                snapshots,
+                snapshot ->
+                    Iterables.transform(
+                        Iterables.filter(
+                            snapshot.deleteManifests(io),
+                            manifest ->
+                                Objects.equals(manifest.snapshotId(), snapshot.snapshotId())),
+                        this::readDeleteManifest)));
 
     try (CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changedDeleteFiles =
         iterate(manifestReadTasks)) {
@@ -226,30 +268,46 @@ public class SnapshotChanges {
   }
 
   public static class Builder {
-    private Snapshot snapshot;
     private final FileIO io;
     private final Map<Integer, PartitionSpec> specsById;
+    private final List<Snapshot> snapshots = Lists.newArrayList();
     private ExecutorService executorService = null;
 
-    private Builder(Snapshot snapshot, FileIO io, Map<Integer, PartitionSpec> specsById) {
-      this.snapshot = snapshot;
+    private Builder(FileIO io, Map<Integer, PartitionSpec> specsById) {
       this.io = io;
       this.specsById = specsById;
     }
 
     /**
-     * Set the snapshot to detect file changes for, overriding the default.
+     * Set the snapshot to detect file changes for, replacing any previously configured snapshots.
      *
-     * @param snapshotOverride the snapshot to use
+     * @param snapshot the snapshot to use
      * @return this builder for method chaining
      */
-    public Builder snapshot(Snapshot snapshotOverride) {
-      this.snapshot = snapshotOverride;
+    public Builder snapshot(Snapshot snapshot) {
+      this.snapshots.clear();
+      this.snapshots.add(snapshot);
       return this;
     }
 
     /**
-     * Configure an executor service to use for parallel manifest reading.
+     * Set the snapshots to detect file changes for, replacing any previously configured snapshots.
+     * The accessors on the resulting {@link SnapshotChanges} return the union of changes across all
+     * of these snapshots.
+     *
+     * @param newSnapshots the snapshots to use; must be non-empty
+     * @return this builder for method chaining
+     */
+    public Builder snapshots(Iterable<Snapshot> newSnapshots) {
+      Preconditions.checkArgument(newSnapshots != null, "Snapshots cannot be null");
+      this.snapshots.clear();
+      Iterables.addAll(this.snapshots, newSnapshots);
+      return this;
+    }
+
+    /**
+     * Configure an executor service to use for parallel manifest reading. When unset and more than
+     * one snapshot is configured, the shared {@link ThreadPools#getWorkerPool()} is used.
      *
      * @param executor the executor service to use for parallel execution
      * @return this builder for method chaining
@@ -265,7 +323,7 @@ public class SnapshotChanges {
      * @return a new SnapshotChanges instance
      */
     public SnapshotChanges build() {
-      return new SnapshotChanges(snapshot, io, specsById, executorService);
+      return new SnapshotChanges(snapshots, io, specsById, executorService);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.ParallelIterable;
 import org.apache.iceberg.util.ThreadPools;
@@ -49,7 +50,7 @@ import org.apache.iceberg.util.ThreadPools;
  *
  * <p>Each manifest is attributed to exactly one snapshot via {@link ManifestFile#snapshotId()}, so
  * the multi-snapshot path never reads the same manifest twice even when the configured snapshots
- * share an ancestor chain.
+ * share an ancestor chain. Duplicate snapshots are deduplicated by snapshot id.
  */
 public class SnapshotChanges {
   private final List<Snapshot> snapshots;
@@ -71,10 +72,14 @@ public class SnapshotChanges {
     Preconditions.checkArgument(!snapshots.isEmpty(), "Snapshots cannot be empty");
     Preconditions.checkArgument(io != null, "FileIO cannot be null");
     Preconditions.checkArgument(specsById != null, "Partition specs cannot be null");
+    // Dedup by snapshot id (first occurrence wins) so a manifest is never read twice when the
+    // same snapshot is passed more than once.
+    Map<Long, Snapshot> distinct = Maps.newLinkedHashMap();
     for (Snapshot snapshot : snapshots) {
       Preconditions.checkArgument(snapshot != null, "Snapshot cannot be null");
+      distinct.putIfAbsent(snapshot.snapshotId(), snapshot);
     }
-    this.snapshots = ImmutableList.copyOf(snapshots);
+    this.snapshots = ImmutableList.copyOf(distinct.values());
     this.io = io;
     this.specsById = specsById;
     this.executorService = executorService;

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.util.List;
@@ -363,6 +364,37 @@ public class TestSnapshotChanges {
     SnapshotChanges changes = SnapshotChanges.builderFor(table, ancestorsAfterSnap1).build();
 
     assertThat(paths(changes.addedDataFiles())).containsExactlyInAnyOrderElementsOf(viaDeprecated);
+  }
+
+  @Test
+  public void testBuilderForTableWithNoCurrentSnapshotFailsOnBuild() {
+    // Fresh table has no current snapshot, so builderFor(table) configures no snapshots.
+    assertThatThrownBy(() -> SnapshotChanges.builderFor(table).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Snapshots cannot be empty");
+  }
+
+  @Test
+  public void testSnapshotsNullRejected() {
+    assertThatThrownBy(() -> SnapshotChanges.builderFor(table).snapshots(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Snapshots cannot be null");
+  }
+
+  @Test
+  public void testEmptySnapshotsRejected() {
+    assertThatThrownBy(
+            () -> SnapshotChanges.builderFor(table, ImmutableList.<Snapshot>of()).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Snapshots cannot be empty");
+  }
+
+  @Test
+  public void testNullSnapshotInListRejected() {
+    List<Snapshot> withNull = Lists.newArrayList((Snapshot) null);
+    assertThatThrownBy(() -> SnapshotChanges.builderFor(table, withNull).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Snapshot cannot be null");
   }
 
   private static DataFile newDataFile(String path) {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -199,6 +199,36 @@ public class TestSnapshotChanges {
   }
 
   @Test
+  public void testMultiSnapshotDoesNotDoubleCountSharedAncestorManifests() throws Exception {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+    DataFile fileC = newDataFile("/path/to/C.parquet");
+
+    // Fast appends chain the snapshots: snap2 sees snap1's manifest and snap3 sees both.
+    // Attribution by ManifestFile#snapshotId() must emit each file exactly once.
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileC).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    SnapshotChanges union =
+        SnapshotChanges.builderFor(table, ImmutableList.of(snap1, snap2, snap3)).build();
+
+    // Assert on the raw List, not the Set: a dedup regression would grow this beyond 3.
+    List<DataFile> cached = Lists.newArrayList(union.addedDataFiles());
+    assertThat(cached).hasSize(3);
+    assertThat(paths(cached))
+        .containsExactlyInAnyOrder(
+            fileA.path().toString(), fileB.path().toString(), fileC.path().toString());
+
+    try (CloseableIterable<DataFile> streamed = union.readAddedDataFiles()) {
+      assertThat(Lists.newArrayList(streamed)).hasSize(3);
+    }
+  }
+
+  @Test
   public void testMultiSnapshotUnionForDeleteFiles() {
     DataFile fileA = newDataFile("/path/to/A.parquet");
     table.newFastAppend().appendFile(fileA).commit();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -250,6 +250,31 @@ public class TestSnapshotChanges {
   }
 
   @Test
+  public void testMultiSnapshotUnionForRemovedDeleteFiles() {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    table.newFastAppend().appendFile(fileA).commit();
+
+    DeleteFile delA = newDeleteFile("/path/to/A-deletes.parquet");
+    DeleteFile delB = newDeleteFile("/path/to/B-deletes.parquet");
+    table.newRowDelta().addDeletes(delA).addDeletes(delB).commit();
+
+    table.newRowDelta().removeDeletes(delA).commit();
+    Snapshot removeDelA = table.currentSnapshot();
+    table.newRowDelta().removeDeletes(delB).commit();
+    Snapshot removeDelB = table.currentSnapshot();
+
+    SnapshotChanges union =
+        SnapshotChanges.builderFor(table, ImmutableList.of(removeDelA, removeDelB)).build();
+
+    // exercise the cached removedDeleteFiles() path; only the streaming variant was covered before
+    Iterable<DeleteFile> first = union.removedDeleteFiles();
+    Iterable<DeleteFile> second = union.removedDeleteFiles();
+    assertThat(first).isSameAs(second);
+    assertThat(paths(first))
+        .containsExactlyInAnyOrder(delA.path().toString(), delB.path().toString());
+  }
+
+  @Test
   public void testStreamingAccessorsForMultiSnapshotChanges() throws Exception {
     DataFile fileA = newDataFile("/path/to/A.parquet");
     DataFile fileB = newDataFile("/path/to/B.parquet");

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -22,7 +22,19 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -54,78 +66,44 @@ public class TestSnapshotChanges {
 
   @Test
   public void testAddedDataFiles() {
-    DataFile addedFile =
-        DataFiles.builder(SPEC)
-            .withPath("/path/to/test-data.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
+    DataFile addedFile = newDataFile("/path/to/test-data.parquet");
 
     table.newFastAppend().appendFile(addedFile).commit();
     Snapshot snapshotWithAddedFile = table.currentSnapshot();
 
-    // Test using SnapshotChanges object directly
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotWithAddedFile).build();
     Iterable<DataFile> filesFromChanges = changes.addedDataFiles();
     assertThat(filesFromChanges).hasSize(1);
 
-    // Verify the file path matches
     DataFile resultFile = filesFromChanges.iterator().next();
     assertThat(resultFile.path().toString()).isEqualTo(addedFile.path().toString());
   }
 
   @Test
   public void testRemovedDataFiles() {
-    DataFile fileToRemove =
-        DataFiles.builder(SPEC)
-            .withPath("/path/to/file-to-remove.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
+    DataFile fileToRemove = newDataFile("/path/to/file-to-remove.parquet");
+    DataFile fileToKeep = newDataFile("/path/to/file-to-keep.parquet");
 
-    DataFile fileToKeep =
-        DataFiles.builder(SPEC)
-            .withPath("/path/to/file-to-keep.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
-
-    // Add both files
     table.newAppend().appendFile(fileToRemove).appendFile(fileToKeep).commit();
-
-    // Remove one file
     table.newDelete().deleteFile(fileToRemove).commit();
 
     Snapshot snapshotAfterDelete = table.currentSnapshot();
 
-    // Test using SnapshotChanges object directly (for caching multiple calls)
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotAfterDelete).build();
     Iterable<DataFile> filesFromChangesFirstCall = changes.removedDataFiles();
     Iterable<DataFile> filesFromChangesSecondCall = changes.removedDataFiles();
     assertThat(filesFromChangesFirstCall).isSameAs(filesFromChangesSecondCall);
 
-    // Verify the file path matches
     DataFile resultFile = filesFromChangesFirstCall.iterator().next();
     assertThat(resultFile.path().toString()).isEqualTo(fileToRemove.path().toString());
   }
 
   @Test
   public void testSnapshotChangesCaching() {
-    DataFile firstFile =
-        DataFiles.builder(SPEC)
-            .withPath("/path/to/file1.parquet")
-            .withFileSizeInBytes(10)
-            .withRecordCount(1)
-            .build();
-
-    DataFile secondFile =
-        DataFiles.builder(SPEC)
-            .withPath("/path/to/file2.parquet")
-            .withFileSizeInBytes(20)
-            .withRecordCount(2)
-            .build();
+    DataFile firstFile = newDataFile("/path/to/file1.parquet");
+    DataFile secondFile = newDataFile("/path/to/file2.parquet");
 
     table.newAppend().appendFile(firstFile).appendFile(secondFile).commit();
     table.newDelete().deleteFile(firstFile).commit();
@@ -135,15 +113,174 @@ public class TestSnapshotChanges {
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotAfterDelete).build();
 
-    // First call should cache the data file changes
     Iterable<DataFile> firstCallResult = changes.removedDataFiles();
     assertThat(firstCallResult).hasSize(1);
 
-    // Second call should return the cached results
     Iterable<DataFile> secondCallResult = changes.removedDataFiles();
     assertThat(secondCallResult).hasSize(1);
 
-    // Both calls should return the same reference (cached)
     assertThat(firstCallResult).isSameAs(secondCallResult);
+  }
+
+  @Test
+  public void testSingleSnapshotBackCompatThroughMultiSnapshotFactory() {
+    DataFile file = newDataFile("/path/to/single-snap.parquet");
+    table.newFastAppend().appendFile(file).commit();
+    Snapshot snapshot = table.currentSnapshot();
+
+    Iterable<DataFile> viaSingle =
+        SnapshotChanges.builderFor(table).snapshot(snapshot).build().addedDataFiles();
+    Iterable<DataFile> viaMulti =
+        SnapshotChanges.builderFor(table, ImmutableList.of(snapshot)).build().addedDataFiles();
+
+    assertThat(paths(viaMulti)).containsExactlyInAnyOrderElementsOf(paths(viaSingle));
+    assertThat(viaMulti).hasSize(1);
+  }
+
+  @Test
+  public void testMultiSnapshotUnionForDataAndDeleteFiles() {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+    DataFile fileC = newDataFile("/path/to/C.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+
+    table.newFastAppend().appendFile(fileB).appendFile(fileC).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    table.newDelete().deleteFile(fileA).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    SnapshotChanges union =
+        SnapshotChanges.builderFor(table, ImmutableList.of(snap1, snap2, snap3)).build();
+
+    assertThat(paths(union.addedDataFiles()))
+        .containsExactlyInAnyOrder(
+            fileA.path().toString(), fileB.path().toString(), fileC.path().toString());
+    assertThat(paths(union.removedDataFiles())).containsExactly(fileA.path().toString());
+  }
+
+  @Test
+  public void testMultiSnapshotUnionForDeleteFiles() {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot dataSnap = table.currentSnapshot();
+
+    DeleteFile delA = newDeleteFile("/path/to/A-deletes.parquet");
+    DeleteFile delB = newDeleteFile("/path/to/B-deletes.parquet");
+    table.newRowDelta().addDeletes(delA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newRowDelta().addDeletes(delB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    SnapshotChanges union =
+        SnapshotChanges.builderFor(table, ImmutableList.of(dataSnap, snap1, snap2)).build();
+
+    assertThat(paths(union.addedDeleteFiles()))
+        .containsExactlyInAnyOrder(delA.path().toString(), delB.path().toString());
+  }
+
+  @Test
+  public void testMultiSnapshotCachingReturnsSameInstance() {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table, ImmutableList.of(snap1, snap2)).build();
+
+    Iterable<DataFile> first = changes.addedDataFiles();
+    Iterable<DataFile> second = changes.addedDataFiles();
+    assertThat(first).isSameAs(second);
+    assertThat(paths(first))
+        .containsExactlyInAnyOrder(fileA.path().toString(), fileB.path().toString());
+  }
+
+  @Test
+  public void testWithCustomExecutor() throws Exception {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+    DataFile fileC = newDataFile("/path/to/C.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileC).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    try {
+      SnapshotChanges changes =
+          SnapshotChanges.builderFor(table, ImmutableList.of(snap1, snap2, snap3))
+              .executeWith(executor)
+              .build();
+
+      assertThat(paths(changes.addedDataFiles()))
+          .containsExactlyInAnyOrder(
+              fileA.path().toString(), fileB.path().toString(), fileC.path().toString());
+    } finally {
+      executor.shutdownNow();
+      assertThat(executor.awaitTermination(5, TimeUnit.SECONDS)).isTrue();
+    }
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void testEquivalenceWithDeprecatedNewFilesBetween() throws Exception {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+    DataFile fileC = newDataFile("/path/to/C.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    table.newFastAppend().appendFile(fileC).commit();
+    Snapshot snap3 = table.currentSnapshot();
+
+    Set<String> viaDeprecated = Sets.newHashSet();
+    try (CloseableIterable<DataFile> deprecated =
+        SnapshotUtil.newFilesBetween(
+            snap1.snapshotId(), snap3.snapshotId(), table::snapshot, table.io())) {
+      for (DataFile f : deprecated) {
+        viaDeprecated.add(f.path().toString());
+      }
+    }
+
+    List<Snapshot> ancestorsAfterSnap1 =
+        Lists.newArrayList(
+            SnapshotUtil.ancestorsBetween(snap3.snapshotId(), snap1.snapshotId(), table::snapshot));
+
+    SnapshotChanges changes = SnapshotChanges.builderFor(table, ancestorsAfterSnap1).build();
+
+    assertThat(paths(changes.addedDataFiles())).containsExactlyInAnyOrderElementsOf(viaDeprecated);
+  }
+
+  private static DataFile newDataFile(String path) {
+    return DataFiles.builder(SPEC)
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private static DeleteFile newDeleteFile(String path) {
+    return FileMetadata.deleteFileBuilder(SPEC)
+        .ofPositionDeletes()
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private static Set<String> paths(Iterable<? extends ContentFile<?>> files) {
+    return StreamSupport.stream(files.spliterator(), false)
+        .map(f -> f.path().toString())
+        .collect(Collectors.toSet());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -219,6 +219,43 @@ public class TestSnapshotChanges {
   }
 
   @Test
+  public void testStreamingAccessorsForMultiSnapshotChanges() throws Exception {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot addFileA = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot addFileB = table.currentSnapshot();
+    table.newDelete().deleteFile(fileA).commit();
+    Snapshot removeFileA = table.currentSnapshot();
+
+    DeleteFile deleteFileA = newDeleteFile("/path/to/A-deletes.parquet");
+    table.newRowDelta().addDeletes(deleteFileA).commit();
+    Snapshot addDeleteFileA = table.currentSnapshot();
+    table.newRowDelta().removeDeletes(deleteFileA).commit();
+    Snapshot removeDeleteFileA = table.currentSnapshot();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(
+                table,
+                ImmutableList.of(
+                    addFileA, addFileB, removeFileA, addDeleteFileA, removeDeleteFileA))
+            .build();
+
+    try (CloseableIterable<DataFile> addedDataFiles = changes.readAddedDataFiles();
+        CloseableIterable<DataFile> removedDataFiles = changes.readRemovedDataFiles();
+        CloseableIterable<DeleteFile> addedDeleteFiles = changes.readAddedDeleteFiles();
+        CloseableIterable<DeleteFile> removedDeleteFiles = changes.readRemovedDeleteFiles()) {
+      assertThat(paths(addedDataFiles))
+          .containsExactlyInAnyOrder(fileA.path().toString(), fileB.path().toString());
+      assertThat(paths(removedDataFiles)).containsExactly(fileA.path().toString());
+      assertThat(paths(addedDeleteFiles)).containsExactly(deleteFileA.path().toString());
+      assertThat(paths(removedDeleteFiles)).containsExactly(deleteFileA.path().toString());
+    }
+  }
+
+  @Test
   public void testMultiSnapshotCachingReturnsSameInstance() {
     DataFile fileA = newDataFile("/path/to/A.parquet");
     DataFile fileB = newDataFile("/path/to/B.parquet");

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -230,6 +230,26 @@ public class TestSnapshotChanges {
   }
 
   @Test
+  public void testDuplicateSnapshotsAreDeduplicated() {
+    DataFile fileA = newDataFile("/path/to/A.parquet");
+    DataFile fileB = newDataFile("/path/to/B.parquet");
+
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot snap1 = table.currentSnapshot();
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot snap2 = table.currentSnapshot();
+
+    // Same snapshot supplied multiple times must not double-count its files.
+    SnapshotChanges union =
+        SnapshotChanges.builderFor(table, ImmutableList.of(snap1, snap1, snap2, snap2)).build();
+
+    List<DataFile> added = Lists.newArrayList(union.addedDataFiles());
+    assertThat(added).hasSize(2);
+    assertThat(paths(added))
+        .containsExactlyInAnyOrder(fileA.path().toString(), fileB.path().toString());
+  }
+
+  @Test
   public void testMultiSnapshotUnionForDeleteFiles() {
     DataFile fileA = newDataFile("/path/to/A.parquet");
     table.newFastAppend().appendFile(fileA).commit();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -66,44 +66,78 @@ public class TestSnapshotChanges {
 
   @Test
   public void testAddedDataFiles() {
-    DataFile addedFile = newDataFile("/path/to/test-data.parquet");
+    DataFile addedFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/test-data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
 
     table.newFastAppend().appendFile(addedFile).commit();
     Snapshot snapshotWithAddedFile = table.currentSnapshot();
 
+    // Test using SnapshotChanges object directly
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotWithAddedFile).build();
     Iterable<DataFile> filesFromChanges = changes.addedDataFiles();
     assertThat(filesFromChanges).hasSize(1);
 
+    // Verify the file path matches
     DataFile resultFile = filesFromChanges.iterator().next();
     assertThat(resultFile.path().toString()).isEqualTo(addedFile.path().toString());
   }
 
   @Test
   public void testRemovedDataFiles() {
-    DataFile fileToRemove = newDataFile("/path/to/file-to-remove.parquet");
-    DataFile fileToKeep = newDataFile("/path/to/file-to-keep.parquet");
+    DataFile fileToRemove =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/file-to-remove.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
 
+    DataFile fileToKeep =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/file-to-keep.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    // Add both files
     table.newAppend().appendFile(fileToRemove).appendFile(fileToKeep).commit();
+
+    // Remove one file
     table.newDelete().deleteFile(fileToRemove).commit();
 
     Snapshot snapshotAfterDelete = table.currentSnapshot();
 
+    // Test using SnapshotChanges object directly (for caching multiple calls)
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotAfterDelete).build();
     Iterable<DataFile> filesFromChangesFirstCall = changes.removedDataFiles();
     Iterable<DataFile> filesFromChangesSecondCall = changes.removedDataFiles();
     assertThat(filesFromChangesFirstCall).isSameAs(filesFromChangesSecondCall);
 
+    // Verify the file path matches
     DataFile resultFile = filesFromChangesFirstCall.iterator().next();
     assertThat(resultFile.path().toString()).isEqualTo(fileToRemove.path().toString());
   }
 
   @Test
   public void testSnapshotChangesCaching() {
-    DataFile firstFile = newDataFile("/path/to/file1.parquet");
-    DataFile secondFile = newDataFile("/path/to/file2.parquet");
+    DataFile firstFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/file1.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    DataFile secondFile =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/file2.parquet")
+            .withFileSizeInBytes(20)
+            .withRecordCount(2)
+            .build();
 
     table.newAppend().appendFile(firstFile).appendFile(secondFile).commit();
     table.newDelete().deleteFile(firstFile).commit();
@@ -113,12 +147,15 @@ public class TestSnapshotChanges {
     SnapshotChanges changes =
         SnapshotChanges.builderFor(table).snapshot(snapshotAfterDelete).build();
 
+    // First call should cache the data file changes
     Iterable<DataFile> firstCallResult = changes.removedDataFiles();
     assertThat(firstCallResult).hasSize(1);
 
+    // Second call should return the cached results
     Iterable<DataFile> secondCallResult = changes.removedDataFiles();
     assertThat(secondCallResult).hasSize(1);
 
+    // Both calls should return the same reference (cached)
     assertThat(firstCallResult).isSameAs(secondCallResult);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -124,6 +124,34 @@ public class TestSnapshotManager extends TestBase {
   }
 
   @TestTemplate
+  public void testCherryPickDynamicOverwriteConflictAcrossMultipleSnapshots() {
+    table.newAppend().appendFile(FILE_A).commit();
+
+    // stage an overwrite that replaces FILE_A's partition (data_bucket=0)
+    table.newReplacePartitions().addFile(REPLACEMENT_FILE_A).stageOnly().commit();
+
+    Snapshot staged = Iterables.getLast(table.snapshots());
+    assertThat(staged.operation())
+        .as("Should find the staged overwrite snapshot")
+        .isEqualTo(DataOperations.OVERWRITE);
+
+    // two intervening appends so ancestorsBetween(current, parent) spans multiple snapshots;
+    // the conflict lands only in the second, forcing the SnapshotChanges union to cover both.
+    table.newAppend().appendFile(FILE_B).commit(); // data_bucket=1, no conflict
+    table.newAppend().appendFile(CONFLICT_FILE_A).commit(); // data_bucket=0, conflicts
+    long lastSnapshotId = table.currentSnapshot().snapshotId();
+
+    assertThatThrownBy(() -> table.manageSnapshots().cherrypick(staged.snapshotId()).commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Cannot cherry-pick replace partitions with changed partition");
+
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("Failed cherry-pick should not change the table state")
+        .isEqualTo(lastSnapshotId);
+    validateTableFiles(table, FILE_A, FILE_B, CONFLICT_FILE_A);
+  }
+
+  @TestTemplate
   public void testCherryPickDynamicOverwriteDeleteConflict() {
     table.newAppend().appendFile(FILE_A).commit();
 


### PR DESCRIPTION

Ref https://github.com/apache/iceberg/issues/15660

* Extend SnapshotChanges from a single snapshot to an arbitrary set of snapshots while preserving the existing single-snapshot API.
* Callers that need changes across an ancestor range (e.g. cherry-pick validation, streaming planners) previously had to loop snapshot-by-snapshot and serialize manifest reads.

**Out of Scope** 

- Streaming accessors / per-snapshot accessors / changesBySnapshot() — belong to #15659.
- Migrating CherryPickOperation and Spark MicroBatchUtils to the new API — separate PR under #15659.
- Removing the deprecated SnapshotUtil.newFiles* methods