### PR TITLE
Azure: Backport License/Notice fix from #16181 to 1.10.x and include Nimbus/ASM in License

### DIFF
--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -203,293 +203,245 @@
 
 --------------------------------------------------------------------------------
 
-This binary artifact contains code from the following projects:
+This product bundles Azure SDK for Java.
 
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-core-http-netty  Version: 1.15.13
 Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
+License: MIT
+
+| Copyright (c) 2015 Microsoft
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+| 
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: com.azure  Name: azure-identity  Version: 1.16.2
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
+This product bundles Jackson JSON Processor.
 
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-json  Version: 1.5.0
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-blob  Version: 12.31.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-common  Version: 12.30.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-file-datalake  Version: 12.24.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.azure  Name: azure-storage-internal-avro  Version: 12.16.1
-Project URL: https://github.com/Azure/azure-sdk-for-java
-License: The MIT License (MIT) - http://opensource.org/licenses/MIT
-
---------------------------------------------------------------------------------
-
-Group: com.fasterxml.jackson.core  Name: jackson-annotations  Version: 2.18.4
 Project URL: http://github.com/FasterXML/jackson
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.4
-Project URL: https://github.com/FasterXML/jackson-core
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles FastDoubleParser (via Jackson JSON Processor).
+
+Copyright: 2023 Werner Randelshofer, Switzerland
+Project URL: https://github.com/wrandelshofer/FastDoubleParser
+License: MIT
+
+| Copyright (c) 2023 Werner Randelshofer, Switzerland
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.4
-Project URL: http://github.com/FasterXML/jackson
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles fast_float (bundled by FastDoubleParser).
+
+Copyright: 2021 The fast_float authors
+Project URL: https://github.com/fastfloat/fast_float
+License: MIT
+
+| Copyright (c) 2021 The fast_float authors
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE.
 
 --------------------------------------------------------------------------------
 
-Group: com.fasterxml.jackson.datatype  Name: jackson-datatype-jsr310  Version: 2.18.4
-Project URL: https://github.com/FasterXML/jackson-modules-java8/jackson-datatype-jsr310
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles bigint (bundled by FastDoubleParser).
+
+Copyright: 2022 Tim Buktu
+Project URL: https://github.com/tbuktu/bigint
+License: BSD 2-Clause
+
+| Copyright 2022 Tim Buktu
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+|
+| 1. Redistributions of source code must retain the above copyright notice, this
+|    list of conditions and the following disclaimer.
+|
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+|    this list of conditions and the following disclaimer in the documentation
+|    and/or other materials provided with the distribution.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+| FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+| DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+| SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+| CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+| OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+| OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 --------------------------------------------------------------------------------
 
-Group: com.github.stephenc.jcip  Name: jcip-annotations  Version: 1.0-1
-Project URL: http://stephenc.github.com/jcip-annotations
-License: Apache License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Microsoft Authentication Library for Java.
 
---------------------------------------------------------------------------------
-
-Group: com.microsoft.azure  Name: msal4j  Version: 1.21.0
 Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
-License: MIT License
+License: MIT
+
+| Copyright (c) Microsoft Corporation. All rights reserved.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE
 
 --------------------------------------------------------------------------------
 
-Group: com.microsoft.azure  Name: msal4j-persistence-extension  Version: 1.3.0
-Project URL: https://github.com/AzureAD/microsoft-authentication-extensions-for-java
-License: MIT License
+This product bundles MSAL4J Persistence Extension.
+
+Project URL: https://github.com/AzureAD/microsoft-authentication-library-for-java
+License: MIT
+
+| Copyright (c) Microsoft Corporation. All rights reserved.
+|
+| Permission is hereby granted, free of charge, to any person obtaining a copy
+| of this software and associated documentation files (the "Software"), to deal
+| in the Software without restriction, including without limitation the rights
+| to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+| copies of the Software, and to permit persons to whom the Software is
+| furnished to do so, subject to the following conditions:
+|
+| The above copyright notice and this permission notice shall be included in all
+| copies or substantial portions of the Software.
+|
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+| IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+| FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+| AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+| LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+| OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+| SOFTWARE
 
 --------------------------------------------------------------------------------
 
-Group: com.nimbusds  Name: content-type  Version: 2.3
-Project URL: https://bitbucket.org/connect2id/nimbus-content-type
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Netty.
 
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: lang-tag  Version: 1.7
-Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: nimbus-jose-jwt  Version: 10.0.1
-Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: com.nimbusds  Name: oauth2-oidc-sdk  Version: 11.23
-Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
-License: Apache License, version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.html
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-buffer  Version: 4.1.118.Final
 Project URL: https://netty.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec  Version: 4.1.118.Final
-Project URL: https://netty.io/
+This product bundles Apache Tomcat Native (netty-tcnative-classes and netty-tcnative-boringssl-static, bundled by Reactor Netty).
+
+Project URL: https://tomcat.apache.org/native-doc/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.netty  Name: netty-codec-dns  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+This product bundles Reactor Core.
 
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-http2  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-codec-socks  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-common  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-handler-proxy  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.112.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.70.Final
-Project URL: https://github.com/netty/netty-tcnative/netty-tcnative-boringssl-static/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.70.Final
-Project URL: https://netty.io/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.118.Final
-Project URL: https://netty.io/
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
-
---------------------------------------------------------------------------------
-
-Group: io.projectreactor  Name: reactor-core  Version: 3.4.41
 Project URL: https://github.com/reactor/reactor-core
-License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-core  Version: 1.0.48
+This product bundles Reactor Netty.
+
 Project URL: https://github.com/reactor/reactor-netty
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: io.projectreactor.netty  Name: reactor-netty-http  Version: 1.0.48
-Project URL: https://github.com/reactor/reactor-netty
-License: The Apache Software License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Reactor Pool (bundled by Reactor Netty).
+
+Project URL: https://github.com/reactor/reactor-pool
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: net.java.dev.jna  Name: jna  Version: 5.13.0
+This product bundles Aalto XML (bundled by Azure SDK for Java).
+
+Project URL: https://github.com/FasterXML/aalto-xml
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles JNA.
+
 Project URL: https://github.com/java-native-access/jna
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-Group: net.java.dev.jna  Name: jna-platform  Version: 5.13.0
-Project URL: https://github.com/java-native-access/jna
-License: Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0.txt
+This product bundles Reactive Streams.
 
---------------------------------------------------------------------------------
-
-Group: net.minidev  Name: accessors-smart  Version: 2.5.2
-Project URL: https://urielch.github.io/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: net.minidev  Name: json-smart  Version: 2.5.2
-Project URL: https://urielch.github.io/
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.ow2.asm  Name: asm  Version: 9.7.1
-Project URL: http://asm.ow2.io/
-License: BSD-3-Clause - https://asm.ow2.io/license.html
-License: The Apache Software License, Version 2.0 - http://www.apache.org/licenses/LICENSE-2.0.txt
-
---------------------------------------------------------------------------------
-
-Group: org.reactivestreams  Name: reactive-streams  Version: 1.0.4
 Project URL: http://www.reactive-streams.org/
-License: MIT-0 - https://spdx.org/licenses/MIT-0.html
+License: MIT-0
+
+| Copyright 2014 Reactive Streams
+| 
+| Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so.
+| 
+| THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+--------------------------------------------------------------------------------
+
+This product bundles JCTools (via Netty).
+
+Project URL: https://github.com/JCTools/JCTools
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -445,3 +445,79 @@ This product bundles JCTools (via Netty).
 
 Project URL: https://github.com/JCTools/JCTools
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Nimbus Content Type.
+
+Project URL: https://bitbucket.org/connect2id/nimbus-content-type/src/master/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Nimbus JOSE + JWT.
+
+Project URL: https://connect2id.com/products/nimbus-jose-jwt
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Nimbus Language Tags.
+
+Project URL: https://bitbucket.org/connect2id/nimbus-language-tags/src/master/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Nimbus OAuth 2.0 SDK with OIDC extensions.
+
+Project URL: https://connect2id.com/products/nimbus-oauth-openid-connect-sdk
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles JSON‑Smart.
+
+Project URL: https://github.com/netplex/json-smart-v2
+License: Apache License, Version 2.0 – https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles Accessors‑Smart.
+
+Project URL: https://github.com/netplex/json-smart-v2
+License: Apache License, Version 2.0 – https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+This product bundles ASM (org.ow2.asm:asm), a Java bytecode manipulation framework.
+
+Project URL: https://asm.ow2.io/
+License: BSD 3‑Clause – https://asm.ow2.io/license.html
+
+| ASM: a very small and fast Java bytecode manipulation framework
+| Copyright (c) 2000-2011 INRIA, France Telecom
+| All rights reserved.
+|
+| Redistribution and use in source and binary forms, with or without
+| modification, are permitted provided that the following conditions
+| are met:
+| 1. Redistributions of source code must retain the above copyright
+|   notice, this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright
+|   notice, this list of conditions and the following disclaimer in the
+|   documentation and/or other materials provided with the distribution.
+| 3. Neither the name of the copyright holders nor the names of its
+|   contributors may be used to endorse or promote products derived from
+|   this software without specific prior written permission.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+| AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+| IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+| ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+| LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+| CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+| SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+| INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+| CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+| ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+| THE POSSIBILITY OF SUCH DAMAGE.

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -489,6 +489,7 @@ Project URL: https://github.com/netplex/json-smart-v2
 License: Apache License, Version 2.0 – https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
+
 This product bundles ASM (org.ow2.asm:asm), a Java bytecode manipulation framework.
 
 Project URL: https://asm.ow2.io/

--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -448,68 +448,74 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus Content Type.
+This product bundles Nimbus JOSE+JWT.
 
-Project URL: https://bitbucket.org/connect2id/nimbus-content-type/src/master/
+Project URL: https://bitbucket.org/connect2id/nimbus-jose-jwt
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus JOSE + JWT.
+This product bundles Nimbus OAuth 2.0 SDK with OpenID Connect extensions.
 
-Project URL: https://connect2id.com/products/nimbus-jose-jwt
+Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus Language Tags.
+This product bundles Nimbus Content Type (bundled by Nimbus OAuth 2.0 SDK).
 
-Project URL: https://bitbucket.org/connect2id/nimbus-language-tags/src/master/
+Project URL: https://bitbucket.org/connect2id/nimbus-content-type
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles Nimbus OAuth 2.0 SDK with OIDC extensions.
+This product bundles Nimbus Language Tags (bundled by Nimbus OAuth 2.0 SDK).
 
-Project URL: https://connect2id.com/products/nimbus-oauth-openid-connect-sdk
+Project URL: https://bitbucket.org/connect2id/nimbus-language-tags
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles JSON‑Smart.
+This product bundles JSON Smart.
 
 Project URL: https://github.com/netplex/json-smart-v2
-License: Apache License, Version 2.0 – https://www.apache.org/licenses/LICENSE-2.0
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles Accessors‑Smart.
+This product bundles ASM Accessors Smart (bundled by JSON Smart).
 
 Project URL: https://github.com/netplex/json-smart-v2
-License: Apache License, Version 2.0 – https://www.apache.org/licenses/LICENSE-2.0
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------
 
-This product bundles ASM (org.ow2.asm:asm), a Java bytecode manipulation framework.
+This product bundles JCIP Annotations.
+
+Project URL: https://github.com/stephenc/jcip-annotations
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product bundles ASM (bundled by Accessors Smart).
 
 Project URL: https://asm.ow2.io/
-License: BSD 3‑Clause – https://asm.ow2.io/license.html
+License: BSD 3-Clause
 
-| ASM: a very small and fast Java bytecode manipulation framework
 | Copyright (c) 2000-2011 INRIA, France Telecom
 | All rights reserved.
 |
 | Redistribution and use in source and binary forms, with or without
-| modification, are permitted provided that the following conditions
-| are met:
-| 1. Redistributions of source code must retain the above copyright
-|   notice, this list of conditions and the following disclaimer.
-| 2. Redistributions in binary form must reproduce the above copyright
-|   notice, this list of conditions and the following disclaimer in the
-|   documentation and/or other materials provided with the distribution.
+| modification, are permitted provided that the following conditions are met:
+|
+| 1. Redistributions of source code must retain the above copyright notice,
+|    this list of conditions and the following disclaimer.
+| 2. Redistributions in binary form must reproduce the above copyright notice,
+|    this list of conditions and the following disclaimer in the documentation
+|    and/or other materials provided with the distribution.
 | 3. Neither the name of the copyright holders nor the names of its
-|   contributors may be used to endorse or promote products derived from
-|   this software without specific prior written permission.
+|    contributors may be used to endorse or promote products derived from this
+|    software without specific prior written permission.
 |
 | THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 | AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -1,21 +1,23 @@
 
 Apache Iceberg
-Copyright 2017-2025 The Apache Software Foundation
+Copyright 2017-2026 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-core  Version: 2.18.4
-NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2.18.4
-
+This product bundles Jackson JSON Processor with the following in its NOTICE file:
 | # Jackson JSON processor
 | 
 | Jackson is a high-performance, Free/Open Source JSON processing library.
 | It was originally written by Tatu Saloranta (tatu.saloranta@iki.fi), and has
 | been in development since 2007.
 | It is currently developed by a community of developers.
+| 
+| ## Copyright
+| 
+| Copyright 2007-, Tatu Saloranta (tatu.saloranta@iki.fi)
 | 
 | ## Licensing
 | 
@@ -27,31 +29,21 @@ NOTICE for Group: com.fasterxml.jackson.core  Name: jackson-databind  Version: 2
 | A list of contributors may be found from CREDITS(-2.x) file, which is included
 | in some artifacts (usually source distributions); but is always available
 | from the source code management (SCM) system project uses.
+| 
+| ## FastDoubleParser
+| 
+| jackson-core bundles a shaded copy of FastDoubleParser <https://github.com/wrandelshofer/FastDoubleParser>.
+| That code is available under an MIT license <https://github.com/wrandelshofer/FastDoubleParser/blob/main/LICENSE>
+| under the following copyright.
+| 
+| Copyright © 2023 Werner Randelshofer, Switzerland. MIT License.
+| 
+| See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
+| and the licenses and copyrights that apply to that code.
 
 --------------------------------------------------------------------------------
 
-NOTICE for Group: io.netty  Name: netty-buffer  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-dns  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-codec-http  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-http2  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-codec-socks  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-common  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-handler  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-handler-proxy  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-resolver  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns-classes-macos  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-resolver-dns-native-macos  Version: 4.1.112.Final
-NOTICE for Group: io.netty  Name: netty-tcnative-boringssl-static  Version: 2.0.69.Final
-NOTICE for Group: io.netty  Name: netty-tcnative-classes  Version: 2.0.69.Final
-NOTICE for Group: io.netty  Name: netty-transport  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-classes-epoll  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-classes-kqueue  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-epoll  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-kqueue  Version: 4.1.118.Final
-NOTICE for Group: io.netty  Name: netty-transport-native-unix-common  Version: 4.1.118.Final
-
+This product bundles Netty with the following in its NOTICE file:
 |                             The Netty Project
 |                             =================
 | 


### PR DESCRIPTION
This change does two things:

1. Copied over the License/Notice for the azure bundle as of #16181 via
```
git checkout 334269cd7d5114564a406a3259aa9919e4590738 -- azure-bundle/LICENSE azure-bundle/NOTICE
```
2. After generating runtime deps https://gist.github.com/amogh-jahagirdar/9c08eb889191bcb696270da884599845 
compared with main's runtime-deps and saw the following differences.

a.) Nimbus dependencies are included in the 1.10 bundle
b.) ASM dependencies are included in the 1.10 bundle

I went ahead and added the LICENSE entries for those. They don't appear to have their own notice so no changes there.