### PR TITLE
AWS: Add MetricPublisher configuration support for S3FileIO (#15182)

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -58,6 +58,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
         .build();
   }
 
@@ -76,6 +77,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -58,7 +58,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
         .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
-        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfigurations)
         .build();
   }
 
@@ -77,7 +77,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
-        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
+        .applyMutation(s3FileIOProperties::applyMetricsPublisherConfigurations)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -49,6 +49,7 @@ import software.amazon.awssdk.core.retry.conditions.OrRetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryCondition;
 import software.amazon.awssdk.core.retry.conditions.RetryOnExceptionsCondition;
 import software.amazon.awssdk.core.retry.conditions.TokenBucketRetryCondition;
+import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
@@ -506,6 +507,14 @@ public class S3FileIOProperties implements Serializable {
 
   public static final boolean S3_DIRECTORY_BUCKET_LIST_PREFIX_AS_DIRECTORY_DEFAULT = true;
 
+  /**
+   * Configure a custom {@link MetricPublisher} implementation for the S3 client.
+   *
+   * <p>The class must implement {@link MetricPublisher}. It will be instantiated via a static
+   * {@code create(Map)} factory method if available, otherwise via a no-arg constructor.
+   */
+  public static final String METRICS_PUBLISHER_IMPL = "s3.metrics-publisher-impl";
+
   private String sseType;
   private String sseKey;
   private String sseMd5;
@@ -547,6 +556,7 @@ public class S3FileIOProperties implements Serializable {
   private long s3RetryMaxWaitMs;
 
   private boolean s3DirectoryBucketListPrefixAsDirectory;
+  private final String metricsPublisherImpl;
   private final Map<String, String> allProperties;
 
   public S3FileIOProperties() {
@@ -590,6 +600,7 @@ public class S3FileIOProperties implements Serializable {
     this.s3AnalyticsacceleratorProperties = Maps.newHashMap();
     this.isS3CRTEnabled = S3_CRT_ENABLED_DEFAULT;
     this.s3CrtMaxConcurrency = S3_CRT_MAX_CONCURRENCY_DEFAULT;
+    this.metricsPublisherImpl = null;
     this.allProperties = Maps.newHashMap();
 
     ValidationException.check(
@@ -715,6 +726,7 @@ public class S3FileIOProperties implements Serializable {
     this.s3CrtMaxConcurrency =
         PropertyUtil.propertyAsInt(
             properties, S3_CRT_MAX_CONCURRENCY, S3_CRT_MAX_CONCURRENCY_DEFAULT);
+    this.metricsPublisherImpl = properties.get(METRICS_PUBLISHER_IMPL);
 
     ValidationException.check(
         keyIdAccessKeyBothConfigured(),
@@ -1196,5 +1208,64 @@ public class S3FileIOProperties implements Serializable {
 
   public Map<String, String> properties() {
     return allProperties;
+  }
+
+  public String metricsPublisherImpl() {
+    return metricsPublisherImpl;
+  }
+
+  /**
+   * Configure a custom {@link MetricPublisher} for an S3 client.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
+   * </pre>
+   */
+  public <T extends S3BaseClientBuilder<T, ?>> void applyMetricsPublisherConfiguration(T builder) {
+    if (metricsPublisherImpl != null) {
+      ClientOverrideConfiguration.Builder configBuilder =
+          null != builder.overrideConfiguration()
+              ? builder.overrideConfiguration().toBuilder()
+              : ClientOverrideConfiguration.builder();
+      builder.overrideConfiguration(
+          configBuilder.addMetricPublisher(loadMetricPublisher()).build());
+    }
+  }
+
+  private MetricPublisher loadMetricPublisher() {
+    // Phase 1: look up the factory. A NoSuchMethodException here means the class does not
+    // declare `create(Map)` — fall back to the no-arg constructor path. Any OTHER exception
+    // from a factory that DOES exist (e.g. the factory itself throws) should surface via the
+    // wrapping IllegalArgumentException in phase 2 so users can distinguish "wrong signature"
+    // from "misconfigured factory".
+    DynMethods.StaticMethod factory = null;
+    try {
+      factory =
+          DynMethods.builder("create")
+              .hiddenImpl(metricsPublisherImpl, Map.class)
+              .buildStaticChecked();
+    } catch (NoSuchMethodException e) {
+      // Expected when the implementation doesn't provide a create(Map) factory — fall through.
+    }
+
+    // Phase 2: invoke whichever path we found. Exceptions here are real failures and are
+    // surfaced with the precise path that failed so the user can diagnose.
+    try {
+      if (factory != null) {
+        return (MetricPublisher) factory.invoke(allProperties);
+      }
+      return Class.forName(metricsPublisherImpl)
+          .asSubclass(MetricPublisher.class)
+          .getDeclaredConstructor()
+          .newInstance();
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot create MetricPublisher from class %s via %s",
+              metricsPublisherImpl, factory != null ? "create(Map)" : "no-arg constructor"),
+          e);
+    }
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -30,6 +30,7 @@ import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.aws.AwsClientProperties;
 import org.apache.iceberg.aws.glue.GlueCatalog;
 import org.apache.iceberg.aws.s3.signer.S3V4RestSignerClient;
+import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -1220,10 +1221,10 @@ public class S3FileIOProperties implements Serializable {
    * <p>Sample usage:
    *
    * <pre>
-   *     S3Client.builder().applyMutation(s3FileIOProperties::applyMetricsPublisherConfiguration)
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyMetricsPublisherConfigurations)
    * </pre>
    */
-  public <T extends S3BaseClientBuilder<T, ?>> void applyMetricsPublisherConfiguration(T builder) {
+  public <T extends S3BaseClientBuilder<T, ?>> void applyMetricsPublisherConfigurations(T builder) {
     if (metricsPublisherImpl != null) {
       ClientOverrideConfiguration.Builder configBuilder =
           null != builder.overrideConfiguration()
@@ -1235,37 +1236,34 @@ public class S3FileIOProperties implements Serializable {
   }
 
   private MetricPublisher loadMetricPublisher() {
-    // Phase 1: look up the factory. A NoSuchMethodException here means the class does not
-    // declare `create(Map)` — fall back to the no-arg constructor path. Any OTHER exception
-    // from a factory that DOES exist (e.g. the factory itself throws) should surface via the
-    // wrapping IllegalArgumentException in phase 2 so users can distinguish "wrong signature"
-    // from "misconfigured factory".
-    DynMethods.StaticMethod factory = null;
+    DynConstructors.Ctor<S3MetricPublisherProvider> ctor;
     try {
-      factory =
-          DynMethods.builder("create")
-              .hiddenImpl(metricsPublisherImpl, Map.class)
-              .buildStaticChecked();
+      ctor =
+          DynConstructors.builder(S3MetricPublisherProvider.class)
+              .loader(S3FileIOProperties.class.getClassLoader())
+              .hiddenImpl(metricsPublisherImpl)
+              .buildChecked();
     } catch (NoSuchMethodException e) {
-      // Expected when the implementation doesn't provide a create(Map) factory — fall through.
-    }
-
-    // Phase 2: invoke whichever path we found. Exceptions here are real failures and are
-    // surfaced with the precise path that failed so the user can diagnose.
-    try {
-      if (factory != null) {
-        return (MetricPublisher) factory.invoke(allProperties);
-      }
-      return Class.forName(metricsPublisherImpl)
-          .asSubclass(MetricPublisher.class)
-          .getDeclaredConstructor()
-          .newInstance();
-    } catch (Exception e) {
       throw new IllegalArgumentException(
           String.format(
-              "Cannot create MetricPublisher from class %s via %s",
-              metricsPublisherImpl, factory != null ? "create(Map)" : "no-arg constructor"),
+              "Cannot initialize S3MetricPublisherProvider, missing no-arg constructor: %s",
+              metricsPublisherImpl),
           e);
     }
+
+    S3MetricPublisherProvider provider;
+    try {
+      provider = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize S3MetricPublisherProvider, "
+                  + "%s does not implement S3MetricPublisherProvider.",
+              metricsPublisherImpl),
+          e);
+    }
+
+    provider.initialize(allProperties);
+    return provider.metricPublisher();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3MetricPublisherProvider.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3MetricPublisherProvider.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import java.io.Serializable;
+import java.util.Map;
+import software.amazon.awssdk.metrics.MetricPublisher;
+
+/**
+ * Interface for providing a configured {@link MetricPublisher} to S3FileIO.
+ *
+ * <p>Implementations must have a no-arg constructor and use {@link #initialize(Map)} to receive
+ * catalog properties. This follows the same pattern as {@link
+ * org.apache.iceberg.aws.AwsClientFactory}.
+ *
+ * <p>Because SDK MetricPublisher implementations (CloudWatchMetricPublisher,
+ * LoggingMetricPublisher, EmfMetricLoggingPublisher) use static factories or builders rather than
+ * public constructors, users implement this interface to wrap the appropriate builder/factory call
+ * and pass any needed configuration from catalog properties.
+ *
+ * <p>Example:
+ *
+ * <pre>{@code
+ * public class MyCloudWatchProvider implements S3MetricPublisherProvider {
+ *   private MetricPublisher publisher;
+ *
+ *   @Override
+ *   public void initialize(Map<String, String> properties) {
+ *     publisher = CloudWatchMetricPublisher.builder()
+ *         .namespace(properties.getOrDefault("s3.metrics.namespace", "Iceberg"))
+ *         .build();
+ *   }
+ *
+ *   @Override
+ *   public MetricPublisher metricPublisher() {
+ *     return publisher;
+ *   }
+ * }
+ * }</pre>
+ */
+public interface S3MetricPublisherProvider extends Serializable {
+
+  /**
+   * Initialize the provider with catalog properties.
+   *
+   * @param properties catalog properties
+   */
+  default void initialize(Map<String, String> properties) {}
+
+  /**
+   * Return the configured {@link MetricPublisher}.
+   *
+   * @return a metric publisher instance
+   */
+  MetricPublisher metricPublisher();
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -591,152 +591,123 @@ public class TestS3FileIOProperties {
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationWithFactoryMethod() {
+  public void testApplyMetricsPublisherConfigurationsWithProvider() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(
-        S3FileIOProperties.METRICS_PUBLISHER_IMPL, FactoryMetricPublisher.class.getName());
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL, TestMetricPublisherProvider.class.getName());
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
-    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+    s3FileIOProperties.applyMetricsPublisherConfigurations(builder);
 
     assertThat(builder.overrideConfiguration()).isNotNull();
     assertThat(builder.overrideConfiguration().metricPublishers()).hasSize(1);
     assertThat(builder.overrideConfiguration().metricPublishers().get(0))
-        .isInstanceOf(FactoryMetricPublisher.class);
+        .isInstanceOf(TestMetricPublisher.class);
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationWithNoArgConstructor() {
+  public void testApplyMetricsPublisherConfigurationsWithInitializedProvider() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, NoArgMetricPublisher.class.getName());
+    properties.put(
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL,
+        InitializableMetricPublisherProvider.class.getName());
+    properties.put("s3.metrics.custom-key", "custom-value");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
-    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+    s3FileIOProperties.applyMetricsPublisherConfigurations(builder);
 
     assertThat(builder.overrideConfiguration()).isNotNull();
     assertThat(builder.overrideConfiguration().metricPublishers()).hasSize(1);
     assertThat(builder.overrideConfiguration().metricPublishers().get(0))
-        .isInstanceOf(NoArgMetricPublisher.class);
+        .isInstanceOf(TestMetricPublisher.class);
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationDisabled() {
+  public void testApplyMetricsPublisherConfigurationsDisabled() {
     Map<String, String> properties = Maps.newHashMap();
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
-    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+    s3FileIOProperties.applyMetricsPublisherConfigurations(builder);
 
     assertThat(s3FileIOProperties.metricsPublisherImpl()).isNull();
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationInvalidClass() {
+  public void testApplyMetricsPublisherConfigurationsInvalidClass() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, "com.invalid.NonExistentClass");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
-    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
+    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfigurations(builder))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Cannot create MetricPublisher from class");
+        .hasMessageContaining("Cannot initialize S3MetricPublisherProvider")
+        .hasMessageContaining("missing no-arg constructor");
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationFactoryThrows() {
-    // The implementation provides a static create(Map) factory that throws. The error message
-    // must identify the factory path so the user can diagnose a bad implementation rather than
-    // being misled into thinking they need to add a no-arg constructor.
+  public void testApplyMetricsPublisherConfigurationsNotAProvider() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(
-        S3FileIOProperties.METRICS_PUBLISHER_IMPL, ThrowingFactoryMetricPublisher.class.getName());
+    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, String.class.getName());
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
-    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
+    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfigurations(builder))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("via create(Map)")
-        .hasMessageContaining(ThrowingFactoryMetricPublisher.class.getName());
+        .hasMessageContaining("does not implement S3MetricPublisherProvider");
   }
 
   @Test
-  public void testApplyMetricsPublisherConfigurationNoArgConstructorThrows() {
-    // The implementation does not declare create(Map) but its no-arg constructor throws.
-    // The error message must identify the no-arg constructor path.
+  public void testApplyMetricsPublisherConfigurationsPreservesExistingOverrideConfig() {
     Map<String, String> properties = Maps.newHashMap();
     properties.put(
-        S3FileIOProperties.METRICS_PUBLISHER_IMPL, ThrowingNoArgMetricPublisher.class.getName());
-    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-
-    S3ClientBuilder builder = S3Client.builder();
-    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("via no-arg constructor")
-        .hasMessageContaining(ThrowingNoArgMetricPublisher.class.getName());
-  }
-
-  @Test
-  public void testApplyMetricsPublisherPreservesExistingOverrideConfig() {
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, NoArgMetricPublisher.class.getName());
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL, TestMetricPublisherProvider.class.getName());
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
 
     S3ClientBuilder builder = S3Client.builder();
     s3FileIOProperties.applyRetryConfigurations(builder);
-    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+    s3FileIOProperties.applyMetricsPublisherConfigurations(builder);
 
     ClientOverrideConfiguration config = builder.overrideConfiguration();
     assertThat(config).isNotNull();
     assertThat(config.retryPolicy()).isPresent();
     assertThat(config.metricPublishers()).hasSize(1);
-    assertThat(config.metricPublishers().get(0)).isInstanceOf(NoArgMetricPublisher.class);
+    assertThat(config.metricPublishers().get(0)).isInstanceOf(TestMetricPublisher.class);
   }
 
-  public static class FactoryMetricPublisher implements MetricPublisher {
-    public static FactoryMetricPublisher create(Map<String, String> properties) {
-      return new FactoryMetricPublisher();
+  public static class TestMetricPublisher implements MetricPublisher {
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
+  }
+
+  public static class TestMetricPublisherProvider implements S3MetricPublisherProvider {
+    @Override
+    public MetricPublisher metricPublisher() {
+      return new TestMetricPublisher();
+    }
+  }
+
+  public static class InitializableMetricPublisherProvider implements S3MetricPublisherProvider {
+    private Map<String, String> props;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.props = properties;
     }
 
     @Override
-    public void publish(MetricCollection metricCollection) {}
-
-    @Override
-    public void close() {}
-  }
-
-  public static class NoArgMetricPublisher implements MetricPublisher {
-    public NoArgMetricPublisher() {}
-
-    @Override
-    public void publish(MetricCollection metricCollection) {}
-
-    @Override
-    public void close() {}
-  }
-
-  public static class ThrowingFactoryMetricPublisher implements MetricPublisher {
-    public static ThrowingFactoryMetricPublisher create(Map<String, String> properties) {
-      throw new IllegalStateException("factory boom");
+    public MetricPublisher metricPublisher() {
+      // Verify properties were passed through
+      if (props == null || !props.containsKey("s3.metrics.custom-key")) {
+        throw new IllegalStateException("Properties not initialized correctly");
+      }
+      return new TestMetricPublisher();
     }
-
-    @Override
-    public void publish(MetricCollection metricCollection) {}
-
-    @Override
-    public void close() {}
-  }
-
-  public static class ThrowingNoArgMetricPublisher implements MetricPublisher {
-    public ThrowingNoArgMetricPublisher() {
-      throw new IllegalStateException("ctor boom");
-    }
-
-    @Override
-    public void publish(MetricCollection metricCollection) {}
-
-    @Override
-    public void close() {}
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -37,6 +37,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
+import software.amazon.awssdk.metrics.MetricCollection;
+import software.amazon.awssdk.metrics.MetricPublisher;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
@@ -586,5 +588,155 @@ public class TestS3FileIOProperties {
     assertThat(s3FileIOProperties.isChunkedEncodingEnabled())
         .as("chunked encoding should be disabled when explicitly set to false")
         .isFalse();
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationWithFactoryMethod() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL, FactoryMetricPublisher.class.getName());
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+
+    assertThat(builder.overrideConfiguration()).isNotNull();
+    assertThat(builder.overrideConfiguration().metricPublishers()).hasSize(1);
+    assertThat(builder.overrideConfiguration().metricPublishers().get(0))
+        .isInstanceOf(FactoryMetricPublisher.class);
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationWithNoArgConstructor() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, NoArgMetricPublisher.class.getName());
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+
+    assertThat(builder.overrideConfiguration()).isNotNull();
+    assertThat(builder.overrideConfiguration().metricPublishers()).hasSize(1);
+    assertThat(builder.overrideConfiguration().metricPublishers().get(0))
+        .isInstanceOf(NoArgMetricPublisher.class);
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationDisabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+
+    assertThat(s3FileIOProperties.metricsPublisherImpl()).isNull();
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationInvalidClass() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, "com.invalid.NonExistentClass");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot create MetricPublisher from class");
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationFactoryThrows() {
+    // The implementation provides a static create(Map) factory that throws. The error message
+    // must identify the factory path so the user can diagnose a bad implementation rather than
+    // being misled into thinking they need to add a no-arg constructor.
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL, ThrowingFactoryMetricPublisher.class.getName());
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("via create(Map)")
+        .hasMessageContaining(ThrowingFactoryMetricPublisher.class.getName());
+  }
+
+  @Test
+  public void testApplyMetricsPublisherConfigurationNoArgConstructorThrows() {
+    // The implementation does not declare create(Map) but its no-arg constructor throws.
+    // The error message must identify the no-arg constructor path.
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(
+        S3FileIOProperties.METRICS_PUBLISHER_IMPL, ThrowingNoArgMetricPublisher.class.getName());
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    assertThatThrownBy(() -> s3FileIOProperties.applyMetricsPublisherConfiguration(builder))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("via no-arg constructor")
+        .hasMessageContaining(ThrowingNoArgMetricPublisher.class.getName());
+  }
+
+  @Test
+  public void testApplyMetricsPublisherPreservesExistingOverrideConfig() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.METRICS_PUBLISHER_IMPL, NoArgMetricPublisher.class.getName());
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+
+    S3ClientBuilder builder = S3Client.builder();
+    s3FileIOProperties.applyRetryConfigurations(builder);
+    s3FileIOProperties.applyMetricsPublisherConfiguration(builder);
+
+    ClientOverrideConfiguration config = builder.overrideConfiguration();
+    assertThat(config).isNotNull();
+    assertThat(config.retryPolicy()).isPresent();
+    assertThat(config.metricPublishers()).hasSize(1);
+    assertThat(config.metricPublishers().get(0)).isInstanceOf(NoArgMetricPublisher.class);
+  }
+
+  public static class FactoryMetricPublisher implements MetricPublisher {
+    public static FactoryMetricPublisher create(Map<String, String> properties) {
+      return new FactoryMetricPublisher();
+    }
+
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
+  }
+
+  public static class NoArgMetricPublisher implements MetricPublisher {
+    public NoArgMetricPublisher() {}
+
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
+  }
+
+  public static class ThrowingFactoryMetricPublisher implements MetricPublisher {
+    public static ThrowingFactoryMetricPublisher create(Map<String, String> properties) {
+      throw new IllegalStateException("factory boom");
+    }
+
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
+  }
+
+  public static class ThrowingNoArgMetricPublisher implements MetricPublisher {
+    public ThrowingNoArgMetricPublisher() {
+      throw new IllegalStateException("ctor boom");
+    }
+
+    @Override
+    public void publish(MetricCollection metricCollection) {}
+
+    @Override
+    public void close() {}
   }
 }

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -659,6 +659,21 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
 
 For more details on using S3 Dual-stack, please refer [Using dual-stack endpoints from the AWS CLI and the AWS SDKs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/dual-stack-endpoints.html#dual-stack-endpoints-cli)
 
+### S3 Custom MetricPublisher
+
+A custom `MetricPublisher` implementation can be plugged into the S3 client by setting the `s3.metrics-publisher-impl` catalog property to the fully qualified class name of a class that implements `software.amazon.awssdk.metrics.MetricPublisher`.
+
+The class will be instantiated via a static `create(Map<String, String>)` factory method if available, otherwise via a no-arg constructor.
+
+For example, to use a custom MetricPublisher with Spark 3.5, you can start the Spark SQL shell with:
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.type=glue \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=org.example.MyMetricPublisher
+```
+
 ## AWS Client Customization
 
 Many organizations have customized their way of configuring AWS clients with their own credential provider, access proxy, retry strategy, etc.

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -674,6 +674,9 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
     --conf spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=org.example.MyMetricPublisher
 ```
 
+!!! note
+    The CRT-based async S3 client does not honor a custom `MetricPublisher`. When `s3.crt.enabled` is `true` (the default), the async client is built via the CRT builder, which exposes no metric-publisher configuration, so a `s3.metrics-publisher-impl` set alongside it has no effect on async S3 operations. Set `s3.crt.enabled` to `false` to use a custom `MetricPublisher` with the async client.
+
 ## AWS Client Customization
 
 Many organizations have customized their way of configuring AWS clients with their own credential provider, access proxy, retry strategy, etc.

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -661,17 +661,41 @@ For more details on using S3 Dual-stack, please refer [Using dual-stack endpoint
 
 ### S3 Custom MetricPublisher
 
-A custom `MetricPublisher` implementation can be plugged into the S3 client by setting the `s3.metrics-publisher-impl` catalog property to the fully qualified class name of a class that implements `software.amazon.awssdk.metrics.MetricPublisher`.
+A custom [`MetricPublisher`](https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/metrics/MetricPublisher.html) can be plugged into the S3 client by implementing the `org.apache.iceberg.aws.s3.S3MetricPublisherProvider` interface and setting the `s3.metrics-publisher-impl` catalog property to the fully qualified class name of the implementation.
 
-The class will be instantiated via a static `create(Map<String, String>)` factory method if available, otherwise via a no-arg constructor.
+The provider class must have a no-arg constructor. Iceberg will instantiate it, call `initialize(Map<String, String>)` with all catalog properties, and then call `metricPublisher()` to obtain the publisher instance. This allows wrapping any SDK MetricPublisher (CloudWatchMetricPublisher, LoggingMetricPublisher, EmfMetricLoggingPublisher, or a custom implementation) with appropriate configuration.
 
-For example, to use a custom MetricPublisher with Spark 3.5, you can start the Spark SQL shell with:
+Example provider implementation:
+```java
+import java.util.Map;
+import org.apache.iceberg.aws.s3.S3MetricPublisherProvider;
+import software.amazon.awssdk.metrics.MetricPublisher;
+import software.amazon.awssdk.metrics.publishers.cloudwatch.CloudWatchMetricPublisher;
+
+public class MyCloudWatchProvider implements S3MetricPublisherProvider {
+  private MetricPublisher publisher;
+
+  @Override
+  public void initialize(Map<String, String> properties) {
+    publisher = CloudWatchMetricPublisher.builder()
+        .namespace(properties.getOrDefault("s3.metrics.namespace", "Iceberg"))
+        .build();
+  }
+
+  @Override
+  public MetricPublisher metricPublisher() {
+    return publisher;
+  }
+}
+```
+
+For example, to use a custom MetricPublisher provider with Spark 3.5, you can start the Spark SQL shell with:
 ```
 spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket2/my/key/prefix \
     --conf spark.sql.catalog.my_catalog.type=glue \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
-    --conf spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=org.example.MyMetricPublisher
+    --conf spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=org.example.MyCloudWatchProvider
 ```
 
 !!! note


### PR DESCRIPTION
Adds support for configuring a custom AWS SDK `MetricPublisher` for S3FileIO via the `s3.metrics-publisher-impl` catalog property. This enables observability into S3 SDK-level metrics (latency, retries, errors) for debugging and monitoring.

This PR builds on the design and initial implementation from #15122 by @rcjverhoef (PR stale-closed). The review feedback from @geruh on that PR — apply to the S3 async client, clean up fully-qualified imports, and add a test for invalid/missing classes — is addressed here.

### Commits in this PR

1. **`AWS: Add MetricPublisher configuration support for S3FileIO`** — co-authored with @rcjverhoef. Adds `METRICS_PUBLISHER_IMPL` property, the `applyMetricsPublisherConfiguration` method, wires it into both the sync `s3()` and async `s3Async()` paths, adds happy-path tests and docs.
2. **`AWS: Improve MetricPublisher factory error reporting`** — splits factory lookup from factory invocation so the error message correctly identifies whether `create(Map)` was missing or present-but-threw. Adds regression tests for both throw paths.

### Changes

- **S3FileIOProperties**: Added `METRICS_PUBLISHER_IMPL` property, `applyMetricsPublisherConfiguration()` method that loads the publisher via a static `create(Map)` factory or, as a fallback, a no-arg constructor.
- **DefaultS3FileIOAwsClientFactory**: Applied the metrics publisher configuration to both sync and async client builders.
- **Tests**: 6 tests covering factory-method, no-arg constructor, disabled, invalid-class, factory-throws, and no-arg-constructor-throws paths.
- **Docs**: Added a section in `aws.md`.

### Usage

```
spark.sql.catalog.my_catalog.s3.metrics-publisher-impl=com.example.MyMetricPublisher
```

The class must implement `software.amazon.awssdk.metrics.MetricPublisher` and provide either a static `create(Map<String, String>)` factory method or a no-arg constructor.

Closes #15182