### PR TITLE
Core: Parallelize RewriteManifests added-manifest copy path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -207,7 +207,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
             .stopOnFailure()
             .throwFailureWhenFinished()
             .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
-    rewrittenAddedManifests.addAll(Arrays.asList(copiedManifests));
+    Collections.addAll(rewrittenAddedManifests, copiedManifests);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -180,15 +180,15 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
       keepActiveManifests(currentManifests);
     }
 
-  if (rewrittenAddedManifests.isEmpty() && !pendingAddedManifests.isEmpty()) {                                                                                                                                                                                                                                                                                                                                                               
-    ManifestFile[] copied = new ManifestFile[pendingAddedManifests.size()];                                                                                                                                                                                                                                                                                                                                                                  
-    Tasks.range(copied.length)                                                                                                                                                                                                                                                                                                                                                                                 
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(workerPool())                                                                                                                                                                                                                                                                                                                                                                                                     
-        .run(index -> copied[index] = copyManifest(pendingAddedManifests.get(index)));                                                                                                                                                                                                                                                                                                                                                       
-    Collections.addAll(rewrittenAddedManifests, copied);                                                                                                                                                                                                                                                                                                                                                                               
-  }                                                     
+    if (rewrittenAddedManifests.isEmpty() && !pendingAddedManifests.isEmpty()) {
+      ManifestFile[] copiedManifests = new ManifestFile[pendingAddedManifests.size()];
+      Tasks.range(copiedManifests.length)
+          .stopOnFailure()
+          .throwFailureWhenFinished()
+          .executeWith(workerPool())
+          .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
+      Collections.addAll(rewrittenAddedManifests, copiedManifests);
+    }
     validateFilesCounts();
 
     Iterable<ManifestFile> newManifestsWithMetadata =
@@ -202,20 +202,6 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     apply.addAll(keptManifests);
 
     return apply;
-  }
-
-  private void prepareRewrittenAddedManifests() {
-    if (pendingAddedManifests.isEmpty() || !rewrittenAddedManifests.isEmpty()) {
-      return;
-    }
-
-    ManifestFile[] copiedManifests = new ManifestFile[pendingAddedManifests.size()];
-    Tasks.range(copiedManifests.length)
-        .executeWith(workerPool())
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
-    Collections.addAll(rewrittenAddedManifests, copiedManifests);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -54,6 +54,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   private final Set<ManifestFile> deletedManifests = Sets.newHashSet();
   private final List<ManifestFile> addedManifests = Lists.newArrayList();
+  private final List<ManifestFile> pendingAddedManifests = Lists.newArrayList();
   private final List<ManifestFile> rewrittenAddedManifests = Lists.newArrayList();
 
   private final Collection<ManifestFile> keptManifests = new ConcurrentLinkedQueue<>();
@@ -144,8 +145,8 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
       addedManifests.add(manifest);
     } else {
       // the manifest must be rewritten with this update's snapshot ID
-      ManifestFile copiedManifest = copyManifest(manifest);
-      rewrittenAddedManifests.add(copiedManifest);
+      // Defer rewrite/copy so added manifests can be copied in parallel during apply.
+      pendingAddedManifests.add(manifest);
     }
 
     return this;
@@ -179,6 +180,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
       keepActiveManifests(currentManifests);
     }
 
+    prepareRewrittenAddedManifests();
     validateFilesCounts();
 
     Iterable<ManifestFile> newManifestsWithMetadata =
@@ -192,6 +194,20 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     apply.addAll(keptManifests);
 
     return apply;
+  }
+
+  private void prepareRewrittenAddedManifests() {
+    if (pendingAddedManifests.isEmpty() || !rewrittenAddedManifests.isEmpty()) {
+      return;
+    }
+
+    ManifestFile[] copiedManifests = new ManifestFile[pendingAddedManifests.size()];
+    Tasks.range(copiedManifests.length)
+            .executeWith(workerPool())
+            .stopOnFailure()
+            .throwFailureWhenFinished()
+            .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
+    rewrittenAddedManifests.addAll(Arrays.asList(copiedManifests));
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -180,7 +180,15 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
       keepActiveManifests(currentManifests);
     }
 
-    prepareRewrittenAddedManifests();
+  if (rewrittenAddedManifests.isEmpty() && !pendingAddedManifests.isEmpty()) {                                                                                                                                                                                                                                                                                                                                                               
+    ManifestFile[] copied = new ManifestFile[pendingAddedManifests.size()];                                                                                                                                                                                                                                                                                                                                                                  
+    Tasks.range(copied.length)                                                                                                                                                                                                                                                                                                                                                                                 
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(workerPool())                                                                                                                                                                                                                                                                                                                                                                                                     
+        .run(index -> copied[index] = copyManifest(pendingAddedManifests.get(index)));                                                                                                                                                                                                                                                                                                                                                       
+    Collections.addAll(rewrittenAddedManifests, copied);                                                                                                                                                                                                                                                                                                                                                                               
+  }                                                     
     validateFilesCounts();
 
     Iterable<ManifestFile> newManifestsWithMetadata =

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -203,10 +203,10 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
     ManifestFile[] copiedManifests = new ManifestFile[pendingAddedManifests.size()];
     Tasks.range(copiedManifests.length)
-            .executeWith(workerPool())
-            .stopOnFailure()
-            .throwFailureWhenFinished()
-            .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
+        .executeWith(workerPool())
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .run(index -> copiedManifests[index] = copyManifest(pendingAddedManifests.get(index)));
     Collections.addAll(rewrittenAddedManifests, copiedManifests);
   }
 


### PR DESCRIPTION
## Summary
- Defer manifest rewriting in `BaseRewriteManifests.addManifest` by collecting manifests that require copy/rewrite into a pending list.
- Perform those manifest copies in parallel during `apply()` using the existing `workerPool()` via `Tasks.range(...)`.
- Preserve deterministic manifest ordering by writing parallel results into an index-addressed array before appending to `rewrittenAddedManifests`.
- Keep existing commit semantics and validation behavior unchanged; this primarily removes driver-side serial copy overhead during manifest rewrite commits (especially when `compatibility.snapshot-id-inheritance.enabled=false`).
## Why
`RewriteManifests` could spend significant time copying added manifests serially on the driver. This change parallelizes that copy step while preserving output correctness and ordering.
## Test Plan
The logic should be the same, it should just run in parallel so it should be faster.
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestRewriteManifests`

