### PR TITLE
Spark 4.1: Upgrade to Spark 4.1.2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -88,7 +88,7 @@ slf4j = "2.0.17"
 snowflake-jdbc = "3.28.0"
 spark35 = "3.5.8"
 spark40 = "4.0.2"
-spark41 = "4.1.1"
+spark41 = "4.1.2"
 sqlite-jdbc = "3.53.1.0"
 testcontainers = "2.0.5"
 tez08 = { strictly = "0.8.4"}  # see rich version usage explanation above


### PR DESCRIPTION
## Summary

This draft PR verifies Apache Spark 4.1.2 with the Spark 4.1 Iceberg modules.

Changes:
- Bump the Spark 4.1 version catalog entry from 4.1.1 to 4.1.2.
- Add the Apache Spark staging Maven repository at https://repository.apache.org/content/repositories/orgapachespark-1519/ so Gradle can resolve the staged 4.1.2 artifacts.

---

Co-authored-by: @codex 
