### PR TITLE
Core, Spark: Clean up uncommitted files when a staged table is aborted

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -410,6 +410,9 @@ acceptedBreaks:
       old: "class org.apache.iceberg.encryption.EncryptingFileIO"
       new: "class org.apache.iceberg.encryption.EncryptingFileIO"
       justification: "New method for Manifest List reading"
+    - code: "java.method.addedToInterface"
+      new: "method void org.apache.iceberg.Transaction::abortTransaction()"
+      justification: "new API method with a default implementation"
     org.apache.iceberg:iceberg-core:
     - code: "java.class.defaultSerializationChanged"
       old: "class org.apache.iceberg.avro.SupportsIndexProjection"

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -183,4 +183,18 @@ public interface Transaction {
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
   void commitTransaction();
+
+  /**
+   * Roll back all pending changes and clean up any uncommitted files written by this transaction.
+   *
+   * <p>This is a best-effort operation intended to be called when a transaction will not be
+   * committed (for example, in a {@code finally} or {@code catch} block of a failed atomic
+   * create/replace operation). It deletes uncommitted manifest lists, manifests, and other files
+   * staged by operations in this transaction. It does not throw if some files cannot be deleted.
+   *
+   * <p>After this method is called, the transaction must not be committed or reused.
+   *
+   * <p>The default implementation does nothing.
+   */
+  default void abortTransaction() {}
 }

--- a/api/src/main/java/org/apache/iceberg/Transaction.java
+++ b/api/src/main/java/org/apache/iceberg/Transaction.java
@@ -183,4 +183,22 @@ public interface Transaction {
    * @throws CommitFailedException If the updates cannot be committed due to conflicts.
    */
   void commitTransaction();
+
+  /**
+   * Roll back all pending changes and clean up any uncommitted files written by this transaction.
+   *
+   * <p>This is a best-effort operation intended to be called when a transaction will not be
+   * committed (for example, in a {@code finally} or {@code catch} block of a failed atomic
+   * create/replace operation). It deletes uncommitted manifest lists, manifests, and other files
+   * staged by operations in this transaction. It does not throw if some files cannot be deleted.
+   *
+   * <p>If {@link #commitTransaction()} was already attempted, this method does nothing. That commit
+   * may have succeeded even though it threw, so deleting files here could remove metadata that a
+   * committed snapshot references.
+   *
+   * <p>After this method is called, the transaction must not be committed or reused.
+   *
+   * <p>The default implementation does nothing.
+   */
+  default void abortTransaction() {}
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -417,6 +417,11 @@ public class BaseTransaction implements Transaction {
     }
   }
 
+  @Override
+  public void abortTransaction() {
+    cleanUp();
+  }
+
   protected void cleanUp() {
     // the commit failed and no files were committed. clean up each update.
     cleanAllUpdates();

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -74,6 +74,7 @@ public class BaseTransaction implements Transaction {
   private TableMetadata base;
   private TableMetadata current;
   private boolean hasLastOpCommitted;
+  private boolean commitAttempted;
   private final MetricsReporter reporter;
 
   BaseTransaction(
@@ -96,6 +97,7 @@ public class BaseTransaction implements Transaction {
     this.base = ops.current();
     this.type = type;
     this.hasLastOpCommitted = true;
+    this.commitAttempted = false;
     this.reporter = reporter;
   }
 
@@ -250,6 +252,8 @@ public class BaseTransaction implements Transaction {
   public void commitTransaction() {
     Preconditions.checkState(
         hasLastOpCommitted, "Cannot commit transaction: last operation has not committed");
+
+    this.commitAttempted = true;
 
     switch (type) {
       case CREATE_TABLE:
@@ -410,6 +414,21 @@ public class BaseTransaction implements Transaction {
     } catch (RuntimeException e) {
       LOG.warn("Failed to load committed metadata, skipping clean-up", e);
     }
+  }
+
+  @Override
+  public void abortTransaction() {
+    if (commitAttempted) {
+      // the commit may have succeeded even though it threw, for example when it fails with
+      // CommitStateUnknownException or when the catalog requires strict cleanup. The commit path
+      // already deleted whatever was safe to delete, so cleaning up here could remove metadata
+      // that a committed snapshot references.
+      LOG.warn(
+          "Not cleaning up {}: a commit was already attempted for this transaction", tableName);
+      return;
+    }
+
+    cleanUp();
   }
 
   protected void cleanUp() {

--- a/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/CommitCallbackTransaction.java
@@ -126,4 +126,9 @@ class CommitCallbackTransaction implements Transaction {
     wrapped.commitTransaction();
     callback.run();
   }
+
+  @Override
+  public void abortTransaction() {
+    wrapped.abortTransaction();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestCreateTransaction.java
@@ -253,4 +253,28 @@ public class TestCreateTransaction extends TestBase {
 
     assertThat(listManifestFiles(tableDir)).isEmpty();
   }
+
+  @TestTemplate
+  public void testAbortTransactionCleansUpUncommittedFiles() {
+    Transaction txn = TestTables.beginCreate(tableDir, "test_abort", SCHEMA, SPEC);
+
+    // append in the transaction to ensure a manifest and a manifest list are written
+    txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    // the staged write produced files on disk, but the table itself is not created yet
+    assertThat(TestTables.readMetadata("test_abort")).isNull();
+    assertThat(listManifestFiles(tableDir)).hasSize(1);
+    assertThat(listManifestLists(tableDir)).hasSize(1);
+
+    // aborting the transaction removes the uncommitted manifests and manifest lists
+    txn.abortTransaction();
+
+    assertThat(listManifestFiles(tableDir)).isEmpty();
+    assertThat(listManifestLists(tableDir)).isEmpty();
+    assertThat(TestTables.readMetadata("test_abort")).isNull();
+
+    // abort is best-effort and idempotent: a second call must not throw
+    txn.abortTransaction();
+    assertThat(listManifestFiles(tableDir)).isEmpty();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -427,6 +427,46 @@ public class TestReplaceTransaction extends TestBase {
     validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
   }
 
+  @TestTemplate
+  public void testAbortTransactionAfterUnknownStateKeepsCommittedFiles() throws IOException {
+    // engines abort a staged table from the catch block that wraps the commit, so an abort can
+    // follow a commit whose outcome is unknown. The committed snapshot still references the files,
+    // so they must survive the abort.
+    TestTables.TestTableOperations ops =
+        TestTables.opsWithCommitSucceedButStateUnknown(tableDir, "test_abort_unknown");
+    Transaction txn =
+        TestTables.beginReplace(
+            tableDir,
+            "test_abort_unknown",
+            SCHEMA,
+            unpartitioned(),
+            SortOrder.unsorted(),
+            ImmutableMap.of(),
+            ops);
+
+    txn.newAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    assertThatThrownBy(txn::commitTransaction)
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("datacenter on fire");
+
+    TableMetadata meta = TestTables.readMetadata("test_abort_unknown");
+    assertThat(meta).isNotNull();
+    assertThat(meta.snapshots()).hasSize(1);
+    assertThat(listManifestFiles(tableDir)).hasSize(1);
+
+    txn.abortTransaction();
+
+    assertThat(listManifestFiles(tableDir))
+        .as("abort must not delete manifests referenced by a committed snapshot")
+        .hasSize(1);
+    assertThat(countAllMetadataFiles(tableDir))
+        .as("abort must not delete the committed manifest list")
+        .isEqualTo(2);
+    assertThat(TestTables.readMetadata("test_abort_unknown")).isNotNull();
+    validateSnapshot(null, meta.currentSnapshot(), FILE_A, FILE_B);
+  }
+
   private static Schema assignFreshIds(Schema schema) {
     AtomicInteger lastColumnId = new AtomicInteger(0);
     return TypeUtil.assignFreshIds(schema, lastColumnId::incrementAndGet);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StagedSparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StagedSparkTable.java
@@ -36,6 +36,6 @@ public class StagedSparkTable extends SparkTable implements StagedTable {
 
   @Override
   public void abortStagedChanges() {
-    // TODO: clean up
+    transaction.abortTransaction();
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStagedSparkTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStagedSparkTable.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.io.File;
+import java.net.URI;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.StagedTable;
+import org.apache.spark.sql.connector.expressions.Transform;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestStagedSparkTable extends CatalogTestBase {
+
+  @TestTemplate
+  public void testAbortStagedChangesCleansUpUncommittedFiles() throws Exception {
+    CatalogPlugin plugin = spark.sessionState().catalogManager().catalog(catalogName);
+    // StagedSparkTable is only produced by SparkCatalog; the session catalog uses
+    // RollbackStagedTable
+    assumeThat(plugin).isInstanceOf(SparkCatalog.class);
+    SparkCatalog catalog = (SparkCatalog) plugin;
+
+    Identifier ident = Identifier.of(new String[] {"default"}, "abort_staged");
+    StructType schema =
+        new StructType()
+            .add("id", DataTypes.LongType, false)
+            .add("data", DataTypes.StringType, true);
+
+    StagedTable staged = catalog.stageCreate(ident, schema, new Transform[0], ImmutableMap.of());
+
+    // route an append into the staged (uncommitted) transaction so a manifest and a manifest list
+    // are written to the table location without the table being committed to the catalog
+    Table table = ((SparkTable) staged).table();
+    DataFile dataFile =
+        DataFiles.builder(table.spec())
+            .withPath("/path/to/data-abort.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+    table.newAppend().appendFile(dataFile).commit();
+
+    File metadataDir = new File(URI.create(table.location()).getPath(), "metadata");
+    File[] stagedFiles = metadataDir.listFiles((dir, name) -> name.endsWith(".avro"));
+    assertThat(stagedFiles)
+        .as("staged write should produce manifest and manifest-list files")
+        .isNotNull()
+        .isNotEmpty();
+
+    staged.abortStagedChanges();
+
+    File[] remaining = metadataDir.listFiles((dir, name) -> name.endsWith(".avro"));
+    assertThat(remaining == null || remaining.length == 0)
+        .as("abort should delete all uncommitted manifest and manifest-list files")
+        .isTrue();
+    assertThat(catalog.tableExists(ident))
+        .as("staged table must not be created in the catalog after abort")
+        .isFalse();
+
+    // abort is best-effort and idempotent: a second call must not throw
+    staged.abortStagedChanges();
+  }
+}


### PR DESCRIPTION
## Summary

`StagedSparkTable.abortStagedChanges()` was an empty `// TODO: clean up`. Spark calls it to roll back an atomic CTAS/RTAS, and it is also used by the snapshot/migrate actions. Iceberg's internal transaction cleanup only runs when `commitTransaction()` is actually invoked and then fails. When a failure happens after the staged write but before `commitStagedChanges()` is called (for example, `SnapshotTableSparkAction`/`MigrateTableSparkAction` failing while importing data, or an interrupted CTAS), nothing cleaned the manifest list and manifests already written into the uncommitted transaction. For a staged CREATE the table is never registered, so those orphans have no table metadata pointing at them and are unreachable by `removeOrphanFiles` - they leak permanently.

## Changes

- Add a best-effort `default void abortTransaction()` to the `Transaction` API. The default is a documented no-op, so existing implementations are unaffected.
- Override it in `BaseTransaction` to run the existing `cleanUp()` (`cleanAllUpdates()` + `deleteUncommittedFiles()`) - the same cleanup Iceberg already performs when a create/replace transaction's own commit fails. The override is skipped once `commitTransaction()` has been attempted (see below).
- Delegate it in `CommitCallbackTransaction`; the post-commit callback is intentionally not run on abort.
- Wire `StagedSparkTable.abortStagedChanges()` to `transaction.abortTransaction()` in `spark/v4.1`. The Spark-side change is identical for 3.5 and 4.0; a backport PR will follow.
- Add the corresponding `java.method.addedToInterface` entry to `.palantir/revapi.yml`.

A no-op default (rather than throwing) is used because `abortTransaction()` runs from `catch`/`finally` blocks where a secondary exception would mask the original failure. The underlying deletion is best-effort and idempotent (`CatalogUtil.deleteFile` swallows `NotFoundException`, `cleanAllUpdates()` suppresses failures).

`abortTransaction()` does nothing once `commitTransaction()` has been attempted. Spark calls `abortStagedChanges()` from the catch block wrapping `commitStagedChanges()`, so an abort can follow a commit that threw `CommitStateUnknownException` after succeeding; cleaning up there would delete metadata the committed snapshot references. The commit path already performs whatever cleanup is safe, guarded by `CommitStateUnknownException` and `TableOperations.requireStrictCleanup()`.

## Out of scope

Executor-written data files in the write-succeeds-then-commit-fails path are not deleted here. That matches Iceberg's existing create-transaction behavior, and those files are handled by `SparkWrite.abort()` on write-job failure.

## Testing

- New abort case in core `TestCreateTransaction` (runs across all format-version templates): stages a create transaction, performs an append, asserts the manifest and manifest list exist, calls `abortTransaction()`, asserts they are removed and the table is not created, and verifies a second `abortTransaction()` does not throw.
- New `TestStagedSparkTable` in `spark/v4.1`: stages a CREATE via `SparkCatalog.stageCreate`, routes an append into the staged transaction, calls `abortStagedChanges()`, and asserts the uncommitted manifest/manifest-list files are deleted and the table is not created. The session-catalog parameterization is skipped (it produces `RollbackStagedTable`, not `StagedSparkTable`). 3 configs (hive/hadoop/rest) pass, 1 skipped, 0 failures.
- New `TestReplaceTransaction.testAbortTransactionAfterUnknownStateKeepsCommittedFiles`: runs a create transaction whose commit succeeds but reports `CommitStateUnknownException`, then calls `abortTransaction()` and asserts the committed manifest and manifest list survive.
- `./gradlew revApiCheck`, `spotlessApply -DallModules`, and the tests above all pass.

---
**AI Disclosure**
- Model: Claude Opus 5 (1M context)
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Implement StagedSparkTable.abortStagedChanges, which was an empty "// TODO: clean up", so aborted staged tables clean up their uncommitted files.


