### PR TITLE
Flink: Fix DynamicIcebergSink writing with stale field IDs after column delete and re-add

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
@@ -124,6 +124,7 @@ class TableMetadataCache {
             true,
             table.refs().keySet(),
             table.schemas(),
+            table.schema().schemaId(),
             table.specs(),
             inputSchemasPerTableCacheMaximumSize));
   }
@@ -156,21 +157,21 @@ class TableMetadataCache {
         return lastResult;
       }
 
-      for (Map.Entry<Integer, Schema> tableSchema : cached.tableSchemas.entrySet()) {
+      // Resolve only against the current schema. A historical schema may match the input
+      // structurally (CompareSchemasVisitor ignores field IDs), but writing with its field
+      // IDs against the evolved current schema causes silent data corruption on read.
+      Schema currentSchema = cached.tableSchemas.get(cached.currentSchemaId);
+      if (currentSchema != null) {
         CompareSchemasVisitor.Result result =
-            CompareSchemasVisitor.visit(
-                input, tableSchema.getValue(), caseSensitive, dropUnusedColumns);
+            CompareSchemasVisitor.visit(input, currentSchema, caseSensitive, dropUnusedColumns);
         if (result == CompareSchemasVisitor.Result.SAME) {
           ResolvedSchemaInfo newResult =
               new ResolvedSchemaInfo(
-                  tableSchema.getValue(),
-                  CompareSchemasVisitor.Result.SAME,
-                  DataConverter.identity());
+                  currentSchema, CompareSchemasVisitor.Result.SAME, DataConverter.identity());
           cached.inputSchemas.put(input, newResult);
           return newResult;
-        } else if (compatible == null
-            && result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
-          compatible = tableSchema.getValue();
+        } else if (result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
+          compatible = currentSchema;
         }
       }
     }
@@ -221,7 +222,7 @@ class TableMetadataCache {
     } catch (NoSuchTableException | NoSuchNamespaceException e) {
       LOG.debug("Table or namespace doesn't exist {}", identifier, e);
       tableCache.put(
-          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, null, 1));
+          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, -1, null, 1));
       return Tuple2.of(false, e);
     }
   }
@@ -256,6 +257,7 @@ class TableMetadataCache {
     private final boolean tableExists;
     private final Set<String> branches;
     private final Map<Integer, Schema> tableSchemas;
+    private final int currentSchemaId;
     private final Map<Integer, PartitionSpec> specs;
     private final Map<Schema, ResolvedSchemaInfo> inputSchemas;
 
@@ -264,12 +266,14 @@ class TableMetadataCache {
         boolean tableExists,
         Set<String> branches,
         Map<Integer, Schema> tableSchemas,
+        int currentSchemaId,
         Map<Integer, PartitionSpec> specs,
         int inputSchemaCacheMaximumSize) {
       this.createdTimestampMillis = createdTimestampMillis;
       this.tableExists = tableExists;
       this.branches = branches;
       this.tableSchemas = tableSchemas;
+      this.currentSchemaId = currentSchemaId;
       this.specs = specs;
       this.inputSchemas =
           new LRUCache<>(inputSchemaCacheMaximumSize, CacheItem::inputSchemaEvictionListener);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1214,10 +1214,14 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     Table table = catalog.loadTable(tableIdentifier);
     table.refresh();
 
-    assertThat(table.schema().columns()).hasSize(2);
+    // Row 1 drops `extra`; row 2 re-adds it. The re-add must take effect (new field id, not the
+    // historical id=3): TableMetadataCache must not match the input against the historical
+    // pre-drop schema, otherwise the re-add is silently skipped.
+    assertThat(table.schema().columns()).hasSize(3);
     assertThat(table.schema().findField("id")).isNotNull();
     assertThat(table.schema().findField("data")).isNotNull();
-    assertThat(table.schema().findField("extra")).isNull();
+    assertThat(table.schema().findField("extra")).isNotNull();
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
 
     List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
     assertThat(records).hasSize(2);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1224,6 +1224,56 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testWriteAfterColumnDeleteAndReaddDoesNotUseHistoricalFieldIds() throws Exception {
+    // Regression for TableMetadataCache historical-schema-shadow bug. After deleteColumn +
+    // addColumn the re-added column gets a new field id, but the historical pre-delete
+    // schema is still kept in table.schemas() with its original field id. Pre-fix, the cache
+    // returned the historical schema as a SAME match for an input with the original shape,
+    // causing writes to use the stale field id. Reads via the current schema then returned
+    // null for the re-added column even though data was written successfully.
+    Schema fullSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()),
+            Types.NestedField.optional(3, "extra", Types.StringType.get()));
+
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.of(DATABASE, "t1");
+    Table table = catalog.createTable(tableIdentifier, fullSchema);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+    table.refresh();
+
+    // Confirm the re-added column has a new field id (otherwise the bug wouldn't manifest).
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
+
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                fullSchema, "t1", SnapshotRef.MAIN_BRANCH, PartitionSpec.unpartitioned()));
+
+    DataStream<DynamicIcebergDataImpl> dataStream =
+        env.fromData(rows, TypeInformation.of(new TypeHint<>() {}));
+    env.setParallelism(1);
+
+    DynamicIcebergSink.forInput(dataStream)
+        .generator(new Generator())
+        .catalogLoader(CATALOG_EXTENSION.catalogLoader())
+        .immediateTableUpdate(true)
+        .append();
+
+    env.execute("Test post-readd schema resolution");
+
+    table.refresh();
+
+    List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
+    assertThat(records).hasSize(1);
+    // Pre-fix this would be null because writes used the historical field id for extra.
+    Object expectedExtra = rows.get(0).rowProvided.getField("extra");
+    assertThat(records.get(0).getField("extra")).isEqualTo(expectedExtra);
+  }
+
+  @Test
   void testCaseInsensitiveSchemaMatching() throws Exception {
     Schema lowerCaseSchema =
         new Schema(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -201,6 +201,27 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testHistoricalSchemaDoesNotShadowCurrentAfterColumnDelete() {
+    // Regression: TableMetadataCache previously iterated all historical schemas and returned
+    // the first SAME match. After deleteColumn, the historical (pre-delete) schema would
+    // structurally match a re-issued full input schema and the sink would write with the
+    // historical schema's field IDs — silent data corruption against the evolved current
+    // schema. The cache must resolve against the current schema only.
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
+    Table table = catalog.createTable(tableIdentifier, SCHEMA2);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.refresh();
+
+    TableMetadataCache cache =
+        new TableMetadataCache(catalog, 10, Long.MAX_VALUE, 10, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    cache.update(tableIdentifier, table);
+
+    TableMetadataCache.ResolvedSchemaInfo info = cache.schema(tableIdentifier, SCHEMA2);
+    assertThat(info).isEqualTo(TableMetadataCache.NOT_FOUND);
+  }
+
+  @Test
   void testCaseSensitiveCachingDoesNotMatch() {
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
@@ -124,6 +124,7 @@ class TableMetadataCache {
             true,
             table.refs().keySet(),
             table.schemas(),
+            table.schema().schemaId(),
             table.specs(),
             inputSchemasPerTableCacheMaximumSize));
   }
@@ -156,21 +157,21 @@ class TableMetadataCache {
         return lastResult;
       }
 
-      for (Map.Entry<Integer, Schema> tableSchema : cached.tableSchemas.entrySet()) {
+      // Resolve only against the current schema. A historical schema may match the input
+      // structurally (CompareSchemasVisitor ignores field IDs), but writing with its field
+      // IDs against the evolved current schema causes silent data corruption on read.
+      Schema currentSchema = cached.tableSchemas.get(cached.currentSchemaId);
+      if (currentSchema != null) {
         CompareSchemasVisitor.Result result =
-            CompareSchemasVisitor.visit(
-                input, tableSchema.getValue(), caseSensitive, dropUnusedColumns);
+            CompareSchemasVisitor.visit(input, currentSchema, caseSensitive, dropUnusedColumns);
         if (result == CompareSchemasVisitor.Result.SAME) {
           ResolvedSchemaInfo newResult =
               new ResolvedSchemaInfo(
-                  tableSchema.getValue(),
-                  CompareSchemasVisitor.Result.SAME,
-                  DataConverter.identity());
+                  currentSchema, CompareSchemasVisitor.Result.SAME, DataConverter.identity());
           cached.inputSchemas.put(input, newResult);
           return newResult;
-        } else if (compatible == null
-            && result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
-          compatible = tableSchema.getValue();
+        } else if (result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
+          compatible = currentSchema;
         }
       }
     }
@@ -221,7 +222,7 @@ class TableMetadataCache {
     } catch (NoSuchTableException | NoSuchNamespaceException e) {
       LOG.debug("Table or namespace doesn't exist {}", identifier, e);
       tableCache.put(
-          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, null, 1));
+          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, -1, null, 1));
       return Tuple2.of(false, e);
     }
   }
@@ -256,6 +257,7 @@ class TableMetadataCache {
     private final boolean tableExists;
     private final Set<String> branches;
     private final Map<Integer, Schema> tableSchemas;
+    private final int currentSchemaId;
     private final Map<Integer, PartitionSpec> specs;
     private final Map<Schema, ResolvedSchemaInfo> inputSchemas;
 
@@ -264,12 +266,14 @@ class TableMetadataCache {
         boolean tableExists,
         Set<String> branches,
         Map<Integer, Schema> tableSchemas,
+        int currentSchemaId,
         Map<Integer, PartitionSpec> specs,
         int inputSchemaCacheMaximumSize) {
       this.createdTimestampMillis = createdTimestampMillis;
       this.tableExists = tableExists;
       this.branches = branches;
       this.tableSchemas = tableSchemas;
+      this.currentSchemaId = currentSchemaId;
       this.specs = specs;
       this.inputSchemas =
           new LRUCache<>(inputSchemaCacheMaximumSize, CacheItem::inputSchemaEvictionListener);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1226,10 +1226,14 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     Table table = catalog.loadTable(tableIdentifier);
     table.refresh();
 
-    assertThat(table.schema().columns()).hasSize(2);
+    // Row 1 drops `extra`; row 2 re-adds it. The re-add must take effect (new field id, not the
+    // historical id=3): TableMetadataCache must not match the input against the historical
+    // pre-drop schema, otherwise the re-add is silently skipped.
+    assertThat(table.schema().columns()).hasSize(3);
     assertThat(table.schema().findField("id")).isNotNull();
     assertThat(table.schema().findField("data")).isNotNull();
-    assertThat(table.schema().findField("extra")).isNull();
+    assertThat(table.schema().findField("extra")).isNotNull();
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
 
     List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
     assertThat(records).hasSize(2);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1236,6 +1236,56 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testWriteAfterColumnDeleteAndReaddDoesNotUseHistoricalFieldIds() throws Exception {
+    // Regression for TableMetadataCache historical-schema-shadow bug. After deleteColumn +
+    // addColumn the re-added column gets a new field id, but the historical pre-delete
+    // schema is still kept in table.schemas() with its original field id. Pre-fix, the cache
+    // returned the historical schema as a SAME match for an input with the original shape,
+    // causing writes to use the stale field id. Reads via the current schema then returned
+    // null for the re-added column even though data was written successfully.
+    Schema fullSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()),
+            Types.NestedField.optional(3, "extra", Types.StringType.get()));
+
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.of(DATABASE, "t1");
+    Table table = catalog.createTable(tableIdentifier, fullSchema);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+    table.refresh();
+
+    // Confirm the re-added column has a new field id (otherwise the bug wouldn't manifest).
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
+
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                fullSchema, "t1", SnapshotRef.MAIN_BRANCH, PartitionSpec.unpartitioned()));
+
+    DataStream<DynamicIcebergDataImpl> dataStream =
+        env.fromData(rows, TypeInformation.of(new TypeHint<>() {}));
+    env.setParallelism(1);
+
+    DynamicIcebergSink.forInput(dataStream)
+        .generator(new Generator())
+        .catalogLoader(CATALOG_EXTENSION.catalogLoader())
+        .immediateTableUpdate(true)
+        .append();
+
+    env.execute("Test post-readd schema resolution");
+
+    table.refresh();
+
+    List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
+    assertThat(records).hasSize(1);
+    // Pre-fix this would be null because writes used the historical field id for extra.
+    Object expectedExtra = rows.get(0).rowProvided.getField("extra");
+    assertThat(records.get(0).getField("extra")).isEqualTo(expectedExtra);
+  }
+
+  @Test
   void testCaseInsensitiveSchemaMatching() throws Exception {
     Schema lowerCaseSchema =
         new Schema(

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -201,6 +201,27 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testHistoricalSchemaDoesNotShadowCurrentAfterColumnDelete() {
+    // Regression: TableMetadataCache previously iterated all historical schemas and returned
+    // the first SAME match. After deleteColumn, the historical (pre-delete) schema would
+    // structurally match a re-issued full input schema and the sink would write with the
+    // historical schema's field IDs — silent data corruption against the evolved current
+    // schema. The cache must resolve against the current schema only.
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
+    Table table = catalog.createTable(tableIdentifier, SCHEMA2);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.refresh();
+
+    TableMetadataCache cache =
+        new TableMetadataCache(catalog, 10, Long.MAX_VALUE, 10, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    cache.update(tableIdentifier, table);
+
+    TableMetadataCache.ResolvedSchemaInfo info = cache.schema(tableIdentifier, SCHEMA2);
+    assertThat(info).isEqualTo(TableMetadataCache.NOT_FOUND);
+  }
+
+  @Test
   void testCaseSensitiveCachingDoesNotMatch() {
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableMetadataCache.java
@@ -124,6 +124,7 @@ class TableMetadataCache {
             true,
             table.refs().keySet(),
             table.schemas(),
+            table.schema().schemaId(),
             table.specs(),
             inputSchemasPerTableCacheMaximumSize));
   }
@@ -156,21 +157,21 @@ class TableMetadataCache {
         return lastResult;
       }
 
-      for (Map.Entry<Integer, Schema> tableSchema : cached.tableSchemas.entrySet()) {
+      // Resolve only against the current schema. A historical schema may match the input
+      // structurally (CompareSchemasVisitor ignores field IDs), but writing with its field
+      // IDs against the evolved current schema causes silent data corruption on read.
+      Schema currentSchema = cached.tableSchemas.get(cached.currentSchemaId);
+      if (currentSchema != null) {
         CompareSchemasVisitor.Result result =
-            CompareSchemasVisitor.visit(
-                input, tableSchema.getValue(), caseSensitive, dropUnusedColumns);
+            CompareSchemasVisitor.visit(input, currentSchema, caseSensitive, dropUnusedColumns);
         if (result == CompareSchemasVisitor.Result.SAME) {
           ResolvedSchemaInfo newResult =
               new ResolvedSchemaInfo(
-                  tableSchema.getValue(),
-                  CompareSchemasVisitor.Result.SAME,
-                  DataConverter.identity());
+                  currentSchema, CompareSchemasVisitor.Result.SAME, DataConverter.identity());
           cached.inputSchemas.put(input, newResult);
           return newResult;
-        } else if (compatible == null
-            && result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
-          compatible = tableSchema.getValue();
+        } else if (result == CompareSchemasVisitor.Result.DATA_CONVERSION_NEEDED) {
+          compatible = currentSchema;
         }
       }
     }
@@ -221,7 +222,7 @@ class TableMetadataCache {
     } catch (NoSuchTableException | NoSuchNamespaceException e) {
       LOG.debug("Table or namespace doesn't exist {}", identifier, e);
       tableCache.put(
-          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, null, 1));
+          identifier, new CacheItem(cacheRefreshClock.millis(), false, null, null, -1, null, 1));
       return Tuple2.of(false, e);
     }
   }
@@ -256,6 +257,7 @@ class TableMetadataCache {
     private final boolean tableExists;
     private final Set<String> branches;
     private final Map<Integer, Schema> tableSchemas;
+    private final int currentSchemaId;
     private final Map<Integer, PartitionSpec> specs;
     private final Map<Schema, ResolvedSchemaInfo> inputSchemas;
 
@@ -264,12 +266,14 @@ class TableMetadataCache {
         boolean tableExists,
         Set<String> branches,
         Map<Integer, Schema> tableSchemas,
+        int currentSchemaId,
         Map<Integer, PartitionSpec> specs,
         int inputSchemaCacheMaximumSize) {
       this.createdTimestampMillis = createdTimestampMillis;
       this.tableExists = tableExists;
       this.branches = branches;
       this.tableSchemas = tableSchemas;
+      this.currentSchemaId = currentSchemaId;
       this.specs = specs;
       this.inputSchemas =
           new LRUCache<>(inputSchemaCacheMaximumSize, CacheItem::inputSchemaEvictionListener);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1226,10 +1226,14 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
     Table table = catalog.loadTable(tableIdentifier);
     table.refresh();
 
-    assertThat(table.schema().columns()).hasSize(2);
+    // Row 1 drops `extra`; row 2 re-adds it. The re-add must take effect (new field id, not the
+    // historical id=3): TableMetadataCache must not match the input against the historical
+    // pre-drop schema, otherwise the re-add is silently skipped.
+    assertThat(table.schema().columns()).hasSize(3);
     assertThat(table.schema().findField("id")).isNotNull();
     assertThat(table.schema().findField("data")).isNotNull();
-    assertThat(table.schema().findField("extra")).isNull();
+    assertThat(table.schema().findField("extra")).isNotNull();
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
 
     List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
     assertThat(records).hasSize(2);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicIcebergSink.java
@@ -1236,6 +1236,56 @@ class TestDynamicIcebergSink extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testWriteAfterColumnDeleteAndReaddDoesNotUseHistoricalFieldIds() throws Exception {
+    // Regression for TableMetadataCache historical-schema-shadow bug. After deleteColumn +
+    // addColumn the re-added column gets a new field id, but the historical pre-delete
+    // schema is still kept in table.schemas() with its original field id. Pre-fix, the cache
+    // returned the historical schema as a SAME match for an input with the original shape,
+    // causing writes to use the stale field id. Reads via the current schema then returned
+    // null for the re-added column even though data was written successfully.
+    Schema fullSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.required(2, "data", Types.StringType.get()),
+            Types.NestedField.optional(3, "extra", Types.StringType.get()));
+
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.of(DATABASE, "t1");
+    Table table = catalog.createTable(tableIdentifier, fullSchema);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.updateSchema().addColumn("extra", Types.StringType.get()).commit();
+    table.refresh();
+
+    // Confirm the re-added column has a new field id (otherwise the bug wouldn't manifest).
+    assertThat(table.schema().findField("extra").fieldId()).isNotEqualTo(3);
+
+    List<DynamicIcebergDataImpl> rows =
+        Lists.newArrayList(
+            new DynamicIcebergDataImpl(
+                fullSchema, "t1", SnapshotRef.MAIN_BRANCH, PartitionSpec.unpartitioned()));
+
+    DataStream<DynamicIcebergDataImpl> dataStream =
+        env.fromData(rows, TypeInformation.of(new TypeHint<>() {}));
+    env.setParallelism(1);
+
+    DynamicIcebergSink.forInput(dataStream)
+        .generator(new Generator())
+        .catalogLoader(CATALOG_EXTENSION.catalogLoader())
+        .immediateTableUpdate(true)
+        .append();
+
+    env.execute("Test post-readd schema resolution");
+
+    table.refresh();
+
+    List<Record> records = Lists.newArrayList(IcebergGenerics.read(table).build());
+    assertThat(records).hasSize(1);
+    // Pre-fix this would be null because writes used the historical field id for extra.
+    Object expectedExtra = rows.get(0).rowProvided.getField("extra");
+    assertThat(records.get(0).getField("extra")).isEqualTo(expectedExtra);
+  }
+
+  @Test
   void testCaseInsensitiveSchemaMatching() throws Exception {
     Schema lowerCaseSchema =
         new Schema(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableMetadataCache.java
@@ -201,6 +201,27 @@ public class TestTableMetadataCache extends TestFlinkIcebergSinkBase {
   }
 
   @Test
+  void testHistoricalSchemaDoesNotShadowCurrentAfterColumnDelete() {
+    // Regression: TableMetadataCache previously iterated all historical schemas and returned
+    // the first SAME match. After deleteColumn, the historical (pre-delete) schema would
+    // structurally match a re-issued full input schema and the sink would write with the
+    // historical schema's field IDs — silent data corruption against the evolved current
+    // schema. The cache must resolve against the current schema only.
+    Catalog catalog = CATALOG_EXTENSION.catalog();
+    TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");
+    Table table = catalog.createTable(tableIdentifier, SCHEMA2);
+    table.updateSchema().deleteColumn("extra").commit();
+    table.refresh();
+
+    TableMetadataCache cache =
+        new TableMetadataCache(catalog, 10, Long.MAX_VALUE, 10, CASE_SENSITIVE, PRESERVE_COLUMNS);
+    cache.update(tableIdentifier, table);
+
+    TableMetadataCache.ResolvedSchemaInfo info = cache.schema(tableIdentifier, SCHEMA2);
+    assertThat(info).isEqualTo(TableMetadataCache.NOT_FOUND);
+  }
+
+  @Test
   void testCaseSensitiveCachingDoesNotMatch() {
     Catalog catalog = CATALOG_EXTENSION.catalog();
     TableIdentifier tableIdentifier = TableIdentifier.parse("default.myTable");


### PR DESCRIPTION
`TableMetadataCache.schema()` in `DynamicIcebergSink` iterates all historical table schemas and returns on the first `SAME` match from `CompareSchemasVisitor`. Since the visitor matches by name+type and not field IDs, an input schema that is structurally identical to an older table schema (e.g. before a `deleteColumn`) deterministically matches the historical schema first, and the sink writes with stale field IDs. The current schema then cannot resolve those columns on read and returns null silently — no exception is thrown.

Reproduction: create a table with `[id, data, extra]`, `updateSchema().deleteColumn("extra").commit()`, then `addColumn("extra", ...)` to bring it back (`extra` now has a new field id). Send a `DynamicRecord` with the original `[id, data, extra]` shape — the cache returns `SAME` against the historical schema and writes use its field id for `extra`. Reads via the current schema then return `null` for `extra`.

This change resolves the input only against the current table schema. `CacheItem` now tracks `currentSchemaId` populated from `table.schema().schemaId()` in `update()`, and historical iteration is removed — selecting a historical schema as a write target was the bug. `SCHEMA_UPDATE_NEEDED` continues to fall through to evolution as before.

Applied identically to `flink/v1.20`, `flink/v2.0`, and `flink/v2.1`. Tests added in each module:
- `TestTableMetadataCache.testHistoricalSchemaDoesNotShadowCurrentAfterColumnDelete` — unit test asserting the cache no longer returns `SAME` against a historical schema after a column delete.
- `TestDynamicIcebergSink.testWriteAfterColumnDeleteAndReaddDoesNotUseHistoricalFieldIds` — end-to-end regression that pre-creates a table, runs `deleteColumn` + `addColumn` to give the column a new field id, writes a record with the pre-delete shape via `DynamicIcebergSink`, and reads back. The re-added column's value must round-trip; pre-fix this assertion fails with `expected: "..." but was: null`, exactly matching the silent-corruption signature.

AI was used to draft the patch and tests; the author verified the root cause against the upstream source, confirmed the integration test reproduces the data-corruption symptom on pre-fix code, and ran the affected module tests + `spotlessCheck` locally.