### PR TITLE
Kafka Connect: Add metric for partial commit failures

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -80,6 +81,7 @@ class Coordinator extends Channel {
   private final String snapshotOffsetsProp;
   private final ExecutorService exec;
   private final CommitState commitState;
+  private final AtomicLong partialCommitFailures = new AtomicLong();
   private volatile boolean terminated;
   private final String taskId;
 
@@ -152,6 +154,7 @@ class Coordinator extends Channel {
       doCommit(partialCommit);
     } catch (RuntimeException e) {
       if (partialCommit) {
+        partialCommitFailures.incrementAndGet();
         LOG.warn(
             "Partial commit {} failed for task {}, will retry",
             commitState.currentCommitId(),
@@ -391,6 +394,10 @@ class Coordinator extends Channel {
     } catch (IOException e) {
       throw new UncheckedIOException(e);
     }
+  }
+
+  long partialCommitFailureCount() {
+    return partialCommitFailures.get();
   }
 
   void terminate() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -242,6 +242,47 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   @Test
+  public void testPartialCommitFailureMetric() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(0);
+
+    Table spiedTable = spy(table);
+    AppendFiles spiedAppend = spy(table.newAppend());
+    doThrow(new CommitFailedException("simulated failure")).when(spiedAppend).commit();
+    when(spiedTable.newAppend()).thenReturn(spiedAppend);
+    when(catalog.loadTable(TABLE_IDENTIFIER)).thenReturn(spiedTable);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+
+    initConsumer();
+
+    coordinator.process();
+
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(0);
+
+    UUID commitId =
+        ((StartCommit) AvroUtil.decode(producer.history().get(0).value()).payload()).commitId();
+    Event commitResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    byte[] bytes = AvroUtil.encode(commitResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+
+    coordinator.process();
+
+    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1);
+  }
+
+  @Test
   public void testCoordinatorRunning() {
     TopicPartition tp0 = new TopicPartition(SRC_TOPIC_NAME, 0);
     TopicPartition tp1 = new TopicPartition(SRC_TOPIC_NAME, 1);


### PR DESCRIPTION
Fixes #16392.

**Summary**

Adds an `AtomicLong` counter to `Coordinator` that increments each time `commit(partialCommit=true)` catches a `RuntimeException`. This gives operators visibility into how often partial commits are failing on overloaded clusters.

**Changes**

- `Coordinator.java`: Added `partialCommitFailures` counter, incremented in the existing `partialCommit` catch block. Exposed via package-private `partialCommitFailureCount()` for testability.
- `TestCoordinator.java`: Added `testPartialCommitFailureMetric()` — mocks a `CommitFailedException` on append, verifies counter starts at 0 and increments to 1 after a failed partial commit cycle.

**Follow-up**

The counter can be wired to a Kafka Connect `Sensor`/MBean for JMX exposure in a separate PR.