### PR TITLE
REST Spec: Add unregister table endpoint

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1577,7 +1577,7 @@ class CreateTableRequest(BaseModel):
 
 class UnregisterTableResult(BaseModel):
     """
-    Last metadata location and current table metadata for the table that was successfully unregistered and is no longer tracked by the catalog.
+    Last metadata location and the corresponding table metadata for the table that was successfully unregistered and is no longer tracked by the catalog.
     """
 
     metadata_location: str = Field(

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1575,6 +1575,19 @@ class CreateTableRequest(BaseModel):
     properties: dict[str, str] | None = None
 
 
+class UnregisterTableResult(BaseModel):
+    """
+    Last metadata location and current table metadata for the table that was successfully unregistered and is no longer tracked by the catalog.
+    """
+
+    metadata_location: str = Field(
+        ...,
+        alias='metadata-location',
+        description='The last metadata location for the table at the time it was unregistered.',
+    )
+    metadata: TableMetadata
+
+
 class CreateViewRequest(BaseModel):
     name: str
     location: str | None = None

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1227,6 +1227,9 @@ paths:
       tags:
         - Catalog API
       summary: Unregister a table without removing its data or metadata files
+      operationId: unregisterTable
+      parameters:
+        - $ref: '#/components/parameters/idempotency-key'
       description:
         Unregister a table from the catalog. This is the opposite of
         `registerTable`. The table no longer exists in the catalog, but the
@@ -1238,7 +1241,6 @@ paths:
         corresponding table metadata. This table metadata must include all
         commits that happened before the unregister operation. All attempted
         commits after the unregister operation in this catalog must fail.
-      operationId: unregisterTable
       responses:
         200:
           $ref: '#/components/responses/UnregisterTableResponse'

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1234,10 +1234,10 @@ paths:
         can be registered in another catalog.
 
 
-        On success, this returns the table's last metadata location and current
-        table metadata. This table metadata must include all commits that
-        happened before the unregister operation. All attempted commits after
-        the unregister operation in this catalog must fail.
+        On success, this returns the table's last metadata location and the
+        corresponding table metadata. This table metadata must include all
+        commits that happened before the unregister operation. All attempted
+        commits after the unregister operation in this catalog must fail.
       operationId: unregisterTable
       responses:
         200:
@@ -3842,8 +3842,9 @@ components:
 
     UnregisterTableResult:
       description:
-        Last metadata location and current table metadata for the table that
-        was successfully unregistered and is no longer tracked by the catalog.
+        Last metadata location and the corresponding table metadata for the
+        table that was successfully unregistered and is no longer tracked by
+        the catalog.
       type: object
       required:
         - metadata-location

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1217,6 +1217,54 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/unregister:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+
+    post:
+      tags:
+        - Catalog API
+      summary: Unregister a table without removing its data or metadata files
+      description:
+        Unregister a table from the catalog. This is the opposite of
+        `registerTable`. The table no longer exists in the catalog, but the
+        underlying data and metadata files are left in place so that the table
+        can be registered in another catalog.
+
+
+        On success, this returns the table's last metadata location and current
+        table metadata. This table metadata must include all commits that
+        happened before the unregister operation. All attempted commits after
+        the unregister operation in this catalog must fail.
+      operationId: unregisterTable
+      responses:
+        200:
+          $ref: '#/components/responses/UnregisterTableResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found - NoSuchTableException, table to unregister does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                TableToUnregisterDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /v1/{prefix}/namespaces/{namespace}/tables/{table}/credentials:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -3792,6 +3840,22 @@ components:
           type: boolean
           default: false
 
+    UnregisterTableResult:
+      description:
+        Last metadata location and current table metadata for the table that
+        was successfully unregistered and is no longer tracked by the catalog.
+      type: object
+      required:
+        - metadata-location
+        - metadata
+      properties:
+        metadata-location:
+          type: string
+          description:
+            The last metadata location for the table at the time it was unregistered.
+        metadata:
+          $ref: '#/components/schemas/TableMetadata'
+
     CreateViewRequest:
       type: object
       required:
@@ -5058,6 +5122,13 @@ components:
       headers:
         etag:
           $ref: '#/components/parameters/etag'
+
+    UnregisterTableResponse:
+      description: Response when a table is successfully unregistered.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UnregisterTableResult'
 
     LoadViewResponse:
       description: View metadata result when loading a view


### PR DESCRIPTION
This adds an endpoint to `unregister` a table from a REST catalog without deleting data or metadata files. A `register` endpoint already exists to add a table to a REST catalog, since most migrations have been to REST from Hive or other catalogs. But an `unregister` endpoint is needed to safely migrate from one REST catalog to another through the API.

This uses an empty POST to `unregister` under a table resource (`/v1/{prefix}/namespaces/{namespace}/tables/{table}/unregister`), rather than along side the `register` endpoint, which would require an unregister-specific request.

The request and endpoint structure were co-authored by Claude Code (Opus 4.7).