### PR TITLE
Aliyun/Dell: Classify missing object reads as NotFoundException

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSErrorCode;
+import com.aliyun.oss.OSSException;
 import com.aliyun.oss.model.GetObjectRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
@@ -147,7 +150,16 @@ class OSSInputStream extends SeekableInputStream {
     closeStream();
 
     GetObjectRequest request = new GetObjectRequest(uri.bucket(), uri.key()).withRange(pos, -1);
-    stream = client.getObject(request).getObjectContent();
+    try {
+      stream = client.getObject(request).getObjectContent();
+    } catch (OSSException e) {
+      if (OSSErrorCode.NO_SUCH_BUCKET.equals(e.getErrorCode())
+          || OSSErrorCode.NO_SUCH_KEY.equals(e.getErrorCode())) {
+        throw new NotFoundException(e, "Location does not exist: %s", uri);
+      }
+
+      throw e;
+    }
   }
 
   private void closeStream() throws IOException {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
@@ -116,6 +117,17 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
       assertThat(actual)
           .as("Should have expected seeking stream")
           .isEqualTo(Arrays.copyOfRange(expected, expected.length / 2, expected.length));
+    }
+  }
+
+  @Test
+  void missingObjectThrowsNotFoundException() throws Exception {
+    OSSURI uri = new OSSURI(location("missing.dat"));
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      assertThatThrownBy(in::read)
+          .isInstanceOf(NotFoundException.class)
+          .hasMessageContaining(uri.location());
     }
   }
 

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -25,6 +25,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
+import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.SeekableInputStream;
@@ -123,6 +124,18 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
   @Test
   void missingObjectThrowsNotFoundException() throws Exception {
     OSSURI uri = new OSSURI(location("missing.dat"));
+
+    try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
+      assertThatThrownBy(in::read)
+          .isInstanceOf(NotFoundException.class)
+          .hasMessageContaining(uri.location());
+    }
+  }
+
+  @Test
+  void missingBucketThrowsNotFoundException() throws Exception {
+    OSSURI uri =
+        new OSSURI(String.format("oss://missing-bucket-%s/missing.dat", UUID.randomUUID()));
 
     try (SeekableInputStream in = new OSSInputStream(ossClient().get(), uri)) {
       assertThatThrownBy(in::read)

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.dell.ecs;
 
 import com.emc.object.Range;
 import com.emc.object.s3.S3Client;
+import com.emc.object.s3.S3Exception;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
@@ -110,7 +112,15 @@ class EcsSeekableInputStream extends SeekableInputStream {
     }
 
     pos = newPos;
-    internalStream = client.readObjectStream(uri.bucket(), uri.name(), Range.fromOffset(pos));
+    try {
+      internalStream = client.readObjectStream(uri.bucket(), uri.name(), Range.fromOffset(pos));
+    } catch (S3Exception e) {
+      if (e.getHttpCode() == 404) {
+        throw new NotFoundException(e, "Location does not exist: %s", uri);
+      }
+
+      throw e;
+    }
     newPos = -1;
   }
 

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -19,11 +19,13 @@
 package org.apache.iceberg.dell.ecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -88,6 +90,19 @@ public class TestEcsSeekableInputStream {
       assertThat(new String(buffer, StandardCharsets.UTF_8))
           .as("The first 3 bytes should be 012")
           .isEqualTo("012");
+    }
+  }
+
+  @Test
+  void missingObjectThrowsNotFoundException() throws IOException {
+    String objectName = rule.randomObjectName();
+    EcsURI uri = new EcsURI(rule.bucket(), objectName);
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(rule.client(), uri, MetricsContext.nullMetrics())) {
+      assertThatThrownBy(input::read)
+          .isInstanceOf(NotFoundException.class)
+          .hasMessageContaining(uri.location());
     }
   }
 }


### PR DESCRIPTION
## Summary

- translate Aliyun OSS `NoSuchKey` / `NoSuchBucket` stream-open failures to Iceberg `NotFoundException`
- translate Dell ECS HTTP 404 `readObjectStream` failures to Iceberg `NotFoundException`
- add regression coverage for both missing-object input stream paths

## Root cause

`BaseMetastoreTableOperations.refreshFromMetadataLocation` stops metadata read retries on Iceberg `NotFoundException`. Aliyun OSS and Dell ECS already treat missing objects as absent in `exists()`, but their stream-read paths leaked provider SDK exceptions. A stale catalog metadata location could therefore retry a permanent missing-object failure instead of failing fast.

Closes #16299.

## Testing

- `JAVA_HOME=/Users/nullwo/.gradle/jdks/amazon_com_inc_-17-aarch64-os_x/amazon-corretto-17.jdk/Contents/Home ./gradlew --no-daemon --max-workers=1 :iceberg-aliyun:check :iceberg-dell:check`