### PR TITLE
Build: Correct actions/labeler version comment to v6.0.1

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -28,6 +28,6 @@ jobs:
   triage:
     runs-on: ubuntu-slim
     steps:
-    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6
+    - uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
       with:
         sync-labels: true


### PR DESCRIPTION
The build is currently failing, see https://github.com/apache/iceberg/actions/runs/25417965188/job/74553312064.

The pinned hash for the current labeler resolves to tag v6.0.1, not v6, letting the zizmor check fail.