### PR TITLE
Spark: Pass path/length to underlying FileIO in SerializableFileIOWithSize

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
@@ -75,6 +75,11 @@ class SerializableFileIOWithSize
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return fileIO.newInputFile(path, length);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return fileIO.newOutputFile(path);
   }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.iceberg.io.FileIO;
+import org.junit.jupiter.api.Test;
+
+class TestSerializableFileIOWithSize {
+
+  @Test
+  void newInputFileWithLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+    long length = 1024L;
+
+    serializableFileIO.newInputFile(path, length);
+
+    verify(mockFileIO).newInputFile(path, length);
+  }
+
+  @Test
+  void newInputFileWithoutLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+
+    serializableFileIO.newInputFile(path);
+
+    verify(mockFileIO).newInputFile(path);
+  }
+}

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
@@ -75,6 +75,11 @@ class SerializableFileIOWithSize
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return fileIO.newInputFile(path, length);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return fileIO.newOutputFile(path);
   }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.iceberg.io.FileIO;
+import org.junit.jupiter.api.Test;
+
+class TestSerializableFileIOWithSize {
+
+  @Test
+  void newInputFileWithLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+    long length = 1024L;
+
+    serializableFileIO.newInputFile(path, length);
+
+    verify(mockFileIO).newInputFile(path, length);
+  }
+
+  @Test
+  void newInputFileWithoutLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+
+    serializableFileIO.newInputFile(path);
+
+    verify(mockFileIO).newInputFile(path);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
@@ -75,6 +75,11 @@ class SerializableFileIOWithSize
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return fileIO.newInputFile(path, length);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return fileIO.newOutputFile(path);
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSerializableFileIOWithSize.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.apache.iceberg.io.FileIO;
+import org.junit.jupiter.api.Test;
+
+class TestSerializableFileIOWithSize {
+
+  @Test
+  void newInputFileWithLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+    long length = 1024L;
+
+    serializableFileIO.newInputFile(path, length);
+
+    verify(mockFileIO).newInputFile(path, length);
+  }
+
+  @Test
+  void newInputFileWithoutLength() {
+    FileIO mockFileIO = mock(FileIO.class);
+    FileIO serializableFileIO = SerializableFileIOWithSize.wrap(mockFileIO);
+    String path = "gs://bucket/path/to/file.parquet";
+
+    serializableFileIO.newInputFile(path);
+
+    verify(mockFileIO).newInputFile(path);
+  }
+}


### PR DESCRIPTION
Fix for issue : https://github.com/apache/iceberg/issues/16283

Testing Done:
Ran a suite of TPCDS benchmark using GCSFileIO and verified that GetObjectMetadata calls are not made after this fix. 