### PR TITLE
Spark: Re-enable subquery-expression view tests for the Hive view catalog

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.view.ViewHistoryEntry;
 import org.apache.iceberg.view.ViewProperties;
 import org.apache.iceberg.view.ViewUtil;
 import org.apache.iceberg.view.ViewVersion;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -1352,12 +1353,9 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void createViewWithSubqueryExpressionInFilterThatIsRewritten()
       throws NoSuchTableException {
-    assumeThat(catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE))
-        .as(
-            "Executing subquery expression with Hive fails due to an exception when instantiating the FileInputFormat")
-        .isNotEqualTo("hive");
     insertRows(5);
     String viewName = viewName("viewWithSubqueryExpression");
     String sql =
@@ -1368,12 +1366,21 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThat(sql("SELECT * FROM %s", viewName)).hasSize(1).containsExactly(row(5));
 
+    String catalogType = catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE);
     if (!catalogName.equals(SPARK_CATALOG)) {
       sql("USE spark_catalog");
 
-      assertThatThrownBy(() -> sql(sql))
-          .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      if ("hive".equals(catalogType)) {
+        // The Hive view catalog shares its metastore with the default spark_catalog, so the
+        // Iceberg table IS resolvable there (unlike the in-memory/REST view catalogs) and does
+        // not raise AnalysisException. It cannot be read natively as a Hive table, so executing
+        // the raw SQL fails at execution time instead.
+        assertThatThrownBy(() -> sql(sql)).isInstanceOf(SparkException.class);
+      } else {
+        assertThatThrownBy(() -> sql(sql))
+            .isInstanceOf(AnalysisException.class)
+            .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      }
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace
@@ -1383,11 +1390,8 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void createViewWithSubqueryExpressionInQueryThatIsRewritten() throws NoSuchTableException {
-    assumeThat(catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE))
-        .as(
-            "Executing subquery expression with Hive fails due to an exception when instantiating the FileInputFormat")
-        .isNotEqualTo("hive");
     insertRows(3);
     String viewName = viewName("viewWithSubqueryExpression");
     String sql =
@@ -1399,12 +1403,21 @@ public class TestViews extends ExtensionsTestBase {
         .hasSize(3)
         .containsExactly(row(3), row(3), row(3));
 
+    String catalogType = catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE);
     if (!catalogName.equals(SPARK_CATALOG)) {
       sql("USE spark_catalog");
 
-      assertThatThrownBy(() -> sql(sql))
-          .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      if ("hive".equals(catalogType)) {
+        // The Hive view catalog shares its metastore with the default spark_catalog, so the
+        // Iceberg table IS resolvable there (unlike the in-memory/REST view catalogs) and does
+        // not raise AnalysisException. It cannot be read natively as a Hive table, so executing
+        // the raw SQL fails at execution time instead.
+        assertThatThrownBy(() -> sql(sql)).isInstanceOf(SparkException.class);
+      } else {
+        assertThatThrownBy(() -> sql(sql))
+            .isInstanceOf(AnalysisException.class)
+            .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      }
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.view.ViewHistoryEntry;
 import org.apache.iceberg.view.ViewProperties;
 import org.apache.iceberg.view.ViewUtil;
 import org.apache.iceberg.view.ViewVersion;
+import org.apache.spark.SparkException;
 import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -1354,12 +1355,9 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void createViewWithSubqueryExpressionInFilterThatIsRewritten()
       throws NoSuchTableException {
-    assumeThat(catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE))
-        .as(
-            "Executing subquery expression with Hive fails due to an exception when instantiating the FileInputFormat")
-        .isNotEqualTo("hive");
     insertRows(5);
     String viewName = viewName("viewWithSubqueryExpression");
     String sql =
@@ -1370,12 +1368,21 @@ public class TestViews extends ExtensionsTestBase {
 
     assertThat(sql("SELECT * FROM %s", viewName)).hasSize(1).containsExactly(row(5));
 
+    String catalogType = catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE);
     if (!catalogName.equals(SPARK_CATALOG)) {
       sql("USE spark_catalog");
 
-      assertThatThrownBy(() -> sql(sql))
-          .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      if ("hive".equals(catalogType)) {
+        // The Hive view catalog shares its metastore with the default spark_catalog, so the
+        // Iceberg table IS resolvable there (unlike the in-memory/REST view catalogs) and does
+        // not raise AnalysisException. It cannot be read natively as a Hive table, so executing
+        // the raw SQL fails at execution time instead.
+        assertThatThrownBy(() -> sql(sql)).isInstanceOf(SparkException.class);
+      } else {
+        assertThatThrownBy(() -> sql(sql))
+            .isInstanceOf(AnalysisException.class)
+            .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      }
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace
@@ -1385,11 +1392,8 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  @SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")
   public void createViewWithSubqueryExpressionInQueryThatIsRewritten() throws NoSuchTableException {
-    assumeThat(catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE))
-        .as(
-            "Executing subquery expression with Hive fails due to an exception when instantiating the FileInputFormat")
-        .isNotEqualTo("hive");
     insertRows(3);
     String viewName = viewName("viewWithSubqueryExpression");
     String sql =
@@ -1401,12 +1405,21 @@ public class TestViews extends ExtensionsTestBase {
         .hasSize(3)
         .containsExactly(row(3), row(3), row(3));
 
+    String catalogType = catalogConfig.get(CatalogUtil.ICEBERG_CATALOG_TYPE);
     if (!catalogName.equals(SPARK_CATALOG)) {
       sql("USE spark_catalog");
 
-      assertThatThrownBy(() -> sql(sql))
-          .isInstanceOf(AnalysisException.class)
-          .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      if ("hive".equals(catalogType)) {
+        // The Hive view catalog shares its metastore with the default spark_catalog, so the
+        // Iceberg table IS resolvable there (unlike the in-memory/REST view catalogs) and does
+        // not raise AnalysisException. It cannot be read natively as a Hive table, so executing
+        // the raw SQL fails at execution time instead.
+        assertThatThrownBy(() -> sql(sql)).isInstanceOf(SparkException.class);
+      } else {
+        assertThatThrownBy(() -> sql(sql))
+            .isInstanceOf(AnalysisException.class)
+            .hasMessageContaining("The table or view `%s` cannot be found", tableName);
+      }
     }
 
     // the underlying SQL in the View should be rewritten to have catalog & namespace


### PR DESCRIPTION
Closes #15053

## What

`TestViews#createViewWithSubqueryExpressionInFilterThatIsRewritten` and `...InQueryThatIsRewritten` were skipped for the Hive view catalog (`SPARK_WITH_HIVE_VIEWS`) by an `assumeThat` that blamed a `FileInputFormat` instantiation error. This re-enables both tests for the Hive view catalog on Spark 4.1.

## Why

Investigation (see #15053) shows the Hive-backed subquery view itself works — creating the view, reading it, and the catalog/namespace SQL rewrite all pass. The only failing step was the cross-catalog negative assertion: it switches to `spark_catalog` and expects the unqualified table to be unresolvable. That premise does not hold for the Hive view catalog, because it shares its Hive Metastore with Spark's built-in `spark_catalog` — the Iceberg table is resolvable there, and a native Hive read of it then fails at execution time (Iceberg deliberately writes a placeholder InputFormat when `engine.hive.enabled` is false, since a native read of an Iceberg table would otherwise return silently-wrong results). So this is a test-correctness issue, not an Iceberg view defect, and the abstract-InputFormat behavior is intentional and out of scope.

## How

- Remove the blanket `assumeThat(...).isNotEqualTo("hive")` so both tests run for the Hive view catalog.
- Branch the cross-catalog negative assertion: for the Hive view catalog assert the raw SQL fails at execution with `SparkException` (table found in the shared metastore but not natively readable); otherwise keep the existing `AnalysisException` not-found assertion.
- Suppress the custom Checkstyle rule `AssertThatThrownByWithMessageCheck` on these two tests via `@SuppressWarnings("checkstyle:AssertThatThrownByWithMessageCheck")` — the same inline mechanism already used elsewhere in the repo (e.g. `TestReadProjection`, `TestSerializedMetadata`) — because a message assertion is intentionally omitted here.
- Applied to `spark/v4.1`. The change is identical for `spark/v3.5` and `spark/v4.0`; a backport PR will follow. (`spark/v3.4` never had the Hive view catalog parameter, so it is unchanged.)

The Hive-specific assertion checks only the exception type because that is the only stable, version-independent signal: the root cause is a message-less `java.lang.InstantiationException` (Spark reflectively instantiating the abstract `FileInputFormat` placeholder), and the top-level `org.apache.spark.SparkException` message differs across Spark 3.5/4.0/4.1. Asserting on either would be empty or fragile, so the message check is deliberately skipped and the Checkstyle rule suppressed for these two tests only.

## Testing

`createViewWithSubqueryExpressionInFilterThatIsRewritten` and `createViewWithSubqueryExpressionInQueryThatIsRewritten` now pass for all parameters, including `SPARK_WITH_HIVE_VIEWS`, on Spark 4.1.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Re-enable the skipped subquery-expression view tests for the Hive view catalog.

