### PR TITLE
Core: Refactor v4 struct builders to improve validation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -165,7 +165,7 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
 
     Builder cardinality(long dvCardinality) {
       Preconditions.checkArgument(
-          dvCardinality > 0, "Invalid cardinality: %s (must be positive)", dvCardinality);
+          dvCardinality >= 0, "Invalid cardinality: %s (must be >= 0)", dvCardinality);
       this.cardinality = dvCardinality;
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -51,7 +51,7 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
   }
 
   private DeletionVectorStruct(String location, long offset, long sizeInBytes, long cardinality) {
-    super(BASE_TYPE, BASE_TYPE);
+    super(BASE_TYPE.fields().size());
     this.location = location;
     this.offset = offset;
     this.sizeInBytes = sizeInBytes;
@@ -140,37 +140,41 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
 
   static class Builder {
     private String location = null;
-    private long offset = -1L;
-    private long sizeInBytes = -1L;
-    private long cardinality = -1L;
+    private Long offset = null;
+    private Long sizeInBytes = null;
+    private Long cardinality = null;
 
     Builder location(String dvLocation) {
+      Preconditions.checkArgument(dvLocation != null, "Invalid location: null");
       this.location = dvLocation;
       return this;
     }
 
     Builder offset(long dvOffset) {
+      Preconditions.checkArgument(dvOffset >= 0, "Invalid offset: %s (must be >= 0)", dvOffset);
       this.offset = dvOffset;
       return this;
     }
 
     Builder sizeInBytes(long dvSizeInBytes) {
+      Preconditions.checkArgument(
+          dvSizeInBytes >= 0, "Invalid size in bytes: %s (must be >= 0)", dvSizeInBytes);
       this.sizeInBytes = dvSizeInBytes;
       return this;
     }
 
     Builder cardinality(long dvCardinality) {
+      Preconditions.checkArgument(
+          dvCardinality > 0, "Invalid cardinality: %s (must be positive)", dvCardinality);
       this.cardinality = dvCardinality;
       return this;
     }
 
     DeletionVectorStruct build() {
-      Preconditions.checkArgument(location != null, "Invalid location: null");
-      Preconditions.checkArgument(offset >= 0, "Invalid offset: %s (must be >= 0)", offset);
-      Preconditions.checkArgument(
-          sizeInBytes >= 0, "Invalid size in bytes: %s (must be >= 0)", sizeInBytes);
-      Preconditions.checkArgument(
-          cardinality >= 0, "Invalid cardinality: %s (must be >= 0)", cardinality);
+      Preconditions.checkArgument(location != null, "Missing required value: location");
+      Preconditions.checkArgument(offset != null, "Missing required value: offset");
+      Preconditions.checkArgument(sizeInBytes != null, "Missing required value: size in bytes");
+      Preconditions.checkArgument(cardinality != null, "Missing required value: cardinality");
       return new DeletionVectorStruct(location, offset, sizeInBytes, cardinality);
     }
   }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -339,7 +339,7 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
 
     Builder dvCardinality(long cardinality) {
       Preconditions.checkArgument(
-          cardinality > 0, "Invalid DV cardinality: %s (must be positive)", cardinality);
+          cardinality >= 0, "Invalid DV cardinality: %s (must be >= 0)", cardinality);
       this.dvCardinality = cardinality;
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -74,7 +74,7 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
     this.dvCardinality = toCopy.dvCardinality;
   }
 
-  private ManifestInfoStruct(
+  ManifestInfoStruct(
       int addedFilesCount,
       int existingFilesCount,
       int deletedFilesCount,

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -252,7 +252,7 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
         .add("replaced_rows_count", replacedRowsCount)
         .add("min_sequence_number", minSequenceNumber)
         .add("dv", dv == null ? "null" : "(binary)")
-        .add("dv_cardinality", dvCardinality == null ? "null" : dvCardinality)
+        .add("dv_cardinality", dvCardinality)
         .toString();
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -86,7 +86,7 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
       long minSequenceNumber,
       byte[] dv,
       Long dvCardinality) {
-    super(BASE_TYPE, BASE_TYPE);
+    super(BASE_TYPE.fields().size());
     this.addedFilesCount = addedFilesCount;
     this.existingFilesCount = existingFilesCount;
     this.deletedFilesCount = deletedFilesCount;
@@ -257,116 +257,135 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
   }
 
   static class Builder {
-    private int addedFilesCount = -1;
-    private int existingFilesCount = -1;
-    private int deletedFilesCount = -1;
-    private int replacedFilesCount = -1;
-    private long addedRowsCount = -1L;
-    private long existingRowsCount = -1L;
-    private long deletedRowsCount = -1L;
-    private long replacedRowsCount = -1L;
-    private long minSequenceNumber = -1L;
+    private Integer addedFilesCount = null;
+    private Integer existingFilesCount = null;
+    private Integer deletedFilesCount = null;
+    private Integer replacedFilesCount = null;
+    private Long addedRowsCount = null;
+    private Long existingRowsCount = null;
+    private Long deletedRowsCount = null;
+    private Long replacedRowsCount = null;
+    private Long minSequenceNumber = null;
     private byte[] dv = null;
     private Long dvCardinality = null;
 
     Builder addedFilesCount(int count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid added files count: %s (must be >= 0)", count);
       this.addedFilesCount = count;
       return this;
     }
 
     Builder existingFilesCount(int count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid existing files count: %s (must be >= 0)", count);
       this.existingFilesCount = count;
       return this;
     }
 
     Builder deletedFilesCount(int count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid deleted files count: %s (must be >= 0)", count);
       this.deletedFilesCount = count;
       return this;
     }
 
     Builder replacedFilesCount(int count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid replaced files count: %s (must be >= 0)", count);
       this.replacedFilesCount = count;
       return this;
     }
 
     Builder addedRowsCount(long count) {
+      Preconditions.checkArgument(count >= 0, "Invalid added rows count: %s (must be >= 0)", count);
       this.addedRowsCount = count;
       return this;
     }
 
     Builder existingRowsCount(long count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid existing rows count: %s (must be >= 0)", count);
       this.existingRowsCount = count;
       return this;
     }
 
     Builder deletedRowsCount(long count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid deleted rows count: %s (must be >= 0)", count);
       this.deletedRowsCount = count;
       return this;
     }
 
     Builder replacedRowsCount(long count) {
+      Preconditions.checkArgument(
+          count >= 0, "Invalid replaced rows count: %s (must be >= 0)", count);
       this.replacedRowsCount = count;
       return this;
     }
 
     Builder minSequenceNumber(long sequenceNumber) {
+      Preconditions.checkArgument(
+          sequenceNumber >= 0, "Invalid min sequence number: %s (must be >= 0)", sequenceNumber);
       this.minSequenceNumber = sequenceNumber;
       return this;
     }
 
     Builder dv(ByteBuffer buffer) {
-      this.dv = buffer != null ? ByteBuffers.toByteArray(buffer) : null;
+      Preconditions.checkArgument(buffer != null, "Invalid DV: null");
+      this.dv = ByteBuffers.toByteArray(buffer);
       return this;
     }
 
-    Builder dv(byte[] buffer) {
-      this.dv = buffer;
-      return this;
-    }
-
-    Builder dvCardinality(Long cardinality) {
+    Builder dvCardinality(long cardinality) {
+      Preconditions.checkArgument(
+          cardinality > 0, "Invalid DV cardinality: %s (must be positive)", cardinality);
       this.dvCardinality = cardinality;
       return this;
     }
 
     ManifestInfoStruct build() {
       Preconditions.checkArgument(
-          addedFilesCount >= 0, "Invalid added files count: %s (must be >= 0)", addedFilesCount);
+          addedFilesCount != null, "Missing required value: added files count");
       Preconditions.checkArgument(
-          existingFilesCount >= 0,
-          "Invalid existing files count: %s (must be >= 0)",
+          existingFilesCount != null, "Missing required value: existing files count");
+      Preconditions.checkArgument(
+          deletedFilesCount != null, "Missing required value: deleted files count");
+      Preconditions.checkArgument(
+          replacedFilesCount != null, "Missing required value: replaced files count");
+      Preconditions.checkArgument(
+          addedRowsCount != null, "Missing required value: added rows count");
+      Preconditions.checkArgument(
+          existingRowsCount != null, "Missing required value: existing rows count");
+      Preconditions.checkArgument(
+          deletedRowsCount != null, "Missing required value: deleted rows count");
+      Preconditions.checkArgument(
+          replacedRowsCount != null, "Missing required value: replaced rows count");
+      Preconditions.checkArgument(
+          minSequenceNumber != null, "Missing required value: min sequence number");
+      Preconditions.checkArgument(
+          addedRowsCount == 0 || addedFilesCount > 0,
+          "Invalid added counts: %s rows in %s files",
+          addedRowsCount,
+          addedFilesCount);
+      Preconditions.checkArgument(
+          existingRowsCount == 0 || existingFilesCount > 0,
+          "Invalid existing counts: %s rows in %s files",
+          existingRowsCount,
           existingFilesCount);
       Preconditions.checkArgument(
-          deletedFilesCount >= 0,
-          "Invalid deleted files count: %s (must be >= 0)",
+          deletedRowsCount == 0 || deletedFilesCount > 0,
+          "Invalid deleted counts: %s rows in %s files",
+          deletedRowsCount,
           deletedFilesCount);
       Preconditions.checkArgument(
-          replacedFilesCount >= 0,
-          "Invalid replaced files count: %s (must be >= 0)",
+          replacedRowsCount == 0 || replacedFilesCount > 0,
+          "Invalid replaced counts: %s rows in %s files",
+          replacedRowsCount,
           replacedFilesCount);
-      Preconditions.checkArgument(
-          addedRowsCount >= 0, "Invalid added rows count: %s (must be >= 0)", addedRowsCount);
-      Preconditions.checkArgument(
-          existingRowsCount >= 0,
-          "Invalid existing rows count: %s (must be >= 0)",
-          existingRowsCount);
-      Preconditions.checkArgument(
-          deletedRowsCount >= 0, "Invalid deleted rows count: %s (must be >= 0)", deletedRowsCount);
-      Preconditions.checkArgument(
-          replacedRowsCount >= 0,
-          "Invalid replaced rows count: %s (must be >= 0)",
-          replacedRowsCount);
-      Preconditions.checkArgument(
-          minSequenceNumber >= 0,
-          "Invalid min sequence number: %s (must be >= 0)",
-          minSequenceNumber);
       Preconditions.checkArgument(
           (dv == null) == (dvCardinality == null),
           "Invalid DV and cardinality: must both be null or non-null");
-      Preconditions.checkArgument(
-          dvCardinality == null || dvCardinality > 0,
-          "Invalid DV cardinality: %s (must be positive)",
-          dvCardinality);
       return new ManifestInfoStruct(
           addedFilesCount,
           existingFilesCount,

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -115,10 +115,4 @@ interface Tracking {
 
   /** Copies this tracking information. */
   Tracking copy();
-
-  /** Returns a DELETED tracking row derived from this one in the given snapshot. */
-  Tracking asDeleted(long currentSnapshotId);
-
-  /** Returns a REPLACED tracking row derived from this one in the given snapshot. */
-  Tracking asReplaced(long currentSnapshotId);
 }

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -115,4 +115,10 @@ interface Tracking {
 
   /** Copies this tracking information. */
   Tracking copy();
+
+  /** Returns a DELETED tracking row derived from this one in the given snapshot. */
+  Tracking asDeleted(long currentSnapshotId);
+
+  /** Returns a REPLACED tracking row derived from this one in the given snapshot. */
+  Tracking asReplaced(long currentSnapshotId);
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -47,13 +47,7 @@ class TrackingBuilder {
     this.replacedPositions = null;
   }
 
-  /**
-   * Constructs a builder derived from {@code source} at the current snapshot.
-   *
-   * <p>Without MODIFIED, output status is always EXISTING and {@code currentSnapshotId} is used
-   * only for {@link #dvUpdated()} stamping. When MODIFIED lands, status will be derived from the
-   * source, snapshot equality, and which mutation methods are called.
-   */
+  /** Constructs a builder derived from {@code source} at the current snapshot. */
   // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
   TrackingBuilder(Tracking source, long currentSnapshotId) {
     validateSource(source);

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -88,7 +88,7 @@ class TrackingBuilder {
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
-    this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+    this.deletedPositions = ByteBuffers.toByteArray(positions);
     return this;
   }
 
@@ -100,7 +100,7 @@ class TrackingBuilder {
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
-    this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+    this.replacedPositions = ByteBuffers.toByteArray(positions);
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -49,7 +49,7 @@ class TrackingBuilder {
    * @param source source tracking from a manifest entry
    * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
    */
-  static TrackingBuilder builder(Tracking source, long newSnapshotId) {
+  static TrackingBuilder from(Tracking source, long newSnapshotId) {
     return new TrackingBuilder(source, newSnapshotId);
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -28,17 +28,55 @@ class TrackingBuilder {
   private final Long dataSequenceNumber;
   private final Long fileSequenceNumber;
   private final Long firstRowId;
-  // Snapshot used to stamp dv_snapshot_id when dvUpdated() is called.
-  private final long currentSnapshotId;
+  // ID of the snapshot in which the new Tracking instance will be committed.
+  private final long newSnapshotId;
   private Long dvSnapshotId;
   private byte[] deletedPositions;
   private byte[] replacedPositions;
 
-  /** Constructs a builder for a fresh ADDED entry in the given snapshot. */
-  TrackingBuilder(long snapshotId) {
+  /**
+   * Creates a builder for a newly added file.
+   *
+   * @param snapshotId the snapshot ID in which the new tracking instance will be committed
+   */
+  static TrackingBuilder added(long snapshotId) {
+    return new TrackingBuilder(snapshotId);
+  }
+
+  /**
+   * Creates a builder for a tracking row derived from {@code source}.
+   *
+   * @param source source tracking from a manifest entry
+   * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
+   */
+  static TrackingBuilder builder(Tracking source, long newSnapshotId) {
+    return new TrackingBuilder(source, newSnapshotId);
+  }
+
+  /**
+   * Returns a DELETED tracking row derived from {@code source}.
+   *
+   * @param source source tracking from a manifest entry
+   * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
+   */
+  static Tracking delete(Tracking source, long newSnapshotId) {
+    return terminal(EntryStatus.DELETED, source, newSnapshotId);
+  }
+
+  /**
+   * Returns a REPLACED tracking row derived from {@code source}.
+   *
+   * @param source source tracking from a manifest entry
+   * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
+   */
+  static Tracking replace(Tracking source, long newSnapshotId) {
+    return terminal(EntryStatus.REPLACED, source, newSnapshotId);
+  }
+
+  private TrackingBuilder(long snapshotId) {
     this.status = EntryStatus.ADDED;
     this.snapshotId = snapshotId;
-    this.currentSnapshotId = snapshotId;
+    this.newSnapshotId = snapshotId;
     this.dataSequenceNumber = null;
     this.fileSequenceNumber = null;
     this.firstRowId = null;
@@ -47,14 +85,12 @@ class TrackingBuilder {
     this.replacedPositions = null;
   }
 
-  /** Constructs a builder derived from {@code source} at the current snapshot. */
-  // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
-  TrackingBuilder(Tracking source, long currentSnapshotId) {
+  private TrackingBuilder(Tracking source, long newSnapshotId) {
     validateSource(source);
     checkStatus(source.status(), EntryStatus.EXISTING);
     this.status = EntryStatus.EXISTING;
     this.snapshotId = source.snapshotId();
-    this.currentSnapshotId = currentSnapshotId;
+    this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = source.dataSequenceNumber();
     this.fileSequenceNumber = source.fileSequenceNumber();
     this.firstRowId = source.firstRowId();
@@ -63,18 +99,16 @@ class TrackingBuilder {
     this.replacedPositions = null;
   }
 
-  /** Stamps {@code dv_snapshot_id} with the builder's current snapshot. */
-  // TODO: revisit when MODIFIED status is added; this should also flip the status to MODIFIED.
+  /** Indicates that the DV has been updated for the new Tracking. */
   TrackingBuilder dvUpdated() {
     // DV applies to data files; deleted/replaced positions apply to manifest files
     Preconditions.checkState(
         deletedPositions == null && replacedPositions == null,
         "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
-    this.dvSnapshotId = currentSnapshotId;
+    this.dvSnapshotId = newSnapshotId;
     return this;
   }
 
-  // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
   TrackingBuilder deletedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
@@ -86,7 +120,6 @@ class TrackingBuilder {
     return this;
   }
 
-  // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
   TrackingBuilder replacedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
@@ -110,13 +143,12 @@ class TrackingBuilder {
         replacedPositions);
   }
 
-  /** Returns a terminal (DELETED or REPLACED) tracking row derived from {@code source}. */
-  static Tracking terminal(EntryStatus to, Tracking source, long currentSnapshotId) {
+  private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {
     validateSource(source);
     checkStatus(source.status(), to);
     return new TrackingStruct(
         to,
-        currentSnapshotId,
+        newSnapshotId,
         source.dataSequenceNumber(),
         source.fileSequenceNumber(),
         source.dvSnapshotId(),
@@ -135,28 +167,13 @@ class TrackingBuilder {
         "Invalid tracking source: file sequence number is null");
   }
 
-  // TODO: extend allowed transitions once MODIFIED status is added.
   private static void checkStatus(EntryStatus from, EntryStatus to) {
     Preconditions.checkState(from != null, "Invalid tracking source: status is null");
-    switch (from) {
-      case ADDED:
-        Preconditions.checkState(
-            to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
-            "Invalid status transition: ADDED -> %s (ADDED is the starting status)",
-            to);
-        break;
-      case EXISTING:
-        Preconditions.checkState(
-            to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
-            "Invalid status transition: EXISTING -> %s",
-            to);
-        break;
-      case DELETED:
-      case REPLACED:
-        throw new IllegalStateException(
-            String.format("Invalid status transition: %s -> %s (%s is terminal)", from, to, from));
-      default:
-        throw new IllegalStateException(String.format("Unknown source status: %s", from));
-    }
+    Preconditions.checkState(
+        from != EntryStatus.DELETED && from != EntryStatus.REPLACED,
+        "Cannot revive non-live entry with status %s",
+        from);
+    Preconditions.checkState(
+        to != EntryStatus.ADDED, "Cannot transition to ADDED: ADDED is the starting status");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -37,10 +37,10 @@ class TrackingBuilder {
   /**
    * Creates a builder for a newly added file.
    *
-   * @param snapshotId the snapshot ID in which the new tracking instance will be committed
+   * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
    */
-  static TrackingBuilder added(long snapshotId) {
-    return new TrackingBuilder(snapshotId);
+  static TrackingBuilder added(long newSnapshotId) {
+    return new TrackingBuilder(newSnapshotId);
   }
 
   /**
@@ -73,10 +73,10 @@ class TrackingBuilder {
     return terminal(EntryStatus.REPLACED, source, newSnapshotId);
   }
 
-  private TrackingBuilder(long snapshotId) {
+  private TrackingBuilder(long newSnapshotId) {
     this.status = EntryStatus.ADDED;
-    this.snapshotId = snapshotId;
-    this.newSnapshotId = snapshotId;
+    this.snapshotId = newSnapshotId;
+    this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = null;
     this.fileSequenceNumber = null;
     this.firstRowId = null;

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ByteBuffers;
+
+class TrackingBuilder {
+  private final EntryStatus status;
+  private final Long snapshotId;
+  private final Long dataSequenceNumber;
+  private final Long fileSequenceNumber;
+  private final Long firstRowId;
+  // Snapshot used to stamp dv_snapshot_id when dvUpdated() is called.
+  private final long currentSnapshotId;
+  private Long dvSnapshotId;
+  private byte[] deletedPositions;
+  private byte[] replacedPositions;
+
+  /** Constructs a builder for a fresh ADDED entry in the given snapshot. */
+  TrackingBuilder(long snapshotId) {
+    this.status = EntryStatus.ADDED;
+    this.snapshotId = snapshotId;
+    this.currentSnapshotId = snapshotId;
+    this.dataSequenceNumber = null;
+    this.fileSequenceNumber = null;
+    this.firstRowId = null;
+    this.dvSnapshotId = null;
+    this.deletedPositions = null;
+    this.replacedPositions = null;
+  }
+
+  /**
+   * Constructs a builder derived from {@code source} at the current snapshot.
+   *
+   * <p>Without MODIFIED, output status is always EXISTING and {@code currentSnapshotId} is used
+   * only for {@link #dvUpdated()} stamping. When MODIFIED lands, status will be derived from the
+   * source, snapshot equality, and which mutation methods are called.
+   */
+  // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
+  TrackingBuilder(Tracking source, long currentSnapshotId) {
+    validateSource(source);
+    checkStatus(source.status(), EntryStatus.EXISTING);
+    this.status = EntryStatus.EXISTING;
+    this.snapshotId = source.snapshotId();
+    this.currentSnapshotId = currentSnapshotId;
+    this.dataSequenceNumber = source.dataSequenceNumber();
+    this.fileSequenceNumber = source.fileSequenceNumber();
+    this.firstRowId = source.firstRowId();
+    this.dvSnapshotId = source.dvSnapshotId();
+    this.deletedPositions = null;
+    this.replacedPositions = null;
+  }
+
+  /** Stamps {@code dv_snapshot_id} with the builder's current snapshot. */
+  // TODO: revisit when MODIFIED status is added; this should also flip the status to MODIFIED.
+  TrackingBuilder dvUpdated() {
+    // DV applies to data files; deleted/replaced positions apply to manifest files
+    Preconditions.checkState(
+        deletedPositions == null && replacedPositions == null,
+        "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
+    this.dvSnapshotId = currentSnapshotId;
+    return this;
+  }
+
+  // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
+  TrackingBuilder deletedPositions(ByteBuffer positions) {
+    Preconditions.checkState(
+        status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
+    // DV applies to data files; deleted positions apply to manifest files
+    Preconditions.checkState(
+        dvSnapshotId == null,
+        "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
+    this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+    return this;
+  }
+
+  // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
+  TrackingBuilder replacedPositions(ByteBuffer positions) {
+    Preconditions.checkState(
+        status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
+    // DV applies to data files; replaced positions apply to manifest files
+    Preconditions.checkState(
+        dvSnapshotId == null,
+        "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
+    this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
+    return this;
+  }
+
+  Tracking build() {
+    return new TrackingStruct(
+        status,
+        snapshotId,
+        dataSequenceNumber,
+        fileSequenceNumber,
+        dvSnapshotId,
+        firstRowId,
+        deletedPositions,
+        replacedPositions);
+  }
+
+  /** Returns a terminal (DELETED or REPLACED) tracking row derived from {@code source}. */
+  static Tracking terminal(EntryStatus to, Tracking source, long currentSnapshotId) {
+    validateSource(source);
+    checkStatus(source.status(), to);
+    return new TrackingStruct(
+        to,
+        currentSnapshotId,
+        source.dataSequenceNumber(),
+        source.fileSequenceNumber(),
+        source.dvSnapshotId(),
+        source.firstRowId(),
+        null,
+        null);
+  }
+
+  private static void validateSource(Tracking source) {
+    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
+    Preconditions.checkArgument(
+        source.dataSequenceNumber() != null,
+        "Invalid tracking source: data sequence number is null");
+    Preconditions.checkArgument(
+        source.fileSequenceNumber() != null,
+        "Invalid tracking source: file sequence number is null");
+  }
+
+  // TODO: extend allowed transitions once MODIFIED status is added.
+  private static void checkStatus(EntryStatus from, EntryStatus to) {
+    Preconditions.checkState(from != null, "Invalid tracking source: status is null");
+    switch (from) {
+      case ADDED:
+        Preconditions.checkState(
+            to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
+            "Invalid status transition: ADDED -> %s (ADDED is the starting status)",
+            to);
+        break;
+      case EXISTING:
+        Preconditions.checkState(
+            to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
+            "Invalid status transition: EXISTING -> %s",
+            to);
+        break;
+      case DELETED:
+      case REPLACED:
+        throw new IllegalStateException(
+            String.format("Invalid status transition: %s -> %s (%s is terminal)", from, to, from));
+      default:
+        throw new IllegalStateException(String.format("Unknown source status: %s", from));
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -59,7 +59,7 @@ class TrackingBuilder {
    * @param source source tracking from a manifest entry
    * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
    */
-  static Tracking delete(Tracking source, long newSnapshotId) {
+  static Tracking deleted(Tracking source, long newSnapshotId) {
     return terminal(EntryStatus.DELETED, source, newSnapshotId);
   }
 
@@ -69,7 +69,7 @@ class TrackingBuilder {
    * @param source source tracking from a manifest entry
    * @param newSnapshotId the snapshot ID in which the new tracking instance will be committed
    */
-  static Tracking replace(Tracking source, long newSnapshotId) {
+  static Tracking replaced(Tracking source, long newSnapshotId) {
     return terminal(EntryStatus.REPLACED, source, newSnapshotId);
   }
 
@@ -87,7 +87,7 @@ class TrackingBuilder {
 
   private TrackingBuilder(Tracking source, long newSnapshotId) {
     validateSource(source);
-    checkStatus(source.status(), EntryStatus.EXISTING);
+    validateStatusTransition(source.status(), EntryStatus.EXISTING);
     this.status = EntryStatus.EXISTING;
     this.snapshotId = source.snapshotId();
     this.newSnapshotId = newSnapshotId;
@@ -145,7 +145,7 @@ class TrackingBuilder {
 
   private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {
     validateSource(source);
-    checkStatus(source.status(), to);
+    validateStatusTransition(source.status(), to);
     return new TrackingStruct(
         to,
         newSnapshotId,
@@ -167,7 +167,7 @@ class TrackingBuilder {
         "Invalid tracking source: file sequence number is null");
   }
 
-  private static void checkStatus(EntryStatus from, EntryStatus to) {
+  private static void validateStatusTransition(EntryStatus from, EntryStatus to) {
     Preconditions.checkState(from != null, "Invalid tracking source: status is null");
     Preconditions.checkState(
         from != EntryStatus.DELETED && from != EntryStatus.REPLACED,

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -261,19 +261,16 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
   /** Creates a builder for an existing file based on tracking read from a manifest. */
   static Builder existing(Tracking source) {
-    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
     return new Builder(source);
   }
 
   /** Creates a builder for a deleted file in the given snapshot. */
   static Builder deleted(Tracking source, long snapshotId) {
-    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
     return new Builder(EntryStatus.DELETED, source, snapshotId);
   }
 
   /** Creates a builder for a replaced file in the given snapshot. */
   static Builder replaced(Tracking source, long snapshotId) {
-    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
     return new Builder(EntryStatus.REPLACED, source, snapshotId);
   }
 
@@ -312,10 +309,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
 
     private Builder(Tracking source) {
-      this(EntryStatus.EXISTING, source, source.snapshotId());
+      this(EntryStatus.EXISTING, source, source == null ? null : source.snapshotId());
     }
 
     private Builder(EntryStatus status, Tracking source, Long snapshotId) {
+      Preconditions.checkArgument(source != null, "Invalid source tracking: null");
       Preconditions.checkArgument(
           source.dataSequenceNumber() != null,
           "Invalid tracking source: data sequence number is null");
@@ -335,24 +333,47 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
     // TODO: extend allowed transitions once MODIFIED status is added.
     private static void checkStatus(EntryStatus from, EntryStatus to) {
-      Preconditions.checkArgument(from != null, "Invalid tracking source: status is null");
-      Preconditions.checkArgument(
-          from == EntryStatus.ADDED || from == EntryStatus.EXISTING,
-          "Cannot transition from %s status",
-          from);
-      Preconditions.checkArgument(
-          to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
-          "Cannot transition to %s status",
-          to);
-      Preconditions.checkArgument(from != to, "Invalid status transition: %s -> %s", from, to);
+      Preconditions.checkState(from != null, "Invalid tracking source: status is null");
+      switch (from) {
+        case ADDED:
+          Preconditions.checkState(
+              to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
+              "Invalid status transition: ADDED -> %s (ADDED is the starting status)",
+              to);
+          break;
+        case EXISTING:
+          Preconditions.checkState(
+              to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
+              "Invalid status transition: EXISTING -> %s",
+              to);
+          break;
+        case DELETED:
+        case REPLACED:
+          throw new IllegalStateException(
+              String.format(
+                  "Invalid status transition: %s -> %s (%s is terminal)", from, to, from));
+        default:
+          throw new IllegalStateException(String.format("Unknown source status: %s", from));
+      }
     }
 
     Builder dvSnapshotId(long id) {
-      Preconditions.checkState(
-          status != EntryStatus.DELETED, "Cannot set dv snapshot ID on DELETED entry");
+      // DV applies to data files; deleted/replaced positions apply to manifest files
       Preconditions.checkState(
           deletedPositions == null && replacedPositions == null,
-          "Cannot set dv snapshot ID with manifest delete vector positions");
+          "Cannot set DV snapshot ID on a manifest entry (deleted/replaced positions are set)");
+      Preconditions.checkState(
+          status == EntryStatus.ADDED || status == EntryStatus.EXISTING,
+          "Cannot set DV snapshot ID on %s entry",
+          status);
+      if (status == EntryStatus.ADDED) {
+        Preconditions.checkArgument(
+            id == snapshotId,
+            "Invalid DV snapshot ID for ADDED entry: %s (must equal entry snapshot ID %s)",
+            id,
+            snapshotId);
+      }
+
       this.dvSnapshotId = id;
       return this;
     }
@@ -361,8 +382,10 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     Builder deletedPositions(ByteBuffer positions) {
       Preconditions.checkState(
           status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
+      // DV applies to data files; deleted positions apply to manifest files
       Preconditions.checkState(
-          dvSnapshotId == null, "Cannot set deleted positions with dv snapshot ID");
+          dvSnapshotId == null,
+          "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
       this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }
@@ -371,8 +394,10 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     Builder replacedPositions(ByteBuffer positions) {
       Preconditions.checkState(
           status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
+      // DV applies to data files; replaced positions apply to manifest files
       Preconditions.checkState(
-          dvSnapshotId == null, "Cannot set replaced positions with dv snapshot ID");
+          dvSnapshotId == null,
+          "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
       this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -349,7 +349,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
     Builder dvSnapshotId(long id) {
       Preconditions.checkState(
-          status != EntryStatus.DELETED, "Cannot set dv snapshot ID on a DELETED entry");
+          status != EntryStatus.DELETED, "Cannot set dv snapshot ID on DELETED entry");
       Preconditions.checkState(
           deletedPositions == null && replacedPositions == null,
           "Cannot set dv snapshot ID with manifest delete vector positions");
@@ -360,7 +360,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
     Builder deletedPositions(ByteBuffer positions) {
       Preconditions.checkState(
-          status == EntryStatus.EXISTING, "Cannot set deleted positions on a %s entry", status);
+          status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
       Preconditions.checkState(
           dvSnapshotId == null, "Cannot set deleted positions with dv snapshot ID");
       this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
@@ -370,7 +370,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
     Builder replacedPositions(ByteBuffer positions) {
       Preconditions.checkState(
-          status == EntryStatus.EXISTING, "Cannot set replaced positions on a %s entry", status);
+          status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
       Preconditions.checkState(
           dvSnapshotId == null, "Cannot set replaced positions with dv snapshot ID");
       this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -259,12 +259,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     return new TrackingBuilder(snapshotId);
   }
 
-  /**
-   * Creates a builder for a tracking row derived from {@code source} at the current snapshot.
-   *
-   * <p>Without MODIFIED status, this produces an EXISTING row. Once MODIFIED lands, the status will
-   * be auto-derived from the source, the snapshot, and which mutation methods are called.
-   */
+  /** Creates a builder for a tracking row derived from {@code source} at the current snapshot. */
   // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
   static TrackingBuilder builder(Tracking source, long currentSnapshotId) {
     return new TrackingBuilder(source, currentSnapshotId);

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -84,7 +84,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     this.manifestPos = toCopy.manifestPos;
   }
 
-  private TrackingStruct(
+  TrackingStruct(
       EntryStatus status,
       Long snapshotId,
       Long dataSequenceNumber,
@@ -255,23 +255,29 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   }
 
   /** Creates a builder for a newly added file in the given snapshot. */
-  static Builder added(long snapshotId) {
-    return new Builder(snapshotId);
+  static TrackingBuilder added(long snapshotId) {
+    return new TrackingBuilder(snapshotId);
   }
 
-  /** Creates a builder for an existing file based on tracking read from a manifest. */
-  static Builder existing(Tracking source) {
-    return new Builder(source);
+  /**
+   * Creates a builder for a tracking row derived from {@code source} at the current snapshot.
+   *
+   * <p>Without MODIFIED status, this produces an EXISTING row. Once MODIFIED lands, the status will
+   * be auto-derived from the source, the snapshot, and which mutation methods are called.
+   */
+  // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
+  static TrackingBuilder builder(Tracking source, long currentSnapshotId) {
+    return new TrackingBuilder(source, currentSnapshotId);
   }
 
-  /** Creates a builder for a deleted file in the given snapshot. */
-  static Builder deleted(Tracking source, long snapshotId) {
-    return new Builder(EntryStatus.DELETED, source, snapshotId);
+  @Override
+  public Tracking asDeleted(long currentSnapshotId) {
+    return TrackingBuilder.terminal(EntryStatus.DELETED, this, currentSnapshotId);
   }
 
-  /** Creates a builder for a replaced file in the given snapshot. */
-  static Builder replaced(Tracking source, long snapshotId) {
-    return new Builder(EntryStatus.REPLACED, source, snapshotId);
+  @Override
+  public Tracking asReplaced(long currentSnapshotId) {
+    return TrackingBuilder.terminal(EntryStatus.REPLACED, this, currentSnapshotId);
   }
 
   @Override
@@ -286,132 +292,5 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
         .add("deleted_positions", deletedPositions == null ? "null" : "(binary)")
         .add("replaced_positions", replacedPositions == null ? "null" : "(binary)")
         .toString();
-  }
-
-  static class Builder {
-    private final EntryStatus status;
-    private final Long snapshotId;
-    private final Long dataSequenceNumber;
-    private final Long fileSequenceNumber;
-    private final Long firstRowId;
-    private Long dvSnapshotId;
-    private byte[] deletedPositions;
-    private byte[] replacedPositions;
-
-    private Builder(long snapshotId) {
-      this.status = EntryStatus.ADDED;
-      this.snapshotId = snapshotId;
-      this.dataSequenceNumber = null;
-      this.fileSequenceNumber = null;
-      this.firstRowId = null;
-      this.deletedPositions = null;
-      this.replacedPositions = null;
-    }
-
-    private Builder(Tracking source) {
-      this(EntryStatus.EXISTING, source, source == null ? null : source.snapshotId());
-    }
-
-    private Builder(EntryStatus status, Tracking source, Long snapshotId) {
-      Preconditions.checkArgument(source != null, "Invalid source tracking: null");
-      Preconditions.checkArgument(
-          source.dataSequenceNumber() != null,
-          "Invalid tracking source: data sequence number is null");
-      Preconditions.checkArgument(
-          source.fileSequenceNumber() != null,
-          "Invalid tracking source: file sequence number is null");
-      checkStatus(source.status(), status);
-      this.status = status;
-      this.snapshotId = snapshotId;
-      this.dataSequenceNumber = source.dataSequenceNumber();
-      this.fileSequenceNumber = source.fileSequenceNumber();
-      this.firstRowId = source.firstRowId();
-      this.dvSnapshotId = source.dvSnapshotId();
-      this.deletedPositions = null;
-      this.replacedPositions = null;
-    }
-
-    // TODO: extend allowed transitions once MODIFIED status is added.
-    private static void checkStatus(EntryStatus from, EntryStatus to) {
-      Preconditions.checkState(from != null, "Invalid tracking source: status is null");
-      switch (from) {
-        case ADDED:
-          Preconditions.checkState(
-              to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
-              "Invalid status transition: ADDED -> %s (ADDED is the starting status)",
-              to);
-          break;
-        case EXISTING:
-          Preconditions.checkState(
-              to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
-              "Invalid status transition: EXISTING -> %s",
-              to);
-          break;
-        case DELETED:
-        case REPLACED:
-          throw new IllegalStateException(
-              String.format(
-                  "Invalid status transition: %s -> %s (%s is terminal)", from, to, from));
-        default:
-          throw new IllegalStateException(String.format("Unknown source status: %s", from));
-      }
-    }
-
-    Builder dvSnapshotId(long id) {
-      // DV applies to data files; deleted/replaced positions apply to manifest files
-      Preconditions.checkState(
-          deletedPositions == null && replacedPositions == null,
-          "Cannot set DV snapshot ID on a manifest entry (deleted/replaced positions are set)");
-      Preconditions.checkState(
-          status == EntryStatus.ADDED || status == EntryStatus.EXISTING,
-          "Cannot set DV snapshot ID on %s entry",
-          status);
-      if (status == EntryStatus.ADDED) {
-        Preconditions.checkArgument(
-            id == snapshotId,
-            "Invalid DV snapshot ID for ADDED entry: %s (must equal entry snapshot ID %s)",
-            id,
-            snapshotId);
-      }
-
-      this.dvSnapshotId = id;
-      return this;
-    }
-
-    // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
-    Builder deletedPositions(ByteBuffer positions) {
-      Preconditions.checkState(
-          status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
-      // DV applies to data files; deleted positions apply to manifest files
-      Preconditions.checkState(
-          dvSnapshotId == null,
-          "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
-      this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
-      return this;
-    }
-
-    // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
-    Builder replacedPositions(ByteBuffer positions) {
-      Preconditions.checkState(
-          status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
-      // DV applies to data files; replaced positions apply to manifest files
-      Preconditions.checkState(
-          dvSnapshotId == null,
-          "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
-      this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
-      return this;
-    }
-
-    TrackingStruct build() {
-      return new TrackingStruct(
-          status,
-          snapshotId,
-          dataSequenceNumber,
-          fileSequenceNumber,
-          dvSnapshotId,
-          firstRowId,
-          deletedPositions,
-          replacedPositions);
-    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -254,27 +254,6 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
   }
 
-  /** Creates a builder for a newly added file in the given snapshot. */
-  static TrackingBuilder added(long snapshotId) {
-    return new TrackingBuilder(snapshotId);
-  }
-
-  /** Creates a builder for a tracking row derived from {@code source} at the current snapshot. */
-  // TODO: when MODIFIED is added, derive status from source + currentSnapshotId + mutations.
-  static TrackingBuilder builder(Tracking source, long currentSnapshotId) {
-    return new TrackingBuilder(source, currentSnapshotId);
-  }
-
-  @Override
-  public Tracking asDeleted(long currentSnapshotId) {
-    return TrackingBuilder.terminal(EntryStatus.DELETED, this, currentSnapshotId);
-  }
-
-  @Override
-  public Tracking asReplaced(long currentSnapshotId) {
-    return TrackingBuilder.terminal(EntryStatus.REPLACED, this, currentSnapshotId);
-  }
-
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -59,6 +59,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     super(BASE_TYPE, type);
   }
 
+  /** Constructor for Java serialization. */
+  TrackingStruct() {
+    super(BASE_TYPE.fields().size());
+  }
+
   private TrackingStruct(TrackingStruct toCopy) {
     super(toCopy);
     this.status = toCopy.status;
@@ -88,7 +93,7 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
       Long firstRowId,
       byte[] deletedPositions,
       byte[] replacedPositions) {
-    super(BASE_TYPE, BASE_TYPE);
+    super(BASE_TYPE.fields().size());
     this.status = status;
     this.snapshotId = snapshotId;
     this.dataSequenceNumber = dataSequenceNumber;
@@ -249,8 +254,21 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     }
   }
 
-  static Builder builder() {
-    return new Builder();
+  /** Creates a builder for a newly added file in the given snapshot. */
+  static Builder added(long snapshotId) {
+    return new Builder(EntryStatus.ADDED, snapshotId);
+  }
+
+  /** Creates a builder for an existing file based on tracking read from a manifest. */
+  static Builder existing(Tracking source) {
+    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
+    return new Builder(EntryStatus.EXISTING, source, source.snapshotId());
+  }
+
+  /** Creates a builder for a deleted file in the given snapshot. */
+  static Builder deleted(Tracking source, long snapshotId) {
+    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
+    return new Builder(EntryStatus.DELETED, source, snapshotId);
   }
 
   @Override
@@ -268,67 +286,67 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   }
 
   static class Builder {
-    private EntryStatus status = null;
-    private Long snapshotId = null;
-    private Long dataSequenceNumber = null;
-    private Long fileSequenceNumber = null;
-    private Long dvSnapshotId = null;
-    private Long firstRowId = null;
-    private byte[] deletedPositions = null;
-    private byte[] replacedPositions = null;
+    private final EntryStatus status;
+    private final Long snapshotId;
+    private final Long dataSequenceNumber;
+    private final Long fileSequenceNumber;
+    private final Long firstRowId;
+    private Long dvSnapshotId;
+    private byte[] deletedPositions;
+    private byte[] replacedPositions;
 
-    Builder status(EntryStatus entryStatus) {
-      this.status = entryStatus;
-      return this;
+    private Builder(EntryStatus status, long snapshotId) {
+      this.status = status;
+      this.snapshotId = snapshotId;
+      this.dataSequenceNumber = null;
+      this.fileSequenceNumber = null;
+      this.firstRowId = null;
     }
 
-    Builder snapshotId(Long id) {
-      this.snapshotId = id;
-      return this;
+    private Builder(EntryStatus status, Tracking source, Long snapshotId) {
+      Preconditions.checkArgument(
+          source.dataSequenceNumber() != null,
+          "Source tracking has no data sequence number; cannot mark as %s",
+          status);
+      Preconditions.checkArgument(
+          source.fileSequenceNumber() != null,
+          "Source tracking has no file sequence number; cannot mark as %s",
+          status);
+      this.status = status;
+      this.snapshotId = snapshotId;
+      this.dataSequenceNumber = source.dataSequenceNumber();
+      this.fileSequenceNumber = source.fileSequenceNumber();
+      this.firstRowId = source.firstRowId();
+      this.dvSnapshotId = source.dvSnapshotId();
+      ByteBuffer sourceDeleted = source.deletedPositions();
+      this.deletedPositions = sourceDeleted != null ? ByteBuffers.toByteArray(sourceDeleted) : null;
+      ByteBuffer sourceReplaced = source.replacedPositions();
+      this.replacedPositions =
+          sourceReplaced != null ? ByteBuffers.toByteArray(sourceReplaced) : null;
     }
 
-    Builder dataSequenceNumber(Long sequenceNumber) {
-      this.dataSequenceNumber = sequenceNumber;
-      return this;
-    }
-
-    Builder fileSequenceNumber(Long sequenceNumber) {
-      this.fileSequenceNumber = sequenceNumber;
-      return this;
-    }
-
-    Builder dvSnapshotId(Long id) {
+    Builder dvSnapshotId(long id) {
+      Preconditions.checkState(
+          status != EntryStatus.DELETED, "Cannot set dv snapshot ID on a DELETED entry");
       this.dvSnapshotId = id;
       return this;
     }
 
-    Builder firstRowId(Long rowId) {
-      this.firstRowId = rowId;
-      return this;
-    }
-
     Builder deletedPositions(ByteBuffer positions) {
+      Preconditions.checkState(
+          status != EntryStatus.DELETED, "Cannot set deleted positions on a DELETED entry");
       this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }
 
-    Builder deletedPositions(byte[] positions) {
-      this.deletedPositions = positions;
-      return this;
-    }
-
     Builder replacedPositions(ByteBuffer positions) {
+      Preconditions.checkState(
+          status != EntryStatus.DELETED, "Cannot set replaced positions on a DELETED entry");
       this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }
 
-    Builder replacedPositions(byte[] positions) {
-      this.replacedPositions = positions;
-      return this;
-    }
-
     TrackingStruct build() {
-      Preconditions.checkArgument(status != null, "Invalid status: null");
       return new TrackingStruct(
           status,
           snapshotId,

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -256,19 +256,25 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
 
   /** Creates a builder for a newly added file in the given snapshot. */
   static Builder added(long snapshotId) {
-    return new Builder(EntryStatus.ADDED, snapshotId);
+    return new Builder(snapshotId);
   }
 
   /** Creates a builder for an existing file based on tracking read from a manifest. */
   static Builder existing(Tracking source) {
     Preconditions.checkArgument(source != null, "Invalid source tracking: null");
-    return new Builder(EntryStatus.EXISTING, source, source.snapshotId());
+    return new Builder(source);
   }
 
   /** Creates a builder for a deleted file in the given snapshot. */
   static Builder deleted(Tracking source, long snapshotId) {
     Preconditions.checkArgument(source != null, "Invalid source tracking: null");
     return new Builder(EntryStatus.DELETED, source, snapshotId);
+  }
+
+  /** Creates a builder for a replaced file in the given snapshot. */
+  static Builder replaced(Tracking source, long snapshotId) {
+    Preconditions.checkArgument(source != null, "Invalid source tracking: null");
+    return new Builder(EntryStatus.REPLACED, source, snapshotId);
   }
 
   @Override
@@ -295,53 +301,78 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
     private byte[] deletedPositions;
     private byte[] replacedPositions;
 
-    private Builder(EntryStatus status, long snapshotId) {
-      this.status = status;
+    private Builder(long snapshotId) {
+      this.status = EntryStatus.ADDED;
       this.snapshotId = snapshotId;
       this.dataSequenceNumber = null;
       this.fileSequenceNumber = null;
       this.firstRowId = null;
+      this.deletedPositions = null;
+      this.replacedPositions = null;
+    }
+
+    private Builder(Tracking source) {
+      this(EntryStatus.EXISTING, source, source.snapshotId());
     }
 
     private Builder(EntryStatus status, Tracking source, Long snapshotId) {
       Preconditions.checkArgument(
           source.dataSequenceNumber() != null,
-          "Source tracking has no data sequence number; cannot mark as %s",
-          status);
+          "Invalid tracking source: data sequence number is null");
       Preconditions.checkArgument(
           source.fileSequenceNumber() != null,
-          "Source tracking has no file sequence number; cannot mark as %s",
-          status);
+          "Invalid tracking source: file sequence number is null");
+      checkStatus(source.status(), status);
       this.status = status;
       this.snapshotId = snapshotId;
       this.dataSequenceNumber = source.dataSequenceNumber();
       this.fileSequenceNumber = source.fileSequenceNumber();
       this.firstRowId = source.firstRowId();
       this.dvSnapshotId = source.dvSnapshotId();
-      ByteBuffer sourceDeleted = source.deletedPositions();
-      this.deletedPositions = sourceDeleted != null ? ByteBuffers.toByteArray(sourceDeleted) : null;
-      ByteBuffer sourceReplaced = source.replacedPositions();
-      this.replacedPositions =
-          sourceReplaced != null ? ByteBuffers.toByteArray(sourceReplaced) : null;
+      this.deletedPositions = null;
+      this.replacedPositions = null;
+    }
+
+    // TODO: extend allowed transitions once MODIFIED status is added.
+    private static void checkStatus(EntryStatus from, EntryStatus to) {
+      Preconditions.checkArgument(from != null, "Invalid tracking source: status is null");
+      Preconditions.checkArgument(
+          from == EntryStatus.ADDED || from == EntryStatus.EXISTING,
+          "Cannot transition from %s status",
+          from);
+      Preconditions.checkArgument(
+          to == EntryStatus.EXISTING || to == EntryStatus.DELETED || to == EntryStatus.REPLACED,
+          "Cannot transition to %s status",
+          to);
+      Preconditions.checkArgument(from != to, "Invalid status transition: %s -> %s", from, to);
     }
 
     Builder dvSnapshotId(long id) {
       Preconditions.checkState(
           status != EntryStatus.DELETED, "Cannot set dv snapshot ID on a DELETED entry");
+      Preconditions.checkState(
+          deletedPositions == null && replacedPositions == null,
+          "Cannot set dv snapshot ID with manifest delete vector positions");
       this.dvSnapshotId = id;
       return this;
     }
 
+    // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
     Builder deletedPositions(ByteBuffer positions) {
       Preconditions.checkState(
-          status != EntryStatus.DELETED, "Cannot set deleted positions on a DELETED entry");
+          status == EntryStatus.EXISTING, "Cannot set deleted positions on a %s entry", status);
+      Preconditions.checkState(
+          dvSnapshotId == null, "Cannot set deleted positions with dv snapshot ID");
       this.deletedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }
 
+    // TODO: revisit when MODIFIED status is added; MDV setters will need to handle MODIFIED.
     Builder replacedPositions(ByteBuffer positions) {
       Preconditions.checkState(
-          status != EntryStatus.DELETED, "Cannot set replaced positions on a DELETED entry");
+          status == EntryStatus.EXISTING, "Cannot set replaced positions on a %s entry", status);
+      Preconditions.checkState(
+          dvSnapshotId == null, "Cannot set replaced positions with dv snapshot ID");
       this.replacedPositions = positions != null ? ByteBuffers.toByteArray(positions) : null;
       return this;
     }

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -284,11 +284,11 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("status", status)
-        .add("snapshot_id", snapshotId == null ? "null" : snapshotId)
-        .add("data_sequence_number", dataSequenceNumber == null ? "null" : dataSequenceNumber)
-        .add("file_sequence_number", fileSequenceNumber == null ? "null" : fileSequenceNumber)
-        .add("dv_snapshot_id", dvSnapshotId == null ? "null" : dvSnapshotId)
-        .add("first_row_id", firstRowId == null ? "null" : firstRowId)
+        .add("snapshot_id", snapshotId)
+        .add("data_sequence_number", dataSequenceNumber)
+        .add("file_sequence_number", fileSequenceNumber)
+        .add("dv_snapshot_id", dvSnapshotId)
+        .add("first_row_id", firstRowId)
         .add("deleted_positions", deletedPositions == null ? "null" : "(binary)")
         .add("replaced_positions", replacedPositions == null ? "null" : "(binary)")
         .toString();

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -88,6 +88,26 @@ class TestDeletionVectorStruct {
   }
 
   @Test
+  void testInternalSetIgnoresUnknownOrdinal() {
+    DeletionVectorStruct dv =
+        DeletionVectorStruct.builder()
+            .location("s3://bucket/data/dv.puffin")
+            .offset(100L)
+            .sizeInBytes(512L)
+            .cardinality(42L)
+            .build();
+
+    // unknown ordinals from a newer format version are silently ignored
+    dv.internalSet(99, "value from a newer format");
+
+    // every field is unchanged
+    assertThat(dv.location()).isEqualTo("s3://bucket/data/dv.puffin");
+    assertThat(dv.offset()).isEqualTo(100L);
+    assertThat(dv.sizeInBytes()).isEqualTo(512L);
+    assertThat(dv.cardinality()).isEqualTo(42L);
+  }
+
+  @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -106,11 +106,11 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testBuilderValidation() {
+  void testBuilderMissingRequiredFields() {
     assertThatThrownBy(
             () -> DeletionVectorStruct.builder().offset(0).sizeInBytes(1).cardinality(1).build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid location: null");
+        .hasMessage("Missing required value: location");
 
     assertThatThrownBy(
             () ->
@@ -119,28 +119,47 @@ class TestDeletionVectorStruct {
                     .sizeInBytes(1)
                     .cardinality(1)
                     .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: offset");
+
+    assertThatThrownBy(
+            () ->
+                DeletionVectorStruct.builder()
+                    .location("s3://bucket/dv.puffin")
+                    .offset(0)
+                    .cardinality(1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: size in bytes");
+
+    assertThatThrownBy(
+            () ->
+                DeletionVectorStruct.builder()
+                    .location("s3://bucket/dv.puffin")
+                    .offset(0)
+                    .sizeInBytes(1)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: cardinality");
+  }
+
+  @Test
+  void testBuilderRejectsInvalidValuesAtSetter() {
+    assertThatThrownBy(() -> DeletionVectorStruct.builder().location(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid location: null");
+
+    assertThatThrownBy(() -> DeletionVectorStruct.builder().offset(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid offset: -1 (must be >= 0)");
 
-    assertThatThrownBy(
-            () ->
-                DeletionVectorStruct.builder()
-                    .location("s3://bucket/dv.puffin")
-                    .offset(0)
-                    .cardinality(1)
-                    .build())
+    assertThatThrownBy(() -> DeletionVectorStruct.builder().sizeInBytes(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid size in bytes: -1 (must be >= 0)");
 
-    assertThatThrownBy(
-            () ->
-                DeletionVectorStruct.builder()
-                    .location("s3://bucket/dv.puffin")
-                    .offset(0)
-                    .sizeInBytes(1)
-                    .build())
+    assertThatThrownBy(() -> DeletionVectorStruct.builder().cardinality(0))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid cardinality: -1 (must be >= 0)");
+        .hasMessage("Invalid cardinality: 0 (must be positive)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -157,9 +157,9 @@ class TestDeletionVectorStruct {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid size in bytes: -1 (must be >= 0)");
 
-    assertThatThrownBy(() -> DeletionVectorStruct.builder().cardinality(0))
+    assertThatThrownBy(() -> DeletionVectorStruct.builder().cardinality(-1))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid cardinality: 0 (must be positive)");
+        .hasMessage("Invalid cardinality: -1 (must be >= 0)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -120,6 +120,40 @@ class TestManifestInfoStruct {
   }
 
   @Test
+  void testInternalSetIgnoresUnknownOrdinal() {
+    ManifestInfoStruct info =
+        ManifestInfoStruct.builder()
+            .addedFilesCount(10)
+            .existingFilesCount(20)
+            .deletedFilesCount(3)
+            .replacedFilesCount(2)
+            .addedRowsCount(1000L)
+            .existingRowsCount(2000L)
+            .deletedRowsCount(300L)
+            .replacedRowsCount(200L)
+            .minSequenceNumber(5L)
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
+            .dvCardinality(1L)
+            .build();
+
+    // unknown ordinals from a newer format version are silently ignored
+    info.internalSet(99, "value from a newer format");
+
+    // every field is unchanged
+    assertThat(info.addedFilesCount()).isEqualTo(10);
+    assertThat(info.existingFilesCount()).isEqualTo(20);
+    assertThat(info.deletedFilesCount()).isEqualTo(3);
+    assertThat(info.replacedFilesCount()).isEqualTo(2);
+    assertThat(info.addedRowsCount()).isEqualTo(1000L);
+    assertThat(info.existingRowsCount()).isEqualTo(2000L);
+    assertThat(info.deletedRowsCount()).isEqualTo(300L);
+    assertThat(info.replacedRowsCount()).isEqualTo(200L);
+    assertThat(info.minSequenceNumber()).isEqualTo(5L);
+    assertThat(info.dv()).isEqualTo(ByteBuffer.wrap(new byte[] {0xF}));
+    assertThat(info.dvCardinality()).isEqualTo(1L);
+  }
+
+  @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -377,10 +377,10 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderRejectsNonPositiveDvCardinality() {
-    assertThatThrownBy(() -> ManifestInfoStruct.builder().dvCardinality(0L))
+  void testBuilderRejectsNegativeDvCardinality() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().dvCardinality(-1L))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid DV cardinality: 0 (must be positive)");
+        .hasMessage("Invalid DV cardinality: -1 (must be >= 0)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -23,57 +23,15 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.List;
-import java.util.Map;
-import java.util.function.Consumer;
-import java.util.stream.Stream;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 class TestManifestInfoStruct {
 
-  // Ordinals looked up from ManifestInfo.schema() so tests don't hard-code positions.
-  private static final List<Types.NestedField> INFO_FIELDS = ManifestInfo.schema().fields();
-  private static final int ADDED_FILES_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.ADDED_FILES_COUNT);
-  private static final int EXISTING_FILES_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.EXISTING_FILES_COUNT);
-  private static final int DELETED_FILES_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.DELETED_FILES_COUNT);
-  private static final int REPLACED_FILES_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.REPLACED_FILES_COUNT);
-  private static final int ADDED_ROWS_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.ADDED_ROWS_COUNT);
-  private static final int EXISTING_ROWS_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.EXISTING_ROWS_COUNT);
-  private static final int DELETED_ROWS_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.DELETED_ROWS_COUNT);
-  private static final int REPLACED_ROWS_COUNT_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.REPLACED_ROWS_COUNT);
-  private static final int MIN_SEQUENCE_NUMBER_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.MIN_SEQUENCE_NUMBER);
-  private static final int DV_ORDINAL = INFO_FIELDS.indexOf(ManifestInfo.DV);
-  private static final int DV_CARDINALITY_ORDINAL =
-      INFO_FIELDS.indexOf(ManifestInfo.DV_CARDINALITY);
-
   @Test
   void testFieldAccess() {
-    ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
-
-    info.set(ADDED_FILES_COUNT_ORDINAL, 10);
-    info.set(EXISTING_FILES_COUNT_ORDINAL, 20);
-    info.set(DELETED_FILES_COUNT_ORDINAL, 3);
-    info.set(REPLACED_FILES_COUNT_ORDINAL, 2);
-    info.set(ADDED_ROWS_COUNT_ORDINAL, 1000L);
-    info.set(EXISTING_ROWS_COUNT_ORDINAL, 2000L);
-    info.set(DELETED_ROWS_COUNT_ORDINAL, 300L);
-    info.set(REPLACED_ROWS_COUNT_ORDINAL, 200L);
-    info.set(MIN_SEQUENCE_NUMBER_ORDINAL, 5L);
-    info.set(DV_ORDINAL, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(DV_CARDINALITY_ORDINAL, 1L);
+    ManifestInfoStruct info =
+        new ManifestInfoStruct(10, 20, 3, 2, 1000L, 2000L, 300L, 200L, 5L, new byte[] {0xF}, 1L);
 
     assertThat(info.addedFilesCount()).isEqualTo(10);
     assertThat(info.existingFilesCount()).isEqualTo(20);
@@ -193,81 +151,236 @@ class TestManifestInfoStruct {
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
   }
 
-  // Keyed by the field name used in the "Missing required value: ..." build() error so each
-  // case has a single source of truth. No dependency on schema field order.
-  private static final Map<String, Consumer<ManifestInfoStruct.Builder>> REQUIRED_SETTERS =
-      Map.ofEntries(
-          Map.entry("added files count", b -> b.addedFilesCount(0)),
-          Map.entry("existing files count", b -> b.existingFilesCount(0)),
-          Map.entry("deleted files count", b -> b.deletedFilesCount(0)),
-          Map.entry("replaced files count", b -> b.replacedFilesCount(0)),
-          Map.entry("added rows count", b -> b.addedRowsCount(0L)),
-          Map.entry("existing rows count", b -> b.existingRowsCount(0L)),
-          Map.entry("deleted rows count", b -> b.deletedRowsCount(0L)),
-          Map.entry("replaced rows count", b -> b.replacedRowsCount(0L)),
-          Map.entry("min sequence number", b -> b.minSequenceNumber(0L)));
-
-  private static Stream<String> missingRequiredFieldCases() {
-    return REQUIRED_SETTERS.keySet().stream();
-  }
-
-  @ParameterizedTest
-  @MethodSource("missingRequiredFieldCases")
-  void testBuilderMissingRequiredFields(String missingField) {
-    ManifestInfoStruct.Builder builder = ManifestInfoStruct.builder();
-    REQUIRED_SETTERS.forEach(
-        (name, setter) -> {
-          if (!name.equals(missingField)) {
-            setter.accept(builder);
-          }
-        });
-
-    assertThatThrownBy(builder::build)
+  @Test
+  void testBuilderMissingAddedFilesCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Missing required value: " + missingField);
+        .hasMessage("Missing required value: added files count");
   }
 
-  private static Stream<Arguments> negativeValueAtSetterCases() {
-    return Stream.of(
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.addedFilesCount(-1),
-            "Invalid added files count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.existingFilesCount(-1),
-            "Invalid existing files count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.deletedFilesCount(-1),
-            "Invalid deleted files count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.replacedFilesCount(-1),
-            "Invalid replaced files count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.addedRowsCount(-1L),
-            "Invalid added rows count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.existingRowsCount(-1L),
-            "Invalid existing rows count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.deletedRowsCount(-1L),
-            "Invalid deleted rows count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.replacedRowsCount(-1L),
-            "Invalid replaced rows count: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.minSequenceNumber(-1L),
-            "Invalid min sequence number: -1 (must be >= 0)"),
-        Arguments.of(
-            (Consumer<ManifestInfoStruct.Builder>) b -> b.dvCardinality(0L),
-            "Invalid DV cardinality: 0 (must be positive)"));
-  }
-
-  @ParameterizedTest
-  @MethodSource("negativeValueAtSetterCases")
-  void testBuilderRejectsNegativeValuesAtSetter(
-      Consumer<ManifestInfoStruct.Builder> apply, String expectedMessage) {
-    assertThatThrownBy(() -> apply.accept(ManifestInfoStruct.builder()))
+  @Test
+  void testBuilderMissingExistingFilesCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(expectedMessage);
+        .hasMessage("Missing required value: existing files count");
+  }
+
+  @Test
+  void testBuilderMissingDeletedFilesCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: deleted files count");
+  }
+
+  @Test
+  void testBuilderMissingReplacedFilesCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: replaced files count");
+  }
+
+  @Test
+  void testBuilderMissingAddedRowsCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: added rows count");
+  }
+
+  @Test
+  void testBuilderMissingExistingRowsCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: existing rows count");
+  }
+
+  @Test
+  void testBuilderMissingDeletedRowsCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: deleted rows count");
+  }
+
+  @Test
+  void testBuilderMissingReplacedRowsCount() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .minSequenceNumber(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: replaced rows count");
+  }
+
+  @Test
+  void testBuilderMissingMinSequenceNumber() {
+    assertThatThrownBy(
+            () ->
+                ManifestInfoStruct.builder()
+                    .addedFilesCount(0)
+                    .existingFilesCount(0)
+                    .deletedFilesCount(0)
+                    .replacedFilesCount(0)
+                    .addedRowsCount(0L)
+                    .existingRowsCount(0L)
+                    .deletedRowsCount(0L)
+                    .replacedRowsCount(0L)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: min sequence number");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeAddedFilesCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().addedFilesCount(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid added files count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeExistingFilesCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().existingFilesCount(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid existing files count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeDeletedFilesCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().deletedFilesCount(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid deleted files count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeReplacedFilesCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().replacedFilesCount(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid replaced files count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeAddedRowsCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().addedRowsCount(-1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid added rows count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeExistingRowsCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().existingRowsCount(-1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid existing rows count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeDeletedRowsCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().deletedRowsCount(-1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid deleted rows count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeReplacedRowsCount() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().replacedRowsCount(-1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid replaced rows count: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNegativeMinSequenceNumber() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().minSequenceNumber(-1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid min sequence number: -1 (must be >= 0)");
+  }
+
+  @Test
+  void testBuilderRejectsNonPositiveDvCardinality() {
+    assertThatThrownBy(() -> ManifestInfoStruct.builder().dvCardinality(0L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid DV cardinality: 0 (must be positive)");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -23,26 +23,56 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestManifestInfoStruct {
+
+  // Ordinals looked up from ManifestInfo.schema() so tests don't hard-code positions.
+  private static final List<Types.NestedField> INFO_FIELDS = ManifestInfo.schema().fields();
+  private static final int ADDED_FILES_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.ADDED_FILES_COUNT);
+  private static final int EXISTING_FILES_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.EXISTING_FILES_COUNT);
+  private static final int DELETED_FILES_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.DELETED_FILES_COUNT);
+  private static final int REPLACED_FILES_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.REPLACED_FILES_COUNT);
+  private static final int ADDED_ROWS_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.ADDED_ROWS_COUNT);
+  private static final int EXISTING_ROWS_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.EXISTING_ROWS_COUNT);
+  private static final int DELETED_ROWS_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.DELETED_ROWS_COUNT);
+  private static final int REPLACED_ROWS_COUNT_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.REPLACED_ROWS_COUNT);
+  private static final int MIN_SEQUENCE_NUMBER_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.MIN_SEQUENCE_NUMBER);
+  private static final int DV_ORDINAL = INFO_FIELDS.indexOf(ManifestInfo.DV);
+  private static final int DV_CARDINALITY_ORDINAL =
+      INFO_FIELDS.indexOf(ManifestInfo.DV_CARDINALITY);
 
   @Test
   void testFieldAccess() {
     ManifestInfoStruct info = new ManifestInfoStruct(ManifestInfo.schema());
 
-    info.set(0, 10);
-    info.set(1, 20);
-    info.set(2, 3);
-    info.set(3, 2);
-    info.set(4, 1000L);
-    info.set(5, 2000L);
-    info.set(6, 300L);
-    info.set(7, 200L);
-    info.set(8, 5L);
-    info.set(9, ByteBuffer.wrap(new byte[] {0xF}));
-    info.set(10, 1L);
+    info.set(ADDED_FILES_COUNT_ORDINAL, 10);
+    info.set(EXISTING_FILES_COUNT_ORDINAL, 20);
+    info.set(DELETED_FILES_COUNT_ORDINAL, 3);
+    info.set(REPLACED_FILES_COUNT_ORDINAL, 2);
+    info.set(ADDED_ROWS_COUNT_ORDINAL, 1000L);
+    info.set(EXISTING_ROWS_COUNT_ORDINAL, 2000L);
+    info.set(DELETED_ROWS_COUNT_ORDINAL, 300L);
+    info.set(REPLACED_ROWS_COUNT_ORDINAL, 200L);
+    info.set(MIN_SEQUENCE_NUMBER_ORDINAL, 5L);
+    info.set(DV_ORDINAL, ByteBuffer.wrap(new byte[] {0xF}));
+    info.set(DV_CARDINALITY_ORDINAL, 1L);
 
     assertThat(info.addedFilesCount()).isEqualTo(10);
     assertThat(info.existingFilesCount()).isEqualTo(20);
@@ -70,7 +100,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(new byte[] {0xF})
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
             .dvCardinality(1L)
             .build();
 
@@ -143,7 +173,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(new byte[] {0xF})
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
             .dvCardinality(1L)
             .build();
 
@@ -162,68 +192,91 @@ class TestManifestInfoStruct {
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
   }
 
+  private static final List<Consumer<ManifestInfoStruct.Builder>> REQUIRED_SETTERS_BY_ORDINAL =
+      List.of(
+          b -> b.addedFilesCount(0),
+          b -> b.existingFilesCount(0),
+          b -> b.deletedFilesCount(0),
+          b -> b.replacedFilesCount(0),
+          b -> b.addedRowsCount(0L),
+          b -> b.existingRowsCount(0L),
+          b -> b.deletedRowsCount(0L),
+          b -> b.replacedRowsCount(0L),
+          b -> b.minSequenceNumber(0L));
+
+  private static Stream<Arguments> missingRequiredFieldCases() {
+    return Stream.of(
+        Arguments.of(ADDED_FILES_COUNT_ORDINAL, "added files count"),
+        Arguments.of(EXISTING_FILES_COUNT_ORDINAL, "existing files count"),
+        Arguments.of(DELETED_FILES_COUNT_ORDINAL, "deleted files count"),
+        Arguments.of(REPLACED_FILES_COUNT_ORDINAL, "replaced files count"),
+        Arguments.of(ADDED_ROWS_COUNT_ORDINAL, "added rows count"),
+        Arguments.of(EXISTING_ROWS_COUNT_ORDINAL, "existing rows count"),
+        Arguments.of(DELETED_ROWS_COUNT_ORDINAL, "deleted rows count"),
+        Arguments.of(REPLACED_ROWS_COUNT_ORDINAL, "replaced rows count"),
+        Arguments.of(MIN_SEQUENCE_NUMBER_ORDINAL, "min sequence number"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("missingRequiredFieldCases")
+  void testBuilderMissingRequiredFields(int omittedOrdinal, String missingField) {
+    ManifestInfoStruct.Builder builder = ManifestInfoStruct.builder();
+    for (int i = 0; i < REQUIRED_SETTERS_BY_ORDINAL.size(); i++) {
+      if (i != omittedOrdinal) {
+        REQUIRED_SETTERS_BY_ORDINAL.get(i).accept(builder);
+      }
+    }
+
+    assertThatThrownBy(builder::build)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Missing required value: " + missingField);
+  }
+
+  private static Stream<Arguments> negativeValueAtSetterCases() {
+    return Stream.of(
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.addedFilesCount(-1),
+            "Invalid added files count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.existingFilesCount(-1),
+            "Invalid existing files count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.deletedFilesCount(-1),
+            "Invalid deleted files count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.replacedFilesCount(-1),
+            "Invalid replaced files count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.addedRowsCount(-1L),
+            "Invalid added rows count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.existingRowsCount(-1L),
+            "Invalid existing rows count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.deletedRowsCount(-1L),
+            "Invalid deleted rows count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.replacedRowsCount(-1L),
+            "Invalid replaced rows count: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.minSequenceNumber(-1L),
+            "Invalid min sequence number: -1 (must be >= 0)"),
+        Arguments.of(
+            (Consumer<ManifestInfoStruct.Builder>) b -> b.dvCardinality(0L),
+            "Invalid DV cardinality: 0 (must be positive)"));
+  }
+
+  @ParameterizedTest
+  @MethodSource("negativeValueAtSetterCases")
+  void testBuilderRejectsNegativeValuesAtSetter(
+      Consumer<ManifestInfoStruct.Builder> apply, String expectedMessage) {
+    assertThatThrownBy(() -> apply.accept(ManifestInfoStruct.builder()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedMessage);
+  }
+
   @Test
-  void testBuilderValidation() {
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .existingFilesCount(0)
-                    .deletedFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .minSequenceNumber(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid added files count: -1 (must be >= 0)");
-
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .addedFilesCount(0)
-                    .deletedFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .minSequenceNumber(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid existing files count: -1 (must be >= 0)");
-
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .addedFilesCount(0)
-                    .existingFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .minSequenceNumber(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid deleted files count: -1 (must be >= 0)");
-
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .addedFilesCount(0)
-                    .existingFilesCount(0)
-                    .deletedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .minSequenceNumber(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid replaced files count: -1 (must be >= 0)");
-
+  void testBuilderRejectsRowsWithoutFiles() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -231,13 +284,14 @@ class TestManifestInfoStruct {
                     .existingFilesCount(0)
                     .deletedFilesCount(0)
                     .replacedFilesCount(0)
+                    .addedRowsCount(10L)
                     .existingRowsCount(0L)
                     .deletedRowsCount(0L)
                     .replacedRowsCount(0L)
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid added rows count: -1 (must be >= 0)");
+        .hasMessage("Invalid added counts: 10 rows in 0 files");
 
     assertThatThrownBy(
             () ->
@@ -247,12 +301,13 @@ class TestManifestInfoStruct {
                     .deletedFilesCount(0)
                     .replacedFilesCount(0)
                     .addedRowsCount(0L)
+                    .existingRowsCount(5L)
                     .deletedRowsCount(0L)
                     .replacedRowsCount(0L)
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid existing rows count: -1 (must be >= 0)");
+        .hasMessage("Invalid existing counts: 5 rows in 0 files");
 
     assertThatThrownBy(
             () ->
@@ -263,11 +318,12 @@ class TestManifestInfoStruct {
                     .replacedFilesCount(0)
                     .addedRowsCount(0L)
                     .existingRowsCount(0L)
+                    .deletedRowsCount(3L)
                     .replacedRowsCount(0L)
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid deleted rows count: -1 (must be >= 0)");
+        .hasMessage("Invalid deleted counts: 3 rows in 0 files");
 
     assertThatThrownBy(
             () ->
@@ -279,25 +335,30 @@ class TestManifestInfoStruct {
                     .addedRowsCount(0L)
                     .existingRowsCount(0L)
                     .deletedRowsCount(0L)
+                    .replacedRowsCount(7L)
                     .minSequenceNumber(0L)
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid replaced rows count: -1 (must be >= 0)");
+        .hasMessage("Invalid replaced counts: 7 rows in 0 files");
+  }
 
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .addedFilesCount(0)
-                    .existingFilesCount(0)
-                    .deletedFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid min sequence number: -1 (must be >= 0)");
+  @Test
+  void testBuilderAllowsFilesWithoutRows() {
+    ManifestInfoStruct info =
+        ManifestInfoStruct.builder()
+            .addedFilesCount(5)
+            .existingFilesCount(5)
+            .deletedFilesCount(5)
+            .replacedFilesCount(5)
+            .addedRowsCount(0L)
+            .existingRowsCount(0L)
+            .deletedRowsCount(0L)
+            .replacedRowsCount(0L)
+            .minSequenceNumber(0L)
+            .build();
+
+    assertThat(info.addedFilesCount()).isEqualTo(5);
+    assertThat(info.addedRowsCount()).isEqualTo(0L);
   }
 
   @Test
@@ -314,7 +375,7 @@ class TestManifestInfoStruct {
                     .deletedRowsCount(0L)
                     .replacedRowsCount(0L)
                     .minSequenceNumber(0L)
-                    .dv(new byte[] {0xF})
+                    .dv(ByteBuffer.wrap(new byte[] {0xF}))
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid DV and cardinality: must both be null or non-null");
@@ -335,24 +396,6 @@ class TestManifestInfoStruct {
                     .build())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid DV and cardinality: must both be null or non-null");
-
-    assertThatThrownBy(
-            () ->
-                ManifestInfoStruct.builder()
-                    .addedFilesCount(0)
-                    .existingFilesCount(0)
-                    .deletedFilesCount(0)
-                    .replacedFilesCount(0)
-                    .addedRowsCount(0L)
-                    .existingRowsCount(0L)
-                    .deletedRowsCount(0L)
-                    .replacedRowsCount(0L)
-                    .minSequenceNumber(0L)
-                    .dv(new byte[] {0xF})
-                    .dvCardinality(0L)
-                    .build())
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid DV cardinality: 0 (must be positive)");
   }
 
   @Test
@@ -368,7 +411,7 @@ class TestManifestInfoStruct {
             .deletedRowsCount(300L)
             .replacedRowsCount(200L)
             .minSequenceNumber(5L)
-            .dv(new byte[] {0xF})
+            .dv(ByteBuffer.wrap(new byte[] {0xF}))
             .dvCardinality(1L)
             .build();
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
 import org.apache.iceberg.types.Types;
@@ -192,40 +193,34 @@ class TestManifestInfoStruct {
     assertThat(deserialized.dvCardinality()).isEqualTo(1L);
   }
 
-  private static final List<Consumer<ManifestInfoStruct.Builder>> REQUIRED_SETTERS_BY_ORDINAL =
-      List.of(
-          b -> b.addedFilesCount(0),
-          b -> b.existingFilesCount(0),
-          b -> b.deletedFilesCount(0),
-          b -> b.replacedFilesCount(0),
-          b -> b.addedRowsCount(0L),
-          b -> b.existingRowsCount(0L),
-          b -> b.deletedRowsCount(0L),
-          b -> b.replacedRowsCount(0L),
-          b -> b.minSequenceNumber(0L));
+  // Keyed by the field name used in the "Missing required value: ..." build() error so each
+  // case has a single source of truth. No dependency on schema field order.
+  private static final Map<String, Consumer<ManifestInfoStruct.Builder>> REQUIRED_SETTERS =
+      Map.ofEntries(
+          Map.entry("added files count", b -> b.addedFilesCount(0)),
+          Map.entry("existing files count", b -> b.existingFilesCount(0)),
+          Map.entry("deleted files count", b -> b.deletedFilesCount(0)),
+          Map.entry("replaced files count", b -> b.replacedFilesCount(0)),
+          Map.entry("added rows count", b -> b.addedRowsCount(0L)),
+          Map.entry("existing rows count", b -> b.existingRowsCount(0L)),
+          Map.entry("deleted rows count", b -> b.deletedRowsCount(0L)),
+          Map.entry("replaced rows count", b -> b.replacedRowsCount(0L)),
+          Map.entry("min sequence number", b -> b.minSequenceNumber(0L)));
 
-  private static Stream<Arguments> missingRequiredFieldCases() {
-    return Stream.of(
-        Arguments.of(ADDED_FILES_COUNT_ORDINAL, "added files count"),
-        Arguments.of(EXISTING_FILES_COUNT_ORDINAL, "existing files count"),
-        Arguments.of(DELETED_FILES_COUNT_ORDINAL, "deleted files count"),
-        Arguments.of(REPLACED_FILES_COUNT_ORDINAL, "replaced files count"),
-        Arguments.of(ADDED_ROWS_COUNT_ORDINAL, "added rows count"),
-        Arguments.of(EXISTING_ROWS_COUNT_ORDINAL, "existing rows count"),
-        Arguments.of(DELETED_ROWS_COUNT_ORDINAL, "deleted rows count"),
-        Arguments.of(REPLACED_ROWS_COUNT_ORDINAL, "replaced rows count"),
-        Arguments.of(MIN_SEQUENCE_NUMBER_ORDINAL, "min sequence number"));
+  private static Stream<String> missingRequiredFieldCases() {
+    return REQUIRED_SETTERS.keySet().stream();
   }
 
   @ParameterizedTest
   @MethodSource("missingRequiredFieldCases")
-  void testBuilderMissingRequiredFields(int omittedOrdinal, String missingField) {
+  void testBuilderMissingRequiredFields(String missingField) {
     ManifestInfoStruct.Builder builder = ManifestInfoStruct.builder();
-    for (int i = 0; i < REQUIRED_SETTERS_BY_ORDINAL.size(); i++) {
-      if (i != omittedOrdinal) {
-        REQUIRED_SETTERS_BY_ORDINAL.get(i).accept(builder);
-      }
-    }
+    REQUIRED_SETTERS.forEach(
+        (name, setter) -> {
+          if (!name.equals(missingField)) {
+            setter.accept(builder);
+          }
+        });
 
     assertThatThrownBy(builder::build)
         .isInstanceOf(IllegalArgumentException.class)
@@ -358,7 +353,13 @@ class TestManifestInfoStruct {
             .build();
 
     assertThat(info.addedFilesCount()).isEqualTo(5);
+    assertThat(info.existingFilesCount()).isEqualTo(5);
+    assertThat(info.deletedFilesCount()).isEqualTo(5);
+    assertThat(info.replacedFilesCount()).isEqualTo(5);
     assertThat(info.addedRowsCount()).isEqualTo(0L);
+    assertThat(info.existingRowsCount()).isEqualTo(0L);
+    assertThat(info.deletedRowsCount()).isEqualTo(0L);
+    assertThat(info.replacedRowsCount()).isEqualTo(0L);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -331,8 +331,7 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking =
-        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
+    TrackingStruct tracking = (TrackingStruct) TrackingBuilder.added(42L).build();
     tracking.setManifestLocation("s3://bucket/manifest.avro");
     tracking.set(MANIFEST_POS_ORDINAL, 3L);
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -101,7 +101,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    TrackingStruct tracking = TrackingStruct.added(42L).build();
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(MANIFEST_POS_ORDINAL, 7L);
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -101,7 +101,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = TrackingStruct.added(0L).build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(MANIFEST_POS_ORDINAL, 7L);
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -42,7 +42,7 @@ class TestTrackedFileStruct {
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    Tracking tracking = TrackingStruct.added(42L).build();
+    Tracking tracking = TrackingBuilder.added(42L).build();
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/dv.puffin")

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -35,11 +35,14 @@ class TestTrackedFileStruct {
           Types.NestedField.optional(1000, "id_bucket", Types.IntegerType.get()),
           Types.NestedField.optional(1001, "category", Types.StringType.get()));
 
+  // Ordinal of MetadataColumns.ROW_POSITION within TrackingStruct's BASE_TYPE,
+  // which appends ROW_POSITION after the Tracking schema fields.
+  private static final int MANIFEST_POS_ORDINAL = Tracking.schema().fields().size();
+
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking =
-        TrackingStruct.builder().status(EntryStatus.ADDED).snapshotId(42L).build();
+    TrackingStruct tracking = TrackingStruct.added(42L).build();
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/dv.puffin")
@@ -98,9 +101,9 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = TrackingStruct.added(0L).build();
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
-    tracking.set(8, 7L);
+    tracking.set(MANIFEST_POS_ORDINAL, 7L);
 
     file.set(0, tracking);
     file.set(1, FileContent.DATA.id());
@@ -328,14 +331,9 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.ADDED)
-            .snapshotId(42L)
-            .dataSequenceNumber(10L)
-            .build();
+    TrackingStruct tracking = TrackingStruct.added(42L).build();
     tracking.setManifestLocation("s3://bucket/manifest.avro");
-    tracking.set(8, 3L);
+    tracking.set(MANIFEST_POS_ORDINAL, 3L);
 
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -42,7 +42,7 @@ class TestTrackedFileStruct {
   @Test
   void testFieldAccess() {
     TrackedFileStruct file = new TrackedFileStruct();
-    TrackingStruct tracking = TrackingStruct.added(42L).build();
+    Tracking tracking = TrackingStruct.added(42L).build();
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/dv.puffin")
@@ -101,7 +101,7 @@ class TestTrackedFileStruct {
   void testReaderSideFields() {
     TrackedFileStruct file = new TrackedFileStruct();
 
-    TrackingStruct tracking = TrackingStruct.added(42L).build();
+    TrackingStruct tracking = new TrackingStruct();
     tracking.setManifestLocation("s3://bucket/metadata/manifest.avro");
     tracking.set(MANIFEST_POS_ORDINAL, 7L);
 
@@ -331,7 +331,8 @@ class TestTrackedFileStruct {
   }
 
   static TrackedFileStruct createFullTrackedFile() {
-    TrackingStruct tracking = TrackingStruct.added(42L).build();
+    TrackingStruct tracking =
+        new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
     tracking.setManifestLocation("s3://bucket/manifest.avro");
     tracking.set(MANIFEST_POS_ORDINAL, 3L);
 

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -42,6 +42,10 @@ class TestTrackingStruct {
   private static final int DV_SNAPSHOT_ID_ORDINAL =
       TRACKING_FIELDS.indexOf(Tracking.DV_SNAPSHOT_ID);
   private static final int FIRST_ROW_ID_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.FIRST_ROW_ID);
+  private static final int DELETED_POSITIONS_ORDINAL =
+      TRACKING_FIELDS.indexOf(Tracking.DELETED_POSITIONS);
+  private static final int REPLACED_POSITIONS_ORDINAL =
+      TRACKING_FIELDS.indexOf(Tracking.REPLACED_POSITIONS);
 
   @Test
   void testFieldAccess() {
@@ -67,16 +71,14 @@ class TestTrackingStruct {
   @Test
   void testCopy() {
     TrackingStruct tracking =
-        TrackingStruct.added(42L)
-            .dvSnapshotId(99L)
+        TrackingStruct.existing(manifestSourceTracking())
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .build();
 
     TrackingStruct copy = tracking.copy();
 
-    assertThat(copy.status()).isEqualTo(EntryStatus.ADDED);
-    assertThat(copy.snapshotId()).isEqualTo(42L);
-    assertThat(copy.dvSnapshotId()).isEqualTo(99L);
+    assertThat(copy.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(copy.snapshotId()).isEqualTo(tracking.snapshotId());
     assertThat(copy.deletedPositions()).isNotNull();
 
     // verify deep copy of ByteBuffer backing array
@@ -199,18 +201,13 @@ class TestTrackingStruct {
 
   @Test
   void testAddedBuilder() {
-    TrackingStruct tracking =
-        TrackingStruct.added(42L)
-            .dvSnapshotId(43L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(43L).build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
     assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
-    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
-    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
+    assertThat(tracking.deletedPositions()).isNull();
+    assertThat(tracking.replacedPositions()).isNull();
     // sequence numbers and firstRowId remain null; populated by inheritance
     assertThat(tracking.dataSequenceNumber()).isNull();
     assertThat(tracking.fileSequenceNumber()).isNull();
@@ -246,6 +243,39 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testReplacedBuilderUpdatesSnapshotIdAndPreservesRest() {
+    Tracking source = sourceTracking();
+
+    TrackingStruct replaced = TrackingStruct.replaced(source, 999L).build();
+
+    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
+    assertThat(replaced.snapshotId()).isEqualTo(999L);
+    assertThat(replaced.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(replaced.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(replaced.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(replaced.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testSourceDvPositionsAreNotCarriedForward() {
+    TrackingStruct source = sourceTracking();
+    source.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
+    source.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
+
+    TrackingStruct existing = TrackingStruct.existing(source).build();
+    assertThat(existing.deletedPositions()).isNull();
+    assertThat(existing.replacedPositions()).isNull();
+
+    TrackingStruct deleted = TrackingStruct.deleted(source, 999L).build();
+    assertThat(deleted.deletedPositions()).isNull();
+    assertThat(deleted.replacedPositions()).isNull();
+
+    TrackingStruct replaced = TrackingStruct.replaced(source, 999L).build();
+    assertThat(replaced.deletedPositions()).isNull();
+    assertThat(replaced.replacedPositions()).isNull();
+  }
+
+  @Test
   void testExistingBuilderAllowsDvMutation() {
     TrackingStruct existing = TrackingStruct.existing(sourceTracking()).dvSnapshotId(999L).build();
     assertThat(existing.dvSnapshotId()).isEqualTo(999L);
@@ -275,6 +305,65 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testMdvMutatorsRejectedOnAdded() {
+    assertThatThrownBy(
+            () -> TrackingStruct.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set deleted positions on a ADDED entry");
+
+    assertThatThrownBy(
+            () -> TrackingStruct.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set replaced positions on a ADDED entry");
+  }
+
+  @Test
+  void testMdvMutatorsRejectedOnReplaced() {
+    Tracking source = sourceTracking();
+
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.replaced(source, 1L)
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set deleted positions on a REPLACED entry");
+
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.replaced(source, 1L)
+                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set replaced positions on a REPLACED entry");
+  }
+
+  @Test
+  void testDvSnapshotIdAndMdvPositionsAreMutuallyExclusive() {
+    // sourceTracking has dvSnapshotId=43, inherited by existing(source)
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.existing(sourceTracking())
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set deleted positions with dv snapshot ID");
+
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.existing(sourceTracking())
+                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set replaced positions with dv snapshot ID");
+
+    // Setting MDV positions first then dvSnapshotId is also rejected
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.existing(manifestSourceTracking())
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
+                    .dvSnapshotId(123L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set dv snapshot ID with manifest delete vector positions");
+  }
+
+  @Test
   void testBuilderRejectsNullSource() {
     assertThatThrownBy(() -> TrackingStruct.existing(null))
         .isInstanceOf(IllegalArgumentException.class)
@@ -283,19 +372,50 @@ class TestTrackingStruct {
     assertThatThrownBy(() -> TrackingStruct.deleted(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid source tracking: null");
+
+    assertThatThrownBy(() -> TrackingStruct.replaced(null, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid source tracking: null");
   }
 
   @Test
-  void testExistingAndDeletedRejectSourceWithoutSequenceNumbers() {
+  void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
     Tracking incomplete = TrackingStruct.added(42L).build();
 
     assertThatThrownBy(() -> TrackingStruct.existing(incomplete))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Source tracking has no data sequence number; cannot mark as EXISTING");
+        .hasMessage("Invalid tracking source: data sequence number is null");
 
     assertThatThrownBy(() -> TrackingStruct.deleted(incomplete, 1L))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Source tracking has no data sequence number; cannot mark as DELETED");
+        .hasMessage("Invalid tracking source: data sequence number is null");
+
+    assertThatThrownBy(() -> TrackingStruct.replaced(incomplete, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: data sequence number is null");
+  }
+
+  @Test
+  void testRejectsTransitionsFromTerminalStatus() {
+    Tracking deletedSource = sourceTrackingWithStatus(EntryStatus.DELETED);
+    Tracking replacedSource = sourceTrackingWithStatus(EntryStatus.REPLACED);
+
+    assertThatThrownBy(() -> TrackingStruct.existing(deletedSource))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot transition from DELETED status");
+
+    assertThatThrownBy(() -> TrackingStruct.deleted(replacedSource, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot transition from REPLACED status");
+  }
+
+  @Test
+  void testRejectsSameStatusTransition() {
+    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
+
+    assertThatThrownBy(() -> TrackingStruct.existing(existingSource))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid status transition: EXISTING -> EXISTING");
   }
 
   @Test
@@ -318,42 +438,64 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
-    TrackingStruct tracking =
-        TrackingStruct.added(42L)
-            .dvSnapshotId(99L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
+  void testDataFileJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
     assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
+    assertThat(deserialized.deletedPositions()).isNull();
+    assertThat(deserialized.replacedPositions()).isNull();
+  }
+
+  @Test
+  void testManifestJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+    TrackingStruct tracking =
+        TrackingStruct.existing(manifestSourceTracking())
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
+            .build();
+
+    TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
+
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(deserialized.dvSnapshotId()).isNull();
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
 
   @Test
-  void testKryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking =
-        TrackingStruct.added(42L)
-            .dvSnapshotId(99L)
-            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
-            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
-            .build();
+  void testDataFileKryoSerializationRoundTrip() throws IOException {
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
     assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
+    assertThat(deserialized.deletedPositions()).isNull();
+    assertThat(deserialized.replacedPositions()).isNull();
+  }
+
+  @Test
+  void testManifestKryoSerializationRoundTrip() throws IOException {
+    TrackingStruct tracking =
+        TrackingStruct.existing(manifestSourceTracking())
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
+            .build();
+
+    TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
+
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(deserialized.dvSnapshotId()).isNull();
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
 
-  private static Tracking sourceTracking() {
+  private static TrackingStruct sourceTracking() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
     tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
@@ -361,6 +503,18 @@ class TestTrackingStruct {
     tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 10L);
     tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
     tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
+    return tracking;
+  }
+
+  private static TrackingStruct sourceTrackingWithStatus(EntryStatus status) {
+    TrackingStruct tracking = sourceTracking();
+    tracking.set(STATUS_ORDINAL, status.id());
+    return tracking;
+  }
+
+  private static TrackingStruct manifestSourceTracking() {
+    TrackingStruct tracking = sourceTracking();
+    tracking.set(DV_SNAPSHOT_ID_ORDINAL, null);
     return tracking;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -24,10 +24,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.function.Consumer;
+import java.util.stream.Stream;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class TestTrackingStruct {
 
@@ -71,7 +75,7 @@ class TestTrackingStruct {
   @Test
   void testCopy() {
     Tracking tracking =
-        TrackingBuilder.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
@@ -197,6 +201,19 @@ class TestTrackingStruct {
     assertThat(tracking.fileSequenceNumber()).isNull();
   }
 
+  @Test
+  void testInheritFromNullIsNoOp() {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+
+    tracking.inheritFrom(null);
+
+    // null source is a no-op; all unset fields stay null
+    assertThat(tracking.snapshotId()).isNull();
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
+  }
+
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
@@ -225,7 +242,7 @@ class TestTrackingStruct {
   void testExistingBuilderPreservesSourceFields() {
     Tracking source = sourceTracking();
 
-    Tracking existing = TrackingBuilder.builder(source, 1L).build();
+    Tracking existing = TrackingBuilder.from(source, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
@@ -269,7 +286,7 @@ class TestTrackingStruct {
     source.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
     source.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
 
-    Tracking existing = TrackingBuilder.builder(source, 1L).build();
+    Tracking existing = TrackingBuilder.from(source, 1L).build();
     assertThat(existing.deletedPositions()).isNull();
     assertThat(existing.replacedPositions()).isNull();
 
@@ -284,12 +301,12 @@ class TestTrackingStruct {
 
   @Test
   void testExistingBuilderAllowsDvMutation() {
-    Tracking existing = TrackingBuilder.builder(sourceTracking(), 999L).dvUpdated().build();
+    Tracking existing = TrackingBuilder.from(sourceTracking(), 999L).dvUpdated().build();
     assertThat(existing.dvSnapshotId()).isEqualTo(999L);
   }
 
   @Test
-  void testMdvMutatorsRejectedOnAdded() {
+  void testManifestDVMutatorsRejectedOnAdded() {
     assertThatThrownBy(
             () -> TrackingBuilder.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
@@ -302,18 +319,18 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDvSnapshotIdAndMdvPositionsAreMutuallyExclusive() {
+  void testDvSnapshotIdAndManifestDVPositionsAreMutuallyExclusive() {
     // sourceTracking has dvSnapshotId=43, inherited by existing(source)
     assertThatThrownBy(
             () ->
-                TrackingBuilder.builder(sourceTracking(), 1L)
+                TrackingBuilder.from(sourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
 
     assertThatThrownBy(
             () ->
-                TrackingBuilder.builder(sourceTracking(), 1L)
+                TrackingBuilder.from(sourceTracking(), 1L)
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
@@ -321,7 +338,7 @@ class TestTrackingStruct {
     // Setting MDV positions first then dvUpdated is also rejected
     assertThatThrownBy(
             () ->
-                TrackingBuilder.builder(manifestSourceTracking(), 1L)
+                TrackingBuilder.from(manifestSourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
                     .dvUpdated())
         .isInstanceOf(IllegalStateException.class)
@@ -331,7 +348,7 @@ class TestTrackingStruct {
 
   @Test
   void testBuilderRejectsNullSource() {
-    assertThatThrownBy(() -> TrackingBuilder.builder(null, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.from(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid source tracking: null");
   }
@@ -340,7 +357,7 @@ class TestTrackingStruct {
   void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
     Tracking missingBoth = TrackingBuilder.added(42L).build();
 
-    assertThatThrownBy(() -> TrackingBuilder.builder(missingBoth, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.from(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
@@ -357,7 +374,7 @@ class TestTrackingStruct {
     missingFileSeq.set(SNAPSHOT_ID_ORDINAL, 42L);
     missingFileSeq.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
 
-    assertThatThrownBy(() -> TrackingBuilder.builder(missingFileSeq, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.from(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
@@ -370,25 +387,34 @@ class TestTrackingStruct {
         .hasMessage("Invalid tracking source: file sequence number is null");
   }
 
-  @Test
-  void testRejectsTransitionsFromTerminalStatus() {
-    Tracking deletedSource = sourceTrackingWithStatus(EntryStatus.DELETED);
-    Tracking replacedSource = sourceTrackingWithStatus(EntryStatus.REPLACED);
+  private static Stream<Arguments> terminalTransitionCases() {
+    Consumer<Tracking> builderCall = source -> TrackingBuilder.from(source, 1L);
+    Consumer<Tracking> deletedCall = source -> TrackingBuilder.deleted(source, 1L);
+    Consumer<Tracking> replacedCall = source -> TrackingBuilder.replaced(source, 1L);
+    return Stream.of(
+        Arguments.of(EntryStatus.DELETED, builderCall),
+        Arguments.of(EntryStatus.DELETED, deletedCall),
+        Arguments.of(EntryStatus.DELETED, replacedCall),
+        Arguments.of(EntryStatus.REPLACED, builderCall),
+        Arguments.of(EntryStatus.REPLACED, deletedCall),
+        Arguments.of(EntryStatus.REPLACED, replacedCall));
+  }
 
-    assertThatThrownBy(() -> TrackingBuilder.builder(deletedSource, 1L))
+  @ParameterizedTest
+  @MethodSource("terminalTransitionCases")
+  void testRejectsTransitionsFromTerminalStatus(
+      EntryStatus sourceStatus, Consumer<Tracking> factoryCall) {
+    Tracking source = sourceTrackingWithStatus(sourceStatus);
+    assertThatThrownBy(() -> factoryCall.accept(source))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot revive non-live entry with status DELETED");
-
-    assertThatThrownBy(() -> TrackingBuilder.deleted(replacedSource, 1L))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot revive non-live entry with status REPLACED");
+        .hasMessage("Cannot revive non-live entry with status " + sourceStatus);
   }
 
   @Test
   void testExistingToExistingIsAllowed() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    Tracking existing = TrackingBuilder.builder(existingSource, 1L).build();
+    Tracking existing = TrackingBuilder.from(existingSource, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
@@ -405,6 +431,32 @@ class TestTrackingStruct {
     Tracking replaced = TrackingBuilder.replaced(existingSource, 999L);
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
+  }
+
+  @Test
+  void testInternalSetIgnoresUnknownOrdinal() {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 11L);
+    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
+    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
+    tracking.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
+    tracking.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
+
+    // unknown ordinals from a newer format version are silently ignored
+    tracking.internalSet(99, "value from a newer format");
+
+    // every field is unchanged
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(11L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.firstRowId()).isEqualTo(1000L);
+    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
 
   @Test
@@ -441,10 +493,10 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExistingWithMdvPositionsJavaSerializationRoundTrip()
+  void testExistingWithManifestDVPositionsJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
     Tracking tracking =
-        TrackingBuilder.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
@@ -471,9 +523,9 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExistingWithMdvPositionsKryoSerializationRoundTrip() throws IOException {
+  void testExistingWithManifestDVPositionsKryoSerializationRoundTrip() throws IOException {
     Tracking tracking =
-        TrackingBuilder.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -395,6 +395,19 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testExistingToTerminalTransitions() {
+    Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
+
+    Tracking deleted = existingSource.asDeleted(999L);
+    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
+    assertThat(deleted.snapshotId()).isEqualTo(999L);
+
+    Tracking replaced = existingSource.asReplaced(999L);
+    assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
+    assertThat(replaced.snapshotId()).isEqualTo(999L);
+  }
+
+  @Test
   void testProjectedStructLike() {
     // project only snapshot_id (field ID 1) and first_row_id (field ID 142)
     Types.StructType projection = Types.StructType.of(Tracking.SNAPSHOT_ID, Tracking.FIRST_ROW_ID);

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -208,17 +208,24 @@ class TestTrackingStruct {
 
   @Test
   void testAddedBuilder() {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(43L).build();
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
-    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(42L);
     assertThat(tracking.deletedPositions()).isNull();
     assertThat(tracking.replacedPositions()).isNull();
     // sequence numbers and firstRowId remain null; populated by inheritance
     assertThat(tracking.dataSequenceNumber()).isNull();
     assertThat(tracking.fileSequenceNumber()).isNull();
     assertThat(tracking.firstRowId()).isNull();
+  }
+
+  @Test
+  void testAddedBuilderRejectsMismatchedDvSnapshotId() {
+    assertThatThrownBy(() -> TrackingStruct.added(42L).dvSnapshotId(43L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid DV snapshot ID for ADDED entry: 43 (must equal entry snapshot ID 42)");
   }
 
   @Test
@@ -294,7 +301,7 @@ class TestTrackingStruct {
 
     assertThatThrownBy(() -> TrackingStruct.deleted(source, 1L).dvSnapshotId(123L))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set dv snapshot ID on DELETED entry");
+        .hasMessage("Cannot set DV snapshot ID on DELETED entry");
 
     assertThatThrownBy(
             () ->
@@ -344,6 +351,13 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testDvSnapshotIdRejectedOnReplaced() {
+    assertThatThrownBy(() -> TrackingStruct.replaced(sourceTracking(), 1L).dvSnapshotId(123L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set DV snapshot ID on REPLACED entry");
+  }
+
+  @Test
   void testDvSnapshotIdAndMdvPositionsAreMutuallyExclusive() {
     // sourceTracking has dvSnapshotId=43, inherited by existing(source)
     assertThatThrownBy(
@@ -351,14 +365,14 @@ class TestTrackingStruct {
                 TrackingStruct.existing(sourceTracking())
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions with dv snapshot ID");
+        .hasMessage("Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
 
     assertThatThrownBy(
             () ->
                 TrackingStruct.existing(sourceTracking())
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions with dv snapshot ID");
+        .hasMessage("Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
 
     // Setting MDV positions first then dvSnapshotId is also rejected
     assertThatThrownBy(
@@ -367,7 +381,8 @@ class TestTrackingStruct {
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
                     .dvSnapshotId(123L))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set dv snapshot ID with manifest delete vector positions");
+        .hasMessage(
+            "Cannot set DV snapshot ID on a manifest entry (deleted/replaced positions are set)");
   }
 
   @Test
@@ -425,21 +440,22 @@ class TestTrackingStruct {
     Tracking replacedSource = sourceTrackingWithStatus(EntryStatus.REPLACED);
 
     assertThatThrownBy(() -> TrackingStruct.existing(deletedSource))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot transition from DELETED status");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Invalid status transition: DELETED -> EXISTING (DELETED is terminal)");
 
     assertThatThrownBy(() -> TrackingStruct.deleted(replacedSource, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot transition from REPLACED status");
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Invalid status transition: REPLACED -> DELETED (REPLACED is terminal)");
   }
 
   @Test
-  void testRejectsSameStatusTransition() {
+  void testExistingToExistingIsAllowed() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    assertThatThrownBy(() -> TrackingStruct.existing(existingSource))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid status transition: EXISTING -> EXISTING");
+    TrackingStruct existing = TrackingStruct.existing(existingSource).build();
+
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
   }
 
   @Test
@@ -464,13 +480,13 @@ class TestTrackingStruct {
   @Test
   void testAddedWithDvSnapshotIdJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(42L);
     assertThat(deserialized.deletedPositions()).isNull();
     assertThat(deserialized.replacedPositions()).isNull();
   }
@@ -494,13 +510,13 @@ class TestTrackingStruct {
 
   @Test
   void testAddedWithDvSnapshotIdKryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
+    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(42L);
     assertThat(deserialized.deletedPositions()).isNull();
     assertThat(deserialized.replacedPositions()).isNull();
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -30,16 +31,28 @@ import org.junit.jupiter.params.provider.EnumSource;
 
 class TestTrackingStruct {
 
+  // Ordinals looked up from Tracking.schema() so tests don't hard-code positions.
+  private static final List<Types.NestedField> TRACKING_FIELDS = Tracking.schema().fields();
+  private static final int STATUS_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.STATUS);
+  private static final int SNAPSHOT_ID_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.SNAPSHOT_ID);
+  private static final int DATA_SEQUENCE_NUMBER_ORDINAL =
+      TRACKING_FIELDS.indexOf(Tracking.SEQUENCE_NUMBER);
+  private static final int FILE_SEQUENCE_NUMBER_ORDINAL =
+      TRACKING_FIELDS.indexOf(Tracking.FILE_SEQUENCE_NUMBER);
+  private static final int DV_SNAPSHOT_ID_ORDINAL =
+      TRACKING_FIELDS.indexOf(Tracking.DV_SNAPSHOT_ID);
+  private static final int FIRST_ROW_ID_ORDINAL = TRACKING_FIELDS.indexOf(Tracking.FIRST_ROW_ID);
+
   @Test
   void testFieldAccess() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
-    tracking.set(0, EntryStatus.ADDED.id());
-    tracking.set(1, 42L);
-    tracking.set(2, 10L);
-    tracking.set(3, 11L);
-    tracking.set(4, 43L);
-    tracking.set(5, 1000L);
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 11L);
+    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
+    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
@@ -54,29 +67,27 @@ class TestTrackingStruct {
   @Test
   void testCopy() {
     TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.ADDED)
-            .snapshotId(42L)
-            .dataSequenceNumber(10L)
-            .deletedPositions(new byte[] {1, 2})
+        TrackingStruct.added(42L)
+            .dvSnapshotId(99L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .build();
 
     TrackingStruct copy = tracking.copy();
 
     assertThat(copy.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(copy.snapshotId()).isEqualTo(42L);
-    assertThat(copy.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(copy.dvSnapshotId()).isEqualTo(99L);
     assertThat(copy.deletedPositions()).isNotNull();
 
-    // verify deep copy of ByteBuffer
-    assertThat(copy.deletedPositions()).isNotSameAs(tracking.deletedPositions());
+    // verify deep copy of ByteBuffer backing array
+    assertThat(copy.deletedPositions().array()).isNotSameAs(tracking.deletedPositions().array());
   }
 
   @ParameterizedTest
   @EnumSource(EntryStatus.class)
   void testAllStatuses(EntryStatus status) {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, status.id());
+    tracking.set(STATUS_ORDINAL, status.id());
     assertThat(tracking.status()).isEqualTo(status);
   }
 
@@ -84,22 +95,24 @@ class TestTrackingStruct {
   void testIsLive() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
 
-    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
     assertThat(tracking.isLive()).isTrue();
 
-    tracking.set(0, EntryStatus.EXISTING.id());
+    tracking.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
     assertThat(tracking.isLive()).isTrue();
 
-    tracking.set(0, EntryStatus.DELETED.id());
+    tracking.set(STATUS_ORDINAL, EntryStatus.DELETED.id());
     assertThat(tracking.isLive()).isFalse();
 
-    tracking.set(0, EntryStatus.REPLACED.id());
+    tracking.set(STATUS_ORDINAL, EntryStatus.REPLACED.id());
     assertThat(tracking.isLive()).isFalse();
   }
 
   @Test
   void testInheritSnapshotId() {
-    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // snapshotId is null, should inherit from manifest
@@ -108,7 +121,9 @@ class TestTrackingStruct {
 
   @Test
   void testInheritSequenceNumberForAddedEntries() {
-    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are null and status is ADDED, should inherit
@@ -118,12 +133,11 @@ class TestTrackingStruct {
 
   @Test
   void testDoNotInheritSequenceNumberForExistingEntries() {
-    TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.EXISTING)
-            .dataSequenceNumber(5L)
-            .fileSequenceNumber(6L)
-            .build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 5L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 6L);
+
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are not inherited for EXISTING entries
@@ -133,13 +147,12 @@ class TestTrackingStruct {
 
   @Test
   void testExplicitValuesOverrideInheritance() {
-    TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.ADDED)
-            .snapshotId(200L)
-            .dataSequenceNumber(75L)
-            .fileSequenceNumber(76L)
-            .build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    tracking.set(SNAPSHOT_ID_ORDINAL, 200L);
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 75L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 76L);
+
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // explicit values should take precedence
@@ -151,13 +164,13 @@ class TestTrackingStruct {
   @Test
   void testInheritFromRejectsUnequalSequenceNumbers() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
-    tracking.set(0, EntryStatus.ADDED.id());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
 
     TrackingStruct manifestTracking = new TrackingStruct(Tracking.schema());
-    manifestTracking.set(0, EntryStatus.ADDED.id());
-    manifestTracking.set(1, 100L);
-    manifestTracking.set(2, 50L);
-    manifestTracking.set(3, 60L);
+    manifestTracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    manifestTracking.set(SNAPSHOT_ID_ORDINAL, 100L);
+    manifestTracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 50L);
+    manifestTracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 60L);
 
     assertThatThrownBy(() -> tracking.inheritFrom(manifestTracking))
         .isInstanceOf(IllegalArgumentException.class)
@@ -166,7 +179,8 @@ class TestTrackingStruct {
 
   @Test
   void testNoDefaultingWithoutInheritance() {
-    TrackingStruct tracking = TrackingStruct.builder().status(EntryStatus.ADDED).build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
 
     // no inheritance, nulls stay null
     assertThat(tracking.snapshotId()).isNull();
@@ -175,19 +189,113 @@ class TestTrackingStruct {
   }
 
   private static Tracking createManifestTracking(long snapshotId, long sequenceNumber) {
-    return TrackingStruct.builder()
-        .status(EntryStatus.ADDED)
-        .snapshotId(snapshotId)
-        .dataSequenceNumber(sequenceNumber)
-        .fileSequenceNumber(sequenceNumber)
-        .build();
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    tracking.set(SNAPSHOT_ID_ORDINAL, snapshotId);
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, sequenceNumber);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, sequenceNumber);
+    return tracking;
   }
 
   @Test
-  void testBuilderValidation() {
-    assertThatThrownBy(() -> TrackingStruct.builder().build())
+  void testAddedBuilder() {
+    TrackingStruct tracking =
+        TrackingStruct.added(42L)
+            .dvSnapshotId(43L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
+            .build();
+
+    assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
+    assertThat(tracking.snapshotId()).isEqualTo(42L);
+    assertThat(tracking.dvSnapshotId()).isEqualTo(43L);
+    assertThat(tracking.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+    assertThat(tracking.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
+    // sequence numbers and firstRowId remain null; populated by inheritance
+    assertThat(tracking.dataSequenceNumber()).isNull();
+    assertThat(tracking.fileSequenceNumber()).isNull();
+    assertThat(tracking.firstRowId()).isNull();
+  }
+
+  @Test
+  void testExistingBuilderPreservesSourceFields() {
+    Tracking source = sourceTracking();
+
+    TrackingStruct existing = TrackingStruct.existing(source).build();
+
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
+    assertThat(existing.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(existing.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(existing.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(existing.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testDeletedBuilderUpdatesSnapshotIdAndPreservesRest() {
+    Tracking source = sourceTracking();
+
+    TrackingStruct deleted = TrackingStruct.deleted(source, 999L).build();
+
+    assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
+    assertThat(deleted.snapshotId()).isEqualTo(999L);
+    assertThat(deleted.dataSequenceNumber()).isEqualTo(source.dataSequenceNumber());
+    assertThat(deleted.fileSequenceNumber()).isEqualTo(source.fileSequenceNumber());
+    assertThat(deleted.dvSnapshotId()).isEqualTo(source.dvSnapshotId());
+    assertThat(deleted.firstRowId()).isEqualTo(source.firstRowId());
+  }
+
+  @Test
+  void testExistingBuilderAllowsDvMutation() {
+    TrackingStruct existing = TrackingStruct.existing(sourceTracking()).dvSnapshotId(999L).build();
+    assertThat(existing.dvSnapshotId()).isEqualTo(999L);
+  }
+
+  @Test
+  void testDeletedBuilderRejectsMutators() {
+    Tracking source = sourceTracking();
+
+    assertThatThrownBy(() -> TrackingStruct.deleted(source, 1L).dvSnapshotId(123L))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set dv snapshot ID on a DELETED entry");
+
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.deleted(source, 1L)
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set deleted positions on a DELETED entry");
+
+    assertThatThrownBy(
+            () ->
+                TrackingStruct.deleted(source, 1L)
+                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Cannot set replaced positions on a DELETED entry");
+  }
+
+  @Test
+  void testBuilderRejectsNullSource() {
+    assertThatThrownBy(() -> TrackingStruct.existing(null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid status: null");
+        .hasMessage("Invalid source tracking: null");
+
+    assertThatThrownBy(() -> TrackingStruct.deleted(null, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid source tracking: null");
+  }
+
+  @Test
+  void testExistingAndDeletedRejectSourceWithoutSequenceNumbers() {
+    Tracking incomplete = TrackingStruct.added(42L).build();
+
+    assertThatThrownBy(() -> TrackingStruct.existing(incomplete))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Source tracking has no data sequence number; cannot mark as EXISTING");
+
+    assertThatThrownBy(() -> TrackingStruct.deleted(incomplete, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Source tracking has no data sequence number; cannot mark as DELETED");
   }
 
   @Test
@@ -212,36 +320,47 @@ class TestTrackingStruct {
   @Test
   void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.ADDED)
-            .snapshotId(42L)
-            .dataSequenceNumber(10L)
-            .deletedPositions(new byte[] {1, 2})
+        TrackingStruct.added(42L)
+            .dvSnapshotId(99L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+    assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
 
   @Test
   void testKryoSerializationRoundTrip() throws IOException {
     TrackingStruct tracking =
-        TrackingStruct.builder()
-            .status(EntryStatus.ADDED)
-            .snapshotId(42L)
-            .dataSequenceNumber(10L)
-            .deletedPositions(new byte[] {1, 2})
+        TrackingStruct.added(42L)
+            .dvSnapshotId(99L)
+            .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
-    assertThat(deserialized.dataSequenceNumber()).isEqualTo(10L);
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(99L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+    assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
+  }
+
+  private static Tracking sourceTracking() {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    tracking.set(SNAPSHOT_ID_ORDINAL, 42L);
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 10L);
+    tracking.set(DV_SNAPSHOT_ID_ORDINAL, 43L);
+    tracking.set(FIRST_ROW_ID_ORDINAL, 1000L);
+    return tracking;
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -70,13 +70,13 @@ class TestTrackingStruct {
 
   @Test
   void testCopy() {
-    TrackingStruct tracking =
-        TrackingStruct.existing(manifestSourceTracking())
+    Tracking tracking =
+        TrackingStruct.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
-    TrackingStruct copy = tracking.copy();
+    Tracking copy = tracking.copy();
 
     assertThat(copy.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(copy.snapshotId()).isEqualTo(tracking.snapshotId());
@@ -208,7 +208,7 @@ class TestTrackingStruct {
 
   @Test
   void testAddedBuilder() {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
+    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
@@ -222,17 +222,10 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testAddedBuilderRejectsMismatchedDvSnapshotId() {
-    assertThatThrownBy(() -> TrackingStruct.added(42L).dvSnapshotId(43L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid DV snapshot ID for ADDED entry: 43 (must equal entry snapshot ID 42)");
-  }
-
-  @Test
   void testExistingBuilderPreservesSourceFields() {
     Tracking source = sourceTracking();
 
-    TrackingStruct existing = TrackingStruct.existing(source).build();
+    Tracking existing = TrackingStruct.builder(source, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
@@ -243,10 +236,10 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDeletedBuilderUpdatesSnapshotIdAndPreservesRest() {
+  void testDeleteUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    TrackingStruct deleted = TrackingStruct.deleted(source, 999L).build();
+    Tracking deleted = source.asDeleted(999L);
 
     assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
     assertThat(deleted.snapshotId()).isEqualTo(999L);
@@ -257,10 +250,10 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testReplacedBuilderUpdatesSnapshotIdAndPreservesRest() {
+  void testReplaceUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    TrackingStruct replaced = TrackingStruct.replaced(source, 999L).build();
+    Tracking replaced = source.asReplaced(999L);
 
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
@@ -276,46 +269,23 @@ class TestTrackingStruct {
     source.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
     source.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
 
-    TrackingStruct existing = TrackingStruct.existing(source).build();
+    Tracking existing = TrackingStruct.builder(source, 1L).build();
     assertThat(existing.deletedPositions()).isNull();
     assertThat(existing.replacedPositions()).isNull();
 
-    TrackingStruct deleted = TrackingStruct.deleted(source, 999L).build();
+    Tracking deleted = source.asDeleted(999L);
     assertThat(deleted.deletedPositions()).isNull();
     assertThat(deleted.replacedPositions()).isNull();
 
-    TrackingStruct replaced = TrackingStruct.replaced(source, 999L).build();
+    Tracking replaced = source.asReplaced(999L);
     assertThat(replaced.deletedPositions()).isNull();
     assertThat(replaced.replacedPositions()).isNull();
   }
 
   @Test
   void testExistingBuilderAllowsDvMutation() {
-    TrackingStruct existing = TrackingStruct.existing(sourceTracking()).dvSnapshotId(999L).build();
+    Tracking existing = TrackingStruct.builder(sourceTracking(), 999L).dvUpdated().build();
     assertThat(existing.dvSnapshotId()).isEqualTo(999L);
-  }
-
-  @Test
-  void testDeletedBuilderRejectsMutators() {
-    Tracking source = sourceTracking();
-
-    assertThatThrownBy(() -> TrackingStruct.deleted(source, 1L).dvSnapshotId(123L))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set DV snapshot ID on DELETED entry");
-
-    assertThatThrownBy(
-            () ->
-                TrackingStruct.deleted(source, 1L)
-                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on DELETED entry");
-
-    assertThatThrownBy(
-            () ->
-                TrackingStruct.deleted(source, 1L)
-                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on DELETED entry");
   }
 
   @Test
@@ -332,70 +302,36 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testMdvMutatorsRejectedOnReplaced() {
-    Tracking source = sourceTracking();
-
-    assertThatThrownBy(
-            () ->
-                TrackingStruct.replaced(source, 1L)
-                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on REPLACED entry");
-
-    assertThatThrownBy(
-            () ->
-                TrackingStruct.replaced(source, 1L)
-                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on REPLACED entry");
-  }
-
-  @Test
-  void testDvSnapshotIdRejectedOnReplaced() {
-    assertThatThrownBy(() -> TrackingStruct.replaced(sourceTracking(), 1L).dvSnapshotId(123L))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set DV snapshot ID on REPLACED entry");
-  }
-
-  @Test
   void testDvSnapshotIdAndMdvPositionsAreMutuallyExclusive() {
     // sourceTracking has dvSnapshotId=43, inherited by existing(source)
     assertThatThrownBy(
             () ->
-                TrackingStruct.existing(sourceTracking())
+                TrackingStruct.builder(sourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
 
     assertThatThrownBy(
             () ->
-                TrackingStruct.existing(sourceTracking())
+                TrackingStruct.builder(sourceTracking(), 1L)
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
 
-    // Setting MDV positions first then dvSnapshotId is also rejected
+    // Setting MDV positions first then dvUpdated is also rejected
     assertThatThrownBy(
             () ->
-                TrackingStruct.existing(manifestSourceTracking())
+                TrackingStruct.builder(manifestSourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
-                    .dvSnapshotId(123L))
+                    .dvUpdated())
         .isInstanceOf(IllegalStateException.class)
         .hasMessage(
-            "Cannot set DV snapshot ID on a manifest entry (deleted/replaced positions are set)");
+            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
   }
 
   @Test
   void testBuilderRejectsNullSource() {
-    assertThatThrownBy(() -> TrackingStruct.existing(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid source tracking: null");
-
-    assertThatThrownBy(() -> TrackingStruct.deleted(null, 1L))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Invalid source tracking: null");
-
-    assertThatThrownBy(() -> TrackingStruct.replaced(null, 1L))
+    assertThatThrownBy(() -> TrackingStruct.builder(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid source tracking: null");
   }
@@ -404,15 +340,15 @@ class TestTrackingStruct {
   void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
     Tracking missingBoth = TrackingStruct.added(42L).build();
 
-    assertThatThrownBy(() -> TrackingStruct.existing(missingBoth))
+    assertThatThrownBy(() -> TrackingStruct.builder(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.deleted(missingBoth, 1L))
+    assertThatThrownBy(() -> missingBoth.asDeleted(1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.replaced(missingBoth, 1L))
+    assertThatThrownBy(() -> missingBoth.asReplaced(1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
@@ -421,15 +357,15 @@ class TestTrackingStruct {
     missingFileSeq.set(SNAPSHOT_ID_ORDINAL, 42L);
     missingFileSeq.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
 
-    assertThatThrownBy(() -> TrackingStruct.existing(missingFileSeq))
+    assertThatThrownBy(() -> TrackingStruct.builder(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.deleted(missingFileSeq, 1L))
+    assertThatThrownBy(() -> missingFileSeq.asDeleted(1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.replaced(missingFileSeq, 1L))
+    assertThatThrownBy(() -> missingFileSeq.asReplaced(1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
   }
@@ -439,11 +375,11 @@ class TestTrackingStruct {
     Tracking deletedSource = sourceTrackingWithStatus(EntryStatus.DELETED);
     Tracking replacedSource = sourceTrackingWithStatus(EntryStatus.REPLACED);
 
-    assertThatThrownBy(() -> TrackingStruct.existing(deletedSource))
+    assertThatThrownBy(() -> TrackingStruct.builder(deletedSource, 1L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Invalid status transition: DELETED -> EXISTING (DELETED is terminal)");
 
-    assertThatThrownBy(() -> TrackingStruct.deleted(replacedSource, 1L))
+    assertThatThrownBy(() -> replacedSource.asDeleted(1L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Invalid status transition: REPLACED -> DELETED (REPLACED is terminal)");
   }
@@ -452,7 +388,7 @@ class TestTrackingStruct {
   void testExistingToExistingIsAllowed() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    TrackingStruct existing = TrackingStruct.existing(existingSource).build();
+    Tracking existing = TrackingStruct.builder(existingSource, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
@@ -480,9 +416,9 @@ class TestTrackingStruct {
   @Test
   void testAddedWithDvSnapshotIdJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
+    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
 
-    TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
+    Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
@@ -494,13 +430,13 @@ class TestTrackingStruct {
   @Test
   void testExistingWithMdvPositionsJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
-    TrackingStruct tracking =
-        TrackingStruct.existing(manifestSourceTracking())
+    Tracking tracking =
+        TrackingStruct.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
-    TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
+    Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(deserialized.dvSnapshotId()).isNull();
@@ -510,9 +446,9 @@ class TestTrackingStruct {
 
   @Test
   void testAddedWithDvSnapshotIdKryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(42L).build();
+    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
 
-    TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
+    Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(deserialized.snapshotId()).isEqualTo(42L);
@@ -523,13 +459,13 @@ class TestTrackingStruct {
 
   @Test
   void testExistingWithMdvPositionsKryoSerializationRoundTrip() throws IOException {
-    TrackingStruct tracking =
-        TrackingStruct.existing(manifestSourceTracking())
+    Tracking tracking =
+        TrackingStruct.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
-    TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
+    Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(deserialized.dvSnapshotId()).isNull();

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -73,16 +73,23 @@ class TestTrackingStruct {
     TrackingStruct tracking =
         TrackingStruct.existing(manifestSourceTracking())
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
+            .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
 
     TrackingStruct copy = tracking.copy();
 
     assertThat(copy.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(copy.snapshotId()).isEqualTo(tracking.snapshotId());
-    assertThat(copy.deletedPositions()).isNotNull();
+    assertThat(copy.dataSequenceNumber()).isEqualTo(tracking.dataSequenceNumber());
+    assertThat(copy.fileSequenceNumber()).isEqualTo(tracking.fileSequenceNumber());
+    assertThat(copy.dvSnapshotId()).isNull();
+    assertThat(copy.firstRowId()).isEqualTo(tracking.firstRowId());
+    assertThat(copy.deletedPositions()).isEqualTo(tracking.deletedPositions());
+    assertThat(copy.replacedPositions()).isEqualTo(tracking.replacedPositions());
 
-    // verify deep copy of ByteBuffer backing array
+    // verify deep copy of ByteBuffer backing arrays
     assertThat(copy.deletedPositions().array()).isNotSameAs(tracking.deletedPositions().array());
+    assertThat(copy.replacedPositions().array()).isNotSameAs(tracking.replacedPositions().array());
   }
 
   @ParameterizedTest
@@ -287,21 +294,21 @@ class TestTrackingStruct {
 
     assertThatThrownBy(() -> TrackingStruct.deleted(source, 1L).dvSnapshotId(123L))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set dv snapshot ID on a DELETED entry");
+        .hasMessage("Cannot set dv snapshot ID on DELETED entry");
 
     assertThatThrownBy(
             () ->
                 TrackingStruct.deleted(source, 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on a DELETED entry");
+        .hasMessage("Cannot set deleted positions on DELETED entry");
 
     assertThatThrownBy(
             () ->
                 TrackingStruct.deleted(source, 1L)
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on a DELETED entry");
+        .hasMessage("Cannot set replaced positions on DELETED entry");
   }
 
   @Test
@@ -309,12 +316,12 @@ class TestTrackingStruct {
     assertThatThrownBy(
             () -> TrackingStruct.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on a ADDED entry");
+        .hasMessage("Cannot set deleted positions on ADDED entry");
 
     assertThatThrownBy(
             () -> TrackingStruct.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on a ADDED entry");
+        .hasMessage("Cannot set replaced positions on ADDED entry");
   }
 
   @Test
@@ -326,14 +333,14 @@ class TestTrackingStruct {
                 TrackingStruct.replaced(source, 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on a REPLACED entry");
+        .hasMessage("Cannot set deleted positions on REPLACED entry");
 
     assertThatThrownBy(
             () ->
                 TrackingStruct.replaced(source, 1L)
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on a REPLACED entry");
+        .hasMessage("Cannot set replaced positions on REPLACED entry");
   }
 
   @Test
@@ -380,19 +387,36 @@ class TestTrackingStruct {
 
   @Test
   void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
-    Tracking incomplete = TrackingStruct.added(42L).build();
+    Tracking missingBoth = TrackingStruct.added(42L).build();
 
-    assertThatThrownBy(() -> TrackingStruct.existing(incomplete))
+    assertThatThrownBy(() -> TrackingStruct.existing(missingBoth))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.deleted(incomplete, 1L))
+    assertThatThrownBy(() -> TrackingStruct.deleted(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingStruct.replaced(incomplete, 1L))
+    assertThatThrownBy(() -> TrackingStruct.replaced(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
+
+    TrackingStruct missingFileSeq = new TrackingStruct(Tracking.schema());
+    missingFileSeq.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
+    missingFileSeq.set(SNAPSHOT_ID_ORDINAL, 42L);
+    missingFileSeq.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
+
+    assertThatThrownBy(() -> TrackingStruct.existing(missingFileSeq))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
+
+    assertThatThrownBy(() -> TrackingStruct.deleted(missingFileSeq, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
+
+    assertThatThrownBy(() -> TrackingStruct.replaced(missingFileSeq, 1L))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid tracking source: file sequence number is null");
   }
 
   @Test
@@ -438,7 +462,8 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDataFileJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testAddedWithDvSnapshotIdJavaSerializationRoundTrip()
+      throws IOException, ClassNotFoundException {
     TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
 
     TrackingStruct deserialized = TestHelpers.roundTripSerialize(tracking);
@@ -451,7 +476,8 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testManifestJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void testExistingWithMdvPositionsJavaSerializationRoundTrip()
+      throws IOException, ClassNotFoundException {
     TrackingStruct tracking =
         TrackingStruct.existing(manifestSourceTracking())
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
@@ -467,7 +493,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDataFileKryoSerializationRoundTrip() throws IOException {
+  void testAddedWithDvSnapshotIdKryoSerializationRoundTrip() throws IOException {
     TrackingStruct tracking = TrackingStruct.added(42L).dvSnapshotId(99L).build();
 
     TrackingStruct deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
@@ -480,7 +506,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testManifestKryoSerializationRoundTrip() throws IOException {
+  void testExistingWithMdvPositionsKryoSerializationRoundTrip() throws IOException {
     TrackingStruct tracking =
         TrackingStruct.existing(manifestSourceTracking())
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -71,7 +71,7 @@ class TestTrackingStruct {
   @Test
   void testCopy() {
     Tracking tracking =
-        TrackingStruct.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
@@ -208,7 +208,7 @@ class TestTrackingStruct {
 
   @Test
   void testAddedBuilder() {
-    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
+    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
     assertThat(tracking.snapshotId()).isEqualTo(42L);
@@ -225,7 +225,7 @@ class TestTrackingStruct {
   void testExistingBuilderPreservesSourceFields() {
     Tracking source = sourceTracking();
 
-    Tracking existing = TrackingStruct.builder(source, 1L).build();
+    Tracking existing = TrackingBuilder.builder(source, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
@@ -239,7 +239,7 @@ class TestTrackingStruct {
   void testDeleteUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    Tracking deleted = source.asDeleted(999L);
+    Tracking deleted = TrackingBuilder.delete(source, 999L);
 
     assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
     assertThat(deleted.snapshotId()).isEqualTo(999L);
@@ -253,7 +253,7 @@ class TestTrackingStruct {
   void testReplaceUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    Tracking replaced = source.asReplaced(999L);
+    Tracking replaced = TrackingBuilder.replace(source, 999L);
 
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
@@ -269,34 +269,34 @@ class TestTrackingStruct {
     source.set(DELETED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {1, 2}));
     source.set(REPLACED_POSITIONS_ORDINAL, ByteBuffer.wrap(new byte[] {3, 4}));
 
-    Tracking existing = TrackingStruct.builder(source, 1L).build();
+    Tracking existing = TrackingBuilder.builder(source, 1L).build();
     assertThat(existing.deletedPositions()).isNull();
     assertThat(existing.replacedPositions()).isNull();
 
-    Tracking deleted = source.asDeleted(999L);
+    Tracking deleted = TrackingBuilder.delete(source, 999L);
     assertThat(deleted.deletedPositions()).isNull();
     assertThat(deleted.replacedPositions()).isNull();
 
-    Tracking replaced = source.asReplaced(999L);
+    Tracking replaced = TrackingBuilder.replace(source, 999L);
     assertThat(replaced.deletedPositions()).isNull();
     assertThat(replaced.replacedPositions()).isNull();
   }
 
   @Test
   void testExistingBuilderAllowsDvMutation() {
-    Tracking existing = TrackingStruct.builder(sourceTracking(), 999L).dvUpdated().build();
+    Tracking existing = TrackingBuilder.builder(sourceTracking(), 999L).dvUpdated().build();
     assertThat(existing.dvSnapshotId()).isEqualTo(999L);
   }
 
   @Test
   void testMdvMutatorsRejectedOnAdded() {
     assertThatThrownBy(
-            () -> TrackingStruct.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
+            () -> TrackingBuilder.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set deleted positions on ADDED entry");
 
     assertThatThrownBy(
-            () -> TrackingStruct.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
+            () -> TrackingBuilder.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set replaced positions on ADDED entry");
   }
@@ -306,14 +306,14 @@ class TestTrackingStruct {
     // sourceTracking has dvSnapshotId=43, inherited by existing(source)
     assertThatThrownBy(
             () ->
-                TrackingStruct.builder(sourceTracking(), 1L)
+                TrackingBuilder.builder(sourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
 
     assertThatThrownBy(
             () ->
-                TrackingStruct.builder(sourceTracking(), 1L)
+                TrackingBuilder.builder(sourceTracking(), 1L)
                     .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
@@ -321,7 +321,7 @@ class TestTrackingStruct {
     // Setting MDV positions first then dvUpdated is also rejected
     assertThatThrownBy(
             () ->
-                TrackingStruct.builder(manifestSourceTracking(), 1L)
+                TrackingBuilder.builder(manifestSourceTracking(), 1L)
                     .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
                     .dvUpdated())
         .isInstanceOf(IllegalStateException.class)
@@ -331,24 +331,24 @@ class TestTrackingStruct {
 
   @Test
   void testBuilderRejectsNullSource() {
-    assertThatThrownBy(() -> TrackingStruct.builder(null, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.builder(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid source tracking: null");
   }
 
   @Test
   void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
-    Tracking missingBoth = TrackingStruct.added(42L).build();
+    Tracking missingBoth = TrackingBuilder.added(42L).build();
 
-    assertThatThrownBy(() -> TrackingStruct.builder(missingBoth, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.builder(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> missingBoth.asDeleted(1L))
+    assertThatThrownBy(() -> TrackingBuilder.delete(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> missingBoth.asReplaced(1L))
+    assertThatThrownBy(() -> TrackingBuilder.replace(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
@@ -357,15 +357,15 @@ class TestTrackingStruct {
     missingFileSeq.set(SNAPSHOT_ID_ORDINAL, 42L);
     missingFileSeq.set(DATA_SEQUENCE_NUMBER_ORDINAL, 10L);
 
-    assertThatThrownBy(() -> TrackingStruct.builder(missingFileSeq, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.builder(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> missingFileSeq.asDeleted(1L))
+    assertThatThrownBy(() -> TrackingBuilder.delete(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> missingFileSeq.asReplaced(1L))
+    assertThatThrownBy(() -> TrackingBuilder.replace(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
   }
@@ -375,20 +375,20 @@ class TestTrackingStruct {
     Tracking deletedSource = sourceTrackingWithStatus(EntryStatus.DELETED);
     Tracking replacedSource = sourceTrackingWithStatus(EntryStatus.REPLACED);
 
-    assertThatThrownBy(() -> TrackingStruct.builder(deletedSource, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.builder(deletedSource, 1L))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Invalid status transition: DELETED -> EXISTING (DELETED is terminal)");
+        .hasMessage("Cannot revive non-live entry with status DELETED");
 
-    assertThatThrownBy(() -> replacedSource.asDeleted(1L))
+    assertThatThrownBy(() -> TrackingBuilder.delete(replacedSource, 1L))
         .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Invalid status transition: REPLACED -> DELETED (REPLACED is terminal)");
+        .hasMessage("Cannot revive non-live entry with status REPLACED");
   }
 
   @Test
   void testExistingToExistingIsAllowed() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    Tracking existing = TrackingStruct.builder(existingSource, 1L).build();
+    Tracking existing = TrackingBuilder.builder(existingSource, 1L).build();
 
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(existing.snapshotId()).isEqualTo(existingSource.snapshotId());
@@ -398,11 +398,11 @@ class TestTrackingStruct {
   void testExistingToTerminalTransitions() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    Tracking deleted = existingSource.asDeleted(999L);
+    Tracking deleted = TrackingBuilder.delete(existingSource, 999L);
     assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
     assertThat(deleted.snapshotId()).isEqualTo(999L);
 
-    Tracking replaced = existingSource.asReplaced(999L);
+    Tracking replaced = TrackingBuilder.replace(existingSource, 999L);
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
   }
@@ -429,7 +429,7 @@ class TestTrackingStruct {
   @Test
   void testAddedWithDvSnapshotIdJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
-    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
+    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
@@ -444,7 +444,7 @@ class TestTrackingStruct {
   void testExistingWithMdvPositionsJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
     Tracking tracking =
-        TrackingStruct.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();
@@ -459,7 +459,7 @@ class TestTrackingStruct {
 
   @Test
   void testAddedWithDvSnapshotIdKryoSerializationRoundTrip() throws IOException {
-    Tracking tracking = TrackingStruct.added(42L).dvUpdated().build();
+    Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
@@ -473,7 +473,7 @@ class TestTrackingStruct {
   @Test
   void testExistingWithMdvPositionsKryoSerializationRoundTrip() throws IOException {
     Tracking tracking =
-        TrackingStruct.builder(manifestSourceTracking(), 1L)
+        TrackingBuilder.builder(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
             .replacedPositions(ByteBuffer.wrap(new byte[] {3, 4}))
             .build();

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -239,7 +239,7 @@ class TestTrackingStruct {
   void testDeleteUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    Tracking deleted = TrackingBuilder.delete(source, 999L);
+    Tracking deleted = TrackingBuilder.deleted(source, 999L);
 
     assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
     assertThat(deleted.snapshotId()).isEqualTo(999L);
@@ -253,7 +253,7 @@ class TestTrackingStruct {
   void testReplaceUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
-    Tracking replaced = TrackingBuilder.replace(source, 999L);
+    Tracking replaced = TrackingBuilder.replaced(source, 999L);
 
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
@@ -273,11 +273,11 @@ class TestTrackingStruct {
     assertThat(existing.deletedPositions()).isNull();
     assertThat(existing.replacedPositions()).isNull();
 
-    Tracking deleted = TrackingBuilder.delete(source, 999L);
+    Tracking deleted = TrackingBuilder.deleted(source, 999L);
     assertThat(deleted.deletedPositions()).isNull();
     assertThat(deleted.replacedPositions()).isNull();
 
-    Tracking replaced = TrackingBuilder.replace(source, 999L);
+    Tracking replaced = TrackingBuilder.replaced(source, 999L);
     assertThat(replaced.deletedPositions()).isNull();
     assertThat(replaced.replacedPositions()).isNull();
   }
@@ -344,11 +344,11 @@ class TestTrackingStruct {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingBuilder.delete(missingBoth, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.deleted(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
-    assertThatThrownBy(() -> TrackingBuilder.replace(missingBoth, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.replaced(missingBoth, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: data sequence number is null");
 
@@ -361,11 +361,11 @@ class TestTrackingStruct {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> TrackingBuilder.delete(missingFileSeq, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.deleted(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
 
-    assertThatThrownBy(() -> TrackingBuilder.replace(missingFileSeq, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.replaced(missingFileSeq, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid tracking source: file sequence number is null");
   }
@@ -379,7 +379,7 @@ class TestTrackingStruct {
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot revive non-live entry with status DELETED");
 
-    assertThatThrownBy(() -> TrackingBuilder.delete(replacedSource, 1L))
+    assertThatThrownBy(() -> TrackingBuilder.deleted(replacedSource, 1L))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot revive non-live entry with status REPLACED");
   }
@@ -398,11 +398,11 @@ class TestTrackingStruct {
   void testExistingToTerminalTransitions() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
-    Tracking deleted = TrackingBuilder.delete(existingSource, 999L);
+    Tracking deleted = TrackingBuilder.deleted(existingSource, 999L);
     assertThat(deleted.status()).isEqualTo(EntryStatus.DELETED);
     assertThat(deleted.snapshotId()).isEqualTo(999L);
 
-    Tracking replaced = TrackingBuilder.replace(existingSource, 999L);
+    Tracking replaced = TrackingBuilder.replaced(existingSource, 999L);
     assertThat(replaced.status()).isEqualTo(EntryStatus.REPLACED);
     assertThat(replaced.snapshotId()).isEqualTo(999L);
   }


### PR DESCRIPTION
This is a follow-up to last round of feedback on #16092 Improves the validation in the v4 struct builders to do early errors guide the state transition. 