### PR TITLE
Core: Fix metrics mode lookup for escaped column names

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -26,14 +26,19 @@ import static org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX
 
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.apache.iceberg.MetricsModes.MetricsMode;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
@@ -49,6 +54,8 @@ import org.slf4j.LoggerFactory;
 public final class MetricsConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
+  private static final Joiner DOT = Joiner.on('.');
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
   // Disable metrics by default for wide tables to prevent excessive metadata
   private static final MetricsMode DEFAULT_MODE =
@@ -70,6 +77,13 @@ public final class MetricsConfig implements Serializable {
               MetadataColumns.DELETE_FILE_POS.name()));
 
   private final Map<String, MetricsMode> columnModes;
+  // Column names are sanitized when written to data files (see
+  // AvroSchemaUtil.makeCompatibleName). Metrics mode lookups that resolve column names from a data
+  // file schema (e.g. when computing metrics for imported or migrated files) therefore query the
+  // sanitized name, while columnModes is keyed by the original name. This map holds the sanitized
+  // form of every column as an alias to the same mode so those lookups resolve correctly. It is
+  // kept separate from columnModes so it never reaches validateReferencedColumns.
+  private final Map<String, MetricsMode> sanitizedColumnModes;
   private final MetricsMode defaultMode;
   private final Map<Integer, String> idToName;
 
@@ -78,8 +92,37 @@ public final class MetricsConfig implements Serializable {
       MetricsMode defaultMode,
       Map<Integer, String> idToName) {
     this.columnModes = SerializableMap.copyOf(columnModes).immutableMap();
+    this.sanitizedColumnModes =
+        SerializableMap.copyOf(sanitizedAliases(this.columnModes)).immutableMap();
     this.defaultMode = defaultMode;
     this.idToName = idToName != null ? SerializableMap.copyOf(idToName).immutableMap() : null;
+  }
+
+  private static Map<String, MetricsMode> sanitizedAliases(Map<String, MetricsMode> columnModes) {
+    Map<String, MetricsMode> aliases = Maps.newHashMap();
+    for (Map.Entry<String, MetricsMode> entry : columnModes.entrySet()) {
+      String sanitized = sanitizeColumnName(entry.getKey());
+      if (!sanitized.equals(entry.getKey())) {
+        // an explicit mode configured directly for the sanitized name wins over the alias
+        aliases.putIfAbsent(sanitized, entry.getValue());
+      }
+    }
+
+    return aliases;
+  }
+
+  private static String sanitizeColumnName(String columnName) {
+    List<String> sanitizedParts = Lists.newArrayList();
+    for (String part : DOT_SPLITTER.split(columnName)) {
+      if (part.isEmpty()) {
+        // not a resolvable dotted path; AvroSchemaUtil rejects empty names, so add no alias
+        return columnName;
+      }
+
+      sanitizedParts.add(AvroSchemaUtil.makeCompatibleName(part));
+    }
+
+    return DOT.join(sanitizedParts);
   }
 
   public static MetricsConfig getDefault() {
@@ -136,7 +179,14 @@ public final class MetricsConfig implements Serializable {
   }
 
   public MetricsMode columnMode(String columnAlias) {
-    return columnModes.getOrDefault(columnAlias, defaultMode);
+    MetricsMode mode = columnModes.get(columnAlias);
+    if (mode != null) {
+      return mode;
+    }
+
+    // fall back to the sanitized name so lookups from a data file schema resolve (see
+    // sanitizedColumnModes); only the original-named columnModes feeds validateReferencedColumns
+    return sanitizedColumnModes.getOrDefault(columnAlias, defaultMode);
   }
 
   public void validateReferencedColumns(Schema schema) {

--- a/core/src/main/java/org/apache/iceberg/MetricsConfig.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsConfig.java
@@ -26,14 +26,19 @@ import static org.apache.iceberg.TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX
 
 import java.io.Serializable;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.Immutable;
 import org.apache.iceberg.MetricsModes.MetricsMode;
+import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Type;
@@ -49,6 +54,8 @@ import org.slf4j.LoggerFactory;
 public final class MetricsConfig implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(MetricsConfig.class);
+  private static final Joiner DOT = Joiner.on('.');
+  private static final Splitter DOT_SPLITTER = Splitter.on('.');
 
   // Disable metrics by default for wide tables to prevent excessive metadata
   private static final MetricsMode DEFAULT_MODE =
@@ -70,6 +77,13 @@ public final class MetricsConfig implements Serializable {
               MetadataColumns.DELETE_FILE_POS.name()));
 
   private final Map<String, MetricsMode> columnModes;
+  // Column names are sanitized when written to data files (see
+  // AvroSchemaUtil.makeCompatibleName). Metrics mode lookups that resolve column names from a data
+  // file schema (e.g. when computing metrics for imported or migrated files) therefore query the
+  // sanitized name, while columnModes is keyed by the original name. This map holds the sanitized
+  // form of every column as an alias to the same mode so those lookups resolve correctly. It is
+  // kept separate from columnModes so it never reaches validateReferencedColumns.
+  private final Map<String, MetricsMode> sanitizedColumnModes;
   private final MetricsMode defaultMode;
   private final Map<Integer, String> idToName;
 
@@ -78,8 +92,37 @@ public final class MetricsConfig implements Serializable {
       MetricsMode defaultMode,
       Map<Integer, String> idToName) {
     this.columnModes = SerializableMap.copyOf(columnModes).immutableMap();
+    this.sanitizedColumnModes =
+        SerializableMap.copyOf(sanitizedAliases(this.columnModes)).immutableMap();
     this.defaultMode = defaultMode;
     this.idToName = idToName != null ? SerializableMap.copyOf(idToName).immutableMap() : null;
+  }
+
+  private static Map<String, MetricsMode> sanitizedAliases(Map<String, MetricsMode> columnModes) {
+    Map<String, MetricsMode> aliases = Maps.newHashMap();
+    for (Map.Entry<String, MetricsMode> entry : columnModes.entrySet()) {
+      String sanitized = sanitizeColumnName(entry.getKey());
+      if (!sanitized.equals(entry.getKey())) {
+        // an explicit mode configured directly for the sanitized name wins over the alias
+        aliases.putIfAbsent(sanitized, entry.getValue());
+      }
+    }
+
+    return aliases;
+  }
+
+  private static String sanitizeColumnName(String columnName) {
+    List<String> sanitizedParts = Lists.newArrayList();
+    for (String part : DOT_SPLITTER.split(columnName)) {
+      if (part.isEmpty()) {
+        // not a resolvable dotted path; AvroSchemaUtil rejects empty names, so add no alias
+        return columnName;
+      }
+
+      sanitizedParts.add(AvroSchemaUtil.makeCompatibleName(part));
+    }
+
+    return DOT.join(sanitizedParts);
   }
 
   public static MetricsConfig getDefault() {
@@ -137,7 +180,14 @@ public final class MetricsConfig implements Serializable {
   }
 
   public MetricsMode columnMode(String columnAlias) {
-    return columnModes.getOrDefault(columnAlias, defaultMode);
+    MetricsMode mode = columnModes.get(columnAlias);
+    if (mode != null) {
+      return mode;
+    }
+
+    // fall back to the sanitized name so lookups from a data file schema resolve (see
+    // sanitizedColumnModes); only the original-named columnModes feeds validateReferencedColumns
+    return sanitizedColumnModes.getOrDefault(columnAlias, defaultMode);
   }
 
   public void validateReferencedColumns(Schema schema) {

--- a/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsModes.java
@@ -200,6 +200,64 @@ public class TestMetricsModes {
   }
 
   @TestTemplate
+  public void testMetricsConfigInferredDefaultModeForEscapedColumn() throws IOException {
+    // "$data" is not a valid Avro/Parquet name and is sanitized to "_x24data" when written, so a
+    // data file schema resolves the column mode by the sanitized name (see issue #11950).
+    Schema schema =
+        new Schema(
+            required(1, "col1", Types.IntegerType.get()),
+            required(2, "$data", Types.IntegerType.get()),
+            required(3, "col3", Types.IntegerType.get()));
+
+    Table table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            formatVersion);
+
+    // only infer a default for the first two columns, disabling metrics for the rest
+    table
+        .updateProperties()
+        .set(TableProperties.METRICS_MAX_INFERRED_COLUMN_DEFAULTS, "2")
+        .commit();
+
+    MetricsConfig config = MetricsConfig.forTable(table);
+
+    // the inferred default applies whether the column is queried by its original or sanitized name
+    assertThat(config.columnMode("$data")).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode("_x24data")).isEqualTo(Truncate.withLength(16));
+    assertThat(config.columnMode("col3")).isEqualTo(None.get());
+  }
+
+  @TestTemplate
+  public void testMetricsConfigExplicitOverrideForEscapedColumn() throws IOException {
+    Schema schema = new Schema(required(1, "$data", Types.IntegerType.get()));
+
+    Table table =
+        TestTables.create(
+            tableDir,
+            "test",
+            schema,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            formatVersion);
+
+    table
+        .updateProperties()
+        .set(TableProperties.METRICS_MODE_COLUMN_CONF_PREFIX + "$data", "full")
+        .commit();
+
+    MetricsConfig config = MetricsConfig.forTable(table);
+
+    // the explicit override is honored whether queried by the original or sanitized name
+    assertThat(config.columnMode("$data")).isEqualTo(Full.get());
+    assertThat(config.columnMode("_x24data")).isEqualTo(Full.get());
+  }
+
+  @TestTemplate
   public void testMetricsVariantSupported() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
     Schema schema =

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -175,6 +175,38 @@ public class TestParquet {
   }
 
   @Test
+  public void testFileMetricsResolvesEscapedColumnName() throws IOException {
+    // Regression for #11950: "$data" is not a valid Parquet name and is sanitized to "_x24data"
+    // in the file schema. When metrics are computed from the footer (the add_files / migrate
+    // path), the metrics mode must still resolve from the configured original column name.
+    Schema schema = new Schema(optional(1, "$data", Types.StringType.get()));
+    String sanitizedName = AvroSchemaUtil.makeCompatibleName("$data");
+
+    File file = createTempFile(temp);
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put(sanitizedName, "value");
+
+    write(file, schema, Collections.emptyMap(), ParquetAvroWriter::buildWriter, record);
+
+    // config keyed by the original column name, as MetricsConfig.forTable would produce; the
+    // "none" default means a missed lookup silently drops all stats for the escaped column
+    MetricsConfig metricsConfig =
+        MetricsConfig.fromProperties(
+            ImmutableMap.of(
+                "write.metadata.metrics.default", "none",
+                "write.metadata.metrics.column.$data", "full"));
+
+    Metrics metrics = ParquetUtil.fileMetrics(Files.localInput(file), metricsConfig);
+
+    assertThat(metrics.valueCounts()).containsEntry(1, 1L);
+    assertThat(metrics.nullValueCounts()).containsEntry(1, 0L);
+    assertThat(metrics.lowerBounds()).containsKey(1);
+    assertThat(metrics.upperBounds()).containsKey(1);
+  }
+
+  @Test
   public void testNumberOfBytesWritten() throws IOException {
     Schema schema = new Schema(optional(1, "intCol", IntegerType.get()));
 


### PR DESCRIPTION
## Problem

Closes #11950

`MetricsConfig` keys per-column metrics modes by the **original** Iceberg column name, while `MetricsUtil.metricsMode(schema, config, fieldId)` resolves the field id to a name using whatever schema it is handed. When metrics are computed from a Parquet **footer** — the `add_files` / `migrate` / `snapshot` path via `ParquetUtil.fileMetrics` (`TableMigrationUtil`, the Delta→Iceberg snapshot action) — the schema is reconstructed from the file and carries **sanitized** names (`AvroSchemaUtil.makeCompatibleName`, e.g. `$event_time` → `_x24event_time`). The name lookup then misses and silently falls back to the default mode, which is `none` once a table exceeds `write.metadata.metrics.max-inferred-column-defaults` (default 100). Column bounds and value counts are silently dropped for escaped columns, degrading scan pruning. Explicit `write.metadata.metrics.column.<escaped-name>` overrides are ignored on the same path.

The write path was already correct because `ParquetWriter.metrics()` passes the writer's original Iceberg schema; only the footer-reconstructed path was affected.

## Fix

Alongside the original-name column modes, `MetricsConfig` now derives a separate alias map keyed by the **sanitized** form of each column name (sanitizing each dotted path component). `columnMode` falls back to this alias map, so a mode resolves whether the caller passes the original name (write path) or the sanitized name (footer path). The alias map is intentionally kept separate from `columnModes` so `validateReferencedColumns` keeps validating only user-supplied original names against the table schema. The change is confined to the private constructor, so every factory path benefits and there is no public API change (revapi clean).

## Relationship to #17022 (MetricsConfig id tracking)

`main` now includes #17022 ("Core: Add id tracking to MetricsConfig"), which added an id-based resolver `columnMode(int id)`. It overlaps in intent but does not replace this fix:

- #17022 did not convert the footer path: `MetricsUtil.metricsMode` still resolves the field id to a name and calls `columnMode(String)`, so #11950 is still reproducible on `main`.
- The sanitized-name fallback is kept rather than routing callers through `columnMode(int id)`, which throws when `idToName` is null (configs built without a schema, e.g. `fromProperties` and `forPositionDelete`) and would require refactoring name-based callers such as `SparkScanBuilder`.

## Tests

- `TestMetricsModes`: inferred-default and explicit-override cases for an escaped column, asserting `columnMode` resolves by both the original and the sanitized name.
- `TestParquet`: end-to-end regression that writes a Parquet file with an escaped column and verifies `ParquetUtil.fileMetrics` collects value counts and bounds for it.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix the per-column metrics mode lookup for escaped column names.
