### PR TITLE
Flink: Handle table comments in FlinkSQL

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
@@ -448,6 +449,11 @@ public class FlinkCatalog extends AbstractCatalog {
           location = entry.getValue();
         }
       }
+    }
+
+    String comment = table.getComment();
+    if (comment != null && !comment.isEmpty()) {
+      properties.put(TableProperties.COMMENT, comment);
     }
 
     try {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -244,17 +244,20 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testCreateTableComment() {
+  public void testCreateTableWithTableComment() {
     // create table with comment
-    sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment' WITH ('param'='some value')");
+    sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment'");
     Map<String, String> properties = Maps.newHashMap();
     properties.put("comment", "table comment");
-    properties.put("param", "some value");
     assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+  }
 
-    // update parameter
-    sql("ALTER TABLE tl SET('param'='new value')");
-    properties.put("param", "new value");
+  @TestTemplate
+  public void testAlterTableModifyTableComment() {
+    // create table with comment
+    sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment'");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("comment", "table comment");
     assertThat(table("tl").properties()).containsAllEntriesOf(properties);
 
     // alter table comment

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -244,6 +244,26 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testCreateTableComment() {
+    // create table with comment
+    sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment' WITH ('param'='some value')");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("comment", "table comment");
+    properties.put("param", "some value");
+    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+
+    // update parameter
+    sql("ALTER TABLE tl SET('param'='new value')");
+    properties.put("param", "new value");
+    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+
+    // alter table comment
+    sql("ALTER TABLE tl SET('comment' = 'new comment')");
+    properties.put("comment", "new comment");
+    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+  }
+
+  @TestTemplate
   public void testCreateTableLocation() {
     assumeThat(isHadoopCatalog)
         .as("HadoopCatalog does not support creating table with location")

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -247,23 +248,18 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
   public void testCreateTableWithTableComment() {
     // create table with comment
     sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment'");
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put("comment", "table comment");
-    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+    assertThat(table("tl").properties()).containsEntry(TableProperties.COMMENT, "table comment");
   }
 
   @TestTemplate
   public void testAlterTableModifyTableComment() {
     // create table with comment
     sql("CREATE TABLE tl(id BIGINT) COMMENT 'table comment'");
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put("comment", "table comment");
-    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+    assertThat(table("tl").properties()).containsEntry(TableProperties.COMMENT, "table comment");
 
     // alter table comment
     sql("ALTER TABLE tl SET('comment' = 'new comment')");
-    properties.put("comment", "new comment");
-    assertThat(table("tl").properties()).containsAllEntriesOf(properties);
+    assertThat(table("tl").properties()).containsEntry(TableProperties.COMMENT, "new comment");
   }
 
   @TestTemplate


### PR DESCRIPTION
This closes #16422.

## Summary 
- _Table comment added to properties map_
- _Added `testCreateTableComment()` to `TestFlinkCatalogTable` to verify changes_