### PR TITLE
Core: Use toOptional and onlyElement methods in MoreCollectors

### DIFF
--- a/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
+++ b/bundled-guava/src/main/java/org/apache/iceberg/GuavaClasses.java
@@ -39,6 +39,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.MapMaker;
 import com.google.common.collect.Maps;
+import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Ordering;
@@ -103,5 +104,6 @@ public class GuavaClasses {
     Stopwatch.class.getName();
     Ints.class.getName();
     UnsignedBytes.class.getName();
+    MoreCollectors.class.getName();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BasePartitionStatisticsScan.java
+++ b/core/src/main/java/org/apache/iceberg/BasePartitionStatisticsScan.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.types.Types;
 
 public class BasePartitionStatisticsScan implements PartitionStatisticsScan {
@@ -65,7 +66,7 @@ public class BasePartitionStatisticsScan implements PartitionStatisticsScan {
     Optional<PartitionStatisticsFile> statsFile =
         table.partitionStatisticsFiles().stream()
             .filter(f -> f.snapshotId() == snapshotId)
-            .findFirst();
+            .collect(MoreCollectors.toOptional());
 
     if (statsFile.isEmpty()) {
       return CloseableIterable.empty();

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -78,6 +78,7 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.requests.CreateNamespaceRequest;
@@ -599,7 +600,7 @@ public class CatalogHandlers {
         request.updates().stream()
             .filter(update -> update instanceof UpgradeFormatVersion)
             .map(update -> ((UpgradeFormatVersion) update).formatVersion())
-            .findFirst();
+            .collect(MoreCollectors.toOptional());
 
     TableMetadata.Builder builder =
         formatVersion.map(TableMetadata::buildFromEmpty).orElseGet(TableMetadata::buildFromEmpty);

--- a/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/PropertyUtil.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -221,7 +222,10 @@ public class PropertyUtil {
           .forEach(
               key -> {
                 String prefix =
-                    columnProperties.stream().filter(key::startsWith).findFirst().orElse(null);
+                    columnProperties.stream()
+                        .filter(key::startsWith)
+                        .collect(MoreCollectors.toOptional())
+                        .orElse(null);
 
                 if (prefix != null) {
                   String columnAlias = key.replaceFirst(prefix, "");

--- a/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SortOrderUtil.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.transforms.SortOrderVisitor;
 
 public class SortOrderUtil {
@@ -59,7 +60,7 @@ public class SortOrderUtil {
   public static SortOrder findTableSortOrder(Table table, SortOrder userSuppliedSortOrder) {
     return table.sortOrders().values().stream()
         .filter(sortOrder -> sortOrder.sameOrder(userSuppliedSortOrder))
-        .findFirst()
+        .collect(MoreCollectors.toOptional())
         .orElseGet(SortOrder::unsorted);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.TestTemplate;
@@ -323,8 +324,7 @@ public class TestRemoveSnapshots extends TestBase {
             Sets.newHashSet(
                 secondSnapshot.manifestListLocation(), // snapshot expired
                 secondSnapshotManifests.stream()
-                    .findFirst()
-                    .get()
+                    .collect(MoreCollectors.onlyElement())
                     .path(), // manifest is no longer referenced
                 FILE_B.location()) // added, but rolled back
             );

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotLoading.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -101,7 +102,9 @@ public class TestSnapshotLoading extends TestBase {
   @TestTemplate
   public void testUnloadedSnapshotLoadsOnce() {
     Snapshot unloadedSnapshot =
-        allSnapshots.stream().filter(s -> !s.equals(currentSnapshot)).findFirst().get();
+        allSnapshots.stream()
+            .filter(s -> !s.equals(currentSnapshot))
+            .collect(MoreCollectors.onlyElement());
 
     latestTableMetadata.snapshot(unloadedSnapshot.snapshotId());
     latestTableMetadata.snapshot(unloadedSnapshot.snapshotId());
@@ -168,7 +171,9 @@ public class TestSnapshotLoading extends TestBase {
   @TestTemplate
   public void testRemovedRefSnapshotFails() {
     Snapshot referencedSnapshot =
-        allSnapshots.stream().filter(Predicate.isEqual(currentSnapshot).negate()).findFirst().get();
+        allSnapshots.stream()
+            .filter(Predicate.isEqual(currentSnapshot).negate())
+            .collect(MoreCollectors.onlyElement());
 
     TableMetadata tableMetadata =
         TableMetadata.buildFrom(originalTableMetadata)

--- a/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
+++ b/core/src/test/java/org/apache/iceberg/TestWapWorkflow.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import org.apache.iceberg.exceptions.CherrypickAncestorCommitException;
 import org.apache.iceberg.exceptions.DuplicateWAPCommitException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -49,8 +50,7 @@ public class TestWapWorkflow extends TestBase {
     Snapshot overwrite =
         Streams.stream(table.snapshots())
             .filter(snap -> DataOperations.OVERWRITE.equals(snap.operation()))
-            .findFirst()
-            .get();
+            .collect(MoreCollectors.onlyElement());
 
     // cherry-pick the overwrite; this works because it is a fast-forward commit
     table.manageSnapshots().cherrypick(overwrite.snapshotId()).commit();
@@ -74,8 +74,7 @@ public class TestWapWorkflow extends TestBase {
     Snapshot overwrite =
         Streams.stream(table.snapshots())
             .filter(snap -> DataOperations.OVERWRITE.equals(snap.operation()))
-            .findFirst()
-            .get();
+            .collect(MoreCollectors.onlyElement());
 
     // try to cherry-pick, which should fail because the overwrite's parent is no longer current
     assertThatThrownBy(() -> table.manageSnapshots().cherrypick(overwrite.snapshotId()).commit())

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -95,6 +95,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.MoreCollectors;
 import org.apache.iceberg.rest.HTTPRequest.HTTPMethod;
 import org.apache.iceberg.rest.RESTCatalogProperties.SnapshotMode;
 import org.apache.iceberg.rest.auth.AuthManager;
@@ -2612,7 +2613,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Optional<MetadataUpdate> appendSnapshot =
                   body.updates().stream()
                       .filter(update -> update instanceof MetadataUpdate.AddSnapshot)
-                      .findFirst();
+                      .collect(MoreCollectors.toOptional());
 
               assertThat(appendSnapshot).isPresent();
               MetadataUpdate.AddSnapshot addSnapshot =
@@ -2659,7 +2660,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Optional<MetadataUpdate> appendSnapshot =
                   body.updates().stream()
                       .filter(update -> update instanceof MetadataUpdate.AddSnapshot)
-                      .findFirst();
+                      .collect(MoreCollectors.toOptional());
               assertThat(appendSnapshot).isPresent();
 
               MetadataUpdate.AddSnapshot addSnapshot =
@@ -2725,7 +2726,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                       body.updates().stream()
                           .filter(MetadataUpdate.AddSnapshot.class::isInstance)
                           .map(MetadataUpdate.AddSnapshot.class::cast)
-                          .findFirst())
+                          .collect(MoreCollectors.toOptional()))
                   .hasValueSatisfying(
                       addSnapshot -> {
                         String manifestListLocation = addSnapshot.snapshot().manifestListLocation();
@@ -2771,7 +2772,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Optional<MetadataUpdate> appendSnapshot =
                   request.updates().stream()
                       .filter(update -> update instanceof MetadataUpdate.AddSnapshot)
-                      .findFirst();
+                      .collect(MoreCollectors.toOptional());
 
               assertThat(appendSnapshot).isPresent();
               MetadataUpdate.AddSnapshot addSnapshot =
@@ -2814,7 +2815,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
               Optional<MetadataUpdate> appendSnapshot =
                   request.updates().stream()
                       .filter(update -> update instanceof MetadataUpdate.AddSnapshot)
-                      .findFirst();
+                      .collect(MoreCollectors.toOptional());
               assertThat(appendSnapshot).isPresent();
 
               MetadataUpdate.AddSnapshot addSnapshot =
@@ -3077,11 +3078,9 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                     (MetadataUpdate.AddSnapshot)
                         req.updates().stream()
                             .filter(u -> u instanceof MetadataUpdate.AddSnapshot)
-                            .findFirst()
-                            .orElseThrow())
+                            .collect(MoreCollectors.onlyElement()))
             .map(add -> add.snapshot().snapshotId())
-            .findFirst()
-            .orElseThrow();
+            .collect(MoreCollectors.onlyElement());
 
     Table reloaded = catalog.loadTable(TABLE);
     assertThat(reloaded.currentSnapshot()).isNotNull();


### PR DESCRIPTION
The existing `findFirst` silently hides multiple matching elements.

This PR replaces it with Guava [MoreCollectors](https://www.javadoc.io/doc/com.google.guava/guava/latest/com/google/common/collect/MoreCollectors.html):

onlyElement method: 
> A collector that takes a stream containing exactly one element and returns that element. The returned collector throws an IllegalArgumentException if the stream consists of two or more elements, and a NoSuchElementException if the stream is empty.

toOptional method: 
> A collector that converts a stream of zero or one elements to an Optional.
> Throws: IllegalArgumentException - if the stream consists of two or more elements.
> Throws: NullPointerException - if any element in the stream is null.

I only updated a few places to demonstrate how to use them. 