### PR TITLE
Aliyun, Dell: Handle EOF in OSS and ECS InputStream read() variants

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -82,12 +82,23 @@ class OSSInputStream extends SeekableInputStream {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     positionStream();
 
+    int byteRead = stream.read();
+    if (byteRead == -1) {
+      // At EOF, the underlying stream returns -1. We must propagate that
+      // to the caller without advancing pos / next or counting a byte that
+      // wasn't actually read. Same pattern as the fix for GCS/S3/ADLS in
+      // #16055 — a sequential reader that loops until EOF would otherwise
+      // spin and the byte counter would drift past the file size. See
+      // #16062.
+      return -1;
+    }
+
     pos += 1;
     next += 1;
     readBytes.increment();
     readOperations.increment();
 
-    return stream.read();
+    return byteRead;
   }
 
   @Override
@@ -96,6 +107,13 @@ class OSSInputStream extends SeekableInputStream {
     positionStream();
 
     int bytesRead = stream.read(b, off, len);
+    if (bytesRead == -1) {
+      // Mirror the single-byte read above: don't advance pos / next or
+      // increment the metrics counters when EOF is reached. Without this
+      // guard, pos/next/readBytes would shift by -1 on every EOF call.
+      return -1;
+    }
+
     pos += bytesRead;
     next += bytesRead;
     readBytes.increment(bytesRead);

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -119,6 +119,59 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
     }
   }
 
+  @Test
+  public void testReadSingleByteAtEof() throws Exception {
+    // Regression test for #16062 — OSSInputStream#read() at EOF must
+    // return -1 and must not advance pos / next or count a byte that was
+    // never read. Without the fix, OSSInputStream forwarded the -1 to
+    // the caller while still incrementing pos and the readBytes /
+    // readOperations metrics.
+    OSSURI uri = new OSSURI(location("eof-single.dat"));
+    byte[] data = randomData(8);
+    writeOSSData(uri, data);
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      // Drain to EOF byte-by-byte.
+      for (int i = 0; i < data.length; i++) {
+        assertThat(in.read()).isEqualTo(data[i] & 0xFF);
+      }
+      assertThat(in.getPos()).isEqualTo(data.length);
+
+      assertThat(in.read()).as("read() at EOF must return -1").isEqualTo(-1);
+      assertThat(in.getPos())
+          .as("pos must not advance past EOF on a -1 read")
+          .isEqualTo(data.length);
+
+      // Idempotent: a second EOF read also returns -1, pos unchanged.
+      assertThat(in.read()).isEqualTo(-1);
+      assertThat(in.getPos()).isEqualTo(data.length);
+    }
+  }
+
+  @Test
+  public void testReadBufferAtEof() throws Exception {
+    // Companion to testReadSingleByteAtEof: read(byte[], off, len) at EOF
+    // must return -1 without polluting pos. Without the fix,
+    // OSSInputStream added -1 to pos and to the metric counters on every
+    // EOF call.
+    OSSURI uri = new OSSURI(location("eof-buffer.dat"));
+    int dataSize = 8;
+    byte[] expected = randomData(dataSize);
+    byte[] actual = new byte[dataSize + 1];
+    writeOSSData(uri, expected);
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      int bytesRead = in.read(actual, 0, dataSize + 1);
+      assertThat(bytesRead).isEqualTo(dataSize);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(expected);
+
+      assertThat(in.read(actual, 0, 10))
+          .as("read(byte[], off, len) at EOF must return -1")
+          .isEqualTo(-1);
+      assertThat(in.getPos()).as("pos must not advance past EOF on a -1 read").isEqualTo(dataSize);
+    }
+  }
+
   private byte[] randomData(int size) {
     byte[] data = new byte[size];
     random.nextBytes(data);

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -79,16 +79,33 @@ class EcsSeekableInputStream extends SeekableInputStream {
   @Override
   public int read() throws IOException {
     checkAndUseNewPos();
+    int byteRead = internalStream.read();
+    if (byteRead == -1) {
+      // At EOF, the underlying stream returns -1. We must propagate that
+      // to the caller without advancing pos or counting a byte that was
+      // never read. Same pattern as the fix for GCS/S3/ADLS in #16055 —
+      // a sequential reader that loops until EOF would otherwise spin
+      // and the byte counter would drift past the file size. See #16062.
+      return -1;
+    }
+
     pos += 1;
     readBytes.increment();
     readOperations.increment();
-    return internalStream.read();
+    return byteRead;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     checkAndUseNewPos();
     int delta = internalStream.read(b, off, len);
+    if (delta == -1) {
+      // Mirror the single-byte read above: don't advance pos or
+      // increment metrics when EOF is reached. Without this guard,
+      // pos/readBytes would shift by -1 on every EOF call.
+      return -1;
+    }
+
     pos += delta;
     readBytes.increment(delta);
     readOperations.increment();

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -90,4 +90,61 @@ public class TestEcsSeekableInputStream {
           .isEqualTo("012");
     }
   }
+
+  @Test
+  public void testReadSingleByteAtEof() throws IOException {
+    // Regression test for #16062 — single-byte read() at EOF must return -1
+    // and must not advance pos. Without the fix, EcsSeekableInputStream
+    // forwarded the underlying -1 to the caller while still incrementing
+    // pos (and the readBytes / readOperations metrics) by 1.
+    String objectName = rule.randomObjectName();
+    byte[] data = "0123".getBytes(StandardCharsets.UTF_8);
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, data));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      // Drain the stream byte-by-byte so the next read sees EOF.
+      for (int i = 0; i < data.length; i++) {
+        assertThat(input.read()).isEqualTo(data[i] & 0xFF);
+      }
+      assertThat(input.getPos()).isEqualTo(data.length);
+
+      // First EOF read returns -1 and pos stays at the file size.
+      assertThat(input.read()).as("read() at EOF must return -1").isEqualTo(-1);
+      assertThat(input.getPos())
+          .as("pos must not advance past EOF on a -1 read")
+          .isEqualTo(data.length);
+
+      // Repeated EOF reads stay idempotent (no drift).
+      assertThat(input.read()).isEqualTo(-1);
+      assertThat(input.getPos()).isEqualTo(data.length);
+    }
+  }
+
+  @Test
+  public void testReadBufferAtEof() throws IOException {
+    // Companion to testReadSingleByteAtEof: read(byte[], off, len) at EOF
+    // must return -1 without advancing pos. Without the fix,
+    // EcsSeekableInputStream still added -1 to pos and to the metric
+    // counters on every EOF call.
+    String objectName = rule.randomObjectName();
+    byte[] data = "0123".getBytes(StandardCharsets.UTF_8);
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, data));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      byte[] buffer = new byte[data.length];
+      assertThat(input.read(buffer, 0, buffer.length)).isEqualTo(data.length);
+      assertThat(input.getPos()).isEqualTo(data.length);
+
+      assertThat(input.read(buffer, 0, buffer.length))
+          .as("read(byte[], off, len) at EOF must return -1")
+          .isEqualTo(-1);
+      assertThat(input.getPos())
+          .as("pos must not advance past EOF on a -1 read")
+          .isEqualTo(data.length);
+    }
+  }
 }


### PR DESCRIPTION
## Summary

`OSSInputStream` (aliyun) and `EcsSeekableInputStream` (dell) had the same EOF-handling bug fixed in #16055 for `GCSInputStream` / `S3InputStream` / `ADLSInputStream`: when the underlying `read()` returns `-1`, the wrapper still advanced `pos` (and `next`, in OSS's case) and incremented the `readBytes` / `readOperations` metric counters by `-1`.

This PR applies the same one-shape fix the maintainers picked in #16055 to the two modules left out of that PR, plus regression tests covering both overloads.

Resolves #16062 for `aliyun` and `dell`. The remaining pieces (`GCS`, `S3`, `ADLS`) are still tracked by the in-flight #16055.

## Context

The original issue body for #16062 explicitly enumerates the four affected files; #16055 covers `GCS`/`S3`/`ADLS` and the issue comment confirms `OSSInputStream` and `EcsSeekableInputStream` are still pending.

In Iceberg's hot path, files are read via known-offset range reads rather than sequential reads-to-EOF, so the bug is *latent* in production today. It still matters because:

1. Any future caller that does loop until `read() == -1` would silently corrupt `pos`/`next` and the metric counters.
2. The behavior diverges from `InputStream`'s contract — every other Iceberg `*InputStream` already returns `-1` cleanly after #16055.
3. The metric drift is observable today via `FileIOMetricsContext` snapshots that overshoot the file size.

## Changes

- `aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java`
  - `read()` and `read(byte[], int, int)` now check the underlying return value and, if `-1`, return immediately without mutating `pos` / `next` or incrementing `readBytes` / `readOperations`. Same pattern as #16055's `S3InputStream` change.
  - Inline comments explain the why and reference both #16055 (the canonical fix) and #16062 (this issue), so a reviewer reading the diff cold doesn't have to re-derive the reasoning.
- `dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java` — same shape.
- `aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java` — adds `testReadSingleByteAtEof` and `testReadBufferAtEof`. Both run against the in-process `AliyunOSSMockExtension` (no live OSS access required).
- `dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java` — same two tests against the existing `EcsS3MockRule`.

All four new tests fail on `origin/main` and pass with this change.

## Reproduce BEFORE/AFTER yourself (copy-paste)

```bash
# --- one-time setup ---
git clone https://github.com/apache/iceberg.git /tmp/repro && cd /tmp/repro

# --- BEFORE (origin/main) ---
git checkout origin/main
# Pull in only the new test methods so the regression is visible against
# the unmodified production code in main:
git fetch https://github.com/jbbqqf/iceberg.git feat/16062-fix-eof-handling-oss-ecs-streams
git checkout FETCH_HEAD -- \
  aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java \
  dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
./gradlew :iceberg-dell:test --tests "org.apache.iceberg.dell.ecs.TestEcsSeekableInputStream"
./gradlew :iceberg-aliyun:test --tests "org.apache.iceberg.aliyun.oss.TestOSSInputStream"
# Expected: 2 failures in each test class —
#   testReadSingleByteAtEof  (pos / readBytes shifted by -1 at EOF)
#   testReadBufferAtEof      (same, for the buffered overload)

# --- AFTER (this PR) ---
git checkout FETCH_HEAD
./gradlew :iceberg-dell:test --tests "org.apache.iceberg.dell.ecs.TestEcsSeekableInputStream"
./gradlew :iceberg-aliyun:test --tests "org.apache.iceberg.aliyun.oss.TestOSSInputStream"
# Expected: all tests green in both modules.
```

The only thing that changes between BEFORE and AFTER is the checked-out ref of the production InputStream classes; the test files are the same in both runs.

## What I ran locally

- `./gradlew :iceberg-dell:test --tests "...TestEcsSeekableInputStream"` on `origin/main` with the new tests imported → **6 tests, 2 failures** (regression visible).
- Same on this branch → **6/6 pass**.
- `./gradlew :iceberg-aliyun:test --tests "...TestOSSInputStream"` on `origin/main` with the new tests imported → **5 tests, 2 failures**.
- Same on this branch → **5/5 pass**.
- `./gradlew :iceberg-aliyun:spotlessCheck :iceberg-dell:spotlessCheck` → **PASS**.

## Edge cases tested

| # | Module | Scenario | Expected | Verified by |
|---|--------|----------|----------|-------------|
| 1 | dell  | Single-byte `read()` past the last byte of a 4-byte object | returns `-1`; `getPos()` stays at file size; idempotent on a second call | `TestEcsSeekableInputStream#testReadSingleByteAtEof` |
| 2 | dell  | Buffered `read(byte[], 0, len)` past EOF | returns `-1`; `getPos()` stays at file size | `TestEcsSeekableInputStream#testReadBufferAtEof` |
| 3 | aliyun | Single-byte `read()` past EOF on an 8-byte object | returns `-1`; `getPos()` stays; idempotent | `TestOSSInputStream#testReadSingleByteAtEof` |
| 4 | aliyun | Buffered `read(byte[], 0, dataSize+1)` followed by another EOF buffered read | first read returns `dataSize`, second returns `-1`; `getPos()` stays at `dataSize` | `TestOSSInputStream#testReadBufferAtEof` |

## Risk / blast radius

- Two-line guard in two `*InputStream` classes, mirroring the GCS/S3/ADLS shape that was already chosen by maintainers in #16055.
- No public API surface modified.
- Behavioral change is strictly *more* contract-compliant: `InputStream.read()` is documented to return `-1` at EOF without side effects, and that is now what these wrappers do.
- Metrics: `readBytes`/`readOperations` no longer drift on EOF reads. Pre-fix snapshots overcounted reads; post-fix they don't. This is observable but should be considered a fix, not a regression.

## Release note

```release-note
Fix OSS (aliyun) and ECS (dell) InputStreams to return -1 at EOF without advancing the position counter or skewing read metrics, matching the GCS/S3/ADLS fix in #16055.
```

---

*PR drafted with assistance from Claude Code. The change was reviewed manually against `apache/iceberg`'s source on `main` and against the corresponding fix shape in #16055. The reproducer block above was used during development; it is the same one a reviewer can paste verbatim.*
