### PR TITLE
Build: Designate a single Gradle cache writer across CI workflows

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -60,6 +60,9 @@ jobs:
           distribution: zulu
           java-version: 17
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+          cache-read-only: true
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";
       - run: ./gradlew revapi --rerun-tasks

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -127,6 +127,9 @@ jobs:
         distribution: zulu
         java-version: 21
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2 # zizmor: ignore[cache-poisoning] -- cache writes are restricted to the default branch by setup-gradle
+      with:
+        # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+        cache-read-only: true
     - name: Build ${{ matrix.distribution }}
       run: |
         ./gradlew -DsparkVersions= -DflinkVersions= \

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -93,7 +93,6 @@ jobs:
         with:
           # Writes cache on main; read-only otherwise.
           cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-          gradle-home-cache-cleanup: true
           gradle-home-cache-excludes: |
             caches/build-cache-1
             caches/keyrings
@@ -126,7 +125,6 @@ jobs:
         with:
           # Writes cache on main; read-only otherwise.
           cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-          gradle-home-cache-cleanup: true
           gradle-home-cache-excludes: |
             caches/build-cache-1
             caches/keyrings

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -90,6 +90,13 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Writes cache on main; read-only otherwise.
+          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+          gradle-home-cache-cleanup: true
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
+            caches/keyrings
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DkafkaVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -116,6 +123,13 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Writes cache on main; read-only otherwise.
+          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+          gradle-home-cache-cleanup: true
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
+            caches/keyrings
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.13 -DkafkaVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -91,11 +91,8 @@ jobs:
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # Writes cache on main; read-only otherwise.
-          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-          gradle-home-cache-excludes: |
-            caches/build-cache-1
-            caches/keyrings
+          # Read-only: java-ci's build-checks (17) is the global canonical writer.
+          cache-read-only: true
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.12 -DkafkaVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -123,11 +120,8 @@ jobs:
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # Writes cache on main; read-only otherwise.
-          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-          gradle-home-cache-excludes: |
-            caches/build-cache-1
-            caches/keyrings
+          # Read-only: java-ci's build-checks (17) is the global canonical writer.
+          cache-read-only: true
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - run: ./gradlew -DsparkVersions=3.5 -DscalaVersion=2.13 -DkafkaVersions= -DflinkVersions= :iceberg-delta-lake:check -Pquick=true -x javadoc
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -97,7 +97,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.flink == '2.1') }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -96,8 +96,6 @@ jobs:
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
         # Read-only: java-ci's build-checks (17) is the global canonical writer.
-        # Its `-DallModules build` resolves the union dependency closure, so the
-        # content-addressed dependencies cache covers Flink modules too.
         cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -DtestParallelism=auto

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -95,11 +95,10 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.flink == '2.1') }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
+        # Its `-DallModules build` resolves the union dependency closure, so the
+        # content-addressed dependencies cache covers Flink modules too.
+        cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -DtestParallelism=auto
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -94,6 +94,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.flink == '2.1') }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -DtestParallelism=auto
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -91,6 +91,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions= -Pquick=true :iceberg-mr:check -x javadoc
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -92,11 +92,8 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
+        cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions= -Pquick=true :iceberg-mr:check -x javadoc
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -94,7 +94,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -87,9 +87,7 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Read-only: build-checks (17) is the canonical writer for the
-        # shared java-ci gradle-home config-hash; this job restores from
-        # it via setup-gradle's restore-keys prefix walk.
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew check -DsparkVersions= -DflinkVersions= -DkafkaVersions= -Pquick=true -x javadoc
@@ -136,9 +134,7 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Read-only: build-checks (17) is the canonical writer for the
-        # shared java-ci gradle-home config-hash; this job restores from
-        # it via setup-gradle's restore-keys prefix walk.
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - run: ./gradlew -Pquick=true javadoc
 
@@ -154,8 +150,6 @@ jobs:
         java-version: 17
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Read-only: build-checks (17) is the canonical writer for java-ci.
-        # Its `-DallModules build` resolves the runtime-dep superset this job
-        # needs, so the content-addressed dependencies cache covers us.
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - run: ./gradlew checkAllRuntimeDeps -q -DallModules=true

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -89,7 +89,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings
@@ -120,7 +119,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings
@@ -144,7 +142,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings
@@ -164,7 +161,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -87,11 +87,10 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: build-checks (17) is the canonical writer for the
+        # shared java-ci gradle-home config-hash; this job restores from
+        # it via setup-gradle's restore-keys prefix walk.
+        cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew check -DsparkVersions= -DflinkVersions= -DkafkaVersions= -Pquick=true -x javadoc
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -119,9 +118,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
     - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
 
   build-javadoc:
@@ -140,11 +136,10 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: build-checks (17) is the canonical writer for the
+        # shared java-ci gradle-home config-hash; this job restores from
+        # it via setup-gradle's restore-keys prefix walk.
+        cache-read-only: true
     - run: ./gradlew -Pquick=true javadoc
 
   check-runtime-deps:
@@ -159,9 +154,8 @@ jobs:
         java-version: 17
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: build-checks (17) is the canonical writer for java-ci.
+        # Its `-DallModules build` resolves the runtime-dep superset this job
+        # needs, so the content-addressed dependencies cache covers us.
+        cache-read-only: true
     - run: ./gradlew checkAllRuntimeDeps -q -DallModules=true

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -86,6 +86,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: ./gradlew check -DsparkVersions= -DflinkVersions= -DkafkaVersions= -Pquick=true -x javadoc
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -110,6 +117,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
 
   build-javadoc:
@@ -127,6 +141,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: ./gradlew -Pquick=true javadoc
 
   check-runtime-deps:
@@ -140,4 +161,11 @@ jobs:
         distribution: zulu
         java-version: 17
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: ./gradlew checkAllRuntimeDeps -q -DallModules=true

--- a/.github/workflows/jmh-benchmarks.yml
+++ b/.github/workflows/jmh-benchmarks.yml
@@ -104,6 +104,9 @@ jobs:
         distribution: zulu
         java-version: 17
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Disabled: dispatched against arbitrary repo/ref inputs; never restore or write to avoid cache poisoning.
+        cache-disabled: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
 
     - name: Run Benchmark

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -91,6 +91,13 @@ jobs:
         distribution: zulu
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Writes cache on main; read-only otherwise.
+        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
+        gradle-home-cache-cleanup: true
+        gradle-home-cache-excludes: |
+          caches/build-cache-1
+          caches/keyrings
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: |
         ./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions=3 \

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -92,11 +92,8 @@ jobs:
         java-version: ${{ matrix.jvm }}
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Writes cache on main; read-only otherwise.
-        cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-excludes: |
-          caches/build-cache-1
-          caches/keyrings
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
+        cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
     - run: |
         ./gradlew -DsparkVersions= -DflinkVersions= -DkafkaVersions=3 \

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -94,7 +94,6 @@ jobs:
       with:
         # Writes cache on main; read-only otherwise.
         cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17) }}
-        gradle-home-cache-cleanup: true
         gradle-home-cache-excludes: |
           caches/build-cache-1
           caches/keyrings

--- a/.github/workflows/publish-iceberg-rest-fixture-docker.yml
+++ b/.github/workflows/publish-iceberg-rest-fixture-docker.yml
@@ -49,6 +49,9 @@ jobs:
         distribution: zulu
         java-version: 21
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+      with:
+        # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+        cache-read-only: true
     - name: Build Iceberg Open API project
       run: ./gradlew :iceberg-open-api:shadowJar
     - name: Login to Docker Hub

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -44,6 +44,9 @@ jobs:
           distribution: zulu
           java-version: 17
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+          cache-read-only: true
       - env:
           NEXUS_USER: ${{ secrets.NEXUS_USER }}
           NEXUS_PW: ${{ secrets.NEXUS_PW }}

--- a/.github/workflows/recurring-jmh-benchmarks.yml
+++ b/.github/workflows/recurring-jmh-benchmarks.yml
@@ -59,6 +59,9 @@ jobs:
           distribution: zulu
           java-version: 17
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+          cache-read-only: true
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
 
       - name: Run Benchmark

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -103,8 +103,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
           # Read-only: java-ci's build-checks (17) is the global canonical writer.
-          # Its `-DallModules build` resolves the union dependency closure, so the
-          # content-addressed dependencies cache covers Spark modules too.
           cache-read-only: true
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -102,11 +102,10 @@ jobs:
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # Writes cache on main; read-only otherwise.
-          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.spark == '4.1' && matrix.scala == '2.13') }}
-          gradle-home-cache-excludes: |
-            caches/build-cache-1
-            caches/keyrings
+          # Read-only: java-ci's build-checks (17) is the global canonical writer.
+          # Its `-DallModules build` resolves the union dependency closure, so the
+          # content-addressed dependencies cache covers Spark modules too.
+          cache-read-only: true
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -104,7 +104,6 @@ jobs:
         with:
           # Writes cache on main; read-only otherwise.
           cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.spark == '4.1' && matrix.scala == '2.13') }}
-          gradle-home-cache-cleanup: true
           gradle-home-cache-excludes: |
             caches/build-cache-1
             caches/keyrings

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -101,6 +101,13 @@ jobs:
           distribution: zulu
           java-version: ${{ matrix.jvm }}
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
+        with:
+          # Writes cache on main; read-only otherwise.
+          cache-read-only: ${{ !(github.ref == 'refs/heads/main' && matrix.jvm == 17 && matrix.spark == '4.1' && matrix.scala == '2.13') }}
+          gradle-home-cache-cleanup: true
+          gradle-home-cache-excludes: |
+            caches/build-cache-1
+            caches/keyrings
       - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false


### PR DESCRIPTION

## Why

The shared gradle caches managed by `gradle/actions/setup-gradle` are written by every job that doesn't explicitly opt out. With ~10 setup-gradle invocations across 12 workflows, parallel jobs race to save overlapping caches on every push to `main`, producing duplicated entries and accelerating LRU pressure against GitHub's 10 GB per-repo cap.

This causes **cache thrashing**: each commit produces ~3–4 GB of fresh per-job `gradle-home-...-<sha>` entries that immediately evict older entries (including hot dependency caches) under LRU. The next build then misses on entries that should have been warm, re-downloads dependencies, writes new entries, and evicts again — a self-perpetuating churn loop that wastes minutes per build and keeps the cache in a permanently cold state despite being at-capacity.

## What

Restrict cache writes to a single canonical job and make every other job read-only:

- **Sole writer:** `java-ci.yml` → `build-checks (17)` on `refs/heads/main` only. This job runs `./gradlew -DallModules build` and therefore resolves the union dependency closure that all other workflows need.
- **Read-only everywhere else:** `cache-read-only: true` added to setup-gradle in `java-ci.yml` (3 other jobs), `spark-ci.yml`, `flink-ci.yml`, `hive-ci.yml`, `kafka-connect-ci.yml`, `delta-conversion-ci.yml` (×2), `cve-scan.yml`, `api-binary-compatibility.yml`, `publish-snapshot.yml`, `publish-iceberg-rest-fixture-docker.yml`, `recurring-jmh-benchmarks.yml`.
- **Cache-disabled:** `jmh-benchmarks.yml` (workflow_dispatch on arbitrary repo/ref) → `cache-disabled: true` to avoid cache poisoning.

Read-only jobs still benefit from cache **restores** (including setup-gradle's `restore-keys` prefix walk that lets matrix variants pull a sibling job's `gradle-home` entry).

## Validation

Validated on a fork (`kevinjqliu/iceberg`) across 4 rounds:

| Round | Trigger | Outcome |
|---|---|---|
| R1 | Initial main push (cold) | New caches saved by `build-checks (17)` only |
| R2 | PR run (`refs/pull/20/*`) | **Zero** new cache entries created (PRs are read-only) |
| R3 | 2nd main push (warm) | `build-checks (17)` updated `gradle-home` and `gradle-dependencies`; no other writers |
| R4 | 3rd main push | All restores hit; only the single per-commit `gradle-home` entry created |

Job logs confirm `Cache is read-only: will not save state for use in subsequent builds.` for every non-writer job, and `Saved cache entry with key gradle-home-v1\|...build-checks[...]-<sha>` only from `build-checks (17)`.

## Impact

- Eliminates inter-job cache write races and duplicate entries across the matrix
- Single deterministic write point makes cache contents predictable and debuggable
- No build-time regression: read-only jobs still get full restore behavior
- Reduces steady-state cache footprint and slows accumulation against the 10 GB cap

## Files changed

12 workflows under `.github/workflows/`, +58 lines (comments + 1–2 new keys per file). No code changes, no test changes.
