### PR TITLE
Flink: Backport Refresh table in ListMetadataFiles to prevent incorrect orphan file deletion to v1.20 and v2.0

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -66,6 +66,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
   public void processElement(Trigger trigger, Context ctx, Collector<String> collector)
       throws Exception {
     try {
+      table.refresh();
       table
           .snapshots()
           .forEach(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
@@ -23,8 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
 class TestListMetadataFiles extends OperatorTestBase {
@@ -83,6 +85,39 @@ class TestListMetadataFiles extends OperatorTestBase {
 
       List<String> tableMetadataFiles = testHarness.extractOutputValues();
       assertThat(tableMetadataFiles).hasSize(0);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesIncludesSnapshotsAddedAfterOpen() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      // Add more snapshots AFTER the operator has been opened
+      insert(table, 2, "b");
+      insert(table, 3, "c");
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+
+      // Verify that manifest lists from ALL 3 snapshots are present, not just the first one.
+      // Without table.refresh() in processElement, only snapshot 1's files would be emitted.
+      table.refresh();
+      List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
+      assertThat(snapshots).hasSize(3);
+      for (Snapshot snapshot : snapshots) {
+        assertThat(tableMetadataFiles).contains(snapshot.manifestListLocation());
+      }
+      // Verify total count matches what 3 snapshots should produce
+      assertThat(tableMetadataFiles).hasSize(24);
 
       assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
     }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -66,6 +66,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
   public void processElement(Trigger trigger, Context ctx, Collector<String> collector)
       throws Exception {
     try {
+      table.refresh();
       table
           .snapshots()
           .forEach(

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestListMetadataFiles.java
@@ -23,8 +23,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.List;
 import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
 import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
 
 class TestListMetadataFiles extends OperatorTestBase {
@@ -83,6 +85,39 @@ class TestListMetadataFiles extends OperatorTestBase {
 
       List<String> tableMetadataFiles = testHarness.extractOutputValues();
       assertThat(tableMetadataFiles).hasSize(0);
+
+      assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+    }
+  }
+
+  @Test
+  void testMetadataFilesIncludesSnapshotsAddedAfterOpen() throws Exception {
+    Table table = createTable();
+    insert(table, 1, "a");
+
+    try (OneInputStreamOperatorTestHarness<Trigger, String> testHarness =
+        ProcessFunctionTestHarnesses.forProcessFunction(
+            new ListMetadataFiles(OperatorTestBase.DUMMY_TABLE_NAME, 0, tableLoader()))) {
+      testHarness.open();
+
+      // Add more snapshots AFTER the operator has been opened
+      insert(table, 2, "b");
+      insert(table, 3, "c");
+
+      OperatorTestBase.trigger(testHarness);
+
+      List<String> tableMetadataFiles = testHarness.extractOutputValues();
+
+      // Verify that manifest lists from ALL 3 snapshots are present, not just the first one.
+      // Without table.refresh() in processElement, only snapshot 1's files would be emitted.
+      table.refresh();
+      List<Snapshot> snapshots = Lists.newArrayList(table.snapshots());
+      assertThat(snapshots).hasSize(3);
+      for (Snapshot snapshot : snapshots) {
+        assertThat(tableMetadataFiles).contains(snapshot.manifestListLocation());
+      }
+      // Verify total count matches what 3 snapshots should produce
+      assertThat(tableMetadataFiles).hasSize(24);
 
       assertThat(testHarness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
     }


### PR DESCRIPTION
Backport #16324 to v1.20 and v2.0

Verified same changes