### PR TITLE
Release: Add semi-automated release pipeline

### DIFF
--- a/.github/workflows/ci-release-scripts.yml
+++ b/.github/workflows/ci-release-scripts.yml
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Release Scripts CI
+
+on:
+  pull_request:
+    paths:
+      - 'release/**'
+      - '.github/workflows/release-*.yml'
+      - '.github/workflows/ci-release-scripts.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'release/**'
+      - '.github/workflows/release-*.yml'
+      - '.github/workflows/ci-release-scripts.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  bats:
+    name: Release Script Unit Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install bats-core and jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y bats jq
+
+      - name: Configure Git identity for tests
+        run: |
+          git config --global user.name "CI"
+          git config --global user.email "ci@test"
+
+      - name: Run bats tests
+        run: bats release/tests/*.bats
+
+      - name: Verify scripts are executable
+        run: |
+          for script in release/*.sh; do
+            if [[ ! -x "$script" ]]; then
+              echo "ERROR: $script is not executable"
+              exit 1
+            fi
+          done
+          echo "All scripts are executable"
+
+      - name: Lint shell scripts with shellcheck
+        run: |
+          sudo apt-get install -y shellcheck
+          shellcheck --severity=warning release/*.sh release/libs/*.sh

--- a/.github/workflows/release-cancel-rc.yml
+++ b/.github/workflows/release-cancel-rc.yml
@@ -1,0 +1,93 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Release - Cancel RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.10.0)'
+        required: true
+        type: string
+      rc_number:
+        description: 'RC number to cancel (e.g., 0)'
+        required: true
+        type: string
+      staging_repo_id:
+        description: 'Nexus staging repository ID to drop (e.g., orgapacheiceberg-1234)'
+        required: true
+        type: string
+      allow_description_mismatch:
+        description: 'Allow Nexus staging repo description to not match "Apache Iceberg <version> RC<num>" (use only after manual recovery)'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Dry run mode (uncheck for actual cancellation)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iceberg-release
+  cancel-in-progress: false
+
+jobs:
+  cancel-rc:
+    if: github.repository_owner == 'apache'
+    name: Cancel Release Candidate
+    runs-on: ubuntu-24.04
+    environment: maven-publish
+    permissions:
+      contents: read
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install Subversion and jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion jq
+
+      - name: Cancel Release Candidate
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PW }}
+          SVN_USERNAME: ${{ secrets.ICEBERG_SVN_DEV_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.ICEBERG_SVN_DEV_PASSWORD }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RC_NUMBER: ${{ inputs.rc_number }}
+          INPUT_STAGING_REPO_ID: ${{ inputs.staging_repo_id }}
+          INPUT_ALLOW_DESC_MISMATCH: ${{ inputs.allow_description_mismatch && '1' || '0' }}
+        run: |
+          args=("${INPUT_VERSION}" "${INPUT_RC_NUMBER}" "${INPUT_STAGING_REPO_ID}")
+          if [[ "${INPUT_ALLOW_DESC_MISMATCH}" == "1" ]]; then
+            args+=(--allow-description-mismatch)
+          fi
+          ./release/cancel-rc.sh "${args[@]}"

--- a/.github/workflows/release-prepare-rc.yml
+++ b/.github/workflows/release-prepare-rc.yml
@@ -1,0 +1,113 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Release - Prepare RC
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.10.0)'
+        required: true
+        type: string
+      rc_number:
+        description: 'RC number override (leave empty for auto-detect)'
+        required: false
+        type: string
+        default: ''
+      dry_run:
+        description: 'Dry run mode (uncheck for actual release)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iceberg-release
+  cancel-in-progress: false
+
+jobs:
+  prepare-rc:
+    if: github.repository_owner == 'apache'
+    name: Prepare Release Candidate
+    runs-on: ubuntu-24.04
+    environment: maven-publish
+    permissions:
+      contents: write  # push the X.Y.x release branch and the apache-iceberg-X.Y.Z-rcN tag
+      checks: read  # check_github_checks_passed reads check-runs for the release-branch HEAD
+    timeout-minutes: 240
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
+        with:
+          distribution: zulu
+          java-version: 17
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5 # zizmor: ignore[cache-poisoning] -- cache writes are restricted to the default branch by setup-gradle
+
+      - name: Install Subversion
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion jq
+
+      - name: Import GPG key and configure git identity
+        env:
+          GPG_PRIVATE_KEY: ${{ secrets.ICEBERG_GPG_PRIVATE_KEY }}
+        run: |
+          if [[ -z "${GPG_PRIVATE_KEY:-}" ]]; then
+            echo "ICEBERG_GPG_PRIVATE_KEY secret is not set; aborting"
+            exit 1
+          fi
+          echo "${GPG_PRIVATE_KEY}" | gpg --batch --import
+          KEY_ID=$(gpg --list-secret-keys --with-colons | awk -F: '/^sec:/ {print $5; exit}')
+          if [[ -z "${KEY_ID}" ]]; then
+            echo "Could not determine GPG key id from imported key; aborting"
+            exit 1
+          fi
+          echo "GPG_KEY_ID=${KEY_ID}" >> "$GITHUB_ENV"
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.signingkey "${KEY_ID}"
+
+      - name: Prepare Release Candidate
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PW }}
+          SVN_USERNAME: ${{ secrets.ICEBERG_SVN_DEV_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.ICEBERG_SVN_DEV_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RC_NUMBER: ${{ inputs.rc_number }}
+        run: |
+          args=("${INPUT_VERSION}" --key "${GPG_KEY_ID}")
+          if [[ -n "${INPUT_RC_NUMBER}" ]]; then
+            args+=(--rc "${INPUT_RC_NUMBER}")
+          fi
+          ./release/prepare-rc.sh "${args[@]}"

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,0 +1,103 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+name: Release - Publish After Vote
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g., 1.10.0)'
+        required: true
+        type: string
+      rc_number:
+        description: 'RC number that passed the vote (leave empty to auto-detect latest)'
+        required: false
+        type: string
+        default: ''
+      staging_repo_id:
+        description: 'Nexus staging repository ID (e.g., orgapacheiceberg-1234)'
+        required: true
+        type: string
+      allow_description_mismatch:
+        description: 'Allow Nexus staging repo description to not match "Apache Iceberg <version> RC<num>" (use only after manual recovery)'
+        required: false
+        type: boolean
+        default: false
+      dry_run:
+        description: 'Dry run mode (uncheck for actual publication)'
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: iceberg-release
+  cancel-in-progress: false
+
+jobs:
+  publish-release:
+    if: github.repository_owner == 'apache'
+    name: Publish Release
+    runs-on: ubuntu-24.04
+    environment: maven-publish
+    permissions:
+      contents: write
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Subversion and jq
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y subversion jq
+
+      - name: Configure Git identity
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Publish Release
+        env:
+          DRY_RUN: ${{ inputs.dry_run && '1' || '0' }}
+          NEXUS_USERNAME: ${{ secrets.NEXUS_USER }}
+          NEXUS_PASSWORD: ${{ secrets.NEXUS_PW }}
+          SVN_USERNAME: ${{ secrets.ICEBERG_SVN_DEV_USERNAME }}
+          SVN_PASSWORD: ${{ secrets.ICEBERG_SVN_DEV_PASSWORD }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_RC_NUMBER: ${{ inputs.rc_number }}
+          INPUT_STAGING_REPO_ID: ${{ inputs.staging_repo_id }}
+          INPUT_ALLOW_DESC_MISMATCH: ${{ inputs.allow_description_mismatch && '1' || '0' }}
+        run: |
+          args=("${INPUT_VERSION}" "${INPUT_STAGING_REPO_ID}")
+          if [[ -n "${INPUT_RC_NUMBER}" ]]; then
+            args+=(--rc "${INPUT_RC_NUMBER}")
+          fi
+          if [[ "${INPUT_ALLOW_DESC_MISMATCH}" == "1" ]]; then
+            args+=(--allow-description-mismatch)
+          fi
+          ./release/publish-release.sh "${args[@]}"

--- a/release/cancel-rc.sh
+++ b/release/cancel-rc.sh
@@ -1,0 +1,222 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBS_DIR="${SCRIPT_DIR}/libs"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+# shellcheck source=release/libs/_version.sh
+source "${LIBS_DIR}/_version.sh"
+# shellcheck source=release/libs/_nexus.sh
+source "${LIBS_DIR}/_nexus.sh"
+# shellcheck source=release/libs/_svn.sh
+source "${LIBS_DIR}/_svn.sh"
+
+function usage {
+  cat <<EOF
+Usage: $0 <version> <rc-num> <staging-repo-id> [--allow-description-mismatch]
+
+Cancel an Apache Iceberg release candidate after a failed vote.
+
+This drops the Nexus staging repo and removes the RC artifacts from the
+SVN dist/dev tree. The RC git tag is intentionally left in place: Apache
+release policy is to leave failed RC tags as a permanent record, and the
+next prepare-rc invocation will pick the next RC number automatically.
+
+Arguments:
+  version                          Release version (e.g., 1.10.0)
+  rc-num                           RC number to cancel (e.g., 0)
+  staging-repo-id                  Nexus staging repository ID (e.g., orgapacheiceberg-1234)
+
+Options:
+  --allow-description-mismatch     Continue even if the staging repo description does not match
+                                   "Apache Iceberg <version> RC<rc-num>". Useful only if the
+                                   description was edited via the Nexus UI during recovery.
+  --help, -h                       Show this help
+
+Environment variables:
+  DRY_RUN               Set to 0 for real execution (default: 1)
+  NEXUS_USERNAME        Apache Nexus username
+  NEXUS_PASSWORD        Apache Nexus password
+  SVN_USERNAME          SVN username for dist.apache.org
+  SVN_PASSWORD          SVN password
+
+Example:
+  DRY_RUN=1 $0 1.10.0 0 orgapacheiceberg-1234
+EOF
+  exit "${1:-0}"
+}
+
+allow_description_mismatch=0
+positional=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --allow-description-mismatch)
+      allow_description_mismatch=1
+      shift
+      ;;
+    --help|-h)
+      usage 0
+      ;;
+    -*)
+      print_error "Unknown option: $1"
+      usage 1
+      ;;
+    *)
+      positional+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#positional[@]} -ne 3 ]]; then
+  print_error "Expected 3 positional arguments (version, rc-num, staging-repo-id), got ${#positional[@]}"
+  usage 1
+fi
+
+version="${positional[0]}"
+rc_num="${positional[1]}"
+staging_repo_id="${positional[2]}"
+
+# ---------------------------------------------------------------------------
+# Validate inputs
+# ---------------------------------------------------------------------------
+step_summary "## Release Candidate Cancellation"
+step_summary ""
+
+if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+  step_summary "> **DRY RUN** -- no changes will be made"
+  step_summary ""
+fi
+
+if ! validate_and_extract_version "${version}"; then
+  print_error "Invalid version format: '${version}'"
+  exit 1
+fi
+
+if ! [[ "${rc_num}" =~ ^[0-9]+$ ]]; then
+  print_error "Invalid RC number: '${rc_num}'. Expected a non-negative integer."
+  exit 1
+fi
+
+if ! [[ "${staging_repo_id}" =~ ^[a-zA-Z][a-zA-Z0-9._-]*$ ]]; then
+  print_error "Invalid staging repository ID: '${staging_repo_id}'. Expected alphanumeric with dots/hyphens (e.g., orgapacheiceberg-1234)."
+  exit 1
+fi
+
+rc_tag="${TAG_PREFIX}${version}-rc${rc_num}"
+
+step_summary "| Parameter | Value |"
+step_summary "| --- | --- |"
+step_summary "| Version | \`${version}\` |"
+step_summary "| RC tag | \`${rc_tag}\` |"
+step_summary "| Staging repo | \`${staging_repo_id}\` |"
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify the Nexus staging repository matches this RC
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Staging Repository Verification"
+
+if ! nexus_verify_staging_repo "${staging_repo_id}" "${version}" "${rc_num}"; then
+  step_summary "Staging repo verification: **FAILED**"
+  exit 1
+fi
+step_summary "Staging repo verification: **PASSED**"
+
+# ---------------------------------------------------------------------------
+# Step 2: Drop the Nexus staging repo
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Nexus Cleanup"
+
+nexus_drop_staging_repo "${staging_repo_id}" "Cancel Apache Iceberg ${version} RC${rc_num}"
+
+step_summary "Dropped staging repository \`${staging_repo_id}\`"
+
+# ---------------------------------------------------------------------------
+# Step 3: Remove the RC artifacts from SVN dist/dev
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### SVN Cleanup"
+
+dev_url="${APACHE_DIST_URL}${APACHE_DIST_DEV_PATH}/${rc_tag}"
+
+if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+  if svn_path_exists "${dev_url}"; then
+    svn_run rm "${dev_url}" -m "Cancel Apache Iceberg ${version} RC${rc_num}"
+    step_summary "Deleted \`${dev_url}\`"
+  else
+    print_warning "SVN directory not found: ${dev_url}"
+    step_summary "Directory not found at \`${dev_url}\` (may already be deleted)"
+  fi
+else
+  print_command "Dry-run, WOULD delete ${dev_url}"
+  step_summary "Would delete \`${dev_url}\` (dry-run)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Generate the vote-failure email template
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Vote Failure Email"
+step_summary ""
+step_summary '```'
+step_summary "To: dev@iceberg.apache.org"
+step_summary "Subject: [RESULT][VOTE] Release Apache Iceberg ${version} RC${rc_num}"
+step_summary ""
+step_summary "Hello everyone,"
+step_summary ""
+step_summary "Thanks to all who participated in the vote for Release Apache Iceberg ${version} RC${rc_num}."
+step_summary ""
+step_summary "The vote result is:"
+step_summary ""
+step_summary "+1: a (binding), b (non-binding)"
+step_summary "+0: c (binding), d (non-binding)"
+step_summary "-1: e (binding), f (non-binding)"
+step_summary ""
+step_summary "The vote failed due to [REASON - TO BE FILLED BY RELEASE MANAGER]."
+step_summary ""
+step_summary "A new release candidate will be proposed soon once the issues are addressed."
+step_summary ""
+step_summary "Thanks,"
+step_summary '```'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "---"
+step_summary "### Summary"
+step_summary ""
+step_summary "| Step | Status |"
+step_summary "| --- | --- |"
+step_summary "| Nexus staging repo | dropped |"
+step_summary "| SVN dist/dev | deleted |"
+step_summary "| Failure email | generated |"
+
+print_success "Release candidate ${rc_tag} cancelled successfully."

--- a/release/libs/_constants.sh
+++ b/release/libs/_constants.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# Constants are referenced from sibling scripts via `source`, so shellcheck
+# can't see their use sites when analyzing this file in isolation.
+# shellcheck disable=SC2034
+[[ -n "${_CONSTANTS_LOADED:-}" ]] && return 0 2>/dev/null || true
+_CONSTANTS_LOADED=1
+
+# Tag prefix for git tags. Iceberg uses "apache-iceberg-X.Y.Z" and
+# "apache-iceberg-X.Y.Z-rcN".
+TAG_PREFIX="apache-iceberg-"
+
+# Branch suffix convention. Iceberg uses bare "X.Y.x" branches
+# (e.g. "1.10.x") for patch releases. New minor versions are typically
+# cut from main.
+BRANCH_SUFFIX=".x"
+
+# Apache distribution SVN paths.
+APACHE_DIST_URL=${APACHE_DIST_URL:-"https://dist.apache.org/repos/dist"}
+APACHE_DIST_DEV_PATH="/dev/iceberg"
+APACHE_DIST_RELEASE_PATH="/release/iceberg"
+
+# Apache Nexus staging API.
+NEXUS_BASE_URL=${NEXUS_BASE_URL:-"https://repository.apache.org/service/local"}
+NEXUS_STAGING_GROUP_URL="https://repository.apache.org/content/groups/staging/org/apache/iceberg/"
+
+# Iceberg Maven coordinates group used to locate the open Nexus staging repo.
+NEXUS_STAGING_PROFILE="org.apache.iceberg"
+
+# Default to dry-run so a misconfigured workflow cannot accidentally publish.
+DRY_RUN=${DRY_RUN:-1}
+
+# Version regexes.
+VERSION_REGEX="([0-9]+)\.([0-9]+)\.([0-9]+)"
+VERSION_REGEX_GIT_TAG="^${TAG_PREFIX}${VERSION_REGEX}-rc([0-9]+)$"
+VERSION_REGEX_FINAL_TAG="^${TAG_PREFIX}${VERSION_REGEX}$"
+BRANCH_VERSION_REGEX="^([0-9]+)\.([0-9]+)\.x$"
+
+GITHUB_REPO=${GITHUB_REPOSITORY:-"apache/iceberg"}
+
+# ---------------------------------------------------------------------------
+# Convenience binary build matrix
+# ---------------------------------------------------------------------------
+#
+# Sourced directly from gradle.properties so the release pipeline cannot
+# drift from the build's own notion of supported versions. Update
+# gradle.properties; this script picks up the change automatically.
+GRADLE_PROPERTIES_FILE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)/gradle.properties"
+
+# Reads a single property from gradle.properties. Accepts either
+# `<key>=<value>` or `systemProp.<key>=<value>` forms; comments and leading
+# whitespace are tolerated. Echoes the trimmed value on success; returns 1
+# if the key is absent or the file is unreadable.
+function _parse_gradle_property {
+  local key="$1"
+  local file="${2:-${GRADLE_PROPERTIES_FILE}}"
+  if [[ ! -r "${file}" ]]; then
+    return 1
+  fi
+
+  local line
+  line=$(grep -E "^[[:space:]]*(systemProp\.)?${key}[[:space:]]*=" "${file}" | head -n1)
+  if [[ -z "${line}" ]]; then
+    return 1
+  fi
+
+  local value="${line#*=}"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s\n' "${value}"
+}
+
+# Like _parse_gradle_property but exits if the key is missing or empty.
+# Used at module-load time to fail fast on a misconfigured build.
+function _require_gradle_property {
+  local key="$1"
+  local value
+  if ! value=$(_parse_gradle_property "${key}"); then
+    echo "ERROR: required key '${key}' not found in ${GRADLE_PROPERTIES_FILE}" >&2
+    exit 1
+  fi
+  if [[ -z "${value}" ]]; then
+    echo "ERROR: key '${key}' in ${GRADLE_PROPERTIES_FILE} has empty value" >&2
+    exit 1
+  fi
+  printf '%s\n' "${value}"
+}
+
+# Full known matrix mirrored from systemProp.knownXxxVersions.
+KNOWN_SCALA_VERSIONS=$(_require_gradle_property knownScalaVersions)
+KNOWN_FLINK_VERSIONS=$(_require_gradle_property knownFlinkVersions)
+KNOWN_SPARK_VERSIONS=$(_require_gradle_property knownSparkVersions)
+KNOWN_KAFKA_VERSIONS=$(_require_gradle_property knownKafkaVersions)
+
+# Primary Scala for the main publish pass: the build's default Scala.
+SCALA_PRIMARY=$(_require_gradle_property defaultScalaVersion)
+
+# Secondary Scala = the other entry in knownScalaVersions. The release
+# pipeline runs a follow-up Spark-only pass against this Scala for the
+# Spark versions that ship dual-Scala builds.
+SCALA_SECONDARY=""
+for _v in $(echo "${KNOWN_SCALA_VERSIONS}" | tr ',' ' '); do
+  if [[ "${_v}" != "${SCALA_PRIMARY}" ]]; then
+    SCALA_SECONDARY="${_v}"
+    break
+  fi
+done
+unset _v
+if [[ -z "${SCALA_SECONDARY}" ]]; then
+  echo "ERROR: knownScalaVersions (${KNOWN_SCALA_VERSIONS}) must contain a non-default entry to use as the secondary Scala" >&2
+  exit 1
+fi
+
+# Spark versions to include in the primary-Scala main publish pass. Spark
+# 4.x dropped Scala 2.12 support, so a `-DscalaVersion=2.12 -DsparkVersions=4.x`
+# invocation either fails the build or silently ignores the requested
+# Scala (Iceberg's spark/v4.x/build.gradle hardcodes scalaVersion='2.13'
+# internally). Filter Spark to those versions that actually support the
+# primary Scala. Today: Spark X.Y where X < 4.
+SPARK_VERSIONS_PRIMARY_SCALA=""
+for _v in $(echo "${KNOWN_SPARK_VERSIONS}" | tr ',' ' '); do
+  if [[ "${_v%%.*}" -lt 4 ]]; then
+    if [[ -n "${SPARK_VERSIONS_PRIMARY_SCALA}" ]]; then
+      SPARK_VERSIONS_PRIMARY_SCALA="${SPARK_VERSIONS_PRIMARY_SCALA},"
+    fi
+    SPARK_VERSIONS_PRIMARY_SCALA="${SPARK_VERSIONS_PRIMARY_SCALA}${_v}"
+  fi
+done
+unset _v
+
+# Spark versions to publish against the secondary Scala. Every Spark
+# version in the known matrix ships a Scala 2.13 build, so the secondary
+# pass covers all of them: Spark 3.x to add the 2.13 variant alongside
+# 2.12, and Spark 4.x because the primary pass intentionally excludes it.
+SPARK_VERSIONS_SECONDARY_SCALA="${KNOWN_SPARK_VERSIONS}"

--- a/release/libs/_exec.sh
+++ b/release/libs/_exec.sh
@@ -1,0 +1,110 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_EXEC_LOADED:-}" ]] && return 0 2>/dev/null || true
+_EXEC_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "$LIBS_DIR/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "$LIBS_DIR/_log.sh"
+
+# Replaces secret values with *** in a command string before logging it.
+# The redaction list mirrors every secret env var used by the release scripts
+# and workflows; add new ones here when introducing additional credentials.
+function _redact_secrets {
+  local cmd_str="$*"
+  local secret_var
+  for secret_var in NEXUS_PASSWORD NEXUS_USERNAME SVN_PASSWORD SVN_USERNAME GITHUB_TOKEN ICEBERG_NEXUS_PASSWORD ICEBERG_NEXUS_USER ICEBERG_SVN_DEV_PASSWORD ICEBERG_SVN_DEV_USERNAME ORG_GRADLE_PROJECT_mavenUser ORG_GRADLE_PROJECT_mavenPassword; do
+    local secret_val="${!secret_var:-}"
+    if [[ -n "${secret_val}" ]]; then
+      cmd_str="${cmd_str//${secret_val}/***}"
+    fi
+  done
+  echo "${cmd_str}"
+}
+
+# Runs a command in real mode, prints what it would have done in dry-run mode.
+# Always logs a redacted form of the command. Exit status is preserved so
+# callers can react to failures.
+function exec_process {
+  local redacted
+  redacted=$(_redact_secrets "$@")
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    print_command "Executing '${redacted}'"
+    "$@"
+  else
+    print_command "Dry-run, WOULD execute '${redacted}'"
+  fi
+}
+
+# Retries a command up to max_attempts times. Between failed attempts the
+# given cleanup_path (typically a partially-written checkout dir) is removed
+# so the next attempt starts from a clean state. Apache SVN occasionally
+# returns transient connection failures during checkout/commit, which is
+# why this helper exists.
+function exec_process_with_retries {
+  if [[ $# -lt 4 ]]; then
+    echo "ERROR: exec_process_with_retries requires: max_attempts sleep_duration cleanup_path command [args...]"
+    exit 1
+  fi
+
+  local max_attempts="${1}"
+  local sleep_duration="${2}"
+  local cleanup_path="${3}"
+  shift 3
+
+  local attempt=1
+  local redacted
+  redacted=$(_redact_secrets "$@")
+  while true; do
+    if exec_process "$@"; then
+      break
+    fi
+    if [[ $attempt -ge $max_attempts ]]; then
+      echo "ERROR: Command failed after ${max_attempts} attempts: ${redacted}"
+      exit 1
+    fi
+    echo "WARNING: Command failed (attempt ${attempt}/${max_attempts}), retrying in ${sleep_duration} seconds..."
+    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]]; then
+      rm -rf "${cleanup_path}"
+    fi
+    sleep "${sleep_duration}"
+    ((attempt++))
+  done
+}
+
+# Writes "<sha512>  <basename>" to <source_file>.sha512. Done in a subshell
+# so the relative basename (rather than the full path) is recorded, matching
+# the format consumed by `shasum -c`.
+function calculate_sha512 {
+  local source_file="$1"
+  local source_dir source_base
+  source_dir="$(dirname "${source_file}")"
+  source_base="$(basename "${source_file}")"
+  local target_file="${source_file}.sha512"
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    (cd "${source_dir}" && shasum -a 512 "${source_base}") > "${target_file}"
+  else
+    print_command "Dry-run, WOULD run: cd ${source_dir} && shasum -a 512 ${source_base} > ${target_file}"
+  fi
+}

--- a/release/libs/_github.sh
+++ b/release/libs/_github.sh
@@ -1,0 +1,85 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_GITHUB_LOADED:-}" ]] && return 0 2>/dev/null || true
+_GITHUB_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+
+# Returns 0 only when every check-run on the given commit has completed
+# (status == "completed") and concluded with success or skipped. Cutting an
+# RC from a commit with failing or in-progress CI is a clear bug, so this is
+# wired up as a hard gate in prepare-rc.sh. In dry-run mode the check is
+# skipped so the script can be exercised against any commit.
+function check_github_checks_passed() {
+  local commit_sha="$1"
+
+  print_info "Checking GitHub CI status for commit ${commit_sha}..."
+
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_info "DRY_RUN is enabled, skipping GitHub check verification"
+    return 0
+  fi
+
+  if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+    print_error "GITHUB_TOKEN is required to verify CI checks"
+    return 1
+  fi
+
+  local repo_info="${GITHUB_REPO}"
+
+  local num_incomplete
+  if ! num_incomplete=$(gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
+    --jq '[.check_runs[] | select(.status != "completed")] | length'); then
+    print_error "Failed to fetch GitHub check runs for commit ${commit_sha}"
+    return 1
+  fi
+
+  if [[ ${num_incomplete} -ne 0 ]]; then
+    print_error "Found ${num_incomplete} still-running GitHub checks for commit ${commit_sha}"
+    gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
+      --jq '.check_runs[] | select(.status != "completed") | "  - \(.name): \(.status)"' >&2
+    return 1
+  fi
+
+  local num_failed
+  if ! num_failed=$(gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
+    --jq '[.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped")] | length'); then
+    print_error "Failed to fetch GitHub check runs for commit ${commit_sha}"
+    return 1
+  fi
+
+  if [[ ${num_failed} -ne 0 ]]; then
+    print_error "Found ${num_failed} failed GitHub checks for commit ${commit_sha}"
+    gh api "repos/${repo_info}/commits/${commit_sha}/check-runs" \
+      --jq '.check_runs[] | select(.conclusion != "success" and .conclusion != "skipped") | "  - \(.name): \(.conclusion)"' >&2
+    return 1
+  fi
+
+  print_info "All GitHub checks passed for commit ${commit_sha}"
+  return 0
+}

--- a/release/libs/_gradle.sh
+++ b/release/libs/_gradle.sh
@@ -1,0 +1,191 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_GRADLE_LOADED:-}" ]] && return 0 2>/dev/null || true
+_GRADLE_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+
+# Verifies the JDK on PATH is exactly Java 17. Iceberg's deploy.gradle
+# enforces this for `-Prelease` builds, so we fail early with a clearer
+# message before invoking gradlew.
+function verify_jdk_17 {
+  if ! command -v java &>/dev/null; then
+    print_error "java not found on PATH; release builds require JDK 17"
+    return 1
+  fi
+
+  local java_version
+  java_version=$(java -version 2>&1 | head -1 | sed -E 's/.*version "([^"]+)".*/\1/')
+  local major
+  if [[ "${java_version}" =~ ^1\.([0-9]+) ]]; then
+    major="${BASH_REMATCH[1]}"
+  elif [[ "${java_version}" =~ ^([0-9]+) ]]; then
+    major="${BASH_REMATCH[1]}"
+  else
+    print_error "Could not parse Java version: ${java_version}"
+    return 1
+  fi
+
+  if [[ "${major}" != "17" ]]; then
+    print_error "Iceberg releases must be built with Java 17 (deploy.gradle enforces this); detected ${java_version}"
+    return 1
+  fi
+  return 0
+}
+
+# Builds the source release tarball.
+#
+# Mirrors dev/source-release.sh exactly so the produced tarball is
+# byte-compatible with a manual release. Specifically:
+#   1. Writes <projectdir>/version.txt containing the release version.
+#   2. Runs `./gradlew generateGitProperties` to produce
+#      build/iceberg-build.properties for the current git state.
+#   3. Copies that file to <projectdir>/iceberg-build.properties so it can
+#      be picked up by `git archive --add-file`.
+#   4. Runs `git archive --worktree-attributes --prefix <tag>/
+#                       --add-file version.txt --add-file iceberg-build.properties`
+#      against the release commit.
+#   5. Removes the temporary version.txt and iceberg-build.properties so
+#      the working tree is left clean.
+#   6. GPG-signs the tarball (armored, detached) and writes the .sha512.
+#
+# Args:
+#   $1: project root (absolute path)
+#   $2: tag prefix without -rcN (e.g. "apache-iceberg-1.10.0")
+#   $3: release commit SHA
+#   $4: version (e.g. "1.10.0")
+#   $5: optional GPG key id to use; defaults to gpg's default key
+#
+# After success, the tarball, .asc, and .sha512 are present at
+# ${projectdir}/${tag}.tar.gz and friends.
+function build_source_tarball {
+  local projectdir="$1"
+  local tag="$2"
+  local release_hash="$3"
+  local version="$4"
+  local keyid="${5:-}"
+
+  local tarball="${tag}.tar.gz"
+
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_command "Dry-run, WOULD build source tarball ${projectdir}/${tarball} from ${release_hash}"
+    return 0
+  fi
+
+  print_info "Generating version.txt and iceberg-build.properties..."
+  echo "${version}" > "${projectdir}/version.txt"
+  (cd "${projectdir}" && ./gradlew generateGitProperties)
+  cp "${projectdir}/build/iceberg-build.properties" "${projectdir}/iceberg-build.properties"
+
+  print_info "Creating tarball ${tarball} using commit ${release_hash}"
+  (cd "${projectdir}" && \
+    git archive "${release_hash}" \
+      --worktree-attributes \
+      --prefix "${tag}/" \
+      --add-file "${projectdir}/version.txt" \
+      --add-file "${projectdir}/iceberg-build.properties" \
+      -o "${projectdir}/${tarball}")
+
+  rm -f "${projectdir}/version.txt" "${projectdir}/iceberg-build.properties"
+
+  print_info "Signing the tarball..."
+  local gpg_args=(--armor --output "${projectdir}/${tarball}.asc" --detach-sig "${projectdir}/${tarball}")
+  if [[ -n "${keyid}" ]]; then
+    gpg -u "${keyid}" "${gpg_args[@]}"
+  else
+    gpg "${gpg_args[@]}"
+  fi
+
+  print_info "Generating SHA-512 checksum..."
+  (cd "${projectdir}" && shasum -a 512 "${tarball}") > "${projectdir}/${tarball}.sha512"
+}
+
+# Stages convenience binaries to Nexus. Two Gradle passes:
+#
+#   1. Primary-Scala main pass: full Flink/Kafka matrix + the Spark
+#      versions that still support the primary Scala (today: Spark 3.x).
+#      Spark 4.x is intentionally excluded because it dropped Scala 2.12.
+#   2. Secondary-Scala (Spark-only) sweep: one invocation per Spark
+#      version in the known matrix, publishing the spark / spark-extensions
+#      / spark-runtime modules against the secondary Scala. This covers
+#      every Spark version: 3.x (to add the 2.13 variant alongside 2.12)
+#      and 4.x (which is published only here).
+#
+# All matrix values are sourced from gradle.properties via _constants.sh.
+#
+# Credentials are exported as ORG_GRADLE_PROJECT_mavenUser / mavenPassword
+# rather than passed as -PmavenUser=/-PmavenPassword=. Gradle promotes any
+# ORG_GRADLE_PROJECT_<name> env var to the project property <name> with
+# identical semantics, but the values never enter argv (and so are not
+# visible via /proc/<pid>/cmdline).
+function stage_convenience_binaries {
+  if [[ -z "${NEXUS_USERNAME:-}" || -z "${NEXUS_PASSWORD:-}" ]]; then
+    print_warning "NEXUS_USERNAME or NEXUS_PASSWORD not set; Gradle publish will likely fail"
+  fi
+
+  export ORG_GRADLE_PROJECT_mavenUser="${NEXUS_USERNAME:-}"
+  export ORG_GRADLE_PROJECT_mavenPassword="${NEXUS_PASSWORD:-}"
+
+  local common_flags=(-Prelease --no-parallel --no-configuration-cache)
+
+  if [[ -n "${SPARK_VERSIONS_PRIMARY_SCALA}" ]]; then
+    print_info "Publishing main matrix (Scala ${SCALA_PRIMARY}, Flink ${KNOWN_FLINK_VERSIONS}, Spark ${SPARK_VERSIONS_PRIMARY_SCALA}, Kafka ${KNOWN_KAFKA_VERSIONS})..."
+    exec_process ./gradlew "${common_flags[@]}" \
+      "-DscalaVersion=${SCALA_PRIMARY}" \
+      "-DflinkVersions=${KNOWN_FLINK_VERSIONS}" \
+      "-DsparkVersions=${SPARK_VERSIONS_PRIMARY_SCALA}" \
+      "-DkafkaVersions=${KNOWN_KAFKA_VERSIONS}" \
+      publishApachePublicationToMavenRepository
+  else
+    print_info "No Spark versions support the primary Scala (${SCALA_PRIMARY}); publishing Flink/Kafka matrix only..."
+    exec_process ./gradlew "${common_flags[@]}" \
+      "-DscalaVersion=${SCALA_PRIMARY}" \
+      "-DflinkVersions=${KNOWN_FLINK_VERSIONS}" \
+      "-DsparkVersions=" \
+      "-DkafkaVersions=${KNOWN_KAFKA_VERSIONS}" \
+      publishApachePublicationToMavenRepository
+  fi
+
+  if [[ -z "${SPARK_VERSIONS_SECONDARY_SCALA}" ]]; then
+    print_info "Known Spark matrix is empty; skipping secondary-Scala (${SCALA_SECONDARY}) sweep."
+    return 0
+  fi
+
+  local secondary_spark
+  IFS=',' read -ra secondary_spark <<< "${SPARK_VERSIONS_SECONDARY_SCALA}"
+  local sv
+  for sv in "${secondary_spark[@]}"; do
+    print_info "Publishing Scala ${SCALA_SECONDARY} artifacts for Spark ${sv}..."
+    exec_process ./gradlew "${common_flags[@]}" \
+      "-DscalaVersion=${SCALA_SECONDARY}" \
+      "-DsparkVersions=${sv}" \
+      ":iceberg-spark:iceberg-spark-${sv}_${SCALA_SECONDARY}:publishApachePublicationToMavenRepository" \
+      ":iceberg-spark:iceberg-spark-extensions-${sv}_${SCALA_SECONDARY}:publishApachePublicationToMavenRepository" \
+      ":iceberg-spark:iceberg-spark-runtime-${sv}_${SCALA_SECONDARY}:publishApachePublicationToMavenRepository"
+  done
+}

--- a/release/libs/_log.sh
+++ b/release/libs/_log.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_LOG_LOADED:-}" ]] && return 0 2>/dev/null || true
+_LOG_LOADED=1
+
+if [[ -t 2 ]] &&
+  [[ "${NO_COLOR:-}" != "1" ]] &&
+  [[ "${TERM:-}" != "dumb" ]] &&
+  command -v tput >/dev/null; then
+  RED=${RED:-$(tput setaf 1)}
+  GREEN=${GREEN:-$(tput setaf 2)}
+  YELLOW=${YELLOW:-$(tput bold; tput setaf 3)}
+  BLUE=${BLUE:-$(tput setaf 4)}
+  RESET=${RESET:-$(tput sgr0)}
+else
+  RED=${RED:-''}
+  GREEN=${GREEN:-''}
+  YELLOW=${YELLOW:-''}
+  BLUE=${BLUE:-''}
+  RESET=${RESET:-''}
+fi
+
+function print_error() {
+  echo -e "${RED}ERROR: $*${RESET}" >&2
+}
+
+function print_warning() {
+  echo -e "${YELLOW}WARNING: $*${RESET}" >&2
+}
+
+function print_info() {
+  echo "INFO: $*" >&2
+}
+
+function print_success() {
+  echo -e "${GREEN}SUCCESS: $*${RESET}" >&2
+}
+
+function print_command() {
+  echo -e "${BLUE}DEBUG: $*${RESET}" >&2
+}
+
+# step_summary writes a line both to stdout (for local terminal visibility)
+# and, when running inside GitHub Actions, to $GITHUB_STEP_SUMMARY so the
+# workflow run page shows a structured recap.
+function step_summary() {
+  local msg="$1"
+  if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+    echo "$msg" >> "$GITHUB_STEP_SUMMARY"
+  fi
+  echo "$msg"
+}

--- a/release/libs/_nexus.sh
+++ b/release/libs/_nexus.sh
@@ -1,0 +1,306 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_NEXUS_LOADED:-}" ]] && return 0 2>/dev/null || true
+_NEXUS_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+
+# nexus_find_open_staging_repo populates the caller-visible global
+# staging_repo_id; shellcheck flags it as unused inside this file.
+# shellcheck disable=SC2034
+
+# Apache's Nexus 2 staging API exposes "close", "promote" and "drop" as
+# bulk operations that take a list of repo IDs plus an optional
+# description. The auth credentials are passed via curl's `-K` flag (config
+# file on stdin) so they never appear on the command line, even in a
+# debug-traced run.
+function _nexus_bulk_action {
+  local action="$1"
+  local repo_id="$2"
+  local description="$3"
+
+  local url="${NEXUS_BASE_URL}/staging/bulk/${action}"
+  local payload
+  payload=$(jq -n --arg id "${repo_id}" --arg desc "${description}" \
+    '{"data": {"stagedRepositoryIds": [$id], "description": $desc}}')
+
+  print_info "Nexus ${action}: repo_id=${repo_id}"
+
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    : "${NEXUS_USERNAME:?NEXUS_USERNAME must be set for real (non-dry-run) execution}"
+    : "${NEXUS_PASSWORD:?NEXUS_PASSWORD must be set for real (non-dry-run) execution}"
+    print_command "Executing 'curl --fail -X POST ${url}' (credentials via stdin)"
+    curl --fail --silent --show-error \
+      -K <(printf 'user = "%s:%s"\n' "${NEXUS_USERNAME}" "${NEXUS_PASSWORD}") \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      "${url}"
+  else
+    print_command "Dry-run, WOULD POST to ${url} with payload for repo ${repo_id}"
+  fi
+}
+
+function nexus_close_staging_repo {
+  local repo_id="$1"
+  local description="${2:-Closing staging repository}"
+  _nexus_bulk_action "close" "${repo_id}" "${description}"
+}
+
+function nexus_release_staging_repo {
+  local repo_id="$1"
+  local description="${2:-Releasing staging repository}"
+  _nexus_bulk_action "promote" "${repo_id}" "${description}"
+}
+
+function nexus_drop_staging_repo {
+  local repo_id="$1"
+  local description="${2:-Dropping staging repository}"
+  _nexus_bulk_action "drop" "${repo_id}" "${description}"
+}
+
+# Locates the single open staging repository for the configured profile
+# (default: org.apache.iceberg) and exports its ID into staging_repo_id.
+# Fails if zero or more than one open repo is found.
+function nexus_find_open_staging_repo {
+  local profile_name="${1:-${NEXUS_STAGING_PROFILE}}"
+
+  print_info "Searching for open staging repository for ${profile_name}..."
+
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_command "Dry-run, WOULD search Nexus for open staging repo"
+    staging_repo_id="DRY-RUN-REPO-ID"
+    return 0
+  fi
+
+  : "${NEXUS_USERNAME:?NEXUS_USERNAME must be set for real (non-dry-run) execution}"
+  : "${NEXUS_PASSWORD:?NEXUS_PASSWORD must be set for real (non-dry-run) execution}"
+
+  local response
+  if ! response=$(curl --fail --silent --show-error \
+    -K <(printf 'user = "%s:%s"\n' "${NEXUS_USERNAME}" "${NEXUS_PASSWORD}") \
+    "${NEXUS_BASE_URL}/staging/profile_repositories"); then
+    print_error "Failed to query Nexus staging repositories"
+    return 1
+  fi
+
+  local matches
+  matches=$(echo "${response}" | \
+    NEXUS_PROFILE_NAME="${profile_name}" python3 -c "
+import sys, os, xml.etree.ElementTree as ET
+profile = os.environ['NEXUS_PROFILE_NAME']
+tree = ET.parse(sys.stdin)
+for repo in tree.findall('.//stagingProfileRepository'):
+    repo_type = repo.find('type')
+    repo_id = repo.find('repositoryId')
+    if repo_type is not None and repo_type.text == 'open' and repo_id is not None:
+        if profile.replace('.', '') in (repo_id.text or ''):
+            print(repo_id.text)
+" 2>/dev/null)
+
+  local match_count
+  match_count=$(echo -n "${matches}" | grep -c . || true)
+
+  if [[ ${match_count} -eq 0 ]]; then
+    print_error "No open staging repository found for ${profile_name}"
+    return 1
+  fi
+
+  if [[ ${match_count} -gt 1 ]]; then
+    print_error "Found ${match_count} open staging repositories for ${profile_name}; expected exactly one"
+    print_error "Open repos: $(echo "${matches}" | tr '\n' ' ')"
+    print_error "Multiple staging repositories typically indicate that gradle parallelism was enabled or"
+    print_error "that the publish ran from a network with floating outbound IPs. Drop the extras manually"
+    print_error "in the Nexus UI and re-run."
+    return 1
+  fi
+
+  staging_repo_id="${matches}"
+  print_info "Found staging repository: ${staging_repo_id}"
+  return 0
+}
+
+# Fetches `<staging-repo>/repository/${repo_id}` from the Nexus 2 API and
+# extracts profileName, type (state), and description. Sets these globals
+# for callers to consume:
+#   _nexus_repo_profile, _nexus_repo_state, _nexus_repo_description
+#
+# Returns non-zero if the repository does not exist or the API call fails.
+# In dry-run mode this is a no-op and returns the placeholder values so
+# downstream verification logic can be exercised end-to-end.
+# shellcheck disable=SC2034
+function nexus_get_staging_repo_metadata {
+  local repo_id="$1"
+
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_command "Dry-run, WOULD fetch Nexus metadata for ${repo_id}"
+    _nexus_repo_profile="${NEXUS_STAGING_PROFILE}"
+    _nexus_repo_state="closed"
+    _nexus_repo_description="DRY-RUN"
+    return 0
+  fi
+
+  : "${NEXUS_USERNAME:?NEXUS_USERNAME must be set for real (non-dry-run) execution}"
+  : "${NEXUS_PASSWORD:?NEXUS_PASSWORD must be set for real (non-dry-run) execution}"
+
+  local response
+  if ! response=$(curl --fail --silent --show-error \
+    -K <(printf 'user = "%s:%s"\n' "${NEXUS_USERNAME}" "${NEXUS_PASSWORD}") \
+    "${NEXUS_BASE_URL}/staging/repository/${repo_id}"); then
+    print_error "Could not fetch Nexus staging repository ${repo_id} (does it exist?)"
+    return 1
+  fi
+
+  local parsed
+  # One field per line. Bash command substitution strips NUL bytes, so
+  # NUL separators do not survive; embedded newlines in description
+  # are squashed to spaces.
+  if ! parsed=$(echo "${response}" | python3 -c "
+import sys, xml.etree.ElementTree as ET
+tree = ET.parse(sys.stdin)
+def clean(s):
+    return (s or '').strip().replace('\n', ' ').replace('\r', ' ')
+print(clean(tree.findtext('.//profileName')))
+print(clean(tree.findtext('.//type')))
+print(clean(tree.findtext('.//description')))
+" 2>/dev/null); then
+    print_error "Could not parse Nexus staging repository metadata for ${repo_id}"
+    return 1
+  fi
+
+  {
+    IFS= read -r _nexus_repo_profile
+    IFS= read -r _nexus_repo_state
+    IFS= read -r _nexus_repo_description
+  } <<< "${parsed}"
+  return 0
+}
+
+# Returns 0 if iceberg-core-${version}.pom exists in the staging
+# repository's content tree, non-zero otherwise.
+function nexus_check_iceberg_artifact_exists {
+  local repo_id="$1"
+  local version="$2"
+
+  # The content base lives at ${NEXUS_BASE_URL%/service/local}/content/repositories/${repo_id}
+  local content_base="${NEXUS_BASE_URL%/service/local}/content/repositories/${repo_id}"
+  local pom_path="org/apache/iceberg/iceberg-core/${version}/iceberg-core-${version}.pom"
+  local url="${content_base}/${pom_path}"
+
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_command "Dry-run, WOULD HEAD ${url}"
+    return 0
+  fi
+
+  : "${NEXUS_USERNAME:?NEXUS_USERNAME must be set for real (non-dry-run) execution}"
+  : "${NEXUS_PASSWORD:?NEXUS_PASSWORD must be set for real (non-dry-run) execution}"
+
+  local http_status
+  if ! http_status=$(curl --silent --output /dev/null --write-out '%{http_code}' \
+    -I -K <(printf 'user = "%s:%s"\n' "${NEXUS_USERNAME}" "${NEXUS_PASSWORD}") \
+    "${url}"); then
+    print_error "HEAD ${url} failed (network error)"
+    return 1
+  fi
+
+  if [[ "${http_status}" != "200" ]]; then
+    print_error "Expected iceberg-core ${version} POM at ${url}, got HTTP ${http_status}"
+    return 1
+  fi
+  return 0
+}
+
+# Verifies that ${repo_id} is the right staging repo for this RC.
+#
+#   1. profile  == NEXUS_STAGING_PROFILE                   (hard fail)
+#   2. state    == "closed"                                (hard fail)
+#   3. iceberg-core-${version}.pom is present              (hard fail)
+#   4. description contains "Apache Iceberg ${version} RC${rc}"
+#                                                          (warn; bypass
+#                                                           with caller-set
+#                                                           allow_description_mismatch=1)
+#
+# Args:
+#   $1: repo_id
+#   $2: expected version (e.g. 1.10.0)
+#   $3: expected RC number (optional - description check is skipped if empty)
+function nexus_verify_staging_repo {
+  local repo_id="$1"
+  local expected_version="$2"
+  local expected_rc="${3:-}"
+
+  print_info "Verifying staging repository ${repo_id} matches Iceberg ${expected_version}${expected_rc:+ RC${expected_rc}}..."
+
+  if ! nexus_get_staging_repo_metadata "${repo_id}"; then
+    return 1
+  fi
+
+  if [[ "${_nexus_repo_profile}" != "${NEXUS_STAGING_PROFILE}" ]]; then
+    print_error "Staging repo ${repo_id} belongs to profile '${_nexus_repo_profile}', expected '${NEXUS_STAGING_PROFILE}'"
+    print_error "This usually means an ID for a different project was pasted into the workflow input."
+    return 1
+  fi
+
+  if [[ "${_nexus_repo_state}" != "closed" ]]; then
+    print_error "Staging repo ${repo_id} is in state '${_nexus_repo_state}', expected 'closed'"
+    case "${_nexus_repo_state}" in
+      open)
+        print_error "The repo is still open; prepare-rc.sh did not finish closing it. Re-run prepare-rc."
+        ;;
+      released)
+        print_error "The repo has already been released; promoting twice is not safe."
+        ;;
+      *)
+        print_error "Unexpected state - check the Nexus UI."
+        ;;
+    esac
+    return 1
+  fi
+
+  if ! nexus_check_iceberg_artifact_exists "${repo_id}" "${expected_version}"; then
+    print_error "Staging repo ${repo_id} does not contain iceberg-core ${expected_version} artifacts."
+    print_error "Either the repository is for a different version or the publish step failed silently."
+    return 1
+  fi
+
+  # Skip the description check in dry-run; the placeholder never matches.
+  if [[ ${DRY_RUN:-1} -ne 1 && -n "${expected_rc}" ]]; then
+    local expected_desc="Apache Iceberg ${expected_version} RC${expected_rc}"
+    if [[ "${_nexus_repo_description}" != *"${expected_desc}"* ]]; then
+      if [[ "${allow_description_mismatch:-0}" == "1" ]]; then
+        print_warning "Staging repo ${repo_id} description '${_nexus_repo_description}' does not contain '${expected_desc}'"
+        print_warning "Continuing anyway because --allow-description-mismatch was passed."
+      else
+        print_error "Staging repo ${repo_id} description '${_nexus_repo_description}' does not contain '${expected_desc}'"
+        print_error "This usually means an ID from a different RC of the same version was pasted."
+        print_error "If you're certain the repo is correct (e.g. description was edited), pass --allow-description-mismatch."
+        return 1
+      fi
+    fi
+  fi
+
+  print_success "Staging repo ${repo_id} verified: profile=${_nexus_repo_profile}, state=${_nexus_repo_state}"
+  return 0
+}

--- a/release/libs/_svn.sh
+++ b/release/libs/_svn.sh
@@ -1,0 +1,163 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_SVN_LOADED:-}" ]] && return 0 2>/dev/null || true
+_SVN_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+
+# Pipes SVN_PASSWORD on stdin so it never appears in argv (visible via
+# /proc/<pid>/cmdline). All svn calls in the release scripts go through
+# this helper.
+#
+# Args are passed straight through to `svn`; standard flags
+# (--username, --password-from-stdin, --non-interactive, --no-auth-cache)
+# are appended automatically. SVN_USERNAME and SVN_PASSWORD must be set
+# in real (non-dry-run) mode.
+function svn_run {
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    : "${SVN_USERNAME:?SVN_USERNAME must be set for real (non-dry-run) execution}"
+    : "${SVN_PASSWORD:?SVN_PASSWORD must be set for real (non-dry-run) execution}"
+  fi
+
+  local cmd=(svn "$@"
+    --username "${SVN_USERNAME:-}"
+    --password-from-stdin
+    --non-interactive
+    --no-auth-cache)
+  local redacted
+  redacted=$(_redact_secrets "${cmd[@]}")
+
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    print_command "Executing '${redacted}'"
+    printf '%s\n' "${SVN_PASSWORD}" | "${cmd[@]}"
+  else
+    print_command "Dry-run, WOULD execute '${redacted}'"
+  fi
+}
+
+# Same as svn_run but with retry semantics matching exec_process_with_retries:
+# on failure, removes cleanup_path and retries up to max_attempts times.
+# Apache SVN occasionally returns transient connection failures during
+# checkout/commit; this helper handles those.
+function svn_run_with_retries {
+  if [[ $# -lt 4 ]]; then
+    echo "ERROR: svn_run_with_retries requires: max_attempts sleep_duration cleanup_path svn-args..."
+    exit 1
+  fi
+
+  local max_attempts="${1}"
+  local sleep_duration="${2}"
+  local cleanup_path="${3}"
+  shift 3
+
+  local attempt=1
+  while true; do
+    if svn_run "$@"; then
+      break
+    fi
+    if [[ $attempt -ge $max_attempts ]]; then
+      local redacted
+      redacted=$(_redact_secrets "svn $*")
+      echo "ERROR: SVN command failed after ${max_attempts} attempts: ${redacted}"
+      exit 1
+    fi
+    echo "WARNING: SVN command failed (attempt ${attempt}/${max_attempts}), retrying in ${sleep_duration} seconds..."
+    if [[ -n "${cleanup_path}" && -e "${cleanup_path}" ]]; then
+      rm -rf "${cleanup_path}"
+    fi
+    sleep "${sleep_duration}"
+    ((attempt++))
+  done
+}
+
+# Returns success (0) if the given URL exists in SVN, failure otherwise.
+# Suppresses output (svn ls is the standard existence probe). In dry-run
+# mode this prints what it would check and returns success.
+function svn_path_exists {
+  if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+    print_command "Dry-run, WOULD probe SVN path: $1"
+    return 0
+  fi
+  : "${SVN_USERNAME:?SVN_USERNAME must be set for real (non-dry-run) execution}"
+  : "${SVN_PASSWORD:?SVN_PASSWORD must be set for real (non-dry-run) execution}"
+
+  printf '%s\n' "${SVN_PASSWORD}" | svn ls \
+    --username "${SVN_USERNAME}" \
+    --password-from-stdin \
+    --non-interactive \
+    --no-auth-cache \
+    "$1" >/dev/null 2>&1
+}
+
+# Captures the output of an `svn list`-style command. Used by the old-release
+# cleanup flow which needs to enumerate directories before deleting them.
+# The password is piped via stdin so it never appears in argv. Output goes
+# to stdout (caller can capture via $(svn_list ...)). Real-mode only;
+# callers must guard with their own DRY_RUN check.
+function svn_list {
+  : "${SVN_USERNAME:?SVN_USERNAME must be set for real (non-dry-run) execution}"
+  : "${SVN_PASSWORD:?SVN_PASSWORD must be set for real (non-dry-run) execution}"
+
+  printf '%s\n' "${SVN_PASSWORD}" | svn list \
+    --username "${SVN_USERNAME}" \
+    --password-from-stdin \
+    --non-interactive \
+    --no-auth-cache \
+    "$@" 2>&1
+}
+
+# Filters an `svn list` of dist/release/iceberg/ to only the patch-release
+# directories that should be deleted as superseded by <new_version>. A
+# directory is selected when:
+#   * its name matches apache-iceberg-<MAJOR>.<MINOR>.<patch>, AND
+#   * <MAJOR>.<MINOR> equals the major.minor of <new_version>, AND
+#   * the directory is not <new_version> itself.
+#
+# Promoting 1.9.2 therefore removes 1.9.0 and 1.9.1 but leaves 1.10.x,
+# 2.0.0, and any KEYS/non-release entries alone. Older minor lines are
+# served from archive.apache.org via the standard ASF release archival.
+#
+# Outputs one bare directory name per line. Returns 0 even when nothing
+# matches.
+function filter_superseded_patch_releases {
+  local listing="$1"
+  local new_version="$2"
+
+  local major minor rest
+  major="${new_version%%.*}"
+  rest="${new_version#*.}"
+  minor="${rest%%.*}"
+
+  local final_tag="${TAG_PREFIX}${new_version}"
+
+  echo "${listing}" \
+    | grep -E "^${TAG_PREFIX}${major}\.${minor}\.[0-9]+/?$" \
+    | sed 's|/$||' \
+    | grep -v "^${final_tag}$" \
+    || true
+}

--- a/release/libs/_version.sh
+++ b/release/libs/_version.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+[[ -n "${_VERSION_LOADED:-}" ]] && return 0 2>/dev/null || true
+_VERSION_LOADED=1
+
+LIBS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "$LIBS_DIR/_constants.sh"
+# shellcheck source=release/libs/_exec.sh
+source "$LIBS_DIR/_exec.sh"
+
+# Functions in this file populate caller-visible globals via dynamic scope
+# (e.g. major/minor/patch/rc_number/latest_rc_number/version_without_rc).
+# Tests cover this contract; shellcheck flags it as unused inside this file.
+# shellcheck disable=SC2034
+
+# Validates an X.Y.Z version string and exports the components.
+# Iceberg releases use plain semver without -SNAPSHOT or -beta suffixes
+# because the gitVersion plugin computes the development version
+# automatically from the latest tag.
+function validate_and_extract_version {
+  local version="$1"
+  if [[ ! ${version} =~ ^${VERSION_REGEX}$ ]]; then
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  patch="${BASH_REMATCH[3]}"
+  version_without_rc="${major}.${minor}.${patch}"
+  return 0
+}
+
+# Validates an "apache-iceberg-X.Y.Z-rcN" RC tag and exports its components.
+function validate_and_extract_git_tag_version {
+  local tag="$1"
+  if [[ ! ${tag} =~ ${VERSION_REGEX_GIT_TAG} ]]; then
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  patch="${BASH_REMATCH[3]}"
+  rc_number="${BASH_REMATCH[4]}"
+  version_without_rc="${major}.${minor}.${patch}"
+  return 0
+}
+
+# Validates a "X.Y.x" release branch name (e.g. "1.10.x") and exports the
+# major/minor components.
+function validate_and_extract_branch_version {
+  local branch="$1"
+  if [[ ! ${branch} =~ ${BRANCH_VERSION_REGEX} ]]; then
+    return 1
+  fi
+  major="${BASH_REMATCH[1]}"
+  minor="${BASH_REMATCH[2]}"
+  return 0
+}
+
+# Lists all RC tags for the given X.Y.Z version, suppressing matches that
+# happen to start with the prefix but contain extra characters.
+function _filter_rc_tags {
+  local version_without_rc="$1"
+  local exact_pattern="^${TAG_PREFIX}${version_without_rc}-rc[0-9]+$"
+  git tag -l "${TAG_PREFIX}${version_without_rc}-rc*" | grep -E "${exact_pattern}"
+}
+
+# Sets rc_number to the next unused RC index for the given version. Returns
+# 0 even when no prior RC exists (in that case rc_number=0).
+function find_next_rc_number {
+  local version_without_rc="$1"
+  local existing_tags
+  existing_tags=$(_filter_rc_tags "${version_without_rc}" || true)
+
+  if [[ -z "${existing_tags}" ]]; then
+    # shellcheck disable=SC2034 # consumed by callers
+    rc_number=0
+  else
+    local highest_rc
+    highest_rc=$(echo "${existing_tags}" | sed "s/${TAG_PREFIX}${version_without_rc}-rc//" | sort -n | tail -1)
+    # shellcheck disable=SC2034 # consumed by callers
+    rc_number=$((highest_rc + 1))
+  fi
+  return 0
+}
+
+# Sets latest_rc_number to the highest existing RC index for the given
+# version. Fails if no RC tag exists, since "latest" is undefined in that
+# case.
+function find_latest_rc_number {
+  local version_without_rc="$1"
+  local existing_tags
+  existing_tags=$(_filter_rc_tags "${version_without_rc}" || true)
+
+  if [[ -z "${existing_tags}" ]]; then
+    print_error "No RC tags found for version ${version_without_rc}"
+    return 1
+  fi
+
+  # shellcheck disable=SC2034 # consumed by callers
+  latest_rc_number=$(echo "${existing_tags}" | sed "s/${TAG_PREFIX}${version_without_rc}-rc//" | sort -n | tail -1)
+  return 0
+}
+
+# Suggests the expected branch name for a given version. Used purely for
+# advisory warnings: the release manager is responsible for being on the
+# correct branch (Iceberg's existing dev/source-release.sh tags HEAD without
+# any branch enforcement, and that behavior is preserved here).
+function expected_branch_for_version {
+  local major_arg="$1"
+  local minor_arg="$2"
+  echo "${major_arg}.${minor_arg}${BRANCH_SUFFIX}"
+}

--- a/release/prepare-rc.sh
+++ b/release/prepare-rc.sh
@@ -1,0 +1,468 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBS_DIR="${SCRIPT_DIR}/libs"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+# shellcheck source=release/libs/_version.sh
+source "${LIBS_DIR}/_version.sh"
+# shellcheck source=release/libs/_github.sh
+source "${LIBS_DIR}/_github.sh"
+# shellcheck source=release/libs/_nexus.sh
+source "${LIBS_DIR}/_nexus.sh"
+# shellcheck source=release/libs/_svn.sh
+source "${LIBS_DIR}/_svn.sh"
+# shellcheck source=release/libs/_gradle.sh
+source "${LIBS_DIR}/_gradle.sh"
+
+function usage {
+  cat <<EOF
+Usage: $0 <version> [OPTIONS]
+
+Prepare a release candidate for Apache Iceberg.
+
+This script automates the steps in dev/source-release.sh and
+dev/stage-binaries.sh, plus Nexus close and GitHub pre-release creation.
+
+Branching follows Iceberg convention:
+  * X.Y.0   RCs are tagged from main; the X.Y.x release branch does
+            not need to exist yet.
+  * X.Y.Z   patch RCs (Z >= 1) require the X.Y.x branch to already
+            exist on the remote. Create it from the apache-iceberg-X.Y.0
+            tag commit after the X.Y.0 final ships.
+
+Arguments:
+  version               Release version (e.g., 1.10.0)
+
+Options:
+  --rc <num>            Override RC number (default: auto-detect from tags)
+  --key <keyid>         GPG key ID to sign the source tarball (default: gpg's default key)
+  --remote <name>       Git remote to push tags to (default: 'apache' if configured, else 'origin')
+  --skip-ci-check       Skip the GitHub CI status check (use with care)
+  --help                Show this help
+
+Environment variables:
+  DRY_RUN               Set to 0 for real execution (default: 1)
+  NEXUS_USERNAME        Apache Nexus username
+  NEXUS_PASSWORD        Apache Nexus password
+  SVN_USERNAME          SVN username for dist.apache.org
+  SVN_PASSWORD          SVN password
+  GITHUB_TOKEN          GitHub token for CI checks and pre-release creation
+
+Examples:
+  DRY_RUN=1 $0 1.10.0
+  DRY_RUN=0 $0 1.10.0 --rc 2 --key ABCD1234
+  DRY_RUN=0 $0 1.10.1 --key ABCD1234     # requires apache/1.10.x to exist
+EOF
+  exit "${1:-0}"
+}
+
+version=""
+rc_override=""
+keyid=""
+remote=""
+skip_ci_check=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rc)
+      if [[ -z "${2:-}" ]]; then
+        print_error "--rc requires a value"
+        usage 1
+      fi
+      rc_override="$2"
+      if [[ ! "${rc_override}" =~ ^[0-9]+$ ]]; then
+        print_error "--rc value must be a non-negative integer, got: '${rc_override}'"
+        exit 1
+      fi
+      shift 2
+      ;;
+    --key)
+      if [[ -z "${2:-}" ]]; then
+        print_error "--key requires a value"
+        usage 1
+      fi
+      keyid="$2"
+      shift 2
+      ;;
+    --remote)
+      if [[ -z "${2:-}" ]]; then
+        print_error "--remote requires a value"
+        usage 1
+      fi
+      remote="$2"
+      shift 2
+      ;;
+    --skip-ci-check)
+      skip_ci_check=true
+      shift
+      ;;
+    --help|-h)
+      usage 0
+      ;;
+    -*)
+      print_error "Unknown option: $1"
+      usage 1
+      ;;
+    *)
+      if [[ -z "${version}" ]]; then
+        version="$1"
+      else
+        print_error "Unexpected argument: $1"
+        usage 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "${version}" ]]; then
+  print_error "Version is required"
+  usage 1
+fi
+
+if [[ -z "${remote}" ]]; then
+  if git remote get-url apache >/dev/null 2>&1; then
+    remote="apache"
+  else
+    remote="origin"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 0: Validate inputs and prerequisites
+# ---------------------------------------------------------------------------
+step_summary "## Release Candidate Preparation"
+step_summary ""
+
+if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+  step_summary "> **DRY RUN** -- no changes will be made"
+  step_summary ""
+fi
+
+if ! validate_and_extract_version "${version}"; then
+  print_error "Invalid version format: '${version}'. Expected: X.Y.Z"
+  exit 1
+fi
+
+step_summary "| Parameter | Value |"
+step_summary "| --- | --- |"
+step_summary "| Version | \`${version}\` |"
+
+if ! command -v gpg &>/dev/null; then
+  print_warning "gpg not found -- GPG signing will fail"
+fi
+if ! command -v svn &>/dev/null; then
+  print_warning "svn not found -- SVN staging will fail"
+fi
+if [[ ! -x "${PROJECT_DIR}/gradlew" ]]; then
+  print_error "gradlew not found at ${PROJECT_DIR}/gradlew. Run from the iceberg repo root."
+  exit 1
+fi
+
+if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+  if ! verify_jdk_17; then
+    exit 1
+  fi
+fi
+
+# Verify the configured git remote is reachable.
+if ! git ls-remote --exit-code "${remote}" >/dev/null 2>&1; then
+  print_error "Git remote '${remote}' is not configured or unreachable. Pass --remote to override."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: Pick the ref to tag from
+# ---------------------------------------------------------------------------
+#
+#   X.Y.0  tags from ${remote}/main; the X.Y.x branch is not required.
+#   X.Y.Z  (Z >= 1) requires ${remote}/X.Y.x to exist on the remote.
+exec_process git fetch "${remote}" --tags
+
+release_branch="$(expected_branch_for_version "${major}" "${minor}")"
+step_summary ""
+step_summary "### Release Source"
+
+if [[ "${patch}" -eq 0 ]]; then
+  if ! git show-ref --verify --quiet "refs/remotes/${remote}/main"; then
+    print_error "Branch '${remote}/main' not found on remote; cannot tag X.Y.0."
+    exit 1
+  fi
+  release_hash="$(git rev-parse "${remote}/main")"
+  print_info "X.Y.0 release: tagging RC from ${remote}/main at ${release_hash}"
+  step_summary "| Tagging from | \`${remote}/main\` |"
+  step_summary "| Release branch | not yet created -- Iceberg convention is to branch from \`apache-iceberg-${version}\` after the final ships |"
+else
+  if ! git show-ref --verify --quiet "refs/remotes/${remote}/${release_branch}"; then
+    print_error "Release branch '${remote}/${release_branch}' not found on remote."
+    print_error "Iceberg's convention is to create the ${release_branch} branch from the"
+    print_error "apache-iceberg-${major}.${minor}.0 final tag commit after that release ships."
+    print_error "To create it now:"
+    print_error "  git push ${remote} apache-iceberg-${major}.${minor}.0:refs/heads/${release_branch}"
+    print_error "Then re-run prepare-rc."
+    exit 1
+  fi
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    if [[ "$(git branch --show-current 2>/dev/null || echo '')" != "${release_branch}" ]]; then
+      if git show-ref --verify --quiet "refs/heads/${release_branch}"; then
+        exec_process git checkout "${release_branch}"
+      else
+        exec_process git checkout -b "${release_branch}" --track "${remote}/${release_branch}"
+      fi
+    fi
+    exec_process git pull --ff-only "${remote}" "${release_branch}"
+  else
+    print_command "Dry-run, WOULD checkout ${release_branch} (tracking ${remote}/${release_branch}) and fast-forward"
+  fi
+  release_hash="$(git rev-parse "${remote}/${release_branch}")"
+  print_info "Patch release: tagging from ${remote}/${release_branch} at ${release_hash}"
+  step_summary "| Tagging from | \`${remote}/${release_branch}\` |"
+  step_summary "| Release branch | \`${release_branch}\` |"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: Auto-detect RC number
+# ---------------------------------------------------------------------------
+if [[ -n "${rc_override}" ]]; then
+  rc_number="${rc_override}"
+  print_info "Using RC override: rc${rc_number}"
+else
+  find_next_rc_number "${version}"
+  print_info "Auto-detected next RC: rc${rc_number}"
+fi
+
+rc_tag="${TAG_PREFIX}${version}-rc${rc_number}"
+final_tag="${TAG_PREFIX}${version}"
+step_summary "| RC number | \`${rc_number}\` |"
+step_summary "| RC tag | \`${rc_tag}\` |"
+
+if git rev-parse "${rc_tag}" >/dev/null 2>&1; then
+  print_error "Tag ${rc_tag} already exists. Use --rc to specify a different RC number."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Verify CI checks on the release commit
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### CI Verification"
+step_summary "| Commit | \`${release_hash}\` |"
+
+if [[ "${skip_ci_check}" == "true" ]]; then
+  print_warning "Skipping CI verification (--skip-ci-check)"
+  step_summary "CI checks: **SKIPPED**"
+elif ! check_github_checks_passed "${release_hash}"; then
+  print_error "CI checks are not passing. Fix CI before creating an RC."
+  step_summary "CI checks: **FAILED**"
+  exit 1
+else
+  step_summary "CI checks: **PASSED**"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Create and push the RC tag
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Tag and Push"
+
+exec_process git tag -a "${rc_tag}" -m "Apache Iceberg ${version} RC${rc_number}" "${release_hash}"
+exec_process git push "${remote}" "${rc_tag}"
+
+step_summary "Created tag \`${rc_tag}\` at \`${release_hash}\` and pushed to \`${remote}\`"
+
+# Align the workspace with release_hash so both the source tarball
+# (which runs `./gradlew generateGitProperties` and `git archive` from
+# the working tree) and the convenience binaries (which run gradle
+# publish tasks against the working tree) build from the same commit.
+# For the patch path we are already at release_hash via the earlier
+# checkout / pull --ff-only, so this is a no-op.
+if [[ "$(git rev-parse HEAD)" != "${release_hash}" ]]; then
+  if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+    exec_process git checkout --detach "${release_hash}"
+  else
+    print_command "Dry-run, WOULD checkout ${release_hash} (detached) so binaries match the tarball"
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Step 5: Build source tarball
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Source Tarball"
+
+tarball_name="${final_tag}.tar.gz"
+build_source_tarball "${PROJECT_DIR}" "${final_tag}" "${release_hash}" "${version}" "${keyid}"
+
+step_summary "Built \`${tarball_name}\` from \`${release_hash}\`"
+step_summary "Wrote \`${tarball_name}.asc\` (GPG signature) and \`${tarball_name}.sha512\` (SHA-512)"
+
+# ---------------------------------------------------------------------------
+# Step 6: Stage source artifacts to SVN dist/dev
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### SVN Staging"
+
+svn_dir="${APACHE_DIST_URL}${APACHE_DIST_DEV_PATH}"
+rc_svn_dir="${rc_tag}"
+
+if [[ ${DRY_RUN:-1} -ne 1 ]]; then
+  : "${SVN_USERNAME:?SVN_USERNAME must be set for real (non-dry-run) execution}"
+  : "${SVN_PASSWORD:?SVN_PASSWORD must be set for real (non-dry-run) execution}"
+
+  tmpdir="${PROJECT_DIR}/tmp-svn-stage"
+  if [[ -d "${tmpdir}" ]]; then
+    rm -rf "${tmpdir}"
+  fi
+
+  svn_run_with_retries 5 60 "${tmpdir}" \
+    co --depth=empty "${svn_dir}" "${tmpdir}"
+
+  mkdir -p "${tmpdir}/${rc_svn_dir}"
+  cp "${PROJECT_DIR}/${tarball_name}" \
+     "${PROJECT_DIR}/${tarball_name}.asc" \
+     "${PROJECT_DIR}/${tarball_name}.sha512" \
+     "${tmpdir}/${rc_svn_dir}/"
+
+  (cd "${tmpdir}" && exec_process svn add "${rc_svn_dir}")
+  (cd "${tmpdir}" && svn_run ci -m "Apache Iceberg ${version} RC${rc_number}")
+
+  rm -rf "${tmpdir}"
+else
+  print_command "Dry-run, WOULD stage to ${svn_dir}/${rc_svn_dir}"
+fi
+
+step_summary "Staged source tarball to \`${svn_dir}/${rc_svn_dir}\`"
+
+# ---------------------------------------------------------------------------
+# Step 7: Stage convenience binaries to Nexus
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Nexus Deployment"
+
+(cd "${PROJECT_DIR}" && stage_convenience_binaries)
+
+step_summary "Published Iceberg artifacts to Apache Nexus staging across the configured Scala/Spark/Flink/Kafka matrix"
+
+# ---------------------------------------------------------------------------
+# Step 8: Find and close the Nexus staging repo
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Nexus Staging Close"
+
+nexus_find_open_staging_repo "${NEXUS_STAGING_PROFILE}"
+nexus_close_staging_repo "${staging_repo_id}" "Apache Iceberg ${version} RC${rc_number}"
+
+step_summary "Closed staging repository: \`${staging_repo_id}\`"
+
+# ---------------------------------------------------------------------------
+# Step 9: Create GitHub pre-release
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### GitHub Pre-Release"
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  exec_process gh release create "${rc_tag}" \
+    --title "Apache Iceberg ${version} RC${rc_number}" \
+    --prerelease \
+    --generate-notes \
+    --target "${release_hash}" \
+    --repo "${GITHUB_REPO}"
+  step_summary "Created GitHub pre-release for \`${rc_tag}\`"
+else
+  print_warning "GITHUB_TOKEN not set, skipping GitHub pre-release creation"
+  step_summary "Skipped GitHub pre-release (no GITHUB_TOKEN)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 10: Generate vote email template
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Vote Email"
+step_summary ""
+step_summary '```'
+step_summary "To: dev@iceberg.apache.org"
+step_summary "Subject: [VOTE] Release Apache Iceberg ${version} RC${rc_number}"
+step_summary ""
+step_summary "Hi everyone,"
+step_summary ""
+step_summary "I propose that we release the following RC as the official Apache Iceberg ${version} release."
+step_summary ""
+step_summary "The commit ID is ${release_hash}"
+step_summary "* This corresponds to the tag: ${rc_tag}"
+step_summary "* https://github.com/${GITHUB_REPO}/commits/${rc_tag}"
+step_summary "* https://github.com/${GITHUB_REPO}/tree/${release_hash}"
+step_summary ""
+step_summary "The release tarball, signature, and checksums are here:"
+step_summary "* ${APACHE_DIST_URL}${APACHE_DIST_DEV_PATH}/${rc_tag}"
+step_summary ""
+step_summary "You can find the KEYS file here:"
+step_summary "* https://downloads.apache.org/iceberg/KEYS"
+step_summary ""
+step_summary "Convenience binary artifacts are staged on Nexus. The Maven repository URL is:"
+step_summary "* https://repository.apache.org/content/repositories/${staging_repo_id}/"
+step_summary ""
+step_summary "Please download, verify, and test."
+step_summary ""
+step_summary "Instructions for verifying a release can be found here:"
+step_summary "* https://iceberg.apache.org/how-to-release/#how-to-verify-a-release"
+step_summary ""
+step_summary "Please vote in the next 72 hours. (Weekends excluded)"
+step_summary ""
+step_summary "[ ] +1 Release this as Apache Iceberg ${version}"
+step_summary "[ ] +0"
+step_summary "[ ] -1 Do not release this because..."
+step_summary ""
+step_summary "Only PMC members have binding votes, but other community members are encouraged to cast"
+step_summary "non-binding votes. This vote will pass if there are 3 binding +1 votes and more binding"
+step_summary "+1 votes than -1 votes."
+step_summary '```'
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "---"
+step_summary "### Summary"
+step_summary ""
+step_summary "| Step | Status |"
+step_summary "| --- | --- |"
+if [[ "${patch}" -eq 0 ]]; then
+  step_summary "| Tagged from | \`${remote}/main\` |"
+else
+  step_summary "| Tagged from | \`${remote}/${release_branch}\` |"
+fi
+step_summary "| RC tag | \`${rc_tag}\` |"
+step_summary "| Source tarball | \`${tarball_name}\` |"
+step_summary "| SVN dist/dev | staged |"
+step_summary "| Nexus staging repo | \`${staging_repo_id:-UNKNOWN}\` (closed) |"
+step_summary "| GitHub pre-release | created |"
+step_summary "| Vote email | generated |"
+
+print_success "Release candidate ${rc_tag} prepared successfully!"

--- a/release/publish-release.sh
+++ b/release/publish-release.sh
@@ -1,0 +1,382 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIBS_DIR="${SCRIPT_DIR}/libs"
+
+# shellcheck source=release/libs/_constants.sh
+source "${LIBS_DIR}/_constants.sh"
+# shellcheck source=release/libs/_log.sh
+source "${LIBS_DIR}/_log.sh"
+# shellcheck source=release/libs/_exec.sh
+source "${LIBS_DIR}/_exec.sh"
+# shellcheck source=release/libs/_version.sh
+source "${LIBS_DIR}/_version.sh"
+# shellcheck source=release/libs/_nexus.sh
+source "${LIBS_DIR}/_nexus.sh"
+# shellcheck source=release/libs/_svn.sh
+source "${LIBS_DIR}/_svn.sh"
+
+function usage {
+  cat <<EOF
+Usage: $0 <version> <staging-repo-id> [--rc <num>]
+
+Publish an Apache Iceberg release after a successful vote.
+
+Iceberg derives its development version from git tags via the gitVersion
+plugin, so this script does not commit a "next development iteration"
+version bump.
+
+Arguments:
+  version               Release version (e.g., 1.10.0)
+  staging-repo-id       Nexus staging repository ID (e.g., orgapacheiceberg-1234)
+
+Options:
+  --rc <num>                       RC number that passed the vote (default: auto-detect latest)
+  --remote <name>                  Git remote to push the final tag to (default: origin)
+  --keep-old-releases              Skip removal of superseded patch releases for this MAJOR.MINOR line
+  --allow-description-mismatch     Continue even if the staging repo description does not match
+                                   "Apache Iceberg <version> RC<num>". Useful only if the
+                                   description was edited via the Nexus UI during recovery.
+  --help                           Show this help
+
+Environment variables:
+  DRY_RUN               Set to 0 for real execution (default: 1)
+  NEXUS_USERNAME        Apache Nexus username
+  NEXUS_PASSWORD        Apache Nexus password
+  SVN_USERNAME          SVN username for dist.apache.org
+  SVN_PASSWORD          SVN password
+  GITHUB_TOKEN          GitHub token for release creation
+
+Examples:
+  DRY_RUN=1 $0 1.10.0 orgapacheiceberg-1234
+  DRY_RUN=0 $0 1.10.0 orgapacheiceberg-1234 --rc 2
+EOF
+  exit "${1:-0}"
+}
+
+version=""
+staging_repo_id=""
+rc_num=""
+remote="origin"
+keep_old_releases=false
+allow_description_mismatch=0
+positional=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --rc)
+      if [[ -z "${2:-}" ]]; then
+        print_error "--rc requires a value"
+        usage 1
+      fi
+      rc_num="$2"
+      shift 2
+      ;;
+    --remote)
+      if [[ -z "${2:-}" ]]; then
+        print_error "--remote requires a value"
+        usage 1
+      fi
+      remote="$2"
+      shift 2
+      ;;
+    --keep-old-releases)
+      keep_old_releases=true
+      shift
+      ;;
+    --allow-description-mismatch)
+      allow_description_mismatch=1
+      shift
+      ;;
+    --help|-h)
+      usage 0
+      ;;
+    -*)
+      print_error "Unknown option: $1"
+      usage 1
+      ;;
+    *)
+      positional+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ ${#positional[@]} -lt 2 ]]; then
+  print_error "Expected 2 positional arguments (version, staging-repo-id), got ${#positional[@]}"
+  usage 1
+fi
+
+version="${positional[0]}"
+staging_repo_id="${positional[1]}"
+
+# ---------------------------------------------------------------------------
+# Validate inputs
+# ---------------------------------------------------------------------------
+step_summary "## Release Publication"
+step_summary ""
+
+if [[ ${DRY_RUN:-1} -eq 1 ]]; then
+  step_summary "> **DRY RUN** -- no changes will be made"
+  step_summary ""
+fi
+
+if ! validate_and_extract_version "${version}"; then
+  print_error "Invalid version format: '${version}'"
+  exit 1
+fi
+
+if ! [[ "${staging_repo_id}" =~ ^[a-zA-Z][a-zA-Z0-9._-]*$ ]]; then
+  print_error "Invalid staging repository ID: '${staging_repo_id}'. Expected alphanumeric with dots/hyphens (e.g., orgapacheiceberg-1234)."
+  exit 1
+fi
+
+if [[ -z "${rc_num}" ]]; then
+  print_info "No RC number specified, auto-detecting latest RC for ${version}..."
+  if ! find_latest_rc_number "${version}"; then
+    exit 1
+  fi
+  rc_num="${latest_rc_number}"
+  print_info "Auto-detected latest RC: rc${rc_num}"
+else
+  if ! [[ "${rc_num}" =~ ^[0-9]+$ ]]; then
+    print_error "Invalid RC number: '${rc_num}'. Expected a non-negative integer."
+    exit 1
+  fi
+
+  if find_latest_rc_number "${version}" 2>/dev/null; then
+    if [[ "${rc_num}" -ne "${latest_rc_number}" ]]; then
+      print_error "RC${rc_num} is not the latest RC for ${version}. Latest is rc${latest_rc_number}."
+      print_error "Publishing an older RC is likely a mistake. If intentional, delete the newer RC tags first."
+      exit 1
+    fi
+  fi
+fi
+
+rc_tag="${TAG_PREFIX}${version}-rc${rc_num}"
+final_tag="${TAG_PREFIX}${version}"
+
+if ! git rev-parse "${rc_tag}" >/dev/null 2>&1; then
+  print_error "RC tag ${rc_tag} does not exist locally; fetch it from the remote and retry"
+  exit 1
+fi
+
+rc_commit=$(git rev-list -1 "${rc_tag}")
+
+if git rev-parse "${final_tag}" >/dev/null 2>&1; then
+  print_error "Final release tag ${final_tag} already exists"
+  exit 1
+fi
+
+# HEAD must match the RC tag commit exactly.
+head_commit=$(git rev-parse HEAD)
+if [[ "${head_commit}" != "${rc_commit}" ]]; then
+  print_error "HEAD (${head_commit}) does not match RC tag ${rc_tag} (${rc_commit})."
+  print_error "Check out the RC tag exactly (e.g. 'git checkout ${rc_tag}') and re-run."
+  exit 1
+fi
+
+step_summary "| Parameter | Value |"
+step_summary "| --- | --- |"
+step_summary "| Version | \`${version}\` |"
+step_summary "| RC tag | \`${rc_tag}\` |"
+step_summary "| Final tag | \`${final_tag}\` |"
+step_summary "| Staging repo | \`${staging_repo_id}\` |"
+step_summary "| Commit | \`${rc_commit}\` |"
+
+# ---------------------------------------------------------------------------
+# Step 1: Verify the Nexus staging repository matches this RC
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Staging Repository Verification"
+
+if ! nexus_verify_staging_repo "${staging_repo_id}" "${version}" "${rc_num}"; then
+  step_summary "Staging repo verification: **FAILED**"
+  exit 1
+fi
+step_summary "Staging repo verification: **PASSED**"
+
+# ---------------------------------------------------------------------------
+# Step 2: Promote SVN artifacts from dist/dev to dist/release
+# ---------------------------------------------------------------------------
+# Requires PMC privileges on dist.apache.org.
+step_summary ""
+step_summary "### SVN Promotion"
+
+dev_url="${APACHE_DIST_URL}${APACHE_DIST_DEV_PATH}/${rc_tag}"
+release_url="${APACHE_DIST_URL}${APACHE_DIST_RELEASE_PATH}/${final_tag}"
+
+svn_run mv "${dev_url}" "${release_url}" -m "Iceberg: Add release ${version}"
+
+step_summary "Moved \`${dev_url}\` -> \`${release_url}\`"
+
+# ---------------------------------------------------------------------------
+# Step 3: Clean up superseded patch releases from dist/release
+# ---------------------------------------------------------------------------
+#
+# When promoting a patch release we remove earlier patches from the same
+# MAJOR.MINOR line (e.g. publishing 1.9.2 removes 1.9.0 and 1.9.1).
+# Older minor lines are left in place; the standard ASF archival flow
+# moves them to archive.apache.org separately.
+step_summary ""
+step_summary "### Old Release Cleanup"
+
+if [[ "${keep_old_releases}" == "true" ]]; then
+  print_info "Skipping dist/release cleanup (--keep-old-releases)"
+  step_summary "Skipped (--keep-old-releases)"
+elif [[ ${DRY_RUN:-1} -ne 1 ]]; then
+  release_base_url="${APACHE_DIST_URL}${APACHE_DIST_RELEASE_PATH}"
+  svn_listing=""
+  if ! svn_listing=$(svn_list "${release_base_url}"); then
+    print_error "Failed to list SVN releases at ${release_base_url}: ${svn_listing}"
+    exit 1
+  fi
+
+  old_versions=$(filter_superseded_patch_releases "${svn_listing}" "${version}")
+
+  if [[ -n "${old_versions}" ]]; then
+    step_summary "Removing superseded patch releases for ${major}.${minor}.x:"
+    while IFS= read -r old_dir; do
+      [[ -z "${old_dir}" ]] && continue
+      svn_run rm "${release_base_url}/${old_dir}" \
+        -m "Remove old release ${old_dir} (superseded by ${version})"
+      step_summary "- Removed \`${old_dir}\`"
+    done <<< "${old_versions}"
+  else
+    step_summary "No superseded patch releases to remove for ${major}.${minor}.x"
+  fi
+else
+  print_command "Dry-run, WOULD remove superseded ${major}.${minor}.x patch releases from ${APACHE_DIST_RELEASE_PATH}"
+  step_summary "Would remove superseded ${major}.${minor}.x patch releases (dry-run)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 4: Create and push the final release tag
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Release Tag"
+
+exec_process git tag -a "${final_tag}" "${rc_commit}" -m "Release Apache Iceberg ${version}"
+exec_process git push "${remote}" "${final_tag}"
+
+step_summary "Created tag \`${final_tag}\` at \`${rc_commit}\` and pushed to \`${remote}\`"
+
+# ---------------------------------------------------------------------------
+# Step 5: Release the Nexus staging repo to Maven Central
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Nexus Release"
+
+nexus_release_staging_repo "${staging_repo_id}" "Apache Iceberg ${version}"
+
+step_summary "Released staging repository \`${staging_repo_id}\` to Maven Central"
+
+# ---------------------------------------------------------------------------
+# Step 6: Create the GitHub Release
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### GitHub Release"
+
+if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+  exec_process gh release create "${final_tag}" \
+    --title "Apache Iceberg ${version}" \
+    --generate-notes \
+    --latest \
+    --target "${rc_commit}" \
+    --repo "${GITHUB_REPO}"
+
+  step_summary "Created GitHub release for \`${final_tag}\`"
+else
+  print_warning "GITHUB_TOKEN not set, skipping GitHub release creation"
+  step_summary "Skipped GitHub release (no GITHUB_TOKEN)"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Generate the announce email template
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Announce Email"
+step_summary ""
+step_summary '```'
+step_summary "To: dev@iceberg.apache.org, announce@apache.org"
+step_summary "Subject: [ANNOUNCE] Apache Iceberg release ${version}"
+step_summary ""
+step_summary "I'm pleased to announce the release of Apache Iceberg ${version}!"
+step_summary ""
+step_summary "Apache Iceberg is an open table format for huge analytic datasets. Iceberg"
+step_summary "delivers high query performance for tables with tens of petabytes of data,"
+step_summary "along with atomic commits, concurrent writes, and SQL-compatible table"
+step_summary "evolution."
+step_summary ""
+step_summary "This release can be downloaded from: https://www.apache.org/dyn/closer.cgi/iceberg/${final_tag}/${final_tag}.tar.gz"
+step_summary ""
+step_summary "Release notes: https://iceberg.apache.org/releases/#${version//./}-release"
+step_summary ""
+step_summary "Java artifacts are available from Maven Central."
+step_summary ""
+step_summary "Thanks to everyone for contributing!"
+step_summary '```'
+
+# ---------------------------------------------------------------------------
+# Step 8: Manual follow-up reminders
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "### Manual Follow-ups"
+step_summary ""
+step_summary "The following steps are still manual and must be completed by the release manager:"
+step_summary ""
+step_summary "1. **Send the announce email** above to dev@iceberg.apache.org and announce@apache.org"
+step_summary "   (only after Maven Central has mirrored the artifacts; allow up to 24 hours)."
+step_summary "2. **Update revapi**: open a PR to enable revapi against the new release"
+step_summary "   ([example](https://github.com/apache/iceberg/pull/6275))."
+step_summary "3. **Update GitHub issue template**: open a PR to add \`${version}\` to the version dropdown"
+step_summary "   ([example](https://github.com/apache/iceberg/pull/6287))."
+step_summary "4. **Update doap.rdf**: open a PR adding a new \`<release/>\` block for \`${version}\`"
+step_summary "   in [doap.rdf](https://github.com/${GITHUB_REPO}/blob/main/doap.rdf)."
+step_summary "5. **Generate versioned docs**: copy \`docs/\` from the release tag onto the \`docs\` branch"
+step_summary "   under \`${version}/\` and update \`docs/latest\` -> \`docs/${version}\` in the copied"
+step_summary "   \`mkdocs.yml\` (see [example](https://github.com/${GITHUB_REPO}/pull/12411))."
+step_summary "6. **Generate versioned Javadoc** (with JDK 17+): \`./gradlew refreshJavadoc\` in an"
+step_summary "   extracted source tarball, copy \`site/docs/javadoc/${version}\` onto the \`javadoc\`"
+step_summary "   branch (see [example](https://github.com/${GITHUB_REPO}/pull/12412))."
+step_summary "7. **Site update**: open a PR updating the Iceberg version, doc links, and release notes"
+step_summary "   on the website (see [example](https://github.com/${GITHUB_REPO}/pull/12242))."
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+step_summary ""
+step_summary "---"
+step_summary "### Summary"
+step_summary ""
+step_summary "| Step | Status |"
+step_summary "| --- | --- |"
+step_summary "| SVN promotion | done |"
+step_summary "| Old release cleanup | done |"
+step_summary "| Final release tag | \`${final_tag}\` |"
+step_summary "| Nexus release | \`${staging_repo_id}\` released |"
+step_summary "| GitHub release | created |"
+step_summary "| Announce email | generated |"
+step_summary "| Manual follow-ups | see above |"
+
+print_success "Release ${version} published successfully!"

--- a/release/tests/cancel_rc.bats
+++ b/release/tests/cancel_rc.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# End-to-end tests for release/cancel-rc.sh exercising argument parsing,
+# validation, and the dry-run happy path. SVN and Nexus interactions are
+# no-ops under DRY_RUN=1.
+
+setup() {
+  load test_helper/common
+  WORKSPACE_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+  TEST_TMPDIR=$(mktemp -d)
+  CLONE="${TEST_TMPDIR}/clone"
+
+  mkdir -p "${CLONE}/release"
+  cp "${WORKSPACE_ROOT}/release/"*.sh "${CLONE}/release/"
+  cp -R "${WORKSPACE_ROOT}/release/libs"  "${CLONE}/release/libs"
+  cp    "${WORKSPACE_ROOT}/gradle.properties" "${CLONE}/gradle.properties"
+  chmod +x "${CLONE}/release/"*.sh
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+run_cancel_rc() {
+  (cd "${CLONE}" && DRY_RUN=1 ./release/cancel-rc.sh "$@" 2>&1)
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing / validation
+# ---------------------------------------------------------------------------
+
+@test "cancel-rc: requires three positional arguments" {
+  run run_cancel_rc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected 3 positional arguments"* ]]
+}
+
+@test "cancel-rc: rejects too few positional arguments" {
+  run run_cancel_rc 1.10.0 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected 3 positional arguments"* ]]
+}
+
+@test "cancel-rc: rejects too many positional arguments" {
+  run run_cancel_rc 1.10.0 0 orgapacheiceberg-1234 extra
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected 3 positional arguments"* ]]
+}
+
+@test "cancel-rc: rejects invalid version format" {
+  run run_cancel_rc 1.10 0 orgapacheiceberg-1234
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid version format"* ]]
+}
+
+@test "cancel-rc: rejects non-numeric RC number" {
+  run run_cancel_rc 1.10.0 not-a-number orgapacheiceberg-1234
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid RC number"* ]]
+}
+
+@test "cancel-rc: rejects negative RC number" {
+  run run_cancel_rc 1.10.0 -1 orgapacheiceberg-1234
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: -1"* ]]
+}
+
+@test "cancel-rc: rejects invalid staging-repo-id format" {
+  run run_cancel_rc 1.10.0 0 "bad id"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid staging repository ID"* ]]
+}
+
+@test "cancel-rc: rejects unknown option" {
+  run run_cancel_rc 1.10.0 0 orgapacheiceberg-1234 --not-a-flag
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: --not-a-flag"* ]]
+}
+
+@test "cancel-rc: --help exits 0" {
+  run run_cancel_rc --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage:"* ]]
+  [[ "$output" == *"<version>"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Dry-run happy path
+# ---------------------------------------------------------------------------
+
+@test "cancel-rc: dry-run completes successfully" {
+  run run_cancel_rc 1.10.0 0 orgapacheiceberg-1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Staging repo verification"* ]]
+  [[ "$output" == *"WOULD"* ]]
+  [[ "$output" == *"cancelled successfully"* ]]
+}
+
+@test "cancel-rc: dry-run prints would-delete for the SVN dev path" {
+  run run_cancel_rc 1.10.0 2 orgapacheiceberg-1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WOULD delete"* ]]
+  [[ "$output" == *"apache-iceberg-1.10.0-rc2"* ]]
+}
+
+@test "cancel-rc: --allow-description-mismatch is recognized" {
+  run run_cancel_rc 1.10.0 0 orgapacheiceberg-1234 --allow-description-mismatch
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"cancelled successfully"* ]]
+}
+
+@test "cancel-rc: dry-run does not leak SVN_PASSWORD into logs" {
+  export SVN_USERNAME="release-mgr"
+  export SVN_PASSWORD="trace-canary-cancel-pw"
+  run run_cancel_rc 1.10.0 0 orgapacheiceberg-1234
+  unset SVN_USERNAME SVN_PASSWORD
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"trace-canary-cancel-pw"* ]]
+}
+
+@test "cancel-rc: validates RC number before SVN-style operations" {
+  run run_cancel_rc 1.10.0 99999999999999999999 orgapacheiceberg-1234
+  [ "$status" -eq 0 ] || [ "$status" -ne 0 ]
+  # Either path: must not call svn rm in dry-run, must not crash
+  [[ "$output" != *"Traceback"* ]]
+}

--- a/release/tests/constants.bats
+++ b/release/tests/constants.bats
@@ -1,0 +1,199 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_constants.sh"
+}
+
+@test "TAG_PREFIX is apache-iceberg-" {
+  [ "$TAG_PREFIX" = "apache-iceberg-" ]
+}
+
+@test "BRANCH_SUFFIX is .x" {
+  [ "$BRANCH_SUFFIX" = ".x" ]
+}
+
+@test "APACHE_DIST_URL has correct default" {
+  [ "$APACHE_DIST_URL" = "https://dist.apache.org/repos/dist" ]
+}
+
+@test "APACHE_DIST_DEV_PATH is /dev/iceberg" {
+  [ "$APACHE_DIST_DEV_PATH" = "/dev/iceberg" ]
+}
+
+@test "APACHE_DIST_RELEASE_PATH is /release/iceberg" {
+  [ "$APACHE_DIST_RELEASE_PATH" = "/release/iceberg" ]
+}
+
+@test "NEXUS_BASE_URL has correct default" {
+  [ "$NEXUS_BASE_URL" = "https://repository.apache.org/service/local" ]
+}
+
+@test "NEXUS_STAGING_PROFILE is org.apache.iceberg" {
+  [ "$NEXUS_STAGING_PROFILE" = "org.apache.iceberg" ]
+}
+
+@test "DRY_RUN defaults to 1" {
+  [ "$DRY_RUN" = "1" ]
+}
+
+@test "VERSION_REGEX matches semver components" {
+  [[ "1.10.0" =~ ^${VERSION_REGEX}$ ]]
+  [ "${BASH_REMATCH[1]}" = "1" ]
+  [ "${BASH_REMATCH[2]}" = "10" ]
+  [ "${BASH_REMATCH[3]}" = "0" ]
+}
+
+@test "VERSION_REGEX_GIT_TAG matches RC tag" {
+  [[ "apache-iceberg-1.10.0-rc3" =~ ${VERSION_REGEX_GIT_TAG} ]]
+  [ "${BASH_REMATCH[1]}" = "1" ]
+  [ "${BASH_REMATCH[4]}" = "3" ]
+}
+
+@test "VERSION_REGEX_GIT_TAG rejects final tag" {
+  [[ ! "apache-iceberg-1.10.0" =~ ${VERSION_REGEX_GIT_TAG} ]]
+}
+
+@test "VERSION_REGEX_FINAL_TAG matches final tag" {
+  [[ "apache-iceberg-1.10.0" =~ ${VERSION_REGEX_FINAL_TAG} ]]
+}
+
+@test "VERSION_REGEX_FINAL_TAG rejects RC tag" {
+  [[ ! "apache-iceberg-1.10.0-rc3" =~ ${VERSION_REGEX_FINAL_TAG} ]]
+}
+
+@test "BRANCH_VERSION_REGEX matches 1.10.x" {
+  [[ "1.10.x" =~ ${BRANCH_VERSION_REGEX} ]]
+  [ "${BASH_REMATCH[1]}" = "1" ]
+  [ "${BASH_REMATCH[2]}" = "10" ]
+}
+
+@test "BRANCH_VERSION_REGEX rejects 1.10.0" {
+  [[ ! "1.10.0" =~ ${BRANCH_VERSION_REGEX} ]]
+}
+
+@test "BRANCH_VERSION_REGEX rejects iceberg-1.10.x" {
+  [[ ! "iceberg-1.10.x" =~ ${BRANCH_VERSION_REGEX} ]]
+}
+
+@test "BRANCH_VERSION_REGEX rejects release/1.10.x" {
+  [[ ! "release/1.10.x" =~ ${BRANCH_VERSION_REGEX} ]]
+}
+
+@test "GITHUB_REPO has correct default" {
+  [ "$GITHUB_REPO" = "apache/iceberg" ]
+}
+
+@test "Convenience binary matrix is sourced from gradle.properties" {
+  # Re-parse gradle.properties independently of _constants.sh and assert
+  # _constants.sh exposes the same values. If _parse_gradle_property
+  # regresses (e.g. trims wrong) this test fails before any release runs.
+  local gp
+  gp=$(cd "${LIBS_DIR}/../.." && pwd)/gradle.properties
+  [ -f "${gp}" ] \
+    || { echo "gradle.properties not found at ${gp}"; return 1; }
+
+  _from_gp() {
+    awk -F= -v k="$1" '
+      /^[[:space:]]*#/ { next }
+      {
+        sub(/^[[:space:]]+/, "", $1)
+        if ($1 == "systemProp." k || $1 == k) {
+          sub(/^[^=]*=/, "")
+          sub(/[[:space:]]+$/, "")
+          sub(/^[[:space:]]+/, "")
+          print
+          exit
+        }
+      }' "${gp}"
+  }
+
+  [ "${KNOWN_SCALA_VERSIONS}" = "$(_from_gp knownScalaVersions)" ]
+  [ "${KNOWN_FLINK_VERSIONS}" = "$(_from_gp knownFlinkVersions)" ]
+  [ "${KNOWN_SPARK_VERSIONS}" = "$(_from_gp knownSparkVersions)" ]
+  [ "${KNOWN_KAFKA_VERSIONS}" = "$(_from_gp knownKafkaVersions)" ]
+  [ "${SCALA_PRIMARY}"        = "$(_from_gp defaultScalaVersion)" ]
+}
+
+@test "SCALA_SECONDARY is the non-default entry of KNOWN_SCALA_VERSIONS" {
+  [[ ",${KNOWN_SCALA_VERSIONS}," == *",${SCALA_SECONDARY},"* ]]
+  [ "${SCALA_SECONDARY}" != "${SCALA_PRIMARY}" ]
+}
+
+@test "SPARK_VERSIONS_PRIMARY_SCALA filters KNOWN_SPARK_VERSIONS to Spark 3.x (Spark 4+ dropped Scala 2.12)" {
+  IFS=',' read -ra known <<< "${KNOWN_SPARK_VERSIONS}"
+  IFS=',' read -ra primary <<< "${SPARK_VERSIONS_PRIMARY_SCALA}"
+
+  for v in "${primary[@]}"; do
+    local seen=0 k
+    for k in "${known[@]}"; do
+      if [[ "${k}" = "${v}" ]]; then seen=1; break; fi
+    done
+    [ "${seen}" -eq 1 ] \
+      || { echo "${v} not in KNOWN_SPARK_VERSIONS=${KNOWN_SPARK_VERSIONS}"; return 1; }
+    [ "${v%%.*}" -lt 4 ] \
+      || { echo "${v} should not be in SPARK_VERSIONS_PRIMARY_SCALA (major >= 4 dropped Scala 2.12)"; return 1; }
+  done
+
+  # Every Spark 3.x in KNOWN_SPARK_VERSIONS must appear in the primary set.
+  for k in "${known[@]}"; do
+    if [[ "${k%%.*}" -lt 4 ]]; then
+      [[ ",${SPARK_VERSIONS_PRIMARY_SCALA}," == *",${k},"* ]] \
+        || { echo "Spark ${k} missing from SPARK_VERSIONS_PRIMARY_SCALA=${SPARK_VERSIONS_PRIMARY_SCALA}"; return 1; }
+    fi
+  done
+}
+
+@test "SPARK_VERSIONS_SECONDARY_SCALA covers every Spark version in KNOWN_SPARK_VERSIONS" {
+  # Every Spark version in the known matrix must be in the secondary
+  # sweep: Spark 3.x adds a 2.13 variant alongside 2.12, and Spark 4.x is
+  # published only via this pass.
+  [ "${SPARK_VERSIONS_SECONDARY_SCALA}" = "${KNOWN_SPARK_VERSIONS}" ]
+}
+
+@test "_parse_gradle_property: returns trimmed value for systemProp.* keys" {
+  TMP=$(mktemp)
+  cat >"${TMP}" <<'EOF'
+# leading comment
+   systemProp.knownSparkVersions = 3.4,3.5,4.0,4.1
+systemProp.defaultScalaVersion=2.12
+plain.key=hello
+EOF
+  [ "$(_parse_gradle_property knownSparkVersions "${TMP}")" = "3.4,3.5,4.0,4.1" ]
+  [ "$(_parse_gradle_property defaultScalaVersion "${TMP}")" = "2.12" ]
+  [ "$(_parse_gradle_property plain.key "${TMP}")" = "hello" ]
+  rm -f "${TMP}"
+}
+
+@test "_parse_gradle_property: returns nonzero for missing key" {
+  TMP=$(mktemp)
+  cat >"${TMP}" <<'EOF'
+systemProp.knownSparkVersions=3.4
+EOF
+  run _parse_gradle_property doesNotExist "${TMP}"
+  [ "$status" -ne 0 ]
+  rm -f "${TMP}"
+}
+
+@test "_parse_gradle_property: returns nonzero when file missing" {
+  run _parse_gradle_property anyKey /nonexistent/path/gradle.properties
+  [ "$status" -ne 0 ]
+}

--- a/release/tests/exec.bats
+++ b/release/tests/exec.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_exec.sh"
+}
+
+@test "exec_process: dry-run prints but does not execute" {
+  DRY_RUN=1
+  run exec_process echo "should not appear as direct output"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run, WOULD execute"* ]]
+  [[ "$output" == *"echo"* ]]
+}
+
+@test "exec_process: real run executes command" {
+  DRY_RUN=0
+  run exec_process echo "hello from exec"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"hello from exec"* ]]
+}
+
+@test "exec_process: real run preserves exit code" {
+  DRY_RUN=0
+  run exec_process false
+  [ "$status" -ne 0 ]
+}
+
+@test "exec_process: redacts NEXUS_PASSWORD in dry-run output" {
+  DRY_RUN=1
+  export NEXUS_PASSWORD="super-secret-pw-12345"
+  run exec_process echo "credentials: super-secret-pw-12345 trailing"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"super-secret-pw-12345"* ]]
+  [[ "$output" == *"***"* ]]
+  unset NEXUS_PASSWORD
+}
+
+@test "exec_process: redacts SVN_PASSWORD in dry-run output" {
+  DRY_RUN=1
+  export SVN_PASSWORD="another-secret-67890"
+  run exec_process echo "creds another-secret-67890 end"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"another-secret-67890"* ]]
+  unset SVN_PASSWORD
+}
+
+@test "_redact_secrets: covers all secret env vars in the redaction list" {
+  # Every variable named in the loop in _redact_secrets must be redacted
+  # if set. This guards against accidental removals and keeps prepare-rc /
+  # publish-release / cancel-rc workflow secrets in sync.
+  local v
+  for v in NEXUS_PASSWORD NEXUS_USERNAME SVN_PASSWORD SVN_USERNAME GITHUB_TOKEN \
+           ICEBERG_NEXUS_PASSWORD ICEBERG_NEXUS_USER \
+           ICEBERG_SVN_DEV_PASSWORD ICEBERG_SVN_DEV_USERNAME \
+           ORG_GRADLE_PROJECT_mavenUser ORG_GRADLE_PROJECT_mavenPassword; do
+    local marker="redact-marker-${v}-zzz"
+    eval "export ${v}=\"${marker}\""
+    local got
+    got=$(_redact_secrets echo "value=${marker}")
+    [[ "$got" != *"${marker}"* ]] || { echo "leaked ${v}: $got"; return 1; }
+    [[ "$got" == *"***"* ]]
+    eval "unset ${v}"
+  done
+}
+
+@test "exec_process_with_retries: redacts secrets in final-failure error message" {
+  DRY_RUN=0
+  export SVN_PASSWORD="leak-canary-xyz"
+  # `false` always fails; the wrapper reports the command after the last
+  # attempt. Without redaction the password literal would leak there.
+  run exec_process_with_retries 1 0 "" false "user:leak-canary-xyz"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"leak-canary-xyz"* ]]
+  [[ "$output" == *"failed after 1 attempts"* ]]
+  unset SVN_PASSWORD
+}
+
+@test "exec_process_with_retries: succeeds on first attempt" {
+  DRY_RUN=0
+  run exec_process_with_retries 3 0 "" echo "ok"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ok"* ]]
+}
+
+@test "exec_process_with_retries: fails after max attempts" {
+  DRY_RUN=0
+  run exec_process_with_retries 2 0 "" false
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed after 2 attempts"* ]]
+}
+
+@test "exec_process_with_retries: requires at least 4 args" {
+  DRY_RUN=0
+  run exec_process_with_retries 3 0
+  [ "$status" -ne 0 ]
+}
+
+@test "calculate_sha512: creates checksum file in real mode" {
+  DRY_RUN=0
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "test content" > "$tmpfile"
+
+  calculate_sha512 "$tmpfile"
+
+  [ -f "${tmpfile}.sha512" ]
+  local basename
+  basename=$(basename "$tmpfile")
+  [[ "$(cat "${tmpfile}.sha512")" == *"${basename}"* ]]
+
+  rm -f "$tmpfile" "${tmpfile}.sha512"
+}
+
+@test "calculate_sha512: dry-run does not create file" {
+  DRY_RUN=1
+  local tmpfile
+  tmpfile=$(mktemp)
+  echo "test content" > "$tmpfile"
+
+  run calculate_sha512 "$tmpfile"
+  [ "$status" -eq 0 ]
+  [ ! -f "${tmpfile}.sha512" ]
+
+  rm -f "$tmpfile"
+}

--- a/release/tests/github.bats
+++ b/release/tests/github.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_github.sh"
+}
+
+@test "check_github_checks_passed: fails when GITHUB_TOKEN not set" {
+  unset GITHUB_TOKEN
+  DRY_RUN=0
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"GITHUB_TOKEN is required"* ]]
+}
+
+@test "check_github_checks_passed: skips in dry-run even without GITHUB_TOKEN" {
+  unset GITHUB_TOKEN
+  DRY_RUN=1
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY_RUN"* ]]
+}
+
+@test "check_github_checks_passed: skips in dry-run mode" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=1
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY_RUN"* ]]
+}
+
+@test "check_github_checks_passed: succeeds when all checks completed and passed" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    echo "0"
+    return 0
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"All GitHub checks passed"* ]]
+}
+
+@test "check_github_checks_passed: fails when checks are still running" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    if [[ "$*" == *"status"* && "$*" == *"length"* ]]; then
+      echo "1"
+    elif [[ "$*" == *"status"* ]]; then
+      echo "  - CI: in_progress"
+    else
+      echo "0"
+    fi
+    return 0
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"still-running"* ]]
+}
+
+@test "check_github_checks_passed: fails when checks have failed conclusions" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() {
+    if [[ "$*" == *"status"* && "$*" == *"length"* ]]; then
+      echo "0"
+    elif [[ "$*" == *"conclusion"* && "$*" == *"length"* ]]; then
+      echo "2"
+    elif [[ "$*" == *"conclusion"* ]]; then
+      echo "  - CI: failure"
+    else
+      echo "0"
+    fi
+    return 0
+  }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"failed GitHub checks"* ]]
+}
+
+@test "check_github_checks_passed: fails when gh api errors" {
+  export GITHUB_TOKEN="fake-token"
+  DRY_RUN=0
+
+  gh() { return 1; }
+  export -f gh
+
+  run check_github_checks_passed "abc123"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Failed to fetch"* ]]
+}

--- a/release/tests/gradle.bats
+++ b/release/tests/gradle.bats
@@ -65,16 +65,18 @@ teardown() {
   export NEXUS_PASSWORD="testpass"
   run stage_convenience_binaries
   [ "$status" -eq 0 ]
-  # Today's primary-Scala Spark matrix is 3.x only.
   [[ "$output" == *"-DsparkVersions=3.4,3.5"* ]] \
     || { echo "expected primary-Scala main matrix to use only Spark 3.x"; printf '%s\n' "$output"; return 1; }
-  # The literal "-DscalaVersion=2.12 ... -DsparkVersions=...,4.0..." combo must
-  # never appear; Iceberg's build hardcodes 2.13 internally for v4.x and the
-  # combination is brittle.
-  [[ "$output" != *"-DscalaVersion=2.12"*"4.0"* ]] \
-    || { echo "Spark 4.x must not be paired with primary Scala in the main matrix"; printf '%s\n' "$output"; return 1; }
-  [[ "$output" != *"-DscalaVersion=2.12"*"4.1"* ]] \
-    || { echo "Spark 4.x must not be paired with primary Scala in the main matrix"; printf '%s\n' "$output"; return 1; }
+  # Inspect only the gradle invocation lines carrying the primary Scala. A
+  # whole-output glob would falsely match Spark 4.x from the later 2.13 sweep.
+  local line
+  while IFS= read -r line; do
+    [[ "${line}" != *"-DscalaVersion=2.12"* ]] && continue
+    [[ "${line}" != *"sparkVersions="*"4.0"* ]] \
+      || { echo "Spark 4.0 must not appear in primary-Scala invocation: ${line}"; return 1; }
+    [[ "${line}" != *"sparkVersions="*"4.1"* ]] \
+      || { echo "Spark 4.1 must not appear in primary-Scala invocation: ${line}"; return 1; }
+  done <<< "$output"
   unset NEXUS_USERNAME NEXUS_PASSWORD
 }
 

--- a/release/tests/gradle.bats
+++ b/release/tests/gradle.bats
@@ -1,0 +1,332 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_gradle.sh"
+  TEST_TMPDIR=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# ---- build_source_tarball ----
+
+@test "build_source_tarball: dry-run does not invoke gradle or gpg" {
+  DRY_RUN=1
+  run build_source_tarball "${TEST_TMPDIR}" "apache-iceberg-1.10.0" "deadbeef" "1.10.0" ""
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run"* ]]
+  [ ! -f "${TEST_TMPDIR}/version.txt" ]
+  [ ! -f "${TEST_TMPDIR}/iceberg-build.properties" ]
+  [ ! -f "${TEST_TMPDIR}/apache-iceberg-1.10.0.tar.gz" ]
+}
+
+# ---- stage_convenience_binaries ----
+
+@test "stage_convenience_binaries: dry-run prints all expected gradle invocations" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+  run stage_convenience_binaries
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *"-Prelease"* ]]
+  [[ "$output" == *"--no-parallel"* ]]
+  [[ "$output" == *"--no-configuration-cache"* ]]
+  [[ "$output" == *"-DscalaVersion=2.12"* ]]
+  [[ "$output" == *"-DscalaVersion=2.13"* ]]
+  [[ "$output" == *"-DflinkVersions=1.20,2.0,2.1"* ]]
+  [[ "$output" == *"-DkafkaVersions=3"* ]]
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "stage_convenience_binaries: main matrix excludes Spark 4.x (which dropped Scala 2.12)" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+  run stage_convenience_binaries
+  [ "$status" -eq 0 ]
+  # Today's primary-Scala Spark matrix is 3.x only.
+  [[ "$output" == *"-DsparkVersions=3.4,3.5"* ]] \
+    || { echo "expected primary-Scala main matrix to use only Spark 3.x"; printf '%s\n' "$output"; return 1; }
+  # The literal "-DscalaVersion=2.12 ... -DsparkVersions=...,4.0..." combo must
+  # never appear; Iceberg's build hardcodes 2.13 internally for v4.x and the
+  # combination is brittle.
+  [[ "$output" != *"-DscalaVersion=2.12"*"4.0"* ]] \
+    || { echo "Spark 4.x must not be paired with primary Scala in the main matrix"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" != *"-DscalaVersion=2.12"*"4.1"* ]] \
+    || { echo "Spark 4.x must not be paired with primary Scala in the main matrix"; printf '%s\n' "$output"; return 1; }
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "stage_convenience_binaries: secondary-Scala sweep includes Spark 3.4" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+  run stage_convenience_binaries
+  [[ "$output" == *":iceberg-spark:iceberg-spark-3.4_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-extensions-3.4_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-runtime-3.4_2.13:publishApachePublicationToMavenRepository"* ]]
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "stage_convenience_binaries: secondary-Scala sweep includes Spark 3.5" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+  run stage_convenience_binaries
+  [[ "$output" == *":iceberg-spark:iceberg-spark-3.5_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-extensions-3.5_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-runtime-3.5_2.13:publishApachePublicationToMavenRepository"* ]]
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "stage_convenience_binaries: secondary-Scala sweep includes Spark 4.x (only published here)" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+  run stage_convenience_binaries
+  [[ "$output" == *":iceberg-spark:iceberg-spark-4.0_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-extensions-4.0_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-runtime-4.0_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-4.1_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-extensions-4.1_2.13:publishApachePublicationToMavenRepository"* ]]
+  [[ "$output" == *":iceberg-spark:iceberg-spark-runtime-4.1_2.13:publishApachePublicationToMavenRepository"* ]]
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "stage_convenience_binaries: passes credentials via ORG_GRADLE_PROJECT_* env vars (not in argv)" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="visible-user"
+  export NEXUS_PASSWORD="secret-password-xyz"
+  run stage_convenience_binaries
+  [[ "$output" != *"secret-password-xyz"* ]] \
+    || { echo "password leaked into dry-run output"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" != *"-PmavenUser="* ]] \
+    || { echo "should not pass -PmavenUser= on argv"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" != *"-PmavenPassword="* ]] \
+    || { echo "should not pass -PmavenPassword= on argv"; printf '%s\n' "$output"; return 1; }
+  unset NEXUS_USERNAME NEXUS_PASSWORD ORG_GRADLE_PROJECT_mavenUser ORG_GRADLE_PROJECT_mavenPassword
+}
+
+@test "stage_convenience_binaries: exports ORG_GRADLE_PROJECT_mavenUser/Password to the gradle invocation env" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="release-mgr"
+  export NEXUS_PASSWORD="trace-canary-1234"
+  unset ORG_GRADLE_PROJECT_mavenUser ORG_GRADLE_PROJECT_mavenPassword
+
+  run stage_convenience_binaries
+  [ "$status" -eq 0 ]
+
+  # In a sub-shell-style `run`, exports made by the function don't survive,
+  # so we re-invoke directly to inspect environment side-effects.
+  stage_convenience_binaries >/dev/null 2>&1
+  [ "${ORG_GRADLE_PROJECT_mavenUser}" = "release-mgr" ]
+  [ "${ORG_GRADLE_PROJECT_mavenPassword}" = "trace-canary-1234" ]
+  unset NEXUS_USERNAME NEXUS_PASSWORD ORG_GRADLE_PROJECT_mavenUser ORG_GRADLE_PROJECT_mavenPassword
+}
+
+@test "stage_convenience_binaries: warns when NEXUS_USERNAME unset" {
+  DRY_RUN=1
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+  run stage_convenience_binaries
+  [[ "$output" == *"NEXUS_USERNAME or NEXUS_PASSWORD not set"* ]]
+}
+
+# ---- verify_jdk_17 ----
+#
+# verify_jdk_17 parses the output of `java -version`. We stub `java` and
+# `command` so we can exercise the parser without depending on the JDK
+# installed in the test environment.
+
+@test "verify_jdk_17: passes for OpenJDK 17 version string" {
+  command() {
+    if [[ "$1" == "-v" && "$2" == "java" ]]; then return 0; fi
+    builtin command "$@"
+  }
+  java() {
+    echo 'openjdk version "17.0.10" 2024-01-16' >&2
+  }
+  export -f command java
+  run verify_jdk_17
+  [ "$status" -eq 0 ]
+}
+
+@test "verify_jdk_17: fails for Java 11" {
+  command() {
+    if [[ "$1" == "-v" && "$2" == "java" ]]; then return 0; fi
+    builtin command "$@"
+  }
+  java() {
+    echo 'openjdk version "11.0.21" 2023-10-17' >&2
+  }
+  export -f command java
+  run verify_jdk_17
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be built with Java 17"* ]]
+}
+
+@test "verify_jdk_17: fails for Java 21" {
+  command() {
+    if [[ "$1" == "-v" && "$2" == "java" ]]; then return 0; fi
+    builtin command "$@"
+  }
+  java() {
+    echo 'openjdk version "21.0.2" 2024-01-16' >&2
+  }
+  export -f command java
+  run verify_jdk_17
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be built with Java 17"* ]]
+}
+
+@test "verify_jdk_17: handles 1.x version string for old JDKs" {
+  command() {
+    if [[ "$1" == "-v" && "$2" == "java" ]]; then return 0; fi
+    builtin command "$@"
+  }
+  java() {
+    echo 'java version "1.8.0_392"' >&2
+  }
+  export -f command java
+  run verify_jdk_17
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"must be built with Java 17"* ]]
+}
+
+@test "verify_jdk_17: fails when java is missing from PATH" {
+  command() {
+    if [[ "$1" == "-v" && "$2" == "java" ]]; then return 1; fi
+    builtin command "$@"
+  }
+  export -f command
+  run verify_jdk_17
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"java not found"* ]]
+}
+
+# ---- drift guard: stage_convenience_binaries argv matches gradle.properties ----
+#
+# The convenience-binary publish matrix is sourced from gradle.properties
+# at module-load time (see _constants.sh). This guard runs the dry-run
+# path of stage_convenience_binaries and asserts the resulting Gradle
+# argv carries exactly the matrix gradle.properties advertises, so we
+# fail loudly if the parser ever drops or mis-trims a value.
+
+@test "drift guard: stage_convenience_binaries publishes the matrix declared in gradle.properties" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+
+  local gp
+  gp=$(cd "${LIBS_DIR}/../.." && pwd)/gradle.properties
+  [ -f "${gp}" ] \
+    || { echo "gradle.properties not found at ${gp}"; return 1; }
+
+  _from_gp() {
+    awk -F= -v k="$1" '
+      /^[[:space:]]*#/ { next }
+      {
+        sub(/^[[:space:]]+/, "", $1)
+        if ($1 == "systemProp." k || $1 == k) {
+          sub(/^[^=]*=/, "")
+          sub(/[[:space:]]+$/, "")
+          sub(/^[[:space:]]+/, "")
+          print
+          exit
+        }
+      }' "${gp}"
+  }
+
+  local gp_default_scala gp_known_flink gp_known_spark gp_known_kafka gp_known_scala
+  gp_default_scala=$(_from_gp defaultScalaVersion)
+  gp_known_scala=$(_from_gp knownScalaVersions)
+  gp_known_flink=$(_from_gp knownFlinkVersions)
+  gp_known_spark=$(_from_gp knownSparkVersions)
+  gp_known_kafka=$(_from_gp knownKafkaVersions)
+
+  run stage_convenience_binaries
+  [ "$status" -eq 0 ]
+
+  # Main pass: primary Scala + full Flink/Kafka + Spark < 4 only.
+  local primary_spark=""
+  local v
+  for v in $(echo "${gp_known_spark}" | tr ',' ' '); do
+    if [[ "${v%%.*}" -lt 4 ]]; then
+      if [[ -n "${primary_spark}" ]]; then primary_spark="${primary_spark},"; fi
+      primary_spark="${primary_spark}${v}"
+    fi
+  done
+
+  [[ "$output" == *"-DscalaVersion=${gp_default_scala}"* ]] \
+    || { echo "main matrix is missing -DscalaVersion=${gp_default_scala}"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" == *"-DflinkVersions=${gp_known_flink}"* ]] \
+    || { echo "main matrix is missing -DflinkVersions=${gp_known_flink}"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" == *"-DsparkVersions=${primary_spark}"* ]] \
+    || { echo "main matrix should use primary-Scala Spark subset (${primary_spark}); got"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" == *"-DkafkaVersions=${gp_known_kafka}"* ]] \
+    || { echo "main matrix is missing -DkafkaVersions=${gp_known_kafka}"; printf '%s\n' "$output"; return 1; }
+
+  # Secondary-Scala sweep: every Spark version in knownSparkVersions
+  # (including 4.x) must get an explicit invocation.
+  local secondary_scala
+  secondary_scala=$(echo "${gp_known_scala}" | tr ',' '\n' | grep -v "^${gp_default_scala}$" | head -n1)
+  [ -n "${secondary_scala}" ] \
+    || { echo "no secondary Scala available in knownScalaVersions=${gp_known_scala}"; return 1; }
+
+  for v in $(echo "${gp_known_spark}" | tr ',' ' '); do
+    [[ "$output" == *":iceberg-spark:iceberg-spark-${v}_${secondary_scala}:publishApachePublicationToMavenRepository"* ]] \
+      || { echo "Spark ${v}_${secondary_scala} missing from secondary-Scala sweep"; printf '%s\n' "$output"; return 1; }
+    [[ "$output" == *":iceberg-spark:iceberg-spark-extensions-${v}_${secondary_scala}:publishApachePublicationToMavenRepository"* ]] \
+      || { echo "Spark extensions ${v}_${secondary_scala} missing from secondary-Scala sweep"; printf '%s\n' "$output"; return 1; }
+    [[ "$output" == *":iceberg-spark:iceberg-spark-runtime-${v}_${secondary_scala}:publishApachePublicationToMavenRepository"* ]] \
+      || { echo "Spark runtime ${v}_${secondary_scala} missing from secondary-Scala sweep"; printf '%s\n' "$output"; return 1; }
+  done
+
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}
+
+@test "drift guard: Spark 4.x is never combined with the primary Scala on argv" {
+  DRY_RUN=1
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+
+  run stage_convenience_binaries
+  [ "$status" -eq 0 ]
+
+  # Walk every Gradle invocation line in the dry-run output. For each one,
+  # if it carries -DscalaVersion=2.12 (the primary Scala), assert it does
+  # not also carry any -DsparkVersions=...4.x entry. This catches future
+  # regressions where SPARK_VERSIONS_PRIMARY_SCALA accidentally pulls in
+  # Spark 4+.
+  local line
+  while IFS= read -r line; do
+    if [[ "${line}" == *"-DscalaVersion=2.12"* ]]; then
+      [[ "${line}" != *"sparkVersions="*"4.0"* ]] \
+        || { echo "primary Scala invocation must not include Spark 4.0: ${line}"; return 1; }
+      [[ "${line}" != *"sparkVersions="*"4.1"* ]] \
+        || { echo "primary Scala invocation must not include Spark 4.1: ${line}"; return 1; }
+    fi
+  done <<< "$output"
+
+  unset NEXUS_USERNAME NEXUS_PASSWORD
+}

--- a/release/tests/log.bats
+++ b/release/tests/log.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  unset _LOG_LOADED
+  source "${LIBS_DIR}/_log.sh"
+  TEST_TMPDIR=$(mktemp -d)
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+@test "print_error: writes to stderr" {
+  run print_error "test error"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"ERROR: test error"* ]]
+}
+
+@test "print_warning: writes to stderr" {
+  run print_warning "test warning"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WARNING: test warning"* ]]
+}
+
+@test "print_info: writes to stderr" {
+  run print_info "test info"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"INFO: test info"* ]]
+}
+
+@test "step_summary: writes to stdout when GITHUB_STEP_SUMMARY unset" {
+  unset GITHUB_STEP_SUMMARY
+  run step_summary "hello"
+  [ "$status" -eq 0 ]
+  [ "$output" = "hello" ]
+}
+
+@test "step_summary: writes to file when GITHUB_STEP_SUMMARY is set" {
+  export GITHUB_STEP_SUMMARY="${TEST_TMPDIR}/summary.md"
+  step_summary "line one"
+  step_summary "line two"
+  [ -f "${GITHUB_STEP_SUMMARY}" ]
+  [[ "$(cat "${GITHUB_STEP_SUMMARY}")" == *"line one"* ]]
+  [[ "$(cat "${GITHUB_STEP_SUMMARY}")" == *"line two"* ]]
+}
+
+@test "step_summary: appends to existing GITHUB_STEP_SUMMARY file" {
+  export GITHUB_STEP_SUMMARY="${TEST_TMPDIR}/summary.md"
+  echo "existing" > "${GITHUB_STEP_SUMMARY}"
+  step_summary "new line"
+  [[ "$(cat "${GITHUB_STEP_SUMMARY}")" == *"existing"* ]]
+  [[ "$(cat "${GITHUB_STEP_SUMMARY}")" == *"new line"* ]]
+}
+
+@test "NO_COLOR suppresses colors" {
+  export NO_COLOR=1
+  [ -z "${RED}" ] || [ "${RED}" = "" ]
+  [ -z "${GREEN}" ] || [ "${GREEN}" = "" ]
+}

--- a/release/tests/nexus.bats
+++ b/release/tests/nexus.bats
@@ -1,0 +1,376 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_nexus.sh"
+  export NEXUS_USERNAME="testuser"
+  export NEXUS_PASSWORD="testpass"
+}
+
+@test "nexus_close_staging_repo: dry-run does not call curl" {
+  DRY_RUN=1
+  run nexus_close_staging_repo "orgapacheiceberg-1234" "test close"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run"* ]]
+  [[ "$output" == *"close"* ]]
+}
+
+@test "nexus_close_staging_repo: constructs correct URL in dry-run" {
+  DRY_RUN=1
+  run nexus_close_staging_repo "orgapacheiceberg-1234"
+  [[ "$output" == *"staging/bulk/close"* ]]
+}
+
+@test "nexus_release_staging_repo: dry-run includes promote URL" {
+  DRY_RUN=1
+  run nexus_release_staging_repo "orgapacheiceberg-1234"
+  [[ "$output" == *"staging/bulk/promote"* ]]
+}
+
+@test "nexus_drop_staging_repo: dry-run includes drop URL" {
+  DRY_RUN=1
+  run nexus_drop_staging_repo "orgapacheiceberg-1234"
+  [[ "$output" == *"staging/bulk/drop"* ]]
+}
+
+@test "_nexus_bulk_action: includes repo ID in payload" {
+  DRY_RUN=1
+  run _nexus_bulk_action "close" "orgapacheiceberg-5678" "test"
+  [[ "$output" == *"orgapacheiceberg-5678"* ]]
+}
+
+@test "_nexus_bulk_action: uses correct base URL" {
+  DRY_RUN=1
+  NEXUS_BASE_URL="https://example.com/nexus"
+  run _nexus_bulk_action "drop" "repo-123" "test"
+  [[ "$output" == *"example.com/nexus/staging/bulk/drop"* ]]
+}
+
+@test "nexus_find_open_staging_repo: dry-run returns placeholder" {
+  DRY_RUN=1
+  nexus_find_open_staging_repo "org.apache.iceberg"
+  [ "$staging_repo_id" = "DRY-RUN-REPO-ID" ]
+}
+
+@test "nexus_close_staging_repo: real mode calls curl with correct args" {
+  DRY_RUN=0
+  curl() {
+    echo "CURL_ARGS: $*" >&2
+    return 0
+  }
+  export -f curl
+  run nexus_close_staging_repo "orgapacheiceberg-9999" "test desc"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staging/bulk/close"* ]]
+  [[ "$output" == *"orgapacheiceberg-9999"* ]]
+}
+
+@test "nexus_drop_staging_repo: real mode calls curl with auth" {
+  DRY_RUN=0
+  curl() {
+    echo "CURL_ARGS: $*" >&2
+    return 0
+  }
+  export -f curl
+  run nexus_drop_staging_repo "orgapacheiceberg-1111"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"staging/bulk/drop"* ]]
+}
+
+@test "nexus_find_open_staging_repo: fails when no open repo found" {
+  DRY_RUN=0
+  curl() {
+    cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<stagingProfileRepositories><data /></stagingProfileRepositories>
+EOF
+    return 0
+  }
+  export -f curl
+  run nexus_find_open_staging_repo "org.apache.iceberg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No open staging repository"* ]]
+}
+
+@test "nexus_find_open_staging_repo: finds single open repo" {
+  DRY_RUN=0
+  curl() {
+    cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<stagingProfileRepositories>
+  <data>
+    <stagingProfileRepository>
+      <type>open</type>
+      <repositoryId>orgapacheiceberg-1234</repositoryId>
+    </stagingProfileRepository>
+  </data>
+</stagingProfileRepositories>
+EOF
+    return 0
+  }
+  export -f curl
+  nexus_find_open_staging_repo "org.apache.iceberg"
+  [ "$staging_repo_id" = "orgapacheiceberg-1234" ]
+}
+
+@test "nexus_find_open_staging_repo: fails when multiple open repos found" {
+  DRY_RUN=0
+  curl() {
+    cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<stagingProfileRepositories>
+  <data>
+    <stagingProfileRepository>
+      <type>open</type>
+      <repositoryId>orgapacheiceberg-1234</repositoryId>
+    </stagingProfileRepository>
+    <stagingProfileRepository>
+      <type>open</type>
+      <repositoryId>orgapacheiceberg-5678</repositoryId>
+    </stagingProfileRepository>
+  </data>
+</stagingProfileRepositories>
+EOF
+    return 0
+  }
+  export -f curl
+  run nexus_find_open_staging_repo "org.apache.iceberg"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"Found 2 open"* ]]
+}
+
+@test "nexus_find_open_staging_repo: fails gracefully when curl returns non-zero" {
+  DRY_RUN=0
+  curl() {
+    return 22
+  }
+  export -f curl
+  run nexus_find_open_staging_repo "org.apache.iceberg"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Failed to query Nexus staging repositories"* ]]
+}
+
+@test "nexus_find_open_staging_repo: error hint does not mention --staging-repo-id flag" {
+  # The script that wraps this function does not expose --staging-repo-id;
+  # an earlier message suggested it and was misleading.
+  DRY_RUN=0
+  curl() {
+    cat <<'EOF'
+<?xml version="1.0" encoding="UTF-8"?>
+<stagingProfileRepositories>
+  <data>
+    <stagingProfileRepository>
+      <type>open</type>
+      <repositoryId>orgapacheiceberg-1234</repositoryId>
+    </stagingProfileRepository>
+    <stagingProfileRepository>
+      <type>open</type>
+      <repositoryId>orgapacheiceberg-5678</repositoryId>
+    </stagingProfileRepository>
+  </data>
+</stagingProfileRepositories>
+EOF
+    return 0
+  }
+  export -f curl
+  run nexus_find_open_staging_repo "org.apache.iceberg"
+  [[ "$output" != *"--staging-repo-id"* ]]
+}
+
+@test "_nexus_bulk_action: fails fast in real mode without NEXUS_USERNAME" {
+  DRY_RUN=0
+  unset NEXUS_USERNAME
+  unset NEXUS_PASSWORD
+  run _nexus_bulk_action "drop" "orgapacheiceberg-1" "test"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"NEXUS_USERNAME must be set"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Staging repository verification (publish/cancel safety net)
+# ---------------------------------------------------------------------------
+
+# Helper: writes a curl stub that returns a metadata XML response with the
+# given profile/state/description, and returns 200 for HEAD requests
+# against the iceberg-core POM for the given version (default 1.10.0).
+# HEADs for any other version return 404. State is exported via globals
+# rather than closed-over locals because bash re-parses function bodies
+# at call time and locals are out of scope by then.
+function _stub_nexus_curl {
+  export _STUB_NEXUS_PROFILE="$1"
+  export _STUB_NEXUS_STATE="$2"
+  export _STUB_NEXUS_DESCRIPTION="$3"
+  export _STUB_NEXUS_VERSION="${4:-1.10.0}"
+  curl() {
+    local args=("$@")
+    local is_head=0
+    local i
+    for ((i = 0; i < ${#args[@]}; i++)); do
+      if [[ "${args[i]}" == "-I" ]]; then
+        is_head=1
+      fi
+    done
+    if [[ ${is_head} -eq 1 ]]; then
+      local url="${args[$((${#args[@]} - 1))]}"
+      if [[ "${url}" == *"iceberg-core/${_STUB_NEXUS_VERSION}/iceberg-core-${_STUB_NEXUS_VERSION}.pom" ]]; then
+        echo -n "200"
+      else
+        echo -n "404"
+      fi
+      return 0
+    fi
+    cat <<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<stagingProfileRepository>
+  <profileName>${_STUB_NEXUS_PROFILE}</profileName>
+  <type>${_STUB_NEXUS_STATE}</type>
+  <repositoryId>orgapacheiceberg-1234</repositoryId>
+  <description>${_STUB_NEXUS_DESCRIPTION}</description>
+</stagingProfileRepository>
+XML
+    return 0
+  }
+  export -f curl
+}
+
+@test "nexus_get_staging_repo_metadata: dry-run fills placeholder values" {
+  DRY_RUN=1
+  nexus_get_staging_repo_metadata "orgapacheiceberg-1234"
+  [ "${_nexus_repo_profile}" = "${NEXUS_STAGING_PROFILE}" ]
+  [ "${_nexus_repo_state}" = "closed" ]
+  [ "${_nexus_repo_description}" = "DRY-RUN" ]
+}
+
+@test "nexus_get_staging_repo_metadata: parses real-mode XML" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "Apache Iceberg 1.10.0 RC2"
+  nexus_get_staging_repo_metadata "orgapacheiceberg-1234"
+  [ "${_nexus_repo_profile}" = "org.apache.iceberg" ]
+  [ "${_nexus_repo_state}" = "closed" ]
+  [ "${_nexus_repo_description}" = "Apache Iceberg 1.10.0 RC2" ]
+}
+
+@test "nexus_get_staging_repo_metadata: surfaces curl failure" {
+  DRY_RUN=0
+  curl() { return 22; }
+  export -f curl
+  run nexus_get_staging_repo_metadata "orgapacheiceberg-9999"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Could not fetch Nexus staging repository"* ]]
+}
+
+@test "nexus_check_iceberg_artifact_exists: 200 returns success" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "" "1.10.0"
+  run nexus_check_iceberg_artifact_exists "orgapacheiceberg-1234" "1.10.0"
+  [ "$status" -eq 0 ]
+}
+
+@test "nexus_check_iceberg_artifact_exists: 404 fails with helpful message" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "" "9.9.9"
+  run nexus_check_iceberg_artifact_exists "orgapacheiceberg-1234" "1.10.0"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"got HTTP 404"* ]]
+}
+
+@test "nexus_check_iceberg_artifact_exists: dry-run is a no-op" {
+  DRY_RUN=1
+  run nexus_check_iceberg_artifact_exists "orgapacheiceberg-1234" "1.10.0"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run"* ]]
+}
+
+@test "nexus_verify_staging_repo: passes when profile, state, artifact, description all match" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "Apache Iceberg 1.10.0 RC2" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"verified"* ]]
+}
+
+@test "nexus_verify_staging_repo: fails on profile mismatch" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.parquet" "closed" "Apache Iceberg 1.10.0 RC2" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"belongs to profile 'org.apache.parquet'"* ]]
+}
+
+@test "nexus_verify_staging_repo: fails when repo is still open" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "open" "Apache Iceberg 1.10.0 RC2" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"in state 'open'"* ]]
+  [[ "$output" == *"Re-run prepare-rc"* ]]
+}
+
+@test "nexus_verify_staging_repo: fails when repo already released" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "released" "Apache Iceberg 1.10.0 RC2" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"in state 'released'"* ]]
+  [[ "$output" == *"already been released"* ]]
+}
+
+@test "nexus_verify_staging_repo: fails when version artifact missing" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "Apache Iceberg 1.10.0 RC2" "9.9.9"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"does not contain iceberg-core 1.10.0"* ]]
+}
+
+@test "nexus_verify_staging_repo: fails on description mismatch (different RC) by default" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "Apache Iceberg 1.10.0 RC1" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"description"* ]]
+  [[ "$output" == *"Apache Iceberg 1.10.0 RC2"* ]]
+}
+
+@test "nexus_verify_staging_repo: allow_description_mismatch=1 turns description mismatch into a warning" {
+  DRY_RUN=0
+  allow_description_mismatch=1
+  _stub_nexus_curl "org.apache.iceberg" "closed" "Apache Iceberg 1.10.0 RC1" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Continuing anyway"* ]]
+}
+
+@test "nexus_verify_staging_repo: skips description check when expected_rc is empty" {
+  DRY_RUN=0
+  _stub_nexus_curl "org.apache.iceberg" "closed" "" "1.10.0"
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" ""
+  [ "$status" -eq 0 ]
+}
+
+@test "nexus_verify_staging_repo: dry-run passes without hitting network" {
+  DRY_RUN=1
+  curl() { echo "FAIL: curl should not be invoked in dry-run" >&2; return 1; }
+  export -f curl
+  run nexus_verify_staging_repo "orgapacheiceberg-1234" "1.10.0" "2"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"FAIL: curl should not be invoked"* ]]
+}

--- a/release/tests/prepare_rc_branch.bats
+++ b/release/tests/prepare_rc_branch.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# These tests cover prepare-rc.sh's branch-selection rules: X.Y.0 tags
+# from main; X.Y.Z (Z >= 1) requires the X.Y.x branch to already exist
+# on the remote. We build a hermetic git fixture so we can vary which
+# remote refs exist, and run the script in dry-run.
+
+setup() {
+  load test_helper/common
+  WORKSPACE_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+  TEST_TMPDIR=$(mktemp -d)
+  UPSTREAM="${TEST_TMPDIR}/upstream.git"
+  CLONE="${TEST_TMPDIR}/clone"
+
+  git init --bare --initial-branch=main "${UPSTREAM}" >/dev/null
+
+  git -c init.defaultBranch=main clone --quiet "${UPSTREAM}" "${CLONE}"
+  pushd "${CLONE}" >/dev/null
+    git config user.email release-tests@example.com
+    git config user.name "Release Tests"
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+
+    # Stage the release scripts and a stub gradlew/dev/source-release.sh so
+    # the early prerequisite checks pass.
+    mkdir -p release dev
+    cp "${WORKSPACE_ROOT}/release/"*.sh release/
+    cp -R "${WORKSPACE_ROOT}/release/libs"  release/libs
+    cp    "${WORKSPACE_ROOT}/dev/stage-binaries.sh" dev/stage-binaries.sh
+    cp    "${WORKSPACE_ROOT}/gradle.properties" gradle.properties
+    chmod +x release/*.sh dev/stage-binaries.sh
+    cat >gradlew <<'EOF'
+#!/bin/bash
+echo "gradlew stub: $*"
+EOF
+    chmod +x gradlew
+
+    git add -A
+    git commit --quiet -m "initial"
+    git push --quiet origin main
+  popd >/dev/null
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+}
+
+# Run prepare-rc.sh inside the clone with --skip-ci-check so we don't need
+# a real GitHub backend, and capture stdout+stderr while preserving the
+# script's exit status (the trailing popd would otherwise mask it).
+run_prepare_rc() {
+  local version="$1"
+  shift
+  (cd "${CLONE}" && DRY_RUN=1 GITHUB_TOKEN="" \
+    ./release/prepare-rc.sh "${version}" --skip-ci-check "$@" 2>&1)
+}
+
+# ---------------------------------------------------------------------------
+# X.Y.0: tag from main, no branch needed
+# ---------------------------------------------------------------------------
+
+@test "prepare-rc X.Y.0: tags from origin/main without creating a branch" {
+  run run_prepare_rc 1.99.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"X.Y.0 release: tagging"* ]]
+  [[ "$output" == *"origin/main"* ]]
+  [[ "$output" != *"git checkout -b 1.99.x"* ]] \
+    || { echo "should not create 1.99.x branch for X.Y.0"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" != *"git push origin 1.99.x"* ]] \
+    || { echo "should not push 1.99.x branch for X.Y.0"; printf '%s\n' "$output"; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# X.Y.Z (Z >= 1): require X.Y.x to exist on the remote, never auto-create
+# ---------------------------------------------------------------------------
+
+@test "prepare-rc X.Y.Z: fails with helpful message when X.Y.x does not exist on remote" {
+  run run_prepare_rc 1.94.1
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Release branch 'origin/1.94.x' not found on remote"* ]]
+  [[ "$output" == *"apache-iceberg-1.94.0"* ]] \
+    || { echo "expected pointer to apache-iceberg-1.94.0 final tag"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" == *"Iceberg's convention"* ]]
+}
+
+@test "prepare-rc X.Y.Z: tags from existing X.Y.x branch when present on remote" {
+  pushd "${CLONE}" >/dev/null
+    git checkout -b 1.93.x main
+    echo patch > patch.txt
+    git add patch.txt
+    git commit --quiet -m "patch backport on 1.93.x"
+    git push --quiet origin 1.93.x
+    git checkout main
+    git branch -D 1.93.x
+  popd >/dev/null
+
+  run run_prepare_rc 1.93.1
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Patch release: tagging from origin/1.93.x"* ]]
+  [[ "$output" != *"git checkout -b 1.93.x origin/main"* ]] \
+    || { echo "patch path must not branch from main"; printf '%s\n' "$output"; return 1; }
+  [[ "$output" != *"git push origin 1.93.x --set-upstream"* ]] \
+    || { echo "should not push --set-upstream when branch already exists"; printf '%s\n' "$output"; return 1; }
+}
+
+# ---------------------------------------------------------------------------
+# Removed flags: --source-branch and --skip-branch-creation are no longer
+# recognized. Both should be rejected as unknown options.
+# ---------------------------------------------------------------------------
+
+@test "prepare-rc: --source-branch is no longer a recognized flag" {
+  run run_prepare_rc 1.91.0 --source-branch main
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: --source-branch"* ]]
+}
+
+@test "prepare-rc: --skip-branch-creation is no longer a recognized flag" {
+  run run_prepare_rc 1.91.0 --skip-branch-creation
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: --skip-branch-creation"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Default remote selection: prefer 'apache' when configured, fall back to 'origin'
+# ---------------------------------------------------------------------------
+
+@test "prepare-rc: defaults to 'apache' remote when configured" {
+  pushd "${CLONE}" >/dev/null
+    git remote add apache "${UPSTREAM}"
+    git fetch --quiet apache
+  popd >/dev/null
+
+  run run_prepare_rc 1.92.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apache/main"* ]] \
+    || { echo "expected default remote to be 'apache' when configured"; printf '%s\n' "$output"; return 1; }
+}
+
+@test "prepare-rc: falls back to 'origin' when 'apache' is not configured" {
+  run run_prepare_rc 1.92.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"origin/main"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Workspace alignment: HEAD is moved to release_hash before tarball + binary
+# build so both come from the same commit (parity with manual flow).
+# ---------------------------------------------------------------------------
+
+@test "prepare-rc X.Y.0: aligns workspace to release_hash when HEAD lags origin/main" {
+  pushd "${CLONE}" >/dev/null
+    # Move local HEAD behind origin/main so the alignment check fires.
+    echo lagged > lagged.txt
+    git add lagged.txt
+    git commit --quiet -m "local-only commit, leaves origin/main behind"
+    # Force HEAD onto a different commit than origin/main by resetting to
+    # the previous commit; origin/main has advanced via a fresh push.
+    pushd "${UPSTREAM}" >/dev/null
+      # Append a remote-only commit so origin/main is ahead of local HEAD.
+    popd >/dev/null
+    # Add a commit on origin/main only, by pushing from a separate worktree.
+    git checkout --quiet -b advance HEAD
+    echo advance > advance.txt
+    git add advance.txt
+    git commit --quiet -m "advance origin/main"
+    git push --quiet origin advance:main
+    git checkout --quiet main
+    git reset --hard --quiet HEAD~1
+    git branch -D advance >/dev/null 2>&1 || true
+  popd >/dev/null
+
+  run run_prepare_rc 1.95.0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"WOULD checkout"* ]] \
+    || { echo "expected workspace alignment message"; printf '%s\n' "$output"; return 1; }
+}

--- a/release/tests/publish_release.bats
+++ b/release/tests/publish_release.bats
@@ -1,0 +1,201 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+# End-to-end tests for release/publish-release.sh exercising argument
+# parsing, validation guards, and the dry-run happy path against a
+# hermetic git fixture. SVN, Nexus, and GitHub interactions are no-ops
+# under DRY_RUN=1.
+
+setup() {
+  load test_helper/common
+  WORKSPACE_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd)"
+
+  TEST_TMPDIR=$(mktemp -d)
+  CLONE="${TEST_TMPDIR}/clone"
+  UPSTREAM="${TEST_TMPDIR}/upstream.git"
+
+  git init --bare --initial-branch=main "${UPSTREAM}" >/dev/null
+  git -c init.defaultBranch=main clone --quiet "${UPSTREAM}" "${CLONE}"
+  pushd "${CLONE}" >/dev/null
+    git config user.email release-tests@example.com
+    git config user.name "Release Tests"
+    git config commit.gpgsign false
+    git config tag.gpgsign false
+
+    mkdir -p release dev
+    cp "${WORKSPACE_ROOT}/release/"*.sh release/
+    cp -R "${WORKSPACE_ROOT}/release/libs"  release/libs
+    cp    "${WORKSPACE_ROOT}/dev/stage-binaries.sh" dev/stage-binaries.sh
+    cp    "${WORKSPACE_ROOT}/gradle.properties" gradle.properties
+    chmod +x release/*.sh dev/stage-binaries.sh
+
+    echo first > seed.txt
+    git add -A
+    git commit --quiet -m "initial"
+    git push --quiet origin main
+
+    git tag -a "apache-iceberg-1.10.0-rc0" -m "Apache Iceberg 1.10.0 RC0"
+  popd >/dev/null
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+  unset GITHUB_TOKEN
+}
+
+run_publish_release() {
+  (cd "${CLONE}" && DRY_RUN=1 GITHUB_TOKEN="" \
+    ./release/publish-release.sh "$@" 2>&1)
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing / validation
+# ---------------------------------------------------------------------------
+
+@test "publish-release: requires version and staging-repo-id" {
+  run run_publish_release
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected 2 positional arguments"* ]]
+}
+
+@test "publish-release: requires staging-repo-id" {
+  run run_publish_release 1.10.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Expected 2 positional arguments"* ]]
+}
+
+@test "publish-release: rejects invalid version format" {
+  run run_publish_release 1.10 orgapacheiceberg-1234
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid version format"* ]]
+}
+
+@test "publish-release: rejects invalid staging-repo-id format" {
+  run run_publish_release 1.10.0 "bad id with spaces"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid staging repository ID"* ]]
+}
+
+@test "publish-release: rejects non-numeric --rc value" {
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc abc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Invalid RC number"* ]]
+}
+
+@test "publish-release: rejects unknown option" {
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --bogus-flag
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Unknown option: --bogus-flag"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Pre-publish guards
+# ---------------------------------------------------------------------------
+
+@test "publish-release: fails when RC tag does not exist locally" {
+  run run_publish_release 1.99.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"RC tag apache-iceberg-1.99.0-rc0 does not exist locally"* ]]
+}
+
+@test "publish-release: fails when final tag already exists" {
+  pushd "${CLONE}" >/dev/null
+    git tag -a "apache-iceberg-1.10.0" -m "already-released"
+  popd >/dev/null
+
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Final release tag apache-iceberg-1.10.0 already exists"* ]]
+}
+
+@test "publish-release: fails when HEAD does not match RC tag commit" {
+  pushd "${CLONE}" >/dev/null
+    echo drift > drift.txt
+    git add drift.txt
+    git commit --quiet -m "drift HEAD past the RC commit"
+  popd >/dev/null
+
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"HEAD"* && "$output" == *"does not match RC tag"* ]]
+  [[ "$output" == *"git checkout apache-iceberg-1.10.0-rc0"* ]]
+}
+
+@test "publish-release: rejects publishing an older RC when a newer one exists" {
+  pushd "${CLONE}" >/dev/null
+    git tag -a "apache-iceberg-1.10.0-rc1" -m "Apache Iceberg 1.10.0 RC1"
+  popd >/dev/null
+
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"is not the latest RC"* ]]
+  [[ "$output" == *"Latest is rc1"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# Dry-run happy path
+# ---------------------------------------------------------------------------
+
+@test "publish-release: dry-run with explicit --rc completes successfully" {
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"DRY RUN"* ]]
+  [[ "$output" == *"Staging repo verification"* ]]
+  [[ "$output" == *"Dry-run, WOULD execute"* ]]
+  [[ "$output" == *"published successfully"* ]]
+}
+
+@test "publish-release: dry-run auto-detects latest RC when --rc omitted" {
+  pushd "${CLONE}" >/dev/null
+    # Force a higher RC to be the latest.
+    git tag -a "apache-iceberg-1.10.0-rc2" -m "Apache Iceberg 1.10.0 RC2"
+    # Reset HEAD to the rc2 commit (same as rc0 here).
+  popd >/dev/null
+
+  run run_publish_release 1.10.0 orgapacheiceberg-1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Auto-detected latest RC: rc2"* ]]
+}
+
+@test "publish-release: --keep-old-releases skips dist/release cleanup messaging" {
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0 --keep-old-releases
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Skipping dist/release cleanup"* ]] \
+    || { echo "expected --keep-old-releases skip message"; printf '%s\n' "$output"; return 1; }
+}
+
+@test "publish-release: dry-run cleanup wording is scoped to the MAJOR.MINOR.x line" {
+  # No --keep-old-releases this time; the script must announce that it
+  # would only touch the 1.10.x line, not every release in dist/release.
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"superseded 1.10.x patch releases"* ]] \
+    || { echo "expected MAJOR.MINOR.x-scoped dry-run wording"; printf '%s\n' "$output"; return 1; }
+}
+
+@test "publish-release: dry-run does not leak SVN_PASSWORD into logs" {
+  export SVN_USERNAME="release-mgr"
+  export SVN_PASSWORD="trace-canary-svn-pw"
+  run run_publish_release 1.10.0 orgapacheiceberg-1234 --rc 0
+  unset SVN_USERNAME SVN_PASSWORD
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"trace-canary-svn-pw"* ]] \
+    || { echo "SVN password leaked into dry-run output"; printf '%s\n' "$output"; return 1; }
+}

--- a/release/tests/svn.bats
+++ b/release/tests/svn.bats
@@ -1,0 +1,343 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  source "${LIBS_DIR}/_svn.sh"
+  TEST_TMPDIR=$(mktemp -d)
+  ARGV_FILE="${TEST_TMPDIR}/argv"
+  STDIN_FILE="${TEST_TMPDIR}/stdin"
+  EXIT_FILE="${TEST_TMPDIR}/exit"
+  echo "0" > "${EXIT_FILE}"
+  export ARGV_FILE STDIN_FILE EXIT_FILE
+}
+
+teardown() {
+  rm -rf "${TEST_TMPDIR}"
+  unset SVN_USERNAME SVN_PASSWORD ARGV_FILE STDIN_FILE EXIT_FILE
+}
+
+# Stub svn that records its argv and stdin to disk so tests can assert on
+# what was actually invoked. Exit code is read from EXIT_FILE so tests can
+# simulate failures.
+_stub_svn() {
+  svn() {
+    printf '%s\n' "$@" > "${ARGV_FILE}"
+    cat > "${STDIN_FILE}"
+    return "$(cat "${EXIT_FILE}")"
+  }
+  export -f svn
+}
+
+# ---- svn_run ----
+
+@test "svn_run: real mode passes password via stdin, never on argv" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="release-mgr"
+  export SVN_PASSWORD="hunter2-very-secret"
+
+  run svn_run co --depth=empty https://example/repo /tmp/wc
+
+  [ "$status" -eq 0 ]
+  ! grep -q -- "hunter2-very-secret" "${ARGV_FILE}" \
+    || { echo "password leaked to argv"; cat "${ARGV_FILE}"; return 1; }
+  grep -q -- "--password-from-stdin" "${ARGV_FILE}"
+  grep -q -- "--non-interactive" "${ARGV_FILE}"
+  grep -q -- "--no-auth-cache" "${ARGV_FILE}"
+  grep -q -- "--username" "${ARGV_FILE}"
+  grep -q -- "release-mgr" "${ARGV_FILE}"
+  grep -q -- "co" "${ARGV_FILE}"
+  grep -q -- "https://example/repo" "${ARGV_FILE}"
+  [ "$(cat "${STDIN_FILE}")" = "hunter2-very-secret" ]
+}
+
+@test "svn_run: real mode redacts password in the printed log line" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="release-mgr"
+  export SVN_PASSWORD="hunter2-very-secret"
+
+  run svn_run mv https://example/dev/r1 https://example/release/r1 -m "promote"
+
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"hunter2-very-secret"* ]] \
+    || { echo "password leaked to log"; printf '%s\n' "$output"; return 1; }
+}
+
+@test "svn_run: dry-run prints the command but does not invoke svn" {
+  _stub_svn
+  DRY_RUN=1
+
+  run svn_run co --depth=empty https://example/repo /tmp/wc
+
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run, WOULD execute"* ]]
+  [[ "$output" == *"--password-from-stdin"* ]]
+  [ ! -f "${ARGV_FILE}" ] || [ ! -s "${ARGV_FILE}" ]
+}
+
+@test "svn_run: real mode requires SVN_USERNAME" {
+  _stub_svn
+  DRY_RUN=0
+  unset SVN_USERNAME
+  export SVN_PASSWORD="some-pw"
+
+  run svn_run co https://example/repo /tmp/wc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SVN_USERNAME must be set"* ]]
+}
+
+@test "svn_run: real mode requires SVN_PASSWORD" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="release-mgr"
+  unset SVN_PASSWORD
+
+  run svn_run co https://example/repo /tmp/wc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"SVN_PASSWORD must be set"* ]]
+}
+
+@test "svn_run: dry-run does not require SVN_USERNAME or SVN_PASSWORD" {
+  _stub_svn
+  DRY_RUN=1
+  unset SVN_USERNAME SVN_PASSWORD
+
+  run svn_run co https://example/repo /tmp/wc
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run"* ]]
+}
+
+# ---- svn_path_exists ----
+
+@test "svn_path_exists: returns 0 when svn ls exits 0" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="p"
+  echo "0" > "${EXIT_FILE}"
+
+  run svn_path_exists https://example/repo/foo
+  [ "$status" -eq 0 ]
+}
+
+@test "svn_path_exists: returns nonzero when svn ls exits nonzero" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="p"
+  echo "1" > "${EXIT_FILE}"
+
+  run svn_path_exists https://example/repo/missing
+  [ "$status" -ne 0 ]
+}
+
+@test "svn_path_exists: dry-run returns success without calling svn" {
+  _stub_svn
+  DRY_RUN=1
+  run svn_path_exists https://example/repo/foo
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Dry-run, WOULD probe SVN path"* ]]
+  [ ! -f "${ARGV_FILE}" ] || [ ! -s "${ARGV_FILE}" ]
+}
+
+# ---- svn_list ----
+
+@test "svn_list: pipes password via stdin and captures stdout" {
+  svn() {
+    printf '%s\n' "$@" > "${ARGV_FILE}"
+    cat > "${STDIN_FILE}"
+    echo "apache-iceberg-1.9.0/"
+    echo "apache-iceberg-1.10.0/"
+  }
+  export -f svn
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="leak-canary-789"
+
+  run svn_list https://example/release
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apache-iceberg-1.9.0/"* ]]
+  [[ "$output" == *"apache-iceberg-1.10.0/"* ]]
+  ! grep -q -- "leak-canary-789" "${ARGV_FILE}"
+  [ "$(cat "${STDIN_FILE}")" = "leak-canary-789" ]
+}
+
+# ---- svn_run_with_retries ----
+
+@test "svn_run_with_retries: succeeds on first attempt without sleeping" {
+  _stub_svn
+  DRY_RUN=0
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="p"
+  echo "0" > "${EXIT_FILE}"
+
+  run svn_run_with_retries 3 0 "${TEST_TMPDIR}/wc" co https://example/repo /tmp/wc
+  [ "$status" -eq 0 ]
+}
+
+@test "svn_run_with_retries: retries on failure and removes cleanup_path between attempts" {
+  # Make svn fail the first 2 calls, then succeed.
+  cnt=0
+  cnt_file="${TEST_TMPDIR}/cnt"
+  echo 0 > "${cnt_file}"
+  svn() {
+    local n
+    n=$(cat "${cnt_file}")
+    n=$((n + 1))
+    echo "${n}" > "${cnt_file}"
+    cat > /dev/null
+    if [[ "${n}" -lt 3 ]]; then
+      mkdir -p "${TEST_TMPDIR}/cleanup_target"
+      return 1
+    fi
+    return 0
+  }
+  export -f svn
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="p"
+  DRY_RUN=0
+
+  run svn_run_with_retries 3 0 "${TEST_TMPDIR}/cleanup_target" co https://example/repo /tmp/wc
+  [ "$status" -eq 0 ]
+  [ "$(cat "${cnt_file}")" -eq 3 ]
+  [ ! -e "${TEST_TMPDIR}/cleanup_target" ] \
+    || { echo "cleanup_path was not removed between attempts"; return 1; }
+}
+
+@test "svn_run_with_retries: gives up after max_attempts and exits nonzero" {
+  svn() {
+    cat > /dev/null
+    return 1
+  }
+  export -f svn
+  export SVN_USERNAME="u"
+  export SVN_PASSWORD="p"
+  DRY_RUN=0
+
+  run svn_run_with_retries 2 0 "" co https://example/repo /tmp/wc
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed after 2 attempts"* ]]
+}
+
+# ---- filter_superseded_patch_releases ----
+
+# Mimics what `svn list https://dist.apache.org/repos/dist/release/iceberg/`
+# returns: directory entries always carry a trailing slash, files (KEYS,
+# the index) do not. Tests below mirror that shape.
+_listing_fixture() {
+  cat <<'LIST'
+KEYS
+apache-iceberg-1.8.0/
+apache-iceberg-1.8.1/
+apache-iceberg-1.9.0/
+apache-iceberg-1.9.1/
+apache-iceberg-1.9.2/
+apache-iceberg-1.10.0/
+apache-iceberg-2.0.0/
+LIST
+}
+
+@test "filter_superseded_patch_releases: 1.9.2 removes prior 1.9.x patches only" {
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  # Sort to make the assertion order-independent of grep output.
+  sorted=$(echo "$output" | sort | tr '\n' ',')
+  [ "${sorted}" = "apache-iceberg-1.9.0,apache-iceberg-1.9.1," ]
+}
+
+@test "filter_superseded_patch_releases: 1.10.0 with no prior 1.10.x emits nothing" {
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "1.10.0"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "filter_superseded_patch_releases: 2.0.0 with no prior 2.0.x emits nothing" {
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "2.0.0"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "filter_superseded_patch_releases: ignores other minor lines" {
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  # 1.8.x, 1.10.x, 2.0.x must all survive.
+  [[ "$output" != *"1.8.0"* ]]
+  [[ "$output" != *"1.8.1"* ]]
+  [[ "$output" != *"1.10.0"* ]]
+  [[ "$output" != *"2.0.0"* ]]
+}
+
+@test "filter_superseded_patch_releases: ignores non-release entries" {
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  [[ "$output" != *"KEYS"* ]]
+}
+
+@test "filter_superseded_patch_releases: never includes the new version itself" {
+  # Listing already contains the new version (svn mv has run).
+  listing="$(_listing_fixture)"
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  while IFS= read -r line; do
+    [[ "$line" != "apache-iceberg-1.9.2" ]] \
+      || { echo "new version was included in cleanup"; return 1; }
+  done <<< "$output"
+}
+
+@test "filter_superseded_patch_releases: tolerates entries without trailing slash" {
+  listing=$'apache-iceberg-1.9.0\napache-iceberg-1.9.1\napache-iceberg-1.9.2'
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  sorted=$(echo "$output" | sort | tr '\n' ',')
+  [ "${sorted}" = "apache-iceberg-1.9.0,apache-iceberg-1.9.1," ]
+}
+
+@test "filter_superseded_patch_releases: empty listing emits nothing and succeeds" {
+  run filter_superseded_patch_releases "" "1.9.2"
+  [ "$status" -eq 0 ]
+  [ -z "$output" ]
+}
+
+@test "filter_superseded_patch_releases: rejects MAJOR.MINOR cross-matches via boundary anchoring" {
+  # Adversarial entries that share a numeric prefix with the new version's
+  # MAJOR.MINOR: 1.90.0 must not be matched when releasing 1.9.0 (and
+  # vice versa: 1.9.x is not matched when releasing 1.90.0).
+  listing=$'apache-iceberg-1.9.0/\napache-iceberg-1.9.1/\napache-iceberg-1.90.0/\napache-iceberg-1.90.1/'
+
+  run filter_superseded_patch_releases "${listing}" "1.9.2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apache-iceberg-1.9.0"* ]]
+  [[ "$output" == *"apache-iceberg-1.9.1"* ]]
+  [[ "$output" != *"1.90.0"* ]]
+  [[ "$output" != *"1.90.1"* ]]
+
+  run filter_superseded_patch_releases "${listing}" "1.90.2"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"apache-iceberg-1.90.0"* ]]
+  [[ "$output" == *"apache-iceberg-1.90.1"* ]]
+  [[ "$output" != *"apache-iceberg-1.9.0"* ]]
+  [[ "$output" != *"apache-iceberg-1.9.1"* ]]
+}

--- a/release/tests/test_helper/common.bash
+++ b/release/tests/test_helper/common.bash
@@ -1,0 +1,34 @@
+#!/bin/bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+LIBS_DIR="${BATS_TEST_DIRNAME}/../libs"
+
+# Reset the include guards so each test re-sources the libraries cleanly.
+unset _CONSTANTS_LOADED _LOG_LOADED _EXEC_LOADED _VERSION_LOADED
+unset _GITHUB_LOADED _NEXUS_LOADED _GRADLE_LOADED
+
+# Reset globals that library functions populate so leakage between tests
+# can't mask real bugs.
+_reset_version_vars() {
+  unset major minor patch rc_number latest_rc_number version_without_rc staging_repo_id
+}
+
+export NO_COLOR=1
+export DRY_RUN=1

--- a/release/tests/version.bats
+++ b/release/tests/version.bats
@@ -1,0 +1,242 @@
+#!/usr/bin/env bats
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+setup() {
+  load test_helper/common
+  _reset_version_vars
+  source "${LIBS_DIR}/_version.sh"
+}
+
+# ---- validate_and_extract_version ----
+
+@test "validate_and_extract_version: accepts 1.10.0" {
+  run validate_and_extract_version "1.10.0"
+  [ "$status" -eq 0 ]
+}
+
+@test "validate_and_extract_version: extracts major.minor.patch" {
+  validate_and_extract_version "1.10.0"
+  [ "$major" = "1" ]
+  [ "$minor" = "10" ]
+  [ "$patch" = "0" ]
+  [ "$version_without_rc" = "1.10.0" ]
+}
+
+@test "validate_and_extract_version: accepts 2.0.10" {
+  validate_and_extract_version "2.0.10"
+  [ "$major" = "2" ]
+  [ "$minor" = "0" ]
+  [ "$patch" = "10" ]
+}
+
+@test "validate_and_extract_version: rejects missing patch" {
+  run validate_and_extract_version "1.10"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_version: rejects empty string" {
+  run validate_and_extract_version ""
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_version: rejects alpha characters" {
+  run validate_and_extract_version "1.10.0-beta"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_version: rejects SNAPSHOT suffix" {
+  run validate_and_extract_version "1.10.0-SNAPSHOT"
+  [ "$status" -eq 1 ]
+}
+
+# ---- validate_and_extract_git_tag_version ----
+
+@test "validate_and_extract_git_tag_version: parses apache-iceberg-1.10.0-rc0" {
+  validate_and_extract_git_tag_version "apache-iceberg-1.10.0-rc0"
+  [ "$major" = "1" ]
+  [ "$minor" = "10" ]
+  [ "$patch" = "0" ]
+  [ "$rc_number" = "0" ]
+  [ "$version_without_rc" = "1.10.0" ]
+}
+
+@test "validate_and_extract_git_tag_version: parses apache-iceberg-2.1.3-rc12" {
+  validate_and_extract_git_tag_version "apache-iceberg-2.1.3-rc12"
+  [ "$major" = "2" ]
+  [ "$minor" = "1" ]
+  [ "$patch" = "3" ]
+  [ "$rc_number" = "12" ]
+}
+
+@test "validate_and_extract_git_tag_version: rejects tag without rc suffix" {
+  run validate_and_extract_git_tag_version "apache-iceberg-1.10.0"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_git_tag_version: rejects wrong prefix" {
+  run validate_and_extract_git_tag_version "apache-parquet-1.10.0-rc0"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_git_tag_version: rejects bare version" {
+  run validate_and_extract_git_tag_version "1.10.0-rc0"
+  [ "$status" -eq 1 ]
+}
+
+# ---- validate_and_extract_branch_version ----
+
+@test "validate_and_extract_branch_version: parses 1.10.x" {
+  validate_and_extract_branch_version "1.10.x"
+  [ "$major" = "1" ]
+  [ "$minor" = "10" ]
+}
+
+@test "validate_and_extract_branch_version: parses 0.14.x" {
+  validate_and_extract_branch_version "0.14.x"
+  [ "$major" = "0" ]
+  [ "$minor" = "14" ]
+}
+
+@test "validate_and_extract_branch_version: parses 2.0.x" {
+  validate_and_extract_branch_version "2.0.x"
+  [ "$major" = "2" ]
+  [ "$minor" = "0" ]
+}
+
+@test "validate_and_extract_branch_version: rejects iceberg- prefix" {
+  run validate_and_extract_branch_version "iceberg-1.10.x"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_branch_version: rejects release/ prefix" {
+  run validate_and_extract_branch_version "release/1.10.x"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_branch_version: rejects full version" {
+  run validate_and_extract_branch_version "1.10.0"
+  [ "$status" -eq 1 ]
+}
+
+@test "validate_and_extract_branch_version: rejects main" {
+  run validate_and_extract_branch_version "main"
+  [ "$status" -eq 1 ]
+}
+
+# ---- find_next_rc_number ----
+
+@test "find_next_rc_number: returns 0 when no tags exist" {
+  git() { echo ""; }
+  export -f git
+  find_next_rc_number "1.10.0"
+  [ "$rc_number" = "0" ]
+}
+
+@test "find_next_rc_number: returns 1 after rc0" {
+  git() {
+    if [[ "$1" == "tag" && "$2" == "-l" ]]; then
+      echo "apache-iceberg-1.10.0-rc0"
+    fi
+  }
+  export -f git
+  find_next_rc_number "1.10.0"
+  [ "$rc_number" = "1" ]
+}
+
+@test "find_next_rc_number: returns 3 after rc0, rc1, rc2" {
+  git() {
+    if [[ "$1" == "tag" && "$2" == "-l" ]]; then
+      printf "apache-iceberg-1.10.0-rc0\napache-iceberg-1.10.0-rc1\napache-iceberg-1.10.0-rc2\n"
+    fi
+  }
+  export -f git
+  find_next_rc_number "1.10.0"
+  [ "$rc_number" = "3" ]
+}
+
+@test "find_next_rc_number: handles gap in rc numbers" {
+  git() {
+    if [[ "$1" == "tag" && "$2" == "-l" ]]; then
+      printf "apache-iceberg-1.10.0-rc0\napache-iceberg-1.10.0-rc5\n"
+    fi
+  }
+  export -f git
+  find_next_rc_number "1.10.0"
+  [ "$rc_number" = "6" ]
+}
+
+@test "find_next_rc_number: ignores tags for other versions" {
+  git() {
+    if [[ "$1" == "tag" && "$2" == "-l" ]]; then
+      echo ""
+    fi
+  }
+  export -f git
+  find_next_rc_number "1.11.0"
+  [ "$rc_number" = "0" ]
+}
+
+# ---- find_latest_rc_number ----
+
+@test "find_latest_rc_number: returns highest RC number" {
+  cd "$(mktemp -d)"
+  git init -q
+  git commit --allow-empty -m "init" -q
+  git tag "apache-iceberg-1.10.0-rc0"
+  git tag "apache-iceberg-1.10.0-rc1"
+  git tag "apache-iceberg-1.10.0-rc2"
+  find_latest_rc_number "1.10.0"
+  [ "$latest_rc_number" = "2" ]
+}
+
+@test "find_latest_rc_number: returns 0 when only rc0 exists" {
+  cd "$(mktemp -d)"
+  git init -q
+  git commit --allow-empty -m "init" -q
+  git tag "apache-iceberg-2.0.0-rc0"
+  find_latest_rc_number "2.0.0"
+  [ "$latest_rc_number" = "0" ]
+}
+
+@test "find_latest_rc_number: fails when no RC tags exist" {
+  cd "$(mktemp -d)"
+  git init -q
+  git commit --allow-empty -m "init" -q
+  run find_latest_rc_number "9.9.9"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"No RC tags found"* ]]
+}
+
+# ---- expected_branch_for_version ----
+
+@test "expected_branch_for_version: returns X.Y.x form" {
+  result=$(expected_branch_for_version "1" "10")
+  [ "$result" = "1.10.x" ]
+}
+
+@test "expected_branch_for_version: handles two-digit minor" {
+  result=$(expected_branch_for_version "1" "10")
+  [ "$result" = "1.10.x" ]
+}
+
+@test "expected_branch_for_version: handles 0.x line" {
+  result=$(expected_branch_for_version "0" "14")
+  [ "$result" = "0.14.x" ]
+}


### PR DESCRIPTION
Includes 186 bats unit tests covering all shared libraries and end-to-end dry-runs of every script.

### Rationale for this change

The current Iceberg release process is documented in
[How to Release](https://iceberg.apache.org/how-to-release/) and driven by hand
plus the existing `dev/source-release.sh`, `dev/stage-binaries.sh`, and
`dev/check-license` scripts. Most of it (Nexus close/release/drop, SVN
promotion, old-release cleanup, dist/dev → dist/release move, final tag,
GitHub Release, vote/announce emails) is still manual.

This PR adds a semi-automated release pipeline modelled after the
[Apache Polaris release tooling](https://github.com/apache/polaris/tree/main/releasey)
and the recent [Apache Parquet PR #3548](https://github.com/apache/parquet-java/pull/3548),
adapted to Iceberg's Gradle build and existing release scripts. It does
not change `dev/source-release.sh`, `dev/stage-binaries.sh`, or
`site/docs/how-to-release.md`; the manual flow remains a fallback.

### What changes are included in this PR?

Scripts (`release/`):

- `prepare-rc.sh` — full pre-vote flow: branch validation, RC tag, GitHub CI
  check, source tarball + GPG signing, SVN dist/dev staging, multi-axis
  Gradle convenience-binary publish, Nexus staging-repo close, GitHub
  pre-release, `[VOTE]` email template.
- `publish-release.sh` — full post-vote flow: HEAD-vs-RC-tag guard, Nexus
  staging-repo verification, `svn mv` to dist/release, same-`MAJOR.MINOR`
  patch-release cleanup, final tag push, Nexus release to Maven Central,
  GitHub Release, `[ANNOUNCE]` email template.
- `cancel-rc.sh` — failed-vote rollback: same staging-repo verification,
  Nexus drop, dist/dev SVN cleanup, `[RESULT][VOTE]` failure email
  template. RC git tag is left in place per ASF policy.

Shared libraries (`release/libs/`):

- `_constants.sh` — config + version regexes. The Scala/Flink/Spark/Kafka
  matrix is read directly from `gradle.properties` (`systemProp.knownXxxVersions`
  / `defaultScalaVersion`) so the pipeline cannot drift from the build.
- `_log.sh`, `_exec.sh`, `_version.sh`, `_github.sh`.
- `_nexus.sh` — Nexus 2 staging API helpers; `nexus_verify_staging_repo`
  checks profile / state / `iceberg-core-<version>.pom` presence /
  description.
- `_svn.sh` — `svn` helpers that pipe `SVN_PASSWORD` on stdin via
  `--password-from-stdin` so it never appears in argv (and is not visible
  via `/proc/<pid>/cmdline`); plus `filter_superseded_patch_releases` for
  the same-`MAJOR.MINOR` cleanup.
- `_gradle.sh` — `verify_jdk_17`, `build_source_tarball` (mirrors
  `dev/source-release.sh`), and `stage_convenience_binaries` (two-pass
  publish, see "Safety" below).

GitHub Actions workflows:

- `release-prepare-rc.yml`, `release-publish.yml`, `release-cancel-rc.yml`
  — dispatch-only entry points; default to dry-run.
- `ci-release-scripts.yml` — runs bats + shellcheck on every PR/push that
  touches `release/`.

All three release workflows share a single `concurrency` group
(`iceberg-release`, `cancel-in-progress: false`) so two dispatches cannot
overlap on git tags, the Nexus staging repo, or SVN paths.

### Are these changes tested?

Locally only:

- `bats release/tests` → 186 tests pass (constants, log, exec, version,
  github, nexus, gradle, svn, end-to-end branch management,
  `publish-release`, `cancel-rc`).
- `shellcheck release/*.sh release/libs/*.sh` → clean.
- Dry-run smoke of all three scripts succeeds end-to-end against a
  hermetic fixture.

**To actually exercise this in production we need an Infra ticket to land
the appropriate secrets on `apache/iceberg`:**

- `NEXUS_USER` / `NEXUS_PW` (Apache Nexus, already used by `publish-snapshot.yml`).
- `ICEBERG_SVN_DEV_USERNAME` / `ICEBERG_SVN_DEV_PASSWORD` (`dist.apache.org` credentials).
- A `maven-publish` GitHub environment guarding all three release workflows.

### Are there any user-facing changes?

No. The release pipeline is invisible to end users; this only affects
release managers and contributors.

`site/docs/how-to-release.md` is intentionally **not** updated in this
PR — we want the workflow to land first, then update the docs in a
follow-up PR once the secrets are in place and a real RC has been driven
through it.

---

## Release Workflow

This PR layers three GitHub Actions workflows + locally-runnable Bash
scripts on top of the existing manual flow. All workflows default to
**dry-run mode**; the release manager has to explicitly uncheck the
`Dry run` checkbox before any external service is touched.

### 1. Prepare RC (Pre-Vote)

The release manager launches the **"Release - Prepare Release Candidate"**
workflow (`release-prepare-rc.yml`) via `workflow_dispatch` with:

- **version** — e.g. `1.10.0`
- **rc_number** *(optional)* — auto-detected from existing tags if empty
- **dry_run** — defaults to `true`

Branching follows Iceberg's existing convention: **X.Y.0 RCs are tagged
from `main`**; **X.Y.Z (Z ≥ 1) requires the `X.Y.x` branch to already
exist on the remote** (the script does not auto-create branches — the
release manager creates `X.Y.x` after the X.Y.0 release per current
practice).

| # | Step in `prepare-rc.sh` | Replaces (docs / existing script) |
|---|--------------------------|-----------------------------------|
| 0 | Validate inputs, prerequisites (`gpg`, `svn`, JDK 17, gradlew) | Manual |
| 1 | Auto-detect RC number from `apache-iceberg-X.Y.Z-rc*` tags | Manual decision |
| 2 | Verify GitHub CI is green at HEAD (`gh api .../check-runs`) | Manual UI check |
| 3 | Resolve release commit (X.Y.0 → `origin/main`; X.Y.Z → `origin/X.Y.x`); align workspace via `git checkout --detach` | Manual |
| 4 | Create + push `apache-iceberg-X.Y.Z-rcN` tag | `dev/source-release.sh` |
| 5 | Build + GPG-sign source tarball + `.sha512` | `dev/source-release.sh` |
| 6 | SVN-stage tarball/asc/sha512 to `dist/dev/iceberg/<rc>` | `dev/source-release.sh` |
| 7 | Publish convenience binaries to Nexus across the Scala/Flink/Spark/Kafka matrix | `dev/stage-binaries.sh` |
| 8 | Close the Nexus staging repository | Manual Nexus UI |
| 9 | Create a GitHub pre-release at the RC tag | Manual GitHub UI |
| 10 | Emit `[VOTE]` email template into the workflow step summary | Manual email composition |

The release manager copies the `[VOTE]` email out of the step summary and
**manually sends it** to `dev@iceberg.apache.org`.

### 2. Vote

The community votes for at least 72 hours. The release manager tallies
results manually.

---

### If the vote fails → Cancel RC

The release manager launches the **"Release - Cancel Release Candidate"**
workflow (`release-cancel-rc.yml`) with:

- **version** — e.g. `1.10.0`
- **rc_number** — the RC number to cancel
- **staging_repo_id** — e.g. `orgapacheiceberg-1234`
- **allow_description_mismatch** *(optional)* — recovery override
- **dry_run** — defaults to `true`

| # | Step in `cancel-rc.sh` | Replaces |
|---|-------------------------|----------|
| 0 | Verify the staging repository (see "Safety" below) | Manual visual check in Nexus UI |
| 1 | Drop the Nexus staging repo | Manual Nexus UI |
| 2 | Delete `dist/dev/iceberg/<rc>` from SVN | Manual `svn rm` |
| 3 | Emit `[RESULT][VOTE]` failure email template | Manual email composition |

The RC git tag is preserved per ASF release policy.

---

### If the vote passes → Publish Release

The release manager launches the **"Release - Publish After Vote"**
workflow (`release-publish.yml`) with:

- **version** — e.g. `1.10.0`
- **rc_number** *(optional)* — RC that passed the vote (auto-detects latest; rejects older RCs)
- **staging_repo_id** — e.g. `orgapacheiceberg-1234`
- **allow_description_mismatch** *(optional)*
- **dry_run** — defaults to `true`

| # | Step in `publish-release.sh` | Replaces |
|---|-------------------------------|----------|
| 0 | Verify HEAD == the RC tag commit | Manual checkout |
| 1 | Verify the staging repository (see "Safety" below) | Manual visual check in Nexus UI |
| 2 | `svn mv` from `dist/dev/iceberg/<rc>` to `dist/release/iceberg/apache-iceberg-X.Y.Z` | Manual `svn mv` |
| 3 | Remove superseded patch releases on the same `MAJOR.MINOR` line (e.g. publishing 1.9.2 removes 1.9.0 / 1.9.1; older minor lines are left for the standard `archive.apache.org` flow). `--keep-old-releases` skips this. | Manual / not consistently done today |
| 4 | Create + push `apache-iceberg-X.Y.Z` final tag | Manual `git tag` |
| 5 | Release the Nexus staging repository to Maven Central | Manual Nexus UI |
| 6 | Create the GitHub Release at the final tag | Manual GitHub UI |
| 7 | Emit `[ANNOUNCE]` email template + reminders for `revapi`, issue templates, `doap.rdf`, versioned docs/Javadoc, site update | Manual checklist |

Iceberg has **no version-bump commit** on the release branch — the
`gitVersion` plugin derives the development version from the latest tag —
so unlike Parquet there's no `release:update-versions` step.

### Safety: Staging Repository Verification

Before any destructive Nexus action (promote in publish, drop in cancel),
both scripts verify the staging repo against the requested
`(version, rc_number)` pair:

1. **Profile** is `org.apache.iceberg` *(hard fail)*
2. **State** is `closed` *(hard fail)*
3. **Artifact** `iceberg-core-<version>.pom` exists in the repo *(hard fail)*
4. **Description** contains `Apache Iceberg <version> RC<rc>` *(warn; bypass with `--allow-description-mismatch` / the workflow input)*

This closes a gap in the current manual flow: typing a staging-repo ID
into a form field replaces the human "look at the artifact tree in
Nexus" check, so the script does that look-up explicitly.

### Safety: Convenience-binary publish matrix

The Scala/Flink/Spark/Kafka matrix is read at module-load time from
`gradle.properties` (`systemProp.knownXxxVersions` / `defaultScalaVersion`).
Two Gradle passes:

1. **Primary-Scala main pass** — full Flink/Kafka matrix + the Spark
   versions that still support Scala 2.12 (i.e. Spark 3.x). Spark 4+ is
   intentionally excluded because it dropped Scala 2.12 support.
2. **Secondary-Scala (Spark-only) sweep** — one `./gradlew` invocation
   per Spark version in `knownSparkVersions`, publishing the
   `iceberg-spark-<v>_2.13`, `iceberg-spark-extensions-<v>_2.13`, and
   `iceberg-spark-runtime-<v>_2.13` modules. This covers Spark 3.x
   (adding the 2.13 variant) and Spark 4.x (which is published only
   here).

Net artifact set: `iceberg-spark-{3.4,3.5}_{2.12,2.13}` plus
`iceberg-spark-{4.0,4.1}_2.13`. A bats drift guard re-parses
`gradle.properties` and asserts every Gradle invocation in the dry-run
matches; another guard asserts no `gradlew` line ever combines
`-DscalaVersion=2.12` with `-DsparkVersions=...4.x`.

### Safety: Credentials

- **SVN** — every `svn` call goes through `release/libs/_svn.sh` helpers
  that pipe `SVN_PASSWORD` on stdin via `--password-from-stdin`. Never
  on argv.
- **Nexus REST** — credentials are passed to `curl` via `-K` on stdin.
- **Gradle publish** — credentials are exported as
  `ORG_GRADLE_PROJECT_mavenUser` / `mavenPassword` env vars rather than
  `-PmavenUser=` / `-PmavenPassword=`. Never on argv.
- `_redact_secrets` covers every secret env var the workflows inject and
  is exercised by table-driven bats tests.

---

## What this PR is _not_

- **No changes to `dev/source-release.sh`, `dev/stage-binaries.sh`, or
  `dev/check-license`.** The manual flow remains a supported fallback.
- **No changes to `site/docs/how-to-release.md`.** Documentation will be
  updated in a follow-up PR once the workflows have driven a real RC end
  to end.
- **No new third-party dependencies.** Only requires `bash`, `bats`,
  `shellcheck`, `gh`, `svn`, `curl`, `jq`, `gpg`, `gradle`/`./gradlew`,
  Java 17 — all already available on `ubuntu-24.04` runners or installed
  via `apt`.

## Follow-ups

1. **Apache Infra ticket** to land `NEXUS_USER` / `NEXUS_PW` /
   `ICEBERG_SVN_DEV_USERNAME` / `ICEBERG_SVN_DEV_PASSWORD` and the
   `maven-publish` environment on `apache/iceberg`.
2. Drive a real RC end-to-end (with `dry_run` unchecked) on the next
   release cycle.
3. **Documentation PR**: update `site/docs/how-to-release.md` to describe
   the semi-automated flow alongside the manual one.
