### PR TITLE
Core, AWS, Azure, GCP: Add per-file failure handler for bulk deletes

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/FailureCategory.java
+++ b/api/src/main/java/org/apache/iceberg/io/FailureCategory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+/**
+ * Best-effort classification of a per-file failure during bulk file operations.
+ *
+ * <p>FileIO implementations translate native cloud error codes into one of these categories so
+ * callers can make retry / alerting decisions without parsing cloud-specific errors. The
+ * categorization is advisory; callers that disagree can inspect the raw error code or cause on
+ * {@link FileFailure} and override the decision.
+ */
+public enum FailureCategory {
+  /** Authentication or authorization failure. Generally not retryable without intervention. */
+  AUTH,
+  /** Target object did not exist. Typically safe to treat as success for deletes. */
+  NOT_FOUND,
+  /** Server-side throttling or rate limiting. Retryable with backoff. */
+  THROTTLED,
+  /** Transient I/O or server error (timeouts, 5xx). Retryable. */
+  TRANSIENT,
+  /** Category could not be determined. Caller should inspect the cause. */
+  UNKNOWN;
+
+  /**
+   * Classifies an HTTP status code using semantics common to object stores.
+   *
+   * <p>FileIO implementations should prefer cloud-specific error codes where available and fall
+   * back to this mapping when only a status code is known.
+   *
+   * @param status an HTTP status code
+   * @return the matching category, or {@link #UNKNOWN} if the status has no mapping
+   */
+  public static FailureCategory fromHttpStatus(int status) {
+    if (status == 401 || status == 403) {
+      return AUTH;
+    }
+    if (status == 404) {
+      return NOT_FOUND;
+    }
+    if (status == 429) {
+      return THROTTLED;
+    }
+    if (status >= 500 && status < 600) {
+      return TRANSIENT;
+    }
+    return UNKNOWN;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/FailureHandler.java
+++ b/api/src/main/java/org/apache/iceberg/io/FailureHandler.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import org.slf4j.Logger;
+
+/**
+ * Callback invoked by {@link SupportsBulkOperations} for each per-file failure during a bulk
+ * operation.
+ *
+ * <p>FileIO implementations invoke this once per failed object with a {@link FileFailure} carrying
+ * the path, a best-effort {@link FailureCategory}, and any available raw error code / cause.
+ * Implementations of this interface decide what to do with that information (log, buffer, build a
+ * retry list, etc.) — they should not throw; any exception thrown from the handler will be
+ * swallowed and logged by the FileIO so a misbehaving handler cannot poison the bulk operation.
+ *
+ * <p><b>Thread safety:</b> implementations must be thread-safe. FileIO implementations delete
+ * objects concurrently (e.g. S3 and ADLS report failures from worker threads), so {@link
+ * #onFailure(FileFailure)} may be invoked concurrently from multiple threads for the same bulk
+ * operation. Handlers that accumulate state must guard it accordingly (e.g. with a {@code
+ * java.util.concurrent.CopyOnWriteArrayList} or other synchronization).
+ */
+@FunctionalInterface
+public interface FailureHandler {
+  /** Handler that drops every failure. */
+  FailureHandler NOOP = failure -> {};
+
+  void onFailure(FileFailure failure);
+
+  /**
+   * Invokes {@code handler} for a single failure, swallowing and logging any exception it throws.
+   *
+   * <p>This enforces the {@link FailureHandler} contract that a misbehaving handler cannot poison a
+   * bulk operation. FileIO implementations should route every per-file failure through this helper
+   * rather than calling {@link #onFailure(FileFailure)} directly.
+   *
+   * @param logger the FileIO's logger, used to report a handler that threw
+   * @param handler the handler to invoke
+   * @param failure the failure to report
+   */
+  static void safeNotify(Logger logger, FailureHandler handler, FileFailure failure) {
+    try {
+      handler.onFailure(failure);
+    } catch (RuntimeException handlerError) {
+      logger.warn(
+          "FailureHandler threw while reporting failure for {}", failure.path(), handlerError);
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/FileFailure.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileFailure.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import javax.annotation.Nullable;
+
+/**
+ * A single per-file failure reported to a {@link FailureHandler} during a bulk file operation.
+ *
+ * <p>The {@link #category()} is the FileIO's best-effort classification of the error. The {@link
+ * #rawErrorCode()} and {@link #cause()} are provided so callers that disagree with the
+ * categorization can re-classify based on the underlying evidence.
+ */
+public class FileFailure {
+  private final String path;
+  private final FailureCategory category;
+  private final String rawErrorCode;
+  private final Throwable cause;
+
+  public FileFailure(
+      String path,
+      FailureCategory category,
+      @Nullable String rawErrorCode,
+      @Nullable Throwable cause) {
+    this.path = path;
+    this.category = category;
+    this.rawErrorCode = rawErrorCode;
+    this.cause = cause;
+  }
+
+  public String path() {
+    return path;
+  }
+
+  public FailureCategory category() {
+    return category;
+  }
+
+  /** Cloud-native error code (e.g. S3 "AccessDenied"), or null if unavailable. */
+  @Nullable
+  public String rawErrorCode() {
+    return rawErrorCode;
+  }
+
+  /** Underlying exception, or null when the failure came from a partial-batch error response. */
+  @Nullable
+  public Throwable cause() {
+    return cause;
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
+++ b/api/src/main/java/org/apache/iceberg/io/SupportsBulkOperations.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.io;
 
+import javax.annotation.Nullable;
+
 public interface SupportsBulkOperations extends FileIO {
   /**
    * Delete the files at the given paths.
@@ -26,4 +28,32 @@ public interface SupportsBulkOperations extends FileIO {
    * @throws BulkDeletionFailureException in case of failure to delete at least 1 file
    */
   void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException;
+
+  /**
+   * Delete the files at the given paths, invoking {@code failureHandler} for each per-file failure.
+   *
+   * <p>The handler receives a {@link FileFailure} for every object that failed to delete, allowing
+   * callers to inspect categorized failures (e.g. for retry decisions) without parsing
+   * cloud-specific errors. The default implementation ignores the handler and delegates to {@link
+   * #deleteFiles(Iterable)}; FileIO implementations should override to invoke the handler.
+   *
+   * <p>Deleting an object that does not exist is the desired end state for a delete and is treated
+   * as success: such an object is neither reported to the handler nor counted toward {@link
+   * BulkDeletionFailureException}, regardless of whether the underlying store signals the missing
+   * object with a success code or an exception. The handler therefore only sees objects that may
+   * still exist (e.g. {@link FailureCategory#AUTH}, {@link FailureCategory#THROTTLED}, {@link
+   * FailureCategory#TRANSIENT}).
+   *
+   * <p>The handler may be invoked concurrently from multiple threads and must be thread-safe; see
+   * {@link FailureHandler}.
+   *
+   * @param pathsToDelete The paths to delete
+   * @param failureHandler Callback invoked once per failed object; a null handler is treated as
+   *     {@link FailureHandler#NOOP}
+   * @throws BulkDeletionFailureException in case of failure to delete at least 1 file
+   */
+  default void deleteFiles(Iterable<String> pathsToDelete, @Nullable FailureHandler failureHandler)
+      throws BulkDeletionFailureException {
+    deleteFiles(pathsToDelete);
+  }
 }

--- a/api/src/test/java/org/apache/iceberg/io/CapturingFailureHandler.java
+++ b/api/src/test/java/org/apache/iceberg/io/CapturingFailureHandler.java
@@ -1,0 +1,58 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Test {@link FailureHandler} that aggregates every reported {@link FileFailure} for inspection.
+ *
+ * <p>Used by FileIO bulk-delete tests to assert that the expected paths and categories were
+ * reported. Thread-safe because some FileIO implementations report failures from worker threads.
+ */
+public class CapturingFailureHandler implements FailureHandler {
+  // Thread-safe: S3 and ADLS report failures from worker threads.
+  private final List<FileFailure> failures = new CopyOnWriteArrayList<>();
+
+  @Override
+  public void onFailure(FileFailure failure) {
+    failures.add(failure);
+  }
+
+  public List<FileFailure> failures() {
+    return Lists.newArrayList(failures);
+  }
+
+  public List<String> paths() {
+    return failures().stream().map(FileFailure::path).collect(Collectors.toList());
+  }
+
+  public Map<FailureCategory, Long> categoryCounts() {
+    return failures().stream()
+        .collect(Collectors.groupingBy(FileFailure::category, Collectors.counting()));
+  }
+
+  public int size() {
+    return failures.size();
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/io/TestFailureCategory.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestFailureCategory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestFailureCategory {
+
+  @ParameterizedTest
+  @CsvSource({
+    "401,AUTH",
+    "403,AUTH",
+    "404,NOT_FOUND",
+    "429,THROTTLED",
+    "500,TRANSIENT",
+    "503,TRANSIENT",
+    "599,TRANSIENT"
+  })
+  public void mapsKnownStatusCodes(int status, FailureCategory expected) {
+    assertThat(FailureCategory.fromHttpStatus(status)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({"200", "400", "418", "499", "600", "0", "-1"})
+  public void unmappedStatusCodesAreUnknown(int status) {
+    assertThat(FailureCategory.fromHttpStatus(status)).isEqualTo(FailureCategory.UNKNOWN);
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/io/TestFailureHandler.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestFailureHandler.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.io;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+
+public class TestFailureHandler {
+
+  private static final FileFailure FAILURE =
+      new FileFailure("s3://b/k", FailureCategory.UNKNOWN, null, null);
+
+  @Test
+  public void noopDropsFailures() {
+    assertThatCode(() -> FailureHandler.NOOP.onFailure(FAILURE)).doesNotThrowAnyException();
+  }
+
+  @Test
+  public void safeNotifyDeliversToHandler() {
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    FailureHandler.safeNotify(LoggerFactory.getLogger(TestFailureHandler.class), handler, FAILURE);
+
+    assertThat(handler.failures()).containsExactly(FAILURE);
+  }
+
+  @Test
+  public void safeNotifySwallowsHandlerException() {
+    FailureHandler throwing =
+        failure -> {
+          throw new RuntimeException("handler blew up");
+        };
+
+    // The contract: a misbehaving handler must not poison the bulk operation.
+    assertThatCode(
+            () ->
+                FailureHandler.safeNotify(
+                    LoggerFactory.getLogger(TestFailureHandler.class), throwing, FAILURE))
+        .doesNotThrowAnyException();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3ErrorInterpreter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3ErrorInterpreter.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import javax.annotation.Nullable;
+import org.apache.iceberg.io.FailureCategory;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+/**
+ * Maps S3 partial-batch errors and SDK exceptions to a {@link FailureCategory}.
+ *
+ * <p>This is the cloud-specific half of the bulk-delete failure reporting contract: it converts
+ * native S3 error codes into the cloud-agnostic categories that callers consume via {@code
+ * FailureHandler}.
+ *
+ * <p>The {@code categorize(Throwable)} overload inspects the throwable directly and does not walk
+ * the cause chain. Callers that wrap SDK exceptions (e.g. via a custom client supplier or async
+ * client returning {@code CompletionException}) should unwrap to the underlying SDK exception
+ * before calling.
+ */
+final class S3ErrorInterpreter {
+  private S3ErrorInterpreter() {}
+
+  /** Categorize a per-object error from a {@code DeleteObjects} response. */
+  static FailureCategory categorize(@Nullable S3Error error) {
+    if (error == null || error.code() == null) {
+      return FailureCategory.UNKNOWN;
+    }
+    return categorizeByCode(error.code());
+  }
+
+  /** Categorize a thrown exception from a bulk-delete request. */
+  static FailureCategory categorize(Throwable throwable) {
+    if (throwable instanceof S3Exception) {
+      S3Exception s3e = (S3Exception) throwable;
+      String code = s3e.awsErrorDetails() != null ? s3e.awsErrorDetails().errorCode() : null;
+      if (code != null) {
+        return categorizeByCode(code);
+      }
+      return FailureCategory.fromHttpStatus(s3e.statusCode());
+    }
+    if (throwable instanceof AwsServiceException ase) {
+      if (ase.isThrottlingException()) {
+        return FailureCategory.THROTTLED;
+      }
+      return FailureCategory.fromHttpStatus(ase.statusCode());
+    }
+    if (throwable instanceof SdkClientException) {
+      // Client-side: network timeouts, connection resets, DNS, etc.
+      return FailureCategory.TRANSIENT;
+    }
+    return FailureCategory.UNKNOWN;
+  }
+
+  /** Cloud-native error code for a thrown exception, or null if unavailable. */
+  @Nullable
+  static String rawErrorCode(Throwable throwable) {
+    if (throwable instanceof S3Exception) {
+      S3Exception s3e = (S3Exception) throwable;
+      return s3e.awsErrorDetails() != null ? s3e.awsErrorDetails().errorCode() : null;
+    }
+    return null;
+  }
+
+  /**
+   * Maps a curated subset of S3 error codes to a {@link FailureCategory}.
+   *
+   * <p>Error codes are free-form strings in the AWS SDK (no enum). The authoritative list of codes
+   * is the S3 API error reference; unrecognized codes fall through to {@link
+   * FailureCategory#UNKNOWN} and are then classified by HTTP status.
+   *
+   * @see <a href="https://docs.aws.amazon.com/AmazonS3/latest/API/ErrorResponses.html">S3 Error
+   *     Responses</a>
+   */
+  private static FailureCategory categorizeByCode(String code) {
+    return switch (code) {
+      case "AccessDenied",
+              "AllAccessDisabled",
+              "InvalidAccessKeyId",
+              "SignatureDoesNotMatch",
+              "TokenRefreshRequired",
+              "ExpiredToken",
+              "InvalidToken" ->
+          FailureCategory.AUTH;
+      case "NoSuchKey", "NoSuchBucket", "NoSuchVersion" -> FailureCategory.NOT_FOUND;
+      case "SlowDown",
+              "RequestLimitExceeded",
+              "TooManyRequests",
+              "Throttling",
+              "ThrottlingException" ->
+          FailureCategory.THROTTLED;
+      case "InternalError", "ServiceUnavailable", "RequestTimeout", "RequestTimeTooSkewed" ->
+          FailureCategory.TRANSIENT;
+      default -> FailureCategory.UNKNOWN;
+    };
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -41,6 +41,9 @@ import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.CredentialSupplier;
 import org.apache.iceberg.io.DelegateFileIO;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FailureHandler;
+import org.apache.iceberg.io.FileFailure;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -200,6 +203,13 @@ public class S3FileIO
    */
   @Override
   public void deleteFiles(Iterable<String> paths) throws BulkDeletionFailureException {
+    deleteFiles(paths, FailureHandler.NOOP);
+  }
+
+  @Override
+  public void deleteFiles(Iterable<String> paths, FailureHandler failureHandler)
+      throws BulkDeletionFailureException {
+    FailureHandler handler = failureHandler != null ? failureHandler : FailureHandler.NOOP;
     S3FileIOProperties s3FileIOProperties = clientForStoragePath(ROOT_PREFIX).s3FileIOProperties();
     if (s3FileIOProperties.deleteTags() != null && !s3FileIOProperties.deleteTags().isEmpty()) {
       Tasks.foreach(paths)
@@ -232,7 +242,7 @@ public class S3FileIO
         if (bucketToObjects.get(bucket).size() == client.s3FileIOProperties().deleteBatchSize()) {
           Set<String> keys = Sets.newHashSet(bucketToObjects.get(bucket));
           Future<List<String>> deletionTask =
-              executorService().submit(() -> deleteBatch(client, bucket, keys));
+              executorService().submit(() -> deleteBatch(client, bucket, keys, handler));
           deletionTasks.add(deletionTask);
           bucketToObjects.removeAll(bucket);
         }
@@ -245,7 +255,9 @@ public class S3FileIO
         Collection<String> keys = bucketToObjectsEntry.getValue();
         Future<List<String>> deletionTask =
             executorService()
-                .submit(() -> deleteBatch(clientForStoragePath("s3://" + bucket), bucket, keys));
+                .submit(
+                    () ->
+                        deleteBatch(clientForStoragePath("s3://" + bucket), bucket, keys, handler));
         deletionTasks.add(deletionTask);
       }
 
@@ -297,7 +309,10 @@ public class S3FileIO
   }
 
   private List<String> deleteBatch(
-      PrefixedS3Client client, String bucket, Collection<String> keysToDelete) {
+      PrefixedS3Client client,
+      String bucket,
+      Collection<String> keysToDelete,
+      FailureHandler handler) {
     List<ObjectIdentifier> objectIds =
         keysToDelete.stream()
             .map(key -> ObjectIdentifier.builder().key(key).build())
@@ -311,19 +326,32 @@ public class S3FileIO
     try {
       DeleteObjectsResponse response = client.s3().deleteObjects(request);
       if (response.hasErrors()) {
-        failures.addAll(
-            response.errors().stream()
-                .map(error -> String.format("s3://%s/%s", request.bucket(), error.key()))
-                .collect(Collectors.toList()));
+        response
+            .errors()
+            .forEach(
+                error -> {
+                  String path = s3Path(request.bucket(), error.key());
+                  FailureCategory category = S3ErrorInterpreter.categorize(error);
+                  FailureHandler.safeNotify(
+                      LOG, handler, new FileFailure(path, category, error.code(), null));
+                  failures.add(path);
+                });
       }
     } catch (Exception e) {
       LOG.warn("Encountered failure when deleting batch", e);
-      failures.addAll(
-          request.delete().objects().stream()
-              .map(obj -> String.format("s3://%s/%s", request.bucket(), obj.key()))
-              .collect(Collectors.toList()));
+      FailureCategory category = S3ErrorInterpreter.categorize(e);
+      String rawCode = S3ErrorInterpreter.rawErrorCode(e);
+      for (ObjectIdentifier obj : request.delete().objects()) {
+        String path = s3Path(request.bucket(), obj.key());
+        FailureHandler.safeNotify(LOG, handler, new FileFailure(path, category, rawCode, e));
+        failures.add(path);
+      }
     }
     return failures;
+  }
+
+  private static String s3Path(String bucket, String key) {
+    return String.format("s3://%s/%s", bucket, key);
   }
 
   @Override

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3ErrorInterpreter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3ErrorInterpreter.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.apache.iceberg.io.FailureCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class TestS3ErrorInterpreter {
+
+  @ParameterizedTest
+  @CsvSource({
+    "AccessDenied,AUTH",
+    "AllAccessDisabled,AUTH",
+    "InvalidAccessKeyId,AUTH",
+    "SignatureDoesNotMatch,AUTH",
+    "TokenRefreshRequired,AUTH",
+    "ExpiredToken,AUTH",
+    "InvalidToken,AUTH",
+    "NoSuchKey,NOT_FOUND",
+    "NoSuchBucket,NOT_FOUND",
+    "NoSuchVersion,NOT_FOUND",
+    "SlowDown,THROTTLED",
+    "RequestLimitExceeded,THROTTLED",
+    "TooManyRequests,THROTTLED",
+    "Throttling,THROTTLED",
+    "ThrottlingException,THROTTLED",
+    "InternalError,TRANSIENT",
+    "ServiceUnavailable,TRANSIENT",
+    "RequestTimeout,TRANSIENT",
+    "RequestTimeTooSkewed,TRANSIENT",
+    "SomeUnknownCode,UNKNOWN"
+  })
+  public void categorizesS3ErrorByCode(String code, FailureCategory expected) {
+    S3Error error = S3Error.builder().code(code).key("k").build();
+    assertThat(S3ErrorInterpreter.categorize(error)).isEqualTo(expected);
+  }
+
+  @Test
+  public void s3ErrorWithNullCodeIsUnknown() {
+    assertThat(S3ErrorInterpreter.categorize((S3Error) null)).isEqualTo(FailureCategory.UNKNOWN);
+    assertThat(S3ErrorInterpreter.categorize(S3Error.builder().key("k").build()))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "AccessDenied,AUTH",
+    "NoSuchKey,NOT_FOUND",
+    "SlowDown,THROTTLED",
+    "InternalError,TRANSIENT"
+  })
+  public void categorizesS3ExceptionByErrorCode(String code, FailureCategory expected) {
+    S3Exception ex =
+        (S3Exception)
+            S3Exception.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode(code).build())
+                .build();
+    assertThat(S3ErrorInterpreter.categorize((Throwable) ex)).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "401,AUTH",
+    "403,AUTH",
+    "404,NOT_FOUND",
+    "429,THROTTLED",
+    "500,TRANSIENT",
+    "503,TRANSIENT",
+    "418,UNKNOWN"
+  })
+  public void s3ExceptionWithoutCodeFallsBackToStatus(int status, FailureCategory expected) {
+    S3Exception ex = (S3Exception) S3Exception.builder().statusCode(status).build();
+    assertThat(S3ErrorInterpreter.categorize((Throwable) ex)).isEqualTo(expected);
+  }
+
+  @Test
+  public void awsThrottlingExceptionMapsToThrottled() {
+    AwsServiceException throttled =
+        AwsServiceException.builder()
+            .awsErrorDetails(AwsErrorDetails.builder().errorCode("ThrottlingException").build())
+            .statusCode(400)
+            .build();
+    assertThat(throttled.isThrottlingException()).isTrue();
+    assertThat(S3ErrorInterpreter.categorize((Throwable) throttled))
+        .isEqualTo(FailureCategory.THROTTLED);
+  }
+
+  @Test
+  public void awsServiceExceptionFallsBackToStatus() {
+    AwsServiceException ex = AwsServiceException.builder().statusCode(503).build();
+    assertThat(S3ErrorInterpreter.categorize((Throwable) ex)).isEqualTo(FailureCategory.TRANSIENT);
+  }
+
+  @Test
+  public void sdkClientExceptionIsTransient() {
+    SdkClientException ex = SdkClientException.builder().message("connection reset").build();
+    assertThat(S3ErrorInterpreter.categorize((Throwable) ex)).isEqualTo(FailureCategory.TRANSIENT);
+  }
+
+  @Test
+  public void unrelatedThrowableIsUnknown() {
+    assertThat(S3ErrorInterpreter.categorize(new IOException("boom")))
+        .isEqualTo(FailureCategory.UNKNOWN);
+    assertThat(S3ErrorInterpreter.categorize(new RuntimeException("boom")))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOFailureHandler.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOFailureHandler.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.s3;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CapturingFailureHandler;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FileFailure;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.awscore.exception.AwsErrorDetails;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectsResponse;
+import software.amazon.awssdk.services.s3.model.S3Error;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+
+public class TestS3FileIOFailureHandler {
+
+  private S3FileIO io(S3Client client) {
+    return new S3FileIO(() -> client);
+  }
+
+  @Test
+  public void singleFailureFromS3Error() {
+    S3Client client = mock(S3Client.class);
+    DeleteObjectsResponse response =
+        DeleteObjectsResponse.builder()
+            .errors(S3Error.builder().key("k1").code("AccessDenied").message("nope").build())
+            .build();
+    when(client.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(response);
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = io(client)) {
+      assertThatThrownBy(() -> fileIO.deleteFiles(List.of("s3://b/k1"), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.failures()).hasSize(1);
+    FileFailure failure = handler.failures().get(0);
+    assertThat(failure.path()).isEqualTo("s3://b/k1");
+    assertThat(failure.category()).isEqualTo(FailureCategory.AUTH);
+    assertThat(failure.rawErrorCode()).isEqualTo("AccessDenied");
+    assertThat(failure.cause()).isNull();
+  }
+
+  @Test
+  public void multipleFailuresFromS3Errors() {
+    S3Client client = mock(S3Client.class);
+    DeleteObjectsResponse response =
+        DeleteObjectsResponse.builder()
+            .errors(
+                S3Error.builder().key("k1").code("NoSuchKey").build(),
+                S3Error.builder().key("k2").code("SlowDown").build(),
+                S3Error.builder().key("k3").code("InternalError").build())
+            .build();
+    when(client.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(response);
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = io(client)) {
+      assertThatThrownBy(
+              () -> fileIO.deleteFiles(List.of("s3://b/k1", "s3://b/k2", "s3://b/k3"), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactlyInAnyOrder("s3://b/k1", "s3://b/k2", "s3://b/k3");
+    assertThat(handler.categoryCounts())
+        .containsEntry(FailureCategory.NOT_FOUND, 1L)
+        .containsEntry(FailureCategory.THROTTLED, 1L)
+        .containsEntry(FailureCategory.TRANSIENT, 1L);
+  }
+
+  @Test
+  public void exceptionThrownAppliesToEveryKeyInBatch() {
+    S3Client client = mock(S3Client.class);
+    S3Exception thrown =
+        (S3Exception)
+            S3Exception.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode("SlowDown").build())
+                .statusCode(503)
+                .build();
+    when(client.deleteObjects(any(DeleteObjectsRequest.class))).thenThrow(thrown);
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = io(client)) {
+      assertThatThrownBy(() -> fileIO.deleteFiles(List.of("s3://b/k1", "s3://b/k2"), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactlyInAnyOrder("s3://b/k1", "s3://b/k2");
+    assertThat(handler.failures())
+        .allSatisfy(
+            f -> {
+              assertThat(f.category()).isEqualTo(FailureCategory.THROTTLED);
+              assertThat(f.rawErrorCode()).isEqualTo("SlowDown");
+              assertThat(f.cause()).isSameAs(thrown);
+            });
+  }
+
+  @Test
+  public void noFailuresWhenResponseIsClean() {
+    S3Client client = mock(S3Client.class);
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = io(client)) {
+      fileIO.deleteFiles(List.of("s3://b/k1", "s3://b/k2"), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+
+  @Test
+  public void mixedSuccessAndFailureOnlyReportsFailedKey() {
+    S3Client client = mock(S3Client.class);
+    // Single batch: only k2 comes back as an error; k1 and k3 succeeded.
+    DeleteObjectsResponse response =
+        DeleteObjectsResponse.builder()
+            .errors(S3Error.builder().key("k2").code("AccessDenied").build())
+            .build();
+    when(client.deleteObjects(any(DeleteObjectsRequest.class))).thenReturn(response);
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = io(client)) {
+      assertThatThrownBy(
+              () -> fileIO.deleteFiles(List.of("s3://b/k1", "s3://b/k2", "s3://b/k3"), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactly("s3://b/k2");
+    FileFailure failure = handler.failures().get(0);
+    assertThat(failure.category()).isEqualTo(FailureCategory.AUTH);
+    assertThat(failure.rawErrorCode()).isEqualTo("AccessDenied");
+  }
+
+  @Test
+  public void failedBatchDoesNotPreventRemainingBatches() {
+    S3Client client = mock(S3Client.class);
+    S3Exception thrown =
+        (S3Exception)
+            S3Exception.builder()
+                .awsErrorDetails(AwsErrorDetails.builder().errorCode("SlowDown").build())
+                .statusCode(503)
+                .build();
+    // Batch size 1 -> two single-key batches. One batch's request throws; the other returns
+    // clean. Both batches must be attempted, and only the failing one is reported.
+    when(client.deleteObjects(any(DeleteObjectsRequest.class)))
+        .thenThrow(thrown)
+        .thenReturn(DeleteObjectsResponse.builder().build());
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (S3FileIO fileIO = new S3FileIO(() -> client)) {
+      fileIO.initialize(Map.of(S3FileIOProperties.DELETE_BATCH_SIZE, "1"));
+      assertThatThrownBy(() -> fileIO.deleteFiles(List.of("s3://b/k1", "s3://b/k2"), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    // Both batches were attempted even though one threw.
+    verify(client, times(2)).deleteObjects(any(DeleteObjectsRequest.class));
+    assertThat(handler.failures()).hasSize(1);
+    FileFailure failure = handler.failures().get(0);
+    assertThat(failure.path()).isIn("s3://b/k1", "s3://b/k2");
+    assertThat(failure.category()).isEqualTo(FailureCategory.THROTTLED);
+    assertThat(failure.rawErrorCode()).isEqualTo("SlowDown");
+    assertThat(failure.cause()).isSameAs(thrown);
+  }
+}

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSErrorInterpreter.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSErrorInterpreter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure.adlsv2;
+
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import java.io.IOException;
+import org.apache.iceberg.io.FailureCategory;
+
+/**
+ * Maps ADLS Gen2 / Blob storage exceptions to a {@link FailureCategory}.
+ *
+ * <p>The throwable is inspected directly; the cause chain is not walked. Callers that wrap SDK
+ * exceptions (e.g. via a custom client supplier) should unwrap before calling.
+ */
+final class ADLSErrorInterpreter {
+  private ADLSErrorInterpreter() {}
+
+  static FailureCategory categorize(Throwable throwable) {
+    if (throwable instanceof DataLakeStorageException) {
+      DataLakeStorageException dse = (DataLakeStorageException) throwable;
+      String code = dse.getErrorCode();
+      FailureCategory byCode = code != null ? categorizeByCode(code) : FailureCategory.UNKNOWN;
+      if (byCode != FailureCategory.UNKNOWN) {
+        return byCode;
+      }
+      return FailureCategory.fromHttpStatus(dse.getStatusCode());
+    }
+    if (throwable instanceof IOException) {
+      return FailureCategory.TRANSIENT;
+    }
+    return FailureCategory.UNKNOWN;
+  }
+
+  static String rawErrorCode(Throwable throwable) {
+    if (throwable instanceof DataLakeStorageException) {
+      return ((DataLakeStorageException) throwable).getErrorCode();
+    }
+    return null;
+  }
+
+  /**
+   * Maps a curated subset of ADLS Gen2 / Blob storage error codes to a {@link FailureCategory}.
+   *
+   * <p>Error codes are free-form strings ({@code DataLakeStorageException.getErrorCode()}); the
+   * datalake SDK ships no error-code enum. Unrecognized codes fall through to {@link
+   * FailureCategory#UNKNOWN} and are then classified by HTTP status.
+   *
+   * @see <a
+   *     href="https://learn.microsoft.com/rest/api/storageservices/datalakestorageerrorcodes">Data
+   *     Lake Storage error codes</a>
+   * @see <a
+   *     href="https://learn.microsoft.com/rest/api/storageservices/common-rest-api-error-codes">Common
+   *     REST API error codes</a>
+   */
+  private static FailureCategory categorizeByCode(String code) {
+    return switch (code) {
+      case "AuthenticationFailed",
+              "AuthorizationFailure",
+              "AuthorizationPermissionMismatch",
+              "InsufficientAccountPermissions",
+              "InvalidAuthenticationInfo",
+              "AccountIsDisabled" ->
+          FailureCategory.AUTH;
+      case "PathNotFound",
+              "BlobNotFound",
+              "ContainerNotFound",
+              "FilesystemNotFound",
+              "ResourceNotFound" ->
+          FailureCategory.NOT_FOUND;
+      case "ServerBusy", "TooManyRequests", "OperationTimedOut" -> FailureCategory.THROTTLED;
+      case "InternalError", "ServiceUnavailable" -> FailureCategory.TRANSIENT;
+      default -> FailureCategory.UNKNOWN;
+    };
+  }
+}

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -112,10 +112,14 @@ public class ADLSFileIO implements DelegateFileIO {
     // and other FileIO providers ignore failure.  Log the failure for
     // now as it is not a required operation for Iceberg.
     try {
-      fileClient(path).delete();
+      deleteFileThrowing(path);
     } catch (RuntimeException e) {
       LOG.warn("Failed to delete path: {}", path, e);
     }
+  }
+
+  private void deleteFileThrowing(String path) {
+    fileClient(path).delete();
   }
 
   @Override
@@ -202,10 +206,16 @@ public class ADLSFileIO implements DelegateFileIO {
         .suppressFailureWhenFinished()
         .onFailure(
             (file, exc) -> {
+              if (exc instanceof DataLakeStorageException dse && dse.getStatusCode() == 404) {
+                // The object is already gone, which is the desired end state for a delete. Other
+                // FileIO implementations skip the delete if nothing is found, so mimic that here
+                // rather than counting it as a failure.
+                return;
+              }
               failureCount.incrementAndGet();
               LOG.warn("Failed to delete file {}", file, exc);
             })
-        .run(this::deleteFile);
+        .run(this::deleteFileThrowing);
 
     if (failureCount.get() > 0) {
       throw new BulkDeletionFailureException(failureCount.get());

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -33,6 +33,9 @@ import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.DelegateFileIO;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FailureHandler;
+import org.apache.iceberg.io.FileFailure;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -196,9 +199,16 @@ public class ADLSFileIO implements DelegateFileIO {
 
   @Override
   public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
+    deleteFiles(pathsToDelete, FailureHandler.NOOP);
+  }
+
+  @Override
+  public void deleteFiles(Iterable<String> pathsToDelete, FailureHandler failureHandler)
+      throws BulkDeletionFailureException {
     // Azure batch operations are not supported in all cases, e.g. with a user
     // delegation SAS token, so avoid using it for now
 
+    FailureHandler handler = failureHandler != null ? failureHandler : FailureHandler.NOOP;
     AtomicInteger failureCount = new AtomicInteger();
     Tasks.foreach(pathsToDelete)
         .executeWith(ThreadPools.getWorkerPool())
@@ -206,14 +216,17 @@ public class ADLSFileIO implements DelegateFileIO {
         .suppressFailureWhenFinished()
         .onFailure(
             (file, exc) -> {
-              if (exc instanceof DataLakeStorageException dse && dse.getStatusCode() == 404) {
-                // The object is already gone, which is the desired end state for a delete. Other
-                // FileIO implementations skip the delete if nothing is found, so mimic that here
-                // rather than counting it as a failure.
+              FailureCategory category = ADLSErrorInterpreter.categorize(exc);
+              if (category == FailureCategory.NOT_FOUND) {
+                // The object is already gone, which is the desired end state for a delete. Treat
+                // it as success: do not count it as a failure or report it to the handler.
                 return;
               }
               failureCount.incrementAndGet();
               LOG.warn("Failed to delete file {}", file, exc);
+              String rawCode = ADLSErrorInterpreter.rawErrorCode(exc);
+              FailureHandler.safeNotify(
+                  LOG, handler, new FileFailure(file, category, rawCode, exc));
             })
         .run(this::deleteFileThrowing);
 

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSErrorInterpreter.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSErrorInterpreter.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure.adlsv2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import java.io.IOException;
+import org.apache.iceberg.io.FailureCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestADLSErrorInterpreter {
+
+  private static final String ERROR_CODE_HEADER = "x-ms-error-code";
+
+  private static DataLakeStorageException exception(String errorCode, int statusCode) {
+    HttpHeaders headers = new HttpHeaders();
+    if (errorCode != null) {
+      headers.set(ERROR_CODE_HEADER, errorCode);
+    }
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getHeaders()).thenReturn(headers);
+    when(response.getStatusCode()).thenReturn(statusCode);
+    return new DataLakeStorageException("test", response, null);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "AuthenticationFailed,AUTH",
+    "AuthorizationFailure,AUTH",
+    "AuthorizationPermissionMismatch,AUTH",
+    "InsufficientAccountPermissions,AUTH",
+    "InvalidAuthenticationInfo,AUTH",
+    "AccountIsDisabled,AUTH",
+    "PathNotFound,NOT_FOUND",
+    "BlobNotFound,NOT_FOUND",
+    "ContainerNotFound,NOT_FOUND",
+    "FilesystemNotFound,NOT_FOUND",
+    "ResourceNotFound,NOT_FOUND",
+    "ServerBusy,THROTTLED",
+    "TooManyRequests,THROTTLED",
+    "OperationTimedOut,THROTTLED",
+    "InternalError,TRANSIENT",
+    "ServiceUnavailable,TRANSIENT"
+  })
+  public void categorizesByErrorCode(String code, FailureCategory expected) {
+    assertThat(ADLSErrorInterpreter.categorize(exception(code, 200))).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "401,AUTH",
+    "403,AUTH",
+    "404,NOT_FOUND",
+    "429,THROTTLED",
+    "500,TRANSIENT",
+    "503,TRANSIENT",
+    "418,UNKNOWN"
+  })
+  public void fallsBackToStatusWhenErrorCodeMissing(int status, FailureCategory expected) {
+    assertThat(ADLSErrorInterpreter.categorize(exception(null, status))).isEqualTo(expected);
+  }
+
+  @Test
+  public void unknownErrorCodeFallsBackToStatus() {
+    assertThat(ADLSErrorInterpreter.categorize(exception("MysteryCode", 503)))
+        .isEqualTo(FailureCategory.TRANSIENT);
+    assertThat(ADLSErrorInterpreter.categorize(exception("MysteryCode", 418)))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+
+  @Test
+  public void ioExceptionIsTransient() {
+    assertThat(ADLSErrorInterpreter.categorize(new IOException("connection reset")))
+        .isEqualTo(FailureCategory.TRANSIENT);
+  }
+
+  @Test
+  public void unrelatedThrowableIsUnknown() {
+    assertThat(ADLSErrorInterpreter.categorize(new RuntimeException("boom")))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+
+  @Test
+  public void rawErrorCodeReturnsCodeForDataLakeException() {
+    assertThat(ADLSErrorInterpreter.rawErrorCode(exception("PathNotFound", 404)))
+        .isEqualTo("PathNotFound");
+    assertThat(ADLSErrorInterpreter.rawErrorCode(new IOException("x"))).isNull();
+  }
+}

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOFailureHandler.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIOFailureHandler.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure.adlsv2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.file.datalake.DataLakeFileClient;
+import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.models.DataLakeStorageException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CapturingFailureHandler;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FileFailure;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.SerializableFunction;
+import org.junit.jupiter.api.Test;
+
+public class TestADLSFileIOFailureHandler {
+
+  private static final String ACCOUNT = "account.dfs.core.windows.net";
+  private static final String CONTAINER = "container";
+
+  private static String path(String key) {
+    return "abfs://" + CONTAINER + "@" + ACCOUNT + "/" + key;
+  }
+
+  private static DataLakeStorageException storageException(String errorCode, int statusCode) {
+    HttpHeaders headers = new HttpHeaders();
+    if (errorCode != null) {
+      headers.set("x-ms-error-code", errorCode);
+    }
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getHeaders()).thenReturn(headers);
+    when(response.getStatusCode()).thenReturn(statusCode);
+    return new DataLakeStorageException("test", response, null);
+  }
+
+  /** Builds an ADLSFileIO whose file-system client routes per-key delete calls per the map. */
+  private ADLSFileIO ioThrowingPerKey(Map<String, DataLakeStorageException> errorsByKey) {
+    DataLakeFileSystemClient fsClient = mock(DataLakeFileSystemClient.class);
+    when(fsClient.getFileClient(anyString()))
+        .thenAnswer(
+            invocation -> {
+              String key = invocation.getArgument(0);
+              DataLakeFileClient fileClient = mock(DataLakeFileClient.class);
+              DataLakeStorageException ex = errorsByKey.get(key);
+              if (ex != null) {
+                doThrow(ex).when(fileClient).delete();
+              }
+              return fileClient;
+            });
+    SerializableFunction<ADLSLocation, DataLakeFileSystemClient> supplier = loc -> fsClient;
+    return new ADLSFileIO(supplier);
+  }
+
+  @Test
+  public void singleFailure() {
+    Map<String, DataLakeStorageException> errors = Maps.newHashMap();
+    errors.put("k1", storageException("AuthenticationFailed", 401));
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    try (ADLSFileIO fileIO = ioThrowingPerKey(errors)) {
+      assertThatThrownBy(() -> fileIO.deleteFiles(List.of(path("k1")), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.failures()).hasSize(1);
+    FileFailure failure = handler.failures().get(0);
+    assertThat(failure.path()).isEqualTo(path("k1"));
+    assertThat(failure.category()).isEqualTo(FailureCategory.AUTH);
+    assertThat(failure.rawErrorCode()).isEqualTo("AuthenticationFailed");
+    assertThat(failure.cause()).isInstanceOf(DataLakeStorageException.class);
+  }
+
+  @Test
+  public void missingObjectIsTreatedAsSuccess() {
+    Map<String, DataLakeStorageException> errors = Maps.newHashMap();
+    // Azure raises PathNotFound when the object is already gone. For a delete that is the desired
+    // end state, so it is not reported to the handler and does not fail the bulk delete.
+    errors.put("k1", storageException("PathNotFound", 404));
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    try (ADLSFileIO fileIO = ioThrowingPerKey(errors)) {
+      fileIO.deleteFiles(List.of(path("k1")), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+
+  @Test
+  public void multipleFailures() {
+    Map<String, DataLakeStorageException> errors = Maps.newHashMap();
+    errors.put("k1", storageException("AuthenticationFailed", 401));
+    errors.put("k2", storageException("ServerBusy", 503));
+    errors.put("k3", storageException("InternalError", 500));
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    try (ADLSFileIO fileIO = ioThrowingPerKey(errors)) {
+      assertThatThrownBy(
+              () -> fileIO.deleteFiles(List.of(path("k1"), path("k2"), path("k3")), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactlyInAnyOrder(path("k1"), path("k2"), path("k3"));
+    assertThat(handler.categoryCounts())
+        .containsEntry(FailureCategory.AUTH, 1L)
+        .containsEntry(FailureCategory.THROTTLED, 1L)
+        .containsEntry(FailureCategory.TRANSIENT, 1L);
+  }
+
+  @Test
+  public void mixedSuccessAndFailureOnlyReportsFailures() {
+    Map<String, DataLakeStorageException> errors = Maps.newHashMap();
+    errors.put("k2", storageException("AuthenticationFailed", 401));
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    try (ADLSFileIO fileIO = ioThrowingPerKey(errors)) {
+      assertThatThrownBy(
+              () -> fileIO.deleteFiles(List.of(path("k1"), path("k2"), path("k3")), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactly(path("k2"));
+  }
+
+  @Test
+  public void noFailuresMeansHandlerNotCalled() {
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+
+    try (ADLSFileIO fileIO = ioThrowingPerKey(Maps.newHashMap())) {
+      fileIO.deleteFiles(List.of(path("k1"), path("k2")), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSErrorInterpreter.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSErrorInterpreter.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import com.google.cloud.storage.StorageException;
+import java.io.IOException;
+import org.apache.iceberg.io.FailureCategory;
+
+/**
+ * Maps Google Cloud Storage exceptions to a {@link FailureCategory}.
+ *
+ * <p>The throwable is inspected directly; the cause chain is not walked. Callers that wrap SDK
+ * exceptions (e.g. via a custom client supplier) should unwrap before calling.
+ */
+final class GCSErrorInterpreter {
+  private GCSErrorInterpreter() {}
+
+  static FailureCategory categorize(Throwable throwable) {
+    if (throwable instanceof StorageException) {
+      StorageException se = (StorageException) throwable;
+      String reason = se.getReason();
+      FailureCategory byReason =
+          reason != null ? categorizeByReason(reason) : FailureCategory.UNKNOWN;
+      if (byReason != FailureCategory.UNKNOWN) {
+        return byReason;
+      }
+      return FailureCategory.fromHttpStatus(se.getCode());
+    }
+    if (throwable instanceof IOException) {
+      return FailureCategory.TRANSIENT;
+    }
+    return FailureCategory.UNKNOWN;
+  }
+
+  static String rawErrorCode(Throwable throwable) {
+    if (throwable instanceof StorageException) {
+      return ((StorageException) throwable).getReason();
+    }
+    return null;
+  }
+
+  /**
+   * Maps a curated subset of GCS JSON API error reasons to a {@link FailureCategory}.
+   *
+   * <p>Reasons are free-form strings from the JSON API {@code error.errors[].reason} field ({@code
+   * StorageException.getReason()}); there is no enum. Unrecognized reasons fall through to {@link
+   * FailureCategory#UNKNOWN} and are then classified by HTTP status.
+   *
+   * @see <a href="https://cloud.google.com/storage/docs/json_api/v1/status-codes">GCS JSON API
+   *     status codes</a>
+   */
+  private static FailureCategory categorizeByReason(String reason) {
+    return switch (reason) {
+      case "forbidden", "unauthorized", "authError" -> FailureCategory.AUTH;
+      case "notFound" -> FailureCategory.NOT_FOUND;
+      case "rateLimitExceeded", "userRateLimitExceeded", "quotaExceeded" ->
+          FailureCategory.THROTTLED;
+      case "backendError", "internalError" -> FailureCategory.TRANSIENT;
+      default -> FailureCategory.UNKNOWN;
+    };
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -42,6 +42,9 @@ import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.DelegateFileIO;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FailureHandler;
+import org.apache.iceberg.io.FileFailure;
 import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -319,16 +322,24 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
   public void deletePrefix(String prefix) {
     internalDeleteFiles(
         Streams.stream(listPrefix(prefix))
-            .map(fileInfo -> BlobId.fromGsUtilUri(fileInfo.location())));
+            .map(fileInfo -> BlobId.fromGsUtilUri(fileInfo.location())),
+        FailureHandler.NOOP);
   }
 
   @Override
   public void deleteFiles(Iterable<String> pathsToDelete) throws BulkDeletionFailureException {
-    internalDeleteFiles(Streams.stream(pathsToDelete).map(BlobId::fromGsUtilUri));
+    deleteFiles(pathsToDelete, FailureHandler.NOOP);
+  }
+
+  @Override
+  public void deleteFiles(Iterable<String> pathsToDelete, FailureHandler failureHandler)
+      throws BulkDeletionFailureException {
+    FailureHandler handler = failureHandler != null ? failureHandler : FailureHandler.NOOP;
+    internalDeleteFiles(Streams.stream(pathsToDelete).map(BlobId::fromGsUtilUri), handler);
   }
 
   @SuppressWarnings("resource")
-  private void internalDeleteFiles(Stream<BlobId> blobIdsToDelete) {
+  private void internalDeleteFiles(Stream<BlobId> blobIdsToDelete, FailureHandler handler) {
     AtomicInteger failureCount = new AtomicInteger();
     Streams.stream(
             Iterators.partition(
@@ -341,13 +352,17 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
               }
               Storage storage = clientForStoragePath(batch.get(0).toGsUtilUri()).storage();
               try {
-                // A false result means the object did not exist, which is the desired end state
-                // for a delete, so it is treated as success.
+                // A false result means the object did not exist. For a delete that is the desired
+                // end state, so it is treated as success and not reported to the handler.
                 storage.delete(batch);
               } catch (StorageException e) {
-                // Best effort: log and keep deleting the remaining batches rather than failing
-                // fast, then surface the failure as BulkDeletionFailureException at the end.
                 LOG.warn("Encountered failure when deleting GCS batch", e);
+                FailureCategory category = GCSErrorInterpreter.categorize(e);
+                String rawCode = GCSErrorInterpreter.rawErrorCode(e);
+                for (BlobId id : batch) {
+                  FailureHandler.safeNotify(
+                      LOG, handler, new FileFailure(id.toGsUtilUri(), category, rawCode, e));
+                }
                 failureCount.addAndGet(batch.size());
               }
             });

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSFileIO.java
@@ -23,6 +23,7 @@ import com.google.api.client.util.Maps;
 import com.google.cloud.storage.Blob;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
@@ -34,6 +35,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.common.DynConstructors;
@@ -327,16 +329,32 @@ public class GCSFileIO implements DelegateFileIO, SupportsStorageCredentials {
 
   @SuppressWarnings("resource")
   private void internalDeleteFiles(Stream<BlobId> blobIdsToDelete) {
+    AtomicInteger failureCount = new AtomicInteger();
     Streams.stream(
             Iterators.partition(
                 blobIdsToDelete.iterator(),
                 clientForStoragePath(ROOT_STORAGE_PREFIX).gcpProperties().deleteBatchSize()))
         .forEach(
             batch -> {
-              if (!batch.isEmpty()) {
-                clientForStoragePath(batch.get(0).toGsUtilUri()).storage().delete(batch);
+              if (batch.isEmpty()) {
+                return;
+              }
+              Storage storage = clientForStoragePath(batch.get(0).toGsUtilUri()).storage();
+              try {
+                // A false result means the object did not exist, which is the desired end state
+                // for a delete, so it is treated as success.
+                storage.delete(batch);
+              } catch (StorageException e) {
+                // Best effort: log and keep deleting the remaining batches rather than failing
+                // fast, then surface the failure as BulkDeletionFailureException at the end.
+                LOG.warn("Encountered failure when deleting GCS batch", e);
+                failureCount.addAndGet(batch.size());
               }
             });
+
+    if (failureCount.get() > 0) {
+      throw new BulkDeletionFailureException(failureCount.get());
+    }
   }
 
   @Override

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSErrorInterpreter.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSErrorInterpreter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.cloud.storage.StorageException;
+import java.io.IOException;
+import org.apache.iceberg.io.FailureCategory;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class TestGCSErrorInterpreter {
+
+  private static StorageException exception(String reason, int code) {
+    return new StorageException(code, "test", reason, null);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "forbidden,AUTH",
+    "unauthorized,AUTH",
+    "authError,AUTH",
+    "notFound,NOT_FOUND",
+    "rateLimitExceeded,THROTTLED",
+    "userRateLimitExceeded,THROTTLED",
+    "quotaExceeded,THROTTLED",
+    "backendError,TRANSIENT",
+    "internalError,TRANSIENT"
+  })
+  public void categorizesByReason(String reason, FailureCategory expected) {
+    assertThat(GCSErrorInterpreter.categorize(exception(reason, 200))).isEqualTo(expected);
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "401,AUTH",
+    "403,AUTH",
+    "404,NOT_FOUND",
+    "429,THROTTLED",
+    "500,TRANSIENT",
+    "503,TRANSIENT",
+    "418,UNKNOWN"
+  })
+  public void fallsBackToStatusWhenReasonMissing(int status, FailureCategory expected) {
+    assertThat(GCSErrorInterpreter.categorize(exception(null, status))).isEqualTo(expected);
+  }
+
+  @Test
+  public void unknownReasonFallsBackToStatus() {
+    assertThat(GCSErrorInterpreter.categorize(exception("mysteryReason", 503)))
+        .isEqualTo(FailureCategory.TRANSIENT);
+    assertThat(GCSErrorInterpreter.categorize(exception("mysteryReason", 418)))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+
+  @Test
+  public void ioExceptionIsTransient() {
+    assertThat(GCSErrorInterpreter.categorize(new IOException("connection reset")))
+        .isEqualTo(FailureCategory.TRANSIENT);
+  }
+
+  @Test
+  public void unrelatedThrowableIsUnknown() {
+    assertThat(GCSErrorInterpreter.categorize(new RuntimeException("boom")))
+        .isEqualTo(FailureCategory.UNKNOWN);
+  }
+
+  @Test
+  public void rawErrorCodeReturnsReasonForStorageException() {
+    assertThat(GCSErrorInterpreter.rawErrorCode(exception("notFound", 404))).isEqualTo("notFound");
+    assertThat(GCSErrorInterpreter.rawErrorCode(new IOException("x"))).isNull();
+  }
+}

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIOFailureHandler.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSFileIOFailureHandler.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.StorageException;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.io.BulkDeletionFailureException;
+import org.apache.iceberg.io.CapturingFailureHandler;
+import org.apache.iceberg.io.FailureCategory;
+import org.apache.iceberg.io.FileFailure;
+import org.junit.jupiter.api.Test;
+
+public class TestGCSFileIOFailureHandler {
+
+  private static final String BUCKET = "test-bucket";
+
+  private static String path(String key) {
+    return "gs://" + BUCKET + "/" + key;
+  }
+
+  private static GCSFileIO ioWithBatchSize(Storage storage, int batchSize) {
+    GCSFileIO io = new GCSFileIO(() -> storage);
+    io.initialize(Map.of(GCPProperties.GCS_DELETE_BATCH_SIZE, String.valueOf(batchSize)));
+    return io;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void missingObjectIsTreatedAsSuccess() {
+    Storage storage = mock(Storage.class);
+    // A false result means the object was already gone, which is the desired end state for a
+    // delete. It is not reported to the handler and does not raise BulkDeletionFailureException.
+    when(storage.delete(any(Iterable.class))).thenReturn(List.of(false));
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (GCSFileIO io = new GCSFileIO(() -> storage)) {
+      io.deleteFiles(List.of(path("k1")), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void mixedMissingAndDeletedObjectsAreAllSuccess() {
+    Storage storage = mock(Storage.class);
+    when(storage.delete(any(Iterable.class))).thenReturn(List.of(false, true, false));
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (GCSFileIO io = new GCSFileIO(() -> storage)) {
+      io.deleteFiles(List.of(path("k1"), path("k2"), path("k3")), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void storageExceptionAppliesToEveryKeyInBatch() {
+    Storage storage = mock(Storage.class);
+    StorageException thrown = new StorageException(403, "forbidden", "forbidden", null);
+    when(storage.delete(any(Iterable.class))).thenThrow(thrown);
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (GCSFileIO io = new GCSFileIO(() -> storage)) {
+      // A StorageException is a real failure: every key in the batch is reported to the
+      // handler and the bulk delete fails loudly with BulkDeletionFailureException.
+      assertThatThrownBy(() -> io.deleteFiles(List.of(path("k1"), path("k2")), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    assertThat(handler.paths()).containsExactlyInAnyOrder(path("k1"), path("k2"));
+    assertThat(handler.failures())
+        .allSatisfy(
+            f -> {
+              assertThat(f.category()).isEqualTo(FailureCategory.AUTH);
+              assertThat(f.rawErrorCode()).isEqualTo("forbidden");
+              assertThat(f.cause()).isSameAs(thrown);
+            });
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void noFailuresWhenAllSucceed() {
+    Storage storage = mock(Storage.class);
+    when(storage.delete(any(Iterable.class))).thenReturn(List.of(true, true));
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (GCSFileIO io = new GCSFileIO(() -> storage)) {
+      io.deleteFiles(List.of(path("k1"), path("k2")), handler);
+    }
+
+    assertThat(handler.failures()).isEmpty();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void failedBatchDoesNotPreventRemainingBatches() {
+    Storage storage = mock(Storage.class);
+    StorageException thrown = new StorageException(403, "forbidden", "forbidden", null);
+    // Batch size 1 -> two single-key batches, deleted serially. The first batch throws; the
+    // second must still be attempted (best-effort), rather than the whole delete failing fast.
+    when(storage.delete(any(Iterable.class))).thenThrow(thrown).thenReturn(List.of(true));
+
+    CapturingFailureHandler handler = new CapturingFailureHandler();
+    try (GCSFileIO io = ioWithBatchSize(storage, 1)) {
+      assertThatThrownBy(() -> io.deleteFiles(List.of(path("k1"), path("k2")), handler))
+          .isInstanceOf(BulkDeletionFailureException.class)
+          .hasMessageContaining("Failed to delete");
+    }
+
+    // Both batches were attempted even though the first one threw.
+    verify(storage, times(2)).delete(any(Iterable.class));
+    // Only the failing batch's key is reported, classified from the StorageException.
+    assertThat(handler.failures()).hasSize(1);
+    FileFailure failure = handler.failures().get(0);
+    assertThat(failure.path()).isEqualTo(path("k1"));
+    assertThat(failure.category()).isEqualTo(FailureCategory.AUTH);
+    assertThat(failure.rawErrorCode()).isEqualTo("forbidden");
+    assertThat(failure.cause()).isSameAs(thrown);
+  }
+}


### PR DESCRIPTION
## What
If you use the FileIo interface, and call a function which throws `BulkDeletionFailureException` you are often left with a stack trace without any meaningful information to act on. You tried to delete 1 million records but a single one failed, all you get in an exception without any information on if you should retry, give up, etc. 

## High level contributions
- An interface to get detailed information on failures during bulk object storage operations
- Basic per cloud error classifiers 

The point of this is to not "force" any classification on errors but give callers all the information they need to be able to debug bulk failures

## FileIo Contract Fixes
I found some additional issues with the FileIO implementations where they did not exhibit the same contract for all implementations

### ADLSFileIO swallowed exceptions
When looking at the code, I noticed `ADLSFileIO` swallowed exceptions during the bulk deletions and never threw a BulkDeletionFailureException (The contract of the `DelegateFileIO`)

### GCSFileIO threw GCS specific exceptions during bulk operations

GCSFileIO would throw StorageException back up if it got it during bulk operations. The general contract is the BulkDeletionException is throw during bulk operations. This would mean callers who caught StorageException would no longer catch anything

### GCSFileIO fails fast on first batch
In the GCS client, we split deletes into batches and executes them serially. If one failed, we would fail quick. 

The other FileIo implementations do a best effort deletion and return errors at the end after trying to delete all of them

