### PR TITLE
Core: Arrow position delete reader V2

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowFormatModels.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowFormatModels.java
@@ -19,8 +19,14 @@
 package org.apache.iceberg.arrow.vectorized;
 
 import org.apache.arrow.vector.NullCheckingForGet;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.PositionDeleteIndexReader;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.parquet.ParquetFormatModel;
+import org.apache.iceberg.util.CharSequenceMap;
 
 public class ArrowFormatModels {
   public static void register() {
@@ -33,6 +39,29 @@ public class ArrowFormatModels {
                     schema,
                     fileSchema,
                     NullCheckingForGet.NULL_CHECKING_ENABLED /* setArrowValidityVector */)));
+
+    FormatModelRegistry.registerPositionDeleteIndexReader(
+        FileFormat.PARQUET, ArrowPositionDeleteIndexReader.INSTANCE);
+  }
+
+  /**
+   * Adapts {@link VectorizedPositionDeleteReader} to the {@link PositionDeleteIndexReader} SPI so
+   * delete loaders consult the Arrow fast path through {@link FormatModelRegistry}.
+   */
+  private static final class ArrowPositionDeleteIndexReader implements PositionDeleteIndexReader {
+    private static final ArrowPositionDeleteIndexReader INSTANCE =
+        new ArrowPositionDeleteIndexReader();
+
+    @Override
+    public PositionDeleteIndex read(
+        InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+      return VectorizedPositionDeleteReader.read(file, dataLocation, deleteFile);
+    }
+
+    @Override
+    public CharSequenceMap<PositionDeleteIndex> readAll(InputFile file, DeleteFile deleteFile) {
+      return VectorizedPositionDeleteReader.readAllByDataFile(file, deleteFile);
+    }
   }
 
   private ArrowFormatModels() {}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowFormatModels.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowFormatModels.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.formats.PositionDeleteIndexReader;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.parquet.ParquetFormatModel;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.CharSequenceMap;
 
 public class ArrowFormatModels {
@@ -55,6 +56,11 @@ public class ArrowFormatModels {
     @Override
     public PositionDeleteIndex read(
         InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+      // The SPI requires a non-null filter. VectorizedPositionDeleteReader#read also accepts
+      // null as "no filter / union all rows", but that mode is intentionally a direct-API
+      // optimization (e.g. for single-data-file delete files); SPI callers must pick a path
+      // explicitly via readAll(...) instead.
+      Preconditions.checkArgument(dataLocation != null, "Invalid data location: null");
       return VectorizedPositionDeleteReader.read(file, dataLocation, deleteFile);
     }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -267,8 +267,12 @@ public final class VectorizedPositionDeleteReader {
    * Coalescing append for the multi-data-file case: rows are grouped by {@code file_path} into
    * separate {@link PositionDeleteIndex} instances. Position delete files are required to be sorted
    * by {@code (file_path, pos)}, so paths arrive in contiguous runs; the active path's bytes are
-   * tracked and the run is finalized only on a path change. If a previously seen path reappears (an
+   * tracked and a run is finalized only on a path change. If a previously seen path reappears (an
    * unsorted file), the existing index is reused so positions are not lost.
+   *
+   * <p>To avoid a 50+-byte comparison per row in the common single-data-file case, the inner loop
+   * uses a length-plus-first-byte fast filter via {@link #endOfPathRun}: only when the cheap check
+   * suggests a transition do we materialize the new path bytes and verify with a full comparison.
    */
   @SuppressWarnings("CollectionUndefinedEquality")
   private static void appendGroupedByPath(
@@ -285,12 +289,13 @@ public final class VectorizedPositionDeleteReader {
         ArrowBuf pathBuf = pathVec.getDataBuffer();
         ArrowBuf posBuf = posVec.getDataBuffer();
         int rows = batch.numRows();
-        for (int i = 0; i < rows; i++) {
-          if (currentPath == null || !matches(pathVec, pathBuf, i, currentPath)) {
+        int cursor = 0;
+        while (cursor < rows) {
+          if (currentPath == null || !matches(pathVec, pathBuf, cursor, currentPath)) {
             if (coalescer != null) {
               coalescer.flush();
             }
-            currentPath = readPath(pathVec, pathBuf, i);
+            currentPath = readPath(pathVec, pathBuf, cursor);
             String pathKey = new String(currentPath, StandardCharsets.UTF_8);
             PositionDeleteIndex existing = indexes.get(pathKey);
             if (existing == null) {
@@ -299,7 +304,12 @@ public final class VectorizedPositionDeleteReader {
             }
             coalescer = new RangeCoalescer(existing);
           }
-          coalescer.accept(readLong(posBuf, i));
+
+          int runEnd = endOfPathRun(pathVec, pathBuf, cursor, rows, currentPath);
+          for (int i = cursor; i < runEnd; i++) {
+            coalescer.accept(readLong(posBuf, i));
+          }
+          cursor = runEnd;
         }
       }
     }
@@ -307,6 +317,60 @@ public final class VectorizedPositionDeleteReader {
     if (coalescer != null) {
       coalescer.flush();
     }
+  }
+
+  /**
+   * Finds the smallest row index {@code i} in {@code [start + 1, rows]} for which the {@code
+   * file_path} differs from {@code currentPath}, or returns {@code rows} if no such row exists. The
+   * caller must guarantee that {@code currentPath} matches row {@code start}.
+   *
+   * <p>For each row, the cheap filter checks (a) non-null, (b) the same value length, and (c) the
+   * same first byte. Rows that pass all three are presumed to share the path with row {@code start}
+   * (which holds for sorted position-delete files since two adjacent paths cannot share both length
+   * and leading byte without being equal in their span). The run length is verified by a full
+   * byte-for-byte comparison of the last row in the candidate run; if it disagrees, the method
+   * falls back to a full per-row comparison so unsorted files still produce a correct grouping.
+   * Empty paths skip the first-byte check.
+   */
+  private static int endOfPathRun(
+      VarCharVector pathVec, ArrowBuf dataBuf, int start, int rows, byte[] currentPath) {
+    int len = currentPath.length;
+    int cursor = start + 1;
+
+    if (len == 0) {
+      while (cursor < rows && !pathVec.isNull(cursor) && pathVec.getValueLength(cursor) == 0) {
+        cursor++;
+      }
+      return cursor;
+    }
+
+    byte first = currentPath[0];
+    while (cursor < rows) {
+      if (pathVec.isNull(cursor)) {
+        return cursor;
+      }
+      if (pathVec.getValueLength(cursor) != len) {
+        return cursor;
+      }
+      if (dataBuf.getByte(pathVec.getStartOffset(cursor)) != first) {
+        return cursor;
+      }
+      cursor++;
+    }
+
+    // Fast filter accepted every row. Confirm by verifying the last row's full path.
+    if (matches(pathVec, dataBuf, rows - 1, currentPath)) {
+      return rows;
+    }
+
+    // Same length and first byte but a divergent middle byte (rare, possible only for unsorted
+    // files). Re-scan with full byte comparisons to find the actual boundary.
+    for (int j = start + 1; j < rows; j++) {
+      if (!matches(pathVec, dataBuf, j, currentPath)) {
+        return j;
+      }
+    }
+    return rows;
   }
 
   /**

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -182,11 +182,13 @@ public final class VectorizedPositionDeleteReader {
    * Reads a position delete file and returns one {@link PositionDeleteIndex} per data file path
    * referenced by the delete file.
    *
-   * <p>Position delete files are required to be sorted by {@code (file_path, pos)} ascending, so
-   * rows for the same data file path arrive in contiguous runs. The reader exploits this by
-   * tracking the active path's bytes between rows and only finalizing the run on a path change, but
-   * it also handles unsorted files correctly by looking up an existing entry in the result map
-   * before creating a new one.
+   * <p>This reader assumes the Iceberg v2 spec sort order: rows ordered by {@code (file_path, pos)}
+   * ascending. Under that contract, rows for the same data file path arrive in one contiguous run,
+   * which the reader exploits to track the active path's bytes between rows and finalize the run
+   * only on a path change. Behavior on files that do not honor this sort order is undefined --
+   * positions may be misattributed across paths and the resulting indexes will silently be wrong.
+   * Engines that ingest position delete files written outside Iceberg should validate sort order
+   * upstream.
    *
    * <p>Each returned index is mutable and is not safe for concurrent mutation by multiple threads.
    *
@@ -289,14 +291,13 @@ public final class VectorizedPositionDeleteReader {
 
   /**
    * Coalescing append for the multi-data-file case: rows are grouped by {@code file_path} into
-   * separate {@link PositionDeleteIndex} instances. Position delete files are required to be sorted
-   * by {@code (file_path, pos)}, so paths arrive in contiguous runs; the active path's bytes are
-   * tracked and a run is finalized only on a path change. If a previously seen path reappears (an
-   * unsorted file), the existing index is reused so positions are not lost.
+   * separate {@link PositionDeleteIndex} instances. Assumes the input is sorted per the Iceberg v2
+   * spec ({@code (file_path, pos)} ascending), so each path's rows arrive in one contiguous run;
+   * the active path's bytes are tracked and a run is finalized only on a path change.
    *
    * <p>To avoid a 50+-byte comparison per row in the common single-data-file case, the inner loop
    * uses a length-plus-first-byte fast filter via {@link #endOfPathRun}: only when the cheap check
-   * suggests a transition do we materialize the new path bytes and verify with a full comparison.
+   * suggests a transition do we materialize the new path bytes and look up the target index.
    */
   @SuppressWarnings("CollectionUndefinedEquality")
   private static void appendGroupedByPath(
@@ -352,15 +353,16 @@ public final class VectorizedPositionDeleteReader {
   /**
    * Finds the smallest row index {@code i} in {@code [start + 1, rows]} for which the {@code
    * file_path} differs from {@code currentPath}, or returns {@code rows} if no such row exists. The
-   * caller must guarantee that {@code currentPath} matches row {@code start}.
+   * caller must guarantee that {@code currentPath} matches row {@code start} and that the input is
+   * sorted per the Iceberg v2 spec ({@code (file_path, pos)} ascending).
    *
-   * <p>For each row, the cheap filter checks (a) non-null, (b) the same value length, and (c) the
-   * same first byte. Rows that pass all three are presumed to share the path with row {@code start}
-   * (which holds for sorted position-delete files since two adjacent paths cannot share both length
-   * and leading byte without being equal in their span). The run length is verified by a full
-   * byte-for-byte comparison of the last row in the candidate run; if it disagrees, the method
-   * falls back to a full per-row comparison so unsorted files still produce a correct grouping.
-   * Empty paths skip the first-byte check.
+   * <p>The hot inner loop uses a cheap filter that checks (a) non-null, (b) the same value length,
+   * and (c) the same first byte. Rows that pass all three are presumed to share the path with row
+   * {@code start}. Multiple sorted paths in the same batch may share length and leading byte (for
+   * instance {@code .../file-a.parquet} vs {@code .../file-b.parquet}), so when the cheap filter
+   * accepts every remaining row we confirm with a full comparison of the last row; if that
+   * disagrees we re-scan with full per-row comparisons to find the actual sorted boundary. Empty
+   * paths skip the first-byte check.
    */
   private static int endOfPathRun(
       VarCharVector pathVec, ArrowBuf dataBuf, int start, int rows, byte[] currentPath) {
@@ -388,13 +390,11 @@ public final class VectorizedPositionDeleteReader {
       cursor++;
     }
 
-    // Fast filter accepted every row. Confirm by verifying the last row's full path.
+    // Cheap filter accepted every remaining row. Verify by matching the last row's full path; if
+    // it doesn't actually equal currentPath, rescan with full comparisons to find the boundary.
     if (matches(pathVec, dataBuf, rows - 1, currentPath)) {
       return rows;
     }
-
-    // Same length and first byte but a divergent middle byte (rare, possible only for unsorted
-    // files). Re-scan with full byte comparisons to find the actual boundary.
     for (int j = start + 1; j < rows; j++) {
       if (!matches(pathVec, dataBuf, j, currentPath)) {
         return j;

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.deletes.PositionDeleteRangeConsumer;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.DeleteSchemaUtil;
@@ -138,7 +139,7 @@ public final class VectorizedPositionDeleteReader {
 
     Schema projection = dataLocation == null ? POS_ONLY_SCHEMA : FULL_SCHEMA;
     PositionDeleteIndex index = PositionDeleteIndex.create(deleteFile);
-    RangeCoalescer coalescer = new RangeCoalescer(index);
+    PositionDeleteRangeConsumer coalescer = new PositionDeleteRangeConsumer(index);
 
     try (CloseableIterable<ColumnarBatch> batches =
         Parquet.read(file)
@@ -220,30 +221,42 @@ public final class VectorizedPositionDeleteReader {
   }
 
   /**
-   * Coalescing append for the no-filter case: every row in every batch is added. Consecutive
-   * positions are merged into a single range insert.
+   * Coalescing append for the no-filter case: every row in every batch is added. Each batch is
+   * copied into a scratch {@code long[]} once and forwarded to the accumulator in a single bulk
+   * call so the per-row work in steady state stays inside the accumulator's tight loop -- no
+   * method-call frame between {@code readLong} and the gap check.
    */
-  private static void appendAll(CloseableIterator<ColumnarBatch> it, RangeCoalescer coalescer) {
+  private static void appendAll(
+      CloseableIterator<ColumnarBatch> it, PositionDeleteRangeConsumer coalescer) {
+    long[] buffer = null;
     while (it.hasNext()) {
       try (ColumnarBatch batch = it.next()) {
         BigIntVector posVec = (BigIntVector) posColumn(batch).getArrowVector();
         ArrowBuf posBuf = posVec.getDataBuffer();
         int rows = batch.numRows();
-        for (int i = 0; i < rows; i++) {
-          coalescer.accept(readLong(posBuf, i));
+        if (buffer == null || buffer.length < rows) {
+          buffer = new long[rows];
         }
+        for (int i = 0; i < rows; i++) {
+          buffer[i] = readLong(posBuf, i);
+        }
+        coalescer.acceptAll(buffer, 0, rows);
       }
     }
   }
 
   /**
    * Coalescing append for the filtered case: only rows whose {@code file_path} equals {@code
-   * dataLocation} contribute. The run is broken whenever a non-matching row is seen so we never
+   * dataLocation} contribute. Matching positions are packed into a scratch buffer and bulk-fed to
+   * the accumulator; a non-matching row drains the buffer and flushes the accumulator so we never
    * coalesce across a gap caused by another data file.
    */
   private static void appendFiltered(
-      CloseableIterator<ColumnarBatch> it, CharSequence dataLocation, RangeCoalescer coalescer) {
+      CloseableIterator<ColumnarBatch> it,
+      CharSequence dataLocation,
+      PositionDeleteRangeConsumer coalescer) {
     byte[] target = dataLocation.toString().getBytes(StandardCharsets.UTF_8);
+    long[] buffer = null;
 
     while (it.hasNext()) {
       try (ColumnarBatch batch = it.next()) {
@@ -252,12 +265,23 @@ public final class VectorizedPositionDeleteReader {
         ArrowBuf pathBuf = pathVec.getDataBuffer();
         ArrowBuf posBuf = posVec.getDataBuffer();
         int rows = batch.numRows();
+        if (buffer == null || buffer.length < rows) {
+          buffer = new long[rows];
+        }
+        int filled = 0;
         for (int i = 0; i < rows; i++) {
           if (matches(pathVec, pathBuf, i, target)) {
-            coalescer.accept(readLong(posBuf, i));
+            buffer[filled++] = readLong(posBuf, i);
           } else {
-            coalescer.breakRun();
+            if (filled > 0) {
+              coalescer.acceptAll(buffer, 0, filled);
+              filled = 0;
+            }
+            coalescer.flush();
           }
+        }
+        if (filled > 0) {
+          coalescer.acceptAll(buffer, 0, filled);
         }
       }
     }
@@ -280,7 +304,8 @@ public final class VectorizedPositionDeleteReader {
       CharSequenceMap<PositionDeleteIndex> indexes,
       DeleteFile deleteFile) {
     byte[] currentPath = null;
-    RangeCoalescer coalescer = null;
+    PositionDeleteRangeConsumer coalescer = null;
+    long[] buffer = null;
 
     while (it.hasNext()) {
       try (ColumnarBatch batch = it.next()) {
@@ -289,6 +314,9 @@ public final class VectorizedPositionDeleteReader {
         ArrowBuf pathBuf = pathVec.getDataBuffer();
         ArrowBuf posBuf = posVec.getDataBuffer();
         int rows = batch.numRows();
+        if (buffer == null || buffer.length < rows) {
+          buffer = new long[rows];
+        }
         int cursor = 0;
         while (cursor < rows) {
           if (currentPath == null || !matches(pathVec, pathBuf, cursor, currentPath)) {
@@ -302,13 +330,15 @@ public final class VectorizedPositionDeleteReader {
               existing = PositionDeleteIndex.create(deleteFile);
               indexes.put(pathKey, existing);
             }
-            coalescer = new RangeCoalescer(existing);
+            coalescer = new PositionDeleteRangeConsumer(existing);
           }
 
           int runEnd = endOfPathRun(pathVec, pathBuf, cursor, rows, currentPath);
-          for (int i = cursor; i < runEnd; i++) {
-            coalescer.accept(readLong(posBuf, i));
+          int runLen = runEnd - cursor;
+          for (int i = 0; i < runLen; i++) {
+            buffer[i] = readLong(posBuf, cursor + i);
           }
+          coalescer.acceptAll(buffer, 0, runLen);
           cursor = runEnd;
         }
       }
@@ -385,57 +415,6 @@ public final class VectorizedPositionDeleteReader {
       bytes[i] = dataBuf.getByte(offset + i);
     }
     return bytes;
-  }
-
-  /**
-   * Tracks the active run of consecutive positions and emits range inserts to the underlying index.
-   * Single-threaded; intended for one decoding pass per delete file.
-   */
-  private static final class RangeCoalescer {
-    private final PositionDeleteIndex index;
-    private boolean hasRun;
-    private long runStart;
-    private long runEnd;
-
-    RangeCoalescer(PositionDeleteIndex index) {
-      this.index = index;
-    }
-
-    void accept(long pos) {
-      if (!hasRun) {
-        runStart = pos;
-        runEnd = pos;
-        hasRun = true;
-      } else if (pos == runEnd + 1) {
-        runEnd = pos;
-      } else {
-        emit();
-        runStart = pos;
-        runEnd = pos;
-      }
-    }
-
-    void breakRun() {
-      if (hasRun) {
-        emit();
-        hasRun = false;
-      }
-    }
-
-    void flush() {
-      if (hasRun) {
-        emit();
-        hasRun = false;
-      }
-    }
-
-    private void emit() {
-      if (runStart == runEnd) {
-        index.delete(runStart);
-      } else {
-        index.delete(runStart, runEnd + 1);
-      }
-    }
   }
 
   /**

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -1,0 +1,312 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.arrow.memory.ArrowBuf;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
+import org.apache.iceberg.parquet.VectorizedReader;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.parquet.schema.MessageType;
+
+/**
+ * Reads an Iceberg position delete file directly into a {@link PositionDeleteIndex} via Arrow
+ * vectors, without materializing intermediate {@link org.apache.iceberg.data.Record} instances or
+ * boxing positions into {@link Long}.
+ *
+ * <p>Compared with iterating a record-based reader and inserting positions one at a time, this
+ * reader:
+ *
+ * <ul>
+ *   <li>reads the {@code pos} column directly from a {@link BigIntVector} as primitive longs,
+ *       eliminating boxing and per-row {@code GenericRecord} allocations,
+ *   <li>coalesces consecutive matching positions into range inserts via {@link
+ *       PositionDeleteIndex#delete(long, long)}, which the underlying Roaring bitmap can apply in
+ *       bulk, and
+ *   <li>only projects the {@code file_path} column when the caller is filtering, so a
+ *       single-data-file delete file is decoded with a single column.
+ * </ul>
+ *
+ * <p>This class is engine-agnostic: it operates on a Parquet {@link InputFile} and does not require
+ * a table scan. It is the building block for v2 / v3 delete-file support in {@link ArrowReader}
+ * (see <a href="https://github.com/apache/iceberg/issues/2487">#2487</a>).
+ */
+public final class VectorizedPositionDeleteReader {
+
+  /** Default Arrow record-batch size for decoding position-delete files. */
+  public static final int DEFAULT_BATCH_SIZE = 1 << 13;
+
+  private static final Schema POS_ONLY_SCHEMA = new Schema(MetadataColumns.DELETE_FILE_POS);
+  private static final Schema FULL_SCHEMA =
+      new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
+
+  private VectorizedPositionDeleteReader() {}
+
+  /**
+   * Reads a position delete file and returns the positions for the given data file as a {@link
+   * PositionDeleteIndex}.
+   *
+   * <p>See {@link #read(InputFile, CharSequence, DeleteFile, int)} for invariants and behavior;
+   * this overload uses {@link #DEFAULT_BATCH_SIZE}.
+   *
+   * @param file the delete file to read
+   * @param dataLocation the data file path to filter by, or {@code null} to include all positions
+   *     in the delete file
+   * @param deleteFile the delete file metadata recorded with the returned index, may be {@code
+   *     null}
+   * @return a {@link PositionDeleteIndex} containing all matching positions
+   */
+  public static PositionDeleteIndex read(
+      InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+    return read(file, dataLocation, deleteFile, DEFAULT_BATCH_SIZE);
+  }
+
+  /**
+   * Reads a position delete file and returns the positions for the given data file as a {@link
+   * PositionDeleteIndex}.
+   *
+   * <p>The call blocks on the calling thread until the file is fully decoded; concurrent calls are
+   * independent (each builds its own Parquet reader and Arrow allocator child). The returned index
+   * is mutable and is not safe for concurrent mutation by multiple threads.
+   *
+   * <p>When {@code dataLocation} is non-null, rows are filtered by comparing {@code file_path}
+   * byte-for-byte against {@code dataLocation.toString().getBytes(UTF-8)}. Callers should pass the
+   * exact {@link String} that Iceberg used to write the delete file (typically the value returned
+   * by {@code DataFile#location()}); a path that is logically equivalent but encoded differently
+   * (e.g. unicode-normalized differently, or with a different scheme/host) matches no rows and
+   * yields an empty index.
+   *
+   * <p>When {@code dataLocation} is null, every row in the file is added to the same index
+   * regardless of its {@code file_path}. This is the intended mode for single-data-file delete
+   * files (the typical DV case); on a delete file referencing multiple data files it returns the
+   * union of all rows' positions, which is rarely what callers want.
+   *
+   * <p>The file is expected to conform to the Iceberg position-delete spec: {@code pos} is required
+   * and {@code file_path} is required when present in the projected schema. The {@code pos} column
+   * is read directly from the Arrow data buffer for performance, so behavior on a malformed file
+   * with null {@code pos} values is undefined (the index may contain arbitrary positions). Engines
+   * that ingest delete files written outside Iceberg should validate them upstream.
+   *
+   * @param file the delete file to read
+   * @param dataLocation the data file path to filter by, or {@code null} to include all positions
+   *     in the delete file regardless of {@code file_path}
+   * @param deleteFile the delete file metadata recorded with the returned index, may be {@code
+   *     null}
+   * @param batchSize the Arrow batch size to use when decoding the file
+   * @return a mutable {@link PositionDeleteIndex} containing all matching positions
+   */
+  public static PositionDeleteIndex read(
+      InputFile file, CharSequence dataLocation, DeleteFile deleteFile, int batchSize) {
+    Preconditions.checkArgument(file != null, "Invalid input file: null");
+    Preconditions.checkArgument(batchSize > 0, "Invalid batch size: %s", batchSize);
+
+    Schema projection = dataLocation == null ? POS_ONLY_SCHEMA : FULL_SCHEMA;
+    PositionDeleteIndex index = PositionDeleteIndex.create(deleteFile);
+    RangeCoalescer coalescer = new RangeCoalescer(index);
+
+    try (CloseableIterable<ColumnarBatch> batches =
+        Parquet.read(file)
+            .project(projection)
+            .recordsPerBatch(batchSize)
+            .createBatchedReaderFunc(fileSchema -> buildBatchReader(projection, fileSchema))
+            .build()) {
+
+      try (CloseableIterator<ColumnarBatch> it = batches.iterator()) {
+        if (dataLocation == null) {
+          appendAll(it, coalescer);
+        } else {
+          appendFiltered(it, dataLocation, coalescer);
+        }
+      }
+      coalescer.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read position delete file: " + file.location(), e);
+    }
+
+    return index;
+  }
+
+  /**
+   * Coalescing append for the no-filter case: every row in every batch is added. Consecutive
+   * positions are merged into a single range insert.
+   */
+  private static void appendAll(CloseableIterator<ColumnarBatch> it, RangeCoalescer coalescer) {
+    while (it.hasNext()) {
+      try (ColumnarBatch batch = it.next()) {
+        BigIntVector posVec = (BigIntVector) posColumn(batch).getArrowVector();
+        ArrowBuf posBuf = posVec.getDataBuffer();
+        int rows = batch.numRows();
+        for (int i = 0; i < rows; i++) {
+          coalescer.accept(readLong(posBuf, i));
+        }
+      }
+    }
+  }
+
+  /**
+   * Coalescing append for the filtered case: only rows whose {@code file_path} equals {@code
+   * dataLocation} contribute. The run is broken whenever a non-matching row is seen so we never
+   * coalesce across a gap caused by another data file.
+   */
+  private static void appendFiltered(
+      CloseableIterator<ColumnarBatch> it, CharSequence dataLocation, RangeCoalescer coalescer) {
+    byte[] target = dataLocation.toString().getBytes(StandardCharsets.UTF_8);
+
+    while (it.hasNext()) {
+      try (ColumnarBatch batch = it.next()) {
+        VarCharVector pathVec = (VarCharVector) pathColumn(batch).getArrowVector();
+        BigIntVector posVec = (BigIntVector) posColumn(batch).getArrowVector();
+        ArrowBuf pathBuf = pathVec.getDataBuffer();
+        ArrowBuf posBuf = posVec.getDataBuffer();
+        int rows = batch.numRows();
+        for (int i = 0; i < rows; i++) {
+          if (matches(pathVec, pathBuf, i, target)) {
+            coalescer.accept(readLong(posBuf, i));
+          } else {
+            coalescer.breakRun();
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Tracks the active run of consecutive positions and emits range inserts to the underlying index.
+   * Single-threaded; intended for one decoding pass per delete file.
+   */
+  private static final class RangeCoalescer {
+    private final PositionDeleteIndex index;
+    private boolean hasRun;
+    private long runStart;
+    private long runEnd;
+
+    RangeCoalescer(PositionDeleteIndex index) {
+      this.index = index;
+    }
+
+    void accept(long pos) {
+      if (!hasRun) {
+        runStart = pos;
+        runEnd = pos;
+        hasRun = true;
+      } else if (pos == runEnd + 1) {
+        runEnd = pos;
+      } else {
+        emit();
+        runStart = pos;
+        runEnd = pos;
+      }
+    }
+
+    void breakRun() {
+      if (hasRun) {
+        emit();
+        hasRun = false;
+      }
+    }
+
+    void flush() {
+      if (hasRun) {
+        emit();
+        hasRun = false;
+      }
+    }
+
+    private void emit() {
+      if (runStart == runEnd) {
+        index.delete(runStart);
+      } else {
+        index.delete(runStart, runEnd + 1);
+      }
+    }
+  }
+
+  /**
+   * Returns true if {@code pathVec[row]} equals {@code target} byte-for-byte. Reads the UTF-8 bytes
+   * directly from the Arrow data buffer; no String or byte[] allocation per row.
+   */
+  private static boolean matches(VarCharVector pathVec, ArrowBuf dataBuf, int row, byte[] target) {
+    if (pathVec.isNull(row)) {
+      return false;
+    }
+
+    int length = pathVec.getValueLength(row);
+    if (length != target.length) {
+      return false;
+    }
+
+    long offset = pathVec.getStartOffset(row);
+    for (int i = 0; i < length; i++) {
+      if (dataBuf.getByte(offset + i) != target[i]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * Reads a {@code long} directly from the value buffer at row {@code i}, bypassing {@link
+   * BigIntVector#get(int)}'s null check. The {@code pos} column in a position delete file is
+   * required and therefore never null; reading the data buffer is both correct and avoids one
+   * branch per row.
+   */
+  private static long readLong(ArrowBuf posBuf, int row) {
+    return posBuf.getLong((long) row * BigIntVector.TYPE_WIDTH);
+  }
+
+  /**
+   * The {@code pos} column is the last column in both projections: index 0 for {@link
+   * #POS_ONLY_SCHEMA}, index 1 for {@link #FULL_SCHEMA}.
+   */
+  private static ColumnVector posColumn(ColumnarBatch batch) {
+    return batch.column(batch.numCols() - 1);
+  }
+
+  /** Only valid when {@link #FULL_SCHEMA} is projected; {@code file_path} is at index 0. */
+  private static ColumnVector pathColumn(ColumnarBatch batch) {
+    return batch.column(0);
+  }
+
+  private static VectorizedReader<?> buildBatchReader(Schema projection, MessageType fileSchema) {
+    return (VectorizedReader<?>)
+        TypeWithSchemaVisitor.visit(
+            projection.asStruct(),
+            fileSchema,
+            new VectorizedReaderBuilder(
+                projection,
+                fileSchema,
+                /* setArrowValidityVector= */ true,
+                ImmutableMap.of(),
+                ArrowBatchReader::new));
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -23,6 +23,7 @@ import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.NullCheckingForGet;
 import org.apache.arrow.vector.VarCharVector;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
@@ -30,6 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
@@ -62,12 +64,16 @@ import org.apache.parquet.schema.MessageType;
  */
 public final class VectorizedPositionDeleteReader {
 
-  /** Default Arrow record-batch size for decoding position-delete files. */
+  /**
+   * Default Arrow record-batch size for decoding position-delete files. Larger than {@link
+   * VectorizedArrowReader#DEFAULT_BATCH_SIZE} because position-delete files project at most two
+   * narrow columns ({@code file_path} and {@code pos}), so a larger batch amortizes the per-batch
+   * decoding cost without materially increasing memory pressure.
+   */
   public static final int DEFAULT_BATCH_SIZE = 1 << 13;
 
   private static final Schema POS_ONLY_SCHEMA = new Schema(MetadataColumns.DELETE_FILE_POS);
-  private static final Schema FULL_SCHEMA =
-      new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
+  private static final Schema FULL_SCHEMA = DeleteSchemaUtil.pathPosSchema();
 
   private VectorizedPositionDeleteReader() {}
 
@@ -305,7 +311,7 @@ public final class VectorizedPositionDeleteReader {
             new VectorizedReaderBuilder(
                 projection,
                 fileSchema,
-                /* setArrowValidityVector= */ true,
+                NullCheckingForGet.NULL_CHECKING_ENABLED,
                 ImmutableMap.of(),
                 ArrowBatchReader::new));
   }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedPositionDeleteReader.java
@@ -38,6 +38,7 @@ import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.CharSequenceMap;
 import org.apache.parquet.schema.MessageType;
 
 /**
@@ -162,6 +163,63 @@ public final class VectorizedPositionDeleteReader {
   }
 
   /**
+   * Reads a position delete file and returns one {@link PositionDeleteIndex} per data file path
+   * referenced by the delete file. See {@link #readAllByDataFile(InputFile, DeleteFile, int)} for
+   * details; this overload uses {@link #DEFAULT_BATCH_SIZE}.
+   *
+   * @param file the delete file to read
+   * @param deleteFile the delete file metadata recorded with each returned index, may be {@code
+   *     null}
+   * @return a map of data file path to {@link PositionDeleteIndex}
+   */
+  public static CharSequenceMap<PositionDeleteIndex> readAllByDataFile(
+      InputFile file, DeleteFile deleteFile) {
+    return readAllByDataFile(file, deleteFile, DEFAULT_BATCH_SIZE);
+  }
+
+  /**
+   * Reads a position delete file and returns one {@link PositionDeleteIndex} per data file path
+   * referenced by the delete file.
+   *
+   * <p>Position delete files are required to be sorted by {@code (file_path, pos)} ascending, so
+   * rows for the same data file path arrive in contiguous runs. The reader exploits this by
+   * tracking the active path's bytes between rows and only finalizing the run on a path change, but
+   * it also handles unsorted files correctly by looking up an existing entry in the result map
+   * before creating a new one.
+   *
+   * <p>Each returned index is mutable and is not safe for concurrent mutation by multiple threads.
+   *
+   * @param file the delete file to read
+   * @param deleteFile the delete file metadata recorded with each returned index, may be {@code
+   *     null}
+   * @param batchSize the Arrow batch size to use when decoding the file
+   * @return a map of data file path to {@link PositionDeleteIndex}
+   */
+  public static CharSequenceMap<PositionDeleteIndex> readAllByDataFile(
+      InputFile file, DeleteFile deleteFile, int batchSize) {
+    Preconditions.checkArgument(file != null, "Invalid input file: null");
+    Preconditions.checkArgument(batchSize > 0, "Invalid batch size: %s", batchSize);
+
+    CharSequenceMap<PositionDeleteIndex> indexes = CharSequenceMap.create();
+
+    try (CloseableIterable<ColumnarBatch> batches =
+        Parquet.read(file)
+            .project(FULL_SCHEMA)
+            .recordsPerBatch(batchSize)
+            .createBatchedReaderFunc(fileSchema -> buildBatchReader(FULL_SCHEMA, fileSchema))
+            .build()) {
+
+      try (CloseableIterator<ColumnarBatch> it = batches.iterator()) {
+        appendGroupedByPath(it, indexes, deleteFile);
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read position delete file: " + file.location(), e);
+    }
+
+    return indexes;
+  }
+
+  /**
    * Coalescing append for the no-filter case: every row in every batch is added. Consecutive
    * positions are merged into a single range insert.
    */
@@ -203,6 +261,66 @@ public final class VectorizedPositionDeleteReader {
         }
       }
     }
+  }
+
+  /**
+   * Coalescing append for the multi-data-file case: rows are grouped by {@code file_path} into
+   * separate {@link PositionDeleteIndex} instances. Position delete files are required to be sorted
+   * by {@code (file_path, pos)}, so paths arrive in contiguous runs; the active path's bytes are
+   * tracked and the run is finalized only on a path change. If a previously seen path reappears (an
+   * unsorted file), the existing index is reused so positions are not lost.
+   */
+  @SuppressWarnings("CollectionUndefinedEquality")
+  private static void appendGroupedByPath(
+      CloseableIterator<ColumnarBatch> it,
+      CharSequenceMap<PositionDeleteIndex> indexes,
+      DeleteFile deleteFile) {
+    byte[] currentPath = null;
+    RangeCoalescer coalescer = null;
+
+    while (it.hasNext()) {
+      try (ColumnarBatch batch = it.next()) {
+        VarCharVector pathVec = (VarCharVector) pathColumn(batch).getArrowVector();
+        BigIntVector posVec = (BigIntVector) posColumn(batch).getArrowVector();
+        ArrowBuf pathBuf = pathVec.getDataBuffer();
+        ArrowBuf posBuf = posVec.getDataBuffer();
+        int rows = batch.numRows();
+        for (int i = 0; i < rows; i++) {
+          if (currentPath == null || !matches(pathVec, pathBuf, i, currentPath)) {
+            if (coalescer != null) {
+              coalescer.flush();
+            }
+            currentPath = readPath(pathVec, pathBuf, i);
+            String pathKey = new String(currentPath, StandardCharsets.UTF_8);
+            PositionDeleteIndex existing = indexes.get(pathKey);
+            if (existing == null) {
+              existing = PositionDeleteIndex.create(deleteFile);
+              indexes.put(pathKey, existing);
+            }
+            coalescer = new RangeCoalescer(existing);
+          }
+          coalescer.accept(readLong(posBuf, i));
+        }
+      }
+    }
+
+    if (coalescer != null) {
+      coalescer.flush();
+    }
+  }
+
+  /**
+   * Reads the {@code file_path} bytes for {@code row} into a freshly-allocated byte array. Used to
+   * track the active path between batches in {@link #appendGroupedByPath}.
+   */
+  private static byte[] readPath(VarCharVector pathVec, ArrowBuf dataBuf, int row) {
+    int length = pathVec.getValueLength(row);
+    byte[] bytes = new byte[length];
+    long offset = pathVec.getStartOffset(row);
+    for (int i = 0; i < length; i++) {
+      bytes[i] = dataBuf.getByte(offset + i);
+    }
+    return bytes;
   }
 
   /**

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.List;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Files;
@@ -42,7 +43,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mockito;
 
-class TestVectorizedPositionDeleteReader {
+public class TestVectorizedPositionDeleteReader {
 
   private static final String FILE_A = "s3://bucket/data/file-a.parquet";
   private static final String FILE_B = "s3://bucket/data/file-b.parquet";
@@ -60,7 +61,7 @@ class TestVectorizedPositionDeleteReader {
     PositionDeleteIndex aIndex =
         VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_A, null);
     assertAllPositionsDeleted(aIndex, aPositions, FILE_A);
-    assertNoPositionsDeleted(aIndex, bPositions, FILE_A);
+    assertNoPositionsDeleted(aIndex, bPositions, "FILE_B positions in FILE_A-filtered index");
     assertThat(aIndex.cardinality()).as("FILE_A index cardinality").isEqualTo(aPositions.size());
 
     PositionDeleteIndex bIndex =
@@ -142,6 +143,60 @@ class TestVectorizedPositionDeleteReader {
   }
 
   @Test
+  void filtersDictionaryEncodedFilePath() throws IOException {
+    // Many rows over only two distinct file_path values force Parquet to encode file_path
+    // with RLE_DICTIONARY. This test pins that the byte-for-byte filter still matches when the
+    // path column was dictionary-encoded. aPositions and bPositions are disjoint so a FILE_B row
+    // leaking into the FILE_A index would surface as a never-deleted position in aIndex.
+    File deleteFile = newDeleteFile("dict-encoded.parquet");
+    int rowsPerFile = 4_096;
+    List<Long> aPositions = Lists.newArrayListWithExpectedSize(rowsPerFile);
+    List<Long> bPositions = Lists.newArrayListWithExpectedSize(rowsPerFile);
+    for (long i = 0; i < rowsPerFile; i++) {
+      aPositions.add(i);
+      bPositions.add(i + rowsPerFile);
+    }
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    PositionDeleteIndex aIndex =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_A, null);
+    assertThat(aIndex.cardinality())
+        .as("dictionary-encoded path filter should keep all FILE_A rows only")
+        .isEqualTo(rowsPerFile);
+    assertAllPositionsDeleted(aIndex, aPositions, "FILE_A (dictionary-encoded)");
+    assertNoPositionsDeleted(
+        aIndex, bPositions, "FILE_B positions in dictionary-encoded FILE_A index");
+  }
+
+  @Test
+  void filteredReadWithUnknownPathReturnsEmptyIndex() throws IOException {
+    File deleteFile = newDeleteFile("unknown-path.parquet");
+    writeDeletesForTwoFiles(deleteFile, ImmutableList.of(1L, 2L, 3L), ImmutableList.of(10L, 20L));
+
+    PositionDeleteIndex index =
+        VectorizedPositionDeleteReader.read(
+            Files.localInput(deleteFile), "s3://bucket/data/file-c.parquet", null);
+
+    assertThat(index.isEmpty())
+        .as("filter for unknown data file path should yield an empty index")
+        .isTrue();
+    assertThat(index.cardinality()).as("empty index cardinality").isEqualTo(0L);
+  }
+
+  @Test
+  void surfacesIOFailuresWithFileLocation() throws IOException {
+    // An unreadable file must not silently produce an empty index; verify a recognizable
+    // Parquet-side message propagates to the caller.
+    File invalid = newDeleteFile("not-parquet.bin");
+    java.nio.file.Files.write(invalid.toPath(), new byte[] {0, 1, 2, 3}, StandardOpenOption.CREATE);
+
+    assertThatThrownBy(
+            () -> VectorizedPositionDeleteReader.read(Files.localInput(invalid), FILE_A, null))
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("not a Parquet file");
+  }
+
+  @Test
   void honorsExplicitBatchSize() throws IOException {
     File deleteFile = newDeleteFile("small-batches.parquet");
     List<Long> positions = Lists.newArrayList();
@@ -170,13 +225,8 @@ class TestVectorizedPositionDeleteReader {
 
   // ---------- helpers ----------
 
-  private File newDeleteFile(String name) throws IOException {
-    File file = tempDir.resolve(name).toFile();
-    if (file.exists()) {
-      file.delete();
-    }
-
-    return file;
+  private File newDeleteFile(String name) {
+    return tempDir.resolve(name).toFile();
   }
 
   private static PositionDeleteWriter<Void> openPositionDeleteWriter(File file) throws IOException {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mockito;
+
+class TestVectorizedPositionDeleteReader {
+
+  private static final String FILE_A = "s3://bucket/data/file-a.parquet";
+  private static final String FILE_B = "s3://bucket/data/file-b.parquet";
+  private static final int SMALL_BATCH_SIZE = 64;
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void filtersByDataFilePath() throws IOException {
+    File deleteFile = newDeleteFile("two-files.parquet");
+    List<Long> aPositions = Lists.newArrayList(1L, 2L, 3L, 5L, 7L, 100L, 101L, 102L, 103L);
+    List<Long> bPositions = Lists.newArrayList(0L, 4L, 6L, 50L, 200L);
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    PositionDeleteIndex aIndex =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_A, null);
+    assertAllPositionsDeleted(aIndex, aPositions, FILE_A);
+    assertNoPositionsDeleted(aIndex, bPositions, FILE_A);
+    assertThat(aIndex.cardinality()).as("FILE_A index cardinality").isEqualTo(aPositions.size());
+
+    PositionDeleteIndex bIndex =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_B, null);
+    assertAllPositionsDeleted(bIndex, bPositions, FILE_B);
+    assertThat(bIndex.cardinality()).as("FILE_B index cardinality").isEqualTo(bPositions.size());
+  }
+
+  @Test
+  void coalescesContiguousRuns() throws IOException {
+    File deleteFile = newDeleteFile("dense.parquet");
+    int count = 50_000;
+    List<Long> positions = Lists.newArrayListWithExpectedSize(count);
+    for (long i = 0; i < count; i++) {
+      positions.add(i);
+    }
+
+    writeDeletesForFile(deleteFile, FILE_A, positions);
+
+    PositionDeleteIndex index =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_A, null);
+    assertThat(index.cardinality()).as("dense index cardinality").isEqualTo(count);
+    assertThat(index.isDeleted(0L)).as("first position deleted").isTrue();
+    assertThat(index.isDeleted(count - 1L)).as("last position deleted").isTrue();
+    assertThat(index.isDeleted((long) count)).as("position past last not deleted").isFalse();
+  }
+
+  @Test
+  void readsAllPositionsWhenNoFilterIsRequested() throws IOException {
+    File deleteFile = newDeleteFile("two-files-no-filter.parquet");
+    List<Long> aPositions = ImmutableList.of(10L, 11L, 12L, 50L, 100L);
+    List<Long> bPositions = ImmutableList.of(0L, 7L, 13L, 99L);
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    PositionDeleteIndex index =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), null, null);
+
+    assertThat(index.cardinality())
+        .as("no-filter index includes positions from both data files")
+        .isEqualTo(aPositions.size() + bPositions.size());
+    assertAllPositionsDeleted(index, aPositions, "no-filter (FILE_A rows)");
+    assertAllPositionsDeleted(index, bPositions, "no-filter (FILE_B rows)");
+  }
+
+  @Test
+  void rejectsNullInputFile() {
+    assertThatThrownBy(() -> VectorizedPositionDeleteReader.read(null, FILE_A, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid input file");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+  void rejectsNonPositiveBatchSize(int batchSize) throws IOException {
+    File deleteFile = newDeleteFile("rejects-batch-size-" + batchSize + ".parquet");
+    writeDeletesForFile(deleteFile, FILE_A, ImmutableList.of(0L));
+
+    assertThatThrownBy(
+            () ->
+                VectorizedPositionDeleteReader.read(
+                    Files.localInput(deleteFile), FILE_A, null, batchSize))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid batch size");
+  }
+
+  @Test
+  void recordsDeleteFileProvenance() throws IOException {
+    File deleteFile = newDeleteFile("with-provenance.parquet");
+    writeDeletesForFile(deleteFile, FILE_A, ImmutableList.of(1L, 2L, 3L));
+    DeleteFile metadata = Mockito.mock(DeleteFile.class);
+
+    PositionDeleteIndex index =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), FILE_A, metadata);
+
+    assertThat(index.deleteFiles())
+        .as("returned index should record the source delete file")
+        .containsExactly(metadata);
+    assertThat(index.cardinality()).as("filtered cardinality").isEqualTo(3L);
+  }
+
+  @Test
+  void honorsExplicitBatchSize() throws IOException {
+    File deleteFile = newDeleteFile("small-batches.parquet");
+    List<Long> positions = Lists.newArrayList();
+    for (long i = 0; i < 1_000; i++) {
+      positions.add(i * 2L);
+    }
+
+    writeDeletesForFile(deleteFile, FILE_A, positions);
+
+    PositionDeleteIndex small =
+        VectorizedPositionDeleteReader.read(
+            Files.localInput(deleteFile), FILE_A, null, SMALL_BATCH_SIZE);
+    PositionDeleteIndex big =
+        VectorizedPositionDeleteReader.read(
+            Files.localInput(deleteFile),
+            FILE_A,
+            null,
+            VectorizedPositionDeleteReader.DEFAULT_BATCH_SIZE);
+    assertThat(small.cardinality())
+        .as("small-batch index cardinality")
+        .isEqualTo(big.cardinality())
+        .isEqualTo(positions.size());
+    assertAllPositionsDeleted(small, positions, "small batches");
+    assertAllPositionsDeleted(big, positions, "default batch size");
+  }
+
+  // ---------- helpers ----------
+
+  private File newDeleteFile(String name) throws IOException {
+    File file = tempDir.resolve(name).toFile();
+    if (file.exists()) {
+      file.delete();
+    }
+
+    return file;
+  }
+
+  private static PositionDeleteWriter<Void> openPositionDeleteWriter(File file) throws IOException {
+    OutputFile out = Files.localOutput(file);
+    return Parquet.writeDeletes(out)
+        .createWriterFunc(GenericParquetWriter::create)
+        .overwrite()
+        .withSpec(PartitionSpec.unpartitioned())
+        .buildPositionWriter();
+  }
+
+  private static void writeDeletesForFile(File file, String dataLocation, List<Long> positions)
+      throws IOException {
+    PositionDelete<Void> pd = PositionDelete.create();
+    try (PositionDeleteWriter<Void> writer = openPositionDeleteWriter(file)) {
+      for (long p : positions) {
+        pd.set(dataLocation, p, null);
+        writer.write(pd);
+      }
+    }
+  }
+
+  /**
+   * Writes a position delete file containing two contiguous blocks of rows: all {@link #FILE_A}
+   * positions first, then all {@link #FILE_B} positions. Position delete files require rows in
+   * {@code (file_path, pos)} order, so true row-by-row interleaving across the two paths is not
+   * representable here.
+   */
+  private static void writeDeletesForTwoFiles(
+      File file, List<Long> aPositions, List<Long> bPositions) throws IOException {
+    PositionDelete<Void> pd = PositionDelete.create();
+    try (PositionDeleteWriter<Void> writer = openPositionDeleteWriter(file)) {
+      for (long p : aPositions) {
+        pd.set(FILE_A, p, null);
+        writer.write(pd);
+      }
+
+      for (long p : bPositions) {
+        pd.set(FILE_B, p, null);
+        writer.write(pd);
+      }
+    }
+  }
+
+  private static void assertAllPositionsDeleted(
+      PositionDeleteIndex index, List<Long> positions, String context) {
+    for (long p : positions) {
+      assertThat(index.isDeleted(p)).as("%s: position %d should be deleted", context, p).isTrue();
+    }
+  }
+
+  private static void assertNoPositionsDeleted(
+      PositionDeleteIndex index, List<Long> positions, String context) {
+    for (long p : positions) {
+      assertThat(index.isDeleted(p))
+          .as("%s: position %d should NOT be deleted", context, p)
+          .isFalse();
+    }
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
@@ -283,6 +283,43 @@ public class TestVectorizedPositionDeleteReader {
   }
 
   @Test
+  void readAllByDataFileHandlesEmptyFilePath() throws IOException {
+    File deleteFile = newDeleteFile("empty-path.parquet");
+    List<Long> emptyPathPositions = ImmutableList.of(0L, 1L, 2L, 5L);
+    List<Long> realPathPositions = ImmutableList.of(10L, 11L, 12L);
+    writeDeletesForTwoFiles(deleteFile, "", emptyPathPositions, FILE_A, realPathPositions);
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(deleteFile), null);
+
+    assertThat(indexes).as("one entry per data file path").hasSize(2);
+    assertThat(indexes.get(""))
+        .as("empty-path index must be populated")
+        .isNotNull()
+        .extracting(PositionDeleteIndex::cardinality)
+        .isEqualTo((long) emptyPathPositions.size());
+    assertAllPositionsDeleted(indexes.get(""), emptyPathPositions, "empty path");
+    assertAllPositionsDeleted(indexes.get(FILE_A), realPathPositions, "FILE_A after empty path");
+  }
+
+  @Test
+  void readFiltersByEmptyFilePath() throws IOException {
+    File deleteFile = newDeleteFile("empty-path-filtered.parquet");
+    List<Long> emptyPathPositions = ImmutableList.of(0L, 1L, 2L, 5L);
+    List<Long> realPathPositions = ImmutableList.of(10L, 11L, 12L);
+    writeDeletesForTwoFiles(deleteFile, "", emptyPathPositions, FILE_A, realPathPositions);
+
+    PositionDeleteIndex emptyIndex =
+        VectorizedPositionDeleteReader.read(Files.localInput(deleteFile), "", null);
+    assertAllPositionsDeleted(emptyIndex, emptyPathPositions, "empty-path filter");
+    assertNoPositionsDeleted(
+        emptyIndex, realPathPositions, "FILE_A positions in empty-path-filtered index");
+    assertThat(emptyIndex.cardinality())
+        .as("empty-path filter cardinality")
+        .isEqualTo(emptyPathPositions.size());
+  }
+
+  @Test
   void honorsExplicitBatchSize() throws IOException {
     File deleteFile = newDeleteFile("small-batches.parquet");
     List<Long> positions = Lists.newArrayList();
@@ -343,15 +380,25 @@ public class TestVectorizedPositionDeleteReader {
    */
   private static void writeDeletesForTwoFiles(
       File file, List<Long> aPositions, List<Long> bPositions) throws IOException {
+    writeDeletesForTwoFiles(file, FILE_A, aPositions, FILE_B, bPositions);
+  }
+
+  private static void writeDeletesForTwoFiles(
+      File file,
+      String firstPath,
+      List<Long> firstPositions,
+      String secondPath,
+      List<Long> secondPositions)
+      throws IOException {
     PositionDelete<Void> pd = PositionDelete.create();
     try (PositionDeleteWriter<Void> writer = openPositionDeleteWriter(file)) {
-      for (long p : aPositions) {
-        pd.set(FILE_A, p, null);
+      for (long p : firstPositions) {
+        pd.set(firstPath, p, null);
         writer.write(pd);
       }
 
-      for (long p : bPositions) {
-        pd.set(FILE_B, p, null);
+      for (long p : secondPositions) {
+        pd.set(secondPath, p, null);
         writer.write(pd);
       }
     }

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
@@ -26,17 +26,22 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.List;
+import java.util.Optional;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.PositionDeleteIndexReader;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceMap;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -194,6 +199,87 @@ public class TestVectorizedPositionDeleteReader {
             () -> VectorizedPositionDeleteReader.read(Files.localInput(invalid), FILE_A, null))
         .isInstanceOf(RuntimeException.class)
         .hasMessageContaining("not a Parquet file");
+  }
+
+  @Test
+  void arrowRegistersAsParquetPositionDeleteIndexReader() throws IOException {
+    // ArrowFormatModels.register() should be invoked by FormatModelRegistry's static initializer
+    // on classpath. The registered reader should round-trip a parquet delete file end-to-end.
+    Optional<PositionDeleteIndexReader> reader =
+        FormatModelRegistry.positionDeleteIndexReader(FileFormat.PARQUET);
+    assertThat(reader)
+        .as("iceberg-arrow on classpath should register a parquet position delete index reader")
+        .isPresent();
+
+    File deleteFile = newDeleteFile("registry-roundtrip.parquet");
+    writeDeletesForFile(deleteFile, FILE_A, ImmutableList.of(1L, 2L, 3L));
+
+    PositionDeleteIndex single = reader.get().read(Files.localInput(deleteFile), FILE_A, null);
+    assertThat(single.cardinality()).as("filtered cardinality").isEqualTo(3L);
+
+    CharSequenceMap<PositionDeleteIndex> grouped =
+        reader.get().readAll(Files.localInput(deleteFile), null);
+    assertThat(grouped).hasSize(1);
+    assertThat(grouped.get(FILE_A).cardinality()).as("grouped cardinality").isEqualTo(3L);
+  }
+
+  @Test
+  void readAllByDataFileSplitsRowsByPath() throws IOException {
+    File deleteFile = newDeleteFile("two-files-grouped.parquet");
+    List<Long> aPositions = Lists.newArrayList(1L, 2L, 3L, 5L, 7L, 100L, 101L, 102L, 103L);
+    List<Long> bPositions = Lists.newArrayList(0L, 4L, 6L, 50L, 200L);
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(deleteFile), null);
+
+    assertThat(indexes).as("one entry per data file path").hasSize(2);
+    assertThat(indexes.get(FILE_A))
+        .as("FILE_A index must be populated")
+        .isNotNull()
+        .extracting(PositionDeleteIndex::cardinality)
+        .isEqualTo((long) aPositions.size());
+    assertThat(indexes.get(FILE_B))
+        .as("FILE_B index must be populated")
+        .isNotNull()
+        .extracting(PositionDeleteIndex::cardinality)
+        .isEqualTo((long) bPositions.size());
+    assertAllPositionsDeleted(indexes.get(FILE_A), aPositions, "FILE_A (grouped)");
+    assertAllPositionsDeleted(indexes.get(FILE_B), bPositions, "FILE_B (grouped)");
+  }
+
+  @Test
+  void readAllByDataFileCoalescesContiguousRunsAcrossBatches() throws IOException {
+    File deleteFile = newDeleteFile("dense-grouped.parquet");
+    int aCount = 50_000;
+    int bCount = 25_000;
+    List<Long> aPositions = Lists.newArrayListWithExpectedSize(aCount);
+    List<Long> bPositions = Lists.newArrayListWithExpectedSize(bCount);
+    for (long i = 0; i < aCount; i++) {
+      aPositions.add(i);
+    }
+    for (long i = 0; i < bCount; i++) {
+      bPositions.add(i);
+    }
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(deleteFile), null);
+
+    assertThat(indexes).hasSize(2);
+    assertThat(indexes.get(FILE_A).cardinality()).as("FILE_A cardinality").isEqualTo(aCount);
+    assertThat(indexes.get(FILE_B).cardinality()).as("FILE_B cardinality").isEqualTo(bCount);
+    assertThat(indexes.get(FILE_A).isDeleted(0L)).isTrue();
+    assertThat(indexes.get(FILE_A).isDeleted(aCount - 1L)).isTrue();
+    assertThat(indexes.get(FILE_A).isDeleted((long) aCount)).isFalse();
+    assertThat(indexes.get(FILE_B).isDeleted(bCount - 1L)).isTrue();
+  }
+
+  @Test
+  void readAllByDataFileRejectsNullInputFile() {
+    assertThatThrownBy(() -> VectorizedPositionDeleteReader.readAllByDataFile(null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid input file");
   }
 
   @Test

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedPositionDeleteReader.java
@@ -185,19 +185,23 @@ public class TestVectorizedPositionDeleteReader {
     assertThat(index.isEmpty())
         .as("filter for unknown data file path should yield an empty index")
         .isTrue();
-    assertThat(index.cardinality()).as("empty index cardinality").isEqualTo(0L);
   }
 
   @Test
-  void surfacesIOFailuresWithFileLocation() throws IOException {
-    // An unreadable file must not silently produce an empty index; verify a recognizable
-    // Parquet-side message propagates to the caller.
+  void surfacesParquetReadFailures() throws IOException {
+    // An unreadable file must not silently produce an empty index. The actual exception from
+    // parquet-mr (a RuntimeException with "not a Parquet file" in the message) is not an
+    // IOException, so it propagates unchanged through the reader's catch (IOException) block.
+    // This is fine -- the parquet-side message is distinctive enough for diagnosis. We
+    // additionally assert it's not an IllegalArgumentException so a regression in our own
+    // precondition checks does not silently satisfy this test.
     File invalid = newDeleteFile("not-parquet.bin");
     java.nio.file.Files.write(invalid.toPath(), new byte[] {0, 1, 2, 3}, StandardOpenOption.CREATE);
 
     assertThatThrownBy(
             () -> VectorizedPositionDeleteReader.read(Files.localInput(invalid), FILE_A, null))
         .isInstanceOf(RuntimeException.class)
+        .isNotInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("not a Parquet file");
   }
 
@@ -219,8 +223,25 @@ public class TestVectorizedPositionDeleteReader {
 
     CharSequenceMap<PositionDeleteIndex> grouped =
         reader.get().readAll(Files.localInput(deleteFile), null);
-    assertThat(grouped).hasSize(1);
+    assertThat(grouped).as("one entry per data file path").hasSize(1);
     assertThat(grouped.get(FILE_A).cardinality()).as("grouped cardinality").isEqualTo(3L);
+  }
+
+  @Test
+  void registeredReaderRejectsNullDataLocation() throws IOException {
+    // The PositionDeleteIndexReader SPI requires a non-null data file path. The direct
+    // VectorizedPositionDeleteReader#read API accepts null as "no filter / union all rows",
+    // but that mode is intentionally not exposed through the registry-based dispatch path.
+    Optional<PositionDeleteIndexReader> reader =
+        FormatModelRegistry.positionDeleteIndexReader(FileFormat.PARQUET);
+    assertThat(reader).as("Arrow reader registered").isPresent();
+
+    File deleteFile = newDeleteFile("reject-null-data-location.parquet");
+    writeDeletesForFile(deleteFile, FILE_A, ImmutableList.of(1L, 2L));
+
+    assertThatThrownBy(() -> reader.get().read(Files.localInput(deleteFile), null, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid data location");
   }
 
   @Test
@@ -266,13 +287,15 @@ public class TestVectorizedPositionDeleteReader {
     CharSequenceMap<PositionDeleteIndex> indexes =
         VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(deleteFile), null);
 
-    assertThat(indexes).hasSize(2);
+    assertThat(indexes).as("one entry per data file path").hasSize(2);
     assertThat(indexes.get(FILE_A).cardinality()).as("FILE_A cardinality").isEqualTo(aCount);
     assertThat(indexes.get(FILE_B).cardinality()).as("FILE_B cardinality").isEqualTo(bCount);
-    assertThat(indexes.get(FILE_A).isDeleted(0L)).isTrue();
-    assertThat(indexes.get(FILE_A).isDeleted(aCount - 1L)).isTrue();
-    assertThat(indexes.get(FILE_A).isDeleted((long) aCount)).isFalse();
-    assertThat(indexes.get(FILE_B).isDeleted(bCount - 1L)).isTrue();
+    assertThat(indexes.get(FILE_A).isDeleted(0L)).as("FILE_A: first position").isTrue();
+    assertThat(indexes.get(FILE_A).isDeleted(aCount - 1L)).as("FILE_A: last position").isTrue();
+    assertThat(indexes.get(FILE_A).isDeleted((long) aCount))
+        .as("FILE_A: one past last must not be deleted")
+        .isFalse();
+    assertThat(indexes.get(FILE_B).isDeleted(bCount - 1L)).as("FILE_B: last position").isTrue();
   }
 
   @Test
@@ -280,6 +303,102 @@ public class TestVectorizedPositionDeleteReader {
     assertThatThrownBy(() -> VectorizedPositionDeleteReader.readAllByDataFile(null, null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Invalid input file");
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {0, -1, Integer.MIN_VALUE})
+  void readAllByDataFileRejectsNonPositiveBatchSize(int batchSize) throws IOException {
+    File deleteFile = newDeleteFile("readall-rejects-batch-size-" + batchSize + ".parquet");
+    writeDeletesForFile(deleteFile, FILE_A, ImmutableList.of(0L));
+
+    assertThatThrownBy(
+            () ->
+                VectorizedPositionDeleteReader.readAllByDataFile(
+                    Files.localInput(deleteFile), null, batchSize))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid batch size");
+  }
+
+  @Test
+  void readAllByDataFileSurfacesParquetReadFailures() throws IOException {
+    File invalid = newDeleteFile("readall-not-parquet.bin");
+    java.nio.file.Files.write(invalid.toPath(), new byte[] {0, 1, 2, 3}, StandardOpenOption.CREATE);
+
+    assertThatThrownBy(
+            () -> VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(invalid), null))
+        .isInstanceOf(RuntimeException.class)
+        .isNotInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a Parquet file");
+  }
+
+  @Test
+  void readAllByDataFileHandlesDictionaryEncodedPaths() throws IOException {
+    // Many rows over two distinct paths force Parquet to encode file_path with RLE_DICTIONARY.
+    // The grouped path uses endOfPathRun's length+first-byte fast filter against the dictionary-
+    // decoded bytes; this test pins that grouping still produces the correct per-path indexes.
+    File deleteFile = newDeleteFile("readall-dict-encoded.parquet");
+    int rowsPerFile = 4_096;
+    List<Long> aPositions = Lists.newArrayListWithExpectedSize(rowsPerFile);
+    List<Long> bPositions = Lists.newArrayListWithExpectedSize(rowsPerFile);
+    for (long i = 0; i < rowsPerFile; i++) {
+      aPositions.add(i);
+      bPositions.add(i + rowsPerFile);
+    }
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        VectorizedPositionDeleteReader.readAllByDataFile(Files.localInput(deleteFile), null);
+
+    assertThat(indexes).as("one entry per data file path").hasSize(2);
+    assertThat(indexes.get(FILE_A).cardinality())
+        .as("FILE_A cardinality with dictionary-encoded path")
+        .isEqualTo(rowsPerFile);
+    assertThat(indexes.get(FILE_B).cardinality())
+        .as("FILE_B cardinality with dictionary-encoded path")
+        .isEqualTo(rowsPerFile);
+    assertAllPositionsDeleted(indexes.get(FILE_A), aPositions, "FILE_A (dict-encoded grouped)");
+    assertAllPositionsDeleted(indexes.get(FILE_B), bPositions, "FILE_B (dict-encoded grouped)");
+  }
+
+  @Test
+  void readAllByDataFileHonorsExplicitBatchSize() throws IOException {
+    // Pin appendGroupedByPath's batch-boundary handling: cross-batch coalescing within each path
+    // and a path transition that lands inside an Arrow batch must produce the same per-path
+    // indexes regardless of batch size. At SMALL_BATCH_SIZE the FILE_A -> FILE_B transition
+    // falls inside a batch (1_000 is not a multiple of 64), exercising endOfPathRun across the
+    // boundary.
+    File deleteFile = newDeleteFile("readall-small-batches.parquet");
+    int aCount = 1_000;
+    int bCount = 500;
+    List<Long> aPositions = Lists.newArrayListWithExpectedSize(aCount);
+    List<Long> bPositions = Lists.newArrayListWithExpectedSize(bCount);
+    for (long i = 0; i < aCount; i++) {
+      aPositions.add(i);
+    }
+    for (long i = 0; i < bCount; i++) {
+      bPositions.add(i);
+    }
+    writeDeletesForTwoFiles(deleteFile, aPositions, bPositions);
+
+    CharSequenceMap<PositionDeleteIndex> small =
+        VectorizedPositionDeleteReader.readAllByDataFile(
+            Files.localInput(deleteFile), null, SMALL_BATCH_SIZE);
+    CharSequenceMap<PositionDeleteIndex> big =
+        VectorizedPositionDeleteReader.readAllByDataFile(
+            Files.localInput(deleteFile), null, VectorizedPositionDeleteReader.DEFAULT_BATCH_SIZE);
+
+    assertThat(small).as("small-batch: one entry per data file path").hasSize(2);
+    assertThat(big).as("default-batch: one entry per data file path").hasSize(2);
+    assertThat(small.get(FILE_A).cardinality())
+        .as("FILE_A cardinality should not depend on batch size")
+        .isEqualTo(big.get(FILE_A).cardinality())
+        .isEqualTo(aCount);
+    assertThat(small.get(FILE_B).cardinality())
+        .as("FILE_B cardinality should not depend on batch size")
+        .isEqualTo(big.get(FILE_B).cardinality())
+        .isEqualTo(bCount);
+    assertAllPositionsDeleted(small.get(FILE_A), aPositions, "FILE_A (small batches)");
+    assertAllPositionsDeleted(small.get(FILE_B), bPositions, "FILE_B (small batches)");
   }
 
   @Test

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -78,7 +78,7 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
     if (that instanceof BitmapPositionDeleteIndex) {
       merge((BitmapPositionDeleteIndex) that);
     } else {
-      that.forEach(this::delete);
+      PositionDeleteRangeConsumer.forEach(that, this);
       deleteFiles.addAll(that.deleteFiles());
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -177,7 +177,7 @@ public class Deletes {
       CloseableIterable<Long> posDeletes, List<DeleteFile> files) {
     try (CloseableIterable<Long> deletes = posDeletes) {
       PositionDeleteIndex positionDeleteIndex = new BitmapPositionDeleteIndex(files);
-      deletes.forEach(positionDeleteIndex::delete);
+      PositionDeleteRangeConsumer.forEach(deletes, positionDeleteIndex);
       return positionDeleteIndex;
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.deletes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Iterator;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -32,10 +33,13 @@ import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.PeekingIterator;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.CharSequenceMap;
+import org.apache.iceberg.util.CharSequenceUtil;
 import org.apache.iceberg.util.Filter;
 import org.apache.iceberg.util.SortedMerge;
 import org.apache.iceberg.util.StructLikeSet;
@@ -131,6 +135,8 @@ public class Deletes {
    *
    * <p>This method builds a position delete index for each referenced data file and does not filter
    * deletes. This can be useful when the entire delete file content is needed (e.g. caching).
+   * Adjacent same-path runs are coalesced via {@link PositionDeleteRangeConsumer#forEach(Iterable,
+   * PositionDeleteIndex)}.
    *
    * @param posDeletes position deletes
    * @param file the source delete file for the deletes
@@ -141,18 +147,40 @@ public class Deletes {
     CharSequenceMap<PositionDeleteIndex> indexes = CharSequenceMap.create();
 
     try (CloseableIterable<T> deletes = posDeletes) {
-      for (T delete : deletes) {
-        CharSequence filePath = (CharSequence) FILENAME_ACCESSOR.get(delete);
-        long position = (long) POSITION_ACCESSOR.get(delete);
+      PeekingIterator<T> records = Iterators.peekingIterator(deletes.iterator());
+      while (records.hasNext()) {
+        CharSequence path = (CharSequence) FILENAME_ACCESSOR.get(records.peek());
         PositionDeleteIndex index =
-            indexes.computeIfAbsent(filePath, key -> new BitmapPositionDeleteIndex(file));
-        index.delete(position);
+            indexes.computeIfAbsent(path, key -> new BitmapPositionDeleteIndex(file));
+        PositionDeleteRangeConsumer.forEach(positionsForPath(records, path), index);
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);
     }
 
     return indexes;
+  }
+
+  /**
+   * Yields positions from {@code records} while the next record's {@code file_path} matches {@code
+   * path}, advancing the iterator as a side effect.
+   */
+  private static <T extends StructLike> Iterable<Long> positionsForPath(
+      PeekingIterator<T> records, CharSequence path) {
+    return () ->
+        new Iterator<Long>() {
+          @Override
+          public boolean hasNext() {
+            return records.hasNext()
+                && !CharSequenceUtil.unequalPaths(
+                    path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
+          }
+
+          @Override
+          public Long next() {
+            return (Long) POSITION_ACCESSOR.get(records.next());
+          }
+        };
   }
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -20,8 +20,8 @@ package org.apache.iceberg.deletes;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.Iterator;
 import java.util.List;
+import java.util.PrimitiveIterator;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -163,25 +163,25 @@ public class Deletes {
 
   /**
    * Drains positions from {@code records} while the next record's {@code file_path} matches {@code
-   * path}. The returned {@code Iterable} consumes {@code records} on iteration and stops as soon as
-   * a record with a different path is peeked; subsequent calls resume from that record.
+   * path}. The returned iterator consumes {@code records} on traversal and stops as soon as a
+   * record with a different path is peeked; subsequent calls resume from that record. Returning a
+   * primitive iterator keeps positions unboxed all the way into the consumer's slice buffer.
    */
-  private static <T extends StructLike> Iterable<Long> drainPositionsForPath(
+  private static <T extends StructLike> PrimitiveIterator.OfLong drainPositionsForPath(
       PeekingIterator<T> records, CharSequence path) {
-    return () ->
-        new Iterator<Long>() {
-          @Override
-          public boolean hasNext() {
-            return records.hasNext()
-                && !CharSequenceUtil.unequalPaths(
-                    path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
-          }
+    return new PrimitiveIterator.OfLong() {
+      @Override
+      public boolean hasNext() {
+        return records.hasNext()
+            && !CharSequenceUtil.unequalPaths(
+                path, (CharSequence) FILENAME_ACCESSOR.get(records.peek()));
+      }
 
-          @Override
-          public Long next() {
-            return (Long) POSITION_ACCESSOR.get(records.next());
-          }
-        };
+      @Override
+      public long nextLong() {
+        return (long) POSITION_ACCESSOR.get(records.next());
+      }
+    };
   }
 
   public static <T extends StructLike> PositionDeleteIndex toPositionIndex(

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
@@ -46,8 +47,7 @@ import org.apache.iceberg.util.StructLikeSet;
 
 public class Deletes {
 
-  private static final Schema POSITION_DELETE_SCHEMA =
-      new Schema(MetadataColumns.DELETE_FILE_PATH, MetadataColumns.DELETE_FILE_POS);
+  private static final Schema POSITION_DELETE_SCHEMA = DeleteSchemaUtil.pathPosSchema();
 
   private static final Accessor<StructLike> FILENAME_ACCESSOR =
       POSITION_DELETE_SCHEMA.accessorForField(MetadataColumns.DELETE_FILE_PATH.fieldId());
@@ -152,7 +152,7 @@ public class Deletes {
         CharSequence path = (CharSequence) FILENAME_ACCESSOR.get(records.peek());
         PositionDeleteIndex index =
             indexes.computeIfAbsent(path, key -> new BitmapPositionDeleteIndex(file));
-        PositionDeleteRangeConsumer.forEach(positionsForPath(records, path), index);
+        PositionDeleteRangeConsumer.forEach(drainPositionsForPath(records, path), index);
       }
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to close position delete source", e);
@@ -162,10 +162,11 @@ public class Deletes {
   }
 
   /**
-   * Yields positions from {@code records} while the next record's {@code file_path} matches {@code
-   * path}, advancing the iterator as a side effect.
+   * Drains positions from {@code records} while the next record's {@code file_path} matches {@code
+   * path}. The returned {@code Iterable} consumes {@code records} on iteration and stops as soon as
+   * a record with a different path is peeked; subsequent calls resume from that record.
    */
-  private static <T extends StructLike> Iterable<Long> positionsForPath(
+  private static <T extends StructLike> Iterable<Long> drainPositionsForPath(
       PeekingIterator<T> records, CharSequence path) {
     return () ->
         new Iterator<Long>() {

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -113,8 +113,38 @@ public interface PositionDeleteIndex {
     return BitmapPositionDeleteIndex.deserialize(bytes, deleteFile);
   }
 
-  /** Returns an empty immutable position delete index. */
+  /**
+   * Returns an empty immutable position delete index.
+   *
+   * @see #create()
+   */
   static PositionDeleteIndex empty() {
     return EmptyPositionDeleteIndex.get();
+  }
+
+  /**
+   * Returns an empty mutable position delete index that supports {@link #delete(long)} and {@link
+   * #delete(long, long)}.
+   *
+   * <p>Unlike {@link #empty()}, the returned index is mutable. It is not safe for concurrent
+   * mutation by multiple threads. The index does not record provenance; positions added to it are
+   * not associated with any source delete file.
+   *
+   * @see #empty()
+   * @see #create(DeleteFile)
+   */
+  static PositionDeleteIndex create() {
+    return new BitmapPositionDeleteIndex();
+  }
+
+  /**
+   * Returns an empty mutable position delete index that records the given delete file as its
+   * source. The returned index is not safe for concurrent mutation by multiple threads.
+   *
+   * @param deleteFile the delete file the index is created for, may be {@code null}
+   * @see #create()
+   */
+  static PositionDeleteIndex create(DeleteFile deleteFile) {
+    return new BitmapPositionDeleteIndex(deleteFile);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteIndex.java
@@ -49,7 +49,7 @@ public interface PositionDeleteIndex {
     if (!that.deleteFiles().isEmpty()) {
       throw new UnsupportedOperationException(getClass().getName() + " does not support merge");
     }
-    that.forEach(this::delete);
+    PositionDeleteRangeConsumer.forEach(that, this);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -1,0 +1,265 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
+ *
+ * <p>The consumer is agnostic to input sortedness: callers can stream any {@code Iterable} or
+ * {@code long[]} of positions and the API flushes them onto the target {@link PositionDeleteIndex}
+ * without requiring a sorted contract. Monotone runs become a single range insert, which touches
+ * fewer bitmap pages than a per-position {@code target.delete(pos)} loop; non-monotone input still
+ * produces a correct index via an internal per-position fallback.
+ *
+ * <p>External callers see three operations: construct with a target index, feed positions via
+ * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done. The
+ * sniff/escape state and the buffering policy used by the package-private {@code forEach} helpers
+ * are internal and may change.
+ *
+ * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
+ * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
+ * class entirely; this class can retire once V2 position delete files are no longer read.
+ */
+public final class PositionDeleteRangeConsumer {
+
+  /**
+   * Batch size for {@link #forEach}. Sized to fit comfortably in L1 (512 bytes). Smaller buffers
+   * miss the bulk-path branch elision; larger buffers add allocation cost without improving the
+   * inner-loop throughput (the {@code acceptAll} body is the same regardless of slice length).
+   */
+  private static final int FOREACH_BATCH_SIZE = 64;
+
+  /**
+   * Source-cardinality cutoff below which the batched path's setup cost (buffer allocation,
+   * consumer state, {@code Preconditions} checks) outweighs the per-position savings from
+   * coalescing. Sources at or below this size are drained directly via {@code target::delete}.
+   */
+  private static final int SMALL_SOURCE_THRESHOLD = 8;
+
+  /** The number of positions to sniff for boundary density. */
+  private static final int SNIFF_SIZE = 256;
+
+  /** The threshold for boundary density at which to switch to the bulk path, as a percentage. */
+  private static final int BOUNDARY_THRESHOLD_PERCENT = 30;
+
+  private final PositionDeleteIndex target;
+  private boolean hasRun;
+  private long rangeStart;
+  private long lastPosition;
+
+  private int processed;
+  private int boundaries;
+  private boolean escaped;
+
+  /**
+   * Creates a new consumer that writes coalesced ranges into {@code target}. Single-threaded; one
+   * instance per target index.
+   */
+  public PositionDeleteRangeConsumer(PositionDeleteIndex target) {
+    Preconditions.checkArgument(target != null, "Invalid target index: null");
+    this.target = target;
+  }
+
+  /**
+   * Adds the half-open slice {@code positions[from, to)} to the target index, coalescing
+   * consecutive positions into range inserts. Safe to call repeatedly; the consumer keeps the
+   * pending run across calls and only emits it on the next gap or on {@link #flush()}.
+   */
+  public void acceptAll(long[] positions, int from, int to) {
+    Preconditions.checkArgument(positions != null, "Invalid positions array: null");
+    Preconditions.checkPositionIndexes(from, to, positions.length);
+    if (from >= to) {
+      return;
+    }
+
+    int cursor = from;
+
+    if (escaped) {
+      drainEscaped(positions, cursor, to);
+      return;
+    }
+
+    if (!hasRun) {
+      initRun(positions[cursor++]);
+    }
+
+    while (cursor < to && processed < SNIFF_SIZE) {
+      coalesceSniff(positions[cursor++]);
+    }
+
+    if (processed == SNIFF_SIZE && shouldEscape()) {
+      enterEscape();
+      drainEscaped(positions, cursor, to);
+      return;
+    }
+
+    while (cursor < to) {
+      coalesce(positions[cursor++]);
+    }
+  }
+
+  /** Emits the active run, if any. The escape decision is sticky across flushes. */
+  public void flush() {
+    if (hasRun) {
+      emit();
+      hasRun = false;
+    }
+  }
+
+  // Per-element entry used internally by the package-private forEach helpers below and exercised
+  // directly by in-package tests. Not exposed to other modules: callers there should buffer into
+  // a long[] and use acceptAll, which keeps the state-machine dispatch out of the inner loop.
+  void accept(long pos) {
+    if (escaped) {
+      target.delete(pos);
+      return;
+    }
+    if (!hasRun) {
+      initRun(pos);
+      return;
+    }
+    coalesceSniff(pos);
+    if (processed == SNIFF_SIZE && shouldEscape()) {
+      enterEscape();
+    }
+  }
+
+  /**
+   * Drains a boxed {@code Iterable<Long>} into {@code target}. Buffers into a small primitive slice
+   * and hands chunks to {@link #acceptAll(long[], int, int)}; keeps the sniff/escape state machine
+   * out of the inner loop. Package-private: external callers should construct the consumer directly
+   * and feed it via {@code acceptAll}.
+   */
+  public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int filled = 0;
+    for (Long pos : positions) {
+      buffer[filled++] = pos;
+      if (filled == FOREACH_BATCH_SIZE) {
+        consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+        filled = 0;
+      }
+    }
+    if (filled > 0) {
+      consumer.acceptAll(buffer, 0, filled);
+    }
+    consumer.flush();
+  }
+
+  /**
+   * Drains all positions from {@code source} into {@code target} via the batched accumulator.
+   * Equivalent to {@code source.forEach(target::delete)} but coalesces consecutive runs into range
+   * inserts. Sources that emit in ascending order (such as {@code BitmapPositionDeleteIndex}, which
+   * iterates a Roaring bitmap) feed straight into the coalescing fast path; out-of-order sources
+   * still produce a correct result via the per-position fallback. Package-private: see the note on
+   * {@link #forEach(Iterable, PositionDeleteIndex)}.
+   */
+  public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
+    if (source.isEmpty()) {
+      return;
+    }
+    if (isSmallSource(source)) {
+      source.forEach(target::delete);
+      return;
+    }
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int[] filled = {0};
+    source.forEach(
+        pos -> {
+          buffer[filled[0]++] = pos;
+          if (filled[0] == FOREACH_BATCH_SIZE) {
+            consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+            filled[0] = 0;
+          }
+        });
+    if (filled[0] > 0) {
+      consumer.acceptAll(buffer, 0, filled[0]);
+    }
+    consumer.flush();
+  }
+
+  // cardinality() is a default method that throws when the impl does not implement it; treat
+  // "unknown" as "use the batched path" so we never regress on bitmap-backed sources.
+  private static boolean isSmallSource(PositionDeleteIndex source) {
+    try {
+      return source.cardinality() <= SMALL_SOURCE_THRESHOLD;
+    } catch (UnsupportedOperationException ignored) {
+      return false;
+    }
+  }
+
+  /** Starts a new active run anchored at {@code first}. */
+  private void initRun(long first) {
+    rangeStart = first;
+    lastPosition = first;
+    hasRun = true;
+    processed = 1;
+  }
+
+  /** Extends the active run with {@code pos} during sniffing; counts gaps to inform escape. */
+  private void coalesceSniff(long pos) {
+    if (pos - lastPosition != 1) {
+      boundaries++;
+      emit();
+      rangeStart = pos;
+    }
+    lastPosition = pos;
+    processed++;
+  }
+
+  /** Extends the active run with {@code pos} after sniffing has decided not to escape. */
+  private void coalesce(long pos) {
+    if (pos - lastPosition != 1) {
+      emit();
+      rangeStart = pos;
+    }
+    lastPosition = pos;
+  }
+
+  /** True if the sniffed prefix has too many gaps to make coalescing worthwhile. */
+  private boolean shouldEscape() {
+    return boundaries * 100 > (SNIFF_SIZE - 1) * BOUNDARY_THRESHOLD_PERCENT;
+  }
+
+  /** Permanently switches to per-position deletes; flushes any pending run. */
+  private void enterEscape() {
+    emit();
+    hasRun = false;
+    escaped = true;
+  }
+
+  /** Per-position fallback used once the consumer has escaped coalescing. */
+  private void drainEscaped(long[] positions, int from, int to) {
+    for (int cursor = from; cursor < to; cursor++) {
+      target.delete(positions[cursor]);
+    }
+  }
+
+  private void emit() {
+    if (rangeStart == lastPosition) {
+      target.delete(rangeStart);
+    } else {
+      target.delete(rangeStart, lastPosition + 1);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -18,8 +18,6 @@
  */
 package org.apache.iceberg.deletes;
 
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
  *
@@ -30,9 +28,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * produces a correct index via an internal per-position fallback.
  *
  * <p>External callers see three operations: construct with a target index, feed positions via
- * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done. The
- * sniff/escape state and the buffering policy used by the package-private {@code forEach} helpers
- * are internal and may change.
+ * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done.
  *
  * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
  * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
@@ -49,8 +45,8 @@ public final class PositionDeleteRangeConsumer {
 
   /**
    * Source-cardinality cutoff below which the batched path's setup cost (buffer allocation,
-   * consumer state, {@code Preconditions} checks) outweighs the per-position savings from
-   * coalescing. Sources at or below this size are drained directly via {@code target::delete}.
+   * consumer state) outweighs the per-position savings from coalescing. Sources at or below this
+   * size are drained directly via {@code target::delete}.
    */
   private static final int SMALL_SOURCE_THRESHOLD = 8;
 
@@ -74,7 +70,6 @@ public final class PositionDeleteRangeConsumer {
    * instance per target index.
    */
   public PositionDeleteRangeConsumer(PositionDeleteIndex target) {
-    Preconditions.checkArgument(target != null, "Invalid target index: null");
     this.target = target;
   }
 
@@ -84,8 +79,6 @@ public final class PositionDeleteRangeConsumer {
    * pending run across calls and only emits it on the next gap or on {@link #flush()}.
    */
   public void acceptAll(long[] positions, int from, int to) {
-    Preconditions.checkArgument(positions != null, "Invalid positions array: null");
-    Preconditions.checkPositionIndexes(from, to, positions.length);
     if (from >= to) {
       return;
     }
@@ -124,29 +117,9 @@ public final class PositionDeleteRangeConsumer {
     }
   }
 
-  // Per-element entry used internally by the package-private forEach helpers below and exercised
-  // directly by in-package tests. Not exposed to other modules: callers there should buffer into
-  // a long[] and use acceptAll, which keeps the state-machine dispatch out of the inner loop.
-  void accept(long pos) {
-    if (escaped) {
-      target.delete(pos);
-      return;
-    }
-    if (!hasRun) {
-      initRun(pos);
-      return;
-    }
-    coalesceSniff(pos);
-    if (processed == SNIFF_SIZE && shouldEscape()) {
-      enterEscape();
-    }
-  }
-
   /**
-   * Drains a boxed {@code Iterable<Long>} into {@code target}. Buffers into a small primitive slice
-   * and hands chunks to {@link #acceptAll(long[], int, int)}; keeps the sniff/escape state machine
-   * out of the inner loop. Package-private: external callers should construct the consumer directly
-   * and feed it via {@code acceptAll}.
+   * Drains a boxed {@code Iterable<Long>} into {@code target}, buffering into a primitive slice and
+   * forwarding chunks to {@link #acceptAll(long[], int, int)}.
    */
   public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
     PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
@@ -166,12 +139,10 @@ public final class PositionDeleteRangeConsumer {
   }
 
   /**
-   * Drains all positions from {@code source} into {@code target} via the batched accumulator.
-   * Equivalent to {@code source.forEach(target::delete)} but coalesces consecutive runs into range
-   * inserts. Sources that emit in ascending order (such as {@code BitmapPositionDeleteIndex}, which
-   * iterates a Roaring bitmap) feed straight into the coalescing fast path; out-of-order sources
-   * still produce a correct result via the per-position fallback. Package-private: see the note on
-   * {@link #forEach(Iterable, PositionDeleteIndex)}.
+   * Drains all positions from {@code source} into {@code target}, coalescing consecutive runs into
+   * range inserts. Equivalent to {@code source.forEach(target::delete)} but cheaper for ascending
+   * sources (such as {@code BitmapPositionDeleteIndex}); out-of-order sources still produce a
+   * correct result via the per-position fallback.
    */
   public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
     if (source.isEmpty()) {

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -18,14 +18,19 @@
  */
 package org.apache.iceberg.deletes;
 
+import java.util.Objects;
+
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
  *
- * <p>The consumer is agnostic to input sortedness: callers can stream any {@code Iterable} or
- * {@code long[]} of positions and the API flushes them onto the target {@link PositionDeleteIndex}
- * without requiring a sorted contract. Monotone runs become a single range insert, which touches
- * fewer bitmap pages than a per-position {@code target.delete(pos)} loop; non-monotone input still
- * produces a correct index via an internal per-position fallback.
+ * <p>Position delete files are spec-sorted, but this consumer accepts any input ordering and still
+ * produces a correct index: callers can stream any {@code Iterable} or {@code long[]} of positions
+ * through this API. Out-of-order input is handled by an internal per-position fallback.
+ *
+ * <p>The coalescing benefit scales with monotone runs in the input. Each ascending run is emitted
+ * as a single range insert, which touches fewer bitmap pages than a per-position {@code
+ * target.delete(pos)} loop. A small sniff window measures gap density at the start of the stream
+ * and switches to the per-position path when coalescing would no longer pay for the bookkeeping.
  *
  * <p>External callers see three operations: construct with a target index, feed positions via
  * {@link #acceptAll(long[], int, int)} (one or more calls), and {@link #flush()} when done.
@@ -33,6 +38,11 @@ package org.apache.iceberg.deletes;
  * <p><b>Note:</b> this class is tied to the V2 position delete file lifecycle. Format-version 3
  * deletion vectors arrive pre-bitmap via {@link PositionDeleteIndex#deserialize} and bypass this
  * class entirely; this class can retire once V2 position delete files are no longer read.
+ *
+ * <p><b>API note:</b> cross-module helper used directly by {@code VectorizedPositionDeleteReader}
+ * in the {@code iceberg-arrow} module; the constructor + {@link #acceptAll} + {@link #flush} shape
+ * is not yet a stable public API and may evolve as the Arrow stack lands. The static {@code
+ * forEach} overloads remain package-private since all callers live in this package.
  */
 public final class PositionDeleteRangeConsumer {
 
@@ -53,7 +63,11 @@ public final class PositionDeleteRangeConsumer {
   /** The number of positions to sniff for boundary density. */
   private static final int SNIFF_SIZE = 256;
 
-  /** The threshold for boundary density at which to switch to the bulk path, as a percentage. */
+  /**
+   * Gap-density threshold for the sniff window, as a percentage. If more than this fraction of
+   * adjacent pairs in the first {@link #SNIFF_SIZE} positions are gaps, the consumer escapes
+   * coalescing for the rest of the stream and routes positions through the per-position fallback.
+   */
   private static final int BOUNDARY_THRESHOLD_PERCENT = 30;
 
   private final PositionDeleteIndex target;
@@ -79,7 +93,8 @@ public final class PositionDeleteRangeConsumer {
    * pending run across calls and only emits it on the next gap or on {@link #flush()}.
    */
   public void acceptAll(long[] positions, int from, int to) {
-    if (from >= to) {
+    Objects.checkFromToIndex(from, to, positions.length);
+    if (from == to) {
       return;
     }
 
@@ -169,8 +184,13 @@ public final class PositionDeleteRangeConsumer {
     consumer.flush();
   }
 
-  // cardinality() is a default method that throws when the impl does not implement it; treat
-  // "unknown" as "use the batched path" so we never regress on bitmap-backed sources.
+  /**
+   * Returns {@code true} when {@code source} is small enough that the per-position drain wins over
+   * the batched path's setup cost. {@link UnsupportedOperationException} from {@link
+   * PositionDeleteIndex#cardinality()} is part of the contract here: implementations that don't
+   * report cardinality are treated as "size unknown" and routed through the batched path, so
+   * bitmap-backed sources never regress to per-position dispatch.
+   */
   private static boolean isSmallSource(PositionDeleteIndex source) {
     try {
       return source.cardinality() <= SMALL_SOURCE_THRESHOLD;

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDeleteRangeConsumer.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.deletes;
 
 import java.util.Objects;
+import java.util.PrimitiveIterator;
 
 /**
  * Coalesces consecutive position deletes into range inserts on a {@link PositionDeleteIndex}.
@@ -136,7 +137,7 @@ public final class PositionDeleteRangeConsumer {
    * Drains a boxed {@code Iterable<Long>} into {@code target}, buffering into a primitive slice and
    * forwarding chunks to {@link #acceptAll(long[], int, int)}.
    */
-  public static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
+  static void forEach(Iterable<Long> positions, PositionDeleteIndex target) {
     PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
     long[] buffer = new long[FOREACH_BATCH_SIZE];
     int filled = 0;
@@ -154,12 +155,35 @@ public final class PositionDeleteRangeConsumer {
   }
 
   /**
+   * Drains a {@link PrimitiveIterator.OfLong} into {@code target}, buffering into a primitive slice
+   * and forwarding chunks to {@link #acceptAll(long[], int, int)}. Equivalent to {@link
+   * #forEach(Iterable, PositionDeleteIndex)} but avoids autoboxing each position, which matters
+   * when the caller is itself unboxing from a {@code StructLike} accessor.
+   */
+  static void forEach(PrimitiveIterator.OfLong positions, PositionDeleteIndex target) {
+    PositionDeleteRangeConsumer consumer = new PositionDeleteRangeConsumer(target);
+    long[] buffer = new long[FOREACH_BATCH_SIZE];
+    int filled = 0;
+    while (positions.hasNext()) {
+      buffer[filled++] = positions.nextLong();
+      if (filled == FOREACH_BATCH_SIZE) {
+        consumer.acceptAll(buffer, 0, FOREACH_BATCH_SIZE);
+        filled = 0;
+      }
+    }
+    if (filled > 0) {
+      consumer.acceptAll(buffer, 0, filled);
+    }
+    consumer.flush();
+  }
+
+  /**
    * Drains all positions from {@code source} into {@code target}, coalescing consecutive runs into
    * range inserts. Equivalent to {@code source.forEach(target::delete)} but cheaper for ascending
    * sources (such as {@code BitmapPositionDeleteIndex}); out-of-order sources still produce a
    * correct result via the per-position fallback.
    */
-  public static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
+  static void forEach(PositionDeleteIndex source, PositionDeleteIndex target) {
     if (source.isEmpty()) {
       return;
     }

--- a/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
+++ b/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.formats;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
@@ -63,6 +64,11 @@ public final class FormatModelRegistry {
 
   // Format models indexed by file format and object model class
   private static final Map<Pair<FileFormat, Class<?>>, FormatModel<?, ?>> MODELS =
+      Maps.newConcurrentMap();
+
+  // Position delete index readers indexed by file format. Unlike MODELS, the output type is
+  // fixed (PositionDeleteIndex), so the registry key only needs the FileFormat.
+  private static final Map<FileFormat, PositionDeleteIndexReader> POSITION_DELETE_INDEX_READERS =
       Maps.newConcurrentMap();
 
   static {
@@ -186,9 +192,55 @@ public final class FormatModelRegistry {
     return FileWriterBuilderImpl.forPositionDelete(model, outputFile);
   }
 
+  /**
+   * Registers a {@link PositionDeleteIndexReader} that decodes position-delete files of the given
+   * {@link FileFormat} directly into {@link org.apache.iceberg.deletes.PositionDeleteIndex}
+   * instances.
+   *
+   * <p>At most one reader may be registered per format; a second registration for an already
+   * registered format throws {@link IllegalArgumentException}. Delete loaders consult this registry
+   * before falling back to the per-row {@link ReadBuilder} pipeline, so registering an
+   * implementation enables a fast path for that format. When no reader is registered for a format,
+   * callers should use the generic record reader as a fallback.
+   *
+   * @param format the file format the reader targets
+   * @param reader the position delete index reader implementation
+   * @throws IllegalArgumentException if a reader is already registered for {@code format}
+   */
+  public static synchronized void registerPositionDeleteIndexReader(
+      FileFormat format, PositionDeleteIndexReader reader) {
+    Preconditions.checkArgument(format != null, "Invalid file format: null");
+    Preconditions.checkArgument(reader != null, "Invalid position delete index reader: null");
+    PositionDeleteIndexReader existing = POSITION_DELETE_INDEX_READERS.get(format);
+    Preconditions.checkArgument(
+        existing == null,
+        "Cannot register %s: %s is already registered as a position delete index reader for "
+            + "format=%s",
+        reader.getClass(),
+        existing == null ? null : existing.getClass(),
+        format);
+    POSITION_DELETE_INDEX_READERS.put(format, reader);
+  }
+
+  /**
+   * Returns the {@link PositionDeleteIndexReader} registered for {@code format}, or {@link
+   * Optional#empty()} if no reader is registered.
+   *
+   * @param format the file format whose reader to look up
+   * @return the registered reader, or empty if none has been registered for {@code format}
+   */
+  public static Optional<PositionDeleteIndexReader> positionDeleteIndexReader(FileFormat format) {
+    return Optional.ofNullable(POSITION_DELETE_INDEX_READERS.get(format));
+  }
+
   @VisibleForTesting
   static Map<Pair<FileFormat, Class<?>>, FormatModel<?, ?>> models() {
     return MODELS;
+  }
+
+  @VisibleForTesting
+  static Map<FileFormat, PositionDeleteIndexReader> positionDeleteIndexReaders() {
+    return POSITION_DELETE_INDEX_READERS;
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/main/java/org/apache/iceberg/formats/PositionDeleteIndexReader.java
+++ b/core/src/main/java/org/apache/iceberg/formats/PositionDeleteIndexReader.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.formats;
+
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.util.CharSequenceMap;
+
+/**
+ * Materializes a position delete file directly into one or more {@link PositionDeleteIndex}
+ * instances, bypassing the per-row {@link org.apache.iceberg.formats.ReadBuilder} pipeline.
+ *
+ * <p>Implementations are registered with {@link FormatModelRegistry} per {@link
+ * org.apache.iceberg.FileFormat} and consulted by delete loaders before falling back to the generic
+ * record-by-record reader. This provides a fast path for engines (e.g. Spark on Arrow) that can
+ * decode the delete file's columnar buffers without materializing intermediate records.
+ *
+ * <p>The contract is intentionally narrow: the interface returns ready-to-query bitmaps, so
+ * implementations are free to use direct buffer access, range coalescing, or any other
+ * format-specific optimization.
+ */
+public interface PositionDeleteIndexReader {
+
+  /**
+   * Reads the positions in {@code file} that target {@code dataLocation} and returns them as a
+   * single index. Implementations must return an empty (but possibly mutable) index when no deletes
+   * target the path.
+   *
+   * @param file the position delete file to read; must not be {@code null}
+   * @param dataLocation the data file path to filter on; must not be {@code null}
+   * @param deleteFile delete-file metadata recorded with the returned index, may be {@code null}
+   * @return a {@link PositionDeleteIndex} containing all positions for {@code dataLocation}
+   */
+  PositionDeleteIndex read(InputFile file, CharSequence dataLocation, DeleteFile deleteFile);
+
+  /**
+   * Reads every position in {@code file} grouped by the data file it targets. Used by the caching
+   * path of delete loaders, which holds onto the entire delete file's content keyed by data file
+   * path.
+   *
+   * @param file the position delete file to read; must not be {@code null}
+   * @param deleteFile delete-file metadata recorded with each returned index, may be {@code null}
+   * @return a map of data file path to its corresponding {@link PositionDeleteIndex}
+   */
+  CharSequenceMap<PositionDeleteIndex> readAll(InputFile file, DeleteFile deleteFile);
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -77,6 +77,41 @@ public class TestBitmapPositionDeleteIndex {
   }
 
   @Test
+  public void testCreateReturnsEmptyMutableIndexWithoutProvenance() {
+    PositionDeleteIndex index = PositionDeleteIndex.create();
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.cardinality()).isZero();
+    assertThat(index.deleteFiles()).isEmpty();
+
+    index.delete(5L);
+    index.delete(10L, 15L);
+    assertThat(index.isDeleted(5L)).isTrue();
+    assertThat(index.isDeleted(10L)).isTrue();
+    assertThat(index.isDeleted(14L)).isTrue();
+    assertThat(index.isDeleted(15L)).isFalse();
+    assertThat(index.cardinality()).isEqualTo(6L);
+  }
+
+  @Test
+  public void testCreateWithDeleteFileRecordsProvenance() {
+    DeleteFile source = mockDV(/* contentSize */ 0L, /* cardinality */ 0L);
+    PositionDeleteIndex index = PositionDeleteIndex.create(source);
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.deleteFiles()).containsExactly(source);
+
+    index.delete(42L);
+    assertThat(index.isDeleted(42L)).isTrue();
+    assertThat(index.deleteFiles()).containsExactly(source);
+  }
+
+  @Test
+  public void testCreateWithNullDeleteFileHasNoProvenance() {
+    PositionDeleteIndex index = PositionDeleteIndex.create(null);
+    assertThat(index.isEmpty()).isTrue();
+    assertThat(index.deleteFiles()).isEmpty();
+  }
+
+  @Test
   public void testMergeBitmapIndexWithNonEmpty() {
     long pos1 = 10L; // Container 0 (high bits = 0)
     long pos2 = 1L << 33; // Container 1 (high bits = 1)

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -23,8 +23,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.ByteBuffer;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.LongConsumer;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.io.Resources;
 import org.junit.jupiter.api.Test;
@@ -93,6 +96,63 @@ public class TestBitmapPositionDeleteIndex {
     // output must be sorted in ascending order across containers
     List<Long> positions = collect(index1);
     assertThat(positions).containsExactly(pos1, pos2, pos3, pos4);
+  }
+
+  @Test
+  public void testMergeNonBitmapSourcePropagatesPositionsAndDeleteFiles() {
+    DeleteFile sourceFile = Mockito.mock(DeleteFile.class);
+    long pos1 = 10L; // Container 0
+    long pos2 = 1L << 33; // Container 1
+    long pos3 = pos2 + 1; // Container 1, consecutive run with pos2
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    target.delete(5L);
+    PositionDeleteIndex nonBitmapSource =
+        new PositionDeleteIndex() {
+          @Override
+          public void delete(long position) {
+            throw new UnsupportedOperationException("test source is read-only");
+          }
+
+          @Override
+          public void delete(long posStart, long posEnd) {
+            throw new UnsupportedOperationException("test source is read-only");
+          }
+
+          @Override
+          public boolean isDeleted(long position) {
+            return position == pos1 || position == pos2 || position == pos3;
+          }
+
+          @Override
+          public boolean isEmpty() {
+            return false;
+          }
+
+          @Override
+          public void forEach(LongConsumer consumer) {
+            consumer.accept(pos1);
+            consumer.accept(pos2);
+            consumer.accept(pos3);
+          }
+
+          @Override
+          public long cardinality() {
+            return 3L;
+          }
+
+          @Override
+          public Collection<DeleteFile> deleteFiles() {
+            return ImmutableList.of(sourceFile);
+          }
+        };
+
+    target.merge(nonBitmapSource);
+
+    assertThat(collect(target)).containsExactly(5L, pos1, pos2, pos3);
+    assertThat(target.deleteFiles())
+        .as("non-bitmap merge should copy source deleteFiles into target")
+        .containsExactly(sourceFile);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.avro.util.Utf8;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.CharSequenceMap;
+import org.junit.jupiter.api.Test;
+
+public class TestDeletesToPositionIndexes {
+
+  @Test
+  public void emptyInputProducesEmptyMap() {
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(Lists.newArrayList()));
+    assertThat(indexes.keySet()).isEmpty();
+    assertThat(indexes.get("file_a.parquet")).isNull();
+  }
+
+  @Test
+  public void singlePathCoalescesContiguousRun() {
+    List<StructLike> deletes = Lists.newArrayList();
+    for (long pos = 0; pos < 1024; pos++) {
+      deletes.add(Row.of("file_a.parquet", pos));
+    }
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(1);
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index).as("index for file_a.parquet").isNotNull();
+    assertThat(index).isInstanceOf(BitmapPositionDeleteIndex.class);
+    for (long pos = 0; pos < 1024; pos++) {
+      assertThat(index.isDeleted(pos)).as("pos %s should be deleted", pos).isTrue();
+    }
+    assertThat(index.isDeleted(1024L)).isFalse();
+  }
+
+  @Test
+  public void multiplePathsBuildIndependentIndexes() {
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 5L),
+            Row.of(new Utf8("file_b.parquet"), 7L),
+            Row.of("file_b.parquet", 8L),
+            Row.of("file_b.parquet", 9L),
+            Row.of("file_c.parquet", 42L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(3);
+
+    PositionDeleteIndex indexA = indexes.get("file_a.parquet");
+    assertThat(indexA).as("index for file_a.parquet").isNotNull();
+    assertThat(indexA.isDeleted(0L)).isTrue();
+    assertThat(indexA.isDeleted(1L)).isTrue();
+    assertThat(indexA.isDeleted(2L)).isFalse();
+    assertThat(indexA.isDeleted(5L)).isTrue();
+    assertThat(indexA.isDeleted(7L)).isFalse();
+
+    PositionDeleteIndex indexB = indexes.get("file_b.parquet");
+    assertThat(indexB).as("index for file_b.parquet").isNotNull();
+    assertThat(indexB.isDeleted(7L)).isTrue();
+    assertThat(indexB.isDeleted(8L)).isTrue();
+    assertThat(indexB.isDeleted(9L)).isTrue();
+    assertThat(indexB.isDeleted(10L)).isFalse();
+
+    PositionDeleteIndex indexC = indexes.get("file_c.parquet");
+    assertThat(indexC).as("index for file_c.parquet").isNotNull();
+    assertThat(indexC.isDeleted(42L)).isTrue();
+    assertThat(indexC.isDeleted(0L)).isFalse();
+  }
+
+  @Test
+  public void outOfOrderPathRevisitMergesIntoExistingIndex() {
+    // Unsorted input: same data file appears on either side of a different path. The implementation
+    // must still produce a single bitmap for file_a containing positions from both runs.
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 2L),
+            Row.of("file_b.parquet", 100L),
+            Row.of("file_a.parquet", 50L),
+            Row.of("file_a.parquet", 51L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(2);
+
+    PositionDeleteIndex indexA = indexes.get("file_a.parquet");
+    assertThat(indexA).as("index for file_a.parquet").isNotNull();
+    assertThat(indexA.isDeleted(1L)).isTrue();
+    assertThat(indexA.isDeleted(2L)).isTrue();
+    assertThat(indexA.isDeleted(50L)).isTrue();
+    assertThat(indexA.isDeleted(51L)).isTrue();
+    assertThat(indexA.isDeleted(3L)).isFalse();
+
+    PositionDeleteIndex indexB = indexes.get("file_b.parquet");
+    assertThat(indexB).as("index for file_b.parquet").isNotNull();
+    assertThat(indexB.isDeleted(100L)).isTrue();
+    assertThat(indexB.isDeleted(1L)).isFalse();
+  }
+
+  @Test
+  public void mixedCharSequenceTypesShareIndex() {
+    // Adjacent records use Utf8 vs String for the same logical path. CharSequenceUtil treats them
+    // as equal, so they must accumulate into a single index without spuriously closing the group.
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of(new Utf8("file_a.parquet"), 1L),
+            Row.of("file_a.parquet", 2L),
+            Row.of(new Utf8("file_a.parquet"), 3L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    assertThat(indexes.keySet()).hasSize(1);
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index.isDeleted(0L)).isTrue();
+    assertThat(index.isDeleted(1L)).isTrue();
+    assertThat(index.isDeleted(2L)).isTrue();
+    assertThat(index.isDeleted(3L)).isTrue();
+    assertThat(index.isDeleted(4L)).isFalse();
+  }
+
+  @Test
+  public void sparseSinglePathRecordsExactPositions() {
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_a.parquet", 17L),
+            Row.of("file_a.parquet", 256L),
+            Row.of("file_a.parquet", 4096L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+
+    PositionDeleteIndex index = indexes.get("file_a.parquet");
+    assertThat(index.isDeleted(0L)).isFalse();
+    assertThat(index.isDeleted(1L)).isTrue();
+    assertThat(index.isDeleted(2L)).isFalse();
+    assertThat(index.isDeleted(17L)).isTrue();
+    assertThat(index.isDeleted(256L)).isTrue();
+    assertThat(index.isDeleted(4096L)).isTrue();
+    assertThat(index.isDeleted(4097L)).isFalse();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestDeletesToPositionIndexes.java
@@ -19,22 +19,27 @@
 package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.List;
 import org.apache.avro.util.Utf8;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.CharSequenceMap;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class TestDeletesToPositionIndexes {
 
   @Test
   public void emptyInputProducesEmptyMap() {
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(Lists.newArrayList()));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(Lists.newArrayList());
     assertThat(indexes.keySet()).isEmpty();
     assertThat(indexes.get("file_a.parquet")).isNull();
   }
@@ -46,8 +51,7 @@ public class TestDeletesToPositionIndexes {
       deletes.add(Row.of("file_a.parquet", pos));
     }
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(1);
     PositionDeleteIndex index = indexes.get("file_a.parquet");
@@ -71,8 +75,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_b.parquet", 9L),
             Row.of("file_c.parquet", 42L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(3);
 
@@ -109,8 +112,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 50L),
             Row.of("file_a.parquet", 51L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(2);
 
@@ -139,8 +141,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 2L),
             Row.of(new Utf8("file_a.parquet"), 3L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     assertThat(indexes.keySet()).hasSize(1);
     PositionDeleteIndex index = indexes.get("file_a.parquet");
@@ -160,8 +161,7 @@ public class TestDeletesToPositionIndexes {
             Row.of("file_a.parquet", 256L),
             Row.of("file_a.parquet", 4096L));
 
-    CharSequenceMap<PositionDeleteIndex> indexes =
-        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes));
+    CharSequenceMap<PositionDeleteIndex> indexes = toIndexes(deletes);
 
     PositionDeleteIndex index = indexes.get("file_a.parquet");
     assertThat(index.isDeleted(0L)).isFalse();
@@ -171,5 +171,52 @@ public class TestDeletesToPositionIndexes {
     assertThat(index.isDeleted(256L)).isTrue();
     assertThat(index.isDeleted(4096L)).isTrue();
     assertThat(index.isDeleted(4097L)).isFalse();
+  }
+
+  @Test
+  public void deleteFilePropagatesToEachIndex() {
+    DeleteFile file = Mockito.mock(DeleteFile.class);
+    List<StructLike> deletes =
+        Lists.newArrayList(
+            Row.of("file_a.parquet", 0L),
+            Row.of("file_a.parquet", 1L),
+            Row.of("file_b.parquet", 5L));
+
+    CharSequenceMap<PositionDeleteIndex> indexes =
+        Deletes.toPositionIndexes(CloseableIterable.withNoopClose(deletes), file);
+
+    assertThat(indexes.keySet()).hasSize(2);
+    assertThat(indexes.get("file_a.parquet").deleteFiles())
+        .as("file_a should record its source delete file")
+        .containsExactly(file);
+    assertThat(indexes.get("file_b.parquet").deleteFiles())
+        .as("file_b should record its source delete file")
+        .containsExactly(file);
+  }
+
+  @Test
+  public void closeFailureSurfacesAsUncheckedIOException() {
+    List<StructLike> rows = Lists.newArrayList(Row.of("file_a.parquet", 0L));
+    CloseableIterable<StructLike> throwingOnClose =
+        new CloseableIterable<StructLike>() {
+          @Override
+          public void close() throws IOException {
+            throw new IOException("boom");
+          }
+
+          @Override
+          public CloseableIterator<StructLike> iterator() {
+            return CloseableIterator.withClose(rows.iterator());
+          }
+        };
+
+    assertThatThrownBy(() -> Deletes.toPositionIndexes(throwingOnClose))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("Failed to close position delete source")
+        .hasCauseInstanceOf(IOException.class);
+  }
+
+  private static CharSequenceMap<PositionDeleteIndex> toIndexes(Iterable<StructLike> rows) {
+    return Deletes.toPositionIndexes(CloseableIterable.withNoopClose(rows));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
@@ -1,0 +1,695 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.deletes;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class TestPositionDeleteRangeConsumer {
+
+  @Test
+  void emptyInput() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(Collections.<Long>emptyList(), index);
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  @Test
+  void singlePosition() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(42L), index);
+
+    assertThat(index.isDeleted(42)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(1);
+  }
+
+  @Test
+  void consecutivePositionsCoalesced() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(10L, 11L, 12L, 13L, 14L), index);
+
+    for (long pos = 10; pos <= 14; pos++) {
+      assertThat(index.isDeleted(pos)).isTrue();
+    }
+
+    assertThat(index.isDeleted(9)).isFalse();
+    assertThat(index.isDeleted(15)).isFalse();
+    assertThat(index.cardinality()).isEqualTo(5);
+  }
+
+  @Test
+  void multipleDisjointRanges() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(3L, 4L, 5L, 10L, 11L, 100L), index);
+
+    assertThat(index.isDeleted(3)).isTrue();
+    assertThat(index.isDeleted(4)).isTrue();
+    assertThat(index.isDeleted(5)).isTrue();
+    assertThat(index.isDeleted(6)).isFalse();
+    assertThat(index.isDeleted(10)).isTrue();
+    assertThat(index.isDeleted(11)).isTrue();
+    assertThat(index.isDeleted(12)).isFalse();
+    assertThat(index.isDeleted(100)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(6);
+  }
+
+  @Test
+  void unsortedInputProducesCorrectResult() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(50L, 10L, 11L, 12L, 1L, 2L, 3L), index);
+
+    assertThat(index.isDeleted(50)).isTrue();
+    assertThat(index.isDeleted(10)).isTrue();
+    assertThat(index.isDeleted(11)).isTrue();
+    assertThat(index.isDeleted(12)).isTrue();
+    assertThat(index.isDeleted(1)).isTrue();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.isDeleted(3)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(7);
+  }
+
+  @Test
+  void duplicatePositions() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(5L, 5L, 6L, 6L), index);
+
+    assertThat(index.isDeleted(5)).isTrue();
+    assertThat(index.isDeleted(6)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(2);
+  }
+
+  @Test
+  void largeConsecutiveRange() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    int rangeSize = 100_000;
+    long[] positions = new long[rangeSize];
+    for (int i = 0; i < rangeSize; i++) {
+      positions[i] = i;
+    }
+
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(rangeSize);
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(rangeSize - 1)).isTrue();
+    assertThat(index.isDeleted(rangeSize)).isFalse();
+  }
+
+  @Test
+  void positionZero() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(0L, 1L, 2L), index);
+
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(1)).isTrue();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(3);
+  }
+
+  @Test
+  void alternatingPositionsNoCoalescing() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(0L, 2L, 4L, 6L), index);
+
+    assertThat(index.isDeleted(0)).isTrue();
+    assertThat(index.isDeleted(1)).isFalse();
+    assertThat(index.isDeleted(2)).isTrue();
+    assertThat(index.isDeleted(3)).isFalse();
+    assertThat(index.isDeleted(4)).isTrue();
+    assertThat(index.isDeleted(5)).isFalse();
+    assertThat(index.isDeleted(6)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(4);
+  }
+
+  @Test
+  void largeSparseInputTakesNaivePath() {
+    // 4096 alternating positions -- sniff sees 100% boundaries on the 256-long prefix and
+    // dispatches to the naive path. The result must still be identical to coalescing.
+    int count = 4096;
+    long[] positions = new long[count];
+    for (int i = 0; i < count; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(index.isDeleted(positions[i])).isTrue();
+      assertThat(index.isDeleted(positions[i] + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void sparsePrefixWithDenseTail() {
+    // First 512 positions alternate, then 2048 consecutive positions. The sniff sees a sparse
+    // prefix and picks the naive path; the dense tail is still emitted correctly.
+    int prefixCount = 512;
+    int tailCount = 2048;
+    long[] positions = new long[prefixCount + tailCount];
+    for (int i = 0; i < prefixCount; i++) {
+      positions[i] = i * 2L;
+    }
+
+    long tailStart = 10_000L;
+    for (int i = 0; i < tailCount; i++) {
+      positions[prefixCount + i] = tailStart + i;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(prefixCount + tailCount);
+    for (int i = 0; i < prefixCount; i++) {
+      assertThat(index.isDeleted(positions[i])).isTrue();
+    }
+
+    for (int i = 0; i < tailCount; i++) {
+      assertThat(index.isDeleted(tailStart + i)).isTrue();
+    }
+
+    assertThat(index.isDeleted(tailStart + tailCount)).isFalse();
+  }
+
+  @Test
+  void densePrefixWithSparseTail() {
+    // First 512 positions are contiguous, then 2048 alternating. The sniff sees a dense prefix
+    // and picks the coalesce path; the sparse tail is still emitted correctly.
+    int prefixCount = 512;
+    int tailCount = 2048;
+    long[] positions = new long[prefixCount + tailCount];
+    for (int i = 0; i < prefixCount; i++) {
+      positions[i] = i;
+    }
+
+    long tailStart = 10_000L;
+    for (int i = 0; i < tailCount; i++) {
+      positions[prefixCount + i] = tailStart + i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(prefixCount + tailCount);
+    for (int i = 0; i < prefixCount; i++) {
+      assertThat(index.isDeleted(i)).isTrue();
+    }
+
+    for (int i = 0; i < tailCount; i++) {
+      assertThat(index.isDeleted(tailStart + i * 2L)).isTrue();
+      assertThat(index.isDeleted(tailStart + i * 2L + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void lengthAtExactSniffBoundary() {
+    // Input length matches the sniff window exactly: the prefix fills, the sniff runs, and the
+    // streaming tail loop never executes. Both dispatch decisions must produce correct output.
+    int count = 256;
+    long[] dense = new long[count];
+    long[] sparse = new long[count];
+    for (int i = 0; i < count; i++) {
+      dense[i] = i;
+      sparse[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex denseIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(dense), denseIndex);
+    assertThat(denseIndex.cardinality()).isEqualTo(count);
+    assertThat(denseIndex.isDeleted(0)).isTrue();
+    assertThat(denseIndex.isDeleted(count - 1)).isTrue();
+
+    BitmapPositionDeleteIndex sparseIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(sparse), sparseIndex);
+    assertThat(sparseIndex.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(sparseIndex.isDeleted(i * 2L)).isTrue();
+    }
+  }
+
+  @Test
+  void smallAdversarialInputSkipsSniff() {
+    // Alternating input shorter than the sniff window -- the prefix never fills, so the sniff
+    // is skipped and we coalesce directly. Verifies correctness on the small-list fast path.
+    int count = 100;
+    long[] positions = new long[count];
+    for (int i = 0; i < count; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(asList(positions), index);
+
+    assertThat(index.cardinality()).isEqualTo(count);
+    for (int i = 0; i < count; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+      assertThat(index.isDeleted(i * 2L + 1)).isFalse();
+    }
+  }
+
+  @Test
+  void accumulatorRejectsNullTarget() {
+    assertThatThrownBy(() -> new PositionDeleteRangeConsumer(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid target index");
+  }
+
+  @Test
+  void accumulatorEmitsSinglePositionOnFlush() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(42L);
+    acc.flush();
+
+    assertThat(index.isDeleted(42L)).isTrue();
+    assertThat(index.cardinality()).isEqualTo(1);
+  }
+
+  @Test
+  void accumulatorCoalescesConsecutivePositions() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    for (long pos = 10L; pos <= 14L; pos++) {
+      acc.accept(pos);
+    }
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(5);
+    assertThat(index.isDeleted(9L)).isFalse();
+    assertThat(index.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void accumulatorBreaksRunOnGap() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(10L);
+    acc.accept(11L);
+    acc.accept(20L);
+    acc.accept(21L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(4);
+    assertThat(index.isDeleted(12L)).isFalse();
+    assertThat(index.isDeleted(19L)).isFalse();
+  }
+
+  @Test
+  void accumulatorFlushAllowsContinuationWithoutCoalescing() {
+    // Explicit flush mid-stream emulates a logical boundary (e.g. a path change in a multi-file
+    // delete file). The next accept must not be coalesced with the just-emitted run even when
+    // its position is consecutive with the previous one.
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(10L);
+    acc.accept(11L);
+    acc.flush();
+    acc.accept(12L);
+    acc.accept(13L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(4);
+    assertThat(index.isDeleted(10L)).isTrue();
+    assertThat(index.isDeleted(13L)).isTrue();
+  }
+
+  @Test
+  void doubleFlushIsNoOp() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.accept(7L);
+    acc.flush();
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(1);
+    assertThat(index.isDeleted(7L)).isTrue();
+  }
+
+  @Test
+  void escapedAccumulatorIgnoresFlush() {
+    // Drive the accumulator into escape mode with a fully-alternating prefix, then flush after
+    // every accept. The result must be identical to the per-position path -- no coalescing
+    // across or within flushes.
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    int sniff = 256;
+    for (int i = 0; i < sniff; i++) {
+      acc.accept(i * 2L);
+    }
+
+    // After the sniff window is full and >30% boundaries observed, the accumulator escapes.
+    // Subsequent accepts go through the per-position path, and flush should be a no-op.
+    acc.accept(10_000L);
+    acc.flush();
+    acc.accept(10_001L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(sniff + 2);
+    for (int i = 0; i < sniff; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+    }
+    assertThat(index.isDeleted(10_000L)).isTrue();
+    assertThat(index.isDeleted(10_001L)).isTrue();
+  }
+
+  @Test
+  void acceptAllRejectsNullArray() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    assertThatThrownBy(() -> acc.acceptAll(null, 0, 0))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid positions array");
+  }
+
+  @Test
+  void acceptAllValidatesIndexes() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {1L, 2L, 3L};
+    assertThatThrownBy(() -> acc.acceptAll(positions, 0, 4))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("end index (4)");
+    assertThatThrownBy(() -> acc.acceptAll(positions, 2, 1))
+        .isInstanceOf(IndexOutOfBoundsException.class)
+        .hasMessageContaining("end index (1)");
+  }
+
+  @Test
+  void acceptAllEmptyRangeIsNoOp() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(new long[] {1L, 2L, 3L}, 1, 1);
+    acc.flush();
+    assertThat(index.isEmpty()).isTrue();
+  }
+
+  @Test
+  void acceptAllCoalescesContiguousRange() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {10L, 11L, 12L, 13L, 14L};
+    acc.acceptAll(positions, 0, positions.length);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(5);
+    assertThat(index.isDeleted(9L)).isFalse();
+    assertThat(index.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void acceptAllHandlesMultipleDisjointRanges() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {3L, 4L, 5L, 10L, 11L, 100L};
+    acc.acceptAll(positions, 0, positions.length);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(6);
+    for (long p : positions) {
+      assertThat(index.isDeleted(p)).isTrue();
+    }
+    assertThat(index.isDeleted(6L)).isFalse();
+    assertThat(index.isDeleted(12L)).isFalse();
+  }
+
+  @Test
+  void acceptAllHonoursFromAndTo() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    long[] positions = {1L, 2L, 100L, 101L, 999L};
+    acc.acceptAll(positions, 2, 4);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(2);
+    assertThat(index.isDeleted(100L)).isTrue();
+    assertThat(index.isDeleted(101L)).isTrue();
+    assertThat(index.isDeleted(1L)).isFalse();
+    assertThat(index.isDeleted(999L)).isFalse();
+  }
+
+  @Test
+  void acceptAllChunksProduceSameResultAsSingleCall() {
+    int rangeSize = 10_000;
+    long[] positions = new long[rangeSize];
+    for (int i = 0; i < rangeSize; i++) {
+      positions[i] = i;
+    }
+
+    BitmapPositionDeleteIndex bulkIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer bulk = new PositionDeleteRangeConsumer(bulkIndex);
+    bulk.acceptAll(positions, 0, rangeSize);
+    bulk.flush();
+
+    BitmapPositionDeleteIndex chunkedIndex = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer chunked = new PositionDeleteRangeConsumer(chunkedIndex);
+    int chunk = 137;
+    int cursor = 0;
+    while (cursor < rangeSize) {
+      int end = Math.min(rangeSize, cursor + chunk);
+      chunked.acceptAll(positions, cursor, end);
+      cursor = end;
+    }
+    chunked.flush();
+
+    assertThat(chunkedIndex.cardinality()).isEqualTo(bulkIndex.cardinality());
+    for (long p : positions) {
+      assertThat(chunkedIndex.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void acceptAllAndAcceptInterleaveCorrectly() {
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(new long[] {10L, 11L}, 0, 2);
+    acc.accept(12L);
+    acc.acceptAll(new long[] {13L, 14L, 20L}, 0, 3);
+    acc.accept(21L);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(7);
+    for (long p : new long[] {10L, 11L, 12L, 13L, 14L, 20L, 21L}) {
+      assertThat(index.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void acceptAllDispatchesToEscapedPath() {
+    int sniff = 256;
+    int total = 4096;
+    long[] positions = new long[total];
+    for (int i = 0; i < total; i++) {
+      positions[i] = i * 2L;
+    }
+
+    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
+    acc.acceptAll(positions, 0, total);
+    acc.flush();
+
+    assertThat(index.cardinality()).isEqualTo(total);
+    for (int i = 0; i < total; i++) {
+      assertThat(index.isDeleted(i * 2L)).isTrue();
+      assertThat(index.isDeleted(i * 2L + 1)).isFalse();
+    }
+    // Unused: silences an unused-variable warning if sniff size assumptions ever change.
+    assertThat(sniff).isLessThan(total);
+  }
+
+  @Test
+  void forEachIndexEmptySourceLeavesTargetUntouched() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    target.delete(99L);
+
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(1);
+    assertThat(target.isDeleted(99L)).isTrue();
+  }
+
+  @Test
+  void forEachIndexBitmapSourceCoalescesRuns() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    for (long p = 10; p <= 14; p++) {
+      source.delete(p);
+    }
+    source.delete(100L);
+    source.delete(101L);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(source.cardinality());
+    for (long p = 10; p <= 14; p++) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+    assertThat(target.isDeleted(100L)).isTrue();
+    assertThat(target.isDeleted(101L)).isTrue();
+    assertThat(target.isDeleted(9L)).isFalse();
+    assertThat(target.isDeleted(15L)).isFalse();
+  }
+
+  @Test
+  void forEachIndexSmallSourceShortCircuitsToPerPosition() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    long[] positions = {1L, 2L, 3L, 5L};
+    for (long p : positions) {
+      source.delete(p);
+    }
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(positions.length);
+    for (long p : positions) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void forEachIndexCardinalityUnknownStillCorrect() {
+    BitmapPositionDeleteIndex backing = new BitmapPositionDeleteIndex();
+    long[] positions = {7L, 8L, 9L, 100L};
+    for (long p : positions) {
+      backing.delete(p);
+    }
+    // Wrap so cardinality() throws -- forces the batched path even though the source is tiny.
+    PositionDeleteIndex source = forwardingWithoutCardinality(backing);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(positions.length);
+    for (long p : positions) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+  }
+
+  @Test
+  void forEachIndexNonBitmapSourceTakesFallbackPath() {
+    BitmapPositionDeleteIndex backing = new BitmapPositionDeleteIndex();
+    for (long p = 1; p <= 5; p++) {
+      backing.delete(p);
+    }
+    backing.delete(42L);
+    PositionDeleteIndex source = forwarding(backing);
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(6);
+    for (long p = 1; p <= 5; p++) {
+      assertThat(target.isDeleted(p)).isTrue();
+    }
+    assertThat(target.isDeleted(42L)).isTrue();
+  }
+
+  @Test
+  void forEachIndexExceedsBatchSize() {
+    BitmapPositionDeleteIndex source = new BitmapPositionDeleteIndex();
+    int total = 1_024; // > FOREACH_BATCH_SIZE = 64
+    for (long p = 0; p < total; p++) {
+      source.delete(p);
+    }
+
+    BitmapPositionDeleteIndex target = new BitmapPositionDeleteIndex();
+    PositionDeleteRangeConsumer.forEach(source, target);
+
+    assertThat(target.cardinality()).isEqualTo(total);
+    assertThat(target.isDeleted(0L)).isTrue();
+    assertThat(target.isDeleted(total - 1L)).isTrue();
+    assertThat(target.isDeleted((long) total)).isFalse();
+  }
+
+  private static PositionDeleteIndex forwarding(PositionDeleteIndex backing) {
+    return new PositionDeleteIndex() {
+      @Override
+      public void delete(long position) {
+        backing.delete(position);
+      }
+
+      @Override
+      public void delete(long posStart, long posEnd) {
+        backing.delete(posStart, posEnd);
+      }
+
+      @Override
+      public boolean isDeleted(long position) {
+        return backing.isDeleted(position);
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return backing.isEmpty();
+      }
+
+      @Override
+      public void forEach(java.util.function.LongConsumer consumer) {
+        backing.forEach(consumer);
+      }
+
+      @Override
+      public long cardinality() {
+        return backing.cardinality();
+      }
+    };
+  }
+
+  private static PositionDeleteIndex forwardingWithoutCardinality(PositionDeleteIndex backing) {
+    return new PositionDeleteIndex() {
+      @Override
+      public void delete(long position) {
+        backing.delete(position);
+      }
+
+      @Override
+      public void delete(long posStart, long posEnd) {
+        backing.delete(posStart, posEnd);
+      }
+
+      @Override
+      public boolean isDeleted(long position) {
+        return backing.isDeleted(position);
+      }
+
+      @Override
+      public boolean isEmpty() {
+        return backing.isEmpty();
+      }
+
+      @Override
+      public void forEach(java.util.function.LongConsumer consumer) {
+        backing.forEach(consumer);
+      }
+      // Intentionally does not override cardinality(); inherits the default that throws.
+    };
+  }
+
+  private static List<Long> asList(long... positions) {
+    return Arrays.stream(positions).boxed().collect(Collectors.toList());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestPositionDeleteRangeConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.Collections;
@@ -271,17 +270,10 @@ class TestPositionDeleteRangeConsumer {
   }
 
   @Test
-  void accumulatorRejectsNullTarget() {
-    assertThatThrownBy(() -> new PositionDeleteRangeConsumer(null))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid target index");
-  }
-
-  @Test
   void accumulatorEmitsSinglePositionOnFlush() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(42L);
+    feed(acc, 42L);
     acc.flush();
 
     assertThat(index.isDeleted(42L)).isTrue();
@@ -293,7 +285,7 @@ class TestPositionDeleteRangeConsumer {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     for (long pos = 10L; pos <= 14L; pos++) {
-      acc.accept(pos);
+      feed(acc, pos);
     }
     acc.flush();
 
@@ -306,10 +298,10 @@ class TestPositionDeleteRangeConsumer {
   void accumulatorBreaksRunOnGap() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(10L);
-    acc.accept(11L);
-    acc.accept(20L);
-    acc.accept(21L);
+    feed(acc, 10L);
+    feed(acc, 11L);
+    feed(acc, 20L);
+    feed(acc, 21L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(4);
@@ -324,11 +316,11 @@ class TestPositionDeleteRangeConsumer {
     // its position is consecutive with the previous one.
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(10L);
-    acc.accept(11L);
+    feed(acc, 10L);
+    feed(acc, 11L);
     acc.flush();
-    acc.accept(12L);
-    acc.accept(13L);
+    feed(acc, 12L);
+    feed(acc, 13L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(4);
@@ -340,7 +332,7 @@ class TestPositionDeleteRangeConsumer {
   void doubleFlushIsNoOp() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    acc.accept(7L);
+    feed(acc, 7L);
     acc.flush();
     acc.flush();
 
@@ -357,14 +349,14 @@ class TestPositionDeleteRangeConsumer {
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     int sniff = 256;
     for (int i = 0; i < sniff; i++) {
-      acc.accept(i * 2L);
+      feed(acc, i * 2L);
     }
 
     // After the sniff window is full and >30% boundaries observed, the accumulator escapes.
     // Subsequent accepts go through the per-position path, and flush should be a no-op.
-    acc.accept(10_000L);
+    feed(acc, 10_000L);
     acc.flush();
-    acc.accept(10_001L);
+    feed(acc, 10_001L);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(sniff + 2);
@@ -373,28 +365,6 @@ class TestPositionDeleteRangeConsumer {
     }
     assertThat(index.isDeleted(10_000L)).isTrue();
     assertThat(index.isDeleted(10_001L)).isTrue();
-  }
-
-  @Test
-  void acceptAllRejectsNullArray() {
-    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
-    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    assertThatThrownBy(() -> acc.acceptAll(null, 0, 0))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid positions array");
-  }
-
-  @Test
-  void acceptAllValidatesIndexes() {
-    BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
-    PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
-    long[] positions = {1L, 2L, 3L};
-    assertThatThrownBy(() -> acc.acceptAll(positions, 0, 4))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessageContaining("end index (4)");
-    assertThatThrownBy(() -> acc.acceptAll(positions, 2, 1))
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessageContaining("end index (1)");
   }
 
   @Test
@@ -481,13 +451,13 @@ class TestPositionDeleteRangeConsumer {
   }
 
   @Test
-  void acceptAllAndAcceptInterleaveCorrectly() {
+  void acceptAllPersistsStateAcrossMixedSliceSizes() {
     BitmapPositionDeleteIndex index = new BitmapPositionDeleteIndex();
     PositionDeleteRangeConsumer acc = new PositionDeleteRangeConsumer(index);
     acc.acceptAll(new long[] {10L, 11L}, 0, 2);
-    acc.accept(12L);
+    acc.acceptAll(new long[] {12L}, 0, 1);
     acc.acceptAll(new long[] {13L, 14L, 20L}, 0, 3);
-    acc.accept(21L);
+    acc.acceptAll(new long[] {21L}, 0, 1);
     acc.flush();
 
     assertThat(index.cardinality()).isEqualTo(7);
@@ -691,5 +661,12 @@ class TestPositionDeleteRangeConsumer {
 
   private static List<Long> asList(long... positions) {
     return Arrays.stream(positions).boxed().collect(Collectors.toList());
+  }
+
+  // Feed one position through the only production entry point. Tests previously called the
+  // removed per-element accept(long); routing through acceptAll keeps the per-position semantics
+  // intact (sniff window, escape decision, run extension) while exercising the real API.
+  private static void feed(PositionDeleteRangeConsumer acc, long pos) {
+    acc.acceptAll(new long[] {pos}, 0, 1);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
+++ b/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
@@ -21,9 +21,12 @@ package org.apache.iceberg.formats;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.util.CharSequenceMap;
 import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +36,7 @@ class TestFormatModelRegistry {
   @BeforeEach
   void clearRegistry() {
     FormatModelRegistry.models().clear();
+    FormatModelRegistry.positionDeleteIndexReaders().clear();
   }
 
   @Test
@@ -84,6 +88,62 @@ class TestFormatModelRegistry {
             () -> FormatModelRegistry.register(new DummyParquetFormatModel(Object.class, null)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot register class");
+  }
+
+  @Test
+  void positionDeleteIndexReaderLookupReturnsEmptyWhenUnregistered() {
+    assertThat(FormatModelRegistry.positionDeleteIndexReader(FileFormat.PARQUET)).isEmpty();
+    assertThat(FormatModelRegistry.positionDeleteIndexReader(FileFormat.AVRO)).isEmpty();
+  }
+
+  @Test
+  void registerPositionDeleteIndexReaderSucceedsOncePerFormat() {
+    PositionDeleteIndexReader reader = new DummyPositionDeleteIndexReader();
+    FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, reader);
+
+    assertThat(FormatModelRegistry.positionDeleteIndexReader(FileFormat.PARQUET))
+        .as("registered reader should be returned")
+        .containsSame(reader);
+    assertThat(FormatModelRegistry.positionDeleteIndexReader(FileFormat.AVRO))
+        .as("readers are scoped per format; AVRO should remain unregistered")
+        .isEmpty();
+  }
+
+  @Test
+  void registerPositionDeleteIndexReaderRejectsDuplicateRegistration() {
+    PositionDeleteIndexReader first = new DummyPositionDeleteIndexReader();
+    PositionDeleteIndexReader second = new DummyPositionDeleteIndexReader();
+    FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, first);
+
+    assertThatThrownBy(
+            () -> FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, second))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("already registered");
+  }
+
+  @Test
+  void registerPositionDeleteIndexReaderRejectsNullArguments() {
+    PositionDeleteIndexReader reader = new DummyPositionDeleteIndexReader();
+    assertThatThrownBy(() -> FormatModelRegistry.registerPositionDeleteIndexReader(null, reader))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid file format");
+    assertThatThrownBy(
+            () -> FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid position delete index reader");
+  }
+
+  private static final class DummyPositionDeleteIndexReader implements PositionDeleteIndexReader {
+    @Override
+    public PositionDeleteIndex read(
+        InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+      return PositionDeleteIndex.empty();
+    }
+
+    @Override
+    public CharSequenceMap<PositionDeleteIndex> readAll(InputFile file, DeleteFile deleteFile) {
+      return CharSequenceMap.create();
+    }
   }
 
   private static class DummyParquetFormatModel implements FormatModel<Object, Object> {

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -205,32 +205,32 @@ public class BaseDeleteLoader implements DeleteLoader {
   }
 
   private CharSequenceMap<PositionDeleteIndex> readPosDeletes(DeleteFile deleteFile) {
-    Optional<PositionDeleteIndexReader> fastReader =
-        FormatModelRegistry.positionDeleteIndexReader(deleteFile.format());
+    Optional<PositionDeleteIndexReader> fastReader = fastReaderFor(deleteFile);
     if (fastReader.isPresent()) {
       LOG.trace("Reading position delete file {} via {}", deleteFile.location(), fastReader.get());
-      InputFile inputFile = loadInputFile.apply(deleteFile);
-      return fastReader.get().readAll(inputFile, deleteFile);
+      return fastReader.get().readAll(loadInputFile.apply(deleteFile), deleteFile);
     }
     CloseableIterable<Record> deletes = openDeletes(deleteFile, POS_DELETE_SCHEMA);
     return Deletes.toPositionIndexes(deletes, deleteFile);
   }
 
   private PositionDeleteIndex readPosDeletes(DeleteFile deleteFile, CharSequence filePath) {
-    Optional<PositionDeleteIndexReader> fastReader =
-        FormatModelRegistry.positionDeleteIndexReader(deleteFile.format());
+    Optional<PositionDeleteIndexReader> fastReader = fastReaderFor(deleteFile);
     if (fastReader.isPresent()) {
       LOG.trace(
           "Reading position delete file {} for {} via {}",
           deleteFile.location(),
           filePath,
           fastReader.get());
-      InputFile inputFile = loadInputFile.apply(deleteFile);
-      return fastReader.get().read(inputFile, filePath, deleteFile);
+      return fastReader.get().read(loadInputFile.apply(deleteFile), filePath, deleteFile);
     }
     Expression filter = Expressions.equal(MetadataColumns.DELETE_FILE_PATH.name(), filePath);
     CloseableIterable<Record> deletes = openDeletes(deleteFile, POS_DELETE_SCHEMA, filter);
     return Deletes.toPositionIndex(filePath, deletes, deleteFile);
+  }
+
+  private static Optional<PositionDeleteIndexReader> fastReaderFor(DeleteFile deleteFile) {
+    return FormatModelRegistry.positionDeleteIndexReader(deleteFile.format());
   }
 
   private CloseableIterable<Record> openDeletes(DeleteFile deleteFile, Schema projection) {

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.data;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +37,7 @@ import org.apache.iceberg.deletes.PositionDeleteIndexUtil;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.PositionDeleteIndexReader;
 import org.apache.iceberg.formats.ReadBuilder;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DeleteSchemaUtil;
@@ -203,11 +205,29 @@ public class BaseDeleteLoader implements DeleteLoader {
   }
 
   private CharSequenceMap<PositionDeleteIndex> readPosDeletes(DeleteFile deleteFile) {
+    Optional<PositionDeleteIndexReader> fastReader =
+        FormatModelRegistry.positionDeleteIndexReader(deleteFile.format());
+    if (fastReader.isPresent()) {
+      LOG.trace("Reading position delete file {} via {}", deleteFile.location(), fastReader.get());
+      InputFile inputFile = loadInputFile.apply(deleteFile);
+      return fastReader.get().readAll(inputFile, deleteFile);
+    }
     CloseableIterable<Record> deletes = openDeletes(deleteFile, POS_DELETE_SCHEMA);
     return Deletes.toPositionIndexes(deletes, deleteFile);
   }
 
   private PositionDeleteIndex readPosDeletes(DeleteFile deleteFile, CharSequence filePath) {
+    Optional<PositionDeleteIndexReader> fastReader =
+        FormatModelRegistry.positionDeleteIndexReader(deleteFile.format());
+    if (fastReader.isPresent()) {
+      LOG.trace(
+          "Reading position delete file {} for {} via {}",
+          deleteFile.location(),
+          filePath,
+          fastReader.get());
+      InputFile inputFile = loadInputFile.apply(deleteFile);
+      return fastReader.get().read(inputFile, filePath, deleteFile);
+    }
     Expression filter = Expressions.equal(MetadataColumns.DELETE_FILE_PATH.name(), filePath);
     CloseableIterable<Record> deletes = openDeletes(deleteFile, POS_DELETE_SCHEMA, filter);
     return Deletes.toPositionIndex(filePath, deletes, deleteFile);

--- a/data/src/test/java/org/apache/iceberg/data/TestBaseDeleteLoaderFastPath.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestBaseDeleteLoaderFastPath.java
@@ -26,6 +26,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
@@ -132,9 +133,72 @@ public class TestBaseDeleteLoaderFastPath {
     assertThat(result.cardinality())
         .as("fallback must read the same positions written to the file")
         .isEqualTo(3L);
-    assertThat(result.isDeleted(1L)).isTrue();
-    assertThat(result.isDeleted(2L)).isTrue();
-    assertThat(result.isDeleted(3L)).isTrue();
+    assertThat(result.isDeleted(1L)).as("position 1 should be deleted").isTrue();
+    assertThat(result.isDeleted(2L)).as("position 2 should be deleted").isTrue();
+    assertThat(result.isDeleted(3L)).as("position 3 should be deleted").isTrue();
+  }
+
+  @Test
+  void delegatesToRegisteredFastReaderReadAllWhenCachingEnabled() throws IOException {
+    // When canCache() is true the loader goes through getOrReadPosDeletes -> readPosDeletes
+    // (without filePath), which dispatches to PositionDeleteIndexReader#readAll. This is the
+    // path Spark's CachingDeleteLoader uses; a regression in readAll wiring would otherwise
+    // be invisible at the loader layer (the existing delegatesToRegisteredFastReader stub
+    // throws from readAll).
+    File rawFile = writePositionDeleteFile("readall-caching.parquet");
+    DeleteFile metadata = parquetPositionDeleteMetadata(rawFile, 3L);
+
+    AtomicInteger readAllInvocations = new AtomicInteger();
+    AtomicInteger readInvocations = new AtomicInteger();
+    PositionDeleteIndexReader stub =
+        new PositionDeleteIndexReader() {
+          @Override
+          public PositionDeleteIndex read(
+              InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+            readInvocations.incrementAndGet();
+            throw new UnsupportedOperationException("filtered read should not be called");
+          }
+
+          @Override
+          public CharSequenceMap<PositionDeleteIndex> readAll(
+              InputFile file, DeleteFile deleteFile) {
+            readAllInvocations.incrementAndGet();
+            CharSequenceMap<PositionDeleteIndex> indexes = CharSequenceMap.create();
+            PositionDeleteIndex index = PositionDeleteIndex.create(deleteFile);
+            index.delete(7L);
+            index.delete(8L);
+            indexes.put(DATA_FILE_A, index);
+            return indexes;
+          }
+        };
+
+    FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, stub);
+
+    BaseDeleteLoader loader =
+        new BaseDeleteLoader(deleteFile -> Files.localInput(rawFile)) {
+          @Override
+          protected boolean canCache(long size) {
+            return true;
+          }
+
+          @Override
+          protected <V> V getOrLoad(String key, Supplier<V> valueSupplier, long valueSize) {
+            // Caching is exercised by canCache() returning true; the actual cache backing
+            // is not under test, so we just invoke the supplier once and return the value.
+            return valueSupplier.get();
+          }
+        };
+
+    PositionDeleteIndex result =
+        loader.loadPositionDeletes(ImmutableList.of(metadata), DATA_FILE_A);
+
+    assertThat(readAllInvocations).as("caching path must dispatch to readAll").hasValue(1);
+    assertThat(readInvocations)
+        .as("filtered read must not be called on the caching path")
+        .hasValue(0);
+    assertThat(result.cardinality()).as("returned cardinality").isEqualTo(2L);
+    assertThat(result.isDeleted(7L)).as("position 7 should be deleted").isTrue();
+    assertThat(result.isDeleted(8L)).as("position 8 should be deleted").isTrue();
   }
 
   private File writePositionDeleteFile(String name) throws IOException {

--- a/data/src/test/java/org/apache/iceberg/data/TestBaseDeleteLoaderFastPath.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestBaseDeleteLoaderFastPath.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Method;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.PositionDeleteIndexReader;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.util.CharSequenceMap;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mockito;
+
+/**
+ * Verifies that {@link BaseDeleteLoader} consults {@link FormatModelRegistry} for a registered
+ * {@link PositionDeleteIndexReader} before falling back to the per-row record reader.
+ */
+public class TestBaseDeleteLoaderFastPath {
+
+  private static final String DATA_FILE_A = "s3://bucket/data/file-a.parquet";
+
+  @TempDir private Path tempDir;
+
+  @BeforeEach
+  @AfterEach
+  void clearRegisteredFastReaders() {
+    // The default classpath for iceberg-data tests does not include iceberg-arrow, so no reader
+    // is registered automatically; clear any test-installed reader so each test starts clean.
+    // The accessor is package-private @VisibleForTesting; reach it reflectively so we don't need
+    // to widen its visibility just to drive cross-package tests.
+    readersMap().remove(FileFormat.PARQUET);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Map<FileFormat, PositionDeleteIndexReader> readersMap() {
+    try {
+      Method method = FormatModelRegistry.class.getDeclaredMethod("positionDeleteIndexReaders");
+      method.setAccessible(true);
+      return (Map<FileFormat, PositionDeleteIndexReader>) method.invoke(null);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalStateException(
+          "Cannot access FormatModelRegistry.positionDeleteIndexReaders()", e);
+    }
+  }
+
+  @Test
+  void delegatesToRegisteredFastReader() throws IOException {
+    File rawFile = writePositionDeleteFile("fast-path.parquet");
+    DeleteFile metadata = parquetPositionDeleteMetadata(rawFile, 3L);
+
+    AtomicInteger invocations = new AtomicInteger();
+    PositionDeleteIndexReader stub =
+        new PositionDeleteIndexReader() {
+          @Override
+          public PositionDeleteIndex read(
+              InputFile file, CharSequence dataLocation, DeleteFile deleteFile) {
+            invocations.incrementAndGet();
+            assertThat(dataLocation).as("dataLocation forwarded").isEqualTo(DATA_FILE_A);
+            PositionDeleteIndex index = PositionDeleteIndex.create(deleteFile);
+            index.delete(42L);
+            return index;
+          }
+
+          @Override
+          public CharSequenceMap<PositionDeleteIndex> readAll(
+              InputFile file, DeleteFile deleteFile) {
+            throw new UnsupportedOperationException("readAll not used in this test");
+          }
+        };
+
+    FormatModelRegistry.registerPositionDeleteIndexReader(FileFormat.PARQUET, stub);
+
+    BaseDeleteLoader loader = new BaseDeleteLoader(deleteFile -> Files.localInput(rawFile));
+
+    PositionDeleteIndex result =
+        loader.loadPositionDeletes(ImmutableList.of(metadata), DATA_FILE_A);
+
+    assertThat(invocations).as("loader should invoke the registered fast reader").hasValue(1);
+    assertThat(result.cardinality())
+        .as("loader should surface the index produced by the fast reader")
+        .isEqualTo(1L);
+    assertThat(result.isDeleted(42L)).as("position from the stub must be present").isTrue();
+  }
+
+  @Test
+  void fallsBackToRecordReaderWhenNoFastReaderRegistered() throws IOException {
+    File rawFile = writePositionDeleteFile("fallback.parquet");
+    DeleteFile metadata = parquetPositionDeleteMetadata(rawFile, 3L);
+
+    BaseDeleteLoader loader = new BaseDeleteLoader(deleteFile -> Files.localInput(rawFile));
+
+    PositionDeleteIndex result =
+        loader.loadPositionDeletes(ImmutableList.of(metadata), DATA_FILE_A);
+
+    assertThat(result.cardinality())
+        .as("fallback must read the same positions written to the file")
+        .isEqualTo(3L);
+    assertThat(result.isDeleted(1L)).isTrue();
+    assertThat(result.isDeleted(2L)).isTrue();
+    assertThat(result.isDeleted(3L)).isTrue();
+  }
+
+  private File writePositionDeleteFile(String name) throws IOException {
+    File file = tempDir.resolve(name).toFile();
+    OutputFile out = Files.localOutput(file);
+    PositionDelete<Void> pd = PositionDelete.create();
+    try (PositionDeleteWriter<Void> writer =
+        Parquet.writeDeletes(out)
+            .createWriterFunc(GenericParquetWriter::create)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .buildPositionWriter()) {
+      pd.set(DATA_FILE_A, 1L, null);
+      writer.write(pd);
+      pd.set(DATA_FILE_A, 2L, null);
+      writer.write(pd);
+      pd.set(DATA_FILE_A, 3L, null);
+      writer.write(pd);
+    }
+    return file;
+  }
+
+  private static DeleteFile parquetPositionDeleteMetadata(File rawFile, long recordCount) {
+    DeleteFile metadata = Mockito.mock(DeleteFile.class);
+    Mockito.when(metadata.format()).thenReturn(FileFormat.PARQUET);
+    Mockito.when(metadata.content()).thenReturn(FileContent.POSITION_DELETES);
+    Mockito.when(metadata.location()).thenReturn(rawFile.getAbsolutePath());
+    Mockito.when(metadata.recordCount()).thenReturn(recordCount);
+    return metadata;
+  }
+}


### PR DESCRIPTION
Add `VectorizedPositionDeleteReader`, an Arrow-vectorized reader for V2 position delete files. Reads `(file_path, pos)` directly from Arrow `VarChar` / `BigInt` buffers and feeds the shared `RangeAccumulator` from #16052, so consecutive positions become `PositionDeleteIndex.delete(start, end)` range inserts. No per-row Java allocation on the hot path.

Stacked on #16052, that PR adds the coalescing primitive in `iceberg-core`; this PR wires it into the Arrow read path.

`BaseDeleteLoader.readPosDeletes` now dispatches through a new `PositionDeleteIndexReader` SPI on `FormatModelRegistry`, so the Arrow path is picked up automatically when `iceberg-arrow` is on the classpath.

Like #16052, this primarily benefits Iceberg V2 tables; V3 DVs deserialize directly and bypass both paths.


### Single-file read (PositionDeleteReaderBenchmark, single-shot)

| Mode             | Distribution | Baseline (s) | Vectorized (s) | Speedup |
|------------------|--------------|-------------:|---------------:|--------:|
| No filter        | dense        |        0.130 |          0.047 |   2.77x |
| No filter        | sparse       |        0.147 |          0.069 |   2.13x |
| Filtered by path | dense        |        0.306 |          0.323 |   0.95x |
| Filtered by path | sparse       |        0.338 |          0.356 |   0.95x |

> Filtered cases are bounded by per-row \`file_path\` comparison cost; both readers pay the same floor there.


### Multi-file via BaseDeleteLoader (BaseDeleteLoaderBenchmark, average time)
| Distribution | v2-legacy (ms) | v2-arrow (ms) | v3-dv (ms) | v2-arrow vs v2-legacy | v3-dv vs v2-arrow |
|---|---:|---:|---:|---:|---:|
| dense  | 152.99 ± 3.72 | 120.72 ± 20.00 |  0.012 ± 0.001 | 1.27x | ~10,000x |
| sparse | 163.42 ± 3.31 | 122.50 ±  2.84 |  1.025 ± 0.006 | 1.33x |   ~120x |

> V3 DVs (Puffin + RoaringBitmap) are on a different order of magnitude: this PR brings the V2 path faster. Recommended takeaway for reviewers: this is the right reader for tables that remain on V2, not a reason to stay on V2.
