### PR TITLE
Website: remove duplicated entries from search

### DIFF
--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -80,7 +80,6 @@ plugins:
       exclude:
         - 'docs/latest/*'
         - 'docs/1*/*'
-      exclude_unreferenced: true
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -77,9 +77,10 @@ plugins:
         'docs/nightly/daft.md': 'integrations/daft.md'
         'docs/nightly/risingwave.md': 'integrations/risingwave.md'
   - exclude-search:
+      # Index only docs/nightly/* to avoid duplicate hits across versions.
       exclude:
-        - 'docs/latest/*'
-        - 'docs/1*/*'
+        - 'docs/latest*'  # excludes latest and its children
+        - 'docs/[0-9]*'    # excludes docs/<x.y.z> and their children
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -76,6 +76,11 @@ plugins:
         'docs/nightly/amoro.md': 'integrations/amoro.md'
         'docs/nightly/daft.md': 'integrations/daft.md'
         'docs/nightly/risingwave.md': 'integrations/risingwave.md'
+  - exclude-search:
+      exclude:
+        - 'docs/latest/*'
+        - 'docs/1*/*'
+      exclude_unreferenced: true
 
 markdown_extensions:
   - pymdownx.highlight:

--- a/site/requirements.txt
+++ b/site/requirements.txt
@@ -22,4 +22,5 @@ mkdocs-material-extensions==1.3.1
 mkdocs-monorepo-plugin @ git+https://github.com/bitsondatadev/mkdocs-monorepo-plugin@url-fix
 mkdocs-redirects==1.2.3
 mkdocs-rss-plugin==1.19.0
+mkdocs-exclude-search==0.6.6
 pymarkdownlnt==0.9.36


### PR DESCRIPTION
The issue was first described in a related email thread from 5/13/2026 `Docs: Are duplicated results in search on iceberg.apache.org a bug or a feature?` on [Iceberg's dev mailing list](https://lists.apache.org/thread/vrt3oytl3dwo34wr07tkf73r0kkx0b1h). 

### Issue
If you open https://iceberg.apache.org// and use a search bar to look for anything, ex: "rewrite", you get duplicated results because results(ex: rewrite_table_path) are found multiple times, once for each version of Iceberg documentation(1.4 to 1.10), all these versions are present on the website under the previous section in the navigation tab and all of them are indexed.

### Solution
Utilize `mkdocs-exclude-search` plug-in to leave only nightly documentation present in the index.

### Notes
There is a related long term solution that adds documentation version selection to the web-site, related issue:  
https://github.com/apache/iceberg/issues/14521