### PR TITLE
Core: Cache splitOffsets list in BaseFile to avoid repeated allocations

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -88,6 +88,12 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   // cached schema
   private transient Schema avroSchema = null;
 
+  // Cached unmodifiable List<Long> view of splitOffsets, allocated lazily on
+  // the first splitOffsets() call and reused thereafter. Invalidated (set to
+  // null) whenever the underlying long[] is reassigned. Marked transient so
+  // it is not part of the wire/serialized state. See #15622.
+  private transient List<Long> splitOffsetsList = null;
+
   // struct type that corresponds to the positions used for internalGet and internalSet
   private static final Types.StructType BASE_TYPE =
       Types.StructType.of(
@@ -187,6 +193,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
     this.lowerBounds = SerializableByteBufferMap.wrap(lowerBounds);
     this.upperBounds = SerializableByteBufferMap.wrap(upperBounds);
     this.splitOffsets = ArrayUtil.toLongArray(splitOffsets);
+    this.splitOffsetsList = null;
     this.equalityIds = equalityFieldIds;
     this.sortOrderId = sortOrderId;
     this.keyMetadata = ByteBuffers.toByteArray(keyMetadata);
@@ -239,6 +246,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         toCopy.splitOffsets == null
             ? null
             : Arrays.copyOf(toCopy.splitOffsets, toCopy.splitOffsets.length);
+    this.splitOffsetsList = null;
     this.equalityIds =
         toCopy.equalityIds != null
             ? Arrays.copyOf(toCopy.equalityIds, toCopy.equalityIds.length)
@@ -360,6 +368,7 @@ abstract class BaseFile<F> extends SupportsIndexProjection
         return;
       case 14:
         this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+        this.splitOffsetsList = null;
         return;
       case 15:
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
@@ -530,11 +539,19 @@ abstract class BaseFile<F> extends SupportsIndexProjection
 
   @Override
   public List<Long> splitOffsets() {
-    if (hasWellDefinedOffsets()) {
-      return ArrayUtil.toUnmodifiableLongList(splitOffsets);
+    if (!hasWellDefinedOffsets()) {
+      return null;
     }
 
-    return null;
+    // Cache the unmodifiable view so that repeated callers (manifest
+    // rewriting, format conversion, toString debugging) don't reallocate
+    // a new List<Long> wrapper on every invocation. The cache is
+    // transient and is invalidated wherever splitOffsets is reassigned.
+    // See #15622.
+    if (splitOffsetsList == null) {
+      splitOffsetsList = ArrayUtil.toUnmodifiableLongList(splitOffsets);
+    }
+    return splitOffsetsList;
   }
 
   long[] splitOffsetArray() {

--- a/core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Regression tests for #15622 — {@code BaseFile.splitOffsets()} previously allocated a fresh
+ * unmodifiable {@code List<Long>} wrapper on every call. After the fix, repeated calls return the
+ * same cached instance, while still preserving value-equality with the underlying long[] and the
+ * documented null-when-corrupted contract.
+ */
+class TestBaseFileSplitOffsets {
+
+  private static final PartitionSpec SPEC = PartitionSpec.unpartitioned();
+  private static final List<Long> OFFSETS = List.of(0L, 1024L, 2048L);
+
+  @Test
+  void splitOffsetsReturnsSameInstanceOnRepeatedCalls() {
+    DataFile file =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(4096)
+            .withRecordCount(10)
+            .withSplitOffsets(OFFSETS)
+            .build();
+
+    List<Long> first = file.splitOffsets();
+    List<Long> second = file.splitOffsets();
+
+    // Before the fix, splitOffsets() wrapped the long[] in a new
+    // ArrayUtil.toUnmodifiableLongList on every invocation, so
+    // first != second by reference. After the fix, the wrapper is
+    // cached and the two calls share the same instance.
+    assertThat(second).as("splitOffsets() should reuse a cached wrapper").isSameAs(first);
+    assertThat(first).containsExactlyElementsOf(OFFSETS);
+  }
+
+  @Test
+  void splitOffsetsNullWhenCorruptedThenReturnsNullStably() {
+    // Corruption is signalled by the last offset being >= fileSize. The
+    // file below has split offsets that exceed the declared file size so
+    // BaseFile.hasWellDefinedOffsets() returns false and splitOffsets()
+    // must return null. Caching must not turn a null into a stale empty
+    // list across calls.
+    DataFile file =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/corrupt.parquet")
+            .withFileSizeInBytes(100)
+            .withRecordCount(5)
+            .withSplitOffsets(List.of(0L, 50L, 200L))
+            .build();
+
+    assertThat(file.splitOffsets()).isNull();
+    assertThat(file.splitOffsets()).isNull();
+  }
+
+  @Test
+  void copyConstructorProducesIndependentCachedView() {
+    // BaseFile copy constructor reassigns splitOffsets via Arrays.copyOf;
+    // the cached wrapper must be invalidated so that the copy produces
+    // its own list view (not the source's cached one).
+    DataFile original =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(4096)
+            .withRecordCount(10)
+            .withSplitOffsets(OFFSETS)
+            .build();
+    List<Long> originalView = original.splitOffsets();
+
+    DataFile copy = original.copy();
+    List<Long> copyView = copy.splitOffsets();
+
+    // Equal contents...
+    assertThat(copyView).containsExactlyElementsOf(originalView);
+    // ...but not the same cached instance — each BaseFile owns its own
+    // long[] (via Arrays.copyOf in the copy constructor) and therefore
+    // its own cached wrapper.
+    assertThat(copyView).isNotSameAs(originalView);
+    // The copy's own cache is also stable across repeated calls.
+    assertThat(copy.splitOffsets()).isSameAs(copyView);
+  }
+
+  @Test
+  void splitOffsetsListIsUnmodifiable() {
+    DataFile file =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(4096)
+            .withRecordCount(10)
+            .withSplitOffsets(OFFSETS)
+            .build();
+
+    List<Long> offsets = file.splitOffsets();
+    org.assertj.core.api.Assertions.assertThatThrownBy(() -> offsets.set(0, 99L))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -112,7 +113,10 @@ class TestBaseFileSplitOffsets {
             .build();
 
     List<Long> offsets = file.splitOffsets();
-    org.assertj.core.api.Assertions.assertThatThrownBy(() -> offsets.set(0, 99L))
-        .isInstanceOf(UnsupportedOperationException.class);
+    // Collections.unmodifiableList throws UOE without a message; .hasMessage(null)
+    // is the established idiom in this codebase (see TestManifestReaderStats).
+    assertThatThrownBy(() -> offsets.set(0, 99L))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -45,7 +45,13 @@ public class TestManifestReader extends TestBase {
               "fileSequenceNumber",
               "fromProjectionPos",
               "manifestLocation",
-              "partitionData.partitionType.fieldsById")
+              "partitionData.partitionType.fieldsById",
+              // Transient cache populated lazily on the first splitOffsets()
+              // call (see BaseFile#splitOffsetsList, #15622). Whether it's
+              // populated depends on whether toString() / splitOffsets() ran
+              // for that instance before the comparison, which is irrelevant
+              // to logical equality.
+              "splitOffsetsList")
           .build();
 
   @TestTemplate

--- a/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/TestEventSerialization.java
+++ b/kafka-connect/kafka-connect-events/src/test/java/org/apache/iceberg/connect/events/TestEventSerialization.java
@@ -64,7 +64,11 @@ public class TestEventSerialization {
             ".*avroSchema",
             ".*icebergSchema",
             ".*schema",
-            ".*fromProjectionPos")
+            ".*fromProjectionPos",
+            // Transient lazy cache populated on first splitOffsets() call;
+            // not part of logical equality. See BaseFile#splitOffsetsList,
+            // apache/iceberg#15622.
+            ".*splitOffsetsList")
         .isEqualTo(event);
   }
 


### PR DESCRIPTION
## Summary

`BaseFile.splitOffsets()` previously wrapped the underlying `long[]` in a fresh `ArrayUtil.toUnmodifiableLongList` on every invocation. Manifest rewriting, format conversion, and `toString()` debugging can call `splitOffsets()` many times for the same file, leaking a `List<Long>` wrapper each call.

This PR caches the unmodifiable view in a transient field, populated lazily on the first call and invalidated wherever the underlying `long[]` is reassigned.

Resolves #15622

## Context

The original ask in #15622 — *"BaseFile.splitOffsets() allocates a new List on every call"* — was previously addressed in #15625 / #15624, both of which were stale-closed at 30 days with no review (no technical objections). This PR is a fresh, minimal revival of that approach with explicit invalidation at every write site, regression tests covering the cache contract, and AI disclosure.

The trade-off is small: one extra reference field per `BaseFile` (a few bytes), zero serialization impact (transient), and a one-line guard in `splitOffsets()` itself. Hot paths that call `splitOffsets()` repeatedly stop paying the per-call allocation cost.

## Changes

- `core/src/main/java/org/apache/iceberg/BaseFile.java`
  - Add a transient `List<Long> splitOffsetsList` cache field.
  - `splitOffsets()` populates the cache on first call and reuses it thereafter; corrupted offsets still return `null` stably.
  - All three sites that reassign the `long[] splitOffsets` field (the long-form constructor, the copy constructor, and the indexed setter `case 14`) now also null out the cache so the next `splitOffsets()` call rebuilds it from the new array.
  - Inline comment on the cache field explains the why and points to the issue, so a reviewer reading the diff cold doesn't have to re-derive it.
- `core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java` *(new)* — four tests covering: repeated-call instance reuse; null-when-corrupted contract is stable across calls; copy-constructor produces an independent cached view; the returned list remains unmodifiable.
- `core/src/test/java/org/apache/iceberg/TestManifestReader.java` — extends `FILE_COMPARISON_CONFIG` to ignore the new transient cache field. Recursive equality on data files should not depend on whether `splitOffsets()` / `toString()` happened to be called on one side of the comparison before the assertion. (This is the same pattern the config already uses for `manifestLocation`, `fileOrdinal`, `fromProjectionPos`, etc.)

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/apache/iceberg.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/main) ---
git checkout origin/main
# Pull in only the new test class to make the regression visible against
# the unmodified BaseFile in main:
git fetch https://github.com/jbbqqf/iceberg.git feat/15622-cache-split-offsets-list
git checkout FETCH_HEAD -- core/src/test/java/org/apache/iceberg/TestBaseFileSplitOffsets.java
./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestBaseFileSplitOffsets"
# Expected: 4 tests, 2 failures —
#   splitOffsetsReturnsSameInstanceOnRepeatedCalls (allocates fresh List per call)
#   copyConstructorProducesIndependentCachedView   (same)
# The other two pass on main because they don't depend on caching.

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestBaseFileSplitOffsets"
# Expected: 4 tests, 4 passes — splitOffsets() reuses a cached
# unmodifiable view, invalidated at every write site.
```

The only thing that changes between BEFORE and AFTER is the checked-out ref of `BaseFile.java`; the test file is the same in both runs.

## What I ran locally

- `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestBaseFileSplitOffsets"` on `origin/main` with the new test imported → **2/4 fail** (regression visible).
- Same on this branch → **4/4 pass**.
- `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestBaseFileSplitOffsets" --tests "org.apache.iceberg.TestContentFileParser" --tests "org.apache.iceberg.TestManifestReader" --tests "org.apache.iceberg.TestTrackedFileStruct"` → **all green**.
- `./gradlew :iceberg-core:spotlessCheck` → **PASS**.

## Edge cases tested

| # | Scenario | Input | Expected | Verified by |
|---|----------|-------|----------|-------------|
| 1 | Repeated `splitOffsets()` calls on a single file | well-formed offsets `[0, 1024, 2048]` | both calls return the **same** `List<Long>` instance, with the same contents | `splitOffsetsReturnsSameInstanceOnRepeatedCalls` |
| 2 | Corrupted offsets (last offset >= file size) | `fileSize=100`, offsets `[0, 50, 200]` | both calls return `null` (caching must not turn null into a stale empty list) | `splitOffsetsNullWhenCorruptedThenReturnsNullStably` |
| 3 | Copy constructor invalidates the cache | copy a file that already has `splitOffsets()` called | copy returns its own list with equal contents but different identity, **and** copy's own cache is stable across repeated calls | `copyConstructorProducesIndependentCachedView` |
| 4 | The returned list remains unmodifiable | `splitOffsets().set(0, 99L)` | throws `UnsupportedOperationException` | `splitOffsetsListIsUnmodifiable` |
| 5 | Recursive comparison on `BaseFile` (existing test) | manifest read+filter, equality vs constructed file | passes regardless of whether `toString()` populated the cache on one side (cache field excluded from comparison) | `TestManifestReader#testReaderWithFilterWithoutSelect` |

## Risk / blast radius

- `BaseFile` is the shared superclass for `DataFile`/`DeleteFile`. The cache is internal, transient, and only read inside `splitOffsets()`.
- Wire/serialization: unaffected — `transient` means the field is excluded from Avro reflection and Java serialization. Existing `equals`/`hashCode` (delegated to `SupportsIndexProjection` / `internalGet`) are also unaffected because they go through the indexed schema, not arbitrary fields.
- Memory: one extra reference field per `BaseFile` (≈ 4 bytes on compressed-oop heaps), plus the cached `List<Long>` itself when populated (which is the same wrapper that today is allocated and discarded on every call — net memory pressure decreases for the common case).
- Concurrency: `BaseFile` instances are not documented as thread-safe across mutation, and the cached field is a benign-data-race scenario (idempotent population of an immutable view); no extra synchronization is introduced.

Additive change. No public API surface modified.

## Release note

```release-note
BaseFile.splitOffsets() now caches its unmodifiable List<Long> view, eliminating per-call allocations during manifest rewrites and format conversions.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `apache/iceberg`'s source on `main`. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
