### PR TITLE
Build: Ban Preconditions.checkState with %d placeholder

### DIFF
--- a/.baseline/checkstyle/checkstyle.xml
+++ b/.baseline/checkstyle/checkstyle.xml
@@ -89,6 +89,12 @@
         <property name="message" value="Preconditions.checkArgument does not support %d. use %s instead"/>
     </module>
     <module name="RegexpMultiline">
+        <property name="fileExtensions" value="java"/>
+        <property name="matchAcrossLines" value="true"/>
+        <property name="format" value="Preconditions\.checkState\([^;]+%d[^;]+\);"/>
+        <property name="message" value="Preconditions.checkState does not support %d. use %s instead"/>
+    </module>
+    <module name="RegexpMultiline">
         <property name="format" value="^\s*import\s+static\s+(?!\Qorg.assertj.core.api.Assertions.\E).*\.assertThatThrownBy;"/>
         <property name="message" value="assertThatThrownBy() should be statically imported from org.assertj.core.api.Assertions"/>
     </module>

--- a/api/src/main/java/org/apache/iceberg/PartitionStatistics.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionStatistics.java
@@ -58,7 +58,7 @@ public interface PartitionStatistics extends StructLike {
 
   static Schema schema(Types.StructType unifiedPartitionType, int formatVersion) {
     Preconditions.checkState(!unifiedPartitionType.fields().isEmpty(), "Table must be partitioned");
-    Preconditions.checkState(formatVersion > 0, "Invalid format version: %d", formatVersion);
+    Preconditions.checkState(formatVersion > 0, "Invalid format version: %s", formatVersion);
 
     if (formatVersion <= 2) {
       return v2Schema(unifiedPartitionType);

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -186,7 +186,7 @@ public class PartitionStatsHandler {
     Preconditions.checkState(!unifiedPartitionType.fields().isEmpty(), "Table must be partitioned");
     Preconditions.checkState(
         formatVersion > 0 && formatVersion <= TableMetadata.SUPPORTED_TABLE_FORMAT_VERSION,
-        "Invalid format version: %d",
+        "Invalid format version: %s",
         formatVersion);
 
     if (formatVersion <= 2) {

--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputFile.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputFile.java
@@ -69,7 +69,7 @@ public class AesGcmInputFile implements InputFile {
     long ciphertextLength = encryptedLength();
     Preconditions.checkState(
         ciphertextLength >= Ciphers.MIN_STREAM_LENGTH,
-        "Invalid encrypted stream: %d is shorter than the minimum possible stream length",
+        "Invalid encrypted stream: %s is shorter than the minimum possible stream length",
         ciphertextLength);
     return new AesGcmInputStream(sourceFile.newStream(), ciphertextLength, dataKey, fileAADPrefix);
   }

--- a/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/AesGcmInputStream.java
@@ -79,7 +79,7 @@ public class AesGcmInputStream extends SeekableInputStream {
     int plainBlockSize = ByteBuffer.wrap(headerBytes, 4, 4).order(ByteOrder.LITTLE_ENDIAN).getInt();
     Preconditions.checkState(
         plainBlockSize == Ciphers.PLAIN_BLOCK_SIZE,
-        "Invalid GCM stream: block size %d != %d",
+        "Invalid GCM stream: block size %s != %s",
         plainBlockSize,
         Ciphers.PLAIN_BLOCK_SIZE);
   }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
@@ -226,7 +226,7 @@ abstract class BaseCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways.containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for (#%d)",
+          "Coordinator of %s already has a subtask gateway for (#%s)",
           operatorName,
           attemptNumber);
       LOG.debug("Coordinator of {} registers gateway for attempt {}", operatorName, attemptNumber);

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -457,7 +457,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways[subtaskIndex].containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for %d (#%d)",
+          "Coordinator of %s already has a subtask gateway for %s (#%s)",
           operatorName,
           subtaskIndex,
           attemptNumber);
@@ -481,7 +481,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
           !gateways[subtaskIndex].isEmpty(),
-          "Coordinator of %s subtask %d is not ready yet to receive events",
+          "Coordinator of %s subtask %s is not ready yet to receive events",
           operatorName,
           subtaskIndex);
       return Iterables.getOnlyElement(gateways[subtaskIndex].values());

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
@@ -226,7 +226,7 @@ abstract class BaseCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways.containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for (#%d)",
+          "Coordinator of %s already has a subtask gateway for (#%s)",
           operatorName,
           attemptNumber);
       LOG.debug("Coordinator of {} registers gateway for attempt {}", operatorName, attemptNumber);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -457,7 +457,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways[subtaskIndex].containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for %d (#%d)",
+          "Coordinator of %s already has a subtask gateway for %s (#%s)",
           operatorName,
           subtaskIndex,
           attemptNumber);
@@ -481,7 +481,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
           !gateways[subtaskIndex].isEmpty(),
-          "Coordinator of %s subtask %d is not ready yet to receive events",
+          "Coordinator of %s subtask %s is not ready yet to receive events",
           operatorName,
           subtaskIndex);
       return Iterables.getOnlyElement(gateways[subtaskIndex].values());

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/BaseCoordinator.java
@@ -226,7 +226,7 @@ abstract class BaseCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways.containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for (#%d)",
+          "Coordinator of %s already has a subtask gateway for (#%s)",
           operatorName,
           attemptNumber);
       LOG.debug("Coordinator of {} registers gateway for attempt {}", operatorName, attemptNumber);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/DataStatisticsCoordinator.java
@@ -457,7 +457,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
       int attemptNumber = gateway.getExecution().getAttemptNumber();
       Preconditions.checkState(
           !gateways[subtaskIndex].containsKey(attemptNumber),
-          "Coordinator of %s already has a subtask gateway for %d (#%d)",
+          "Coordinator of %s already has a subtask gateway for %s (#%s)",
           operatorName,
           subtaskIndex,
           attemptNumber);
@@ -481,7 +481,7 @@ class DataStatisticsCoordinator implements OperatorCoordinator {
     private OperatorCoordinator.SubtaskGateway getSubtaskGateway(int subtaskIndex) {
       Preconditions.checkState(
           !gateways[subtaskIndex].isEmpty(),
-          "Coordinator of %s subtask %d is not ready yet to receive events",
+          "Coordinator of %s subtask %s is not ready yet to receive events",
           operatorName,
           subtaskIndex);
       return Iterables.getOnlyElement(gateways[subtaskIndex].values());


### PR DESCRIPTION
The guava `Preconditions.checkState` method only supports the `%s` placeholder.

This PR replaces invalid patterns and adds a new checkstyle rule similar to the existing `checkArgument` rule. 

https://github.com/apache/iceberg/blob/1802dbfada36bc281ce70669d88c6e00c85e70fc/.baseline/checkstyle/checkstyle.xml#L85-L90