### PR TITLE
AWS: Check for existing Glue database before attempting to create one

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -61,6 +62,7 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
 import software.amazon.awssdk.services.glue.model.Database;
@@ -466,17 +468,32 @@ public class GlueCatalog extends BaseMetastoreCatalog
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
     try {
-      glue.createDatabase(
-          CreateDatabaseRequest.builder()
+      // first test if it already exists
+      glue.getDatabase(
+          GetDatabaseRequest.builder()
               .catalogId(awsProperties.glueCatalogId())
-              .databaseInput(
-                  IcebergToGlueConverter.toDatabaseInput(
-                      namespace, metadata, awsProperties.glueCatalogSkipNameValidation()))
+              .name(
+                  IcebergToGlueConverter.toDatabaseName(
+                      namespace, awsProperties.glueCatalogSkipNameValidation()))
               .build());
-      LOG.info("Created namespace: {}", namespace);
-    } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
-      throw new AlreadyExistsException(
-          "Cannot create namespace %s because it already exists in Glue", namespace);
+    } catch (EntityNotFoundException notFoundE) {
+      LOG.info("Namespace '{}' does not exist, creating it", namespace, notFoundE);
+      try {
+        glue.createDatabase(
+            CreateDatabaseRequest.builder()
+                .catalogId(awsProperties.glueCatalogId())
+                .databaseInput(
+                    IcebergToGlueConverter.toDatabaseInput(
+                        namespace, metadata, awsProperties.glueCatalogSkipNameValidation()))
+                .build());
+        LOG.info("Created namespace: {}", namespace);
+      } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
+        throw new AlreadyExistsException(
+            "Cannot create namespace %s because it already exists in Glue", namespace);
+      } catch (AccessDeniedException e) {
+        throw new ForbiddenException(
+            e, "Cannot create namespace '%s' due to missing Glue permissions", namespace);
+      }
     }
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -44,6 +45,7 @@ import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.AccessDeniedException;
 import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
 import software.amazon.awssdk.services.glue.model.CreateDatabaseResponse;
 import software.amazon.awssdk.services.glue.model.CreateTableRequest;
@@ -425,10 +427,40 @@ public class TestGlueCatalog {
 
   @Test
   public void testCreateNamespace() {
+    Mockito.doThrow(EntityNotFoundException.builder().build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
     Mockito.doReturn(CreateDatabaseResponse.builder().build())
         .when(glue)
         .createDatabase(Mockito.any(CreateDatabaseRequest.class));
     glueCatalog.createNamespace(Namespace.of("db"));
+  }
+
+  @Test
+  public void testCreateNamespaceAlreadyExists() {
+    Mockito.doReturn(GetDatabaseResponse.builder().build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+    // next exception should not be thrown
+    Mockito.doThrow(AccessDeniedException.builder().build())
+        .when(glue)
+        .createDatabase(Mockito.any(CreateDatabaseRequest.class));
+    glueCatalog.createNamespace(Namespace.of("db"));
+  }
+
+  @Test
+  public void testCreateNamespaceAlreadyExistsAndCannotCreate() {
+    Mockito.doThrow(EntityNotFoundException.builder().build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+    // next exception should be thrown
+    Mockito.doThrow(AccessDeniedException.builder().build())
+        .when(glue)
+        .createDatabase(Mockito.any(CreateDatabaseRequest.class));
+    assertThatThrownBy(() -> glueCatalog.createNamespace(Namespace.of("db")))
+        .isInstanceOf(ForbiddenException.class)
+        .hasMessage("Cannot create namespace 'db' due to missing Glue permissions")
+        .hasCauseInstanceOf(AccessDeniedException.class);
   }
 
   @Test


### PR DESCRIPTION
Fixes #13758. Just check if the database exists, and if it does, do nothing. This means that the sink task does not need to have `glue:CreateDatabase` permission if the database already exists. Currently, the connector will fail if it does not have `glue:CreateDatabase` permission, which violates the principle of least privilege if the database already exists.