### PR TITLE
Core: Enforce that v4 manifests do not contain POSITION_DELETES

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -292,6 +293,9 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
         break;
       case 1:
         this.contentType = FileContent.fromId((Integer) value);
+        Preconditions.checkArgument(
+            contentType != FileContent.POSITION_DELETES,
+            "POSITION_DELETES is not supported in tracked file manifests (v4)");
         break;
       case 2:
         // always coerce to String for Serializable

--- a/core/src/main/java/org/apache/iceberg/V4Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V4Metadata.java
@@ -296,10 +296,7 @@ class V4Metadata {
         DataFile.SPLIT_OFFSETS,
         DataFile.EQUALITY_IDS,
         DataFile.SORT_ORDER_ID,
-        DataFile.FIRST_ROW_ID,
-        DataFile.REFERENCED_DATA_FILE,
-        DataFile.CONTENT_OFFSET,
-        DataFile.CONTENT_SIZE);
+        DataFile.FIRST_ROW_ID);
   }
 
   static class ManifestEntryWrapper<F extends ContentFile<F>>
@@ -488,24 +485,6 @@ class V4Metadata {
         case 16:
           if (wrapped.content() == FileContent.DATA) {
             return wrapped.firstRowId();
-          } else {
-            return null;
-          }
-        case 17:
-          if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).referencedDataFile();
-          } else {
-            return null;
-          }
-        case 18:
-          if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentOffset();
-          } else {
-            return null;
-          }
-        case 19:
-          if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
             return null;
           }

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -275,10 +275,22 @@ class TestTrackedFileStruct {
   @Test
   void testAllFileContentTypesSupported() {
     for (FileContent content : FileContent.values()) {
+      if (content == FileContent.POSITION_DELETES) {
+        continue;
+      }
       TrackedFileStruct file = new TrackedFileStruct();
       file.set(1, content.id());
       assertThat(file.contentType()).isEqualTo(content);
     }
+  }
+
+  @Test
+  void testPositionDeletesRejected() {
+    TrackedFileStruct file = new TrackedFileStruct();
+    org.assertj.core.api.Assertions.assertThatThrownBy(
+            () -> file.set(1, FileContent.POSITION_DELETES.id()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("POSITION_DELETES is not supported");
   }
 
   @Test


### PR DESCRIPTION
Fixes #16340.

Follow-up from PR #16100 discussion.

## Problem

The Variant v4 format uses deletion vectors instead of positional delete files. `TrackedFileStruct` currently accepts `POSITION_DELETES` content type without validation, and `V4Metadata` includes fields (`REFERENCED_DATA_FILE`, `CONTENT_OFFSET`, `CONTENT_SIZE`) that are only relevant to positional deletes.

## Fix

1. **TrackedFileStruct**: Add validation in `internalSet` to reject `FileContent.POSITION_DELETES` with a clear error message.
2. **V4Metadata**: Remove positional-delete-specific fields from the file type schema and remove POSITION_DELETES handling from `DataFileWrapper.get()`.

## Testing

- Added `testPositionDeletesRejected` verifying IllegalArgumentException when attempting to set POSITION_DELETES content type.
- Updated `testAllFileContentTypesSupported` to skip POSITION_DELETES for v4.
- All existing manifest tests pass.
