### PR TITLE
API: Deprecate duplicate MAX_FILE_GROUP_SIZE_BYTES in RewriteDataFiles

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteDataFiles.java
@@ -63,18 +63,27 @@ public interface RewriteDataFiles
    * The entire rewrite operation is broken down into pieces based on partitioning and within
    * partitions based on size into groups. These sub-units of the rewrite are referred to as file
    * groups. The largest amount of data that should be compacted in a single group is controlled by
-   * {@link #MAX_FILE_GROUP_SIZE_BYTES}. This helps with breaking down the rewriting of very large
-   * partitions which may not be rewritable otherwise due to the resource constraints of the
-   * cluster. For example a sort based rewrite may not scale to terabyte sized partitions, those
-   * partitions need to be worked on in small subsections to avoid exhaustion of resources.
+   * {@code SizeBasedFileRewritePlanner#MAX_FILE_GROUP_SIZE_BYTES}. This helps with breaking down
+   * the rewriting of very large partitions which may not be rewritable otherwise due to the
+   * resource constraints of the cluster. For example a sort based rewrite may not scale to terabyte
+   * sized partitions, those partitions need to be worked on in small subsections to avoid
+   * exhaustion of resources.
    *
    * <p>When grouping files, the underlying rewrite strategy will use this value as to limit the
    * files which will be included in a single file group. A group will be processed by a single
    * framework "action". For example, in Spark this means that each group would be rewritten in its
    * own Spark action. A group will never contain files for multiple output partitions.
+   *
+   * @deprecated since 1.11.0, will be removed in 2.0.0; use {@code
+   *     SizeBasedFileRewritePlanner#MAX_FILE_GROUP_SIZE_BYTES} instead.
    */
-  String MAX_FILE_GROUP_SIZE_BYTES = "max-file-group-size-bytes";
+  @Deprecated String MAX_FILE_GROUP_SIZE_BYTES = "max-file-group-size-bytes";
 
+  /**
+   * @deprecated since 1.11.0, will be removed in 2.0.0; use {@code
+   *     SizeBasedFileRewritePlanner#MAX_FILE_GROUP_SIZE_BYTES_DEFAULT} instead.
+   */
+  @Deprecated
   long MAX_FILE_GROUP_SIZE_BYTES_DEFAULT = 1024L * 1024L * 1024L * 100L; // 100 Gigabytes
 
   /**

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.actions.ImmutableRewriteDataFiles.Result.Builder;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
@@ -73,7 +74,7 @@ public class RewriteDataFilesSparkAction
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
           MAX_CONCURRENT_FILE_GROUP_REWRITES,
-          MAX_FILE_GROUP_SIZE_BYTES,
+          SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
           PARTIAL_PROGRESS_ENABLED,
           PARTIAL_PROGRESS_MAX_COMMITS,
           PARTIAL_PROGRESS_MAX_FAILED_COMMITS,

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1049,7 +1049,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         basicRewrite(table)
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "10")
             .execute();
 
@@ -1075,7 +1076,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
             .execute();
 
@@ -1101,7 +1103,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
             .execute();
@@ -1126,7 +1129,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
 
@@ -1158,7 +1162,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1190,7 +1195,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1222,7 +1228,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3");
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
@@ -1256,7 +1263,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
 
@@ -1296,7 +1304,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1337,7 +1346,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1379,7 +1389,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
@@ -1419,7 +1430,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             // Since we can have at most one commit per file group and there are only 10 file
@@ -1500,7 +1512,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .sort()
             .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .execute();
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.actions.ImmutableRewriteDataFiles.Result.Builder;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
@@ -73,7 +74,7 @@ public class RewriteDataFilesSparkAction
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
           MAX_CONCURRENT_FILE_GROUP_REWRITES,
-          MAX_FILE_GROUP_SIZE_BYTES,
+          SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
           PARTIAL_PROGRESS_ENABLED,
           PARTIAL_PROGRESS_MAX_COMMITS,
           PARTIAL_PROGRESS_MAX_FAILED_COMMITS,

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1049,7 +1049,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         basicRewrite(table)
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "10")
             .execute();
 
@@ -1075,7 +1076,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
             .execute();
 
@@ -1101,7 +1103,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
             .execute();
@@ -1126,7 +1129,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
 
@@ -1158,7 +1162,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1190,7 +1195,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1222,7 +1228,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3");
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
@@ -1256,7 +1263,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
 
@@ -1296,7 +1304,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1337,7 +1346,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1379,7 +1389,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
@@ -1419,7 +1430,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             // Since we can have at most one commit per file group and there are only 10 file
@@ -1500,7 +1512,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .sort()
             .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .execute();
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.actions.ImmutableRewriteDataFiles.Result.Builder;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
@@ -73,7 +74,7 @@ public class RewriteDataFilesSparkAction
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
           MAX_CONCURRENT_FILE_GROUP_REWRITES,
-          MAX_FILE_GROUP_SIZE_BYTES,
+          SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
           PARTIAL_PROGRESS_ENABLED,
           PARTIAL_PROGRESS_MAX_COMMITS,
           PARTIAL_PROGRESS_MAX_FAILED_COMMITS,

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1052,7 +1052,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         basicRewrite(table)
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "10")
             .execute();
 
@@ -1078,7 +1079,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
             .execute();
 
@@ -1104,7 +1106,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
             .execute();
@@ -1129,7 +1132,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
 
@@ -1161,7 +1165,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1193,7 +1198,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1225,7 +1231,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3");
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
@@ -1259,7 +1266,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
 
@@ -1299,7 +1307,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1340,7 +1349,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1382,7 +1392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
@@ -1422,7 +1433,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             // Since we can have at most one commit per file group and there are only 10 file
@@ -1503,7 +1515,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .sort()
             .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .execute();
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteDataFilesSparkAction.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.actions.ImmutableRewriteDataFiles.Result.Builder;
 import org.apache.iceberg.actions.RewriteDataFiles;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
+import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
@@ -73,7 +74,7 @@ public class RewriteDataFilesSparkAction
   private static final Set<String> VALID_OPTIONS =
       ImmutableSet.of(
           MAX_CONCURRENT_FILE_GROUP_REWRITES,
-          MAX_FILE_GROUP_SIZE_BYTES,
+          SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
           PARTIAL_PROGRESS_ENABLED,
           PARTIAL_PROGRESS_MAX_COMMITS,
           PARTIAL_PROGRESS_MAX_FAILED_COMMITS,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1052,7 +1052,8 @@ public class TestRewriteDataFilesAction extends TestBase {
         basicRewrite(table)
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "10")
             .execute();
 
@@ -1078,7 +1079,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(SizeBasedFileRewritePlanner.MIN_INPUT_FILES, "1")
             .execute();
 
@@ -1104,7 +1106,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFiles.Result result =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
             .execute();
@@ -1129,7 +1132,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
 
@@ -1161,7 +1165,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1193,7 +1198,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000));
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000));
 
     RewriteDataFilesSparkAction spyRewrite = spy(realRewrite);
     RewriteDataFilesCommitManager util = spy(new RewriteDataFilesCommitManager(table));
@@ -1225,7 +1231,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3");
 
     RewriteDataFilesSparkAction spyRewrite = Mockito.spy(realRewrite);
@@ -1259,7 +1266,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
 
@@ -1299,7 +1307,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1340,7 +1349,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3");
@@ -1382,7 +1392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_MAX_COMMITS, "3")
@@ -1422,7 +1433,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .option(RewriteDataFiles.MAX_CONCURRENT_FILE_GROUP_REWRITES, "3")
             .option(RewriteDataFiles.PARTIAL_PROGRESS_ENABLED, "true")
             // Since we can have at most one commit per file group and there are only 10 file
@@ -1503,7 +1515,8 @@ public class TestRewriteDataFilesAction extends TestBase {
             .sort()
             .option(SizeBasedFileRewritePlanner.REWRITE_ALL, "true")
             .option(
-                RewriteDataFiles.MAX_FILE_GROUP_SIZE_BYTES, Integer.toString(fileSize * 2 + 1000))
+                SizeBasedFileRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                Integer.toString(fileSize * 2 + 1000))
             .execute();
 
     assertThat(result.rewriteResults()).as("Should have 10 fileGroups").hasSize(10);


### PR DESCRIPTION
Fixes #16248

## Summary
- Deprecate `MAX_FILE_GROUP_SIZE_BYTES` and `MAX_FILE_GROUP_SIZE_BYTES_DEFAULT` in `RewriteDataFiles` in favor of the canonical definitions in `SizeBasedFileRewritePlanner`
- Update Spark actions and tests across all 4 Spark versions to reference the non-deprecated constants
- Flink and core modules already reference `SizeBasedFileRewritePlanner` and require no changes