### PR TITLE
Build: Bump org.openapitools:openapi-generator-gradle-plugin from 7.21.0 to 7.22.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -36,7 +36,7 @@ buildscript {
     classpath 'org.revapi:gradle-revapi:1.8.0'
     classpath 'com.gorylenko.gradle-git-properties:gradle-git-properties:2.5.7'
     classpath 'com.palantir.gradle.gitversion:gradle-git-version:4.3.0'
-    classpath 'org.openapitools:openapi-generator-gradle-plugin:7.21.0'
+    classpath 'org.openapitools:openapi-generator-gradle-plugin:7.22.0'
   }
 }
 
@@ -581,7 +581,7 @@ project(':iceberg-aws') {
   }
 
   // TODO delete once s3-signer-open-api.yaml is removed
-  def s3SignerSpec = "$projectDir/src/main/resources/s3-signer-open-api.yaml"
+  def s3SignerSpec = layout.projectDirectory.file("src/main/resources/s3-signer-open-api.yaml")
   tasks.register('validateS3SignerSpec', org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
     inputSpec.set(s3SignerSpec)
     recommend.set(true)
@@ -1140,7 +1140,7 @@ project(':iceberg-open-api') {
             .collectEntries { k, v -> { [(k):v, (k.replaceFirst("rck.", "")):v] }} // strip prefix
   }
 
-  def restCatalogSpec = "$projectDir/rest-catalog-open-api.yaml"
+  def restCatalogSpec = layout.projectDirectory.file("rest-catalog-open-api.yaml")
   tasks.register('validateRESTCatalogSpec', org.openapitools.generator.gradle.plugin.tasks.ValidateTask) {
     inputSpec.set(restCatalogSpec)
     recommend.set(true)


### PR DESCRIPTION
Supersedes #16274.

The dependabot PR fails CI because plugin 7.22.0 [migrated to Gradle's Lazy Configuration API](https://github.com/OpenAPITools/openapi-generator/pull/23042), changing `ValidateTask.inputSpec` from `String` to a `RegularFileProperty`. Passing a Groovy `GString` now fails configuration with:

```
Cannot set the value of task ':iceberg-aws:validateS3SignerSpec' property 'inputSpec'
of type org.gradle.api.file.RegularFile
using an instance of type org.codehaus.groovy.runtime.GStringImpl.
```

This is a configuration-time error that breaks every Gradle invocation, which is why nearly all CI jobs failed on #16274.

This PR makes the same plugin bump and migrates the two affected call sites (`validateS3SignerSpec` in `iceberg-aws`, `validateRESTCatalogSpec` in `iceberg-open-api`) to construct `inputSpec` via `layout.projectDirectory.file(...)`, which yields a proper `RegularFile`.

Verified locally:

```
$ ./gradlew :iceberg-aws:validateS3SignerSpec :iceberg-open-api:validateRESTCatalogSpec

> Task :iceberg-open-api:validateRESTCatalogSpec
Validating spec /.../open-api/rest-catalog-open-api.yaml
Spec is valid.

> Task :iceberg-aws:validateS3SignerSpec
Validating spec /.../aws/src/main/resources/s3-signer-open-api.yaml
Spec is valid.

BUILD SUCCESSFUL
```

Made with [Cursor](https://cursor.com)