### PR TITLE
Core: Add partition to TrackedFile

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TrackedFile.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFile.java
@@ -53,6 +53,10 @@ interface TrackedFile {
       Types.NestedField.optional(
           141, "spec_id", Types.IntegerType.get(), "Spec ID used to partition the file");
 
+  int PARTITION_ID = 102;
+  String PARTITION_NAME = "partition";
+  String PARTITION_DOC = "Partition data tuple, schema based on the partition spec";
+
   int CONTENT_STATS_ID = 146;
   String CONTENT_STATS_NAME = "content_stats";
   String CONTENT_STATS_DOC = "Content statistics for this entry";
@@ -88,7 +92,8 @@ interface TrackedFile {
           Types.ListType.ofRequired(136, Types.IntegerType.get()),
           "Field ids used to determine row equality in equality delete files");
 
-  static Types.StructType schemaWithContentStats(Types.StructType contentStatsType) {
+  static Types.StructType schemaWithContentStats(
+      Types.StructType partitionType, Types.StructType contentStatsType) {
     return Types.StructType.of(
         TRACKING,
         CONTENT_TYPE,
@@ -97,6 +102,7 @@ interface TrackedFile {
         RECORD_COUNT,
         FILE_SIZE_IN_BYTES,
         SPEC_ID,
+        Types.NestedField.required(PARTITION_ID, PARTITION_NAME, partitionType, PARTITION_DOC),
         Types.NestedField.optional(
             CONTENT_STATS_ID, CONTENT_STATS_NAME, contentStatsType, CONTENT_STATS_DOC),
         SORT_ORDER_ID,
@@ -127,6 +133,9 @@ interface TrackedFile {
 
   /** Returns the ID of the partition spec used to partition this file, or null. */
   Integer specId();
+
+  /** Returns partition for this file as a {@link StructLike}. */
+  StructLike partition();
 
   /** Returns the content stats for this entry. */
   ContentStats contentStats();

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -73,7 +73,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   private long recordCount = -1L;
   private long fileSizeInBytes = -1L;
   private Integer specId = null;
-  private PartitionData partitionData = null;
+  private PartitionData partitionData = EMPTY_PARTITION_DATA;
 
   // optional fields
   private Tracking tracking = null;
@@ -90,16 +90,14 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     super(BASE_TYPE, projection);
     // partition type may be null if the field was not projected
     Type partType = projection.fieldType("partition");
-    this.partitionData =
-        null != partType
-            ? new PartitionData(partType.asNestedType().asStructType())
-            : EMPTY_PARTITION_DATA;
+    if (partType != null) {
+      this.partitionData = new PartitionData(partType.asNestedType().asStructType());
+    }
   }
 
   /** No-projection constructor for direct construction. */
   TrackedFileStruct() {
     super(BASE_TYPE.fields().size());
-    this.partitionData = EMPTY_PARTITION_DATA;
   }
 
   /** Constructor that accepts required fields. */
@@ -116,9 +114,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.contentType = contentType;
     this.location = location;
     this.fileFormat = fileFormat;
-    this.partitionData = null != partition ? partition : EMPTY_PARTITION_DATA;
     this.recordCount = recordCount;
     this.fileSizeInBytes = fileSizeInBytes;
+    if (partition != null) {
+      this.partitionData = partition;
+    }
   }
 
   /** Copy constructor. */

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
 import org.apache.iceberg.util.ByteBuffers;
@@ -32,6 +33,13 @@ import org.apache.iceberg.util.ByteBuffers;
 /** Mutable {@link StructLike} implementation of {@link TrackedFile}. */
 class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, Serializable {
   private static final Types.StructType EMPTY_STRUCT_TYPE = Types.StructType.of();
+  private static final PartitionData EMPTY_PARTITION_DATA =
+      new PartitionData(EMPTY_STRUCT_TYPE) {
+        @Override
+        public PartitionData copy() {
+          return this; // this does not change
+        }
+      };
 
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
@@ -42,6 +50,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
           TrackedFile.RECORD_COUNT,
           TrackedFile.FILE_SIZE_IN_BYTES,
           TrackedFile.SPEC_ID,
+          Types.NestedField.required(
+              TrackedFile.PARTITION_ID,
+              TrackedFile.PARTITION_NAME,
+              EMPTY_STRUCT_TYPE,
+              TrackedFile.PARTITION_DOC),
           Types.NestedField.optional(
               TrackedFile.CONTENT_STATS_ID,
               TrackedFile.CONTENT_STATS_NAME,
@@ -60,6 +73,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   private long recordCount = -1L;
   private long fileSizeInBytes = -1L;
   private Integer specId = null;
+  private PartitionData partitionData = null;
 
   // optional fields
   private Tracking tracking = null;
@@ -74,11 +88,18 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   /** Used by internal readers to instantiate this class with a projection schema. */
   TrackedFileStruct(Types.StructType projection) {
     super(BASE_TYPE, projection);
+    // partition type may be null if the field was not projected
+    Type partType = projection.fieldType("partition");
+    this.partitionData =
+        null != partType
+            ? new PartitionData(partType.asNestedType().asStructType())
+            : EMPTY_PARTITION_DATA;
   }
 
   /** No-projection constructor for direct construction. */
   TrackedFileStruct() {
     super(BASE_TYPE.fields().size());
+    this.partitionData = EMPTY_PARTITION_DATA;
   }
 
   /** Constructor that accepts required fields. */
@@ -87,6 +108,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       FileContent contentType,
       String location,
       FileFormat fileFormat,
+      PartitionData partition,
       long recordCount,
       long fileSizeInBytes) {
     super(BASE_TYPE.fields().size());
@@ -94,6 +116,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.contentType = contentType;
     this.location = location;
     this.fileFormat = fileFormat;
+    this.partitionData = null != partition ? partition : EMPTY_PARTITION_DATA;
     this.recordCount = recordCount;
     this.fileSizeInBytes = fileSizeInBytes;
   }
@@ -107,9 +130,8 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     this.recordCount = toCopy.recordCount;
     this.fileSizeInBytes = toCopy.fileSizeInBytes;
     this.specId = toCopy.specId;
-
+    this.partitionData = toCopy.partitionData.copy();
     this.tracking = toCopy.tracking != null ? toCopy.tracking.copy() : null;
-
     this.sortOrderId = toCopy.sortOrderId;
     this.deletionVector = toCopy.deletionVector != null ? toCopy.deletionVector.copy() : null;
 
@@ -168,6 +190,11 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   @Override
   public Integer specId() {
     return specId;
+  }
+
+  @Override
+  public StructLike partition() {
+    return partitionData;
   }
 
   @Override
@@ -237,18 +264,20 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
       case 6:
         return specId;
       case 7:
-        return contentStats;
+        return partitionData;
       case 8:
-        return sortOrderId;
+        return contentStats;
       case 9:
-        return deletionVector;
+        return sortOrderId;
       case 10:
-        return manifestInfo;
+        return deletionVector;
       case 11:
-        return keyMetadata();
+        return manifestInfo;
       case 12:
-        return splitOffsets();
+        return keyMetadata();
       case 13:
+        return splitOffsets();
+      case 14:
         return equalityIds();
       default:
         throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
@@ -281,24 +310,27 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         this.specId = (Integer) value;
         break;
       case 7:
-        this.contentStats = (ContentStats) value;
+        this.partitionData = (PartitionData) value;
         break;
       case 8:
-        this.sortOrderId = (Integer) value;
+        this.contentStats = (ContentStats) value;
         break;
       case 9:
-        this.deletionVector = (DeletionVector) value;
+        this.sortOrderId = (Integer) value;
         break;
       case 10:
-        this.manifestInfo = (ManifestInfo) value;
+        this.deletionVector = (DeletionVector) value;
         break;
       case 11:
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+        this.manifestInfo = (ManifestInfo) value;
         break;
       case 12:
-        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
         break;
       case 13:
+        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+        break;
+      case 14:
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         break;
       default:
@@ -315,6 +347,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         .add("record_count", recordCount)
         .add("file_size_in_bytes", fileSizeInBytes)
         .add("spec_id", specId())
+        .add("partition", partitionData)
         .add("tracking", tracking)
         .add("content_stats", contentStats)
         .add("sort_order_id", sortOrderId)

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFile.java
@@ -34,9 +34,12 @@ public class TestTrackedFile {
   private static final Types.StructType CONTENT_STATS_TYPE =
       StatsUtil.contentStatsFor(TABLE_SCHEMA).type().asStructType();
 
+  private static final Types.StructType PARTITION_TYPE =
+      PartitionSpec.builderFor(TABLE_SCHEMA).identity("id").build().partitionType();
+
   @Test
   public void schemaWithContentStatsFieldOrder() {
-    Types.StructType type = TrackedFile.schemaWithContentStats(CONTENT_STATS_TYPE);
+    Types.StructType type = TrackedFile.schemaWithContentStats(PARTITION_TYPE, CONTENT_STATS_TYPE);
     List<Types.NestedField> fields = type.fields();
 
     assertThat(fields)
@@ -49,6 +52,7 @@ public class TestTrackedFile {
             "record_count",
             "file_size_in_bytes",
             "spec_id",
+            "partition",
             "content_stats",
             "sort_order_id",
             "deletion_vector",
@@ -60,20 +64,22 @@ public class TestTrackedFile {
 
   @Test
   public void schemaWithContentStatsFieldIds() {
-    Types.StructType type = TrackedFile.schemaWithContentStats(CONTENT_STATS_TYPE);
+    Types.StructType type = TrackedFile.schemaWithContentStats(PARTITION_TYPE, CONTENT_STATS_TYPE);
     List<Types.NestedField> fields = type.fields();
 
     assertThat(fields)
         .extracting(Types.NestedField::fieldId)
-        .containsExactly(147, 134, 100, 101, 103, 104, 141, 146, 140, 148, 150, 131, 132, 135);
+        .containsExactly(147, 134, 100, 101, 103, 104, 141, 102, 146, 140, 148, 150, 131, 132, 135);
   }
 
   @Test
   public void schemaWithContentStatsUsesProvidedType() {
-    Types.StructType type = TrackedFile.schemaWithContentStats(CONTENT_STATS_TYPE);
+    Types.StructType type = TrackedFile.schemaWithContentStats(PARTITION_TYPE, CONTENT_STATS_TYPE);
     Types.NestedField contentStatsField = type.field(TrackedFile.CONTENT_STATS_ID);
+    Types.NestedField partitionField = type.field(TrackedFile.PARTITION_ID);
 
     assertThat(contentStatsField.type().asStructType()).isEqualTo(CONTENT_STATS_TYPE);
+    assertThat(partitionField.type().asStructType()).isEqualTo(PARTITION_TYPE);
   }
 
   @Test
@@ -88,8 +94,8 @@ public class TestTrackedFile {
     Types.StructType smallStats = StatsUtil.contentStatsFor(smallSchema).type().asStructType();
     Types.StructType largeStats = StatsUtil.contentStatsFor(largeSchema).type().asStructType();
 
-    Types.StructType smallType = TrackedFile.schemaWithContentStats(smallStats);
-    Types.StructType largeType = TrackedFile.schemaWithContentStats(largeStats);
+    Types.StructType smallType = TrackedFile.schemaWithContentStats(PARTITION_TYPE, smallStats);
+    Types.StructType largeType = TrackedFile.schemaWithContentStats(PARTITION_TYPE, largeStats);
 
     Types.StructType smallResult =
         smallType.field(TrackedFile.CONTENT_STATS_ID).type().asStructType();
@@ -98,5 +104,15 @@ public class TestTrackedFile {
 
     assertThat(smallResult.fields()).hasSize(1);
     assertThat(largeResult.fields()).hasSize(3);
+  }
+
+  @Test
+  public void schemaWithContentStatsPartitionIsRequired() {
+    Types.StructType type = TrackedFile.schemaWithContentStats(PARTITION_TYPE, CONTENT_STATS_TYPE);
+    Types.NestedField partitionField = type.field(TrackedFile.PARTITION_ID);
+
+    assertThat(partitionField.isRequired()).isTrue();
+    assertThat(partitionField.name()).isEqualTo(TrackedFile.PARTITION_NAME);
+    assertThat(partitionField.doc()).isEqualTo(TrackedFile.PARTITION_DOC);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -30,6 +30,11 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 class TestTrackedFileStruct {
+  private static final Types.StructType PARTITION_TYPE =
+      Types.StructType.of(
+          Types.NestedField.optional(1000, "id_bucket", Types.IntegerType.get()),
+          Types.NestedField.optional(1001, "category", Types.StringType.get()));
+
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
@@ -123,13 +128,7 @@ class TestTrackedFileStruct {
 
   @Test
   void partitionAccess() {
-    Types.StructType partitionType =
-        Types.StructType.of(
-            Types.NestedField.optional(1000, "id", Types.IntegerType.get()),
-            Types.NestedField.optional(1001, "category", Types.StringType.get()));
-    PartitionData partition = new PartitionData(partitionType);
-    partition.set(0, 5);
-    partition.set(1, "books");
+    PartitionData partition = newPartition(5, "books");
 
     TrackedFileStruct file = new TrackedFileStruct();
     file.set(7, partition);
@@ -141,14 +140,7 @@ class TestTrackedFileStruct {
 
   @Test
   void partitionIsCopied() {
-    Types.StructType partitionType =
-        Types.StructType.of(
-            Types.NestedField.optional(1000, "id", Types.IntegerType.get()),
-            Types.NestedField.optional(1001, "category", Types.StringType.get()));
-    PartitionData partition = new PartitionData(partitionType);
-    partition.set(0, 5);
-    partition.set(1, "books");
-
+    PartitionData partition = newPartition(5, "books");
     TrackedFileStruct file = createFullTrackedFile();
     file.set(7, partition);
 
@@ -182,6 +174,7 @@ class TestTrackedFileStruct {
     assertThat(copy.equalityIds()).isNull();
     assertThat(copy.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
     assertThat(copy.tracking().manifestPos()).isEqualTo(3L);
+    assertThat(copy.partition()).isEqualTo(newPartition(7, "music"));
   }
 
   @Test
@@ -308,6 +301,7 @@ class TestTrackedFileStruct {
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
     assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.partition()).isEqualTo(newPartition(7, "music"));
   }
 
   @Test
@@ -330,6 +324,7 @@ class TestTrackedFileStruct {
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.tracking().manifestPos()).isEqualTo(3L);
     assertThat(deserialized.tracking().manifestLocation()).isEqualTo("s3://bucket/manifest.avro");
+    assertThat(deserialized.partition()).isEqualTo(newPartition(7, "music"));
   }
 
   static TrackedFileStruct createFullTrackedFile() {
@@ -356,7 +351,7 @@ class TestTrackedFileStruct {
             FileContent.DATA,
             "s3://bucket/data/file.parquet",
             FileFormat.PARQUET,
-            new PartitionData(Types.StructType.of()),
+            newPartition(7, "music"),
             100L,
             1024L);
     file.set(6, 0);
@@ -366,6 +361,13 @@ class TestTrackedFileStruct {
     file.set(13, ImmutableList.of(50L));
 
     return file;
+  }
+
+  private static PartitionData newPartition(int idBucket, String category) {
+    PartitionData partition = new PartitionData(PARTITION_TYPE);
+    partition.set(0, idBucket);
+    partition.set(1, category);
+    return partition;
   }
 
   static TrackedFileStruct createTrackedFileWithStats() {

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -62,12 +62,12 @@ class TestTrackedFileStruct {
     file.set(4, 50L);
     file.set(5, 512L);
     file.set(6, 1);
-    file.set(8, 5);
-    file.set(9, dv);
-    file.set(10, info);
-    file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
-    file.set(12, ImmutableList.of(100L, 200L));
-    file.set(13, ImmutableList.of(1, 2, 3));
+    file.set(9, 5);
+    file.set(10, dv);
+    file.set(11, info);
+    file.set(12, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    file.set(13, ImmutableList.of(100L, 200L));
+    file.set(14, ImmutableList.of(1, 2, 3));
 
     assertThat(file.tracking()).isNotNull();
     assertThat(file.tracking().status()).isEqualTo(EntryStatus.ADDED);
@@ -84,6 +84,9 @@ class TestTrackedFileStruct {
     assertThat(file.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(file.splitOffsets()).containsExactly(100L, 200L);
     assertThat(file.equalityIds()).containsExactly(1, 2, 3);
+    // should return EMPTY_PARTITION_DATA
+    assertThat(file.partition()).isNotNull();
+    assertThat(file.partition().size()).isEqualTo(0);
   }
 
   @Test
@@ -103,6 +106,58 @@ class TestTrackedFileStruct {
 
     assertThat(file.tracking().manifestLocation()).isEqualTo("s3://bucket/metadata/manifest.avro");
     assertThat(file.tracking().manifestPos()).isEqualTo(7L);
+  }
+
+  @Test
+  void projectionWithoutPartition() {
+    // project only location (field ID 100) and file_size_in_bytes (field ID 104)
+    Types.StructType projection =
+        Types.StructType.of(TrackedFile.LOCATION, TrackedFile.FILE_SIZE_IN_BYTES);
+
+    TrackedFileStruct file = new TrackedFileStruct(projection);
+    assertThat(file.size()).isEqualTo(2);
+    // should return EMPTY_PARTITION_DATA
+    assertThat(file.partition()).isNotNull();
+    assertThat(file.partition().size()).isEqualTo(0);
+  }
+
+  @Test
+  void partitionAccess() {
+    Types.StructType partitionType =
+        Types.StructType.of(
+            Types.NestedField.optional(1000, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(1001, "category", Types.StringType.get()));
+    PartitionData partition = new PartitionData(partitionType);
+    partition.set(0, 5);
+    partition.set(1, "books");
+
+    TrackedFileStruct file = new TrackedFileStruct();
+    file.set(7, partition);
+
+    assertThat(file.partition()).isSameAs(partition);
+    assertThat(file.partition().get(0, Integer.class)).isEqualTo(5);
+    assertThat(file.partition().get(1, String.class)).isEqualTo("books");
+  }
+
+  @Test
+  void partitionIsCopied() {
+    Types.StructType partitionType =
+        Types.StructType.of(
+            Types.NestedField.optional(1000, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(1001, "category", Types.StringType.get()));
+    PartitionData partition = new PartitionData(partitionType);
+    partition.set(0, 5);
+    partition.set(1, "books");
+
+    TrackedFileStruct file = createFullTrackedFile();
+    file.set(7, partition);
+
+    TrackedFile copy = file.copy();
+
+    assertThat(copy.partition()).isNotNull().isNotSameAs(partition);
+    assertThat(copy.partition()).isEqualTo(partition);
+    assertThat(copy.partition().get(0, Integer.class)).isEqualTo(5);
+    assertThat(copy.partition().get(1, String.class)).isEqualTo("books");
   }
 
   @Test
@@ -167,7 +222,7 @@ class TestTrackedFileStruct {
   @Test
   void testStructLikeSize() {
     TrackedFileStruct file = new TrackedFileStruct();
-    assertThat(file.size()).isEqualTo(14);
+    assertThat(file.size()).isEqualTo(15);
   }
 
   @Test
@@ -301,18 +356,18 @@ class TestTrackedFileStruct {
             FileContent.DATA,
             "s3://bucket/data/file.parquet",
             FileFormat.PARQUET,
+            new PartitionData(Types.StructType.of()),
             100L,
             1024L);
     file.set(6, 0);
-    file.set(8, 1);
-    file.set(9, dv);
-    file.set(11, ByteBuffer.wrap(new byte[] {1, 2, 3}));
-    file.set(12, ImmutableList.of(50L));
+    file.set(9, 1);
+    file.set(10, dv);
+    file.set(12, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    file.set(13, ImmutableList.of(50L));
 
     return file;
   }
 
-  @SuppressWarnings("unchecked")
   static TrackedFileStruct createTrackedFileWithStats() {
     Types.StructType statsStruct =
         Types.StructType.of(
@@ -337,25 +392,23 @@ class TestTrackedFileStruct {
 
     List<FieldStats<?>> fieldStatsList =
         ImmutableList.of(
-            (FieldStats<?>)
-                BaseFieldStats.<Integer>builder()
-                    .fieldId(1)
-                    .type(Types.IntegerType.get())
-                    .valueCount(100L)
-                    .nullValueCount(5L)
-                    .lowerBound(1)
-                    .upperBound(1000)
-                    .build(),
-            (FieldStats<?>)
-                BaseFieldStats.<Float>builder()
-                    .fieldId(2)
-                    .type(Types.FloatType.get())
-                    .valueCount(200L)
-                    .nullValueCount(10L)
-                    .nanValueCount(3L)
-                    .lowerBound(1.0f)
-                    .upperBound(100.0f)
-                    .build());
+            BaseFieldStats.<Integer>builder()
+                .fieldId(1)
+                .type(Types.IntegerType.get())
+                .valueCount(100L)
+                .nullValueCount(5L)
+                .lowerBound(1)
+                .upperBound(1000)
+                .build(),
+            BaseFieldStats.<Float>builder()
+                .fieldId(2)
+                .type(Types.FloatType.get())
+                .valueCount(200L)
+                .nullValueCount(10L)
+                .nanValueCount(3L)
+                .lowerBound(1.0f)
+                .upperBound(100.0f)
+                .build());
 
     BaseContentStats stats =
         BaseContentStats.builder()
@@ -369,10 +422,11 @@ class TestTrackedFileStruct {
             FileContent.DATA,
             "s3://bucket/data/file.parquet",
             FileFormat.PARQUET,
+            new PartitionData(Types.StructType.of()),
             100L,
             1024L);
     file.set(6, 0);
-    file.set(7, stats);
+    file.set(8, stats);
 
     return file;
   }


### PR DESCRIPTION
Adds the v1-v3 `DataFile.partition` (field ID `102`) to the v4 `TrackedFile`, so partition data continues to be tracked per-file in v4 manifests