### PR TITLE
Aliyun, Dell: Classify missing object reads as NotFoundException

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSInputStream.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSErrorCode;
+import com.aliyun.oss.OSSException;
 import com.aliyun.oss.model.GetObjectRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
@@ -147,7 +150,15 @@ class OSSInputStream extends SeekableInputStream {
     closeStream();
 
     GetObjectRequest request = new GetObjectRequest(uri.bucket(), uri.key()).withRange(pos, -1);
-    stream = client.getObject(request).getObjectContent();
+    try {
+      stream = client.getObject(request).getObjectContent();
+    } catch (OSSException e) {
+      if (OSSErrorCode.NO_SUCH_KEY.equals(e.getErrorCode())
+          || OSSErrorCode.NO_SUCH_BUCKET.equals(e.getErrorCode())) {
+        throw new NotFoundException(e, "Location does not exist: %s", uri.location());
+      }
+      throw e;
+    }
   }
 
   private void closeStream() throws IOException {

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSInputStream.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
@@ -127,5 +128,15 @@ public class TestOSSInputStream extends AliyunOSSTestBase {
 
   private void writeOSSData(OSSURI uri, byte[] data) {
     ossClient().get().putObject(uri.bucket(), uri.key(), new ByteArrayInputStream(data));
+  }
+
+  @Test
+  public void testReadMissingObjectThrowsNotFoundException() {
+    OSSURI uri = new OSSURI(location("nonexistent.dat"));
+
+    SeekableInputStream in = new OSSInputStream(ossClient().get(), uri);
+    assertThatThrownBy(in::read)
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Location does not exist");
   }
 }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.dell.ecs;
 
 import com.emc.object.Range;
 import com.emc.object.s3.S3Client;
+import com.emc.object.s3.S3Exception;
 import java.io.IOException;
 import java.io.InputStream;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.Counter;
@@ -110,7 +112,14 @@ class EcsSeekableInputStream extends SeekableInputStream {
     }
 
     pos = newPos;
-    internalStream = client.readObjectStream(uri.bucket(), uri.name(), Range.fromOffset(pos));
+    try {
+      internalStream = client.readObjectStream(uri.bucket(), uri.name(), Range.fromOffset(pos));
+    } catch (S3Exception e) {
+      if (e.getHttpCode() == 404) {
+        throw new NotFoundException(e, "Location does not exist: %s", uri.location());
+      }
+      throw e;
+    }
     newPos = -1;
   }
 

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -19,11 +19,13 @@
 package org.apache.iceberg.dell.ecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -89,5 +91,17 @@ public class TestEcsSeekableInputStream {
           .as("The first 3 bytes should be 012")
           .isEqualTo("012");
     }
+  }
+
+  @Test
+  public void testReadMissingObjectThrowsNotFoundException() {
+    String objectName = rule.randomObjectName();
+
+    EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics());
+    assertThatThrownBy(input::read)
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Location does not exist");
   }
 }


### PR DESCRIPTION
Fixes #16299.

## Problem

`BaseMetastoreTableOperations.refreshFromMetadataLocation` retries metadata reads and stops retrying when loading fails with `NotFoundException`. Some object-storage read paths (Aliyun OSS and Dell ECS) do not classify permanent missing-object failures as `NotFoundException`, so a stale catalog pointer causes infinite retry loops instead of failing fast.

## Fix

- **OSSInputStream**: Catch `OSSException` with error codes `NoSuchKey`/`NoSuchBucket` and wrap as `NotFoundException`.
- **EcsSeekableInputStream**: Catch `S3Exception` with HTTP 404 and wrap as `NotFoundException`.

This matches the behavior of the S3 and GCS FileIO implementations which already throw `NotFoundException` for missing objects.

## Testing

Added tests for both implementations verifying that reading a missing object throws `NotFoundException`. Tests fail without the fix (raw provider exceptions propagate).
