### PR TITLE
Core: Add streaming CloseableIterable accessors to SnapshotChanges

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -24,21 +24,27 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
-import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.ParallelIterable;
 
 /**
- * Helper class for retrieving file changes in a snapshot with caching.
+ * Helper class for retrieving file changes in a snapshot.
  *
- * <p>This class caches the results of file change detection operations, making it efficient to
- * query multiple file change types for the same snapshot. By default, manifests are read
- * single-threaded. Use {@link Builder#executeWith(ExecutorService)} to enable parallel manifest
- * reading.
+ * <p>Two access modes are provided. The cached accessors ({@link #addedDataFiles()}, {@link
+ * #removedDataFiles()}, {@link #addedDeleteFiles()}, {@link #removedDeleteFiles()}) eagerly
+ * materialize file changes into in-memory lists and cache them, making it efficient to query the
+ * same change type multiple times. The streaming accessors ({@link #addedDataFilesIterable()},
+ * {@link #removedDataFilesIterable()}, {@link #addedDeleteFilesIterable()}, {@link
+ * #removedDeleteFilesIterable()}) return lazily-evaluated {@link CloseableIterable}s that the
+ * caller must close and that are not cached.
+ *
+ * <p>By default, manifests are read single-threaded. Use {@link
+ * Builder#executeWith(ExecutorService)} to enable parallel manifest reading.
  */
 public class SnapshotChanges {
   private final Snapshot snapshot;
@@ -87,142 +93,191 @@ public class SnapshotChanges {
     }
   }
 
-  /** Returns all data files added to the table in this snapshot */
+  /**
+   * Returns all data files added to the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * For a lazily-evaluated, streaming view, use {@link #addedDataFilesIterable()}.
+   */
   public Iterable<DataFile> addedDataFiles() {
     if (addedDataFiles == null) {
-      cacheDataFileChanges();
+      this.addedDataFiles = materialize(addedDataFilesIterable());
     }
 
     return addedDataFiles;
   }
 
-  /** Returns all data files removed from the table in this snapshot. */
+  /**
+   * Returns all data files removed from the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * For a lazily-evaluated, streaming view, use {@link #removedDataFilesIterable()}.
+   */
   public Iterable<DataFile> removedDataFiles() {
     if (removedDataFiles == null) {
-      cacheDataFileChanges();
+      this.removedDataFiles = materialize(removedDataFilesIterable());
     }
 
     return removedDataFiles;
   }
 
-  /** Returns all delete files added to the table in this snapshot. */
+  /**
+   * Returns all delete files added to the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * For a lazily-evaluated, streaming view, use {@link #addedDeleteFilesIterable()}.
+   */
   public Iterable<DeleteFile> addedDeleteFiles() {
     if (addedDeleteFiles == null) {
-      cacheDeleteFileChanges();
+      this.addedDeleteFiles = materialize(addedDeleteFilesIterable());
     }
 
     return addedDeleteFiles;
   }
 
-  /** Returns all delete files removed from the table in this snapshot. */
+  /**
+   * Returns all delete files removed from the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * For a lazily-evaluated, streaming view, use {@link #removedDeleteFilesIterable()}.
+   */
   public Iterable<DeleteFile> removedDeleteFiles() {
     if (removedDeleteFiles == null) {
-      cacheDeleteFileChanges();
+      this.removedDeleteFiles = materialize(removedDeleteFilesIterable());
     }
 
     return removedDeleteFiles;
   }
 
-  private void cacheDataFileChanges() {
-    ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
-    ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
-
-    Iterable<ManifestFile> relevantDataManifests =
-        Iterables.filter(
-            snapshot.dataManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DataFile>>> manifestReadTasks =
-        Iterables.transform(relevantDataManifests, this::readDataManifest);
-
-    try (CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changedDataFiles =
-        iterate(manifestReadTasks)) {
-      for (Pair<ManifestEntry.Status, DataFile> pair : changedDataFiles) {
-        switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
-        }
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to close manifest reader", e);
-    }
-
-    this.addedDataFiles = adds.build();
-    this.removedDataFiles = deletes.build();
+  /**
+   * Returns a lazily-evaluated, streaming view of all data files added to the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #addedDataFiles()}, the result is not cached: each invocation returns a fresh
+   * {@link CloseableIterable} that reads manifests on demand. Manifests are read single-threaded
+   * unless an executor was configured via {@link Builder#executeWith(ExecutorService)}, in which
+   * case manifests are read in parallel with a bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DataFile}
+   * instances are defensive copies that retain column statistics.
+   *
+   * @return a closeable iterable over data files added in this snapshot
+   */
+  public CloseableIterable<DataFile> addedDataFilesIterable() {
+    return changedDataFiles(ManifestEntry.Status.ADDED);
   }
 
-  private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> readDataManifest(
-      ManifestFile manifest) {
-    CloseableIterable<ManifestEntry<DataFile>> entries =
-        ManifestFiles.read(manifest, io, specsById).entries();
+  /**
+   * Returns a lazily-evaluated, streaming view of all data files removed from the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #removedDataFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DataFile}
+   * instances are defensive copies without column statistics.
+   *
+   * @return a closeable iterable over data files removed in this snapshot
+   */
+  public CloseableIterable<DataFile> removedDataFilesIterable() {
+    return changedDataFiles(ManifestEntry.Status.DELETED);
+  }
 
-    CloseableIterable<ManifestEntry<DataFile>> relevant =
-        CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
+  /**
+   * Returns a lazily-evaluated, streaming view of all delete files added to the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #addedDeleteFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DeleteFile}
+   * instances are defensive copies that retain column statistics.
+   *
+   * @return a closeable iterable over delete files added in this snapshot
+   */
+  public CloseableIterable<DeleteFile> addedDeleteFilesIterable() {
+    return changedDeleteFiles(ManifestEntry.Status.ADDED);
+  }
+
+  /**
+   * Returns a lazily-evaluated, streaming view of all delete files removed from the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #removedDeleteFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DeleteFile}
+   * instances are defensive copies without column statistics.
+   *
+   * @return a closeable iterable over delete files removed in this snapshot
+   */
+  public CloseableIterable<DeleteFile> removedDeleteFilesIterable() {
+    return changedDeleteFiles(ManifestEntry.Status.DELETED);
+  }
+
+  // materializes the iterable and releases resources so that the result can be cached
+  private <T> List<T> materialize(CloseableIterable<T> iterable) {
+    try (CloseableIterable<T> closeable = iterable) {
+      return ImmutableList.copyOf(closeable);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close iterable", e);
+    }
+  }
+
+  private CloseableIterable<DataFile> changedDataFiles(ManifestEntry.Status targetStatus) {
+    return changedFiles(
+        snapshot.dataManifests(io),
+        manifest -> ManifestFiles.read(manifest, io, specsById),
+        targetStatus);
+  }
+
+  private CloseableIterable<DeleteFile> changedDeleteFiles(ManifestEntry.Status targetStatus) {
+    return changedFiles(
+        snapshot.deleteManifests(io),
+        manifest -> ManifestFiles.readDeleteManifest(manifest, io, specsById),
+        targetStatus);
+  }
+
+  private <F extends ContentFile<F>> CloseableIterable<F> changedFiles(
+      Iterable<ManifestFile> allManifests,
+      Function<ManifestFile, ManifestReader<F>> readerFunction,
+      ManifestEntry.Status targetStatus) {
+    Iterable<ManifestFile> relevantManifests =
+        Iterables.filter(
+            allManifests, manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
+
+    Iterable<CloseableIterable<F>> manifestReadTasks =
+        Iterables.transform(
+            relevantManifests, manifest -> readManifest(manifest, readerFunction, targetStatus));
+
+    return iterate(manifestReadTasks);
+  }
+
+  private <F extends ContentFile<F>> CloseableIterable<F> readManifest(
+      ManifestFile manifest,
+      Function<ManifestFile, ManifestReader<F>> readerFunction,
+      ManifestEntry.Status targetStatus) {
+    CloseableIterable<ManifestEntry<F>> entries = readerFunction.apply(manifest).entries();
+
+    // keep only entries matching the requested change type; this also excludes EXISTING entries
+    CloseableIterable<ManifestEntry<F>> matching =
+        CloseableIterable.filter(entries, entry -> entry.status() == targetStatus);
 
     return CloseableIterable.transform(
-        relevant,
-        entry -> {
-          if (entry.status() == ManifestEntry.Status.ADDED) {
-            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());
-          } else {
-            return Pair.of(ManifestEntry.Status.DELETED, entry.file().copyWithoutStats());
-          }
-        });
-  }
-
-  private void cacheDeleteFileChanges() {
-    ImmutableList.Builder<DeleteFile> adds = ImmutableList.builder();
-    ImmutableList.Builder<DeleteFile> deletes = ImmutableList.builder();
-
-    Iterable<ManifestFile> relevantDeleteManifests =
-        Iterables.filter(
-            snapshot.deleteManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>>> manifestReadTasks =
-        Iterables.transform(relevantDeleteManifests, this::readDeleteManifest);
-
-    try (CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changedDeleteFiles =
-        iterate(manifestReadTasks)) {
-      for (Pair<ManifestEntry.Status, DeleteFile> pair : changedDeleteFiles) {
-        switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
-        }
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to close manifest reader", e);
-    }
-
-    this.addedDeleteFiles = adds.build();
-    this.removedDeleteFiles = deletes.build();
-  }
-
-  private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> readDeleteManifest(
-      ManifestFile manifest) {
-    CloseableIterable<ManifestEntry<DeleteFile>> entries =
-        ManifestFiles.readDeleteManifest(manifest, io, specsById).entries();
-
-    CloseableIterable<ManifestEntry<DeleteFile>> relevant =
-        CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
-
-    return CloseableIterable.transform(
-        relevant,
-        entry -> {
-          if (entry.status() == ManifestEntry.Status.ADDED) {
-            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());
-          } else {
-            return Pair.of(ManifestEntry.Status.DELETED, entry.file().copyWithoutStats());
-          }
-        });
+        matching,
+        entry ->
+            targetStatus == ManifestEntry.Status.ADDED
+                ? entry.file().copy()
+                : entry.file().copyWithoutStats());
   }
 
   public static class Builder {

--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -33,14 +35,24 @@ import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.ParallelIterable;
 
 /**
- * Helper class for retrieving file changes in a snapshot with caching.
+ * Helper class for retrieving file changes in a snapshot.
  *
- * <p>This class caches the results of file change detection operations, making it efficient to
- * query multiple file change types for the same snapshot. By default, manifests are read
- * single-threaded. Use {@link Builder#executeWith(ExecutorService)} to enable parallel manifest
- * reading.
+ * <p>Two access modes are provided. The cached accessors ({@link #addedDataFiles()}, {@link
+ * #removedDataFiles()}, {@link #addedDeleteFiles()}, {@link #removedDeleteFiles()}) eagerly
+ * materialize file changes into in-memory lists and cache them, making it efficient to query the
+ * same change type multiple times. Added and removed files of the same content type are cached by a
+ * single pass over the snapshot's manifests, so reading both costs one read per manifest. The
+ * streaming accessors ({@link #addedDataFilesIterable()}, {@link #removedDataFilesIterable()},
+ * {@link #addedDeleteFilesIterable()}, {@link #removedDeleteFilesIterable()}) return
+ * lazily-evaluated {@link CloseableIterable}s that the caller must close and that are not cached.
+ *
+ * <p>By default, manifests are read single-threaded. Use {@link
+ * Builder#executeWith(ExecutorService)} to enable parallel manifest reading.
  */
 public class SnapshotChanges {
+  private static final Predicate<ManifestEntry.Status> ADDED_OR_DELETED =
+      status -> status != ManifestEntry.Status.EXISTING;
+
   private final Snapshot snapshot;
   private final FileIO io;
   private final Map<Integer, PartitionSpec> specsById;
@@ -87,7 +99,13 @@ public class SnapshotChanges {
     }
   }
 
-  /** Returns all data files added to the table in this snapshot */
+  /**
+   * Returns all data files added to the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * The same pass also caches {@link #removedDataFiles()}. For a lazily-evaluated, streaming view,
+   * use {@link #addedDataFilesIterable()}.
+   */
   public Iterable<DataFile> addedDataFiles() {
     if (addedDataFiles == null) {
       cacheDataFileChanges();
@@ -96,7 +114,13 @@ public class SnapshotChanges {
     return addedDataFiles;
   }
 
-  /** Returns all data files removed from the table in this snapshot. */
+  /**
+   * Returns all data files removed from the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * The same pass also caches {@link #addedDataFiles()}. For a lazily-evaluated, streaming view,
+   * use {@link #removedDataFilesIterable()}.
+   */
   public Iterable<DataFile> removedDataFiles() {
     if (removedDataFiles == null) {
       cacheDataFileChanges();
@@ -105,7 +129,13 @@ public class SnapshotChanges {
     return removedDataFiles;
   }
 
-  /** Returns all delete files added to the table in this snapshot. */
+  /**
+   * Returns all delete files added to the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * The same pass also caches {@link #removedDeleteFiles()}. For a lazily-evaluated, streaming
+   * view, use {@link #addedDeleteFilesIterable()}.
+   */
   public Iterable<DeleteFile> addedDeleteFiles() {
     if (addedDeleteFiles == null) {
       cacheDeleteFileChanges();
@@ -114,7 +144,13 @@ public class SnapshotChanges {
     return addedDeleteFiles;
   }
 
-  /** Returns all delete files removed from the table in this snapshot. */
+  /**
+   * Returns all delete files removed from the table in this snapshot.
+   *
+   * <p>The result is materialized into memory and cached, so repeated calls return the same list.
+   * The same pass also caches {@link #addedDeleteFiles()}. For a lazily-evaluated, streaming view,
+   * use {@link #removedDeleteFilesIterable()}.
+   */
   public Iterable<DeleteFile> removedDeleteFiles() {
     if (removedDeleteFiles == null) {
       cacheDeleteFileChanges();
@@ -123,99 +159,166 @@ public class SnapshotChanges {
     return removedDeleteFiles;
   }
 
-  private void cacheDataFileChanges() {
-    ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
-    ImmutableList.Builder<DataFile> deletes = ImmutableList.builder();
-
-    Iterable<ManifestFile> relevantDataManifests =
-        Iterables.filter(
-            snapshot.dataManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DataFile>>> manifestReadTasks =
-        Iterables.transform(relevantDataManifests, this::readDataManifest);
-
-    try (CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changedDataFiles =
-        iterate(manifestReadTasks)) {
-      for (Pair<ManifestEntry.Status, DataFile> pair : changedDataFiles) {
-        switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
-        }
-      }
-    } catch (IOException e) {
-      throw new UncheckedIOException("Failed to close manifest reader", e);
-    }
-
-    this.addedDataFiles = adds.build();
-    this.removedDataFiles = deletes.build();
+  /**
+   * Returns a lazily-evaluated, streaming view of all data files added to the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #addedDataFiles()}, the result is not cached: each invocation returns a fresh
+   * {@link CloseableIterable} that reads manifests on demand. Manifests are read single-threaded
+   * unless an executor was configured via {@link Builder#executeWith(ExecutorService)}, in which
+   * case manifests are read in parallel with a bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DataFile}
+   * instances are defensive copies that retain column statistics.
+   *
+   * @return a closeable iterable over data files added in this snapshot
+   */
+  public CloseableIterable<DataFile> addedDataFilesIterable() {
+    return CloseableIterable.transform(
+        changedDataFiles(only(ManifestEntry.Status.ADDED)), Pair::second);
   }
 
-  private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> readDataManifest(
-      ManifestFile manifest) {
-    CloseableIterable<ManifestEntry<DataFile>> entries =
-        ManifestFiles.read(manifest, io, specsById).entries();
-
-    CloseableIterable<ManifestEntry<DataFile>> relevant =
-        CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
-
+  /**
+   * Returns a lazily-evaluated, streaming view of all data files removed from the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #removedDataFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DataFile}
+   * instances are defensive copies without column statistics.
+   *
+   * @return a closeable iterable over data files removed in this snapshot
+   */
+  public CloseableIterable<DataFile> removedDataFilesIterable() {
     return CloseableIterable.transform(
-        relevant,
-        entry -> {
-          if (entry.status() == ManifestEntry.Status.ADDED) {
-            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());
-          } else {
-            return Pair.of(ManifestEntry.Status.DELETED, entry.file().copyWithoutStats());
-          }
-        });
+        changedDataFiles(only(ManifestEntry.Status.DELETED)), Pair::second);
+  }
+
+  /**
+   * Returns a lazily-evaluated, streaming view of all delete files added to the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #addedDeleteFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DeleteFile}
+   * instances are defensive copies that retain column statistics.
+   *
+   * @return a closeable iterable over delete files added in this snapshot
+   */
+  public CloseableIterable<DeleteFile> addedDeleteFilesIterable() {
+    return CloseableIterable.transform(
+        changedDeleteFiles(only(ManifestEntry.Status.ADDED)), Pair::second);
+  }
+
+  /**
+   * Returns a lazily-evaluated, streaming view of all delete files removed from the table in this
+   * snapshot.
+   *
+   * <p>Unlike {@link #removedDeleteFiles()}, the result is not cached: each invocation returns a
+   * fresh {@link CloseableIterable} that reads manifests on demand. Manifests are read
+   * single-threaded unless an executor was configured via {@link
+   * Builder#executeWith(ExecutorService)}, in which case manifests are read in parallel with a
+   * bounded queue.
+   *
+   * <p>The caller is responsible for closing the returned iterable. Returned {@link DeleteFile}
+   * instances are defensive copies without column statistics.
+   *
+   * @return a closeable iterable over delete files removed in this snapshot
+   */
+  public CloseableIterable<DeleteFile> removedDeleteFilesIterable() {
+    return CloseableIterable.transform(
+        changedDeleteFiles(only(ManifestEntry.Status.DELETED)), Pair::second);
+  }
+
+  private static Predicate<ManifestEntry.Status> only(ManifestEntry.Status status) {
+    return entryStatus -> entryStatus == status;
+  }
+
+  private void cacheDataFileChanges() {
+    ImmutableList.Builder<DataFile> adds = ImmutableList.builder();
+    ImmutableList.Builder<DataFile> removes = ImmutableList.builder();
+    partition(changedDataFiles(ADDED_OR_DELETED), adds, removes);
+    this.addedDataFiles = adds.build();
+    this.removedDataFiles = removes.build();
   }
 
   private void cacheDeleteFileChanges() {
     ImmutableList.Builder<DeleteFile> adds = ImmutableList.builder();
-    ImmutableList.Builder<DeleteFile> deletes = ImmutableList.builder();
+    ImmutableList.Builder<DeleteFile> removes = ImmutableList.builder();
+    partition(changedDeleteFiles(ADDED_OR_DELETED), adds, removes);
+    this.addedDeleteFiles = adds.build();
+    this.removedDeleteFiles = removes.build();
+  }
 
-    Iterable<ManifestFile> relevantDeleteManifests =
-        Iterables.filter(
-            snapshot.deleteManifests(io),
-            manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
-
-    Iterable<CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>>> manifestReadTasks =
-        Iterables.transform(relevantDeleteManifests, this::readDeleteManifest);
-
-    try (CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changedDeleteFiles =
-        iterate(manifestReadTasks)) {
-      for (Pair<ManifestEntry.Status, DeleteFile> pair : changedDeleteFiles) {
-        switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
+  // drains the changes in a single pass, so that both caches are filled by one read per manifest
+  private static <F extends ContentFile<F>> void partition(
+      CloseableIterable<Pair<ManifestEntry.Status, F>> changes,
+      ImmutableList.Builder<F> adds,
+      ImmutableList.Builder<F> removes) {
+    try (CloseableIterable<Pair<ManifestEntry.Status, F>> closeable = changes) {
+      for (Pair<ManifestEntry.Status, F> change : closeable) {
+        if (change.first() == ManifestEntry.Status.ADDED) {
+          adds.add(change.second());
+        } else {
+          removes.add(change.second());
         }
       }
     } catch (IOException e) {
-      throw new UncheckedIOException("Failed to close manifest reader", e);
+      throw new UncheckedIOException("Failed to close iterable", e);
     }
-
-    this.addedDeleteFiles = adds.build();
-    this.removedDeleteFiles = deletes.build();
   }
 
-  private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> readDeleteManifest(
-      ManifestFile manifest) {
-    CloseableIterable<ManifestEntry<DeleteFile>> entries =
-        ManifestFiles.readDeleteManifest(manifest, io, specsById).entries();
+  private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> changedDataFiles(
+      Predicate<ManifestEntry.Status> statusFilter) {
+    return changedFiles(
+        snapshot.dataManifests(io),
+        manifest -> ManifestFiles.read(manifest, io, specsById),
+        statusFilter);
+  }
 
-    CloseableIterable<ManifestEntry<DeleteFile>> relevant =
-        CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
+  private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> changedDeleteFiles(
+      Predicate<ManifestEntry.Status> statusFilter) {
+    return changedFiles(
+        snapshot.deleteManifests(io),
+        manifest -> ManifestFiles.readDeleteManifest(manifest, io, specsById),
+        statusFilter);
+  }
+
+  private <F extends ContentFile<F>> CloseableIterable<Pair<ManifestEntry.Status, F>> changedFiles(
+      Iterable<ManifestFile> allManifests,
+      Function<ManifestFile, ManifestReader<F>> readerFunction,
+      Predicate<ManifestEntry.Status> statusFilter) {
+    Iterable<ManifestFile> relevantManifests =
+        Iterables.filter(
+            allManifests, manifest -> Objects.equals(manifest.snapshotId(), snapshot.snapshotId()));
+
+    Iterable<CloseableIterable<Pair<ManifestEntry.Status, F>>> manifestReadTasks =
+        Iterables.transform(
+            relevantManifests, manifest -> readManifest(manifest, readerFunction, statusFilter));
+
+    return iterate(manifestReadTasks);
+  }
+
+  private <F extends ContentFile<F>> CloseableIterable<Pair<ManifestEntry.Status, F>> readManifest(
+      ManifestFile manifest,
+      Function<ManifestFile, ManifestReader<F>> readerFunction,
+      Predicate<ManifestEntry.Status> statusFilter) {
+    CloseableIterable<ManifestEntry<F>> entries = readerFunction.apply(manifest).entries();
+
+    // filter before copying so that entries the caller did not ask for are never copied
+    CloseableIterable<ManifestEntry<F>> matching =
+        CloseableIterable.filter(entries, entry -> statusFilter.test(entry.status()));
 
     return CloseableIterable.transform(
-        relevant,
+        matching,
         entry -> {
           if (entry.status() == ManifestEntry.Status.ADDED) {
             return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -22,6 +22,13 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -145,5 +152,219 @@ public class TestSnapshotChanges {
 
     // Both calls should return the same reference (cached)
     assertThat(firstCallResult).isSameAs(secondCallResult);
+  }
+
+  @Test
+  public void testAddedDataFilesIterable() {
+    DataFile added = dataFile("/path/to/added.parquet");
+    table.newFastAppend().appendFile(added).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DataFile> files = drain(changes.addedDataFilesIterable());
+    assertThat(files).hasSize(1);
+    assertThat(files.get(0).location()).isEqualTo(added.location());
+  }
+
+  @Test
+  public void testRemovedDataFilesIterable() {
+    DataFile fileToRemove = dataFile("/path/to/remove.parquet");
+    DataFile fileToKeep = dataFile("/path/to/keep.parquet");
+    table.newAppend().appendFile(fileToRemove).appendFile(fileToKeep).commit();
+    table.newDelete().deleteFile(fileToRemove).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DataFile> removed = drain(changes.removedDataFilesIterable());
+    assertThat(removed).hasSize(1);
+    assertThat(removed.get(0).location()).isEqualTo(fileToRemove.location());
+  }
+
+  @Test
+  public void testAddedDeleteFilesIterable() {
+    table.newAppend().appendFile(dataFile("/path/to/data.parquet")).commit();
+    DeleteFile positionDelete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(positionDelete).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DeleteFile> added = drain(changes.addedDeleteFilesIterable());
+    assertThat(added).hasSize(1);
+    assertThat(added.get(0).location()).isEqualTo(positionDelete.location());
+  }
+
+  @Test
+  public void testRemovedDeleteFilesIterable() {
+    table.newAppend().appendFile(dataFile("/path/to/data.parquet")).commit();
+    DeleteFile delete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(delete).commit();
+    table.newRowDelta().removeDeletes(delete).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DeleteFile> removed = drain(changes.removedDeleteFilesIterable());
+    assertThat(removed).hasSize(1);
+    assertThat(removed.get(0).location()).isEqualTo(delete.location());
+  }
+
+  @Test
+  public void testStreamingResultsEqualCachedResults() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newAppend().appendFile(fileA).appendFile(fileB).commit();
+    Snapshot appendSnapshot = table.currentSnapshot();
+    table.newDelete().deleteFile(fileA).commit();
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    SnapshotChanges appendChanges =
+        SnapshotChanges.builderFor(table).snapshot(appendSnapshot).build();
+    assertThat(locations(drain(appendChanges.addedDataFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(appendChanges.addedDataFiles()));
+
+    SnapshotChanges deleteChanges =
+        SnapshotChanges.builderFor(table).snapshot(deleteSnapshot).build();
+    assertThat(locations(drain(deleteChanges.removedDataFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(deleteChanges.removedDataFiles()));
+
+    DeleteFile delete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(delete).commit();
+    SnapshotChanges addDeleteChanges =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+    assertThat(locations(drain(addDeleteChanges.addedDeleteFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(addDeleteChanges.addedDeleteFiles()));
+  }
+
+  @Test
+  public void testStreamingDoesNotCache() {
+    table.newFastAppend().appendFile(dataFile("/path/to/a.parquet")).commit();
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    CloseableIterable<DataFile> first = changes.addedDataFilesIterable();
+    CloseableIterable<DataFile> second = changes.addedDataFilesIterable();
+
+    // each call builds a fresh, independent pipeline (unlike the cached accessors)
+    assertThat(first).isNotSameAs(second);
+    assertThat(drain(first)).hasSize(1);
+    assertThat(drain(second)).hasSize(1);
+
+    // the cached accessor must still return the same cached reference across calls
+    assertThat(changes.addedDataFiles()).isSameAs(changes.addedDataFiles());
+  }
+
+  @Test
+  public void testAddedDataFilesRetainStatsRemovedFilesDropStats() {
+    DataFile fileWithStats = FileGenerationUtil.generateDataFile(table, TestHelpers.Row.of());
+    assertThat(fileWithStats.columnSizes()).isNotEmpty();
+
+    table.newAppend().appendFile(fileWithStats).commit();
+    Snapshot appendSnapshot = table.currentSnapshot();
+    table.newDelete().deleteFile(fileWithStats).commit();
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    SnapshotChanges added = SnapshotChanges.builderFor(table).snapshot(appendSnapshot).build();
+    List<DataFile> addedFiles = drain(added.addedDataFilesIterable());
+    assertThat(addedFiles).hasSize(1);
+    assertThat(addedFiles.get(0).columnSizes()).isNotEmpty();
+
+    SnapshotChanges removed = SnapshotChanges.builderFor(table).snapshot(deleteSnapshot).build();
+    List<DataFile> removedFiles = drain(removed.removedDataFilesIterable());
+    assertThat(removedFiles).hasSize(1);
+    assertThat(removedFiles.get(0).columnSizes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void testExistingEntriesExcluded() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newAppend().appendFile(fileA).appendFile(fileB).commit();
+    table.newDelete().deleteFile(fileA).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    // fileA is DELETED in this snapshot; fileB is carried forward as EXISTING and excluded
+    assertThat(locations(drain(changes.removedDataFilesIterable())))
+        .containsExactly(fileA.location());
+    assertThat(drain(changes.addedDataFilesIterable())).isEmpty();
+  }
+
+  @Test
+  public void testOnlyTargetSnapshotChangesReturned() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot first = table.currentSnapshot();
+
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot second = table.currentSnapshot();
+
+    SnapshotChanges firstChanges = SnapshotChanges.builderFor(table).snapshot(first).build();
+    assertThat(locations(drain(firstChanges.addedDataFilesIterable())))
+        .containsExactly(fileA.location());
+
+    // the second snapshot must not surface fileA, whose manifest belongs to the first snapshot
+    SnapshotChanges secondChanges = SnapshotChanges.builderFor(table).snapshot(second).build();
+    assertThat(locations(drain(secondChanges.addedDataFilesIterable())))
+        .containsExactly(fileB.location());
+  }
+
+  @Test
+  public void testParallelStreamingMatchesSerial() {
+    AppendFiles append = table.newFastAppend();
+    for (int i = 0; i < 8; i++) {
+      append.appendFile(dataFile("/path/to/file-" + i + ".parquet"));
+    }
+    append.commit();
+    Snapshot snapshot = table.currentSnapshot();
+
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    try {
+      SnapshotChanges serial = SnapshotChanges.builderFor(table).snapshot(snapshot).build();
+      SnapshotChanges parallel =
+          SnapshotChanges.builderFor(table).snapshot(snapshot).executeWith(executor).build();
+
+      assertThat(locations(drain(parallel.addedDataFilesIterable())))
+          .containsExactlyInAnyOrderElementsOf(locations(drain(serial.addedDataFilesIterable())));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  private DataFile dataFile(String path) {
+    return DataFiles.builder(SPEC)
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private DeleteFile positionDeleteFile(String path) {
+    return FileMetadata.deleteFileBuilder(SPEC)
+        .ofPositionDeletes()
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private <T> List<T> drain(CloseableIterable<T> iterable) {
+    try (CloseableIterable<T> closeable = iterable) {
+      return Lists.newArrayList(closeable);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close iterable", e);
+    }
+  }
+
+  private static List<String> locations(Iterable<? extends ContentFile<?>> files) {
+    List<String> paths = Lists.newArrayList();
+    for (ContentFile<?> file : files) {
+      paths.add(file.location());
+    }
+    return paths;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -22,6 +22,17 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -145,5 +156,284 @@ public class TestSnapshotChanges {
 
     // Both calls should return the same reference (cached)
     assertThat(firstCallResult).isSameAs(secondCallResult);
+  }
+
+  @Test
+  public void testAddedDataFilesIterable() {
+    DataFile added = dataFile("/path/to/added.parquet");
+    table.newFastAppend().appendFile(added).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DataFile> files = drain(changes.addedDataFilesIterable());
+    assertThat(files).hasSize(1);
+    assertThat(files.get(0).location()).isEqualTo(added.location());
+  }
+
+  @Test
+  public void testRemovedDataFilesIterable() {
+    DataFile fileToRemove = dataFile("/path/to/remove.parquet");
+    DataFile fileToKeep = dataFile("/path/to/keep.parquet");
+    table.newAppend().appendFile(fileToRemove).appendFile(fileToKeep).commit();
+    table.newDelete().deleteFile(fileToRemove).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DataFile> removed = drain(changes.removedDataFilesIterable());
+    assertThat(removed).hasSize(1);
+    assertThat(removed.get(0).location()).isEqualTo(fileToRemove.location());
+  }
+
+  @Test
+  public void testAddedDeleteFilesIterable() {
+    table.newAppend().appendFile(dataFile("/path/to/data.parquet")).commit();
+    DeleteFile positionDelete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(positionDelete).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DeleteFile> added = drain(changes.addedDeleteFilesIterable());
+    assertThat(added).hasSize(1);
+    assertThat(added.get(0).location()).isEqualTo(positionDelete.location());
+  }
+
+  @Test
+  public void testRemovedDeleteFilesIterable() {
+    table.newAppend().appendFile(dataFile("/path/to/data.parquet")).commit();
+    DeleteFile delete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(delete).commit();
+    table.newRowDelta().removeDeletes(delete).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    List<DeleteFile> removed = drain(changes.removedDeleteFilesIterable());
+    assertThat(removed).hasSize(1);
+    assertThat(removed.get(0).location()).isEqualTo(delete.location());
+  }
+
+  @Test
+  public void testStreamingResultsEqualCachedResults() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newAppend().appendFile(fileA).appendFile(fileB).commit();
+    Snapshot appendSnapshot = table.currentSnapshot();
+    table.newDelete().deleteFile(fileA).commit();
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    SnapshotChanges appendChanges =
+        SnapshotChanges.builderFor(table).snapshot(appendSnapshot).build();
+    assertThat(locations(drain(appendChanges.addedDataFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(appendChanges.addedDataFiles()));
+
+    SnapshotChanges deleteChanges =
+        SnapshotChanges.builderFor(table).snapshot(deleteSnapshot).build();
+    assertThat(locations(drain(deleteChanges.removedDataFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(deleteChanges.removedDataFiles()));
+
+    DeleteFile delete = positionDeleteFile("/path/to/pos-deletes.parquet");
+    table.newRowDelta().addDeletes(delete).commit();
+    SnapshotChanges addDeleteChanges =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+    assertThat(locations(drain(addDeleteChanges.addedDeleteFilesIterable())))
+        .containsExactlyInAnyOrderElementsOf(locations(addDeleteChanges.addedDeleteFiles()));
+  }
+
+  @Test
+  public void testStreamingDoesNotCache() {
+    table.newFastAppend().appendFile(dataFile("/path/to/a.parquet")).commit();
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    CloseableIterable<DataFile> first = changes.addedDataFilesIterable();
+    CloseableIterable<DataFile> second = changes.addedDataFilesIterable();
+
+    // each call builds a fresh, independent pipeline (unlike the cached accessors)
+    assertThat(first).isNotSameAs(second);
+    assertThat(drain(first)).hasSize(1);
+    assertThat(drain(second)).hasSize(1);
+
+    // the cached accessor must still return the same cached reference across calls
+    assertThat(changes.addedDataFiles()).isSameAs(changes.addedDataFiles());
+  }
+
+  @Test
+  public void testAddedDataFilesRetainStatsRemovedFilesDropStats() {
+    DataFile fileWithStats = FileGenerationUtil.generateDataFile(table, TestHelpers.Row.of());
+    assertThat(fileWithStats.columnSizes()).isNotEmpty();
+
+    table.newAppend().appendFile(fileWithStats).commit();
+    Snapshot appendSnapshot = table.currentSnapshot();
+    table.newDelete().deleteFile(fileWithStats).commit();
+    Snapshot deleteSnapshot = table.currentSnapshot();
+
+    SnapshotChanges added = SnapshotChanges.builderFor(table).snapshot(appendSnapshot).build();
+    List<DataFile> addedFiles = drain(added.addedDataFilesIterable());
+    assertThat(addedFiles).hasSize(1);
+    assertThat(addedFiles.get(0).columnSizes()).isNotEmpty();
+
+    SnapshotChanges removed = SnapshotChanges.builderFor(table).snapshot(deleteSnapshot).build();
+    List<DataFile> removedFiles = drain(removed.removedDataFilesIterable());
+    assertThat(removedFiles).hasSize(1);
+    assertThat(removedFiles.get(0).columnSizes()).isNullOrEmpty();
+  }
+
+  @Test
+  public void testExistingEntriesExcluded() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newAppend().appendFile(fileA).appendFile(fileB).commit();
+    table.newDelete().deleteFile(fileA).commit();
+
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(table).snapshot(table.currentSnapshot()).build();
+
+    // fileA is DELETED in this snapshot; fileB is carried forward as EXISTING and excluded
+    assertThat(locations(drain(changes.removedDataFilesIterable())))
+        .containsExactly(fileA.location());
+    assertThat(drain(changes.addedDataFilesIterable())).isEmpty();
+  }
+
+  @Test
+  public void testOnlyTargetSnapshotChangesReturned() {
+    DataFile fileA = dataFile("/path/to/a.parquet");
+    table.newFastAppend().appendFile(fileA).commit();
+    Snapshot first = table.currentSnapshot();
+
+    DataFile fileB = dataFile("/path/to/b.parquet");
+    table.newFastAppend().appendFile(fileB).commit();
+    Snapshot second = table.currentSnapshot();
+
+    SnapshotChanges firstChanges = SnapshotChanges.builderFor(table).snapshot(first).build();
+    assertThat(locations(drain(firstChanges.addedDataFilesIterable())))
+        .containsExactly(fileA.location());
+
+    // the second snapshot must not surface fileA, whose manifest belongs to the first snapshot
+    SnapshotChanges secondChanges = SnapshotChanges.builderFor(table).snapshot(second).build();
+    assertThat(locations(drain(secondChanges.addedDataFilesIterable())))
+        .containsExactly(fileB.location());
+  }
+
+  @Test
+  public void testParallelStreamingMatchesSerial() {
+    List<DataFile> deleted = commitFilesInSeparateManifestsThenDeleteAll(3);
+    Snapshot snapshot = table.currentSnapshot();
+
+    // a single append would put every file in one manifest, leaving the parallel path with one
+    // task; this snapshot owns three manifests so they are really read concurrently
+    assertThat(snapshot.dataManifests(table.io())).hasSize(3);
+
+    ExecutorService executor = Executors.newFixedThreadPool(3);
+    try {
+      SnapshotChanges serial = SnapshotChanges.builderFor(table).snapshot(snapshot).build();
+      SnapshotChanges parallel =
+          SnapshotChanges.builderFor(table).snapshot(snapshot).executeWith(executor).build();
+
+      assertThat(locations(drain(parallel.removedDataFilesIterable())))
+          .containsExactlyInAnyOrderElementsOf(locations(drain(serial.removedDataFilesIterable())))
+          .containsExactlyInAnyOrderElementsOf(locations(deleted));
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  public void testCachedAccessorsShareOneManifestPass() {
+    commitFilesInSeparateManifestsThenDeleteAll(3);
+
+    Snapshot snapshot = table.currentSnapshot();
+    assertThat(snapshot.dataManifests(table.io())).hasSize(3);
+    CountingFileIO countingIO = new CountingFileIO(table.io());
+    SnapshotChanges changes =
+        SnapshotChanges.builderFor(snapshot, countingIO, table.specs()).build();
+
+    assertThat(changes.removedDataFiles()).hasSize(3);
+    int readsAfterFirstAccessor = countingIO.inputFiles();
+    assertThat(readsAfterFirstAccessor).isGreaterThan(0);
+
+    // the added-file cache was filled by the same pass, so no manifest is opened a second time
+    assertThat(changes.addedDataFiles()).isEmpty();
+    assertThat(countingIO.inputFiles()).isEqualTo(readsAfterFirstAccessor);
+  }
+
+  // commits one file per snapshot so each lands in its own manifest, then deletes them all, which
+  // rewrites every manifest into the delete snapshot
+  private List<DataFile> commitFilesInSeparateManifestsThenDeleteAll(int fileCount) {
+    List<DataFile> files = Lists.newArrayList();
+    for (int i = 0; i < fileCount; i++) {
+      DataFile file = dataFile("/path/to/file-" + i + ".parquet");
+      files.add(file);
+      table.newFastAppend().appendFile(file).commit();
+    }
+
+    DeleteFiles delete = table.newDelete();
+    files.forEach(delete::deleteFile);
+    delete.commit();
+    return files;
+  }
+
+  private DataFile dataFile(String path) {
+    return DataFiles.builder(SPEC)
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private DeleteFile positionDeleteFile(String path) {
+    return FileMetadata.deleteFileBuilder(SPEC)
+        .ofPositionDeletes()
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withRecordCount(1)
+        .build();
+  }
+
+  private <T> List<T> drain(CloseableIterable<T> iterable) {
+    try (CloseableIterable<T> closeable = iterable) {
+      return Lists.newArrayList(closeable);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close iterable", e);
+    }
+  }
+
+  private static List<String> locations(Iterable<? extends ContentFile<?>> files) {
+    List<String> paths = Lists.newArrayList();
+    for (ContentFile<?> file : files) {
+      paths.add(file.location());
+    }
+    return paths;
+  }
+
+  private static class CountingFileIO implements FileIO {
+    private final FileIO wrapped;
+    private final AtomicInteger inputFiles = new AtomicInteger();
+
+    private CountingFileIO(FileIO wrapped) {
+      this.wrapped = wrapped;
+    }
+
+    private int inputFiles() {
+      return inputFiles.get();
+    }
+
+    @Override
+    public InputFile newInputFile(String path) {
+      inputFiles.incrementAndGet();
+      return wrapped.newInputFile(path);
+    }
+
+    @Override
+    public OutputFile newOutputFile(String path) {
+      return wrapped.newOutputFile(path);
+    }
+
+    @Override
+    public void deleteFile(String path) {
+      wrapped.deleteFile(path);
+    }
   }
 }


### PR DESCRIPTION
Closes #15659

## What

`SnapshotChanges` previously exposed only cached accessors that eagerly materialize all file changes into in-memory lists and return `Iterable`. Some callers (for example replaced-partition validation, see #13556) need to stream changes without loading every file into memory. This PR adds streaming `CloseableIterable` accessors and re-implements the cached accessors on top of the same manifest-reading pipeline, as suggested in #15659.

## Changes

- Add `addedDataFilesIterable()`, `removedDataFilesIterable()`, `addedDeleteFilesIterable()` and `removedDeleteFilesIterable()`, which return lazily-evaluated `CloseableIterable`s that the caller must close and that are not cached.
- Replace the per-type cache/read methods with a single generic manifest-reading pipeline, parameterized by an entry-status filter. Manifests are still read single-threaded by default and in parallel with a bounded queue when an executor is configured via `Builder.executeWith`.
- Preserve the cached accessors' behaviour exactly: added and removed files of the same content type are still filled by a single pass over the snapshot's manifests, so reading both costs one read per manifest, and repeated calls still return the same list.
- Filter entries by status before copying them, so a caller streaming added files never pays to copy removed ones.

## Testing

Adds 11 tests in `TestSnapshotChanges` (the 3 existing tests are unchanged), each guarding a distinct code path: streaming added/removed data and delete files, equivalence with the cached results, non-caching semantics, statistics retention versus stripping (`copy()` vs `copyWithoutStats()`), EXISTING-entry exclusion, snapshot-id manifest filtering, the parallel execution path across several manifests, and a regression test that counts manifest opens through a wrapping `FileIO` to prove the cached accessors still share one pass. Reverting that single pass makes it fail with `expected: 3 but was: 6`.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Add streaming CloseableIterable accessors to SnapshotChanges alongside the eager cached ones.
