### PR TITLE
Flink: Fix ALTER TABLE to add column to specific position

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/util/FlinkAlterTableUtil.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/util/FlinkAlterTableUtil.java
@@ -124,20 +124,7 @@ public class FlinkAlterTableUtil {
       UpdateSchema pendingUpdate, List<TableChange> schemaChanges) {
     for (TableChange change : schemaChanges) {
       if (change instanceof TableChange.AddColumn) {
-        TableChange.AddColumn addColumn = (TableChange.AddColumn) change;
-        Column flinkColumn = addColumn.getColumn();
-        Preconditions.checkArgument(
-            FlinkCompatibilityUtil.isPhysicalColumn(flinkColumn),
-            "Unsupported table change: Adding computed column %s.",
-            flinkColumn.getName());
-        Type icebergType = FlinkSchemaUtil.convert(flinkColumn.getDataType().getLogicalType());
-        if (flinkColumn.getDataType().getLogicalType().isNullable()) {
-          pendingUpdate.addColumn(
-              flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
-        } else {
-          pendingUpdate.addRequiredColumn(
-              flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
-        }
+        applyAddColumn(pendingUpdate, (TableChange.AddColumn) change);
       } else if (change instanceof TableChange.ModifyColumn) {
         TableChange.ModifyColumn modifyColumn = (TableChange.ModifyColumn) change;
         applyModifyColumn(pendingUpdate, modifyColumn);
@@ -161,6 +148,31 @@ public class FlinkAlterTableUtil {
       } else {
         throw new UnsupportedOperationException("Cannot apply unknown table change: " + change);
       }
+    }
+  }
+
+  private static void applyAddColumn(UpdateSchema pendingUpdate, TableChange.AddColumn addColumn) {
+    Column flinkColumn = addColumn.getColumn();
+    Preconditions.checkArgument(
+        FlinkCompatibilityUtil.isPhysicalColumn(flinkColumn),
+        "Unsupported table change: Adding computed column %s.",
+        flinkColumn.getName());
+
+    Type icebergType = FlinkSchemaUtil.convert(flinkColumn.getDataType().getLogicalType());
+
+    if (flinkColumn.getDataType().getLogicalType().isNullable()) {
+      pendingUpdate.addColumn(
+          flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
+    } else {
+      pendingUpdate.addRequiredColumn(
+          flinkColumn.getName(), icebergType, flinkColumn.getComment().orElse(null));
+    }
+
+    if (addColumn.getPosition() != null) {
+      TableChange.ColumnPosition position = addColumn.getPosition();
+      TableChange.ModifyColumnPosition modifyColumnPosition =
+          new TableChange.ModifyColumnPosition(addColumn.getColumn(), position);
+      applyModifyColumnPosition(pendingUpdate, modifyColumnPosition);
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -405,6 +405,31 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testAlterTableAddColumnPosition() {
+    sql("CREATE TABLE tl(id BIGINT, name STRING)");
+    Schema schemaBefore = table("tl").schema();
+    assertThat(schemaBefore.asStruct())
+        .isEqualTo(
+            new Schema(
+                    Types.NestedField.optional(1, "id", Types.LongType.get()),
+                    Types.NestedField.optional(2, "name", Types.StringType.get()))
+                .asStruct());
+
+    sql("ALTER TABLE tl ADD (col1 STRING FIRST)");
+    sql("ALTER TABLE tl ADD (col2 INT AFTER id)");
+
+    Schema schemaAfter = table("tl").schema();
+    assertThat(schemaAfter.asStruct())
+        .isEqualTo(
+            new Schema(
+                    Types.NestedField.optional(3, "col1", Types.StringType.get()),
+                    Types.NestedField.optional(1, "id", Types.LongType.get()),
+                    Types.NestedField.optional(4, "col2", Types.IntegerType.get()),
+                    Types.NestedField.optional(2, "name", Types.StringType.get()))
+                .asStruct());
+  }
+
+  @TestTemplate
   public void testAlterTableDropColumn() {
     sql("CREATE TABLE tl(id BIGINT, dt STRING, col1 STRING, col2 BIGINT)");
     Schema schemaBefore = table("tl").schema();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -254,11 +254,10 @@ public class TestAlterTable extends CatalogTestBase {
 
   @TestTemplate
   public void testAlterColumnPositionAfter() {
-    // first add then modify position
     sql("ALTER TABLE %s ADD COLUMN count int", tableName);
     sql("ALTER TABLE %s ALTER COLUMN count AFTER id", tableName);
 
-    Types.StructType expectedSchema1 =
+    Types.StructType expectedSchema =
         Types.StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(3, "count", Types.IntegerType.get()),
@@ -266,30 +265,15 @@ public class TestAlterTable extends CatalogTestBase {
 
     assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
         .as("Schema should match expected")
-        .isEqualTo(expectedSchema1);
-
-    // add to exact position
-    sql("ALTER TABLE %s ADD COLUMN name string AFTER id", tableName);
-
-    Types.StructType expectedSchema2 =
-        Types.StructType.of(
-            NestedField.required(1, "id", Types.LongType.get()),
-            NestedField.optional(4, "name", Types.StringType.get()),
-            NestedField.optional(3, "count", Types.IntegerType.get()),
-            NestedField.optional(2, "data", Types.StringType.get()));
-
-    assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
-        .as("Schema should match expected")
-        .isEqualTo(expectedSchema2);
+        .isEqualTo(expectedSchema);
   }
 
   @TestTemplate
   public void testAlterColumnPositionFirst() {
-    // first add then modify position
     sql("ALTER TABLE %s ADD COLUMN count int", tableName);
     sql("ALTER TABLE %s ALTER COLUMN count FIRST", tableName);
 
-    Types.StructType expectedSchema1 =
+    Types.StructType expectedSchema =
         Types.StructType.of(
             NestedField.optional(3, "count", Types.IntegerType.get()),
             NestedField.required(1, "id", Types.LongType.get()),
@@ -297,21 +281,7 @@ public class TestAlterTable extends CatalogTestBase {
 
     assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
         .as("Schema should match expected")
-        .isEqualTo(expectedSchema1);
-
-    // add to exact position
-    sql("ALTER TABLE %s ADD COLUMN name string FIRST", tableName);
-
-    Types.StructType expectedSchema2 =
-        Types.StructType.of(
-            NestedField.optional(4, "name", Types.StringType.get()),
-            NestedField.optional(3, "count", Types.IntegerType.get()),
-            NestedField.required(1, "id", Types.LongType.get()),
-            NestedField.optional(2, "data", Types.StringType.get()));
-
-    assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
-        .as("Schema should match expected")
-        .isEqualTo(expectedSchema2);
+        .isEqualTo(expectedSchema);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -254,10 +254,11 @@ public class TestAlterTable extends CatalogTestBase {
 
   @TestTemplate
   public void testAlterColumnPositionAfter() {
+    // first add then modify position
     sql("ALTER TABLE %s ADD COLUMN count int", tableName);
     sql("ALTER TABLE %s ALTER COLUMN count AFTER id", tableName);
 
-    Types.StructType expectedSchema =
+    Types.StructType expectedSchema1 =
         Types.StructType.of(
             NestedField.required(1, "id", Types.LongType.get()),
             NestedField.optional(3, "count", Types.IntegerType.get()),
@@ -265,15 +266,30 @@ public class TestAlterTable extends CatalogTestBase {
 
     assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
         .as("Schema should match expected")
-        .isEqualTo(expectedSchema);
+        .isEqualTo(expectedSchema1);
+
+    // add to exact position
+    sql("ALTER TABLE %s ADD COLUMN name string AFTER id", tableName);
+
+    Types.StructType expectedSchema2 =
+        Types.StructType.of(
+            NestedField.required(1, "id", Types.LongType.get()),
+            NestedField.optional(4, "name", Types.StringType.get()),
+            NestedField.optional(3, "count", Types.IntegerType.get()),
+            NestedField.optional(2, "data", Types.StringType.get()));
+
+    assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
+        .as("Schema should match expected")
+        .isEqualTo(expectedSchema2);
   }
 
   @TestTemplate
   public void testAlterColumnPositionFirst() {
+    // first add then modify position
     sql("ALTER TABLE %s ADD COLUMN count int", tableName);
     sql("ALTER TABLE %s ALTER COLUMN count FIRST", tableName);
 
-    Types.StructType expectedSchema =
+    Types.StructType expectedSchema1 =
         Types.StructType.of(
             NestedField.optional(3, "count", Types.IntegerType.get()),
             NestedField.required(1, "id", Types.LongType.get()),
@@ -281,7 +297,21 @@ public class TestAlterTable extends CatalogTestBase {
 
     assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
         .as("Schema should match expected")
-        .isEqualTo(expectedSchema);
+        .isEqualTo(expectedSchema1);
+
+    // add to exact position
+    sql("ALTER TABLE %s ADD COLUMN name string FIRST", tableName);
+
+    Types.StructType expectedSchema2 =
+        Types.StructType.of(
+            NestedField.optional(4, "name", Types.StringType.get()),
+            NestedField.optional(3, "count", Types.IntegerType.get()),
+            NestedField.required(1, "id", Types.LongType.get()),
+            NestedField.optional(2, "data", Types.StringType.get()));
+
+    assertThat(validationCatalog.loadTable(tableIdent).schema().asStruct())
+        .as("Schema should match expected")
+        .isEqualTo(expectedSchema2);
   }
 
   @TestTemplate


### PR DESCRIPTION
This closes #16420.

## Summary
- _Modified `FlinkAlterTableUtil` to fix the bug_
- _Added `testAlterTableAddColumnPosition()` to `TestFlinkCatalogTable` to verify changes_