### PR TITLE
Core, Flink: Add UUID to DataTestBase SUPPORTED_PRIMITIVES

### DIFF
--- a/core/src/test/java/org/apache/iceberg/data/DataTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/data/DataTestBase.java
@@ -96,6 +96,7 @@ public abstract class DataTestBase {
           required(108, "ts_tz", Types.TimestampType.withZone()),
           required(109, "ts", Types.TimestampType.withoutZone()),
           required(110, "s", Types.StringType.get()),
+          required(111, "uuid", Types.UUIDType.get()),
           required(112, "fixed", Types.FixedType.ofLength(7)),
           optional(113, "bytes", Types.BinaryType.get()),
           required(114, "dec_9_0", Types.DecimalType.of(9, 0)),

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -138,34 +138,41 @@ public class TestFlinkParquetReader extends DataTestBase {
                 .id(110)
                 .as(LogicalTypeAnnotation.stringType())
                 .named("s"),
-            // 11: required(112, "fixed", Types.FixedType.ofLength(7))
+            // 11: required(111, "uuid", Types.UUIDType.get())
+            primitive(
+                    PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
+                .id(111)
+                .length(16)
+                .as(LogicalTypeAnnotation.uuidType())
+                .named("uuid"),
+            // 12: required(112, "fixed", Types.FixedType.ofLength(7))
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(112)
                 .length(7)
                 .named("f"),
-            // 12: optional(113, "bytes", Types.BinaryType.get())
+            // 13: optional(113, "bytes", Types.BinaryType.get())
             primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.OPTIONAL)
                 .id(113)
                 .named("bytes"),
-            // 13: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
+            // 14: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(114)
                 .as(LogicalTypeAnnotation.decimalType(0, 9))
                 .named("dec_9_0"),
-            // 14: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
+            // 15: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(115)
                 .as(LogicalTypeAnnotation.decimalType(2, 11))
                 .named("dec_11_2"),
-            // 15: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
+            // 16: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(116)
                 .length(16)
                 .as(LogicalTypeAnnotation.decimalType(10, 38))
                 .named("dec_38_10"),
-            // 16: required(117, "time", Types.TimeType.get())
+            // 17: required(117, "time", Types.TimeType.get())
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.OPTIONAL)
                 .id(117)
                 .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS))

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -138,34 +138,41 @@ public class TestFlinkParquetReader extends DataTestBase {
                 .id(110)
                 .as(LogicalTypeAnnotation.stringType())
                 .named("s"),
-            // 11: required(112, "fixed", Types.FixedType.ofLength(7))
+            // 11: required(111, "uuid", Types.UUIDType.get())
+            primitive(
+                    PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
+                .id(111)
+                .length(16)
+                .as(LogicalTypeAnnotation.uuidType())
+                .named("uuid"),
+            // 12: required(112, "fixed", Types.FixedType.ofLength(7))
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(112)
                 .length(7)
                 .named("f"),
-            // 12: optional(113, "bytes", Types.BinaryType.get())
+            // 13: optional(113, "bytes", Types.BinaryType.get())
             primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.OPTIONAL)
                 .id(113)
                 .named("bytes"),
-            // 13: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
+            // 14: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(114)
                 .as(LogicalTypeAnnotation.decimalType(0, 9))
                 .named("dec_9_0"),
-            // 14: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
+            // 15: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(115)
                 .as(LogicalTypeAnnotation.decimalType(2, 11))
                 .named("dec_11_2"),
-            // 15: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
+            // 16: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(116)
                 .length(16)
                 .as(LogicalTypeAnnotation.decimalType(10, 38))
                 .named("dec_38_10"),
-            // 16: required(117, "time", Types.TimeType.get())
+            // 17: required(117, "time", Types.TimeType.get())
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.OPTIONAL)
                 .id(117)
                 .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS))

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java
@@ -138,34 +138,41 @@ public class TestFlinkParquetReader extends DataTestBase {
                 .id(110)
                 .as(LogicalTypeAnnotation.stringType())
                 .named("s"),
-            // 11: required(112, "fixed", Types.FixedType.ofLength(7))
+            // 11: required(111, "uuid", Types.UUIDType.get())
+            primitive(
+                    PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
+                .id(111)
+                .length(16)
+                .as(LogicalTypeAnnotation.uuidType())
+                .named("uuid"),
+            // 12: required(112, "fixed", Types.FixedType.ofLength(7))
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(112)
                 .length(7)
                 .named("f"),
-            // 12: optional(113, "bytes", Types.BinaryType.get())
+            // 13: optional(113, "bytes", Types.BinaryType.get())
             primitive(PrimitiveType.PrimitiveTypeName.BINARY, Type.Repetition.OPTIONAL)
                 .id(113)
                 .named("bytes"),
-            // 13: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
+            // 14: required(114, "dec_9_0", Types.DecimalType.of(9, 0))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(114)
                 .as(LogicalTypeAnnotation.decimalType(0, 9))
                 .named("dec_9_0"),
-            // 14: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
+            // 15: required(115, "dec_11_2", Types.DecimalType.of(11, 2))
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.REQUIRED)
                 .id(115)
                 .as(LogicalTypeAnnotation.decimalType(2, 11))
                 .named("dec_11_2"),
-            // 15: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
+            // 16: required(116, "dec_38_10", Types.DecimalType.of(38, 10)) // maximum precision
             primitive(
                     PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY, Type.Repetition.REQUIRED)
                 .id(116)
                 .length(16)
                 .as(LogicalTypeAnnotation.decimalType(10, 38))
                 .named("dec_38_10"),
-            // 16: required(117, "time", Types.TimeType.get())
+            // 17: required(117, "time", Types.TimeType.get())
             primitive(PrimitiveType.PrimitiveTypeName.INT64, Type.Repetition.OPTIONAL)
                 .id(117)
                 .as(LogicalTypeAnnotation.timeType(true, LogicalTypeAnnotation.TimeUnit.MICROS))


### PR DESCRIPTION
Follow-up to #16097.

Adds a UUID field to `SUPPORTED_PRIMITIVES` in [DataTestBase](https://github.com/apache/iceberg/blob/6976e020b894f6a6777704df2b8c4458cb291ae9/core/src/test/java/org/apache/iceberg/data/DataTestBase.java#L86). `UUID` was only tested in Flink's [TestFlinkUuidType](https://github.com/apache/iceberg/blob/main/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkUuidType.java) before. Now every test that extends `DataTestBase` reads and writes `UUID` too.

[TestFlinkParquetReader](https://github.com/apache/iceberg/blob/6976e020b894f6a6777704df2b8c4458cb291ae9/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkParquetReader.java#L61) extends `DataTestBase` and has a test with a Parquet schema written out by hand to match `SUPPORTED_PRIMITIVES`. Updated that schema to add the `UUID` column, for Flink `2.1`, `2.0` and `1.20`.