### PR TITLE
Api: Harden Variant Reading

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/SerializedArray.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedArray.java
@@ -55,9 +55,25 @@ class SerializedArray implements VariantArray, SerializedValue {
     this.value = value;
     this.offsetSize = 1 + ((header & OFFSET_SIZE_MASK) >> OFFSET_SIZE_SHIFT);
     int numElementsSize = ((header & IS_LARGE) == IS_LARGE) ? 4 : 1;
+    int remaining = value.remaining();
+    Preconditions.checkArgument(
+        HEADER_SIZE + numElementsSize <= remaining,
+        "Variant array truncated: cannot read element count (numElementsSize=%s remaining=%s)",
+        numElementsSize,
+        remaining);
     int numElements = VariantUtil.readLittleEndianUnsigned(value, HEADER_SIZE, numElementsSize);
+    Preconditions.checkArgument(
+        numElements >= 0, "Invalid variant array element count: %s", numElements);
     this.offsetListOffset = HEADER_SIZE + numElementsSize;
-    this.dataOffset = offsetListOffset + ((1 + numElements) * offsetSize);
+    long offsetTableBytes = (1L + numElements) * offsetSize;
+    long computedDataOffset = (long) offsetListOffset + offsetTableBytes;
+    Preconditions.checkArgument(
+        computedDataOffset <= remaining,
+        "Variant array offset table extends past buffer: numElements=%s offsetSize=%s remaining=%s",
+        numElements,
+        offsetSize,
+        remaining);
+    this.dataOffset = (int) computedDataOffset;
     this.array = new VariantValue[numElements];
   }
 

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
@@ -58,15 +58,38 @@ class SerializedMetadata implements VariantMetadata, Serialized {
   private SerializedMetadata(ByteBuffer metadata, int header) {
     this.isSorted = (header & SORTED_STRINGS) == SORTED_STRINGS;
     this.offsetSize = 1 + ((header & OFFSET_SIZE_MASK) >> OFFSET_SIZE_SHIFT);
+    int remaining = metadata.remaining();
+    Preconditions.checkArgument(
+        HEADER_SIZE + offsetSize <= remaining,
+        "Variant metadata truncated: cannot read dictionary size (offsetSize=%s remaining=%s)",
+        offsetSize,
+        remaining);
     int dictSize = VariantUtil.readLittleEndianUnsigned(metadata, HEADER_SIZE, offsetSize);
-    this.dict = new String[dictSize];
+    Preconditions.checkArgument(
+        dictSize >= 0, "Invalid variant metadata dictionary size: %s", dictSize);
     this.offsetListOffset = HEADER_SIZE + offsetSize;
-    this.dataOffset = offsetListOffset + ((1 + dictSize) * offsetSize);
-    int endOffset =
-        dataOffset
+    // Use long arithmetic so a malformed dictSize/offsetSize cannot overflow into a small int.
+    long offsetTableBytes = (1L + dictSize) * offsetSize;
+    long computedDataOffset = (long) offsetListOffset + offsetTableBytes;
+    Preconditions.checkArgument(
+        computedDataOffset <= remaining,
+        "Variant metadata offset table extends past buffer: dictSize=%s offsetSize=%s remaining=%s",
+        dictSize,
+        offsetSize,
+        remaining);
+    long computedEnd =
+        computedDataOffset
             + VariantUtil.readLittleEndianUnsigned(
                 metadata, offsetListOffset + (offsetSize * dictSize), offsetSize);
-    if (endOffset < metadata.limit()) {
+    Preconditions.checkArgument(
+        computedEnd <= remaining,
+        "Variant metadata data section extends past buffer: end=%s remaining=%s",
+        computedEnd,
+        remaining);
+    this.dict = new String[dictSize];
+    this.dataOffset = (int) computedDataOffset;
+    int endOffset = (int) computedEnd;
+    if (endOffset < remaining) {
       this.metadata = VariantUtil.slice(metadata, 0, endOffset);
     } else {
       this.metadata = metadata;

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
@@ -67,13 +67,32 @@ class SerializedObject implements VariantObject, SerializedValue {
     this.offsetSize = 1 + ((header & OFFSET_SIZE_MASK) >> OFFSET_SIZE_SHIFT);
     this.fieldIdSize = 1 + ((header & FIELD_ID_SIZE_MASK) >> FIELD_ID_SIZE_SHIFT);
     int numElementsSize = ((header & IS_LARGE) == IS_LARGE) ? 4 : 1;
+    int remaining = value.remaining();
+    Preconditions.checkArgument(
+        HEADER_SIZE + numElementsSize <= remaining,
+        "Variant object truncated: cannot read element count (numElementsSize=%s remaining=%s)",
+        numElementsSize,
+        remaining);
     int numElements = VariantUtil.readLittleEndianUnsigned(value, HEADER_SIZE, numElementsSize);
+    Preconditions.checkArgument(
+        numElements >= 0, "Invalid variant object element count: %s", numElements);
     this.fieldIdListOffset = HEADER_SIZE + numElementsSize;
+    long fieldIdBytes = (long) numElements * fieldIdSize;
+    long offsetTableBytes = (1L + numElements) * offsetSize;
+    long computedOffsetListOffset = (long) fieldIdListOffset + fieldIdBytes;
+    long computedDataOffset = computedOffsetListOffset + offsetTableBytes;
+    Preconditions.checkArgument(
+        computedDataOffset <= remaining,
+        "Variant object tables extend past buffer: numElements=%s fieldIdSize=%s offsetSize=%s remaining=%s",
+        numElements,
+        fieldIdSize,
+        offsetSize,
+        remaining);
     this.fieldIds = new Integer[numElements];
-    this.offsetListOffset = fieldIdListOffset + (numElements * fieldIdSize);
+    this.offsetListOffset = (int) computedOffsetListOffset;
     this.offsets = new int[numElements];
     this.lengths = new int[numElements];
-    this.dataOffset = offsetListOffset + ((1 + numElements) * offsetSize);
+    this.dataOffset = (int) computedDataOffset;
     this.values = new VariantValue[numElements];
 
     if (numElements > 0) {


### PR DESCRIPTION
Hardens variant metadata and value data parsing

* long multiplication to avoid overflows
* reject metadata, array data or object data which extends beyond the range of the variant data in the file.

No checks on variant size (spark has this), or the depth limits of https://github.com/apache/parquet-java/pull/3562 . I think that should be discussed there as to whether its appropriate *at all*, before copying.

No tests yet


Fixes #16334
