### PR TITLE
Azure: [1.10.x] Add missing LICENSE entry for Gson shaded by Nimbus JOSE+JWT

### DIFF
--- a/azure-bundle/LICENSE
+++ b/azure-bundle/LICENSE
@@ -455,6 +455,13 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product bundles Google Gson (shaded by Nimbus JOSE+JWT).
+
+Project URL: https://github.com/google/gson
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Nimbus OAuth 2.0 SDK with OpenID Connect extensions.
 
 Project URL: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions


### PR DESCRIPTION
Follow-up to #16242 which added Nimbus JOSE+JWT to the azure-bundle LICENSE. Nimbus JOSE+JWT shades Google Gson internally (`com/nimbusds/jose/shaded/gson/`), which also needs a LICENSE entry.

## Verification

```bash
./gradlew :iceberg-azure-bundle:clean :iceberg-azure-bundle:shadowJar
jar tf azure-bundle/build/libs/iceberg-azure-bundle-*.jar | grep 'com/nimbusds/jose/shaded/gson/' | head -5
```

