### PR TITLE
Build: Bump io.grpc:grpc-netty-shaded from 1.80.0 to 1.81.0

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -81,7 +81,7 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
         force 'org.apache.hadoop.thirdparty:hadoop-shaded-guava:1.5.0'
         force 'com.fasterxml.woodstox:woodstox-core:6.7.0'
         force 'commons-beanutils:commons-beanutils:1.11.0'
-        force 'io.grpc:grpc-netty-shaded:1.80.0'
+        force 'io.grpc:grpc-netty-shaded:1.81.0'
       }
     }
   }

--- a/kafka-connect/kafka-connect-runtime/runtime-deps.txt
+++ b/kafka-connect/kafka-connect-runtime/runtime-deps.txt
@@ -90,7 +90,7 @@ io.grpc:grpc-core:1.80.0
 io.grpc:grpc-googleapis:1.80.0
 io.grpc:grpc-grpclb:1.80.0
 io.grpc:grpc-inprocess:1.80.0
-io.grpc:grpc-netty-shaded:1.80.0
+io.grpc:grpc-netty-shaded:1.81.0
 io.grpc:grpc-opentelemetry:1.80.0
 io.grpc:grpc-protobuf-lite:1.80.0
 io.grpc:grpc-protobuf:1.80.0


### PR DESCRIPTION
Supersedes #16276.

The dependabot PR fails CI because it bumps `io.grpc:grpc-netty-shaded` in `kafka-connect/build.gradle` but does not regenerate `kafka-connect/kafka-connect-runtime/runtime-deps.txt`, causing `:iceberg-kafka-connect:iceberg-kafka-connect-runtime:checkRuntimeDeps` to fail.

This PR makes the same version bump and also updates the runtime-deps baseline to match.

Made with [Cursor](https://cursor.com)