### PR TITLE
Parquet: Enforce row group size limit with compression

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetWriter.java
@@ -65,7 +65,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   private ColumnWriteStore writeStore;
   private long recordCount = 0;
   private long nextCheckRecordCount = 10;
-  private long rowGroupUncompressedSize = 0;
+  private long uncompressedBufferedSize = 0;
   private boolean closed;
   private ParquetFileWriter writer;
   private int rowGroupOrdinal;
@@ -139,19 +139,11 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   @Override
   public void add(T value) {
     recordCount += 1;
-    if (trackUncompressedSize) {
-      writeTracked(value);
-    } else {
-      model.write(0, value);
-    }
-    writeStore.endRecord();
-    checkSize();
-  }
-
-  private void writeTracked(T value) {
     long sizeBefore = writeStore.getBufferedSize();
     model.write(0, value);
-    rowGroupUncompressedSize += writeStore.getBufferedSize() - sizeBefore;
+    uncompressedBufferedSize += writeStore.getBufferedSize() - sizeBefore;
+    writeStore.endRecord();
+    checkSize();
   }
 
   @Override
@@ -204,30 +196,21 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
   }
 
   private void checkSize() {
-    if (trackUncompressedSize) {
-      if (rowGroupUncompressedSize >= targetRowGroupSize) {
-        flushRowGroup(false);
-      } else if (recordCount >= nextCheckRecordCount) {
-        evaluateRowGroupSize(rowGroupUncompressedSize, false);
-      }
-    } else if (recordCount >= nextCheckRecordCount) {
-      evaluateRowGroupSize(writeStore.getBufferedSize(), true);
-    }
-  }
+    if (recordCount >= nextCheckRecordCount) {
+      long bufferedSize = uncompressedBufferedSize;
+      double avgRecordSize = ((double) bufferedSize) / recordCount;
 
-  private void evaluateRowGroupSize(long currentSize, boolean useMinRecordCountFloor) {
-    double avgRecordSize = ((double) currentSize) / recordCount;
-    if (currentSize > (targetRowGroupSize - 2 * avgRecordSize)) {
-      flushRowGroup(false);
-    } else {
-      long remainingSpace = targetRowGroupSize - currentSize;
-      long remainingRecords = (long) (remainingSpace / avgRecordSize);
-      long interval = remainingRecords / 2;
-      if (useMinRecordCountFloor) {
-        interval = Math.max(interval, props.getMinRowCountForPageSizeCheck());
+      if (bufferedSize > (targetRowGroupSize - 2 * avgRecordSize)) {
+        flushRowGroup(false);
+      } else {
+        long remainingSpace = targetRowGroupSize - bufferedSize;
+        long remainingRecords = (long) (remainingSpace / avgRecordSize);
+        this.nextCheckRecordCount =
+            recordCount
+                + Math.min(
+                    Math.max(remainingRecords / 2, props.getMinRowCountForPageSizeCheck()),
+                    props.getMaxRowCountForPageSizeCheck());
       }
-      this.nextCheckRecordCount =
-          recordCount + Math.min(interval, props.getMaxRowCountForPageSizeCheck());
     }
   }
 
@@ -257,7 +240,7 @@ class ParquetWriter<T> implements FileAppender<T>, Closeable {
             Math.max(recordCount / 2, props.getMinRowCountForPageSizeCheck()),
             props.getMaxRowCountForPageSizeCheck());
     this.recordCount = 0;
-    this.rowGroupUncompressedSize = 0;
+    this.uncompressedBufferedSize = 0;
 
     this.pageStore =
         new ColumnChunkPageWriteStore(

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.parquet;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX;
+import static org.apache.iceberg.TableProperties.PARQUET_COMPRESSION;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
@@ -345,6 +346,50 @@ public class TestParquet {
     assertThatThrownBy(() -> ParquetAvroWriter.buildWriter(schema))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Avro writer does not support variant types");
+  }
+
+  @Test
+  public void testRowGroupSizeEnforcedWithCompression() throws IOException {
+    // Regression test for #16325: with compression enabled, row group size check used compressed
+    // bytes, causing row groups to grow unbounded.
+    Schema schema = new Schema(optional(1, "stringCol", Types.StringType.get()));
+
+    File file = createTempFile(temp);
+
+    // Write data that is highly compressible but unique enough to avoid dictionary encoding
+    // from collapsing it. Each record has a unique prefix + repeated padding.
+    int rowGroupSize = 64 * 1024; // 64 KB
+    int pageSize = 4 * 1024; // 4 KB page size to force frequent page flushes
+    int numRecords = 500;
+
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(numRecords);
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    for (int i = 0; i < numRecords; i++) {
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      // Unique prefix ensures no dictionary, repeated suffix ensures high compression
+      record.put("stringCol", String.format("%010d", i) + Strings.repeat("a", 1014));
+      records.add(record);
+    }
+
+    write(
+        file,
+        schema,
+        ImmutableMap.<String, String>builder()
+            .put(PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(rowGroupSize))
+            .put(PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT, "1")
+            .put(PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT, "100")
+            .put(PARQUET_COMPRESSION, "gzip")
+            .put("write.parquet.page-size-bytes", Integer.toString(pageSize))
+            .buildOrThrow(),
+        ParquetAvroWriter::buildWriter,
+        records.toArray(new GenericData.Record[] {}));
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(localInput(file)))) {
+      List<BlockMetaData> rowGroups = reader.getRowGroups();
+      // With 500 KB of uncompressed data and a 64 KB row group target,
+      // we must get multiple row groups
+      assertThat(rowGroups).hasSizeGreaterThan(1);
+    }
   }
 
   private Pair<File, Long> generateFile(


### PR DESCRIPTION
Fixes #16325.

## Problem

When using GZIP or ZSTD compression, the row group size check in `ParquetWriter` uses `writeStore.getBufferedSize()` which reports compressed bytes after page flushes. Since compressed size is significantly smaller than the configured `targetRowGroupSize`, the threshold is never reached and row groups grow unbounded.

## Fix

Track uncompressed bytes by measuring the `getBufferedSize()` delta before and after each `model.write()` call (before `endRecord()` triggers page flush and compression). Use this accumulated uncompressed size in `checkSize()` instead of the post-compression buffered size. Reset on row group flush.

## Testing

Added `testRowGroupSizeEnforcedWithCompression` in `TestParquet` -- writes 500 records of ~1KB each with GZIP compression and a 64KB row group target. Asserts multiple row groups are created.

- **Without fix**: all 500 records end up in 1 row group (compressed size never hits threshold)
- **With fix**: multiple row groups created respecting the 64KB target
