### PR TITLE
Flink: Refresh table in ListMetadataFiles to prevent incorrect orphan file deletion

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -66,6 +66,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
   public void processElement(Trigger trigger, Context ctx, Collector<String> collector)
       throws Exception {
     try {
+      table.refresh();
       table
           .snapshots()
           .forEach(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
@@ -23,8 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
 class TestListMetadataFiles extends OperatorTestBase {
@@ -83,6 +85,39 @@ class TestListMetadataFiles extends OperatorTestBase {
 
       List<String> tableMetadataFiles = testHarness.extractOutputValues();
       assertThat(tableMetadataFiles).hasSize(0);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesIncludesSnapshotsAddedAfterOpen() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      // Add more snapshots AFTER the operator has been opened
+      insert(table, 2, "b");
+      insert(table, 3, "c");
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+
+      // Verify that manifest lists from ALL 3 snapshots are present, not just the first one.
+      // Without table.refresh() in processElement, only snapshot 1's files would be emitted.
+      table.refresh();
+      List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
+      assertThat(snapshots).hasSize(3);
+      for (Snapshot snapshot : snapshots) {
+        assertThat(tableMetadataFiles).contains(snapshot.manifestListLocation());
+      }
+      // Verify total count matches what 3 snapshots should produce
+      assertThat(tableMetadataFiles).hasSize(24);
 
       assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
     }


### PR DESCRIPTION
## Problem

Fixes #15487.

When Flink TableMaintenance runs both `ExpireSnapshots` and `DeleteOrphanFiles`, manifest list files of live snapshots are incorrectly deleted as orphans, causing `NotFoundException` in subsequent `ExpireSnapshots` runs.

## Root cause

`ListMetadataFiles` loads the table once at operator startup (`open()`) and never calls `table.refresh()` in `processElement()`. It only emits manifest list and manifest file paths for snapshots that existed when the Flink job started.

Any snapshot added after job start has its metadata files missing from the "referenced" set that `DeleteOrphanFiles` uses. When those manifest lists are older than `minAge`, `OrphanFilesDetector` classifies them as orphans and `DeleteFilesProcessor` deletes them.

On the next maintenance cycle, `ExpireSnapshots` tries to read those manifest lists in `IncrementalFileCleanup.cleanFiles()` and fails with `NotFoundException`.

This explains why the bug:
- only occurs with `DeleteOrphanFiles` enabled (it is the one incorrectly deleting the files)
- never occurs with `ExpireSnapshots` alone (it only deletes manifest lists of snapshots it has already expired and read)
- becomes more likely over time (more snapshots added after job start = more unprotected manifest lists)

## Fix

Add `table.refresh()` at the top of `ListMetadataFiles.processElement()`, matching what `MetadataTablePlanner` already does. This ensures the "referenced" set always reflects the current table state.
