### PR TITLE
Spec: require monotonically increasing snapshot timestamp-ms in v4

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -960,6 +960,8 @@ A snapshot consists of the following fields:
     |            |            | _required_ | **`added-rows`**             | The upper bound of the number of rows with assigned row IDs, see [Row Lineage](#row-lineage) |
     |            |            | _optional_ | **`key-id`**                 | ID of the encryption key that encrypts the manifest list key metadata |
 
+In format version 4 and above, a snapshot's `timestamp-ms` must be strictly greater than the `timestamp-ms` of its parent snapshot on the same branch. The requirement applies only to snapshots committed while the table is at format version 4 or higher; root snapshots, and snapshots that existed before a table was upgraded to v4, are not constrained.
+
 The snapshot summary's `operation` field is used by some operations, like snapshot expiration, to skip processing certain snapshots. Possible `operation` values are:
 
 * `append` -- Only data files were added and no files were removed.
@@ -1907,6 +1909,12 @@ Reading v4 metadata:
 * Readers must check whether location fields contain a URI scheme to determine if a path is absolute or relative
 * Relative paths must be resolved against the table location before use (see [Path Resolution](#path-resolution))
 * When `location` is omitted, the table location must be provided (see [Table Location Specification](#table-location-specification))
+
+Snapshot timestamp changes:
+
+* A snapshot's `timestamp-ms` must be strictly greater than the `timestamp-ms` of its parent snapshot on the same branch.
+* The requirement applies only to snapshots committed while the table is at format version 4 or higher; snapshots that existed before a table was upgraded to v4 are not constrained.
+* Root snapshots (snapshots with no parent) are not constrained by this requirement.
 
 ### Version 3
 


### PR DESCRIPTION
## Summary

Adds a v4 spec requirement that a snapshot's `timestamp-ms` must be strictly greater than the parent snapshot's `timestamp-ms` on the same branch. Root snapshots (with no parent) are not constrained.

- `format/spec.md` Snapshots section: notes the v4-only requirement directly under the snapshot field table.
- `format/spec.md` Appendix E: adds a new `Version 4` subsection (above `Version 3`) listing the snapshot-timestamp rule. This is the first v4 entry in Appendix E and is intentionally minimal\u2014other v4 changes can be appended as they land.

The spec only states the requirement; it does not prescribe how writers should achieve it or enumerate downstream features that benefit from it.

No table or schema fields are added. v1\u2013v3 semantics are unchanged.

## Companion PR

A reference implementation in `SnapshotProducer` is proposed in apache/iceberg#16293.

## Test plan

- [x] `format/spec.md` renders correctly (note added to the v1\u2013v3 Snapshots tab; new `Version 4` subsection in Appendix E above `Version 3`)
- [ ] Spec review