### PR TITLE
Core: Adjust calculations for reserved field IDs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -34,80 +34,67 @@ import org.slf4j.LoggerFactory;
 
 class StatsUtil {
   private static final Logger LOG = LoggerFactory.getLogger(StatsUtil.class);
-  // the number of reserved field IDs from the reserved field ID space as defined in
-  // https://iceberg.apache.org/spec/#reserved-field-ids
-  static final int NUM_RESERVED_FIELD_IDS = 200;
-  // the starting field ID of the reserved field ID space
-  static final int RESERVED_FIELD_IDS_START = Integer.MAX_VALUE - NUM_RESERVED_FIELD_IDS;
-  // the number of supported stats per table column
+  private static final int FIRST_SUPPORTED_METADATA_FIELD_ID =
+      MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
+  static final Set<Integer> SUPPORTED_METADATA_FIELD_IDS =
+      Sets.newHashSet(
+          MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), MetadataColumns.ROW_ID.fieldId());
   static final int NUM_SUPPORTED_STATS_PER_COLUMN = 200;
-  // the starting field ID of the stats space for data field IDs
+  static final int STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS = 9_000;
   static final int STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS = 10_000;
-  // the starting field ID of the stats space for metadata field IDs
-  static final int STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS = 2_147_000_000;
-  // support stats for only up to this amount of data field IDs
-  static final int MAX_DATA_FIELD_ID = 1_000_000;
-  static final int MAX_DATA_STATS_FIELD_ID = 200_010_000;
+  // exclusive upper bound of the stats field ID range reserved for content_stats
+  static final int STATS_SPACE_FIELD_ID_END = 200_000_000;
+  static final int MAX_DATA_STATS_FIELD_ID =
+      STATS_SPACE_FIELD_ID_END - NUM_SUPPORTED_STATS_PER_COLUMN;
+  // the max data field ID whose stats struct fits within the reserved range
+  static final int MAX_DATA_FIELD_ID =
+      (MAX_DATA_STATS_FIELD_ID - STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS)
+          / NUM_SUPPORTED_STATS_PER_COLUMN;
 
   private StatsUtil() {}
 
   public static int statsFieldIdForField(int fieldId) {
-    return fieldId >= RESERVED_FIELD_IDS_START
+    return SUPPORTED_METADATA_FIELD_IDS.contains(fieldId)
         ? statsFieldIdForReservedField(fieldId)
         : statsFieldIdForDataField(fieldId);
   }
 
   private static int statsFieldIdForDataField(int fieldId) {
-    long statsFieldId =
-        STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS
-            + (NUM_SUPPORTED_STATS_PER_COLUMN * (long) fieldId);
     if (fieldId < 0 || fieldId > MAX_DATA_FIELD_ID) {
       return -1;
     }
 
-    return (int) statsFieldId;
+    return STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS + (NUM_SUPPORTED_STATS_PER_COLUMN * fieldId);
   }
 
   private static int statsFieldIdForReservedField(int fieldId) {
-    int offset = NUM_RESERVED_FIELD_IDS - (Integer.MAX_VALUE - fieldId);
-
-    long statsFieldId =
-        STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS
-            + (NUM_SUPPORTED_STATS_PER_COLUMN * (long) offset);
-    if (statsFieldId < 0 || statsFieldId > RESERVED_FIELD_IDS_START) {
-      // ID overflows
-      return -1;
-    }
-
-    return (int) statsFieldId;
+    return STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS
+        + (NUM_SUPPORTED_STATS_PER_COLUMN * (fieldId - FIRST_SUPPORTED_METADATA_FIELD_ID));
   }
 
   public static int fieldIdForStatsField(int statsFieldId) {
-    if (statsFieldId < STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS
+    if (statsFieldId < STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS
+        || statsFieldId >= STATS_SPACE_FIELD_ID_END
         || statsFieldId % NUM_SUPPORTED_STATS_PER_COLUMN != 0) {
       return -1;
     }
 
-    return statsFieldId < STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS
-        ? fieldIdForStatsFieldFromDataField(statsFieldId)
-        : fieldIdForStatsFieldFromReservedField(statsFieldId);
+    return statsFieldId < STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS
+        ? fieldIdForStatsFieldFromReservedField(statsFieldId)
+        : fieldIdForStatsFieldFromDataField(statsFieldId);
   }
 
   private static int fieldIdForStatsFieldFromDataField(int statsFieldId) {
-    return Math.max(
-        -1,
-        (statsFieldId - STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS)
-            / NUM_SUPPORTED_STATS_PER_COLUMN);
+    return (statsFieldId - STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS)
+        / NUM_SUPPORTED_STATS_PER_COLUMN;
   }
 
   private static int fieldIdForStatsFieldFromReservedField(int statsFieldId) {
-    return Math.max(
-        -1,
-        statsFieldId
-            - NUM_RESERVED_FIELD_IDS
-            + (Integer.MAX_VALUE - statsFieldId)
-            + (statsFieldId - STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS)
-                / NUM_SUPPORTED_STATS_PER_COLUMN);
+    int fieldId =
+        (statsFieldId - STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS)
+                / NUM_SUPPORTED_STATS_PER_COLUMN
+            + FIRST_SUPPORTED_METADATA_FIELD_ID;
+    return SUPPORTED_METADATA_FIELD_IDS.contains(fieldId) ? fieldId : -1;
   }
 
   public static Types.NestedField contentStatsFor(Schema schema) {

--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -20,11 +20,13 @@ package org.apache.iceberg;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -34,11 +36,11 @@ import org.slf4j.LoggerFactory;
 
 class StatsUtil {
   private static final Logger LOG = LoggerFactory.getLogger(StatsUtil.class);
-  private static final int FIRST_SUPPORTED_METADATA_FIELD_ID =
-      MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
   static final Set<Integer> SUPPORTED_METADATA_FIELD_IDS =
-      Sets.newHashSet(
+      ImmutableSet.of(
           MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), MetadataColumns.ROW_ID.fieldId());
+  private static final int FIRST_SUPPORTED_METADATA_FIELD_ID =
+      Collections.min(SUPPORTED_METADATA_FIELD_IDS);
   static final int NUM_SUPPORTED_STATS_PER_COLUMN = 200;
   static final int STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS = 9_000;
   static final int STATS_SPACE_FIELD_ID_START_FOR_DATA_FIELDS = 10_000;

--- a/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
@@ -123,7 +123,7 @@ public class TestStatsUtil {
   }
 
   @Test
-  public void statsIdsForReservedColumns() {
+  public void statsIdsForMetadataColumns() {
     int fieldId = MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
     int statsFieldId = 9_000;
     assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);

--- a/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestStatsUtil.java
@@ -31,10 +31,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestStatsUtil {
+  // the reserved field IDs from the reserved field ID space as defined in
+  // https://iceberg.apache.org/spec/#reserved-field-ids
+  private static final int RESERVED_FIELD_IDS_START = Integer.MAX_VALUE - 200;
 
   @Test
   public void statsIdsForTableColumns() {
@@ -86,62 +90,63 @@ public class TestStatsUtil {
 
   @Test
   public void statsIdsOverflowForTableColumns() {
-    // pick 100 random IDs that are > MAX_FIELD_ID and < METADATA_SPACE_FIELD_ID_START as going over
+    // pick 100 random IDs that are > MAX_FIELD_ID and < RESERVED_FIELD_IDS_START as going over
     // the entire ID range takes too long
     int invalidFieldId = -1;
     for (int i = 0; i < 100; i++) {
       int id =
           ThreadLocalRandom.current()
-              .nextInt(
-                  StatsUtil.MAX_DATA_FIELD_ID + 1,
-                  StatsUtil.STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS);
+              .nextInt(StatsUtil.MAX_DATA_FIELD_ID + 1, RESERVED_FIELD_IDS_START);
       assertThat(StatsUtil.statsFieldIdForField(id)).as("at pos %s", id).isEqualTo(invalidFieldId);
     }
 
     assertThat(StatsUtil.fieldIdForStatsField(-1)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(0)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(200)).isEqualTo(invalidFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(5_000)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(8_600)).isEqualTo(invalidFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(10_001)).isEqualTo(invalidFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(10_201)).isEqualTo(invalidFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(10_500)).isEqualTo(invalidFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(10_900)).isEqualTo(invalidFieldId);
+
+    // stats field IDs at or above the exclusive upper bound are invalid
+    assertThat(StatsUtil.fieldIdForStatsField(StatsUtil.STATS_SPACE_FIELD_ID_END))
+        .isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(StatsUtil.STATS_SPACE_FIELD_ID_END + 200))
+        .isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(Integer.MAX_VALUE)).isEqualTo(invalidFieldId);
+
+    // field ID just past MAX_DATA_FIELD_ID is invalid
+    assertThat(StatsUtil.statsFieldIdForField(StatsUtil.MAX_DATA_FIELD_ID + 1))
+        .isEqualTo(invalidFieldId);
   }
 
   @Test
   public void statsIdsForReservedColumns() {
-    int offset = 0;
-    for (int id = StatsUtil.RESERVED_FIELD_IDS_START; id < Integer.MAX_VALUE; id++) {
-      int statsFieldId = StatsUtil.statsFieldIdForField(id);
-      int expected = StatsUtil.STATS_SPACE_FIELD_ID_START_FOR_METADATA_FIELDS + offset;
-      assertThat(statsFieldId).as("at pos %s", id).isEqualTo(expected);
-      offset = offset + StatsUtil.NUM_SUPPORTED_STATS_PER_COLUMN;
-      assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).as("at pos %s", id).isEqualTo(id);
-    }
-
-    // also verify hardcoded IDs that are mentioned in the docs
-    int fieldId = 2_147_483_447;
-    int statsFieldId = 2_147_000_000;
+    int fieldId = MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId();
+    int statsFieldId = 9_000;
     assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).isEqualTo(fieldId);
 
-    fieldId = 2_147_483_448;
-    statsFieldId = 2_147_000_200;
+    fieldId = MetadataColumns.ROW_ID.fieldId();
+    statsFieldId = 9_200;
     assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);
     assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).isEqualTo(fieldId);
 
-    fieldId = 2_147_483_541;
-    statsFieldId = 2_147_018_800;
-    assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);
-    assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).isEqualTo(fieldId);
-
-    fieldId = 2_147_483_645;
-    statsFieldId = 2_147_039_600;
-    assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);
-    assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).isEqualTo(fieldId);
-
-    fieldId = 2_147_483_646;
-    statsFieldId = 2_147_039_800;
-    assertThat(StatsUtil.statsFieldIdForField(fieldId)).isEqualTo(statsFieldId);
-    assertThat(StatsUtil.fieldIdForStatsField(statsFieldId)).isEqualTo(fieldId);
+    // reserved metadata fields with IDs below/above the reserved stats range have no stats
+    int invalidFieldId = -1;
+    assertThat(StatsUtil.fieldIdForStatsField(8_800)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(9_400)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(9_600)).isEqualTo(invalidFieldId);
+    assertThat(StatsUtil.fieldIdForStatsField(9_800)).isEqualTo(invalidFieldId);
+    assertThat(IntStream.range(RESERVED_FIELD_IDS_START, Integer.MAX_VALUE))
+        .filteredOn(id -> !StatsUtil.SUPPORTED_METADATA_FIELD_IDS.contains(id))
+        .allSatisfy(
+            id ->
+                assertThat(StatsUtil.statsFieldIdForField(id))
+                    .as("at pos %s", id)
+                    .isEqualTo(invalidFieldId));
   }
 
   @Test
@@ -150,7 +155,7 @@ public class TestStatsUtil {
     Types.NestedField floatField = required(2, "f", Types.FloatType.get());
     Types.NestedField stringField = required(4, "s", Types.StringType.get());
     Types.NestedField booleanField = required(6, "b", Types.BooleanType.get());
-    Types.NestedField uuidField = required(1_000_000, "u", Types.UUIDType.get());
+    Types.NestedField uuidField = required(StatsUtil.MAX_DATA_FIELD_ID, "u", Types.UUIDType.get());
     Schema schema = new Schema(intField, floatField, stringField, booleanField, uuidField);
     Schema expectedStatsSchema =
         new Schema(
@@ -162,7 +167,11 @@ public class TestStatsUtil {
                     optional(10400, "f", FieldStatistic.fieldStatsFor(floatField, 10400)),
                     optional(10800, "s", FieldStatistic.fieldStatsFor(stringField, 10800)),
                     optional(11200, "b", FieldStatistic.fieldStatsFor(booleanField, 11200)),
-                    optional(200010000, "u", FieldStatistic.fieldStatsFor(uuidField, 200010000)))));
+                    optional(
+                        StatsUtil.MAX_DATA_STATS_FIELD_ID,
+                        "u",
+                        FieldStatistic.fieldStatsFor(
+                            uuidField, StatsUtil.MAX_DATA_STATS_FIELD_ID)))));
     Schema statsSchema = new Schema(StatsUtil.contentStatsFor(schema));
     assertThat(statsSchema.asStruct()).isEqualTo(expectedStatsSchema.asStruct());
   }
@@ -175,7 +184,7 @@ public class TestStatsUtil {
     Types.NestedField mapKey = required(22, "key", Types.IntegerType.get());
     Types.NestedField mapValue = optional(24, "value", Types.StringType.get());
     Types.NestedField variantField = required(30, "variant", Types.VariantType.get());
-    Types.NestedField uuidField = required(100_000, "u", Types.UUIDType.get());
+    Types.NestedField uuidField = required(StatsUtil.MAX_DATA_FIELD_ID, "u", Types.UUIDType.get());
     Schema schema =
         new Schema(
             required(0, "i", Types.IntegerType.get()),
@@ -214,7 +223,11 @@ public class TestStatsUtil {
                     optional(14400, "b.key", FieldStatistic.fieldStatsFor(mapKey, 14400)),
                     optional(14800, "b.value", FieldStatistic.fieldStatsFor(mapValue, 14800)),
                     optional(16000, "variant", FieldStatistic.fieldStatsFor(variantField, 16000)),
-                    optional(20010000, "u", FieldStatistic.fieldStatsFor(uuidField, 20010000)))));
+                    optional(
+                        StatsUtil.MAX_DATA_STATS_FIELD_ID,
+                        "u",
+                        FieldStatistic.fieldStatsFor(
+                            uuidField, StatsUtil.MAX_DATA_STATS_FIELD_ID)))));
     Schema statsSchema = new Schema(StatsUtil.contentStatsFor(schema));
     assertThat(statsSchema.asStruct()).isEqualTo(expectedStatsSchema.asStruct());
   }
@@ -231,6 +244,23 @@ public class TestStatsUtil {
     assertThat(contentStats.fields().stream().map(Types.NestedField::name).toList())
         .doesNotHaveDuplicates()
         .containsExactly("a.x", "b.x");
+  }
+
+  @Test
+  public void contentStatsSkipsFieldsOutsideStatsRange() {
+    Types.NestedField validField = required(0, "i", Types.IntegerType.get());
+    Types.NestedField outOfRangeField =
+        required(StatsUtil.MAX_DATA_FIELD_ID + 1, "out_of_range", Types.IntegerType.get());
+    Schema schema = new Schema(validField, outOfRangeField);
+    Schema expectedStatsSchema =
+        new Schema(
+            optional(
+                146,
+                "content_stats",
+                Types.StructType.of(
+                    optional(10000, "i", FieldStatistic.fieldStatsFor(validField, 10000)))));
+    Schema statsSchema = new Schema(StatsUtil.contentStatsFor(schema));
+    assertThat(statsSchema.asStruct()).isEqualTo(expectedStatsSchema.asStruct());
   }
 
   @Test


### PR DESCRIPTION
This adjusts the calculations around stats field IDs for data and metadata columns and also updates the code to only support stats for the stats ID range `[10_000, 200_000_000)`.

The PR was created with the help of Claude Opus 4.7 and manually adjusted in a few places.