### PR TITLE
Kafka Connect: Include connector name in coordinator and committer thread names

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -207,7 +207,7 @@ public class CommitterImpl implements Committer {
           config.taskId());
       Coordinator coordinator =
           new Coordinator(catalog, config, membersWhenWorkerIsCoordinator, clientFactory, context);
-      coordinatorThread = new CoordinatorThread(coordinator);
+      coordinatorThread = new CoordinatorThread(coordinator, config.connectorName());
       coordinatorThread.start();
     }
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -107,7 +107,7 @@ class Coordinator extends Channel {
             new LinkedBlockingQueue<>(),
             new ThreadFactoryBuilder()
                 .setDaemon(true)
-                .setNameFormat("iceberg-committer" + "-%d")
+                .setNameFormat("iceberg-committer-" + config.connectorName() + "-%d")
                 .build());
     this.commitState = new CommitState(config);
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -23,13 +23,12 @@ import org.slf4j.LoggerFactory;
 
 class CoordinatorThread extends Thread {
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorThread.class);
-  private static final String THREAD_NAME = "iceberg-coord";
 
   private final Coordinator coordinator;
   private volatile boolean terminated;
 
-  CoordinatorThread(Coordinator coordinator) {
-    super(THREAD_NAME);
+  CoordinatorThread(Coordinator coordinator, String connectorName) {
+    super("iceberg-coord-" + connectorName);
     this.coordinator = coordinator;
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
@@ -31,7 +31,9 @@ public class TestCoordinatorThread {
   @Test
   public void testRun() {
     Coordinator coordinator = mock(Coordinator.class);
-    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator, "test-connector");
+
+    assertThat(coordinatorThread.getName()).isEqualTo("iceberg-coord-test-connector");
 
     coordinatorThread.start();
 


### PR DESCRIPTION
## Problem
When multiple Iceberg sink connectors run in the same Kafka Connect worker process, all
coordinator threads share the same name `iceberg-coord` and all committer threads share
names like `iceberg-committer-0`, `iceberg-committer-1`, etc.
This makes log-based debugging difficult: when a coordinator fails to commit or a committer
thread throws an error, the log output gives no indication of which connector is responsible.
## Proposed Change
Include the connector name in the thread names:
- `CoordinatorThread`: rename from `iceberg-coord` → `iceberg-coord-<connectorName>`
- Committer `ThreadPoolExecutor` inside `Coordinator`: rename from `iceberg-committer-%d` → `iceberg-committer-<connectorName>-%d`
## Impact
With this change, operators running multiple connectors on the same worker can immediately
identify which connector's coordinator or committer thread is present in a log line, without
needing additional context or MDC instrumentation.

Closes #16354