### PR TITLE
Build: Speed up Spark CI with parallel test execution

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -76,7 +76,9 @@ jobs:
   spark-tests:
     runs-on: ubuntu-24.04
     strategy:
-      max-parallel: 15
+      # 20 is the Apache infra policy ceiling (infra.apache.org/github-actions-policy.html).
+      # Keep matrix <= 20 jobs; exceeding it queues a second wave and slows CI.
+      max-parallel: 20
       matrix:
         jvm: [17, 21]
         spark: ['3.4', '3.5', '4.0', '4.1']

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -83,9 +83,9 @@ jobs:
         jvm: [17, 21]
         spark: ['3.4', '3.5', '4.0', '4.1']
         scala: ['2.12', '2.13']
-        # Split iceberg-spark and iceberg-spark-extensions/-runtime into
-        # separate jobs so they run concurrently rather than serially.
-        module: ['spark', 'spark-extensions-and-runtime']
+        # Split iceberg-spark (core) from iceberg-spark-extensions/-runtime
+        # so they run as concurrent jobs rather than serially in one job.
+        tests: [core, extensions]
         exclude:
           # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
           # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
@@ -113,19 +113,15 @@ jobs:
         with:
           tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - name: Run iceberg-spark tests
-        if: matrix.module == 'spark'
+      - name: Run tests
         run: |
+          if [[ "${{ matrix.tests }}" == "core" ]]; then
+            projects=":iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check"
+          else
+            projects=":iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala }}:check"
+          fi
           ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DflinkVersions= -DkafkaVersions= \
-            :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check \
-            -Pquick=true -x javadoc -DtestParallelism=auto
-      - name: Run iceberg-spark-extensions and iceberg-spark-runtime tests
-        if: matrix.module == 'spark-extensions-and-runtime'
-        run: |
-          ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DflinkVersions= -DkafkaVersions= \
-            :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala }}:check \
-            :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala }}:check \
-            -Pquick=true -x javadoc -DtestParallelism=auto
+            $projects -Pquick=true -x javadoc -DtestParallelism=auto
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
-      # 20 is the Apache infra policy ceiling (infra.apache.org/github-actions-policy.html).
+      # 20 is the Apache infra policy ceiling (https://infra.apache.org/github-actions-policy.html).
       # Keep matrix <= 20 jobs; exceeding it queues a second wave and slows CI.
       max-parallel: 20
       matrix:
@@ -110,9 +110,6 @@ jobs:
         with:
           # Read-only: java-ci's build-checks (17) is the global canonical writer.
           cache-read-only: true
-      - uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
-        with:
-          tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - name: Run tests
         run: |

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -75,6 +75,7 @@ concurrency:
 jobs:
   spark-tests:
     runs-on: ubuntu-24.04
+    timeout-minutes: 90
     strategy:
       # 20 is the Apache infra policy ceiling (infra.apache.org/github-actions-policy.html).
       # Keep matrix <= 20 jobs; exceeding it queues a second wave and slows CI.
@@ -125,6 +126,7 @@ jobs:
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: test logs (${{ matrix.jvm }}, ${{ matrix.spark }}, ${{ matrix.scala }}, ${{ matrix.module }})
+          name: test logs (${{ matrix.jvm }}, ${{ matrix.spark }}, ${{ matrix.scala }}, ${{ matrix.tests }})
+          retention-days: 7
           path: |
             **/build/testlogs

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -81,6 +81,9 @@ jobs:
         jvm: [17, 21]
         spark: ['3.4', '3.5', '4.0', '4.1']
         scala: ['2.12', '2.13']
+        # Split iceberg-spark and iceberg-spark-extensions/-runtime into
+        # separate jobs so they run concurrently rather than serially.
+        module: ['spark', 'spark-extensions-and-runtime']
         exclude:
           # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
           # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
@@ -108,15 +111,22 @@ jobs:
         with:
           tool-cache: false
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-      - run: |
+      - name: Run iceberg-spark tests
+        if: matrix.module == 'spark'
+        run: |
           ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DflinkVersions= -DkafkaVersions= \
             :iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check \
+            -Pquick=true -x javadoc -DtestParallelism=auto
+      - name: Run iceberg-spark-extensions and iceberg-spark-runtime tests
+        if: matrix.module == 'spark-extensions-and-runtime'
+        run: |
+          ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DflinkVersions= -DkafkaVersions= \
             :iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala }}:check \
             :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala }}:check \
-            -Pquick=true -x javadoc
+            -Pquick=true -x javadoc -DtestParallelism=auto
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: test logs
+          name: test logs (${{ matrix.jvm }}, ${{ matrix.spark }}, ${{ matrix.scala }}, ${{ matrix.module }})
           path: |
             **/build/testlogs


### PR DESCRIPTION
Cuts Spark CI walltime from ~84 min to ~58 min (−31%) on `apache/iceberg` `main`, validated empirically on this branch.

### Changes

- **Split matrix on `tests: [core, extensions]`.** `iceberg-spark`, `-extensions`, and `-runtime` previously ran serially in one job. Splitting them into two concurrent jobs cuts the critical path from ~86 min (full suite) to ~58 min (longest single leg). Doubles the matrix from 10 → 20 jobs.

- **`-DtestParallelism=auto`.** Runs Gradle test workers in parallel. On ubuntu-24.04 (4 vCPU) `auto` resolves to 2 forks per JVM. Empirically this is the dominant per-job speedup; no test stability issues observed.

- **`max-parallel: 15` → `20`.** With 20 matrix cells, capping at 15 queues 5 jobs into a second wave (simulated ~87 min walltime — worse than baseline). 20 is the [Apache infra policy ceiling](https://infra.apache.org/github-actions-policy.html) and lets the full matrix run in a single wave.

- **`timeout-minutes: 90`.** Catches hangs (we hit one during this work) instead of burning the GitHub default 360 min. ~30 min headroom above the observed max job (60 min).

- **Removed `jlumbroso/free-disk-space`.** ubuntu-24.04 starts with ~88 GB free; Spark CI never approaches that. Confirmed no `ENOSPC` failures across 20+ recent main runs. Saves ~1–2 min per job.

- **Artifact name includes `matrix.tests`; `retention-days: 7`.** Required to avoid collisions on `upload-artifact@v7` with the split matrix. Short retention keeps storage bounded across 20 jobs × every PR push.

### Validation

**Baseline** = last 20 successful `spark-ci.yml` runs on `apache/iceberg` `main` (170 jobs sampled, pre-change config: `max-parallel: 15`, 10-cell matrix, full suite per job).
**This PR** = run [25965870161](https://github.com/apache/iceberg/actions/runs/25965870161) on head `47507cda`.

| Metric | Baseline (main) | This PR | Δ |
|---|---|---|---|
| Walltime | 84 min | **58 min** | **−26 min (−31%)** |
| Critical-path job | 86 min (p99), 83 min (p95) | **58 min** | **−28 min (−33%)** |
| Median job | 78 min | **42 min** | **−36 min (−46%)** |
| Jobs in matrix | 10 | 20 | +10 |
| Job concurrency | 15 | 20 | +5 |

Critical path: `spark-tests (17, 4.0, 2.13, core)` at 58.0 min. All 20 jobs started within 3 s of run start — `max-parallel: 20` runs the full matrix in a single wave with no queueing.