### PR TITLE
Build: Improve PR title check pattern for multi-word prefixes and reverts

### DIFF
--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -41,6 +41,7 @@ on:
       - '.github/workflows/labeler.yml'
       - '.github/workflows/license-check.yml'
       - '.github/workflows/open-api.yml'
+      - '.github/workflows/pr-title-check.yml'
       - '.github/workflows/publish-snapshot.yml'
       - '.github/workflows/recurring-jmh-benchmarks.yml'
       - '.github/workflows/site-ci.yml'

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -41,6 +41,7 @@ on:
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'
+    - '.github/workflows/pr-title-check.yml'
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -41,6 +41,7 @@ on:
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'
+    - '.github/workflows/pr-title-check.yml'
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -41,6 +41,7 @@ on:
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'
+    - '.github/workflows/pr-title-check.yml'
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -40,6 +40,7 @@ on:
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'
+    - '.github/workflows/pr-title-check.yml'
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -34,7 +34,7 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^[A-Za-z][A-Za-z0-9._+/&-]*( [A-Za-z0-9][A-Za-z0-9._+/&-]*)*: .+'
+          PATTERN='^(Revert ")?[A-Za-z][A-Za-z0-9._+/&,-]*( [A-Za-z0-9][A-Za-z0-9._+/&,-]*)*: .+'
           if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
             echo "::error::PR title must follow 'Module: Description' format. Got: '$PR_TITLE'"
             echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'Flink 2.1: Add ...', 'Docs: Update ...'"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -37,7 +37,7 @@ jobs:
           PATTERN='^(Revert ")?[A-Za-z][A-Za-z0-9._+/&,-]*( [A-Za-z0-9][A-Za-z0-9._+/&,-]*)*: .+'
           if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
             echo "::error::PR title must follow 'Module: Description' format. Got: '$PR_TITLE'"
-            echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'Flink 2.1: Add ...', 'Docs: Update ...'"
+            echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'Flink 2.1: Add ...', 'API, Core: Update ...'"
             exit 1
           fi
 

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -34,10 +34,10 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^[A-Za-z][A-Za-z0-9._+/&-]*: .+'
+          PATTERN='^[A-Za-z][A-Za-z0-9._+/&-]*( [A-Za-z0-9][A-Za-z0-9._+/&-]*)*: .+'
           if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
             echo "::error::PR title must follow 'Module: Description' format. Got: '$PR_TITLE'"
-            echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'API: Remove ...', 'Docs: Update ...'"
+            echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'Flink 2.1: Add ...', 'Docs: Update ...'"
             exit 1
           fi
 

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -42,6 +42,7 @@ on:
     - '.github/workflows/labeler.yml'
     - '.github/workflows/license-check.yml'
     - '.github/workflows/open-api.yml'
+    - '.github/workflows/pr-title-check.yml'
     - '.github/workflows/publish-snapshot.yml'
     - '.github/workflows/recurring-jmh-benchmarks.yml'
     - '.github/workflows/site-ci.yml'


### PR DESCRIPTION
Relaxes the PR title regex to accept patterns already in common use:

- **Multi-word prefixes**: `Flink 2.1:`, `Kafka Connect:`
- **Comma-separated modules**: `API, Core:`, `Spark 3.4, 3.5, 4.0:`
- **Reverts**: `Revert "Build: Bump ..."`

Validated against 500 recent merged PR titles — no regressions, 7 previously-rejected valid titles now pass.