### PR TITLE
Kafka Connect: Fix CME in IcebergSinkConfig causing flaky multi-table tests

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -244,7 +244,7 @@ public class IcebergSinkConfig extends AbstractConfig {
   private final Map<String, String> kafkaProps;
   private final Map<String, String> autoCreateProps;
   private final Map<String, String> writeProps;
-  private final Map<String, TableSinkConfig> tableConfigMap = Maps.newHashMap();
+  private final Map<String, TableSinkConfig> tableConfigMap = Maps.newConcurrentMap();
   private final JsonConverter jsonConverter;
 
   public IcebergSinkConfig(Map<String, String> originalProps) {


### PR DESCRIPTION
## Summary

Multi-table integration tests in `kafka-connect-tests` (`TestIntegrationDynamicTable.testIcebergSink`, `TestIntegrationMultiTable.testIcebergSink`) were flaking ~5/10 runs on `assertThat(table.snapshots()).hasSize(1)`. Root cause is a thread-safety bug in `IcebergSinkConfig.tableConfig` exposed under parallel multi-table commits.

## Root cause

`tableConfig(...)` uses `HashMap.computeIfAbsent` on a non-thread-safe `tableConfigMap`. `Coordinator.commit()` parallelizes per-table commits via `Tasks.foreach.executeWith(exec)` (`Coordinator.java:173`); each task calls `config.tableConfig(...)` at `Coordinator.java:231`. On 2+ table commits, the second thread's `computeIfAbsent` sees the first's insertion mid-traversal and throws `ConcurrentModificationException`, killing the Coordinator after the first table commits but before the second. The Awaitility `hasSize(1)` assertion on the lost table then times out. Single-table sinks invoke `commitToTable` exactly once and never hit the race — matching the historical failure pattern. CME stack trace from CI run [#26213568037](https://github.com/apache/iceberg/actions/runs/26213568037).

## Fix

Switch `tableConfigMap` from `Maps.newHashMap()` to `Maps.newConcurrentMap()`. `ConcurrentHashMap.computeIfAbsent` is documented atomic per the JDK contract — the race becomes structurally impossible.

## Related

#16504 — diagnostic CI plumbing (per-test integration test reports + docker container log capture) used to capture the CME stack trace, split out per reviewer request.