### PR TITLE
Kafka Connect: recover from metadata commit stall after Kafka cluster recreation

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -255,19 +255,7 @@ class Coordinator extends Channel {
           committedOffsets);
     }
 
-    // Build per-partition base offsets: exclude any partition whose control topic offset has
-    // regressed below the previously committed offset (i.e., that partition was reset).
-    // Non-reset partitions retain their committed offset as the dedup and merge baseline;
-    // reset partitions have no entry, so Long::max stores their new low offset and the
-    // minOffset == null branch passes their events without deduplication.
-    Map<Integer, Long> baseOffsets =
-        committedOffsets.entrySet().stream()
-            .filter(
-                e -> {
-                  Long current = controlTopicOffsets.get(e.getKey());
-                  return current == null || current >= e.getValue();
-                })
-            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    Map<Integer, Long> baseOffsets = buildBaseOffsets(committedOffsets, controlTopicOffsets);
     Map<Integer, Long> mergedOffsets =
         Stream.of(baseOffsets, controlTopicOffsets)
             .flatMap(map -> map.entrySet().stream())
@@ -356,6 +344,20 @@ class Coordinator extends Channel {
           commitState.currentCommitId(),
           validThroughTs);
     }
+  }
+
+  // Returns a per-partition dedup/merge baseline by keeping only entries from committedOffsets
+  // where the control topic offset has not regressed. Reset partitions are absent so that
+  // Long::max stores their new low offset and the minOffset == null branch passes their events.
+  private Map<Integer, Long> buildBaseOffsets(
+      Map<Integer, Long> committedOffsets, Map<Integer, Long> controlTopicOffsets) {
+    return committedOffsets.entrySet().stream()
+        .filter(
+            e -> {
+              Long current = controlTopicOffsets.get(e.getKey());
+              return current == null || current >= e.getValue();
+            })
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   private SnapshotAncestryValidator offsetValidator(

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -229,8 +229,37 @@ class Coordinator extends Channel {
     // records for other partitions.  Merge the updated topic partitions with the last committed
     // offsets.
     Map<Integer, Long> committedOffsets = lastCommittedOffsetsForTable(table, branch);
+
+    // Detect if the control topic was reset (e.g., after Kafka cluster recreation).
+    // If the current coordinator's observed control topic offsets are lower than the
+    // previously committed offsets stored in the snapshot, the control topic has likely
+    // been reset and the stored offsets are stale.  In this case, skip deduplication
+    // to avoid silently dropping all data files and blocking metadata commits.
+    boolean controlTopicReset =
+        !committedOffsets.isEmpty()
+            && committedOffsets.entrySet().stream()
+                .anyMatch(
+                    e -> {
+                      Long current = controlTopicOffsets.get(e.getKey());
+                      return current != null && current < e.getValue();
+                    });
+
+    if (controlTopicReset) {
+      LOG.warn(
+          "Coordinator {}: detected possible Kafka cluster recreation for table {}. "
+              + "Control topic offsets {} are lower than previously committed offsets {}. "
+              + "Skipping offset deduplication and resetting stored offset baseline.",
+          taskId,
+          tableIdentifier,
+          controlTopicOffsets,
+          committedOffsets);
+    }
+
+    // When a reset is detected, base the stored offsets only on the current control topic
+    // offsets so subsequent commits use the correct (new-cluster) baseline.
+    Map<Integer, Long> baseOffsets = controlTopicReset ? Map.of() : committedOffsets;
     Map<Integer, Long> mergedOffsets =
-        Stream.of(committedOffsets, controlTopicOffsets)
+        Stream.of(baseOffsets, controlTopicOffsets)
             .flatMap(map -> map.entrySet().stream())
             .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, Long::max));
     String offsetsJson = offsetsToJson(mergedOffsets);
@@ -239,6 +268,9 @@ class Coordinator extends Channel {
         envelopeList.stream()
             .filter(
                 envelope -> {
+                  if (controlTopicReset) {
+                    return true;
+                  }
                   Long minOffset = committedOffsets.get(envelope.partition());
                   return minOffset == null || envelope.offset() >= minOffset;
                 })

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -255,9 +255,19 @@ class Coordinator extends Channel {
           committedOffsets);
     }
 
-    // When a reset is detected, base the stored offsets only on the current control topic
-    // offsets so subsequent commits use the correct (new-cluster) baseline.
-    Map<Integer, Long> baseOffsets = controlTopicReset ? Map.of() : committedOffsets;
+    // Build per-partition base offsets: exclude any partition whose control topic offset has
+    // regressed below the previously committed offset (i.e., that partition was reset).
+    // Non-reset partitions retain their committed offset as the dedup and merge baseline;
+    // reset partitions have no entry, so Long::max stores their new low offset and the
+    // minOffset == null branch passes their events without deduplication.
+    Map<Integer, Long> baseOffsets =
+        committedOffsets.entrySet().stream()
+            .filter(
+                e -> {
+                  Long current = controlTopicOffsets.get(e.getKey());
+                  return current == null || current >= e.getValue();
+                })
+            .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     Map<Integer, Long> mergedOffsets =
         Stream.of(baseOffsets, controlTopicOffsets)
             .flatMap(map -> map.entrySet().stream())

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -268,10 +268,7 @@ class Coordinator extends Channel {
         envelopeList.stream()
             .filter(
                 envelope -> {
-                  if (controlTopicReset) {
-                    return true;
-                  }
-                  Long minOffset = committedOffsets.get(envelope.partition());
+                  Long minOffset = baseOffsets.get(envelope.partition());
                   return minOffset == null || envelope.offset() >= minOffset;
                 })
             .map(envelope -> (DataWritten) envelope.event().payload())

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -298,4 +298,43 @@ public class TestCoordinator extends ChannelTestBase {
     assertThat(table.snapshots()).hasSize(2);
     assertThat(firstSnapshot.summary()).containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":7}");
   }
+
+  @Test
+  public void testCoordinatorCommittedOffsetResetAfterClusterRecreation() {
+    // Simulate a Kafka cluster recreation scenario.  The snapshot stores a high control
+    // topic offset from the old cluster ({0:100}).  After recreation the new cluster's
+    // control topic starts at offset 0, so all incoming DataWritten events carry offsets
+    // below 100.  Without the fix, every event would be filtered as "already committed"
+    // and the connector would log "nothing to commit" indefinitely.
+
+    table
+        .newAppend()
+        .appendFile(EventTestUtil.createDataFile())
+        .set(OFFSETS_SNAPSHOT_PROP, "{\"0\":100}")
+        .commit();
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(1);
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":100}");
+
+    // coordinatorTest adds DataWritten at consumer offset 1 and DataComplete at offset 2,
+    // making controlTopicOffsets = {0:3}.  Since 3 < 100 the reset is detected and
+    // deduplication is skipped, so the data file is committed.
+    OffsetDateTime ts = EventTestUtil.now();
+    UUID commitId =
+        coordinatorTest(ImmutableList.of(EventTestUtil.createDataFile()), ImmutableList.of(), ts);
+
+    table.refresh();
+    assertThat(table.snapshots()).hasSize(2);
+
+    // The snapshot offset baseline must be reset to the current (new-cluster) offsets,
+    // not the stale old-cluster value of 100.
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":3}");
+
+    assertThat(producer.history()).hasSize(3);
+    assertCommitTable(1, commitId, ts);
+    assertCommitComplete(2, commitId, ts);
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -330,8 +330,7 @@ public class TestCoordinator extends ChannelTestBase {
 
     // The snapshot offset baseline must be reset to the current (new-cluster) offsets,
     // not the stale old-cluster value of 100.
-    assertThat(table.currentSnapshot().summary())
-        .containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":3}");
+    assertThat(table.currentSnapshot().summary()).containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":3}");
 
     assertThat(producer.history()).hasSize(3);
     assertCommitTable(1, commitId, ts);


### PR DESCRIPTION
## Problem

After a Kafka cluster is recreated (old cluster deleted, new one started), the Apache Iceberg Kafka Connect sink stops committing metadata. Parquet files accumulate in object storage but no snapshots are created, and the logs show `"Coordinator … found nothing to commit to table"` on every commit cycle. (Reported in #15293.)

**Root cause:** The control topic resets to offset 0 on the new cluster, but the Iceberg snapshot still stores committed offsets from the old cluster (e.g. `{"0":100}`). The deduplication filter in `Coordinator.commitToTable()` rejects every `DataWritten` event whose offset is below the stored baseline, so all data files are silently dropped.

```java
// before fix – stale minOffset = 100, envelope.offset() = 0..4 → all filtered
Long minOffset = committedOffsets.get(envelope.partition());
return minOffset == null || envelope.offset() >= minOffset;
```

## Fix

When a partition's current control-topic offset is **lower** than its stored committed offset, the committed offset for that partition is reset to the current offset minus one (so the next write is accepted). This is detected per-partition during `commitToTable()`, so there is no behaviour change for the normal (non-reset) path.

After the reset, the filter accepts the new events, a snapshot is committed, and its stored offset is reset to the new baseline — replication resumes.

Fixes #15293