### PR TITLE
Core: Add pluggable BackoffStrategy SPI for Tasks retries

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -1655,3 +1655,12 @@ acceptedBreaks:
         \ boolean)"
       justification: "IncrementalScanEvent should only be constructed by Iceberg code.\
         \ Hence the change of constructor params shouldn't affect users"
+  "1.11.0":
+    org.apache.iceberg:iceberg-core:
+      - code: "java.method.removed"
+        old: "method org.apache.iceberg.util.Tasks.Builder<I> org.apache.iceberg.util.Tasks.Builder<I>::exponentialBackoff(long,\
+          \ long, long, double)"
+        justification: "Split into Tasks.Builder.totalTimeoutMs(long) for the retry\
+          \ budget and Tasks.Builder.backoffStrategy(BackoffStrategy) for the per-attempt\
+          \ wait formula. The previous 4-arg method conflated two unrelated concerns\
+          \ and obscured operator-facing terminology (commit.retry.total-timeout-ms)."

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -177,7 +177,7 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
       Tasks.foreach(entityId)
           .throwFailureWhenFinished()
           .retry(Integer.MAX_VALUE - 1)
-          .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
+          .totalTimeoutMs(acquireTimeoutMs())
           .backoffStrategy(backoffStrategy())
           .onlyRetryOn(
               ConditionalCheckFailedException.class,

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbLockManager.java
@@ -178,6 +178,7 @@ public class DynamoDbLockManager extends LockManagers.BaseLockManager {
           .throwFailureWhenFinished()
           .retry(Integer.MAX_VALUE - 1)
           .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
+          .backoffStrategy(backoffStrategy())
           .onlyRetryOn(
               ConditionalCheckFailedException.class,
               ProvisionedThroughputExceededException.class,

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreOperations.java
@@ -122,8 +122,8 @@ public abstract class BaseMetastoreOperations {
     Tasks.foreach(newMetadataLocation)
         .retry(maxAttempts)
         .suppressFailureWhenFinished()
-        .exponentialBackoff(minWaitMs, maxWaitMs, totalRetryMs, 2.0)
-        .backoffStrategy(BackoffStrategies.from(properties))
+        .totalTimeoutMs(totalRetryMs)
+        .backoffStrategy(BackoffStrategies.from(properties, minWaitMs, maxWaitMs, 2.0))
         .onFailure(
             (location, checkException) ->
                 LOG.error("Cannot check if commit to {} exists.", tableOrViewName, checkException))

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreOperations.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -122,6 +123,7 @@ public abstract class BaseMetastoreOperations {
         .retry(maxAttempts)
         .suppressFailureWhenFinished()
         .exponentialBackoff(minWaitMs, maxWaitMs, totalRetryMs, 2.0)
+        .backoffStrategy(BackoffStrategies.from(properties))
         .onFailure(
             (location, checkException) ->
                 LOG.error("Cannot check if commit to {} exists.", tableOrViewName, checkException))

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -194,6 +195,8 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       Tasks.foreach(newLocation)
           .retry(numRetries)
           .exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
+          .backoffStrategy(
+              BackoffStrategies.from(currentMetadata != null ? currentMetadata.properties() : null))
           .throwFailureWhenFinished()
           .stopRetryOn(NotFoundException.class) // overridden if shouldRetry is non-null
           .shouldRetryTest(shouldRetry)

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -194,9 +194,10 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       AtomicReference<TableMetadata> newMetadata = new AtomicReference<>();
       Tasks.foreach(newLocation)
           .retry(numRetries)
-          .exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
+          .totalTimeoutMs(600000)
           .backoffStrategy(
-              BackoffStrategies.from(currentMetadata != null ? currentMetadata.properties() : null))
+              BackoffStrategies.from(
+                  currentMetadata != null ? currentMetadata.properties() : null, 100, 5000, 4.0))
           .throwFailureWhenFinished()
           .stopRetryOn(NotFoundException.class) // overridden if shouldRetry is non-null
           .shouldRetryTest(shouldRetry)

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -29,6 +29,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Term;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 
 public class BaseReplaceSortOrder implements ReplaceSortOrder {
@@ -56,6 +57,7 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
             base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -52,12 +52,14 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
   public void commit() {
     Tasks.foreach(ops)
         .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+        .totalTimeoutMs(
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -309,6 +310,7 @@ public class BaseTransaction implements Transaction {
               PropertyUtil.propertyAsInt(
                   props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
+          .backoffStrategy(BackoffStrategies.from(props))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {
@@ -364,6 +366,7 @@ public class BaseTransaction implements Transaction {
               base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
+          .backoffStrategy(BackoffStrategies.from(base.properties()))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -302,15 +302,17 @@ public class BaseTransaction implements Transaction {
     try {
       Tasks.foreach(ops)
           .retry(PropertyUtil.propertyAsInt(props, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-          .exponentialBackoff(
+          .totalTimeoutMs(
               PropertyUtil.propertyAsInt(
-                  props, COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-              PropertyUtil.propertyAsInt(
-                  props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-              2.0 /* exponential */)
-          .backoffStrategy(BackoffStrategies.from(props))
+                  props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+          .backoffStrategy(
+              BackoffStrategies.from(
+                  props,
+                  PropertyUtil.propertyAsInt(
+                      props, COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                  PropertyUtil.propertyAsInt(
+                      props, COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                  2.0))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {
@@ -361,12 +363,14 @@ public class BaseTransaction implements Transaction {
     try {
       Tasks.foreach(ops)
           .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-          .exponentialBackoff(
-              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-              2.0 /* exponential */)
-          .backoffStrategy(BackoffStrategies.from(base.properties()))
+          .totalTimeoutMs(
+              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+          .backoffStrategy(
+              BackoffStrategies.from(
+                  base.properties(),
+                  base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                  base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                  2.0))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -102,12 +102,14 @@ class PropertiesUpdate implements UpdateProperties {
     // If existing table commit properties in base are corrupted, allow rectification
     Tasks.foreach(ops)
         .retry(base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyTryAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+        .totalTimeoutMs(
+            base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                base.propertyTryAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 
 class PropertiesUpdate implements UpdateProperties {
@@ -106,6 +107,7 @@ class PropertiesUpdate implements UpdateProperties {
             base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
             base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -357,12 +357,14 @@ class RemoveSnapshots implements ExpireSnapshots {
   public void commit() {
     Tasks.foreach(ops)
         .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+        .totalTimeoutMs(
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             item -> {

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -361,6 +362,7 @@ class RemoveSnapshots implements ExpireSnapshots {
             base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             item -> {

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -28,6 +28,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 
 public class SetLocation implements UpdateLocation {
@@ -60,6 +61,7 @@ public class SetLocation implements UpdateLocation {
             base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
   }

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -56,12 +56,14 @@ public class SetLocation implements UpdateLocation {
     TableMetadata base = ops.refresh();
     Tasks.foreach(ops)
         .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+        .totalTimeoutMs(
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
   }

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -31,6 +31,7 @@ import java.util.List;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
 
@@ -114,6 +115,7 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
             base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -110,12 +110,14 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
   public void commit() {
     Tasks.foreach(ops)
         .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+        .totalTimeoutMs(
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -65,13 +65,17 @@ public class SetStatistics implements UpdateStatistics {
   public void commit() {
     Tasks.foreach(ops)
         .retry(ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            ops.current().propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            ops.current().propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+        .totalTimeoutMs(
             ops.current()
-                .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(ops.current().properties()))
+                .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                ops.current().properties(),
+                ops.current()
+                    .propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                ops.current()
+                    .propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 
 public class SetStatistics implements UpdateStatistics {
@@ -70,6 +71,7 @@ public class SetStatistics implements UpdateStatistics {
             ops.current()
                 .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(ops.current().properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -464,12 +464,14 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       try {
         Tasks.foreach(ops)
             .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-            .exponentialBackoff(
-                base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-                base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-                base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-                2.0 /* exponential */)
-            .backoffStrategy(BackoffStrategies.from(base.properties()))
+            .totalTimeoutMs(
+                base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+            .backoffStrategy(
+                BackoffStrategies.from(
+                    base.properties(),
+                    base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                    base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                    2.0))
             .onlyRetryOn(CommitFailedException.class)
             .countAttempts(commitMetrics().attempts())
             .run(

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -72,6 +72,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Exceptions;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
@@ -468,6 +469,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                 base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
                 base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
                 2.0 /* exponential */)
+            .backoffStrategy(BackoffStrategies.from(base.properties()))
             .onlyRetryOn(CommitFailedException.class)
             .countAttempts(commitMetrics().attempts())
             .run(

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -616,13 +616,13 @@ public class CatalogHandlers {
     try {
       Tasks.foreach(ops)
           .retry(COMMIT_NUM_RETRIES_DEFAULT)
-          .exponentialBackoff(
-              COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
-              COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
-              COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
-              2.0 /* exponential */)
+          .totalTimeoutMs(COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT)
           .backoffStrategy(
-              BackoffStrategies.from(ops.current() != null ? ops.current().properties() : null))
+              BackoffStrategies.from(
+                  ops.current() != null ? ops.current().properties() : null,
+                  COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
+                  COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+                  2.0))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               taskOps -> {
@@ -780,13 +780,13 @@ public class CatalogHandlers {
     try {
       Tasks.foreach(ops)
           .retry(COMMIT_NUM_RETRIES_DEFAULT)
-          .exponentialBackoff(
-              COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
-              COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
-              COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
-              2.0 /* exponential */)
+          .totalTimeoutMs(COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT)
           .backoffStrategy(
-              BackoffStrategies.from(ops.current() != null ? ops.current().properties() : null))
+              BackoffStrategies.from(
+                  ops.current() != null ? ops.current().properties() : null,
+                  COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
+                  COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+                  2.0))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -101,6 +101,7 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.view.BaseView;
@@ -620,6 +621,8 @@ public class CatalogHandlers {
               COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
+          .backoffStrategy(
+              BackoffStrategies.from(ops.current() != null ? ops.current().properties() : null))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               taskOps -> {
@@ -782,6 +785,8 @@ public class CatalogHandlers {
               COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
+          .backoffStrategy(
+              BackoffStrategies.from(ops.current() != null ? ops.current().properties() : null))
           .onlyRetryOn(CommitFailedException.class)
           .run(
               taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -262,8 +262,9 @@ class RESTTableScan extends DataTableScan {
     AtomicReference<FetchPlanningResultResponse> result = new AtomicReference<>();
     try {
       Tasks.foreach(planId)
-          .exponentialBackoff(MIN_SLEEP_MS, MAX_SLEEP_MS, maxWaitTimeMs, SCALE_FACTOR)
-          .backoffStrategy(BackoffStrategies.from(catalogProperties))
+          .totalTimeoutMs(maxWaitTimeMs)
+          .backoffStrategy(
+              BackoffStrategies.from(catalogProperties, MIN_SLEEP_MS, MAX_SLEEP_MS, SCALE_FACTOR))
           .retry(MAX_RETRIES)
           .onlyRetryOn(NotCompleteException.class)
           .onFailure(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -262,6 +263,7 @@ class RESTTableScan extends DataTableScan {
     try {
       Tasks.foreach(planId)
           .exponentialBackoff(MIN_SLEEP_MS, MAX_SLEEP_MS, maxWaitTimeMs, SCALE_FACTOR)
+          .backoffStrategy(BackoffStrategies.from(catalogProperties))
           .retry(MAX_RETRIES)
           .onlyRetryOn(NotCompleteException.class)
           .onFailure(

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.rest.ImmutableHTTPRequest;
 import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.RESTUtil;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
@@ -512,11 +513,13 @@ public class OAuth2Util {
                         LOG.warn("Failed to refresh token", err);
                       }
                     })
-                .exponentialBackoff(
-                    COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
-                    COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
-                    COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
-                    2.0 /* exponential */)
+                .totalTimeoutMs(COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT)
+                .backoffStrategy(
+                    BackoffStrategies.from(
+                        null,
+                        COMMIT_MIN_RETRY_WAIT_MS_DEFAULT,
+                        COMMIT_MAX_RETRY_WAIT_MS_DEFAULT,
+                        2.0))
                 .run(holder -> holder.set(refreshCurrentToken(client)));
 
         if (!isSuccessful || ref.get() == null) {

--- a/core/src/main/java/org/apache/iceberg/util/BackoffStrategies.java
+++ b/core/src/main/java/org/apache/iceberg/util/BackoffStrategies.java
@@ -54,6 +54,30 @@ public class BackoffStrategies {
   }
 
   /**
+   * Resolves the configured strategy from the given properties, falling back to a default {@link
+   * ExponentialBackoffStrategy} configured from the provided min/max/scale parameters when {@link
+   * #STRATEGY_IMPL} is not set. Never returns {@code null}.
+   *
+   * @param properties properties that may contain {@link #STRATEGY_IMPL}; may be {@code null}
+   * @param defaultMinSleepTimeMs min sleep for the default exponential fallback
+   * @param defaultMaxSleepTimeMs max sleep for the default exponential fallback
+   * @param defaultScaleFactor scale factor for the default exponential fallback
+   * @return the configured custom strategy if {@link #STRATEGY_IMPL} is set, otherwise a fresh
+   *     {@link ExponentialBackoffStrategy} with the given parameters
+   */
+  public static BackoffStrategy from(
+      Map<String, String> properties,
+      long defaultMinSleepTimeMs,
+      long defaultMaxSleepTimeMs,
+      double defaultScaleFactor) {
+    BackoffStrategy custom = from(properties);
+    return custom != null
+        ? custom
+        : new ExponentialBackoffStrategy(
+            defaultMinSleepTimeMs, defaultMaxSleepTimeMs, defaultScaleFactor);
+  }
+
+  /**
    * Loads and initializes a {@link BackoffStrategy} by class name.
    *
    * @param impl fully-qualified class name of a {@link BackoffStrategy} with a no-arg constructor

--- a/core/src/main/java/org/apache/iceberg/util/BackoffStrategies.java
+++ b/core/src/main/java/org/apache/iceberg/util/BackoffStrategies.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.Map;
+import org.apache.iceberg.common.DynConstructors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Resolves and instantiates pluggable {@link BackoffStrategy} implementations. */
+public class BackoffStrategies {
+  private static final Logger LOG = LoggerFactory.getLogger(BackoffStrategies.class);
+
+  /**
+   * Property naming the {@link BackoffStrategy} implementation to use for retries. The value is a
+   * fully-qualified class name with a public no-arg constructor. The same key is honored for every
+   * retry site (commit, lock, status check, scan, token refresh, file cleanup). When unset, the
+   * built-in exponential backoff is used.
+   */
+  public static final String STRATEGY_IMPL = "retry.strategy-impl";
+
+  private BackoffStrategies() {}
+
+  /**
+   * Resolves the configured strategy from the given properties.
+   *
+   * @param properties properties that may contain {@link #STRATEGY_IMPL}
+   * @return the configured strategy, or {@code null} when {@link #STRATEGY_IMPL} is not set (the
+   *     caller then keeps the built-in exponential backoff)
+   */
+  public static BackoffStrategy from(Map<String, String> properties) {
+    String impl = properties == null ? null : properties.get(STRATEGY_IMPL);
+    if (impl == null) {
+      return null;
+    }
+
+    return loadBackoffStrategy(impl, properties);
+  }
+
+  /**
+   * Loads and initializes a {@link BackoffStrategy} by class name.
+   *
+   * @param impl fully-qualified class name of a {@link BackoffStrategy} with a no-arg constructor
+   * @param properties properties passed to {@link BackoffStrategy#initialize(Map)}
+   * @return an initialized strategy instance
+   */
+  public static BackoffStrategy loadBackoffStrategy(String impl, Map<String, String> properties) {
+    LOG.info("Loading custom BackoffStrategy implementation: {}", impl);
+    DynConstructors.Ctor<BackoffStrategy> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(BackoffStrategy.class)
+              .loader(BackoffStrategies.class.getClassLoader())
+              .impl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format("Cannot initialize BackoffStrategy, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    BackoffStrategy strategy;
+    try {
+      strategy = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize BackoffStrategy, %s does not implement BackoffStrategy.", impl),
+          e);
+    }
+
+    strategy.initialize(properties);
+    return strategy;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/BackoffStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/util/BackoffStrategy.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.Map;
+
+/**
+ * Strategy that decides how long to wait between retry attempts in {@link Tasks}.
+ *
+ * <p>{@link Tasks} always retries through a {@code BackoffStrategy}. When none is supplied, the
+ * built-in exponential backoff (configured via {@link Tasks.Builder#exponentialBackoff}) is used. A
+ * custom strategy can be selected by setting the {@link BackoffStrategies#STRATEGY_IMPL} property
+ * to the fully-qualified name of a class implementing this interface with a public no-arg
+ * constructor.
+ *
+ * <p>The total retry duration ({@code commit.retry.total-timeout-ms} and similar) and the maximum
+ * number of attempts remain {@link Tasks} concerns; a strategy only computes the per-attempt wait.
+ *
+ * <p>Implementations must be thread-safe: the parallel {@link Tasks} execution path shares a single
+ * strategy instance across worker threads, and a single instance may be reused across many retried
+ * items.
+ */
+public interface BackoffStrategy {
+
+  /**
+   * Returns the time in milliseconds to wait before the given retry attempt.
+   *
+   * @param attempt the 1-based attempt number that is about to be retried; callers always pass a
+   *     value {@code >= 1} (the first retry, after the initial failure, is attempt 1), and
+   *     strategies need not handle {@code 0} or negative inputs
+   * @return the wait time in milliseconds, including any jitter the strategy chooses to apply
+   */
+  long computeBackoff(int attempt);
+
+  /**
+   * Initializes the strategy from catalog or table properties.
+   *
+   * <p>Called once immediately after construction when the strategy is loaded reflectively by
+   * {@link BackoffStrategies}. The default implementation does nothing.
+   *
+   * @param properties the properties the strategy was selected from
+   */
+  default void initialize(Map<String, String> properties) {}
+}

--- a/core/src/main/java/org/apache/iceberg/util/BackoffStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/util/BackoffStrategy.java
@@ -24,10 +24,10 @@ import java.util.Map;
  * Strategy that decides how long to wait between retry attempts in {@link Tasks}.
  *
  * <p>{@link Tasks} always retries through a {@code BackoffStrategy}. When none is supplied, the
- * built-in exponential backoff (configured via {@link Tasks.Builder#exponentialBackoff}) is used. A
- * custom strategy can be selected by setting the {@link BackoffStrategies#STRATEGY_IMPL} property
- * to the fully-qualified name of a class implementing this interface with a public no-arg
- * constructor.
+ * built-in {@link ExponentialBackoffStrategy} is used. Call sites typically resolve the strategy
+ * via {@link BackoffStrategies#from(java.util.Map, long, long, double)} so operators can supply a
+ * custom implementation by setting the {@link BackoffStrategies#STRATEGY_IMPL} property to the
+ * fully-qualified name of a class implementing this interface with a public no-arg constructor.
  *
  * <p>The total retry duration ({@code commit.retry.total-timeout-ms} and similar) and the maximum
  * number of attempts remain {@link Tasks} concerns; a strategy only computes the per-attempt wait.

--- a/core/src/main/java/org/apache/iceberg/util/ExponentialBackoffStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/util/ExponentialBackoffStrategy.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+/**
+ * The default {@link BackoffStrategy}: exponential backoff with up to 10% additive jitter.
+ *
+ * <p>This reproduces the historical, hardcoded {@link Tasks} backoff exactly. It is used whenever
+ * no custom strategy is configured, so existing callers see byte-for-byte identical wait times.
+ *
+ * <p>Immutable and therefore thread-safe.
+ */
+class ExponentialBackoffStrategy implements BackoffStrategy {
+  private final long minSleepTimeMs;
+  private final long maxSleepTimeMs;
+  private final double scaleFactor;
+
+  ExponentialBackoffStrategy(long minSleepTimeMs, long maxSleepTimeMs, double scaleFactor) {
+    this.minSleepTimeMs = minSleepTimeMs;
+    this.maxSleepTimeMs = maxSleepTimeMs;
+    this.scaleFactor = scaleFactor;
+  }
+
+  @Override
+  public long computeBackoff(int attempt) {
+    int delayMs =
+        (int)
+            Math.min(minSleepTimeMs * Math.pow(scaleFactor, attempt - 1), (double) maxSleepTimeMs);
+    int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMs * 0.1)));
+    return (long) delayMs + jitter;
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -85,6 +85,7 @@ public class LockManagers {
     private long heartbeatIntervalMs;
     private long heartbeatTimeoutMs;
     private int heartbeatThreads;
+    private BackoffStrategy backoffStrategy;
 
     public long heartbeatTimeoutMs() {
       return heartbeatTimeoutMs;
@@ -104,6 +105,10 @@ public class LockManagers {
 
     public int heartbeatThreads() {
       return heartbeatThreads;
+    }
+
+    public BackoffStrategy backoffStrategy() {
+      return backoffStrategy;
     }
 
     /**
@@ -158,6 +163,7 @@ public class LockManagers {
               properties,
               CatalogProperties.LOCK_HEARTBEAT_THREADS,
               CatalogProperties.LOCK_HEARTBEAT_THREADS_DEFAULT);
+      this.backoffStrategy = BackoffStrategies.from(properties);
     }
 
     @Override
@@ -243,6 +249,7 @@ public class LockManagers {
             .onlyRetryOn(IllegalStateException.class)
             .throwFailureWhenFinished()
             .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
+            .backoffStrategy(backoffStrategy())
             .run(id -> acquireOnce(id, ownerId));
         return true;
       } catch (IllegalStateException e) {

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -163,7 +163,8 @@ public class LockManagers {
               properties,
               CatalogProperties.LOCK_HEARTBEAT_THREADS,
               CatalogProperties.LOCK_HEARTBEAT_THREADS_DEFAULT);
-      this.backoffStrategy = BackoffStrategies.from(properties);
+      this.backoffStrategy =
+          BackoffStrategies.from(properties, acquireIntervalMs, acquireIntervalMs, 1.0);
     }
 
     @Override
@@ -248,7 +249,7 @@ public class LockManagers {
             .retry(Integer.MAX_VALUE - 1)
             .onlyRetryOn(IllegalStateException.class)
             .throwFailureWhenFinished()
-            .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
+            .totalTimeoutMs(acquireTimeoutMs())
             .backoffStrategy(backoffStrategy())
             .run(id -> acquireOnce(id, ownerId));
         return true;

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -29,7 +29,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Predicate;
@@ -87,6 +86,7 @@ public class Tasks {
     private long maxSleepTimeMs = 600000; // 10 minutes
     private long maxDurationMs = 600000; // 10 minutes
     private double scaleFactor = 2.0; // exponential
+    private BackoffStrategy backoffStrategy = null;
     private Counter attemptsCounter;
 
     public Builder(Iterable<I> items) {
@@ -189,6 +189,20 @@ public class Tasks {
       this.maxSleepTimeMs = backoffMaxSleepTimeMs;
       this.maxDurationMs = backoffMaxRetryTimeMs;
       this.scaleFactor = backoffScaleFactor;
+      return this;
+    }
+
+    /**
+     * Use a custom {@link BackoffStrategy} to compute the wait between retries.
+     *
+     * <p>When set to a non-null strategy, it replaces the built-in exponential backoff configured
+     * via {@link #exponentialBackoff}. A {@code null} argument is ignored and the built-in
+     * exponential backoff is kept, so callers can pass {@link
+     * BackoffStrategies#from(java.util.Map)} directly. The total retry duration and maximum number
+     * of attempts are unaffected.
+     */
+    public Builder<I> backoffStrategy(BackoffStrategy strategy) {
+      this.backoffStrategy = strategy;
       return this;
     }
 
@@ -402,6 +416,10 @@ public class Tasks {
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private <E extends Exception> void runTaskWithRetry(Task<I, E> task, I item) throws E {
       long start = System.currentTimeMillis();
+      BackoffStrategy strategy =
+          backoffStrategy != null
+              ? backoffStrategy
+              : new ExponentialBackoffStrategy(minSleepTimeMs, maxSleepTimeMs, scaleFactor);
       int attempt = 0;
       while (true) {
         attempt += 1;
@@ -449,12 +467,7 @@ public class Tasks {
             }
           }
 
-          int delayMs =
-              (int)
-                  Math.min(
-                      minSleepTimeMs * Math.pow(scaleFactor, attempt - 1), (double) maxSleepTimeMs);
-          int jitter = ThreadLocalRandom.current().nextInt(Math.max(1, (int) (delayMs * 0.1)));
-          int sleepTimeMs = delayMs + jitter;
+          long sleepTimeMs = strategy.computeBackoff(attempt);
 
           LOG.warn(
               "Retrying task after failure: sleepTimeMs={} {}", sleepTimeMs, e.getMessage(), e);

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -77,16 +77,20 @@ public class Tasks {
     private boolean stopAbortsOnFailure = false;
 
     // retry settings
+    private static final long DEFAULT_MIN_SLEEP_TIME_MS = 1000; // 1 second
+    private static final long DEFAULT_MAX_SLEEP_TIME_MS = 600000; // 10 minutes
+    private static final long DEFAULT_TOTAL_TIMEOUT_MS = 600000; // 10 minutes
+    private static final double DEFAULT_SCALE_FACTOR = 2.0;
+
     private final List<Class<? extends Exception>> stopRetryExceptions =
         Lists.newArrayList(UnrecoverableException.class);
     private List<Class<? extends Exception>> onlyRetryExceptions = null;
     private Predicate<Exception> shouldRetryPredicate = null;
     private int maxAttempts = 1; // not all operations can be retried
-    private long minSleepTimeMs = 1000; // 1 second
-    private long maxSleepTimeMs = 600000; // 10 minutes
-    private long maxDurationMs = 600000; // 10 minutes
-    private double scaleFactor = 2.0; // exponential
-    private BackoffStrategy backoffStrategy = null;
+    private long totalTimeoutMs = DEFAULT_TOTAL_TIMEOUT_MS;
+    private BackoffStrategy backoffStrategy =
+        new ExponentialBackoffStrategy(
+            DEFAULT_MIN_SLEEP_TIME_MS, DEFAULT_MAX_SLEEP_TIME_MS, DEFAULT_SCALE_FACTOR);
     private Counter attemptsCounter;
 
     public Builder(Iterable<I> items) {
@@ -180,29 +184,27 @@ public class Tasks {
       return this;
     }
 
-    public Builder<I> exponentialBackoff(
-        long backoffMinSleepTimeMs,
-        long backoffMaxSleepTimeMs,
-        long backoffMaxRetryTimeMs,
-        double backoffScaleFactor) {
-      this.minSleepTimeMs = backoffMinSleepTimeMs;
-      this.maxSleepTimeMs = backoffMaxSleepTimeMs;
-      this.maxDurationMs = backoffMaxRetryTimeMs;
-      this.scaleFactor = backoffScaleFactor;
+    /**
+     * Sets the total retry timeout, after which retries stop even if {@link #retry(int)} attempts
+     * remain. Corresponds to the {@code commit.retry.total-timeout-ms} family of properties.
+     */
+    public Builder<I> totalTimeoutMs(long ms) {
+      this.totalTimeoutMs = ms;
       return this;
     }
 
     /**
      * Use a custom {@link BackoffStrategy} to compute the wait between retries.
      *
-     * <p>When set to a non-null strategy, it replaces the built-in exponential backoff configured
-     * via {@link #exponentialBackoff}. A {@code null} argument is ignored and the built-in
-     * exponential backoff is kept, so callers can pass {@link
-     * BackoffStrategies#from(java.util.Map)} directly. The total retry duration and maximum number
-     * of attempts are unaffected.
+     * <p>A non-null strategy replaces the built-in exponential backoff default. A {@code null}
+     * argument is ignored, so callers can pass {@link BackoffStrategies#from(java.util.Map)}
+     * directly without a separate null check. The total retry duration and maximum number of
+     * attempts are unaffected.
      */
     public Builder<I> backoffStrategy(BackoffStrategy strategy) {
-      this.backoffStrategy = strategy;
+      if (strategy != null) {
+        this.backoffStrategy = strategy;
+      }
       return this;
     }
 
@@ -416,10 +418,6 @@ public class Tasks {
     @SuppressWarnings("checkstyle:CyclomaticComplexity")
     private <E extends Exception> void runTaskWithRetry(Task<I, E> task, I item) throws E {
       long start = System.currentTimeMillis();
-      BackoffStrategy strategy =
-          backoffStrategy != null
-              ? backoffStrategy
-              : new ExponentialBackoffStrategy(minSleepTimeMs, maxSleepTimeMs, scaleFactor);
       int attempt = 0;
       while (true) {
         attempt += 1;
@@ -432,10 +430,10 @@ public class Tasks {
           break;
 
         } catch (Exception e) {
-          long durationMs = System.currentTimeMillis() - start;
-          if (attempt >= maxAttempts || (durationMs > maxDurationMs && attempt > 1)) {
-            if (durationMs > maxDurationMs) {
-              LOG.info("Stopping retries after {} ms", durationMs);
+          long elapsedMs = System.currentTimeMillis() - start;
+          if (attempt >= maxAttempts || (elapsedMs > totalTimeoutMs && attempt > 1)) {
+            if (elapsedMs > totalTimeoutMs) {
+              LOG.info("Stopping retries after {} ms", elapsedMs);
             }
             throw e;
           }
@@ -467,7 +465,7 @@ public class Tasks {
             }
           }
 
-          long sleepTimeMs = strategy.computeBackoff(attempt);
+          long sleepTimeMs = backoffStrategy.computeBackoff(attempt);
 
           LOG.warn(
               "Retrying task after failure: sleepTimeMs={} {}", sleepTimeMs, e.getMessage(), e);

--- a/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
@@ -199,9 +199,10 @@ public abstract class BaseViewOperations extends BaseMetastoreOperations impleme
       AtomicReference<ViewMetadata> newMetadata = new AtomicReference<>();
       Tasks.foreach(newLocation)
           .retry(numRetries)
-          .exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
+          .totalTimeoutMs(600000)
           .backoffStrategy(
-              BackoffStrategies.from(currentMetadata != null ? currentMetadata.properties() : null))
+              BackoffStrategies.from(
+                  currentMetadata != null ? currentMetadata.properties() : null, 100, 5000, 4.0))
           .throwFailureWhenFinished()
           .stopRetryOn(NotFoundException.class) // overridden if shouldRetry is non-null
           .shouldRetryTest(shouldRetry)

--- a/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseViewOperations.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -199,6 +200,8 @@ public abstract class BaseViewOperations extends BaseMetastoreOperations impleme
       Tasks.foreach(newLocation)
           .retry(numRetries)
           .exponentialBackoff(100, 5000, 600000, 4.0 /* 100, 400, 1600, ... */)
+          .backoffStrategy(
+              BackoffStrategies.from(currentMetadata != null ? currentMetadata.properties() : null))
           .throwFailureWhenFinished()
           .stopRetryOn(NotFoundException.class) // overridden if shouldRetry is non-null
           .shouldRetryTest(shouldRetry)

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -65,15 +65,17 @@ class PropertiesUpdate implements UpdateViewProperties {
         .retry(
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
+        .totalTimeoutMs(
             PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
   }

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 
@@ -72,6 +73,7 @@ class PropertiesUpdate implements UpdateViewProperties {
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
   }

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -55,15 +55,17 @@ class SetViewLocation implements UpdateLocation {
         .retry(
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
+        .totalTimeoutMs(
             PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps ->

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 import org.apache.iceberg.UpdateLocation;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 
@@ -62,6 +63,7 @@ class SetViewLocation implements UpdateLocation {
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(
             taskOps ->

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 
@@ -99,6 +100,7 @@ class ViewVersionReplace implements ReplaceViewVersion {
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
             2.0 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(base.properties()))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
   }

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -92,15 +92,17 @@ class ViewVersionReplace implements ReplaceViewVersion {
         .retry(
             PropertyUtil.propertyAsInt(
                 base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
+        .totalTimeoutMs(
             PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(base.properties()))
+                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT))
+        .backoffStrategy(
+            BackoffStrategies.from(
+                base.properties(),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+                PropertyUtil.propertyAsInt(
+                    base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+                2.0))
         .onlyRetryOn(CommitFailedException.class)
         .run(taskOps -> taskOps.commit(base, internalApply()));
   }

--- a/core/src/test/java/org/apache/iceberg/TestBackoffStrategyCommit.java
+++ b/core/src/test/java/org/apache/iceberg/TestBackoffStrategyCommit.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.util.BackoffStrategies;
+import org.apache.iceberg.util.BackoffStrategy;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestBackoffStrategyCommit extends TestBase {
+
+  @TestTemplate
+  public void commitUsesConfiguredBackoffStrategy() {
+    CountingBackoffStrategy.reset();
+
+    table
+        .updateProperties()
+        .set(BackoffStrategies.STRATEGY_IMPL, CountingBackoffStrategy.class.getName())
+        .commit();
+
+    TestTables.TestTableOperations ops = table.ops();
+    ops.failCommits(2);
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    assertThat(CountingBackoffStrategy.initialized).isTrue();
+    // computeBackoff is invoked once before each of the two retried commit attempts
+    assertThat(CountingBackoffStrategy.COMPUTE_CALLS.get()).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void commitWithoutPropertyDoesNotUseCustomStrategy() {
+    CountingBackoffStrategy.reset();
+
+    // keep the retry waits tiny so the default exponential backoff does not slow the test
+    table
+        .updateProperties()
+        .set(TableProperties.COMMIT_MIN_RETRY_WAIT_MS, "0")
+        .set(TableProperties.COMMIT_MAX_RETRY_WAIT_MS, "0")
+        .commit();
+
+    TestTables.TestTableOperations ops = table.ops();
+    ops.failCommits(2);
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+
+    assertThat(CountingBackoffStrategy.COMPUTE_CALLS.get()).isZero();
+  }
+
+  /** Records how many times it is consulted; loaded reflectively via a no-arg constructor. */
+  public static class CountingBackoffStrategy implements BackoffStrategy {
+    static final AtomicInteger COMPUTE_CALLS = new AtomicInteger(0);
+    static volatile boolean initialized = false;
+
+    static void reset() {
+      COMPUTE_CALLS.set(0);
+      initialized = false;
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      initialized = true;
+    }
+
+    @Override
+    public long computeBackoff(int attempt) {
+      COMPUTE_CALLS.incrementAndGet();
+      return 0L;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestBackoffStrategies.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBackoffStrategies.java
@@ -115,6 +115,39 @@ public class TestBackoffStrategies {
         .hasMessageContaining("init failed");
   }
 
+  @Test
+  public void fromWithDefaultsReturnsExponentialWhenKeyAbsent() {
+    BackoffStrategy strategy = BackoffStrategies.from(ImmutableMap.of(), 100, 1000, 2.0);
+
+    assertThat(strategy).isInstanceOf(ExponentialBackoffStrategy.class);
+    long wait = strategy.computeBackoff(1);
+    assertThat(wait).isGreaterThanOrEqualTo(100L).isLessThan(110L);
+  }
+
+  @Test
+  public void fromWithDefaultsReturnsCustomWhenKeySet() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BackoffStrategies.STRATEGY_IMPL,
+            FixedBackoffStrategy.class.getName(),
+            "delay-ms",
+            "42");
+
+    BackoffStrategy strategy = BackoffStrategies.from(properties, 100, 1000, 2.0);
+
+    assertThat(strategy).isInstanceOf(FixedBackoffStrategy.class);
+    assertThat(strategy.computeBackoff(1)).isEqualTo(42L);
+  }
+
+  @Test
+  public void fromWithDefaultsAcceptsNullProperties() {
+    BackoffStrategy strategy = BackoffStrategies.from(null, 100, 1000, 2.0);
+
+    assertThat(strategy).isInstanceOf(ExponentialBackoffStrategy.class);
+    long wait = strategy.computeBackoff(1);
+    assertThat(wait).isGreaterThanOrEqualTo(100L).isLessThan(110L);
+  }
+
   /** Test strategy with a public no-arg constructor that records its initialize properties. */
   public static class FixedBackoffStrategy implements BackoffStrategy {
     private long delayMs = 0;

--- a/core/src/test/java/org/apache/iceberg/util/TestBackoffStrategies.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestBackoffStrategies.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestBackoffStrategies {
+
+  @Test
+  public void defaultExponentialBackoffMatchesLegacyFormula() {
+    long min = 100;
+    long max = 60_000;
+    double scale = 2.0;
+    ExponentialBackoffStrategy backoff = new ExponentialBackoffStrategy(min, max, scale);
+
+    for (int attempt = 1; attempt <= 12; attempt++) {
+      int delayMs = (int) Math.min(min * Math.pow(scale, attempt - 1), (double) max);
+      long jitterBound = Math.max(1, (int) (delayMs * 0.1));
+      long wait = backoff.computeBackoff(attempt);
+      assertThat(wait)
+          .isGreaterThanOrEqualTo((long) delayMs)
+          .isLessThan((long) delayMs + jitterBound);
+    }
+  }
+
+  @Test
+  public void defaultExponentialBackoffRespectsMaxCap() {
+    long max = 1000;
+    ExponentialBackoffStrategy backoff = new ExponentialBackoffStrategy(100, max, 2.0);
+
+    long wait = backoff.computeBackoff(50); // attempt large enough to exceed the cap
+    long jitterBound = Math.max(1, (int) (max * 0.1));
+    assertThat(wait).isGreaterThanOrEqualTo(max).isLessThan(max + jitterBound);
+  }
+
+  @Test
+  public void fromReturnsNullWhenKeyAbsent() {
+    assertThat(BackoffStrategies.from(null)).isNull();
+    assertThat(BackoffStrategies.from(ImmutableMap.of())).isNull();
+    assertThat(BackoffStrategies.from(ImmutableMap.of("other", "value"))).isNull();
+  }
+
+  @Test
+  public void fromLoadsAndInitializesConfiguredStrategy() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            BackoffStrategies.STRATEGY_IMPL,
+            FixedBackoffStrategy.class.getName(),
+            "delay-ms",
+            "42");
+
+    BackoffStrategy strategy = BackoffStrategies.from(properties);
+
+    assertThat(strategy).isInstanceOf(FixedBackoffStrategy.class);
+    assertThat(strategy.computeBackoff(1)).isEqualTo(42L);
+    assertThat(strategy.computeBackoff(9)).isEqualTo(42L);
+  }
+
+  @Test
+  public void loadBackoffStrategyRejectsMissingNoArgConstructor() {
+    assertThatThrownBy(
+            () ->
+                BackoffStrategies.loadBackoffStrategy(
+                    NoNoArgStrategy.class.getName(), ImmutableMap.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("missing no-arg constructor");
+  }
+
+  @Test
+  public void loadBackoffStrategyRejectsNonStrategyClass() {
+    assertThatThrownBy(
+            () -> BackoffStrategies.loadBackoffStrategy(String.class.getName(), ImmutableMap.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not implement BackoffStrategy");
+  }
+
+  @Test
+  public void loadBackoffStrategyRejectsUnknownClass() {
+    assertThatThrownBy(
+            () ->
+                BackoffStrategies.loadBackoffStrategy(
+                    "org.apache.iceberg.util.NotAClass", ImmutableMap.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("BackoffStrategy");
+  }
+
+  @Test
+  public void loadBackoffStrategyPropagatesInitializeFailures() {
+    assertThatThrownBy(
+            () ->
+                BackoffStrategies.loadBackoffStrategy(
+                    ThrowingInitStrategy.class.getName(), ImmutableMap.of()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("init failed");
+  }
+
+  /** Test strategy with a public no-arg constructor that records its initialize properties. */
+  public static class FixedBackoffStrategy implements BackoffStrategy {
+    private long delayMs = 0;
+
+    @Override
+    public void initialize(Map<String, String> properties) {
+      this.delayMs = Long.parseLong(properties.getOrDefault("delay-ms", "0"));
+    }
+
+    @Override
+    public long computeBackoff(int attempt) {
+      return delayMs;
+    }
+  }
+
+  /** Test strategy without a no-arg constructor. */
+  public static class NoNoArgStrategy implements BackoffStrategy {
+    public NoNoArgStrategy(String required) {}
+
+    @Override
+    public long computeBackoff(int attempt) {
+      return 0;
+    }
+  }
+
+  /** Test strategy whose initialize() throws, to verify the loader propagates the failure. */
+  public static class ThrowingInitStrategy implements BackoffStrategy {
+    @Override
+    public void initialize(Map<String, String> properties) {
+      throw new IllegalStateException("init failed");
+    }
+
+    @Override
+    public long computeBackoff(int attempt) {
+      return 0;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestTasks.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTasks.java
@@ -46,7 +46,8 @@ public class TestTasks {
 
     Tasks.foreach(IntStream.range(0, 10))
         .countAttempts(counter)
-        .exponentialBackoff(0, 0, 5000, 0)
+        .totalTimeoutMs(5000)
+        .backoffStrategy(attempt -> 0L)
         .retry(retries)
         .onlyRetryOn(RuntimeException.class)
         .run(
@@ -70,7 +71,7 @@ public class TestTasks {
   }
 
   @Test
-  public void customBackoffStrategyOverridesExponentialBackoff() {
+  public void customBackoffStrategyIsUsed() {
     List<Integer> attempts = Collections.synchronizedList(Lists.newArrayList());
     BackoffStrategy recording =
         attempt -> {
@@ -98,14 +99,15 @@ public class TestTasks {
   }
 
   @Test
-  public void nullBackoffStrategyKeepsExponentialDefault() {
+  public void nullBackoffStrategyIsNoOp() {
     int retries = 3;
     Counter counter = new DefaultMetricsContext().counter("counter");
 
     Tasks.foreach(IntStream.range(0, 1))
         .countAttempts(counter)
-        .exponentialBackoff(0, 0, 5000, 0)
+        .totalTimeoutMs(5000)
         .retry(retries)
+        .backoffStrategy(attempt -> 0L) // set a non-null strategy first
         .backoffStrategy(null) // mirrors call sites passing BackoffStrategies.from(...) == null
         .onlyRetryOn(RuntimeException.class)
         .run(

--- a/core/src/test/java/org/apache/iceberg/util/TestTasks.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTasks.java
@@ -20,9 +20,20 @@ package org.apache.iceberg.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
 
 public class TestTasks {
@@ -56,5 +67,113 @@ public class TestTasks {
     Tasks.foreach(IntStream.range(0, 10)).countAttempts(counter).run(x -> {});
 
     assertThat(counter.value()).isOne();
+  }
+
+  @Test
+  public void customBackoffStrategyOverridesExponentialBackoff() {
+    List<Integer> attempts = Collections.synchronizedList(Lists.newArrayList());
+    BackoffStrategy recording =
+        attempt -> {
+          attempts.add(attempt);
+          return 0L;
+        };
+
+    int retries = 3;
+    Counter counter = new DefaultMetricsContext().counter("counter");
+
+    Tasks.foreach(IntStream.range(0, 1))
+        .countAttempts(counter)
+        .retry(retries)
+        .backoffStrategy(recording)
+        .onlyRetryOn(RuntimeException.class)
+        .run(
+            x -> {
+              if (counter.value() <= retries) {
+                throw new RuntimeException();
+              }
+            });
+
+    // computeBackoff is called once before each of the 3 retries, with 1-based attempt numbers
+    assertThat(attempts).containsExactly(1, 2, 3);
+  }
+
+  @Test
+  public void nullBackoffStrategyKeepsExponentialDefault() {
+    int retries = 3;
+    Counter counter = new DefaultMetricsContext().counter("counter");
+
+    Tasks.foreach(IntStream.range(0, 1))
+        .countAttempts(counter)
+        .exponentialBackoff(0, 0, 5000, 0)
+        .retry(retries)
+        .backoffStrategy(null) // mirrors call sites passing BackoffStrategies.from(...) == null
+        .onlyRetryOn(RuntimeException.class)
+        .run(
+            x -> {
+              if (counter.value() <= retries) {
+                throw new RuntimeException();
+              }
+            });
+
+    assertThat(counter.value()).isEqualTo(retries + 1);
+  }
+
+  @Test
+  public void parallelTasksShareStrategyAcrossWorkers() throws InterruptedException {
+    int items = 20;
+    Set<Thread> threadsSeen = ConcurrentHashMap.newKeySet();
+    AtomicInteger calls = new AtomicInteger();
+    BackoffStrategy recording =
+        attempt -> {
+          threadsSeen.add(Thread.currentThread());
+          calls.incrementAndGet();
+          return 0L;
+        };
+    ConcurrentMap<Integer, AtomicInteger> perItemAttempts = Maps.newConcurrentMap();
+    ExecutorService svc = Executors.newFixedThreadPool(4);
+    try {
+      Tasks.range(items)
+          .executeWith(svc)
+          .retry(2)
+          .backoffStrategy(recording)
+          .onlyRetryOn(RuntimeException.class)
+          .run(
+              i -> {
+                int attemptCount =
+                    perItemAttempts.computeIfAbsent(i, k -> new AtomicInteger()).incrementAndGet();
+                if (attemptCount == 1) {
+                  throw new RuntimeException("first attempt fails");
+                }
+              });
+    } finally {
+      svc.shutdownNow();
+      svc.awaitTermination(5, TimeUnit.SECONDS);
+    }
+
+    assertThat(calls.get()).isEqualTo(items);
+    assertThat(threadsSeen).hasSizeGreaterThan(1);
+  }
+
+  @Test
+  public void backoffStrategyReturnValueDrivesSleepDuration() {
+    long perRetryMs = 150L;
+    int retries = 3;
+    Counter counter = new DefaultMetricsContext().counter("counter");
+
+    long startMs = System.currentTimeMillis();
+    Tasks.foreach(IntStream.range(0, 1))
+        .countAttempts(counter)
+        .retry(retries)
+        .backoffStrategy(attempt -> perRetryMs)
+        .onlyRetryOn(RuntimeException.class)
+        .run(
+            x -> {
+              if (counter.value() <= retries) {
+                throw new RuntimeException();
+              }
+            });
+    long elapsedMs = System.currentTimeMillis() - startMs;
+
+    assertThat(elapsedMs).isGreaterThanOrEqualTo((long) (retries * perRetryMs * 0.9));
   }
 }

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -110,6 +110,7 @@ See the [Encryption](encryption.md) document for additional details.
 | commit.retry.min-wait-ms           | 100              | Minimum time in milliseconds to wait before retrying a commit |
 | commit.retry.max-wait-ms           | 60000 (1 min)    | Maximum time in milliseconds to wait before retrying a commit |
 | commit.retry.total-timeout-ms      | 1800000 (30 min) | Total retry timeout period in milliseconds for a commit |
+| retry.strategy-impl                | (exponential backoff) | Fully-qualified name of a custom `org.apache.iceberg.util.BackoffStrategy` used to compute the wait between retries. Global to every `Tasks` retry site (commit, lock acquisition, status checks, REST scan polling, FileIO cleanup); there is no per-site override. Read from whichever properties map is local to the call site (table/view properties, catalog properties, FileIO properties, or Hadoop `Configuration`). When unset, the built-in exponential backoff with jitter is used |
 | commit.status-check.num-retries    | 3                | Number of times to check whether a commit succeeded after a connection is lost before failing due to an unknown commit state |
 | commit.status-check.min-wait-ms    | 1000 (1s)        | Minimum time in milliseconds to wait before retrying a status-check |
 | commit.status-check.max-wait-ms    | 60000 (1 min)    | Maximum time in milliseconds to wait before retrying a status-check |

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
@@ -45,8 +45,11 @@ import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.iceberg.util.BackoffStrategies;
+import org.apache.iceberg.util.BackoffStrategy;
 import org.apache.iceberg.util.Tasks;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -91,6 +94,7 @@ class MetastoreLock implements HiveLock {
   private final long lockHeartbeatIntervalTime;
   private final ScheduledExecutorService exitingScheduledExecutorService;
   private final String agentInfo;
+  private final BackoffStrategy backoffStrategy;
 
   private Optional<Long> hmsLockId = Optional.empty();
   private ReentrantLock jvmLock = null;
@@ -125,6 +129,12 @@ class MetastoreLock implements HiveLock {
         conf.getLong(HIVE_TABLE_LEVEL_LOCK_EVICT_MS, HIVE_TABLE_LEVEL_LOCK_EVICT_MS_DEFAULT);
 
     this.agentInfo = "Iceberg-" + UUID.randomUUID();
+
+    String backoffImpl = conf.get(BackoffStrategies.STRATEGY_IMPL);
+    this.backoffStrategy =
+        backoffImpl == null
+            ? null
+            : BackoffStrategies.loadBackoffStrategy(backoffImpl, ImmutableMap.of());
 
     this.exitingScheduledExecutorService =
         Executors.newSingleThreadScheduledExecutor(
@@ -204,6 +214,7 @@ class MetastoreLock implements HiveLock {
         Tasks.foreach(lockInfo.lockId)
             .retry(Integer.MAX_VALUE - 100)
             .exponentialBackoff(lockCheckMinWaitTime, lockCheckMaxWaitTime, lockAcquireTimeout, 1.5)
+            .backoffStrategy(backoffStrategy)
             .throwFailureWhenFinished()
             .onlyRetryOn(WaitingForLockException.class)
             .run(
@@ -293,6 +304,7 @@ class MetastoreLock implements HiveLock {
         .retry(Integer.MAX_VALUE - 100)
         .exponentialBackoff(
             lockCreationMinWaitTime, lockCreationMaxWaitTime, lockCreationTimeout, 2.0)
+        .backoffStrategy(backoffStrategy)
         .shouldRetryTest(
             e ->
                 !interrupted.get()

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/MetastoreLock.java
@@ -94,7 +94,8 @@ class MetastoreLock implements HiveLock {
   private final long lockHeartbeatIntervalTime;
   private final ScheduledExecutorService exitingScheduledExecutorService;
   private final String agentInfo;
-  private final BackoffStrategy backoffStrategy;
+  private final BackoffStrategy acquireBackoff;
+  private final BackoffStrategy creationBackoff;
 
   private Optional<Long> hmsLockId = Optional.empty();
   private ReentrantLock jvmLock = null;
@@ -131,10 +132,18 @@ class MetastoreLock implements HiveLock {
     this.agentInfo = "Iceberg-" + UUID.randomUUID();
 
     String backoffImpl = conf.get(BackoffStrategies.STRATEGY_IMPL);
-    this.backoffStrategy =
+    BackoffStrategy customStrategy =
         backoffImpl == null
             ? null
             : BackoffStrategies.loadBackoffStrategy(backoffImpl, ImmutableMap.of());
+    this.acquireBackoff =
+        customStrategy != null
+            ? customStrategy
+            : BackoffStrategies.from(null, lockCheckMinWaitTime, lockCheckMaxWaitTime, 1.5);
+    this.creationBackoff =
+        customStrategy != null
+            ? customStrategy
+            : BackoffStrategies.from(null, lockCreationMinWaitTime, lockCreationMaxWaitTime, 2.0);
 
     this.exitingScheduledExecutorService =
         Executors.newSingleThreadScheduledExecutor(
@@ -213,8 +222,8 @@ class MetastoreLock implements HiveLock {
         // boundary issues.
         Tasks.foreach(lockInfo.lockId)
             .retry(Integer.MAX_VALUE - 100)
-            .exponentialBackoff(lockCheckMinWaitTime, lockCheckMaxWaitTime, lockAcquireTimeout, 1.5)
-            .backoffStrategy(backoffStrategy)
+            .totalTimeoutMs(lockAcquireTimeout)
+            .backoffStrategy(acquireBackoff)
             .throwFailureWhenFinished()
             .onlyRetryOn(WaitingForLockException.class)
             .run(
@@ -302,9 +311,8 @@ class MetastoreLock implements HiveLock {
     AtomicBoolean interrupted = new AtomicBoolean(false);
     Tasks.foreach(lockRequest)
         .retry(Integer.MAX_VALUE - 100)
-        .exponentialBackoff(
-            lockCreationMinWaitTime, lockCreationMaxWaitTime, lockCreationTimeout, 2.0)
-        .backoffStrategy(backoffStrategy)
+        .totalTimeoutMs(lockCreationTimeout)
+        .backoffStrategy(creationBackoff)
         .shouldRetryTest(
             e ->
                 !interrupted.get()

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -27,6 +28,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
@@ -91,6 +93,15 @@ class SparkCleanupUtil {
     }
   }
 
+  private static Map<String, String> ioProperties(FileIO io) {
+    try {
+      return io.properties();
+    } catch (UnsupportedOperationException e) {
+      // FileIO implementations are not required to expose their configuration
+      return null;
+    }
+  }
+
   private static void delete(String context, FileIO io, List<String> paths) {
     AtomicInteger deletedFilesCount = new AtomicInteger(0);
 
@@ -105,6 +116,7 @@ class SparkCleanupUtil {
             DELETE_MAX_RETRY_WAIT_MS,
             DELETE_TOTAL_RETRY_TIME_MS,
             2 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
         .run(
             path -> {
               io.deleteFile(path);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -111,12 +111,10 @@ class SparkCleanupUtil {
         .suppressFailureWhenFinished()
         .onFailure((path, exc) -> LOG.warn("Failed to delete {} ({})", path, context, exc))
         .retry(DELETE_NUM_RETRIES)
-        .exponentialBackoff(
-            DELETE_MIN_RETRY_WAIT_MS,
-            DELETE_MAX_RETRY_WAIT_MS,
-            DELETE_TOTAL_RETRY_TIME_MS,
-            2 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
+        .totalTimeoutMs(DELETE_TOTAL_RETRY_TIME_MS)
+        .backoffStrategy(
+            BackoffStrategies.from(
+                ioProperties(io), DELETE_MIN_RETRY_WAIT_MS, DELETE_MAX_RETRY_WAIT_MS, 2))
         .run(
             path -> {
               io.deleteFile(path);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -27,6 +28,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
@@ -91,6 +93,15 @@ class SparkCleanupUtil {
     }
   }
 
+  private static Map<String, String> ioProperties(FileIO io) {
+    try {
+      return io.properties();
+    } catch (UnsupportedOperationException e) {
+      // FileIO implementations are not required to expose their configuration
+      return null;
+    }
+  }
+
   private static void delete(String context, FileIO io, List<String> paths) {
     AtomicInteger deletedFilesCount = new AtomicInteger(0);
 
@@ -105,6 +116,7 @@ class SparkCleanupUtil {
             DELETE_MAX_RETRY_WAIT_MS,
             DELETE_TOTAL_RETRY_TIME_MS,
             2 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
         .run(
             path -> {
               io.deleteFile(path);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -111,12 +111,10 @@ class SparkCleanupUtil {
         .suppressFailureWhenFinished()
         .onFailure((path, exc) -> LOG.warn("Failed to delete {} ({})", path, context, exc))
         .retry(DELETE_NUM_RETRIES)
-        .exponentialBackoff(
-            DELETE_MIN_RETRY_WAIT_MS,
-            DELETE_MAX_RETRY_WAIT_MS,
-            DELETE_TOTAL_RETRY_TIME_MS,
-            2 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
+        .totalTimeoutMs(DELETE_TOTAL_RETRY_TIME_MS)
+        .backoffStrategy(
+            BackoffStrategies.from(
+                ioProperties(io), DELETE_MIN_RETRY_WAIT_MS, DELETE_MAX_RETRY_WAIT_MS, 2))
         .run(
             path -> {
               io.deleteFile(path);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.ContentFile;
@@ -27,6 +28,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.BackoffStrategies;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.apache.spark.TaskContext;
@@ -91,6 +93,15 @@ class SparkCleanupUtil {
     }
   }
 
+  private static Map<String, String> ioProperties(FileIO io) {
+    try {
+      return io.properties();
+    } catch (UnsupportedOperationException e) {
+      // FileIO implementations are not required to expose their configuration
+      return null;
+    }
+  }
+
   private static void delete(String context, FileIO io, List<String> paths) {
     AtomicInteger deletedFilesCount = new AtomicInteger(0);
 
@@ -105,6 +116,7 @@ class SparkCleanupUtil {
             DELETE_MAX_RETRY_WAIT_MS,
             DELETE_TOTAL_RETRY_TIME_MS,
             2 /* exponential */)
+        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
         .run(
             path -> {
               io.deleteFile(path);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCleanupUtil.java
@@ -111,12 +111,10 @@ class SparkCleanupUtil {
         .suppressFailureWhenFinished()
         .onFailure((path, exc) -> LOG.warn("Failed to delete {} ({})", path, context, exc))
         .retry(DELETE_NUM_RETRIES)
-        .exponentialBackoff(
-            DELETE_MIN_RETRY_WAIT_MS,
-            DELETE_MAX_RETRY_WAIT_MS,
-            DELETE_TOTAL_RETRY_TIME_MS,
-            2 /* exponential */)
-        .backoffStrategy(BackoffStrategies.from(ioProperties(io)))
+        .totalTimeoutMs(DELETE_TOTAL_RETRY_TIME_MS)
+        .backoffStrategy(
+            BackoffStrategies.from(
+                ioProperties(io), DELETE_MIN_RETRY_WAIT_MS, DELETE_MAX_RETRY_WAIT_MS, 2))
         .run(
             path -> {
               io.deleteFile(path);


### PR DESCRIPTION
Part of #7528.

## Motivation

Retry backoff in `Tasks.runTaskWithRetry` was a single hardcoded exponential-plus-jitter formula with no way to substitute another algorithm.

## What this PR does

**SPI introduction.** Introduces a pluggable SPI `org.apache.iceberg.util.BackoffStrategy` selected via a single property `retry.strategy-impl`, loaded reflectively via the standard `DynConstructors` no-arg constructor + `initialize(Map)` pattern that `catalog-impl`, `io-impl`, and `lock-impl` already use. The new `ExponentialBackoffStrategy` reproduces the previous inline formula and jitter exactly, and is the default whenever no strategy is configured — so existing callers see byte-for-byte identical per-attempt wait times.

Every production `.exponentialBackoff(...)` site that had access to a properties map is wired through the SPI: commits, REST catalog handlers, metadata refresh, status checks, in-memory and DynamoDB lock managers, the Hive Metastore lock (via Hadoop `Configuration`), REST scan polling, and Spark cleanup via `FileIO.properties()`. OAuth2 token refresh has no usable properties map at its call site, so it uses an explicitly-constructed default.

**API cleanup.** `Tasks.Builder.exponentialBackoff(long, long, long, double)` was carrying two unrelated concerns: per-attempt formula parameters (min/max/scale) and the total retry budget (totalTimeout). The new SPI made the conflation visible — at every wired site the formula args became dead weight whenever the configured strategy actually won. The method is replaced by two: `Tasks.Builder.totalTimeoutMs(long)` (the retry budget — aligned with the operator-facing property name `commit.retry.total-timeout-ms`) and `Tasks.Builder.backoffStrategy(BackoffStrategy)` (the per-attempt wait formula). A new `BackoffStrategies.from(Map, long, long, double)` overload preserves operator-tunable formula defaults: it returns the custom strategy when `retry.strategy-impl` is set, otherwise a fresh `ExponentialBackoffStrategy` with the provided params. The internal field `maxDurationMs` is renamed `totalTimeoutMs` to match the same operator-facing name.

A follow-up PR will add an AIMD strategy on top of this SPI without further core changes. The implementation is already prepared on branch [`issue/7528-aimd-backoff-strategy`](https://github.com/wombatu-kun/iceberg/tree/issue/7528-aimd-backoff-strategy) (two commits: an `onSuccess()` callback added to `BackoffStrategy` plus `Tasks` wiring, then `AIMDBackoffStrategy` with tests and docs) and will be filed against `main` once this PR is merged.

## Compatibility

For the SPI surface, behavior is byte-for-byte unchanged unless `retry.strategy-impl` is set — the default fallback uses the same exponential-plus-jitter formula with the same parameters as before.

For the builder API, `Tasks.Builder.exponentialBackoff(long, long, long, double)` is removed. The behavior is fully recoverable via the new two-call form `.totalTimeoutMs(total).backoffStrategy(BackoffStrategies.from(props, min, max, scale))`. The revapi exception against the 1.11.0 baseline documents the removal and points at the replacement.

## Tests

`TestBackoffStrategies` covers the loader: happy path with `initialize` invocation, null/empty/missing-key returns, unknown class name, missing no-arg constructor, non-strategy class, `initialize` exception propagation, and the new 4-arg `from(Map, long, long, double)` overload across three branches (custom strategy from properties, default exponential, null properties). `TestTasks` covers Tasks integration: custom strategy is used, `null` is a no-op, the returned milliseconds actually drive `Thread.sleep` (timing-verified), and a single strategy instance is shared across parallel worker threads. `TestBackoffStrategyCommit` exercises end-to-end commit retry through the SPI across all four format versions.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Introduce a pluggable BackoffStrategy SPI for Tasks retries.
