### PR TITLE
Docs: switch default docs version from nightly to latest

### DIFF
--- a/site/mkdocs-dev.yml
+++ b/site/mkdocs-dev.yml
@@ -108,11 +108,10 @@ nav:
 
 exclude_docs: |
   !.asf.yaml
-  docs/*
-  docs/nightly/docs/**
-  docs/latest/docs/**
+  docs/
+  javadoc/
   !docs/nightly/
-  !docs/latest/
-  javadoc/*
   !javadoc/nightly/
+  !docs/latest/
   !javadoc/latest/
+

--- a/site/mkdocs-dev.yml
+++ b/site/mkdocs-dev.yml
@@ -29,8 +29,8 @@ nav:
     - Hive: hive-quickstart.md
   - Docs:
     - Java:
-      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
       - Latest (1.10.1): '!include docs/docs/latest/mkdocs.yml'
+      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
     - Other Implementations:
       - Python: https://py.iceberg.apache.org/
       - Rust: https://rust.iceberg.apache.org/
@@ -108,9 +108,11 @@ nav:
 
 exclude_docs: |
   !.asf.yaml
-  docs/
-  javadoc/
+  docs/*
+  docs/nightly/docs/**
+  docs/latest/docs/**
   !docs/nightly/
-  !javadoc/nightly/
   !docs/latest/
+  javadoc/*
+  !javadoc/nightly/
   !javadoc/latest/

--- a/site/mkdocs-dev.yml
+++ b/site/mkdocs-dev.yml
@@ -114,4 +114,3 @@ exclude_docs: |
   !javadoc/nightly/
   !docs/latest/
   !javadoc/latest/
-

--- a/site/mkdocs-dev.yml
+++ b/site/mkdocs-dev.yml
@@ -29,6 +29,7 @@ nav:
     - Hive: hive-quickstart.md
   - Docs:
     - Java:
+      # First entry determines the default landing page for the Docs tab.
       - Latest (1.10.1): '!include docs/docs/latest/mkdocs.yml'
       - Nightly: '!include docs/docs/nightly/mkdocs.yml'
     - Other Implementations:

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -126,12 +126,8 @@ extra:
       link: 'https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ'
       title: slack
 
-# docs/xxx/docs/xxx.md excludes original md files which are copied to build's output by default
 exclude_docs: |
   !.asf.yaml
-  docs/latest/docs/**
-  docs/nightly/docs/**
-  docs/[0-9]*/docs/**
 
 extra_css:
   - assets/stylesheets/extra.css

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -77,9 +77,9 @@ plugins:
         'docs/nightly/daft.md': 'integrations/daft.md'
         'docs/nightly/risingwave.md': 'integrations/risingwave.md'
   - exclude-search:
-      # Index only docs/nightly/* to avoid duplicate hits across versions.
+      # Index only docs/latest/* to avoid duplicate hits across versions.
       exclude:
-        - 'docs/latest*'  # excludes latest and its children
+        - 'docs/nightly*'  # excludes nightly and its children
         - 'docs/[0-9]*'    # excludes docs/<x.y.z> and their children
 
 markdown_extensions:
@@ -126,8 +126,12 @@ extra:
       link: 'https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ'
       title: slack
 
+# docs/xxx/docs/xxx.md excludes original md files which are copied to build's output by default
 exclude_docs: |
   !.asf.yaml
+  docs/latest/docs/**
+  docs/nightly/docs/**
+  docs/[0-9]*/docs/**
 
 extra_css:
   - assets/stylesheets/extra.css

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -23,8 +23,8 @@ nav:
     - Hive: hive-quickstart.md
   - Docs:
     - Java:
-      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
       - Latest (1.10.1): '!include docs/docs/latest/mkdocs.yml'
+      - Nightly: '!include docs/docs/nightly/mkdocs.yml'
       - Previous:
         - 1.10.0: '!include docs/docs/1.10.0/mkdocs.yml'
         - 1.9.2: '!include docs/docs/1.9.2/mkdocs.yml'

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -23,6 +23,7 @@ nav:
     - Hive: hive-quickstart.md
   - Docs:
     - Java:
+      # First entry determines the default landing page for the Docs tab.
       - Latest (1.10.1): '!include docs/docs/latest/mkdocs.yml'
       - Nightly: '!include docs/docs/nightly/mkdocs.yml'
       - Previous:


### PR DESCRIPTION
### Background
The issue was first described by Kevin Liu(@kevinjqliu) as a follow-up task in an email thread from 5/13/2026 Docs: Are duplicated results in search on iceberg.apache.org a bug or a feature? on [Iceberg's dev mailing list](https://lists.apache.org/thread/vrt3oytl3dwo34wr07tkf73r0kkx0b1h). Related PRs: https://github.com/apache/iceberg/pull/16368, https://github.com/apache/iceberg/pull/16371.

### Problem statement
Both the "Docs" tab on https://iceberg.apache.org/ and the search index currently point to `nightly` (the most up-to-date documentation based on the main branch). This could be confusing if it includes changes that haven't been released yet. We would like to update both to link to `latest` (the most recent release version) instead.


### Solution
- Switches `nightly` and `latest` in md files, as the result `latest` become the first expandable container on the top and it becomes a default landing version which is what we want.
- Exclude `nightly` from a search index and leave just `latest` as the only indexed version to align search with new default docs version.