### PR TITLE
Spark: Backport aggregate pushdown tests with NaN's

### DIFF
--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -768,6 +768,51 @@ public class TestAggregatePushDown extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testNanWithLowerAndUpperBoundMetrics() {
+    sql("CREATE TABLE %s (id int, data float) USING iceberg PARTITIONED BY (id)", tableName);
+    sql(
+        "INSERT INTO %s VALUES (1, float('nan')),"
+            + "(1, float('nan')), "
+            + "(1, 10.0), "
+            + "(2, 2), "
+            + "(2, float('nan')), "
+            + "(3, float('nan')), "
+            + "(3, 1)",
+        tableName);
+
+    // Validate all files has upper bound, lower bound and nan count
+    String countsQuery =
+        "select readable_metrics.data.nan_value_count > 0, "
+            + "isnull(readable_metrics.data.lower_bound), "
+            + "isnull(readable_metrics.data.upper_bound) "
+            + "from  %s.files";
+
+    Object[] expectedResult = new Object[] {true, false, false};
+    assertThat(sql(countsQuery, tableName))
+        .as("Data files should contain nan count, lower bound and upper bound.")
+        .allMatch(row -> Arrays.equals(row, expectedResult));
+
+    // Check aggregates are not pushed down
+    String select = "SELECT count(*), max(data), min(data), count(data) FROM %s";
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
+    boolean explainContainsPushDownAggregates =
+        (explainString.contains("max(data)")
+            || explainString.contains("min(data)")
+            || explainString.contains("count(data)"));
+
+    assertThat(explainContainsPushDownAggregates)
+        .as("explain should not contain the pushed down aggregates")
+        .isFalse();
+
+    List<Object[]> actual = sql(select, tableName);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {7L, Float.NaN, 1.0F, 7L});
+    assertEquals("expected and actual should equal", expected, actual);
+  }
+
+  @TestTemplate
   public void testInfinity() {
     sql(
         "CREATE TABLE %s (id int, data1 float, data2 double, data3 double) USING iceberg PARTITIONED BY (id)",

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -768,6 +768,51 @@ public class TestAggregatePushDown extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testNanWithLowerAndUpperBoundMetrics() {
+    sql("CREATE TABLE %s (id int, data float) USING iceberg PARTITIONED BY (id)", tableName);
+    sql(
+        "INSERT INTO %s VALUES (1, float('nan')),"
+            + "(1, float('nan')), "
+            + "(1, 10.0), "
+            + "(2, 2), "
+            + "(2, float('nan')), "
+            + "(3, float('nan')), "
+            + "(3, 1)",
+        tableName);
+
+    // Validate all files has upper bound, lower bound and nan count
+    String countsQuery =
+        "select readable_metrics.data.nan_value_count > 0, "
+            + "isnull(readable_metrics.data.lower_bound), "
+            + "isnull(readable_metrics.data.upper_bound) "
+            + "from  %s.files";
+
+    Object[] expectedResult = new Object[] {true, false, false};
+    assertThat(sql(countsQuery, tableName))
+        .as("Data files should contain nan count, lower bound and upper bound.")
+        .allMatch(row -> Arrays.equals(row, expectedResult));
+
+    // Check aggregates are not pushed down
+    String select = "SELECT count(*), max(data), min(data), count(data) FROM %s";
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
+    boolean explainContainsPushDownAggregates =
+        (explainString.contains("max(data)")
+            || explainString.contains("min(data)")
+            || explainString.contains("count(data)"));
+
+    assertThat(explainContainsPushDownAggregates)
+        .as("explain should not contain the pushed down aggregates")
+        .isFalse();
+
+    List<Object[]> actual = sql(select, tableName);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {7L, Float.NaN, 1.0F, 7L});
+    assertEquals("expected and actual should equal", expected, actual);
+  }
+
+  @TestTemplate
   public void testInfinity() {
     sql(
         "CREATE TABLE %s (id int, data1 float, data2 double, data3 double) USING iceberg PARTITIONED BY (id)",

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestAggregatePushDown.java
@@ -768,6 +768,51 @@ public class TestAggregatePushDown extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testNanWithLowerAndUpperBoundMetrics() {
+    sql("CREATE TABLE %s (id int, data float) USING iceberg PARTITIONED BY (id)", tableName);
+    sql(
+        "INSERT INTO %s VALUES (1, float('nan')),"
+            + "(1, float('nan')), "
+            + "(1, 10.0), "
+            + "(2, 2), "
+            + "(2, float('nan')), "
+            + "(3, float('nan')), "
+            + "(3, 1)",
+        tableName);
+
+    // Validate all files has upper bound, lower bound and nan count
+    String countsQuery =
+        "select readable_metrics.data.nan_value_count > 0, "
+            + "isnull(readable_metrics.data.lower_bound), "
+            + "isnull(readable_metrics.data.upper_bound) "
+            + "from  %s.files";
+
+    Object[] expectedResult = new Object[] {true, false, false};
+    assertThat(sql(countsQuery, tableName))
+        .as("Data files should contain nan count, lower bound and upper bound.")
+        .allMatch(row -> Arrays.equals(row, expectedResult));
+
+    // Check aggregates are not pushed down
+    String select = "SELECT count(*), max(data), min(data), count(data) FROM %s";
+
+    List<Object[]> explain = sql("EXPLAIN " + select, tableName);
+    String explainString = explain.get(0)[0].toString().toLowerCase(Locale.ROOT);
+    boolean explainContainsPushDownAggregates =
+        (explainString.contains("max(data)")
+            || explainString.contains("min(data)")
+            || explainString.contains("count(data)"));
+
+    assertThat(explainContainsPushDownAggregates)
+        .as("explain should not contain the pushed down aggregates")
+        .isFalse();
+
+    List<Object[]> actual = sql(select, tableName);
+    List<Object[]> expected = Lists.newArrayList();
+    expected.add(new Object[] {7L, Float.NaN, 1.0F, 7L});
+    assertEquals("expected and actual should equal", expected, actual);
+  }
+
+  @TestTemplate
   public void testInfinity() {
     sql(
         "CREATE TABLE %s (id int, data1 float, data2 double, data3 double) USING iceberg PARTITIONED BY (id)",


### PR DESCRIPTION
Backports aggregate pushdown with NaNs test case created as part of PR https://github.com/apache/iceberg/pull/15070 for all spark versions.