### PR TITLE
Core: ensure snapshot timestamp is monotonically increasing for V4 tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -35,6 +35,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.io.IOException;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
@@ -119,6 +120,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private SnapshotAncestryValidator snapshotAncestryValidator =
       SnapshotAncestryValidator.NON_VALIDATING;
 
+  private Clock clock = Clock.systemUTC();
   private ExecutorService workerPool;
   private ExecutorService writePool;
   private int writePoolParallelism = ThreadPools.WORKER_THREAD_POOL_SIZE;
@@ -358,7 +360,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         sequenceNumber,
         snapshotId(),
         parentSnapshotId,
-        System.currentTimeMillis(),
+        snapshotTimestampMillis(parentSnapshot),
         operation(),
         summary(base),
         base.currentSchemaId(),
@@ -681,6 +683,31 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   protected ManifestReader<DeleteFile> newDeleteManifestReader(ManifestFile manifest) {
     return ManifestFiles.readDeleteManifest(manifest, ops.io(), ops.current().specsById());
+  }
+
+  @VisibleForTesting
+  void setClock(Clock newClock) {
+    this.clock = newClock;
+  }
+
+  /**
+   * Generates the snapshot timestamp in milliseconds.
+   *
+   * <p>For format version 4 and above, this implements the Lamport clock algorithm to guarantee
+   * monotonically increasing snapshot timestamps. For older format versions, this returns the
+   * current wall clock time.
+   *
+   * @param parentSnapshot the parent snapshot on the target branch, or null if there is no parent
+   * @return the snapshot timestamp in milliseconds
+   */
+  private long snapshotTimestampMillis(Snapshot parentSnapshot) {
+    long now = clock.millis();
+    if (base.formatVersion() >= TableMetadata.MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS
+        && parentSnapshot != null) {
+      return Math.max(now, parentSnapshot.timestampMillis() + 1);
+    }
+
+    return now;
   }
 
   protected long snapshotId() {

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -59,6 +59,7 @@ public class TableMetadata implements Serializable {
   static final int MIN_FORMAT_VERSION_ROW_LINEAGE = 3;
   static final int MIN_FORMAT_VERSION_PARQUET_MANIFESTS = 4;
   static final int MIN_FORMAT_VERSION_OPTIONAL_LOCATION = 4;
+  static final int MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS = 4;
   static final int INITIAL_SPEC_ID = 0;
   static final int INITIAL_SORT_ORDER_ID = 1;
   static final int INITIAL_SCHEMA_ID = 0;

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
@@ -27,6 +27,9 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Paths;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -275,5 +278,48 @@ public class TestSnapshotProducer extends TestBase {
     } finally {
       executor.shutdownNow();
     }
+  }
+
+  @TestTemplate
+  public void testSnapshotTimestampsAreMonotonicallyIncreasing() {
+    assumeThat(formatVersion)
+        .isGreaterThanOrEqualTo(TableMetadata.MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot first = table.currentSnapshot();
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot second = table.currentSnapshot();
+    assertThat(second.timestampMillis())
+        .as("V4 snapshot timestamps must be strictly increasing")
+        .isGreaterThan(first.timestampMillis());
+
+    table.newFastAppend().appendFile(FILE_C).commit();
+    Snapshot third = table.currentSnapshot();
+    assertThat(third.timestampMillis())
+        .as("V4 snapshot timestamps must be strictly increasing")
+        .isGreaterThan(second.timestampMillis());
+  }
+
+  @TestTemplate
+  public void testV4LamportClockFastForwardsDriftedClock() {
+    assumeThat(formatVersion)
+        .isGreaterThanOrEqualTo(TableMetadata.MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long firstTs = table.currentSnapshot().timestampMillis();
+
+    // simulate clock drift: wall clock reports a time far in the past
+    long driftedTime = firstTs - 10_000;
+    Clock driftedClock = Clock.fixed(Instant.ofEpochMilli(driftedTime), ZoneOffset.UTC);
+    AppendFiles append = table.newFastAppend().appendFile(FILE_B);
+    ((SnapshotProducer<?>) append).setClock(driftedClock);
+    append.commit();
+
+    long secondTs = table.currentSnapshot().timestampMillis();
+    assertThat(secondTs)
+        .as(
+            "Lamport clock should fast-forward past the drifted wall clock to the last snapshot timestamp + 1 ms")
+        .isEqualTo(firstTs + 1);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotProducer.java
@@ -322,4 +322,46 @@ public class TestSnapshotProducer extends TestBase {
             "Lamport clock should fast-forward past the drifted wall clock to the last snapshot timestamp + 1 ms")
         .isEqualTo(firstTs + 1);
   }
+
+  @TestTemplate
+  public void testV4MonotonicityIsScopedToTargetBranch() {
+    assumeThat(formatVersion)
+        .isGreaterThanOrEqualTo(TableMetadata.MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS);
+
+    // Establish a base snapshot on main.
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long mainParentTs = table.currentSnapshot().timestampMillis();
+
+    // Create a branch pointing at the current main head.
+    String branchName = "test-branch";
+    table.manageSnapshots().createBranch(branchName).commit();
+
+    // Commit to the branch with a clock far in the future so the branch head's
+    // timestamp-ms is much higher than main's head timestamp-ms.
+    long branchFutureTs = mainParentTs + 1_000_000L;
+    Clock branchClock = Clock.fixed(Instant.ofEpochMilli(branchFutureTs), ZoneOffset.UTC);
+    AppendFiles branchAppend = table.newFastAppend().appendFile(FILE_B).toBranch(branchName);
+    ((SnapshotProducer<?>) branchAppend).setClock(branchClock);
+    branchAppend.commit();
+    long branchTs = table.snapshot(branchName).timestampMillis();
+    assertThat(branchTs)
+        .as("Sanity: branch commit should adopt the simulated far-future wall-clock value")
+        .isEqualTo(branchFutureTs);
+
+    // Commit to main with a clock just slightly after mainParentTs but far below branchTs.
+    // The spec requires monotonicity "on the same branch", so main's new timestamp must be
+    // constrained only by main's previous head, not by the unrelated future timestamp on
+    // the other branch.
+    long mainNewTs = mainParentTs + 5;
+    Clock mainClock = Clock.fixed(Instant.ofEpochMilli(mainNewTs), ZoneOffset.UTC);
+    AppendFiles mainAppend = table.newFastAppend().appendFile(FILE_C);
+    ((SnapshotProducer<?>) mainAppend).setClock(mainClock);
+    mainAppend.commit();
+
+    long actualMainTs = table.currentSnapshot().timestampMillis();
+    assertThat(actualMainTs)
+        .as("Main's monotonicity must be relative to main's parent, not the branch head")
+        .isEqualTo(mainNewTs)
+        .isLessThan(branchTs);
+  }
 }


### PR DESCRIPTION
## Summary

For format version 4 and above, this change makes `SnapshotProducer` produce snapshot timestamps that are strictly greater than the parent snapshot's `timestamp-ms`, using a Lamport-clock style fast-forward when the wall clock has drifted backward.

- Adds `TableMetadata.MIN_FORMAT_VERSION_MONOTONIC_TIMESTAMPS = 4`.
- In `SnapshotProducer.commit()`, replaces `System.currentTimeMillis()` with `snapshotTimestampMillis(parentSnapshot)`. The new helper returns `clock.millis()` for V1\u2013V3 (and for V4 root snapshots with no parent), and `max(clock.millis(), parentSnapshot.timestampMillis() + 1)` for V4+ with a parent on the target branch. This preserves wall-clock timestamps in the steady state and only fast-forwards by the minimum amount needed when the clock has drifted backward.
- Adds an `@VisibleForTesting` `setClock(Clock)` hook so the Lamport behavior can be exercised deterministically.

This is a behavior change for V4 only. V1\u2013V3 commits continue to use the wall clock unchanged.

## Why

The format-v4 row-timestamp feature exposes each manifest entry's `commit_timestamp_ms` as the `_last_updated_timestamp_ms` metadata column. Time-travel and \"latest update\" queries on that column become incoherent if a backward jump in the writer's wall clock produces snapshots whose `timestamp-ms` does not strictly increase with sequence number. Enforcing monotonicity at write time keeps the per-row \"last updated\" timestamp consistent with snapshot order.

The change is also defensive against clock skew between writers in distributed environments: a stale clock that briefly reports a past time no longer rewrites history.

## Test plan

- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestSnapshotProducer` (29 tests, 6 skipped for pre-V4 by `assumeThat`, 0 failures)
- [x] `./gradlew :iceberg-core:spotlessCheck`
- [ ] CI

New tests in `TestSnapshotProducer`:
- `testSnapshotTimestampsAreMonotonicallyIncreasing` \u2014 three consecutive V4 appends produce strictly increasing `timestamp-ms`.
- `testV4LamportClockFastForwardsDriftedClock` \u2014 with the producer's `Clock` pinned 10s in the past, the second V4 snapshot's `timestamp-ms` equals `firstTs + 1`, confirming the fast-forward branch is exercised.

## Related

A separate PR will propose the corresponding [table spec](../tree/main/format/spec.md) change documenting the monotonic-`timestamp-ms` requirement for V4.

Made with [Cursor](https://cursor.com)