### PR TITLE
Core: Fix row ID assignment for EXISTING entry during a manifest merge

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -151,6 +151,11 @@ public class ManifestFiles {
    */
   public static ManifestReader<DataFile> read(
       ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
+    return read(manifest, io, specsById, true);
+  }
+
+  static ManifestReader<DataFile> read(
+      ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById, boolean committed) {
     Preconditions.checkArgument(
         manifest.content() == ManifestContent.DATA,
         "Cannot read a delete manifest with a ManifestReader: %s",
@@ -163,6 +168,7 @@ public class ManifestFiles {
         specsById,
         inheritableMetadata,
         manifest.firstRowId(),
+        committed,
         FileType.DATA_FILES);
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -155,7 +155,10 @@ public class ManifestFiles {
   }
 
   static ManifestReader<DataFile> read(
-      ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById, boolean committed) {
+      ManifestFile manifest,
+      FileIO io,
+      Map<Integer, PartitionSpec> specsById,
+      boolean isCommitted) {
     Preconditions.checkArgument(
         manifest.content() == ManifestContent.DATA,
         "Cannot read a delete manifest with a ManifestReader: %s",
@@ -168,7 +171,7 @@ public class ManifestFiles {
         specsById,
         inheritableMetadata,
         manifest.firstRowId(),
-        committed,
+        isCommitted,
         FileType.DATA_FILES);
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
@@ -196,7 +196,7 @@ abstract class ManifestMergeManager<F extends ContentFile<F>> {
     boolean threw = true;
     try {
       for (ManifestFile manifest : bin) {
-        boolean committed = snapshotId() != manifest.snapshotId();
+        boolean committed = manifest.snapshotId() != null && snapshotId() != manifest.snapshotId();
         try (ManifestReader<F> reader = newManifestReader(manifest, committed)) {
           for (ManifestEntry<F> entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {

--- a/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
@@ -72,6 +72,10 @@ abstract class ManifestMergeManager<F extends ContentFile<F>> {
 
   protected abstract ManifestReader<F> newManifestReader(ManifestFile manifest);
 
+  protected ManifestReader<F> newManifestReader(ManifestFile manifest, boolean committed) {
+    return newManifestReader(manifest);
+  }
+
   Iterable<ManifestFile> mergeManifests(Iterable<ManifestFile> manifests) {
     Iterator<ManifestFile> manifestIter = manifests.iterator();
     if (!mergeEnabled || !manifestIter.hasNext()) {
@@ -192,7 +196,8 @@ abstract class ManifestMergeManager<F extends ContentFile<F>> {
     boolean threw = true;
     try {
       for (ManifestFile manifest : bin) {
-        try (ManifestReader<F> reader = newManifestReader(manifest)) {
+        boolean committed = snapshotId() != manifest.snapshotId();
+        try (ManifestReader<F> reader = newManifestReader(manifest, committed)) {
           for (ManifestEntry<F> entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot

--- a/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestMergeManager.java
@@ -72,7 +72,7 @@ abstract class ManifestMergeManager<F extends ContentFile<F>> {
 
   protected abstract ManifestReader<F> newManifestReader(ManifestFile manifest);
 
-  protected ManifestReader<F> newManifestReader(ManifestFile manifest, boolean committed) {
+  protected ManifestReader<F> newManifestReader(ManifestFile manifest, boolean isCommitted) {
     return newManifestReader(manifest);
   }
 
@@ -196,8 +196,9 @@ abstract class ManifestMergeManager<F extends ContentFile<F>> {
     boolean threw = true;
     try {
       for (ManifestFile manifest : bin) {
-        boolean committed = manifest.snapshotId() != null && snapshotId() != manifest.snapshotId();
-        try (ManifestReader<F> reader = newManifestReader(manifest, committed)) {
+        boolean isCommitted =
+            manifest.snapshotId() != null && snapshotId() != manifest.snapshotId();
+        try (ManifestReader<F> reader = newManifestReader(manifest, isCommitted)) {
           for (ManifestEntry<F> entry : reader.entries()) {
             if (entry.status() == Status.DELETED) {
               // suppress deletes from previous snapshots. only files deleted by this snapshot

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -435,7 +435,8 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
       // EXISTING entries)
       return Function.identity();
     } else {
-      // committed pre-v3 manifest with a null manifest-level firstRowId
+      // committed pre-v3 manifest with a null manifest-level firstRowId, defensively assign null
+      // first row IDs
       return entry -> {
         if (entry.file() instanceof BaseFile) {
           ((BaseFile<?>) entry.file()).setFirstRowId(null);

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -92,6 +92,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   private final InputFile file;
   private final InheritableMetadata inheritableMetadata;
   private final Long firstRowId;
+  private final boolean committed;
   private final FileType content;
   private final PartitionSpec spec;
   private final Schema fileSchema;
@@ -125,12 +126,24 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
       InheritableMetadata inheritableMetadata,
       Long firstRowId,
       FileType content) {
+    this(file, specId, specsById, inheritableMetadata, firstRowId, true, content);
+  }
+
+  protected ManifestReader(
+      InputFile file,
+      int specId,
+      Map<Integer, PartitionSpec> specsById,
+      InheritableMetadata inheritableMetadata,
+      Long firstRowId,
+      boolean committed,
+      FileType content) {
     Preconditions.checkArgument(
         firstRowId == null || content == FileType.DATA_FILES,
         "First row ID is not valid for delete manifests");
     this.file = file;
     this.inheritableMetadata = inheritableMetadata;
     this.firstRowId = firstRowId;
+    this.committed = committed;
     this.content = content;
 
     if (specsById != null) {
@@ -308,7 +321,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
     CloseableIterable<ManifestEntry<F>> withMetadata =
         CloseableIterable.transform(reader, inheritableMetadata::apply);
-    return CloseableIterable.transform(withMetadata, idAssigner(firstRowId));
+    return CloseableIterable.transform(withMetadata, idAssigner(firstRowId, committed));
   }
 
   CloseableIterable<ManifestEntry<F>> liveEntries() {
@@ -398,7 +411,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   }
 
   private static <F extends ContentFile<F>> Function<ManifestEntry<F>, ManifestEntry<F>> idAssigner(
-      Long firstRowId) {
+      Long firstRowId, boolean committed) {
     if (firstRowId != null) {
       return new Function<>() {
         private long nextRowId = firstRowId;
@@ -416,10 +429,19 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
           return entry;
         }
       };
-    } else {
-      // Preserve the source entry’s first row ID even if the manifest hasn’t assigned one since it
-      // may be EXISTING
+    } else if (!committed) {
+      // Preserve the entry with its firstRowId
+      // as this is an uncommitted manifest which may have already assigned row IDs (e.g. for
+      // EXISTING entries)
       return Function.identity();
+    } else {
+      // committed pre-v3 manifest with a null manifest-level firstRowId
+      return entry -> {
+        if (entry.file() instanceof BaseFile) {
+          ((BaseFile<?>) entry.file()).setFirstRowId(null);
+        }
+        return entry;
+      };
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -92,7 +92,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   private final InputFile file;
   private final InheritableMetadata inheritableMetadata;
   private final Long firstRowId;
-  private final boolean committed;
+  private final boolean isCommitted;
   private final FileType content;
   private final PartitionSpec spec;
   private final Schema fileSchema;
@@ -135,7 +135,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
       Map<Integer, PartitionSpec> specsById,
       InheritableMetadata inheritableMetadata,
       Long firstRowId,
-      boolean committed,
+      boolean isCommitted,
       FileType content) {
     Preconditions.checkArgument(
         firstRowId == null || content == FileType.DATA_FILES,
@@ -143,7 +143,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
     this.file = file;
     this.inheritableMetadata = inheritableMetadata;
     this.firstRowId = firstRowId;
-    this.committed = committed;
+    this.isCommitted = isCommitted;
     this.content = content;
 
     if (specsById != null) {
@@ -321,7 +321,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
 
     CloseableIterable<ManifestEntry<F>> withMetadata =
         CloseableIterable.transform(reader, inheritableMetadata::apply);
-    return CloseableIterable.transform(withMetadata, idAssigner(firstRowId, committed));
+    return CloseableIterable.transform(withMetadata, idAssigner(firstRowId, isCommitted));
   }
 
   CloseableIterable<ManifestEntry<F>> liveEntries() {
@@ -411,7 +411,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
   }
 
   private static <F extends ContentFile<F>> Function<ManifestEntry<F>, ManifestEntry<F>> idAssigner(
-      Long firstRowId, boolean committed) {
+      Long firstRowId, boolean isCommitted) {
     if (firstRowId != null) {
       return new Function<>() {
         private long nextRowId = firstRowId;
@@ -429,14 +429,13 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
           return entry;
         }
       };
-    } else if (!committed) {
-      // Preserve the entry with its firstRowId
-      // as this is an uncommitted manifest which may have already assigned row IDs (e.g. for
-      // EXISTING entries)
+    } else if (!isCommitted) {
+      // uncommitted manifest: EXISTING entries carry explicit per-file firstRowId values written
+      // by ManifestFilterManager; ManifestListWriter hasn't run yet so manifest-level is null
       return Function.identity();
     } else {
-      // committed pre-v3 manifest with a null manifest-level firstRowId, defensively assign null
-      // first row IDs
+      // committed manifest with null manifest-level firstRowId (pre-v3 upgrade path):
+      // entries must not carry a per-file firstRowId
       return entry -> {
         if (entry.file() instanceof BaseFile) {
           ((BaseFile<?>) entry.file()).setFirstRowId(null);

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -430,12 +430,12 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
         }
       };
     } else if (!isCommitted) {
-      // uncommitted manifest: EXISTING entries carry explicit per-file firstRowId values written
-      // by ManifestFilterManager; ManifestListWriter hasn't run yet so manifest-level is null
+      // Preserve firstRowId for entries in uncommitted manifests, including EXISTING entries that
+      // may be merged later
       return Function.identity();
     } else {
-      // committed manifest with null manifest-level firstRowId (pre-v3 upgrade path):
-      // entries must not carry a per-file firstRowId
+      // committed manifest with null manifest-level firstRowId (pre-v3 upgrade path)
+      // defensively set the first row ID for every entry to be null
       return entry -> {
         if (entry.file() instanceof BaseFile) {
           ((BaseFile<?>) entry.file()).setFirstRowId(null);

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -417,14 +417,9 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
         }
       };
     } else {
-      // data file's first_row_id is null when the manifest's first_row_id is null
-      return entry -> {
-        if (entry.file() instanceof BaseFile) {
-          ((BaseFile<?>) entry.file()).setFirstRowId(null);
-        }
-
-        return entry;
-      };
+      // Preserve the source entry’s first row ID even if the manifest hasn’t assigned one since it
+      // may be EXISTING
+      return Function.identity();
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestReader.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestReader.java
@@ -441,6 +441,7 @@ public class ManifestReader<F extends ContentFile<F>> extends CloseableGroup
         if (entry.file() instanceof BaseFile) {
           ((BaseFile<?>) entry.file()).setFirstRowId(null);
         }
+
         return entry;
       };
     }

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -1250,12 +1250,13 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
     @Override
     protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
-      return MergingSnapshotProducer.this.newManifestReader(manifest);
+      return newManifestReader(manifest, true);
     }
 
     @Override
-    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest, boolean committed) {
-      return ManifestFiles.read(manifest, ops().io(), ops().current().specsById(), committed);
+    protected ManifestReader<DataFile> newManifestReader(
+        ManifestFile manifest, boolean isCommitted) {
+      return ManifestFiles.read(manifest, ops().io(), ops().current().specsById(), isCommitted);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -1252,6 +1252,11 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
     protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest) {
       return MergingSnapshotProducer.this.newManifestReader(manifest);
     }
+
+    @Override
+    protected ManifestReader<DataFile> newManifestReader(ManifestFile manifest, boolean committed) {
+      return ManifestFiles.read(manifest, ops().io(), ops().current().specsById(), committed);
+    }
   }
 
   private class DeleteFileFilterManager extends ManifestFilterManager<DeleteFile> {

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -219,6 +219,42 @@ public class TestManifestReader extends TestBase {
   }
 
   @TestTemplate
+  public void testReadCommitedManifestNullifiesEntryRowId() throws IOException {
+    long firstRowId = 42L;
+    DataFile fileWithRowId =
+        DataFiles.builder(SPEC).copy(FILE_A).withFirstRowId(firstRowId).build();
+    // the manifest has no manifest-level first_row_id (the v3+ entry still carries one)
+    ManifestFile manifest =
+        writeManifest(1000L, manifestEntry(Status.EXISTING, 123L, fileWithRowId));
+    assertThat(manifest.firstRowId()).isNull();
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, table.specs())) {
+      assertThat(Iterables.getOnlyElement(reader).firstRowId()).isNull();
+    }
+  }
+
+  @TestTemplate
+  public void testReadUncommittedManifestPreservesEntryRowId() throws IOException {
+    assumeThat(formatVersion)
+        .as("first_row_id is only written in v3+ manifests")
+        .isGreaterThanOrEqualTo(3);
+
+    long firstRowId = 42L;
+    DataFile fileWithRowId =
+        DataFiles.builder(SPEC).copy(FILE_A).withFirstRowId(firstRowId).build();
+    // the manifest has no manifest-level first_row_id, but the entry has one
+    ManifestFile manifest =
+        writeManifest(1000L, manifestEntry(Status.EXISTING, 123L, fileWithRowId));
+    assertThat(manifest.firstRowId()).isNull();
+    assertThat(fileWithRowId.firstRowId()).isEqualTo(firstRowId);
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifest, FILE_IO, table.specs(), false /* isCommitted */)) {
+      assertThat(Iterables.getOnlyElement(reader).firstRowId()).isEqualTo(firstRowId);
+    }
+  }
+
+  @TestTemplate
   public void testDataFileSplitOffsetsNullWhenInvalid() throws IOException {
     DataFile invalidOffset =
         DataFiles.builder(SPEC)

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -784,9 +784,20 @@ public class TestRowLineageAssignment {
   @Test
   public void testRewritePreservesExistingFileFirstRowIds() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    // FILE_A->0, FILE_B->125; nextRowId=225
+
+    // FILE_A gets firstRowId=0, FILE_B gets firstRowId=FILE_A.recordCount()=125; assert before
+    // rewrite
+    ManifestFile preRewriteManifest =
+        Iterables.getOnlyElement(table.currentSnapshot().dataManifests(table.io()));
+    checkDataFileAssignment(table, preRewriteManifest, 0L, FILE_A.recordCount());
+
+    // set low to trigger an internal manifest merge during the rewrite
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
+    // FILE_A and FILE_C must be removed and added in the same operation. Removing FILE_A creates
+    // an uncommitted manifest containing FILE_B as an existing entry. Adding FILE_C triggers the
+    // internal manifest merge to read that uncommitted manifest before its firstRowId is assigned.
     table.newRewrite().deleteFile(FILE_A).addFile(FILE_C).commit();
+
     // merged manifest live files: [FILE_C (added), FILE_B (existing)]
     ManifestFile manifest =
         Iterables.getOnlyElement(table.currentSnapshot().dataManifests(table.io()));

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -781,6 +781,22 @@ public class TestRowLineageAssignment {
         FILE_C.recordCount() + FILE_B.recordCount());
   }
 
+  @Test
+  public void testRewritePreservesExistingFileFirstRowIds() {
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    // FILE_A→0, FILE_B→125; nextRowId=225
+    table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
+    table.newRewrite().deleteFile(FILE_A).addFile(FILE_C).commit();
+    // merged manifest live files: [FILE_C (added), FILE_B (existing)]
+    ManifestFile manifest =
+        Iterables.getOnlyElement(table.currentSnapshot().dataManifests(table.io()));
+    checkDataFileAssignment(
+        table,
+        manifest,
+        FILE_A.recordCount() + FILE_B.recordCount(), // FILE_C gets 225
+        FILE_A.recordCount()); // FILE_B must retain its original firstRowId (125)
+  }
+
   private static ManifestContent content(int ordinal) {
     return ManifestContent.values()[ordinal];
   }

--- a/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowLineageAssignment.java
@@ -784,7 +784,7 @@ public class TestRowLineageAssignment {
   @Test
   public void testRewritePreservesExistingFileFirstRowIds() {
     table.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-    // FILE_A→0, FILE_B→125; nextRowId=225
+    // FILE_A->0, FILE_B->125; nextRowId=225
     table.updateProperties().set(TableProperties.MANIFEST_MIN_MERGE_COUNT, "1").commit();
     table.newRewrite().deleteFile(FILE_A).addFile(FILE_C).commit();
     // merged manifest live files: [FILE_C (added), FILE_B (existing)]


### PR DESCRIPTION
We observed some cases where when EXISTING entries are carried over in an operation as part of a manifest merge, the first row ID assignment is not preserved and instead gets a new first row ID based on the inheritance rules which is unexpected (and is a spec violation).