### PR TITLE
Kafka Connect: Add bounded retry for transient commit exceptions

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -81,6 +81,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.control.commit.interval-ms         | Commit interval in msec, default is 300,000 (5 min)                                                              |
 | iceberg.control.commit.timeout-ms          | Commit timeout interval in msec, default is 30,000 (30 sec)                                                      |
 | iceberg.control.commit.threads             | Number of threads to use for commits, default is (`cores * 2`)                                                     |
+| iceberg.control.commit.max-consecutive-failures | Maximum number of consecutive commit failures before the coordinator terminates, default is `1`              |
 | iceberg.coordinator.transactional.prefix   | Prefix for the transactional id to use for the coordinator producer, default is to use no/empty prefix           |
 | iceberg.catalog                            | Name of the catalog, default is `iceberg`                                                                        |
 | iceberg.catalog.*                          | Properties passed through to Iceberg catalog initialization                                                      |

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -243,6 +243,7 @@ public class IcebergSinkConfig extends AbstractConfig {
         COMMIT_MAX_CONSECUTIVE_FAILURES_PROP,
         ConfigDef.Type.INT,
         COMMIT_MAX_CONSECUTIVE_FAILURES_DEFAULT,
+        ConfigDef.Range.atLeast(1),
         Importance.MEDIUM,
         "Maximum number of consecutive commit failures before the coordinator terminates");
     return configDef;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -105,6 +105,10 @@ public class IcebergSinkConfig extends AbstractConfig {
   private static final String COORDINATOR_EXECUTOR_KEEP_ALIVE_TIMEOUT_MS =
       "iceberg.coordinator-executor-keep-alive-timeout-ms";
 
+  private static final String COMMIT_MAX_CONSECUTIVE_FAILURES_PROP =
+      "iceberg.control.commit.max-consecutive-failures";
+  private static final int COMMIT_MAX_CONSECUTIVE_FAILURES_DEFAULT = 1;
+
   @VisibleForTesting static final String COMMA_NO_PARENS_REGEX = ",(?![^()]*+\\))";
 
   public static final ConfigDef CONFIG_DEF = newConfigDef();
@@ -235,6 +239,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         120000L,
         Importance.LOW,
         "config to control coordinator executor keep alive time");
+    configDef.define(
+        COMMIT_MAX_CONSECUTIVE_FAILURES_PROP,
+        ConfigDef.Type.INT,
+        COMMIT_MAX_CONSECUTIVE_FAILURES_DEFAULT,
+        Importance.MEDIUM,
+        "Maximum number of consecutive commit failures before the coordinator terminates");
     return configDef;
   }
 
@@ -353,6 +363,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public long keepAliveTimeoutInMs() {
     return getLong(COORDINATOR_EXECUTOR_KEEP_ALIVE_TIMEOUT_MS);
+  }
+
+  public int commitMaxConsecutiveFailures() {
+    return getInt(COMMIT_MAX_CONSECUTIVE_FAILURES_PROP);
   }
 
   public TableSinkConfig tableConfig(String tableName) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
@@ -82,6 +83,7 @@ class Coordinator extends Channel {
   private final CommitState commitState;
   private volatile boolean terminated;
   private final String taskId;
+  private int consecutiveCommitFailures;
 
   Coordinator(
       Catalog catalog,
@@ -150,6 +152,9 @@ class Coordinator extends Channel {
   private void commit(boolean partialCommit) {
     try {
       doCommit(partialCommit);
+      if (!partialCommit) {
+        consecutiveCommitFailures = 0;
+      }
     } catch (RuntimeException e) {
       if (partialCommit) {
         LOG.warn(
@@ -157,13 +162,45 @@ class Coordinator extends Channel {
             commitState.currentCommitId(),
             taskId,
             e);
-      } else {
-        LOG.error("Commit {} failed for task {}", commitState.currentCommitId(), taskId, e);
+        return;
+      }
+
+      if (!isCommitFailedException(e)) {
+        // CommitStateUnknownException, ValidationException, ForbiddenException,
+        // NPE, anything else -- not retryable, terminate immediately
         throw e;
       }
+
+      consecutiveCommitFailures++;
+      if (consecutiveCommitFailures >= config.commitMaxConsecutiveFailures()) {
+        LOG.error(
+            "Commit {} failed for task {} ({} consecutive failures, terminating)",
+            commitState.currentCommitId(),
+            taskId,
+            consecutiveCommitFailures,
+            e);
+        throw e;
+      }
+      LOG.warn(
+          "Commit {} failed for task {} ({} consecutive failures, will retry)",
+          commitState.currentCommitId(),
+          taskId,
+          consecutiveCommitFailures,
+          e);
     } finally {
       commitState.endCurrentCommit();
     }
+  }
+
+  private static boolean isCommitFailedException(Throwable throwable) {
+    Throwable current = throwable;
+    while (current != null) {
+      if (current instanceof CommitFailedException) {
+        return true;
+      }
+      current = current.getCause();
+    }
+    return false;
   }
 
   private void doCommit(boolean partialCommit) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -165,7 +165,7 @@ class Coordinator extends Channel {
         return;
       }
 
-      if (!isCommitFailedException(e)) {
+      if (!(e instanceof CommitFailedException)) {
         // CommitStateUnknownException, ValidationException, ForbiddenException,
         // NPE, anything else -- not retryable, terminate immediately
         throw e;
@@ -190,10 +190,6 @@ class Coordinator extends Channel {
     } finally {
       commitState.endCurrentCommit();
     }
-  }
-
-  private static boolean isCommitFailedException(Throwable throwable) {
-    return throwable instanceof CommitFailedException;
   }
 
   private void doCommit(boolean partialCommit) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -193,14 +193,7 @@ class Coordinator extends Channel {
   }
 
   private static boolean isCommitFailedException(Throwable throwable) {
-    Throwable current = throwable;
-    while (current != null) {
-      if (current instanceof CommitFailedException) {
-        return true;
-      }
-      current = current.getCause();
-    }
-    return false;
+    return throwable instanceof CommitFailedException;
   }
 
   private void doCommit(boolean partialCommit) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -102,6 +102,7 @@ public class ChannelTestBase {
     when(config.commitThreads()).thenReturn(1);
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -102,7 +102,7 @@ public class ChannelTestBase {
     when(config.commitThreads()).thenReturn(1);
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
-    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
+    when(config.commitMaxConsecutiveFailures()).thenReturn(1);
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -257,7 +257,7 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   @Test
-  public void testCommitFailedExceptionCauseChainWithMultipleThreads() {
+  public void testCommitBoundedRetryWithMultipleThreads() {
     when(config.commitMaxConsecutiveFailures()).thenReturn(2);
     when(config.commitThreads()).thenReturn(2);
     when(config.commitIntervalMs()).thenReturn(0);
@@ -265,10 +265,7 @@ public class TestCoordinator extends ChannelTestBase {
 
     Table spiedTable = spy(table);
     AppendFiles spiedAppend = spy(table.newAppend());
-    // Wrap CommitFailedException as a cause — proves the cause-chain walk finds it
-    doThrow(new RuntimeException("wrapped", new CommitFailedException("concurrent update")))
-        .when(spiedAppend)
-        .commit();
+    doThrow(new CommitFailedException("concurrent update")).when(spiedAppend).commit();
     when(spiedTable.newAppend()).thenReturn(spiedAppend);
     when(catalog.loadTable(TABLE_IDENTIFIER)).thenReturn(spiedTable);
 
@@ -278,13 +275,13 @@ public class TestCoordinator extends ChannelTestBase {
     coordinator.start();
     initConsumer();
 
-    // first failure is retried (cause-chain walk found CommitFailedException)
+    // first failure is retried
     triggerCommitCycle(coordinator);
 
     // second consecutive failure terminates
     assertThatThrownBy(() -> triggerCommitCycle(coordinator))
-        .isInstanceOf(RuntimeException.class)
-        .hasMessageContaining("wrapped");
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("concurrent update");
   }
 
   private long nextOffset = 1;

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -130,6 +131,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitError() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(1);
+
     // this spec isn't registered with the table
     PartitionSpec badPartitionSpec =
         PartitionSpec.builderFor(SCHEMA).withSpecId(1).identity("id").build();
@@ -152,6 +155,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitFailedExceptionPropagates() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(1);
+
     Table spiedTable = spy(table);
     AppendFiles spiedAppend = spy(table.newAppend());
     doThrow(new CommitFailedException("Glue detected concurrent update"))
@@ -168,6 +173,150 @@ public class TestCoordinator extends ChannelTestBase {
                     EventTestUtil.now()))
         .isInstanceOf(CommitFailedException.class)
         .hasMessageContaining("Glue detected concurrent update");
+  }
+
+  @Test
+  public void testCommitBoundedRetry() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    Table spiedTable = spy(table);
+    AppendFiles spiedAppend = spy(table.newAppend());
+    doThrow(new CommitFailedException("transient error")).when(spiedAppend).commit();
+    when(spiedTable.newAppend()).thenReturn(spiedAppend);
+    when(catalog.loadTable(TABLE_IDENTIFIER)).thenReturn(spiedTable);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // first two failures should not throw
+    triggerCommitCycle(coordinator);
+    triggerCommitCycle(coordinator);
+
+    // third consecutive failure should terminate
+    assertThatThrownBy(() -> triggerCommitCycle(coordinator))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("transient error");
+  }
+
+  @Test
+  public void testCommitCounterResetsOnSuccess() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(3);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    // pre-populate a snapshot so latestSnapshot() is non-null after no-op commit
+    table.newAppend().appendFile(EventTestUtil.createDataFile()).commit();
+
+    Table spiedTable = spy(table);
+    AppendFiles failingAppend = spy(table.newAppend());
+    doThrow(new CommitFailedException("transient error")).when(failingAppend).commit();
+
+    // no-op mock that succeeds without writing a snapshot
+    AppendFiles noOpAppend = mock(AppendFiles.class);
+    when(noOpAppend.validateWith(any())).thenReturn(noOpAppend);
+    when(noOpAppend.set(any(), any())).thenReturn(noOpAppend);
+    when(noOpAppend.toBranch(any())).thenReturn(noOpAppend);
+    when(noOpAppend.appendFile(any())).thenReturn(noOpAppend);
+
+    // fail, fail, succeed (no-op), fail, fail, fail — third failure after reset terminates
+    when(spiedTable.newAppend())
+        .thenReturn(failingAppend)
+        .thenReturn(failingAppend)
+        .thenReturn(noOpAppend)
+        .thenReturn(failingAppend)
+        .thenReturn(failingAppend)
+        .thenReturn(failingAppend);
+    when(catalog.loadTable(TABLE_IDENTIFIER)).thenReturn(spiedTable);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // two failures (counter = 1, 2)
+    triggerCommitCycle(coordinator);
+    triggerCommitCycle(coordinator);
+
+    // success resets counter to 0
+    triggerCommitCycle(coordinator);
+
+    // two more failures — still under threshold (counter = 1, 2)
+    triggerCommitCycle(coordinator);
+    triggerCommitCycle(coordinator);
+
+    // third failure after reset — terminates (counter = 3), proving reset happened
+    assertThatThrownBy(() -> triggerCommitCycle(coordinator))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessageContaining("transient error");
+  }
+
+  @Test
+  public void testCommitFailedExceptionCauseChainWithMultipleThreads() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(2);
+    when(config.commitThreads()).thenReturn(2);
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    Table spiedTable = spy(table);
+    AppendFiles spiedAppend = spy(table.newAppend());
+    // Wrap CommitFailedException as a cause — proves the cause-chain walk finds it
+    doThrow(new RuntimeException("wrapped", new CommitFailedException("concurrent update")))
+        .when(spiedAppend)
+        .commit();
+    when(spiedTable.newAppend()).thenReturn(spiedAppend);
+    when(catalog.loadTable(TABLE_IDENTIFIER)).thenReturn(spiedTable);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    // first failure is retried (cause-chain walk found CommitFailedException)
+    triggerCommitCycle(coordinator);
+
+    // second consecutive failure terminates
+    assertThatThrownBy(() -> triggerCommitCycle(coordinator))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("wrapped");
+  }
+
+  private long nextOffset = 1;
+
+  private void triggerCommitCycle(Coordinator coordinator) {
+    coordinator.process();
+
+    byte[] startBytes = producer.history().get(producer.history().size() - 1).value();
+    Event startEvent = AvroUtil.decode(startBytes);
+    UUID commitId = ((StartCommit) startEvent.payload()).commitId();
+
+    Event commitResponse =
+        new Event(
+            config.connectGroupId(),
+            new DataWritten(
+                StructType.of(),
+                commitId,
+                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                ImmutableList.of(EventTestUtil.createDataFile()),
+                ImmutableList.of()));
+    byte[] bytes = AvroUtil.encode(commitResponse);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, nextOffset++, "key", bytes));
+
+    Event commitReady =
+        new Event(
+            config.connectGroupId(),
+            new DataComplete(
+                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, null))));
+    bytes = AvroUtil.encode(commitReady);
+    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, nextOffset++, "key", bytes));
+
+    coordinator.process();
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {
@@ -288,6 +437,8 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCoordinatorCommittedOffsetValidation() {
+    when(config.commitMaxConsecutiveFailures()).thenReturn(1);
+
     // This test demonstrates that the Coordinator's validateAndCommit method
     // prevents commits when another independent commit has updated the offsets
     // during the commit process


### PR DESCRIPTION
Fixes #16393.

## Problem

Currently, any full-commit failure immediately terminates the coordinator. For transient `CommitFailedException` errors (e.g., catalog contention from concurrent commits), this requires unnecessary operator intervention.

## Fix

Add a configurable consecutive-failure threshold (`iceberg.control.commit.max-consecutive-failures`, default: 1). The coordinator only terminates after N consecutive `CommitFailedException` failures. On successful full commit, the counter resets to 0.

Key design decisions:
- **Only `CommitFailedException` is retried** -- all other exceptions (CommitStateUnknownException, ValidationException, ForbiddenException) are fatal immediately
- **Default is 1** -- preserves existing behavior out-of-the-box; users opt-in to retries by setting a higher value
- **Only full-commit success resets the counter** -- partial-commit success does not renew the retry budget

## Testing

- `testCommitBoundedRetry`: fail, fail, terminate -- verifies termination after N consecutive failures
- `testCommitCounterResetsOnSuccess`: fail, fail, succeed, fail, fail -- verifies counter resets on success and does not terminate prematurely
- Existing tests updated with threshold=1 to preserve immediate-failure semantics