### PR TITLE
Core: Improving comment documentation for SnapshotUtil.snapshotIdsBetween

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SnapshotUtil.java
@@ -190,7 +190,7 @@ public class SnapshotUtil {
   }
 
   /**
-   * Returns list of snapshot ids in the range - (fromSnapshotId, toSnapshotId]
+   * Returns list of snapshot ids in the range - (fromSnapshotId, toSnapshotId] from newest to oldest
    *
    * <p>This method assumes that fromSnapshotId is an ancestor of toSnapshotId.
    */


### PR DESCRIPTION
Explicitly stating the return order of `SnapshotUtil.snapshotIdsBetween`.