### PR TITLE
Flink: SQL: Add variant avro dynamic record generator

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -340,6 +340,7 @@ This product includes code from Apache Flink.
 * RowData to Avro conversion logic in RowDataToAvroConverters.java
 * Avro schema conversion logic in AvroSchemaConverter.java
 * Joda optional dependency encapsulation in JodaConverter.java
+* Binary variant accessor utility methods in BinaryVariantAccessorUtils.java
 
 Copyright: 1999-2022 The Apache Software Foundation.
 Home page: https://flink.apache.org/

--- a/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
@@ -56,7 +56,7 @@ public class BinaryVariantAccessorUtils extends BinaryVariantUtil {
    *
    * @return List of field names if this is an instance of BinaryVariant and is an object
    * @throws IllegalArgumentException If this variant is not an instance of BinaryVariant or not an
-   *     array.
+   *     object.
    */
   public static List<String> fieldNames(Variant variant) {
     Preconditions.checkArgument(

--- a/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/flink/types/variant/BinaryVariantAccessorUtils.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.flink.types.variant;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * These Accessor utils should be part of Flink Variant interface itself. Added in the PR, <a
+ * href="https://github.com/apache/flink/pull/27600">...</a>. This is a workaround until we upgrade
+ * Flink to a release version with above changes.
+ */
+public class BinaryVariantAccessorUtils extends BinaryVariantUtil {
+  /**
+   * Get the size of an array variant.
+   *
+   * @return Number of elements if this variant is an instance of BinaryVariant and an array
+   * @throws IllegalArgumentException If this variant is not an instance of BinaryVariant or not an
+   *     array.
+   */
+  public static int arraySize(Variant variant) {
+    Preconditions.checkArgument(
+        variant instanceof BinaryVariant,
+        "Invalid variant implementation instance:%s. Only BinaryVariant is supported.",
+        variant.getClass().getName());
+
+    Preconditions.checkArgument(
+        variant.getType() == Variant.Type.ARRAY,
+        "Invalid variant type:%s. Expecting ARRAY variant type.",
+        variant.getType());
+
+    BinaryVariant binaryArrayVariant = (BinaryVariant) variant;
+    return handleArray(
+        binaryArrayVariant.getValue(), 0, (size, offsetSize, offsetStart, dataStart) -> size);
+  }
+
+  /**
+   * Get the field names of an object variant only at top level. Doesn't include the nested fields.
+   *
+   * @return List of field names if this is an instance of BinaryVariant and is an object
+   * @throws IllegalArgumentException If this variant is not an instance of BinaryVariant or not an
+   *     array.
+   */
+  public static List<String> fieldNames(Variant variant) {
+    Preconditions.checkArgument(
+        variant instanceof BinaryVariant,
+        "Invalid variant implementation instance:%s. Only BinaryVariant is supported.",
+        variant.getClass().getName());
+
+    Preconditions.checkArgument(
+        variant.getType() == Variant.Type.OBJECT,
+        "Invalid variant type:%s. Expecting OBJECT variant type.",
+        variant.getType());
+
+    BinaryVariant binaryArrayVariant = (BinaryVariant) variant;
+    return BinaryVariantUtil.handleObject(
+        binaryArrayVariant.getValue(),
+        0,
+        (size, idSize, offsetSize, idStart, offsetStart, dataStart) -> {
+          List<String> fieldNames = Lists.newArrayList();
+          for (int i = 0; i < size; i++) {
+            int id = readUnsigned(binaryArrayVariant.getValue(), idStart + idSize * i, idSize);
+            String fieldName = getMetadataKey(binaryArrayVariant.getMetadata(), id);
+            fieldNames.add(fieldName);
+          }
+          return fieldNames;
+        });
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.flink;
 
-import java.util.Map;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -22,7 +22,7 @@ import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
-class FlinkCreateTableOptions {
+public class FlinkCreateTableOptions {
   private final String catalogName;
   private final String catalogDb;
   private final String catalogTable;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -18,10 +18,13 @@
  */
 package org.apache.iceberg.flink;
 
+import java.util.Map;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.util.JsonUtil;
 
+@Internal
 public class FlinkCreateTableOptions {
   private final String catalogName;
   private final String catalogDb;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -117,4 +117,11 @@ public class FlinkWriteOptions {
 
   public static final ConfigOption<Integer> VARIANT_INFERENCE_BUFFER_SIZE =
       ConfigOptions.key("variant-inference-buffer-size").intType().noDefaultValue();
+
+  public static final ConfigOption<Integer> CACHE_MAX_SIZE =
+      ConfigOptions.key("cache-max-size")
+          .intType()
+          .defaultValue(100)
+          .withDescription(
+              "Maximum size of the caches used in Dynamic Sink for table data and serializers.");
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -117,11 +117,4 @@ public class FlinkWriteOptions {
 
   public static final ConfigOption<Integer> VARIANT_INFERENCE_BUFFER_SIZE =
       ConfigOptions.key("variant-inference-buffer-size").intType().noDefaultValue();
-
-  public static final ConfigOption<Integer> CACHE_MAX_SIZE =
-      ConfigOptions.key("cache-max-size")
-          .intType()
-          .defaultValue(100)
-          .withDescription(
-              "Maximum size of the caches used in Dynamic Sink for table data and serializers.");
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -284,9 +284,9 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       ctor =
           DynConstructors.builder(DynamicTableRecordGenerator.class)
               .loader(IcebergTableSink.class.getClassLoader())
-              .impl(generatorImpl, RowType.class)
+              .impl(generatorImpl, RowType.class, Map.class)
               .buildChecked();
-      return ctor.newInstance(rowType);
+      return ctor.newInstance(rowType, writeProps);
     } catch (ClassCastException e) {
       throw new IllegalArgumentException(
           String.format("Class %s does not implement DynamicRecordGeneratorSQL", generatorImpl), e);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -285,6 +285,7 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       ctor =
           DynConstructors.builder(DynamicTableRecordGenerator.class)
               .loader(IcebergTableSink.class.getClassLoader())
+              .impl(generatorImpl, RowType.class)
               .impl(generatorImpl, RowType.class, Map.class, Configuration.class)
               .buildChecked();
       return ctor.newInstance(rowType, writeProps, fromReadableConfig());

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/IcebergTableSink.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.DataStreamSink;
@@ -284,9 +285,9 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       ctor =
           DynConstructors.builder(DynamicTableRecordGenerator.class)
               .loader(IcebergTableSink.class.getClassLoader())
-              .impl(generatorImpl, RowType.class, Map.class)
+              .impl(generatorImpl, RowType.class, Map.class, Configuration.class)
               .buildChecked();
-      return ctor.newInstance(rowType, writeProps);
+      return ctor.newInstance(rowType, writeProps, fromReadableConfig());
     } catch (ClassCastException e) {
       throw new IllegalArgumentException(
           String.format("Class %s does not implement DynamicRecordGeneratorSQL", generatorImpl), e);
@@ -294,5 +295,11 @@ public class IcebergTableSink implements DynamicTableSink, SupportsPartitioning,
       throw new RuntimeException(
           String.format("Failed to instantiate DynamicRecordGeneratorSQL %s", generatorImpl), e);
     }
+  }
+
+  private Configuration fromReadableConfig() {
+    return readableConfig instanceof Configuration
+        ? (Configuration) readableConfig
+        : Configuration.fromMap(readableConfig.toMap());
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -1,0 +1,316 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.MapData;
+import org.apache.flink.table.data.RawValueData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.Variant;
+
+public class VariantRowDataWrapper implements RowData {
+
+  private final RowType rowType;
+  private RowKind rowKind;
+  private Variant variantData;
+
+  public VariantRowDataWrapper(RowType rowType) {
+    this(rowType, RowKind.INSERT);
+  }
+
+  public VariantRowDataWrapper(RowType rowType, RowKind rowKind) {
+    this.rowType = rowType;
+    this.rowKind = rowKind;
+  }
+
+  public VariantRowDataWrapper wrap(Variant variant) {
+    this.variantData = variant;
+    return this;
+  }
+
+  @Override
+  public int getArity() {
+    return rowType.getFieldCount();
+  }
+
+  @Override
+  public RowKind getRowKind() {
+    return rowKind;
+  }
+
+  @Override
+  public void setRowKind(RowKind rowKind) {
+    this.rowKind = rowKind;
+  }
+
+  @Override
+  public boolean isNullAt(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    Variant value = variantData.getField(fieldName);
+    return value == null || value.isNull();
+  }
+
+  @Override
+  public boolean getBoolean(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getBoolean();
+  }
+
+  @Override
+  public byte getByte(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getByte();
+  }
+
+  @Override
+  public short getShort(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getShort();
+  }
+
+  @Override
+  public int getInt(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getIntValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public long getLong(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getLongValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public float getFloat(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getFloat();
+  }
+
+  @Override
+  public double getDouble(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return getDoubleValue(variantData.getField(fieldName));
+  }
+
+  @Override
+  public StringData getString(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos)
+        ? null
+        : StringData.fromString(variantData.getField(fieldName).getString());
+  }
+
+  @Override
+  public DecimalData getDecimal(int pos, int precision, int scale) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos)
+        ? null
+        : DecimalData.fromBigDecimal(
+            variantData.getField(fieldName).getDecimal(), precision, scale);
+  }
+
+  @Override
+  public TimestampData getTimestamp(int pos, int precision) {
+    String fieldName = getFieldNameByIndex(pos);
+    return isNullAt(pos) ? null : getTimestamp(variantData.getField(fieldName));
+  }
+
+  @Override
+  public <T> RawValueData<T> getRawValue(int pos) {
+    throw new UnsupportedOperationException("RawValue in Variant column is not supported.");
+  }
+
+  @Override
+  public byte[] getBinary(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName).getBytes();
+  }
+
+  @Override
+  public ArrayData getArray(int pos) {
+    //    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
+    //    LogicalType elementType = arrayType.getElementType();
+    //
+    //    String fieldName = getFieldNameByIndex(pos);
+    //    Variant arrayVariant = variantData.getField(fieldName);
+    //
+    //    if (arrayVariant != null) {
+    //        Preconditions.checkArgument(arrayVariant.getType().equals(Variant.Type.ARRAY),
+    //                "Expected Array type, but got " + arrayVariant.getType());
+    //        int arraySize = arrayVariant.getArraySize();
+    //        Object[] elements = new Object[arraySize];
+    //
+    //        for (int i=0;i< arraySize;i++) {
+    //            Variant element = arrayVariant.getElement(i);
+    //            elements[i] = element == null ? null : getElementValue(elementType, element);
+    //        }
+    //
+    //        return new GenericArrayData(elements);
+    //    }
+    //
+    //    return null;
+    throw new UnsupportedOperationException("Array Type is not supported yet.");
+  }
+
+  @Override
+  public MapData getMap(int pos) {
+    //    MapType mapType = (MapType) rowType.getTypeAt(pos);
+    //    LogicalType keyType = mapType.getKeyType();
+    //    LogicalType valueType = mapType.getValueType();
+    //
+    //    Preconditions.checkArgument(keyType instanceof VarCharType,
+    //            "Map with STRING key types are only supported in Variant to RowData conversion");
+    //
+    //    String mapFieldName = getFieldNameByIndex(pos);
+    //    Variant mapVariant = variantData.getField(mapFieldName);
+    //
+    //    Map<Object, Object> mapData = Maps.newHashMap();
+    //    if (mapVariant != null) {
+    //        List<String> keys = mapVariant.getFieldNames();
+    //        for (String key: keys) {
+    //            mapData.put(StringData.fromString(key), getElementValue(valueType,
+    // mapVariant.getField(key)));
+    //        }
+    //
+    //        return new GenericMapData(mapData);
+    //    }
+    //
+    //    return null;
+    throw new UnsupportedOperationException("Map Type is not supported yet.");
+  }
+
+  @Override
+  public RowData getRow(int pos, int numFields) {
+    String fieldName = getFieldNameByIndex(pos);
+    VariantRowDataWrapper rowDataWrapper =
+        new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos));
+    return rowDataWrapper.wrap(variantData.getField(fieldName));
+  }
+
+  @Override
+  public Variant getVariant(int pos) {
+    String fieldName = getFieldNameByIndex(pos);
+    return variantData.getField(fieldName);
+  }
+
+  /* private Object getElementValue(LogicalType elementType, Variant variant) {
+    LogicalTypeRoot root = elementType.getTypeRoot();
+
+    switch (root) {
+      case NULL:
+        return null;
+      case BOOLEAN:
+        return variant.getBoolean();
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INTEGER:
+        return getIntValue(variant);
+      case BIGINT:
+        return getLongValue(variant);
+      case FLOAT:
+        return variant.getFloat();
+      case DOUBLE:
+        return getDoubleValue(variant);
+      case DECIMAL:
+        DecimalType decimalType = (DecimalType) elementType;
+        return DecimalData.fromBigDecimal(
+            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+      case CHAR:
+      case VARCHAR:
+        return StringData.fromString(variant.getString());
+      case TIMESTAMP_WITHOUT_TIME_ZONE:
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
+        return getTimestamp(variant);
+      case BINARY:
+      case VARBINARY:
+        return variant.getBytes();
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported Element type in Array/Map type:" + elementType);
+    }
+  }*/
+
+  private int getIntValue(Variant variant) {
+    switch (variant.getType()) {
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INT:
+        return variant.getInt();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "int"));
+    }
+  }
+
+  private long getLongValue(Variant variant) {
+    switch (variant.getType()) {
+      case TINYINT:
+        return variant.getByte();
+      case SMALLINT:
+        return variant.getShort();
+      case INT:
+        return variant.getInt();
+      case BIGINT:
+        return variant.getLong();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "long"));
+    }
+  }
+
+  private double getDoubleValue(Variant variant) {
+    switch (variant.getType()) {
+      case FLOAT:
+        return variant.getFloat();
+      case DOUBLE:
+        return variant.getDouble();
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "double"));
+    }
+  }
+
+  private TimestampData getTimestamp(Variant variant) {
+    switch (variant.getType()) {
+      case TIMESTAMP:
+        return TimestampData.fromLocalDateTime(variant.getDateTime());
+      case TIMESTAMP_LTZ:
+        return TimestampData.fromInstant(variant.getInstant());
+      case BIGINT:
+        long timeLong = variant.getLong();
+        return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
+      default:
+        throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+    }
+  }
+
+  private static String errMsg(Variant variant, String type) {
+    return String.format("Failed to read Variant %s as %s", variant.toJson(), type);
+  }
+
+  private String getFieldNameByIndex(int pos) {
+    return rowType.getFields().get(pos).getName();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -31,10 +31,12 @@ import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.ArrayType;
 import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LocalZonedTimestampType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
 import org.apache.flink.types.variant.BinaryVariantAccessorUtils;
@@ -43,6 +45,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class VariantRowDataWrapper implements RowData {
+
+  private static final int MICROSECOND_PRECISION = 6;
 
   private final RowType rowType;
   private RowKind rowKind;
@@ -79,61 +83,60 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public boolean isNullAt(int pos) {
-    Variant value = fieldByIndex(pos);
-    return value == null || value.isNull();
+    return isNull(field(pos));
   }
 
   @Override
   public boolean getBoolean(int pos) {
-    return fieldByIndex(pos).getBoolean();
+    return field(pos).getBoolean();
   }
 
   @Override
   public byte getByte(int pos) {
-    return fieldByIndex(pos).getByte();
+    return field(pos).getByte();
   }
 
   @Override
   public short getShort(int pos) {
-    return fieldByIndex(pos).getShort();
+    return field(pos).getShort();
   }
 
   @Override
   public int getInt(int pos) {
-    return intValue(fieldByIndex(pos));
+    return intValue(field(pos));
   }
 
   @Override
   public long getLong(int pos) {
-    return longValue(fieldByIndex(pos));
+    return longValue(field(pos));
   }
 
   @Override
   public float getFloat(int pos) {
-    return fieldByIndex(pos).getFloat();
+    return field(pos).getFloat();
   }
 
   @Override
   public double getDouble(int pos) {
-    return doubleValue(fieldByIndex(pos));
+    return doubleValue(field(pos));
   }
 
   @Override
   public StringData getString(int pos) {
-    Variant value = fieldByIndex(pos);
-    return value == null ? null : StringData.fromString(value.getString());
+    Variant value = field(pos);
+    return isNull(value) ? null : StringData.fromString(value.getString());
   }
 
   @Override
   public DecimalData getDecimal(int pos, int precision, int scale) {
-    Variant value = fieldByIndex(pos);
-    return value == null ? null : DecimalData.fromBigDecimal(value.getDecimal(), precision, scale);
+    Variant value = field(pos);
+    return isNull(value) ? null : DecimalData.fromBigDecimal(value.getDecimal(), precision, scale);
   }
 
   @Override
   public TimestampData getTimestamp(int pos, int precision) {
-    Variant value = fieldByIndex(pos);
-    return value == null ? null : timestampValue(value);
+    Variant value = field(pos);
+    return isNull(value) ? null : timestampValue(value, precision);
   }
 
   @Override
@@ -143,37 +146,36 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public byte[] getBinary(int pos) {
-    return fieldByIndex(pos).getBytes();
+    Variant value = field(pos);
+    return isNull(value) ? null : value.getBytes();
   }
 
   @Override
   public ArrayData getArray(int pos) {
     ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
     LogicalType elementType = arrayType.getElementType();
-    Variant arrayVariant = fieldByIndex(pos);
+    Variant arrayVariant = field(pos);
     return arrayDataValue(arrayVariant, elementType);
   }
 
   @Override
   public MapData getMap(int pos) {
     MapType mapType = (MapType) rowType.getTypeAt(pos);
-    Variant mapVariant = fieldByIndex(pos);
+    Variant mapVariant = field(pos);
     return mapDataValue(mapVariant, mapType);
   }
 
   @Override
   public RowData getRow(int pos, int numFields) {
-    VariantRowDataWrapper rowDataWrapper =
-        new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos));
-    return rowDataWrapper.wrap(fieldByIndex(pos));
+    return new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos)).wrap(field(pos));
   }
 
   @Override
   public Variant getVariant(int pos) {
-    return fieldByIndex(pos);
+    return field(pos);
   }
 
-  private Object element(Variant variant, LogicalType elementType) {
+  private static Object elementValue(Variant variant, LogicalType elementType) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
     return switch (root) {
@@ -187,63 +189,58 @@ public class VariantRowDataWrapper implements RowData {
       case DOUBLE -> doubleValue(variant);
       case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
       case CHAR, VARCHAR -> StringData.fromString(variant.getString());
-      case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
+      case TIMESTAMP_WITHOUT_TIME_ZONE ->
+          timestampValue(variant, ((TimestampType) elementType).getPrecision());
+      case TIMESTAMP_WITH_LOCAL_TIME_ZONE ->
+          timestampValue(variant, ((LocalZonedTimestampType) elementType).getPrecision());
       case BINARY, VARBINARY -> variant.getBytes();
       case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
       case MAP -> mapDataValue(variant, (MapType) elementType);
       case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
       default ->
           throw new UnsupportedOperationException(
-              "Unsupported Element type in Array/Map type:" + elementType);
+              String.format("Unsupported element type for Array or Map: %s", elementType));
     };
   }
 
-  private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
-    return DecimalData.fromBigDecimal(
-        variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
-  }
+  private static MapData mapDataValue(Variant variant, MapType mapType) {
+    if (variant == null) {
+      return null;
+    }
 
-  private MapData mapDataValue(Variant variant, MapType mapType) {
     LogicalType keyType = mapType.getKeyType();
     LogicalType valueType = mapType.getValueType();
 
     Preconditions.checkArgument(
         keyType instanceof VarCharType,
-        "Map with STRING key types are only supported in Variant to RowData conversion");
+        "Only Map with STRING key type is supported in Variant to RowData conversion");
 
     Map<Object, Object> mapData = Maps.newHashMap();
-    if (variant != null) {
-      List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
-      for (String key : keys) {
-        mapData.put(StringData.fromString(key), element(variant.getField(key), valueType));
-      }
-
-      return new GenericMapData(mapData);
+    List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
+    for (String key : keys) {
+      mapData.put(StringData.fromString(key), elementValue(variant.getField(key), valueType));
     }
 
-    return null;
+    return new GenericMapData(mapData);
   }
 
-  private ArrayData arrayDataValue(Variant variant, LogicalType innerElementType) {
-    if (variant != null) {
-      Preconditions.checkArgument(
-          variant.getType().equals(Variant.Type.ARRAY),
-          "Expected Array type, but got " + variant.getType());
-      int arraySize = BinaryVariantAccessorUtils.arraySize(variant);
-      Object[] elements = new Object[arraySize];
-
-      for (int i = 0; i < arraySize; i++) {
-        Variant element = variant.getElement(i);
-        elements[i] = element == null ? null : element(element, innerElementType);
-      }
-
-      return new GenericArrayData(elements);
+  private static ArrayData arrayDataValue(Variant variant, LogicalType innerElementType) {
+    if (variant == null) {
+      return null;
     }
 
-    return null;
+    int arraySize = BinaryVariantAccessorUtils.arraySize(variant);
+    Object[] elements = new Object[arraySize];
+
+    for (int i = 0; i < arraySize; i++) {
+      Variant element = variant.getElement(i);
+      elements[i] = element == null ? null : elementValue(element, innerElementType);
+    }
+
+    return new GenericArrayData(elements);
   }
 
-  private int intValue(Variant variant) {
+  private static int intValue(Variant variant) {
     return switch (variant.getType()) {
       case TINYINT -> variant.getByte();
       case SMALLINT -> variant.getShort();
@@ -252,7 +249,7 @@ public class VariantRowDataWrapper implements RowData {
     };
   }
 
-  private long longValue(Variant variant) {
+  private static long longValue(Variant variant) {
     return switch (variant.getType()) {
       case TINYINT -> variant.getByte();
       case SMALLINT -> variant.getShort();
@@ -262,7 +259,7 @@ public class VariantRowDataWrapper implements RowData {
     };
   }
 
-  private double doubleValue(Variant variant) {
+  private static double doubleValue(Variant variant) {
     return switch (variant.getType()) {
       case FLOAT -> variant.getFloat();
       case DOUBLE -> variant.getDouble();
@@ -270,26 +267,42 @@ public class VariantRowDataWrapper implements RowData {
     };
   }
 
-  private TimestampData timestampValue(Variant variant) {
+  private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
+    return DecimalData.fromBigDecimal(
+        variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  private static TimestampData timestampValue(Variant variant, int precision) {
     return switch (variant.getType()) {
       case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
       case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
-      case BIGINT -> timestampDataValue(variant.getLong());
+      case BIGINT ->
+          precision > MICROSECOND_PRECISION
+              ? nanoTimestampValue(variant.getLong())
+              : microTimestampValue(variant.getLong());
       default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
     };
   }
 
-  private static TimestampData timestampDataValue(long timeLong) {
-    return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
+  private static TimestampData microTimestampValue(long micros) {
+    return TimestampData.fromEpochMillis(micros / 1000, (int) (micros % 1000) * 1000);
+  }
+
+  private static TimestampData nanoTimestampValue(long nanos) {
+    return TimestampData.fromEpochMillis(nanos / 1_000_000L, (int) (nanos % 1_000_000L));
+  }
+
+  private Variant field(int position) {
+    String fieldName = rowType.getFields().get(position).getName();
+    return variantData.getField(fieldName);
+  }
+
+  private static boolean isNull(Variant value) {
+    return value == null || value.isNull();
   }
 
   private static String errMsg(Variant variant, String type) {
     return String.format(
         "Failed to read Variant %s of type %s as %s", variant.toJson(), variant.getType(), type);
-  }
-
-  private Variant fieldByIndex(int pos) {
-    String fieldName = rowType.getFields().get(pos).getName();
-    return variantData.getField(fieldName);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -18,16 +18,29 @@
  */
 package org.apache.iceberg.flink.data;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.DecimalData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
 import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RawValueData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.types.RowKind;
+import org.apache.flink.types.variant.BinaryVariantAccessorUtils;
 import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class VariantRowDataWrapper implements RowData {
 
@@ -149,55 +162,23 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public ArrayData getArray(int pos) {
-    //    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
-    //    LogicalType elementType = arrayType.getElementType();
-    //
-    //    String fieldName = getFieldNameByIndex(pos);
-    //    Variant arrayVariant = variantData.getField(fieldName);
-    //
-    //    if (arrayVariant != null) {
-    //        Preconditions.checkArgument(arrayVariant.getType().equals(Variant.Type.ARRAY),
-    //                "Expected Array type, but got " + arrayVariant.getType());
-    //        int arraySize = arrayVariant.getArraySize();
-    //        Object[] elements = new Object[arraySize];
-    //
-    //        for (int i=0;i< arraySize;i++) {
-    //            Variant element = arrayVariant.getElement(i);
-    //            elements[i] = element == null ? null : getElementValue(elementType, element);
-    //        }
-    //
-    //        return new GenericArrayData(elements);
-    //    }
-    //
-    //    return null;
-    throw new UnsupportedOperationException("Array Type is not supported yet.");
+    ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
+    LogicalType elementType = arrayType.getElementType();
+
+    String fieldName = getFieldNameByIndex(pos);
+    Variant arrayVariant = variantData.getField(fieldName);
+
+    return getArrayData(arrayVariant, elementType);
   }
 
   @Override
   public MapData getMap(int pos) {
-    //    MapType mapType = (MapType) rowType.getTypeAt(pos);
-    //    LogicalType keyType = mapType.getKeyType();
-    //    LogicalType valueType = mapType.getValueType();
-    //
-    //    Preconditions.checkArgument(keyType instanceof VarCharType,
-    //            "Map with STRING key types are only supported in Variant to RowData conversion");
-    //
-    //    String mapFieldName = getFieldNameByIndex(pos);
-    //    Variant mapVariant = variantData.getField(mapFieldName);
-    //
-    //    Map<Object, Object> mapData = Maps.newHashMap();
-    //    if (mapVariant != null) {
-    //        List<String> keys = mapVariant.getFieldNames();
-    //        for (String key: keys) {
-    //            mapData.put(StringData.fromString(key), getElementValue(valueType,
-    // mapVariant.getField(key)));
-    //        }
-    //
-    //        return new GenericMapData(mapData);
-    //    }
-    //
-    //    return null;
-    throw new UnsupportedOperationException("Map Type is not supported yet.");
+    MapType mapType = (MapType) rowType.getTypeAt(pos);
+
+    String mapFieldName = getFieldNameByIndex(pos);
+    Variant mapVariant = variantData.getField(mapFieldName);
+
+    return getMapData(mapVariant, mapType);
   }
 
   @Override
@@ -214,7 +195,7 @@ public class VariantRowDataWrapper implements RowData {
     return variantData.getField(fieldName);
   }
 
-  /* private Object getElementValue(LogicalType elementType, Variant variant) {
+  private Object getElementValue(LogicalType elementType, Variant variant) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
     switch (root) {
@@ -247,11 +228,59 @@ public class VariantRowDataWrapper implements RowData {
       case BINARY:
       case VARBINARY:
         return variant.getBytes();
+      case ARRAY:
+        ArrayType arrayType = (ArrayType) elementType;
+        LogicalType innerElementType = arrayType.getElementType();
+        return getArrayData(variant, innerElementType);
+      case MAP:
+        return getMapData(variant, (MapType) elementType);
+      case ROW:
+        VariantRowDataWrapper rowDataWrapper = new VariantRowDataWrapper((RowType) elementType);
+        return rowDataWrapper.wrap(variant);
       default:
         throw new UnsupportedOperationException(
             "Unsupported Element type in Array/Map type:" + elementType);
     }
-  }*/
+  }
+
+  private MapData getMapData(Variant variant, MapType mapType) {
+    LogicalType keyType = mapType.getKeyType();
+    LogicalType valueType = mapType.getValueType();
+
+    Preconditions.checkArgument(
+        keyType instanceof VarCharType,
+        "Map with STRING key types are only supported in Variant to RowData conversion");
+
+    Map<Object, Object> mapData = Maps.newHashMap();
+    if (variant != null) {
+      List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
+      for (String key : keys) {
+        mapData.put(StringData.fromString(key), getElementValue(valueType, variant.getField(key)));
+      }
+
+      return new GenericMapData(mapData);
+    }
+
+    return null;
+  }
+
+  private ArrayData getArrayData(Variant variant, LogicalType innerElementType) {
+    if (variant != null) {
+      Preconditions.checkArgument(
+          variant.getType().equals(Variant.Type.ARRAY),
+          "Expected Array type, but got " + variant.getType());
+      int arraySize = BinaryVariantAccessorUtils.arraySize(variant);
+      Object[] elements = new Object[arraySize];
+
+      for (int i = 0; i < arraySize; i++) {
+        Variant element = variant.getElement(i);
+        elements[i] = element == null ? null : getElementValue(innerElementType, element);
+      }
+
+      return new GenericArrayData(elements);
+    }
+    return null;
+  }
 
   private int getIntValue(Variant variant) {
     switch (variant.getType()) {
@@ -307,7 +336,8 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static String errMsg(Variant variant, String type) {
-    return String.format("Failed to read Variant %s as %s", variant.toJson(), type);
+    return String.format(
+        "Failed to read Variant %s of type %s as %s", variant.toJson(), variant.getType(), type);
   }
 
   private String getFieldNameByIndex(int pos) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -167,7 +167,10 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public RowData getRow(int pos, int numFields) {
-    return new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos)).wrap(field(pos));
+    Variant value = field(pos);
+    return isNull(value)
+        ? null
+        : new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos)).wrap(value);
   }
 
   @Override
@@ -176,8 +179,11 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static Object elementValue(Variant variant, LogicalType elementType) {
-    LogicalTypeRoot root = elementType.getTypeRoot();
+    if (isNull(variant)) {
+      return null;
+    }
 
+    LogicalTypeRoot root = elementType.getTypeRoot();
     return switch (root) {
       case NULL -> null;
       case BOOLEAN -> variant.getBoolean();
@@ -204,7 +210,7 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static MapData mapDataValue(Variant variant, MapType mapType) {
-    if (variant == null) {
+    if (isNull(variant)) {
       return null;
     }
 
@@ -225,7 +231,7 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static ArrayData arrayDataValue(Variant variant, LogicalType innerElementType) {
-    if (variant == null) {
+    if (isNull(variant)) {
       return null;
     }
 
@@ -234,7 +240,7 @@ public class VariantRowDataWrapper implements RowData {
 
     for (int i = 0; i < arraySize; i++) {
       Variant element = variant.getElement(i);
-      elements[i] = element == null ? null : elementValue(element, innerElementType);
+      elements[i] = elementValue(element, innerElementType);
     }
 
     return new GenericArrayData(elements);
@@ -285,11 +291,13 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private static TimestampData microTimestampValue(long micros) {
-    return TimestampData.fromEpochMillis(micros / 1000, (int) (micros % 1000) * 1000);
+    return TimestampData.fromEpochMillis(
+        Math.floorDiv(micros, 1000L), (int) Math.floorMod(micros, 1000L) * 1000);
   }
 
   private static TimestampData nanoTimestampValue(long nanos) {
-    return TimestampData.fromEpochMillis(nanos / 1_000_000L, (int) (nanos % 1_000_000L));
+    return TimestampData.fromEpochMillis(
+        Math.floorDiv(nanos, 1_000_000L), (int) Math.floorMod(nanos, 1_000_000L));
   }
 
   private Variant field(int position) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public class VariantRowDataWrapper implements RowData {
 
   private static final int MICROSECOND_PRECISION = 6;
+  private static final int NANOSECOND_PRECISION = 9;
 
   private final RowType rowType;
   private RowKind rowKind;
@@ -282,10 +283,15 @@ public class VariantRowDataWrapper implements RowData {
     return switch (variant.getType()) {
       case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
       case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
-      case BIGINT ->
-          precision > MICROSECOND_PRECISION
-              ? nanoTimestampValue(variant.getLong())
-              : microTimestampValue(variant.getLong());
+      case BIGINT -> {
+        Preconditions.checkArgument(
+            precision >= MICROSECOND_PRECISION && precision <= NANOSECOND_PRECISION,
+            "Invalid precision: %s. Only micros and nanos precision are supported.",
+            precision);
+        yield precision > MICROSECOND_PRECISION
+            ? nanoTimestampValue(variant.getLong())
+            : microTimestampValue(variant.getLong());
+      }
       default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
     };
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -121,18 +121,13 @@ public class VariantRowDataWrapper implements RowData {
   @Override
   public StringData getString(int pos) {
     Variant value = fieldByIndex(pos);
-    return value == null
-        ? null
-        : StringData.fromString(value.getString());
+    return value == null ? null : StringData.fromString(value.getString());
   }
 
   @Override
   public DecimalData getDecimal(int pos, int precision, int scale) {
     Variant value = fieldByIndex(pos);
-    return value == null
-        ? null
-        : DecimalData.fromBigDecimal(
-            value.getDecimal(), precision, scale);
+    return value == null ? null : DecimalData.fromBigDecimal(value.getDecimal(), precision, scale);
   }
 
   @Override
@@ -181,30 +176,31 @@ public class VariantRowDataWrapper implements RowData {
   private Object element(Variant variant, LogicalType elementType) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
-      return switch (root) {
-          case NULL -> null;
-          case BOOLEAN -> variant.getBoolean();
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INTEGER -> intValue(variant);
-          case BIGINT -> longValue(variant);
-          case FLOAT -> variant.getFloat();
-          case DOUBLE -> doubleValue(variant);
-          case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
-          case CHAR, VARCHAR -> StringData.fromString(variant.getString());
-          case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
-          case BINARY, VARBINARY -> variant.getBytes();
-          case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
-          case MAP -> mapDataValue(variant, (MapType) elementType);
-          case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
-          default -> throw new UnsupportedOperationException(
-                  "Unsupported Element type in Array/Map type:" + elementType);
-      };
+    return switch (root) {
+      case NULL -> null;
+      case BOOLEAN -> variant.getBoolean();
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INTEGER -> intValue(variant);
+      case BIGINT -> longValue(variant);
+      case FLOAT -> variant.getFloat();
+      case DOUBLE -> doubleValue(variant);
+      case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
+      case CHAR, VARCHAR -> StringData.fromString(variant.getString());
+      case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
+      case BINARY, VARBINARY -> variant.getBytes();
+      case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
+      case MAP -> mapDataValue(variant, (MapType) elementType);
+      case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported Element type in Array/Map type:" + elementType);
+    };
   }
 
   private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
     return DecimalData.fromBigDecimal(
-            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+        variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
   }
 
   private MapData mapDataValue(Variant variant, MapType mapType) {
@@ -248,39 +244,39 @@ public class VariantRowDataWrapper implements RowData {
   }
 
   private int intValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INT -> variant.getInt();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
-      };
+    return switch (variant.getType()) {
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INT -> variant.getInt();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
+    };
   }
 
   private long longValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TINYINT -> variant.getByte();
-          case SMALLINT -> variant.getShort();
-          case INT -> variant.getInt();
-          case BIGINT -> variant.getLong();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
-      };
+    return switch (variant.getType()) {
+      case TINYINT -> variant.getByte();
+      case SMALLINT -> variant.getShort();
+      case INT -> variant.getInt();
+      case BIGINT -> variant.getLong();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
+    };
   }
 
   private double doubleValue(Variant variant) {
-      return switch (variant.getType()) {
-          case FLOAT -> variant.getFloat();
-          case DOUBLE -> variant.getDouble();
-          default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
-      };
+    return switch (variant.getType()) {
+      case FLOAT -> variant.getFloat();
+      case DOUBLE -> variant.getDouble();
+      default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
+    };
   }
 
   private TimestampData timestampValue(Variant variant) {
-      return switch (variant.getType()) {
-          case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
-          case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
-          case BIGINT -> timestampDataValue(variant.getLong());
-          default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
-      };
+    return switch (variant.getType()) {
+      case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
+      case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
+      case BIGINT -> timestampDataValue(variant.getLong());
+      default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+    };
   }
 
   private static TimestampData timestampDataValue(long timeLong) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/VariantRowDataWrapper.java
@@ -79,74 +79,66 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public boolean isNullAt(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    Variant value = variantData.getField(fieldName);
+    Variant value = fieldByIndex(pos);
     return value == null || value.isNull();
   }
 
   @Override
   public boolean getBoolean(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getBoolean();
+    return fieldByIndex(pos).getBoolean();
   }
 
   @Override
   public byte getByte(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getByte();
+    return fieldByIndex(pos).getByte();
   }
 
   @Override
   public short getShort(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getShort();
+    return fieldByIndex(pos).getShort();
   }
 
   @Override
   public int getInt(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getIntValue(variantData.getField(fieldName));
+    return intValue(fieldByIndex(pos));
   }
 
   @Override
   public long getLong(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getLongValue(variantData.getField(fieldName));
+    return longValue(fieldByIndex(pos));
   }
 
   @Override
   public float getFloat(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getFloat();
+    return fieldByIndex(pos).getFloat();
   }
 
   @Override
   public double getDouble(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return getDoubleValue(variantData.getField(fieldName));
+    return doubleValue(fieldByIndex(pos));
   }
 
   @Override
   public StringData getString(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos)
+    Variant value = fieldByIndex(pos);
+    return value == null
         ? null
-        : StringData.fromString(variantData.getField(fieldName).getString());
+        : StringData.fromString(value.getString());
   }
 
   @Override
   public DecimalData getDecimal(int pos, int precision, int scale) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos)
+    Variant value = fieldByIndex(pos);
+    return value == null
         ? null
         : DecimalData.fromBigDecimal(
-            variantData.getField(fieldName).getDecimal(), precision, scale);
+            value.getDecimal(), precision, scale);
   }
 
   @Override
   public TimestampData getTimestamp(int pos, int precision) {
-    String fieldName = getFieldNameByIndex(pos);
-    return isNullAt(pos) ? null : getTimestamp(variantData.getField(fieldName));
+    Variant value = fieldByIndex(pos);
+    return value == null ? null : timestampValue(value);
   }
 
   @Override
@@ -156,94 +148,66 @@ public class VariantRowDataWrapper implements RowData {
 
   @Override
   public byte[] getBinary(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName).getBytes();
+    return fieldByIndex(pos).getBytes();
   }
 
   @Override
   public ArrayData getArray(int pos) {
     ArrayType arrayType = (ArrayType) rowType.getTypeAt(pos);
     LogicalType elementType = arrayType.getElementType();
-
-    String fieldName = getFieldNameByIndex(pos);
-    Variant arrayVariant = variantData.getField(fieldName);
-
-    return getArrayData(arrayVariant, elementType);
+    Variant arrayVariant = fieldByIndex(pos);
+    return arrayDataValue(arrayVariant, elementType);
   }
 
   @Override
   public MapData getMap(int pos) {
     MapType mapType = (MapType) rowType.getTypeAt(pos);
-
-    String mapFieldName = getFieldNameByIndex(pos);
-    Variant mapVariant = variantData.getField(mapFieldName);
-
-    return getMapData(mapVariant, mapType);
+    Variant mapVariant = fieldByIndex(pos);
+    return mapDataValue(mapVariant, mapType);
   }
 
   @Override
   public RowData getRow(int pos, int numFields) {
-    String fieldName = getFieldNameByIndex(pos);
     VariantRowDataWrapper rowDataWrapper =
         new VariantRowDataWrapper((RowType) rowType.getTypeAt(pos));
-    return rowDataWrapper.wrap(variantData.getField(fieldName));
+    return rowDataWrapper.wrap(fieldByIndex(pos));
   }
 
   @Override
   public Variant getVariant(int pos) {
-    String fieldName = getFieldNameByIndex(pos);
-    return variantData.getField(fieldName);
+    return fieldByIndex(pos);
   }
 
-  private Object getElementValue(LogicalType elementType, Variant variant) {
+  private Object element(Variant variant, LogicalType elementType) {
     LogicalTypeRoot root = elementType.getTypeRoot();
 
-    switch (root) {
-      case NULL:
-        return null;
-      case BOOLEAN:
-        return variant.getBoolean();
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INTEGER:
-        return getIntValue(variant);
-      case BIGINT:
-        return getLongValue(variant);
-      case FLOAT:
-        return variant.getFloat();
-      case DOUBLE:
-        return getDoubleValue(variant);
-      case DECIMAL:
-        DecimalType decimalType = (DecimalType) elementType;
-        return DecimalData.fromBigDecimal(
-            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
-      case CHAR:
-      case VARCHAR:
-        return StringData.fromString(variant.getString());
-      case TIMESTAMP_WITHOUT_TIME_ZONE:
-      case TIMESTAMP_WITH_LOCAL_TIME_ZONE:
-        return getTimestamp(variant);
-      case BINARY:
-      case VARBINARY:
-        return variant.getBytes();
-      case ARRAY:
-        ArrayType arrayType = (ArrayType) elementType;
-        LogicalType innerElementType = arrayType.getElementType();
-        return getArrayData(variant, innerElementType);
-      case MAP:
-        return getMapData(variant, (MapType) elementType);
-      case ROW:
-        VariantRowDataWrapper rowDataWrapper = new VariantRowDataWrapper((RowType) elementType);
-        return rowDataWrapper.wrap(variant);
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported Element type in Array/Map type:" + elementType);
-    }
+      return switch (root) {
+          case NULL -> null;
+          case BOOLEAN -> variant.getBoolean();
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INTEGER -> intValue(variant);
+          case BIGINT -> longValue(variant);
+          case FLOAT -> variant.getFloat();
+          case DOUBLE -> doubleValue(variant);
+          case DECIMAL -> decimalDataValue(variant, (DecimalType) elementType);
+          case CHAR, VARCHAR -> StringData.fromString(variant.getString());
+          case TIMESTAMP_WITHOUT_TIME_ZONE, TIMESTAMP_WITH_LOCAL_TIME_ZONE -> timestampValue(variant);
+          case BINARY, VARBINARY -> variant.getBytes();
+          case ARRAY -> arrayDataValue(variant, ((ArrayType) elementType).getElementType());
+          case MAP -> mapDataValue(variant, (MapType) elementType);
+          case ROW -> new VariantRowDataWrapper((RowType) elementType).wrap(variant);
+          default -> throw new UnsupportedOperationException(
+                  "Unsupported Element type in Array/Map type:" + elementType);
+      };
   }
 
-  private MapData getMapData(Variant variant, MapType mapType) {
+  private static DecimalData decimalDataValue(Variant variant, DecimalType decimalType) {
+    return DecimalData.fromBigDecimal(
+            variant.getDecimal(), decimalType.getPrecision(), decimalType.getScale());
+  }
+
+  private MapData mapDataValue(Variant variant, MapType mapType) {
     LogicalType keyType = mapType.getKeyType();
     LogicalType valueType = mapType.getValueType();
 
@@ -255,7 +219,7 @@ public class VariantRowDataWrapper implements RowData {
     if (variant != null) {
       List<String> keys = BinaryVariantAccessorUtils.fieldNames(variant);
       for (String key : keys) {
-        mapData.put(StringData.fromString(key), getElementValue(valueType, variant.getField(key)));
+        mapData.put(StringData.fromString(key), element(variant.getField(key), valueType));
       }
 
       return new GenericMapData(mapData);
@@ -264,7 +228,7 @@ public class VariantRowDataWrapper implements RowData {
     return null;
   }
 
-  private ArrayData getArrayData(Variant variant, LogicalType innerElementType) {
+  private ArrayData arrayDataValue(Variant variant, LogicalType innerElementType) {
     if (variant != null) {
       Preconditions.checkArgument(
           variant.getType().equals(Variant.Type.ARRAY),
@@ -274,65 +238,53 @@ public class VariantRowDataWrapper implements RowData {
 
       for (int i = 0; i < arraySize; i++) {
         Variant element = variant.getElement(i);
-        elements[i] = element == null ? null : getElementValue(innerElementType, element);
+        elements[i] = element == null ? null : element(element, innerElementType);
       }
 
       return new GenericArrayData(elements);
     }
+
     return null;
   }
 
-  private int getIntValue(Variant variant) {
-    switch (variant.getType()) {
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INT:
-        return variant.getInt();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "int"));
-    }
+  private int intValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INT -> variant.getInt();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "int"));
+      };
   }
 
-  private long getLongValue(Variant variant) {
-    switch (variant.getType()) {
-      case TINYINT:
-        return variant.getByte();
-      case SMALLINT:
-        return variant.getShort();
-      case INT:
-        return variant.getInt();
-      case BIGINT:
-        return variant.getLong();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "long"));
-    }
+  private long longValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TINYINT -> variant.getByte();
+          case SMALLINT -> variant.getShort();
+          case INT -> variant.getInt();
+          case BIGINT -> variant.getLong();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "long"));
+      };
   }
 
-  private double getDoubleValue(Variant variant) {
-    switch (variant.getType()) {
-      case FLOAT:
-        return variant.getFloat();
-      case DOUBLE:
-        return variant.getDouble();
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "double"));
-    }
+  private double doubleValue(Variant variant) {
+      return switch (variant.getType()) {
+          case FLOAT -> variant.getFloat();
+          case DOUBLE -> variant.getDouble();
+          default -> throw new UnsupportedOperationException(errMsg(variant, "double"));
+      };
   }
 
-  private TimestampData getTimestamp(Variant variant) {
-    switch (variant.getType()) {
-      case TIMESTAMP:
-        return TimestampData.fromLocalDateTime(variant.getDateTime());
-      case TIMESTAMP_LTZ:
-        return TimestampData.fromInstant(variant.getInstant());
-      case BIGINT:
-        long timeLong = variant.getLong();
-        return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
-      default:
-        throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
-    }
+  private TimestampData timestampValue(Variant variant) {
+      return switch (variant.getType()) {
+          case TIMESTAMP -> TimestampData.fromLocalDateTime(variant.getDateTime());
+          case TIMESTAMP_LTZ -> TimestampData.fromInstant(variant.getInstant());
+          case BIGINT -> timestampDataValue(variant.getLong());
+          default -> throw new UnsupportedOperationException(errMsg(variant, "timestamp"));
+      };
+  }
+
+  private static TimestampData timestampDataValue(long timeLong) {
+    return TimestampData.fromEpochMillis(timeLong / 1000, (int) (timeLong % 1000) * 1000);
   }
 
   private static String errMsg(Variant variant, String type) {
@@ -340,7 +292,8 @@ public class VariantRowDataWrapper implements RowData {
         "Failed to read Variant %s of type %s as %s", variant.toJson(), variant.getType(), type);
   }
 
-  private String getFieldNameByIndex(int pos) {
-    return rowType.getFields().get(pos).getName();
+  private Variant fieldByIndex(int pos) {
+    String fieldName = rowType.getFields().get(pos).getName();
+    return variantData.getField(fieldName);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -18,8 +18,13 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import java.util.List;
+import java.util.Map;
 import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 /**
  * Abstract base class for SQL-based dynamic record generators. Users will extend this class to
@@ -28,12 +33,44 @@ import org.apache.flink.table.types.logical.RowType;
 public abstract class DynamicTableRecordGenerator implements DynamicRecordGenerator<RowData> {
 
   private final RowType rowType;
+  private final Map<String, String> writeProps;
 
-  public DynamicTableRecordGenerator(RowType rowType) {
+  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
     this.rowType = rowType;
+    this.writeProps = writeProps;
   }
 
-  protected RowType rowType() {
+  public RowType rowType() {
     return rowType;
+  }
+
+  public Map<String, String> writeProps() {
+    return writeProps;
+  }
+
+  protected Map<String, Integer> getFieldPositionIndex() {
+    Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
+    List<RowType.RowField> fields = rowType.getFields();
+
+    for (int i = 0; i < fields.size(); i++) {
+      RowType.RowField field = fields.get(i);
+      fieldNameToPosition.put(field.getName(), i);
+    }
+
+    return fieldNameToPosition;
+  }
+
+  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
+    int fieldIndex = rowType.getFieldIndex(columnName);
+
+    Preconditions.checkArgument(fieldIndex != -1, "Missing column %s", columnName);
+
+    LogicalType actualType = rowType.getTypeAt(fieldIndex);
+    Preconditions.checkArgument(
+        actualType.is(expectedType.getTypeRoot()),
+        "Invalid column type for %s:%s. Expected column type:%s",
+        columnName,
+        actualType,
+        expectedType);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -34,10 +34,12 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
 
   private final RowType rowType;
   private final Map<String, String> writeProperties;
+  private final Map<String, Integer> fieldNameToPosition;
 
   public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
+    this.fieldNameToPosition = fieldNameToPositionMapping(rowType);
   }
 
   protected RowType rowType() {
@@ -48,7 +50,29 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     return writeProperties;
   }
 
-  protected Map<String, Integer> fieldNameToPositionMapping() {
+  protected Map<String, Integer> fieldNameToPosition() {
+    return fieldNameToPosition;
+  }
+
+  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
+    int fieldIndex = rowType.getFieldIndex(columnName);
+    Preconditions.checkArgument(
+        fieldIndex != -1,
+        "Missing column %s. Expected column %s of type %s.",
+        columnName,
+        columnName,
+        expectedType);
+
+    LogicalType actualType = rowType.getTypeAt(fieldIndex);
+    Preconditions.checkArgument(
+        actualType.is(expectedType.getTypeRoot()),
+        "Invalid column type for %s:%s. Expected column type: %s",
+        columnName,
+        actualType,
+        expectedType);
+  }
+
+  private Map<String, Integer> fieldNameToPositionMapping(RowType rowType) {
     Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
     List<RowType.RowField> fields = rowType.getFields();
 
@@ -58,24 +82,5 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     }
 
     return fieldNameToPosition;
-  }
-
-  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
-    int fieldIndex = rowType.getFieldIndex(columnName);
-
-    Preconditions.checkArgument(
-        fieldIndex != -1,
-        "Missing column %s.Expected column %s of type %s.",
-        columnName,
-        columnName,
-        expectedType);
-
-    LogicalType actualType = rowType.getTypeAt(fieldIndex);
-    Preconditions.checkArgument(
-        actualType.is(expectedType.getTypeRoot()),
-        "Invalid column type for %s:%s. Expected column type:%s",
-        columnName,
-        actualType,
-        expectedType);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -54,7 +54,7 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     return fieldNameToPosition;
   }
 
-  protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
+  protected void validateRequiredColumnAndType(String columnName, LogicalType expectedType) {
     int fieldIndex = rowType.getFieldIndex(columnName);
     Preconditions.checkArgument(
         fieldIndex != -1,
@@ -66,7 +66,7 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
     LogicalType actualType = rowType.getTypeAt(fieldIndex);
     Preconditions.checkArgument(
         actualType.is(expectedType.getTypeRoot()),
-        "Invalid column type for %s:%s. Expected column type: %s",
+        "Invalid column type for %s: %s. Expected column type: %s",
         columnName,
         actualType,
         expectedType);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -39,7 +39,7 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
   public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
-    this.fieldNameToPosition = fieldNameToPositionMapping(rowType);
+    this.fieldNameToPosition = fieldNameToPositionMapping();
   }
 
   protected RowType rowType() {
@@ -72,15 +72,15 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
         expectedType);
   }
 
-  private Map<String, Integer> fieldNameToPositionMapping(RowType rowType) {
-    Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
-    List<RowType.RowField> fields = rowType.getFields();
+  private Map<String, Integer> fieldNameToPositionMapping() {
+    Map<String, Integer> fieldNameToPositionMap = Maps.newHashMap();
+    List<RowType.RowField> fields = this.rowType.getFields();
 
     for (int i = 0; i < fields.size(); i++) {
       RowType.RowField field = fields.get(i);
-      fieldNameToPosition.put(field.getName(), i);
+      fieldNameToPositionMap.put(field.getName(), i);
     }
 
-    return fieldNameToPosition;
+    return fieldNameToPositionMap;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
@@ -33,13 +34,16 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public abstract class DynamicTableRecordGenerator implements DynamicRecordGenerator<RowData> {
 
   private final RowType rowType;
+  private final Configuration flinkConfiguration;
   private final Map<String, String> writeProperties;
   private final Map<String, Integer> fieldNameToPosition;
 
-  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
+  public DynamicTableRecordGenerator(
+      RowType rowType, Map<String, String> writeProperties, Configuration flinkConfiguration) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
     this.fieldNameToPosition = fieldNameToPositionMapping();
+    this.flinkConfiguration = flinkConfiguration;
   }
 
   protected RowType rowType() {
@@ -48,6 +52,10 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
 
   protected Map<String, String> writeProperties() {
     return writeProperties;
+  }
+
+  protected Configuration flinkConfiguration() {
+    return flinkConfiguration;
   }
 
   protected Map<String, Integer> fieldNameToPosition() {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -20,11 +20,13 @@ package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 /**
@@ -37,25 +39,31 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
   private final Configuration flinkConfiguration;
   private final Map<String, String> writeProperties;
   private final Map<String, Integer> fieldNameToPosition;
+  private transient FlinkDynamicSinkConf flinkDynamicSinkConf;
+
+  public DynamicTableRecordGenerator(RowType rowType) {
+    this(rowType, ImmutableMap.of(), new Configuration());
+  }
 
   public DynamicTableRecordGenerator(
       RowType rowType, Map<String, String> writeProperties, Configuration flinkConfiguration) {
     this.rowType = rowType;
     this.writeProperties = writeProperties;
-    this.fieldNameToPosition = fieldNameToPositionMapping();
     this.flinkConfiguration = flinkConfiguration;
+    this.fieldNameToPosition = fieldNameToPositionMapping();
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    this.flinkDynamicSinkConf = new FlinkDynamicSinkConf(writeProperties, flinkConfiguration);
   }
 
   protected RowType rowType() {
     return rowType;
   }
 
-  protected Map<String, String> writeProperties() {
-    return writeProperties;
-  }
-
-  protected Configuration flinkConfiguration() {
-    return flinkConfiguration;
+  protected FlinkDynamicSinkConf flinkDynamicSinkConf() {
+    return flinkDynamicSinkConf;
   }
 
   protected Map<String, Integer> fieldNameToPosition() {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicTableRecordGenerator.java
@@ -33,22 +33,22 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 public abstract class DynamicTableRecordGenerator implements DynamicRecordGenerator<RowData> {
 
   private final RowType rowType;
-  private final Map<String, String> writeProps;
+  private final Map<String, String> writeProperties;
 
-  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+  public DynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProperties) {
     this.rowType = rowType;
-    this.writeProps = writeProps;
+    this.writeProperties = writeProperties;
   }
 
-  public RowType rowType() {
+  protected RowType rowType() {
     return rowType;
   }
 
-  public Map<String, String> writeProps() {
-    return writeProps;
+  protected Map<String, String> writeProperties() {
+    return writeProperties;
   }
 
-  protected Map<String, Integer> getFieldPositionIndex() {
+  protected Map<String, Integer> fieldNameToPositionMapping() {
     Map<String, Integer> fieldNameToPosition = Maps.newHashMap();
     List<RowType.RowField> fields = rowType.getFields();
 
@@ -63,7 +63,12 @@ public abstract class DynamicTableRecordGenerator implements DynamicRecordGenera
   protected void validateRequiredFieldAndType(String columnName, LogicalType expectedType) {
     int fieldIndex = rowType.getFieldIndex(columnName);
 
-    Preconditions.checkArgument(fieldIndex != -1, "Missing column %s", columnName);
+    Preconditions.checkArgument(
+        fieldIndex != -1,
+        "Missing column %s.Expected column %s of type %s.",
+        columnName,
+        columnName,
+        expectedType);
 
     LogicalType actualType = rowType.getTypeAt(fieldIndex);
     Preconditions.checkArgument(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/FlinkDynamicSinkConf.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.sink.dynamic;
 
 import java.util.Map;
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.iceberg.flink.FlinkConfParser;
 
@@ -38,7 +39,8 @@ import org.apache.iceberg.flink.FlinkConfParser;
  * no write option is provided, this class checks the flink configuration for any overrides. If no
  * applicable value is found in the write options, this class uses the default values.
  */
-class FlinkDynamicSinkConf {
+@Internal
+public class FlinkDynamicSinkConf {
 
   private final FlinkConfParser confParser;
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import java.util.Map;
+import org.apache.avro.Schema.Parser;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.DistributionMode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.FlinkCreateTableOptions;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.data.VariantRowDataWrapper;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+
+public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
+  private transient Map<String, Integer> fieldNameToPosition;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
+  private static final Parser PARSER = new Parser();
+  private static final String DEFAULT_CACHE_MAX_SIZE = "100";
+  private static final Splitter COMMA = Splitter.on(',');
+  private transient int maxCacheSize;
+
+  public VariantAvroDynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+    super(rowType, writeProps);
+
+    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
+    Preconditions.checkArgument(
+        rowType.getFieldIndex(catalogDatabaseColumn) != -1
+            || writeProps().containsKey(catalogDatabaseColumn),
+        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+        catalogDatabaseColumn,
+        catalogDatabaseColumn);
+
+    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
+    Preconditions.checkArgument(
+        rowType.getFieldIndex(catalogTableColumn) != -1
+            || writeProps().containsKey(catalogTableColumn),
+        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+        catalogTableColumn,
+        catalogTableColumn);
+
+    validateRequiredFieldAndType("data", new VariantType(false));
+    validateRequiredFieldAndType("avro_schema", new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType("avro_schema_id", new VarCharType(false, Integer.MAX_VALUE));
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+
+    this.fieldNameToPosition = getFieldPositionIndex();
+
+    this.maxCacheSize =
+        Integer.parseInt(
+            writeProps().getOrDefault("schema-cache-max-size", DEFAULT_CACHE_MAX_SIZE));
+    this.tableCache = new LRUCache<>(maxCacheSize);
+  }
+
+  @Override
+  public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
+    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
+    String catalogDb =
+        getStringColumnValue(
+            inputRecord, catalogDatabaseColumn, writeProps().get(catalogDatabaseColumn));
+
+    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
+    String catalogTable =
+        getStringColumnValue(inputRecord, catalogTableColumn, writeProps().get(catalogTableColumn));
+
+    // All write options overrides should be inferred in DynamicIcebergSink
+    String branch = getStringColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+
+    DistributionMode distributionMode = null;
+    String distributionModeStr =
+        getStringColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
+    if (distributionModeStr != null) {
+      distributionMode = DistributionMode.fromName(distributionModeStr);
+    }
+
+    int writeParallelism = -1;
+    Integer pos = fieldNameToPosition.get(FlinkWriteOptions.WRITE_PARALLELISM.key());
+    if (pos != null) {
+      writeParallelism = inputRecord.getInt(pos);
+    }
+
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get("data"));
+    String avroSchema = getStringColumnValue(inputRecord, "avro_schema");
+    String avroSchemaId = getStringColumnValue(inputRecord, "avro_schema_id");
+
+    TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
+    SchemaAndPartitionSpecCacheItem cacheItem =
+        tableCache.computeIfAbsent(
+            tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
+
+    SchemaCacheItem schemaCacheItem = cacheItem.getOrCreateSchema(avroSchemaId, avroSchema);
+
+    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
+    String partitionCols = getStringColumnValue(inputRecord, "partition_cols", null);
+    if (partitionCols != null) {
+      partitionSpec =
+          cacheItem.getOrCreatePartitionSpec(partitionCols, schemaCacheItem.tableSchema());
+    }
+
+    out.collect(
+        new DynamicRecord(
+            tableIdentifier,
+            branch,
+            schemaCacheItem.tableSchema(),
+            schemaCacheItem.variantRowDataWrapper().wrap(variantData),
+            partitionSpec,
+            distributionMode,
+            writeParallelism));
+  }
+
+  private String getStringColumnValue(RowData rowData, String col, String defaultValue) {
+    Integer pos = fieldNameToPosition.get(col);
+    if (pos != null) {
+      StringData value = rowData.getString(pos);
+      return value == null ? defaultValue : value.toString();
+    }
+
+    return defaultValue;
+  }
+
+  private String getStringColumnValue(RowData rowData, String col) {
+    return getStringColumnValue(rowData, col, null);
+  }
+
+  private static class SchemaAndPartitionSpecCacheItem {
+    private final Map<String, SchemaCacheItem> schemaCache;
+    private final Map<String, PartitionSpec> partitionSpecCache;
+
+    SchemaAndPartitionSpecCacheItem(int maximumSize) {
+      this.schemaCache = new LRUCache<>(maximumSize);
+      this.partitionSpecCache = new LRUCache<>(maximumSize);
+    }
+
+    SchemaCacheItem getOrCreateSchema(String avroSchemaId, String avroSchema) {
+      SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
+      if (schemaCacheItem == null) {
+        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(PARSER.parse(avroSchema));
+        RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
+        VariantRowDataWrapper variantRowDataWrapper = new VariantRowDataWrapper(rowType);
+        schemaCacheItem = new SchemaCacheItem(icebergTableSchema, variantRowDataWrapper);
+        schemaCache.put(avroSchemaId, schemaCacheItem);
+      }
+
+      return schemaCacheItem;
+    }
+
+    PartitionSpec getOrCreatePartitionSpec(String partitionCols, Schema schema) {
+      PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
+
+      if (partitionSpec == null) {
+        PartitionSpec.Builder partitionSpecBuilder = PartitionSpec.builderFor(schema);
+        for (String col : COMMA.split(partitionCols)) {
+          partitionSpecBuilder.identity(col);
+        }
+
+        partitionSpec = partitionSpecBuilder.build();
+        partitionSpecCache.put(partitionCols, partitionSpec);
+      }
+
+      return partitionSpec;
+    }
+  }
+
+  private record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -45,21 +45,22 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
 
-  private static final Splitter COMMA = Splitter.on(',');
   @VisibleForTesting static final String DATA_COLUMN = "data";
   @VisibleForTesting static final String AVRO_SCHEMA_COLUMN = "avro_schema";
   @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
   @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
 
+  private static final Splitter COMMA = Splitter.on(',');
+
   private transient int maxCacheSize;
   private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
 
   public VariantAvroDynamicTableRecordGenerator(
-      RowType rowType, Map<String, String> writeProperties) {
-    super(rowType, writeProperties);
+      RowType rowType, Map<String, String> writeProperties, Configuration flinkConfiguration) {
+    super(rowType, writeProperties, flinkConfiguration);
 
-    validateColumnWithFallback(rowType, FlinkCreateTableOptions.CATALOG_DATABASE);
-    validateColumnWithFallback(rowType, FlinkCreateTableOptions.CATALOG_TABLE);
+    validateColumnWithConfigFallback(rowType, FlinkCreateTableOptions.CATALOG_DATABASE);
+    validateColumnWithConfigFallback(rowType, FlinkCreateTableOptions.CATALOG_TABLE);
 
     validateRequiredColumnAndType(DATA_COLUMN, new VariantType(false));
     validateRequiredColumnAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
@@ -70,25 +71,28 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    // TODO: check configuration
-    FlinkDynamicSinkConf flinkDynamicSinkConf = new FlinkDynamicSinkConf(writeProperties(), new Configuration());
+    FlinkDynamicSinkConf flinkDynamicSinkConf =
+        new FlinkDynamicSinkConf(writeProperties(), flinkConfiguration());
     this.maxCacheSize = flinkDynamicSinkConf.cacheMaxSize();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDb = columnValueWithFallback(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE);
-    String catalogTable = columnValueWithFallback(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE);
+    String catalogDb =
+        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE);
+    String catalogTable =
+        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE);
 
-    String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
+    String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH.key());
 
-    String distributionModeStr = columnValueWithFallback(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+    String distributionModeName =
+        columnValueWithConfigFallback(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
     DistributionMode distributionMode =
-        distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
+        distributionModeName != null ? DistributionMode.fromName(distributionModeName) : null;
 
-    Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
-    int writeParallelism = pos != null ? inputRecord.getInt(pos) : 0;
+    Integer position = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
+    int writeParallelism = position != null ? inputRecord.getInt(position) : 0;
 
     Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
     String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
@@ -99,13 +103,13 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
         tableCache.computeIfAbsent(
             tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
 
-    SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
+    SchemaCacheItem schemaCacheItem = cacheItem.schemaItem(avroSchemaId, avroSchema);
 
-    PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = columnValueAsString(inputRecord, PARTITION_COLUMNS);
-    if (partitionCols != null) {
-      partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
-    }
+    String partitionColumns = columnValueAsString(inputRecord, PARTITION_COLUMNS);
+    PartitionSpec partitionSpec =
+        partitionColumns != null
+            ? cacheItem.partitionSpec(partitionColumns, schemaCacheItem.tableSchema())
+            : PartitionSpec.unpartitioned();
 
     out.collect(
         new DynamicRecord(
@@ -118,42 +122,37 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  private String columnValueAsString(RowData rowData, ConfigOption<String> config) {
-    return columnValueAsString(rowData, config.key());
+  @VisibleForTesting
+  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
+    return tableCache;
   }
 
   private String columnValueAsString(RowData rowData, String columnName) {
     return columnValueAsString(rowData, columnName, null);
   }
 
-  private String columnValueAsString(RowData rowData, String column, String defaultValue) {
-    Integer pos = fieldNameToPosition().get(column);
-    if (pos != null) {
-      StringData value = rowData.getString(pos);
+  private String columnValueAsString(RowData rowData, String columnName, String defaultValue) {
+    Integer position = fieldNameToPosition().get(columnName);
+    if (position != null) {
+      StringData value = rowData.getString(position);
       return value == null ? defaultValue : value.toString();
     }
 
     return defaultValue;
   }
 
-  private String columnValueWithFallback(
-          RowData rowData, ConfigOption<String> config) {
+  private String columnValueWithConfigFallback(RowData rowData, ConfigOption<String> config) {
     return columnValueAsString(rowData, config.key(), writeProperties().get(config.key()));
   }
 
-  private void validateColumnWithFallback(RowType rowType, ConfigOption<String> column) {
+  private void validateColumnWithConfigFallback(RowType rowType, ConfigOption<String> column) {
     String columnName = column.key();
     Preconditions.checkArgument(
-            rowType.getFieldIndex(columnName) != -1
-                    || writeProperties().containsKey(columnName),
-            "Invalid %s: null. Either %s column should be passed in Row or set in table options",
-            columnName,
-            columnName);
-  }
-
-  @VisibleForTesting
-  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
-    return tableCache;
+        rowType.getFieldIndex(columnName) != -1 || writeProperties().containsKey(columnName),
+        "Invalid %s: null. Either pass column %s in Row or set %s in table options",
+        columnName,
+        columnName,
+        columnName);
   }
 
   @VisibleForTesting
@@ -166,33 +165,26 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       this.partitionSpecCache = new LRUCache<>(maximumSize);
     }
 
-    private SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
-      SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
-      if (schemaCacheItem == null) {
-        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
-        RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
-        VariantRowDataWrapper variantRowDataWrapper = new VariantRowDataWrapper(rowType);
-        schemaCacheItem = new SchemaCacheItem(icebergTableSchema, variantRowDataWrapper);
-        schemaCache.put(avroSchemaId, schemaCacheItem);
-      }
-
-      return schemaCacheItem;
+    private SchemaCacheItem schemaItem(String avroSchemaId, String avroSchema) {
+      return schemaCache.computeIfAbsent(
+          avroSchemaId,
+          key -> {
+            Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
+            RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
+            return new SchemaCacheItem(icebergTableSchema, new VariantRowDataWrapper(rowType));
+          });
     }
 
-    private PartitionSpec partitionSpec(String partitionCols, Schema schema) {
-      PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
-
-      if (partitionSpec == null) {
-        PartitionSpec.Builder partitionSpecBuilder = PartitionSpec.builderFor(schema);
-        for (String col : COMMA.split(partitionCols)) {
-          partitionSpecBuilder.identity(col);
-        }
-
-        partitionSpec = partitionSpecBuilder.build();
-        partitionSpecCache.put(partitionCols, partitionSpec);
-      }
-
-      return partitionSpec;
+    private PartitionSpec partitionSpec(String partitionColumns, Schema schema) {
+      return partitionSpecCache.computeIfAbsent(
+          partitionColumns,
+          key -> {
+            PartitionSpec.Builder partitionSpecBuilder = PartitionSpec.builderFor(schema);
+            for (String column : COMMA.split(key)) {
+              partitionSpecBuilder.identity(column);
+            }
+            return partitionSpecBuilder.build();
+          });
     }
 
     @VisibleForTesting
@@ -201,8 +193,8 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     }
 
     @VisibleForTesting
-    PartitionSpec partitionSpec(String partitionCols) {
-      return partitionSpecCache.get(partitionCols);
+    PartitionSpec partitionSpec(String partitionColumns) {
+      return partitionSpecCache.get(partitionColumns);
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.apache.avro.Schema.Parser;
 import org.apache.flink.api.common.functions.OpenContext;
 import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
@@ -57,54 +58,37 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       RowType rowType, Map<String, String> writeProperties) {
     super(rowType, writeProperties);
 
-    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
-    Preconditions.checkArgument(
-        rowType.getFieldIndex(catalogDatabaseColumn) != -1
-            || writeProperties().containsKey(catalogDatabaseColumn),
-        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
-        catalogDatabaseColumn,
-        catalogDatabaseColumn);
+    validateColumnWithFallback(rowType, FlinkCreateTableOptions.CATALOG_DATABASE);
+    validateColumnWithFallback(rowType, FlinkCreateTableOptions.CATALOG_TABLE);
 
-    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
-    Preconditions.checkArgument(
-        rowType.getFieldIndex(catalogTableColumn) != -1
-            || writeProperties().containsKey(catalogTableColumn),
-        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
-        catalogTableColumn,
-        catalogTableColumn);
-
-    validateRequiredFieldAndType(DATA_COLUMN, new VariantType(false));
-    validateRequiredFieldAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
-    validateRequiredFieldAndType(AVRO_SCHEMA_ID_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredColumnAndType(DATA_COLUMN, new VariantType(false));
+    validateRequiredColumnAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredColumnAndType(AVRO_SCHEMA_ID_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
   }
 
   @Override
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
-    this.maxCacheSize =
-        value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
+    // TODO: check configuration
+    FlinkDynamicSinkConf flinkDynamicSinkConf = new FlinkDynamicSinkConf(writeProperties(), new Configuration());
+    this.maxCacheSize = flinkDynamicSinkConf.cacheMaxSize();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDb =
-        columnValueAsString(
-            inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
-    String catalogTable =
-        columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
+    String catalogDb = columnValueWithFallback(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE);
+    String catalogTable = columnValueWithFallback(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE);
 
-    // All write options overrides will be inferred in DynamicIcebergSink
     String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
-    String distributionModeStr =
-        columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+
+    String distributionModeStr = columnValueWithFallback(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
     DistributionMode distributionMode =
         distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
 
     Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
-    int writeParallelism = pos != null ? inputRecord.getInt(pos) : -1;
+    int writeParallelism = pos != null ? inputRecord.getInt(pos) : 0;
 
     Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
     String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
@@ -118,7 +102,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
 
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = columnValueAsString(inputRecord, PARTITION_COLUMNS, null);
+    String partitionCols = columnValueAsString(inputRecord, PARTITION_COLUMNS);
     if (partitionCols != null) {
       partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
     }
@@ -132,11 +116,6 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             partitionSpec,
             distributionMode,
             writeParallelism));
-  }
-
-  private String columnValueAsString(
-      RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
-    return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 
   private String columnValueAsString(RowData rowData, ConfigOption<String> config) {
@@ -155,6 +134,21 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     }
 
     return defaultValue;
+  }
+
+  private String columnValueWithFallback(
+          RowData rowData, ConfigOption<String> config) {
+    return columnValueAsString(rowData, config.key(), writeProperties().get(config.key()));
+  }
+
+  private void validateColumnWithFallback(RowType rowType, ConfigOption<String> column) {
+    String columnName = column.key();
+    Preconditions.checkArgument(
+            rowType.getFieldIndex(columnName) != -1
+                    || writeProperties().containsKey(columnName),
+            "Invalid %s: null. Either %s column should be passed in Row or set in table options",
+            columnName,
+            columnName);
   }
 
   @VisibleForTesting

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -84,20 +84,24 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
     String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
     this.maxCacheSize =
-            value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
+        value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDb = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
-    String catalogTable = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
+    String catalogDb =
+        columnValueAsString(
+            inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
+    String catalogTable =
+        columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
 
     // All write options overrides will be inferred in DynamicIcebergSink
     String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
-    String distributionModeStr = columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+    String distributionModeStr =
+        columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
     DistributionMode distributionMode =
-            distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
+        distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
 
     Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
     int writeParallelism = pos != null ? inputRecord.getInt(pos) : -1;
@@ -130,7 +134,8 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  private String columnValueAsString(RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
+  private String columnValueAsString(
+      RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
     return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -37,50 +37,59 @@ import org.apache.iceberg.flink.FlinkCreateTableOptions;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.data.VariantRowDataWrapper;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
+
   private transient Map<String, Integer> fieldNameToPosition;
-  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
-  private static final Parser PARSER = new Parser();
-  private static final String DEFAULT_CACHE_MAX_SIZE = "100";
   private static final Splitter COMMA = Splitter.on(',');
   private transient int maxCacheSize;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
+  @VisibleForTesting static final String DATA_COLUMN = "data";
+  @VisibleForTesting static final String AVRO_SCHEMA_COLUMN = "avro_schema";
+  @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
+  @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
 
-  public VariantAvroDynamicTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
-    super(rowType, writeProps);
+  public VariantAvroDynamicTableRecordGenerator(
+      RowType rowType, Map<String, String> writeProperties) {
+    super(rowType, writeProperties);
 
     String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogDatabaseColumn) != -1
-            || writeProps().containsKey(catalogDatabaseColumn),
-        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+            || writeProperties().containsKey(catalogDatabaseColumn),
+        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
         catalogDatabaseColumn,
         catalogDatabaseColumn);
 
     String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogTableColumn) != -1
-            || writeProps().containsKey(catalogTableColumn),
-        "Invalid %s:null." + "Either %s column should be passed in Row or set in table options",
+            || writeProperties().containsKey(catalogTableColumn),
+        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
         catalogTableColumn,
         catalogTableColumn);
 
-    validateRequiredFieldAndType("data", new VariantType(false));
-    validateRequiredFieldAndType("avro_schema", new VarCharType(false, Integer.MAX_VALUE));
-    validateRequiredFieldAndType("avro_schema_id", new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType(DATA_COLUMN, new VariantType(false));
+    validateRequiredFieldAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredFieldAndType(AVRO_SCHEMA_ID_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
   }
 
   @Override
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    this.fieldNameToPosition = getFieldPositionIndex();
+    this.fieldNameToPosition = fieldNameToPositionMapping();
 
-    this.maxCacheSize =
-        Integer.parseInt(
-            writeProps().getOrDefault("schema-cache-max-size", DEFAULT_CACHE_MAX_SIZE));
+    String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
+    if (value != null) {
+      maxCacheSize = Integer.parseInt(value);
+    } else {
+      maxCacheSize = FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
+    }
+
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
@@ -88,19 +97,20 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
     String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
     String catalogDb =
-        getStringColumnValue(
-            inputRecord, catalogDatabaseColumn, writeProps().get(catalogDatabaseColumn));
+        stringTypedColumnValue(
+            inputRecord, catalogDatabaseColumn, writeProperties().get(catalogDatabaseColumn));
 
     String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
     String catalogTable =
-        getStringColumnValue(inputRecord, catalogTableColumn, writeProps().get(catalogTableColumn));
+        stringTypedColumnValue(
+            inputRecord, catalogTableColumn, writeProperties().get(catalogTableColumn));
 
     // All write options overrides should be inferred in DynamicIcebergSink
-    String branch = getStringColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+    String branch = stringTypedColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
 
     DistributionMode distributionMode = null;
     String distributionModeStr =
-        getStringColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
+        stringTypedColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
     if (distributionModeStr != null) {
       distributionMode = DistributionMode.fromName(distributionModeStr);
     }
@@ -111,22 +121,21 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       writeParallelism = inputRecord.getInt(pos);
     }
 
-    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get("data"));
-    String avroSchema = getStringColumnValue(inputRecord, "avro_schema");
-    String avroSchemaId = getStringColumnValue(inputRecord, "avro_schema_id");
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get(DATA_COLUMN));
+    String avroSchema = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_COLUMN);
+    String avroSchemaId = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_ID_COLUMN);
 
     TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
     SchemaAndPartitionSpecCacheItem cacheItem =
         tableCache.computeIfAbsent(
             tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
 
-    SchemaCacheItem schemaCacheItem = cacheItem.getOrCreateSchema(avroSchemaId, avroSchema);
+    SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
 
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = getStringColumnValue(inputRecord, "partition_cols", null);
+    String partitionCols = stringTypedColumnValue(inputRecord, PARTITION_COLUMNS, null);
     if (partitionCols != null) {
-      partitionSpec =
-          cacheItem.getOrCreatePartitionSpec(partitionCols, schemaCacheItem.tableSchema());
+      partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
     }
 
     out.collect(
@@ -140,8 +149,13 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  private String getStringColumnValue(RowData rowData, String col, String defaultValue) {
-    Integer pos = fieldNameToPosition.get(col);
+  @VisibleForTesting
+  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
+    return tableCache;
+  }
+
+  private String stringTypedColumnValue(RowData rowData, String column, String defaultValue) {
+    Integer pos = fieldNameToPosition.get(column);
     if (pos != null) {
       StringData value = rowData.getString(pos);
       return value == null ? defaultValue : value.toString();
@@ -150,11 +164,12 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     return defaultValue;
   }
 
-  private String getStringColumnValue(RowData rowData, String col) {
-    return getStringColumnValue(rowData, col, null);
+  private String stringTypedColumnValue(RowData rowData, String column) {
+    return stringTypedColumnValue(rowData, column, null);
   }
 
-  private static class SchemaAndPartitionSpecCacheItem {
+  @VisibleForTesting
+  static class SchemaAndPartitionSpecCacheItem {
     private final Map<String, SchemaCacheItem> schemaCache;
     private final Map<String, PartitionSpec> partitionSpecCache;
 
@@ -163,10 +178,10 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       this.partitionSpecCache = new LRUCache<>(maximumSize);
     }
 
-    SchemaCacheItem getOrCreateSchema(String avroSchemaId, String avroSchema) {
+    SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
       SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
       if (schemaCacheItem == null) {
-        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(PARSER.parse(avroSchema));
+        Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
         RowType rowType = FlinkSchemaUtil.convert(icebergTableSchema);
         VariantRowDataWrapper variantRowDataWrapper = new VariantRowDataWrapper(rowType);
         schemaCacheItem = new SchemaCacheItem(icebergTableSchema, variantRowDataWrapper);
@@ -176,7 +191,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       return schemaCacheItem;
     }
 
-    PartitionSpec getOrCreatePartitionSpec(String partitionCols, Schema schema) {
+    PartitionSpec partitionSpec(String partitionCols, Schema schema) {
       PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
 
       if (partitionSpec == null) {
@@ -191,7 +206,18 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
       return partitionSpec;
     }
+
+    @VisibleForTesting
+    SchemaCacheItem schemaCacheItem(String avroSchemaId) {
+      return schemaCache.get(avroSchemaId);
+    }
+
+    @VisibleForTesting
+    PartitionSpec partitionSpec(String partitionCols) {
+      return partitionSpecCache.get(partitionCols);
+    }
   }
 
-  private record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
+  @VisibleForTesting
+  record SchemaCacheItem(Schema tableSchema, VariantRowDataWrapper variantRowDataWrapper) {}
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.sink.dynamic;
 import java.util.Map;
 import org.apache.avro.Schema.Parser;
 import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.RowType;
@@ -43,14 +44,14 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 
 public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGenerator {
 
-  private transient Map<String, Integer> fieldNameToPosition;
   private static final Splitter COMMA = Splitter.on(',');
-  private transient int maxCacheSize;
-  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
   @VisibleForTesting static final String DATA_COLUMN = "data";
   @VisibleForTesting static final String AVRO_SCHEMA_COLUMN = "avro_schema";
   @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
   @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
+
+  private transient int maxCacheSize;
+  private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
 
   public VariantAvroDynamicTableRecordGenerator(
       RowType rowType, Map<String, String> writeProperties) {
@@ -60,7 +61,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogDatabaseColumn) != -1
             || writeProperties().containsKey(catalogDatabaseColumn),
-        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
+        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
         catalogDatabaseColumn,
         catalogDatabaseColumn);
 
@@ -68,7 +69,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     Preconditions.checkArgument(
         rowType.getFieldIndex(catalogTableColumn) != -1
             || writeProperties().containsKey(catalogTableColumn),
-        "Invalid %s:null.Either %s column should be passed in Row or set in table options",
+        "Invalid %s:null. Either %s column should be passed in Row or set in table options",
         catalogTableColumn,
         catalogTableColumn);
 
@@ -81,49 +82,29 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    this.fieldNameToPosition = fieldNameToPositionMapping();
-
     String value = writeProperties().get(FlinkWriteOptions.CACHE_MAX_SIZE.key());
-    if (value != null) {
-      maxCacheSize = Integer.parseInt(value);
-    } else {
-      maxCacheSize = FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
-    }
-
+    this.maxCacheSize =
+            value != null ? Integer.parseInt(value) : FlinkWriteOptions.CACHE_MAX_SIZE.defaultValue();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDatabaseColumn = FlinkCreateTableOptions.CATALOG_DATABASE.key();
-    String catalogDb =
-        stringTypedColumnValue(
-            inputRecord, catalogDatabaseColumn, writeProperties().get(catalogDatabaseColumn));
+    String catalogDb = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE, writeProperties());
+    String catalogTable = columnValueAsString(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE, writeProperties());
 
-    String catalogTableColumn = FlinkCreateTableOptions.CATALOG_TABLE.key();
-    String catalogTable =
-        stringTypedColumnValue(
-            inputRecord, catalogTableColumn, writeProperties().get(catalogTableColumn));
+    // All write options overrides will be inferred in DynamicIcebergSink
+    String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH);
+    String distributionModeStr = columnValueAsString(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
+    DistributionMode distributionMode =
+            distributionModeStr != null ? DistributionMode.fromName(distributionModeStr) : null;
 
-    // All write options overrides should be inferred in DynamicIcebergSink
-    String branch = stringTypedColumnValue(inputRecord, FlinkWriteOptions.BRANCH.key());
+    Integer pos = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
+    int writeParallelism = pos != null ? inputRecord.getInt(pos) : -1;
 
-    DistributionMode distributionMode = null;
-    String distributionModeStr =
-        stringTypedColumnValue(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE.key());
-    if (distributionModeStr != null) {
-      distributionMode = DistributionMode.fromName(distributionModeStr);
-    }
-
-    int writeParallelism = -1;
-    Integer pos = fieldNameToPosition.get(FlinkWriteOptions.WRITE_PARALLELISM.key());
-    if (pos != null) {
-      writeParallelism = inputRecord.getInt(pos);
-    }
-
-    Variant variantData = inputRecord.getVariant(fieldNameToPosition.get(DATA_COLUMN));
-    String avroSchema = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_COLUMN);
-    String avroSchemaId = stringTypedColumnValue(inputRecord, AVRO_SCHEMA_ID_COLUMN);
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
+    String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
+    String avroSchemaId = columnValueAsString(inputRecord, AVRO_SCHEMA_ID_COLUMN);
 
     TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
     SchemaAndPartitionSpecCacheItem cacheItem =
@@ -133,7 +114,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     SchemaCacheItem schemaCacheItem = cacheItem.schema(avroSchemaId, avroSchema);
 
     PartitionSpec partitionSpec = PartitionSpec.unpartitioned();
-    String partitionCols = stringTypedColumnValue(inputRecord, PARTITION_COLUMNS, null);
+    String partitionCols = columnValueAsString(inputRecord, PARTITION_COLUMNS, null);
     if (partitionCols != null) {
       partitionSpec = cacheItem.partitionSpec(partitionCols, schemaCacheItem.tableSchema());
     }
@@ -149,13 +130,20 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             writeParallelism));
   }
 
-  @VisibleForTesting
-  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
-    return tableCache;
+  private String columnValueAsString(RowData rowData, ConfigOption<String> config, Map<String, String> writeProperties) {
+    return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 
-  private String stringTypedColumnValue(RowData rowData, String column, String defaultValue) {
-    Integer pos = fieldNameToPosition.get(column);
+  private String columnValueAsString(RowData rowData, ConfigOption<String> config) {
+    return columnValueAsString(rowData, config.key());
+  }
+
+  private String columnValueAsString(RowData rowData, String columnName) {
+    return columnValueAsString(rowData, columnName, null);
+  }
+
+  private String columnValueAsString(RowData rowData, String column, String defaultValue) {
+    Integer pos = fieldNameToPosition().get(column);
     if (pos != null) {
       StringData value = rowData.getString(pos);
       return value == null ? defaultValue : value.toString();
@@ -164,8 +152,9 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     return defaultValue;
   }
 
-  private String stringTypedColumnValue(RowData rowData, String column) {
-    return stringTypedColumnValue(rowData, column, null);
+  @VisibleForTesting
+  Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache() {
+    return tableCache;
   }
 
   @VisibleForTesting
@@ -178,7 +167,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       this.partitionSpecCache = new LRUCache<>(maximumSize);
     }
 
-    SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
+    private SchemaCacheItem schema(String avroSchemaId, String avroSchema) {
       SchemaCacheItem schemaCacheItem = schemaCache.get(avroSchemaId);
       if (schemaCacheItem == null) {
         Schema icebergTableSchema = AvroSchemaUtil.toIceberg(new Parser().parse(avroSchema));
@@ -191,7 +180,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
       return schemaCacheItem;
     }
 
-    PartitionSpec partitionSpec(String partitionCols, Schema schema) {
+    private PartitionSpec partitionSpec(String partitionCols, Schema schema) {
       PartitionSpec partitionSpec = partitionSpecCache.get(partitionCols);
 
       if (partitionSpec == null) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -149,9 +149,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     String columnName = column.key();
     Preconditions.checkArgument(
         rowType.getFieldIndex(columnName) != -1 || writeProperties().containsKey(columnName),
-        "Invalid %s: null. Either pass column %s in Row or set %s in table options",
-        columnName,
-        columnName,
+        "Invalid %s: null. Either pass the column in Row or set it in table options.",
         columnName);
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -53,7 +53,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   private static final Splitter COMMA = Splitter.on(',').trimResults().omitEmptyStrings();
 
   private final Map<String, String> writeProperties;
-  private transient int maxCacheSize;
+  private transient int inputSchemasPerTableCacheMaxSize;
   private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
 
   public VariantAvroDynamicTableRecordGenerator(
@@ -73,8 +73,9 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    this.maxCacheSize = flinkDynamicSinkConf().cacheMaxSize();
-    this.tableCache = new LRUCache<>(maxCacheSize);
+    this.inputSchemasPerTableCacheMaxSize =
+        flinkDynamicSinkConf().inputSchemasPerTableCacheMaxSize();
+    this.tableCache = new LRUCache<>(flinkDynamicSinkConf().cacheMaxSize());
   }
 
   @Override
@@ -102,7 +103,8 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
     SchemaAndPartitionSpecCacheItem cacheItem =
         tableCache.computeIfAbsent(
-            tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
+            tableIdentifier,
+            identifier -> new SchemaAndPartitionSpecCacheItem(inputSchemasPerTableCacheMaxSize));
 
     SchemaCacheItem schemaCacheItem = cacheItem.schemaItem(avroSchemaId, avroSchema);
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -52,12 +52,14 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
   private static final Splitter COMMA = Splitter.on(',').trimResults().omitEmptyStrings();
 
+  private final Map<String, String> writeProperties;
   private transient int maxCacheSize;
   private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
 
   public VariantAvroDynamicTableRecordGenerator(
       RowType rowType, Map<String, String> writeProperties, Configuration flinkConfiguration) {
     super(rowType, writeProperties, flinkConfiguration);
+    this.writeProperties = writeProperties;
 
     validateColumnWithConfigFallback(rowType, FlinkCreateTableOptions.CATALOG_DATABASE);
     validateColumnWithConfigFallback(rowType, FlinkCreateTableOptions.CATALOG_TABLE);
@@ -71,9 +73,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   public void open(OpenContext openContext) throws Exception {
     super.open(openContext);
 
-    FlinkDynamicSinkConf flinkDynamicSinkConf =
-        new FlinkDynamicSinkConf(writeProperties(), flinkConfiguration());
-    this.maxCacheSize = flinkDynamicSinkConf.cacheMaxSize();
+    this.maxCacheSize = flinkDynamicSinkConf().cacheMaxSize();
     this.tableCache = new LRUCache<>(maxCacheSize);
   }
 
@@ -143,13 +143,13 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   }
 
   private String columnValueWithConfigFallback(RowData rowData, ConfigOption<String> config) {
-    return columnValueAsString(rowData, config.key(), writeProperties().get(config.key()));
+    return columnValueAsString(rowData, config.key(), writeProperties.get(config.key()));
   }
 
   private void validateColumnWithConfigFallback(RowType rowType, ConfigOption<String> column) {
     String columnName = column.key();
     Preconditions.checkArgument(
-        rowType.getFieldIndex(columnName) != -1 || writeProperties().containsKey(columnName),
+        rowType.getFieldIndex(columnName) != -1 || writeProperties.containsKey(columnName),
         "Invalid %s: null. Either pass the column in Row or set it in table options.",
         columnName);
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -200,6 +200,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
             for (String column : COMMA.split(key)) {
               partitionSpecBuilder.identity(column);
             }
+
             return partitionSpecBuilder.build();
           });
     }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/VariantAvroDynamicTableRecordGenerator.java
@@ -50,7 +50,7 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
   @VisibleForTesting static final String AVRO_SCHEMA_ID_COLUMN = "avro_schema_id";
   @VisibleForTesting static final String PARTITION_COLUMNS = "partition_columns";
 
-  private static final Splitter COMMA = Splitter.on(',');
+  private static final Splitter COMMA = Splitter.on(',').trimResults().omitEmptyStrings();
 
   private transient int maxCacheSize;
   private transient Map<TableIdentifier, SchemaAndPartitionSpecCacheItem> tableCache;
@@ -63,8 +63,8 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
     validateColumnWithConfigFallback(rowType, FlinkCreateTableOptions.CATALOG_TABLE);
 
     validateRequiredColumnAndType(DATA_COLUMN, new VariantType(false));
-    validateRequiredColumnAndType(AVRO_SCHEMA_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
-    validateRequiredColumnAndType(AVRO_SCHEMA_ID_COLUMN, new VarCharType(false, Integer.MAX_VALUE));
+    validateRequiredColumnAndType(AVRO_SCHEMA_COLUMN, VarCharType.STRING_TYPE);
+    validateRequiredColumnAndType(AVRO_SCHEMA_ID_COLUMN, VarCharType.STRING_TYPE);
   }
 
   @Override
@@ -79,26 +79,27 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
 
   @Override
   public void generate(RowData inputRecord, Collector<DynamicRecord> out) throws Exception {
-    String catalogDb =
-        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE);
-    String catalogTable =
-        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE);
+    Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
+    String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
+    String avroSchemaId = columnValueAsString(inputRecord, AVRO_SCHEMA_ID_COLUMN);
 
+    if (variantData == null || avroSchema == null || avroSchemaId == null) {
+      return;
+    }
+
+    TableIdentifier tableIdentifier = extractTableIdentifier(inputRecord);
     String branch = columnValueAsString(inputRecord, FlinkWriteOptions.BRANCH.key());
-
     String distributionModeName =
         columnValueWithConfigFallback(inputRecord, FlinkWriteOptions.DISTRIBUTION_MODE);
     DistributionMode distributionMode =
         distributionModeName != null ? DistributionMode.fromName(distributionModeName) : null;
 
+    int writeParallelism = 0;
     Integer position = fieldNameToPosition().get(FlinkWriteOptions.WRITE_PARALLELISM.key());
-    int writeParallelism = position != null ? inputRecord.getInt(position) : 0;
+    if (position != null && !inputRecord.isNullAt(position)) {
+      writeParallelism = inputRecord.getInt(position);
+    }
 
-    Variant variantData = inputRecord.getVariant(fieldNameToPosition().get(DATA_COLUMN));
-    String avroSchema = columnValueAsString(inputRecord, AVRO_SCHEMA_COLUMN);
-    String avroSchemaId = columnValueAsString(inputRecord, AVRO_SCHEMA_ID_COLUMN);
-
-    TableIdentifier tableIdentifier = TableIdentifier.of(catalogDb, catalogTable);
     SchemaAndPartitionSpecCacheItem cacheItem =
         tableCache.computeIfAbsent(
             tableIdentifier, identifier -> new SchemaAndPartitionSpecCacheItem(maxCacheSize));
@@ -151,6 +152,24 @@ public class VariantAvroDynamicTableRecordGenerator extends DynamicTableRecordGe
         rowType.getFieldIndex(columnName) != -1 || writeProperties().containsKey(columnName),
         "Invalid %s: null. Either pass the column in Row or set it in table options.",
         columnName);
+  }
+
+  private TableIdentifier extractTableIdentifier(RowData inputRecord) {
+    String catalogDb =
+        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_DATABASE);
+    Preconditions.checkNotNull(
+        catalogDb,
+        "Invalid %s: null. Either pass the value in Row or set it in table options.",
+        FlinkCreateTableOptions.CATALOG_DATABASE.key());
+
+    String catalogTable =
+        columnValueWithConfigFallback(inputRecord, FlinkCreateTableOptions.CATALOG_TABLE);
+    Preconditions.checkNotNull(
+        catalogTable,
+        "Invalid %s: null. Either pass the value in Row or set it in table options.",
+        FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    return TableIdentifier.of(catalogDb, catalogTable);
   }
 
   @VisibleForTesting

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerator.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 
@@ -37,6 +38,8 @@ public interface DataGenerator {
   GenericRecord generateIcebergGenericRecord();
 
   GenericRowData generateFlinkRowData();
+
+  Variant generateFlinkVariantData();
 
   org.apache.avro.generic.GenericRecord generateAvroGenericRecord();
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -45,6 +46,8 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.GenericRecord;
@@ -74,6 +77,8 @@ public class DataGenerators {
     private static final LocalTime JAVA_LOCAL_TIME_HOUR8 = LocalTime.of(8, 0);
     private static final OffsetDateTime JAVA_OFFSET_DATE_TIME_20220110 =
         OffsetDateTime.of(2022, 1, 10, 0, 0, 0, 0, ZoneOffset.UTC);
+    private static final Instant JAVA_INSTANT_DATE_TIME_20220110 =
+        Instant.ofEpochSecond(JAVA_OFFSET_DATE_TIME_20220110.toEpochSecond(), 0);
     private static final LocalDateTime JAVA_LOCAL_DATE_TIME_20220110 =
         LocalDateTime.of(2022, 1, 10, 0, 0, 0);
     private static final OffsetDateTime JAVA_OFFSET_DATE_TIME_MAX_NANO =
@@ -242,6 +247,39 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      byte[] uuidBytes = new byte[16];
+      for (int i = 0; i < 16; ++i) {
+        uuidBytes[i] = (byte) i;
+      }
+
+      byte[] binaryBytes = new byte[7];
+      for (int i = 0; i < 7; ++i) {
+        binaryBytes[i] = (byte) i;
+      }
+
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add("boolean_field", builder.of(false))
+          .add("int_field", builder.of(Integer.MAX_VALUE))
+          .add("long_field", builder.of(Long.MAX_VALUE))
+          .add("float_field", builder.of(Float.MAX_VALUE))
+          .add("double_field", builder.of(Double.MAX_VALUE))
+          .add("string_field", builder.of("str"))
+          .add("date_field", builder.of(DAYS_BTW_EPOC_AND_20220110))
+          .add("time_field", builder.of(HOUR_8_IN_MILLI))
+          .add("ts_with_zone_field", builder.of(JAVA_INSTANT_DATE_TIME_20220110))
+          .add("ts_without_zone_field", builder.of(JAVA_LOCAL_DATE_TIME_20220110))
+          .add("uuid_field", builder.of(uuidBytes))
+          .add("binary_field", builder.of(binaryBytes))
+          .add("decimal_field", builder.of(BIG_DECIMAL_NEGATIVE))
+          .add("fixed_field", builder.of(FIXED_BYTES))
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", new Utf8("row_id_value"));
@@ -340,6 +378,18 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_primitive",
+              builder.object().add("id", builder.of(1)).add("name", builder.of("Jane")).build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.Schema structSchema = avroSchema.getField("struct_of_primitive").schema();
       org.apache.avro.generic.GenericRecord struct = new GenericData.Record(structSchema);
@@ -402,6 +452,24 @@ public class DataGenerators {
       StringData[] names = {StringData.fromString("Jane"), StringData.fromString("Joe")};
       return GenericRowData.of(
           StringData.fromString("row_id_value"), GenericRowData.of(1, new GenericArrayData(names)));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_array",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "names",
+                      builder.array().add(builder.of("Jane")).add(builder.of("Joe")).build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -480,6 +548,28 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_map",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "names",
+                      builder
+                          .object()
+                          .add("Jane", builder.of("female"))
+                          .add("Joe", builder.of("male"))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.Schema structSchema = avroSchema.getField("struct_of_map").schema();
       org.apache.avro.generic.GenericRecord struct = new GenericData.Record(structSchema);
@@ -554,6 +644,28 @@ public class DataGenerators {
               1,
               GenericRowData.of(
                   StringData.fromString("Jane"), StringData.fromString("Apple Park"))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "struct_of_struct",
+              builder
+                  .object()
+                  .add("id", builder.of(1))
+                  .add(
+                      "person_struct",
+                      builder
+                          .object()
+                          .add("name", builder.of("Jane"))
+                          .add("address", builder.of("Apple Park"))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -639,6 +751,18 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_int",
+              builder.array().add(builder.of(1)).add(builder.of(2)).add(builder.of(3)).build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", "row_id_value");
@@ -707,6 +831,34 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_array",
+              builder
+                  .array()
+                  .add(
+                      builder
+                          .array()
+                          .add(builder.of(1))
+                          .add(builder.of(2))
+                          .add(builder.of(3))
+                          .build())
+                  .add(
+                      builder
+                          .array()
+                          .add(builder.of(4))
+                          .add(builder.of(5))
+                          .add(builder.of(6))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", "row_id_value");
@@ -768,6 +920,28 @@ public class DataGenerators {
             ImmutableMap.of(StringData.fromString("Alice"), 3, StringData.fromString("Bob"), 4))
       };
       return GenericRowData.of(StringData.fromString("row_id_value"), new GenericArrayData(array));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_map",
+              builder
+                  .array()
+                  .add(
+                      builder.object().add("Jane", builder.of(1)).add("Joe", builder.of(2)).build())
+                  .add(
+                      builder
+                          .object()
+                          .add("Alice", builder.of(3))
+                          .add("Bob", builder.of(4))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -839,6 +1013,32 @@ public class DataGenerators {
       };
       return GenericRowData.of(
           StringData.fromString("row_id_value"), new GenericArrayData(structArray));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "array_of_struct",
+              builder
+                  .array()
+                  .add(
+                      builder
+                          .object()
+                          .add("id", builder.of(1))
+                          .add("name", builder.of("Jane"))
+                          .build())
+                  .add(
+                      builder
+                          .object()
+                          .add("id", builder.of(2))
+                          .add("name", builder.of("Joe"))
+                          .build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -930,6 +1130,18 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_primitives",
+              builder.object().add("Jane", builder.of(1)).add("Joe", builder.of(2)).build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", "row_id_value");
@@ -1007,6 +1219,36 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_array",
+              builder
+                  .object()
+                  .add(
+                      "Jane",
+                      builder
+                          .array()
+                          .add(builder.of(1))
+                          .add(builder.of(2))
+                          .add(builder.of(3))
+                          .build())
+                  .add(
+                      "Joe",
+                      builder
+                          .array()
+                          .add(builder.of(4))
+                          .add(builder.of(5))
+                          .add(builder.of(6))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord genericRecord = new GenericData.Record(avroSchema);
       genericRecord.put("row_id", "row_id_value");
@@ -1079,6 +1321,30 @@ public class DataGenerators {
                   new GenericMapData(
                       ImmutableMap.of(
                           StringData.fromString("Joe"), 3, StringData.fromString("Bob"), 4)))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_map",
+              builder
+                  .object()
+                  .add(
+                      "female",
+                      builder
+                          .object()
+                          .add("Jane", builder.of(1))
+                          .add("Alice", builder.of(2))
+                          .build())
+                  .add(
+                      "male",
+                      builder.object().add("Joe", builder.of(3)).add("Bob", builder.of(4)).build())
+                  .build())
+          .build();
     }
 
     @Override
@@ -1192,6 +1458,34 @@ public class DataGenerators {
     }
 
     @Override
+    public Variant generateFlinkVariantData() {
+      VariantBuilder builder = Variant.newBuilder();
+      return builder
+          .object()
+          .add("row_id", builder.of("row_id_value"))
+          .add(
+              "map_of_struct",
+              builder
+                  .object()
+                  .add(
+                      "struct1",
+                      builder
+                          .object()
+                          .add("id", builder.of(1))
+                          .add("name", builder.of("Jane"))
+                          .build())
+                  .add(
+                      "struct2",
+                      builder
+                          .object()
+                          .add("id", builder.of(2))
+                          .add("name", builder.of("Joe"))
+                          .build())
+                  .build())
+          .build();
+    }
+
+    @Override
     public org.apache.avro.generic.GenericRecord generateAvroGenericRecord() {
       org.apache.avro.generic.GenericRecord struct1 = new GenericData.Record(structAvroSchema);
       struct1.put("id", 1);
@@ -1254,6 +1548,11 @@ public class DataGenerators {
               ImmutableMap.of(
                   GenericRowData.of(1L, StringData.fromString("key_data")),
                   GenericRowData.of(1L, StringData.fromString("value_data")))));
+    }
+
+    @Override
+    public Variant generateFlinkVariantData() {
+      throw new UnsupportedOperationException("Variant Map only support string key type");
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -276,6 +276,12 @@ public class DataGenerators {
           .add("binary_field", builder.of(binaryBytes))
           .add("decimal_field", builder.of(BIG_DECIMAL_NEGATIVE))
           .add("fixed_field", builder.of(FIXED_BYTES))
+          // Flink Variant natively supports TIMESTAMP, TIMESTAMP_LTZ for timestamp and both assume
+          // MicroSecond Precision.
+          // Fields need to be serialized as BIGINT Variant type inorder to be read using Nano
+          // precision.
+          .add("ts_ns_with_zone_field", builder.of(ICEBERG_MAX_NANOS_EPOCH))
+          .add("ts_ns_without_zone_field", builder.of(ICEBERG_MAX_NANOS_EPOCH))
           .build();
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -703,6 +703,9 @@ public class DataGenerators {
                 Types.ListType.ofRequired(102, Types.TimestampNanoType.withoutZone())));
 
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
+    private final LocalDateTime tsAfterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789);
+    private final LocalDateTime tsBeforeEpoch =
+        LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321);
 
     private final org.apache.avro.Schema avroSchema =
         AvroSchemaUtil.convert(icebergSchema, "table");
@@ -738,12 +741,9 @@ public class DataGenerators {
     public GenericRowData generateFlinkRowData() {
       Integer[] arr = {1, 2, 3};
 
-      long posNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789));
-      long negNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321));
+      long posNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsAfterEpoch);
+      long negNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsBeforeEpoch);
+
       TimestampData[] tsArr = {
         TimestampData.fromEpochMillis(
             Math.floorDiv(posNanos, 1_000_000L), (int) Math.floorMod(posNanos, 1_000_000L)),
@@ -759,12 +759,19 @@ public class DataGenerators {
     @Override
     public Variant generateFlinkVariantData() {
       VariantBuilder builder = Variant.newBuilder();
+
+      long posNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsAfterEpoch);
+      long negNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsBeforeEpoch);
+
       return builder
           .object()
           .add("row_id", builder.of("row_id_value"))
           .add(
               "array_of_int",
               builder.array().add(builder.of(1)).add(builder.of(2)).add(builder.of(3)).build())
+          .add(
+              "array_of_ts_ns",
+              builder.array().add(builder.of(posNanos)).add(builder.of(negNanos)).build())
           .build();
     }
 
@@ -774,12 +781,8 @@ public class DataGenerators {
       genericRecord.put("row_id", "row_id_value");
       genericRecord.put("array_of_int", Arrays.asList(1, 2, 3));
 
-      long posNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789));
-      long negNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321));
+      long posNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsAfterEpoch);
+      long negNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsBeforeEpoch);
       genericRecord.put("array_of_ts_ns", Arrays.asList(posNanos, negNanos));
       return genericRecord;
     }
@@ -1063,6 +1066,10 @@ public class DataGenerators {
   }
 
   public static class MapOfPrimitives implements DataGenerator {
+    private final LocalDateTime tsAfterEpoch = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789);
+    private final LocalDateTime tsBeforeEpoch =
+        LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321);
+
     private final Schema icebergSchema =
         new Schema(
             Types.NestedField.required(1, "row_id", Types.StringType.get()),
@@ -1103,21 +1110,15 @@ public class DataGenerators {
       genericRecord.setField("row_id", "row_id_value");
       genericRecord.setField("map_of_primitives", ImmutableMap.of("Jane", 1, "Joe", 2));
 
-      LocalDateTime posNanos = LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789);
-      LocalDateTime negNanos = LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321);
       genericRecord.setField(
-          "map_of_ts_ns", ImmutableMap.of("positive", posNanos, "negative", negNanos));
+          "map_of_ts_ns", ImmutableMap.of("positive", tsAfterEpoch, "negative", tsBeforeEpoch));
       return genericRecord;
     }
 
     @Override
     public GenericRowData generateFlinkRowData() {
-      long posNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(2023, 1, 1, 12, 0, 0, 123456789));
-      long negNanos =
-          org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(
-              LocalDateTime.of(1969, 12, 31, 23, 59, 59, 987654321));
+      long posNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsAfterEpoch);
+      long negNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsBeforeEpoch);
 
       return GenericRowData.of(
           StringData.fromString("row_id_value"),
@@ -1138,12 +1139,22 @@ public class DataGenerators {
     @Override
     public Variant generateFlinkVariantData() {
       VariantBuilder builder = Variant.newBuilder();
+      long posNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsAfterEpoch);
+      long negNanos = org.apache.iceberg.util.DateTimeUtil.nanosFromTimestamp(tsBeforeEpoch);
+
       return builder
           .object()
           .add("row_id", builder.of("row_id_value"))
           .add(
               "map_of_primitives",
               builder.object().add("Jane", builder.of(1)).add("Joe", builder.of(2)).build())
+          .add(
+              "map_of_ts_ns",
+              builder
+                  .object()
+                  .add("positive", builder.of(posNanos))
+                  .add("negative", builder.of(negNanos))
+                  .build())
           .build();
     }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -270,8 +270,13 @@ public class DataGenerators {
           .add("string_field", builder.of("str"))
           .add("date_field", builder.of(DAYS_BTW_EPOC_AND_20220110))
           .add("time_field", builder.of(HOUR_8_IN_MILLI))
-          .add("ts_with_zone_field", builder.of(JAVA_INSTANT_DATE_TIME_20220110))
-          .add("ts_without_zone_field", builder.of(JAVA_LOCAL_DATE_TIME_20220110))
+          .add(
+              "ts_with_zone_field",
+              builder.of(
+                  JAVA_INSTANT_DATE_TIME_20220110.plusNanos(MICROS_OF_MILLI_20220110 * 1000)))
+          .add(
+              "ts_without_zone_field",
+              builder.of(JAVA_LOCAL_DATE_TIME_20220110.plusNanos(MICROS_OF_MILLI_20220110 * 1000)))
           .add("uuid_field", builder.of(uuidBytes))
           .add("binary_field", builder.of(binaryBytes))
           .add("decimal_field", builder.of(BIG_DECIMAL_NEGATIVE))

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.sink.dynamic.DynamicRecord;
 import org.apache.iceberg.flink.sink.dynamic.DynamicTableRecordGenerator;
+import org.apache.iceberg.flink.sink.dynamic.VariantAvroDynamicTableRecordGenerator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -400,6 +401,74 @@ public class TestIcebergConnector extends TestBase {
   }
 
   @TestTemplate
+  public void testVariantAvroDynamicIcebergSink() throws DatabaseAlreadyExistException {
+    Map<String, String> tableProps = createTableProps();
+    Map<String, String> dynamicTableProps = Maps.newHashMap(tableProps);
+    dynamicTableProps.put("use-dynamic-iceberg-sink", "true");
+    dynamicTableProps.put(
+        "dynamic-record-generator-impl", VariantAvroDynamicTableRecordGenerator.class.getName());
+
+    FlinkCatalogFactory factory = new FlinkCatalogFactory();
+    FlinkCatalog flinkCatalog =
+        (FlinkCatalog) factory.createCatalog(catalogName, tableProps, new Configuration());
+    flinkCatalog.createDatabase(
+        databaseName(), new CatalogDatabaseImpl(Maps.newHashMap(), null), true);
+
+    String avroSchema =
+        """
+      {
+        "type": "record",
+        "name": "TestSchema",
+        "fields": [
+          {
+            "name": "id",
+            "type": "long"
+          },
+          {
+            "name": "name",
+            "type": "string"
+          }
+        ]
+      }
+      """;
+
+    String avroSchemaId = "TestSchema:1";
+    // Create table with dynamic sink enabled
+    sql(
+        "CREATE TABLE %s (data VARIANT, `catalog-database` STRING, `catalog-table` STRING, avro_schema STRING, avro_schema_id STRING, branch STRING, `write-parallelism` INT) WITH %s",
+        TABLE_NAME + "_dynamic", toWithClause(dynamicTableProps));
+
+    // Insert data with database and table information
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(PARSE_JSON('{\"id\": 1, \"name\": \"AAA\"}'), '%s', '%s', '%s', '%s', 'main', 1), "
+            + "(PARSE_JSON('{\"id\": 2, \"name\": \"BBB\"}'), '%s', '%s', '%s', '%s', 'main', 1)",
+        TABLE_NAME + "_dynamic",
+        databaseName(),
+        tableName(),
+        avroSchema,
+        avroSchemaId,
+        databaseName(),
+        tableName(),
+        avroSchema,
+        avroSchemaId);
+
+    // Verify the table and data exists
+    ObjectPath objectPath = new ObjectPath(databaseName(), tableName());
+    assertThat(flinkCatalog.tableExists(objectPath)).isTrue();
+    Table table =
+        flinkCatalog
+            .getCatalogLoader()
+            .loadCatalog()
+            .loadTable(TableIdentifier.of(databaseName(), tableName()));
+
+    tableProps.put("catalog-database", databaseName());
+    sql("CREATE TABLE %s (id BIGINT, name STRING) WITH %s", tableName(), toWithClause(tableProps));
+    assertThat(sql("SELECT * FROM %s", tableName()))
+        .containsExactlyInAnyOrder(Row.of(1L, "AAA"), Row.of(2L, "BBB"));
+  }
+
+  @TestTemplate
   public void testMissingDynamicRecordGeneratorImpl() throws DatabaseAlreadyExistException {
     Map<String, String> tableProps = createTableProps();
     tableProps.put("use-dynamic-iceberg-sink", "true");
@@ -430,8 +499,8 @@ public class TestIcebergConnector extends TestBase {
     private int databaseFieldIndex = -1;
     private int tableFieldIndex = -1;
 
-    public SimpleRowDataTableRecordGenerator(RowType rowType) {
-      super(rowType);
+    public SimpleRowDataTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
+      super(rowType, writeProps);
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -503,11 +503,8 @@ public class TestIcebergConnector extends TestBase {
     private int databaseFieldIndex = -1;
     private int tableFieldIndex = -1;
 
-    public SimpleRowDataTableRecordGenerator(
-        RowType rowType,
-        Map<String, String> writeProps,
-        org.apache.flink.configuration.Configuration flinkConfiguration) {
-      super(rowType, writeProps, flinkConfiguration);
+    public SimpleRowDataTableRecordGenerator(RowType rowType) {
+      super(rowType);
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -407,6 +407,7 @@ public class TestIcebergConnector extends TestBase {
     dynamicTableProps.put("use-dynamic-iceberg-sink", "true");
     dynamicTableProps.put(
         "dynamic-record-generator-impl", VariantAvroDynamicTableRecordGenerator.class.getName());
+    dynamicTableProps.put("table.props.key1", "val1");
 
     FlinkCatalogFactory factory = new FlinkCatalogFactory();
     FlinkCatalog flinkCatalog =
@@ -461,6 +462,7 @@ public class TestIcebergConnector extends TestBase {
             .getCatalogLoader()
             .loadCatalog()
             .loadTable(TableIdentifier.of(databaseName(), tableName()));
+    assertThat(table.properties()).containsEntry("key1", "val1");
 
     tableProps.put("catalog-database", databaseName());
     sql("CREATE TABLE %s (id BIGINT, name STRING) WITH %s", tableName(), toWithClause(tableProps));

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -436,15 +436,15 @@ public class TestIcebergConnector extends TestBase {
     String avroSchemaId = "TestSchema:1";
     // Create table with dynamic sink enabled
     sql(
-        "CREATE TABLE %s (data VARIANT, `catalog-database` STRING, `catalog-table` STRING, avro_schema STRING, avro_schema_id STRING, branch STRING, `write-parallelism` INT) WITH %s",
+        "CREATE TABLE %s (data VARIANT NOT NULL, `catalog-database` STRING, `catalog-table` STRING, avro_schema STRING NOT NULL, avro_schema_id STRING NOT NULL, branch STRING, `write-parallelism` INT) WITH %s",
         TABLE_NAME + "_dynamic", toWithClause(dynamicTableProps));
 
     // Insert data with database and table information
     sql(
         """
-        INSERT INTO %s VALUES \
-        (PARSE_JSON('{"id": 1, "name": "AAA"}'), '%s', '%s', '%s', '%s', 'main', 1), \
-        (PARSE_JSON('{"id": 2, "name": "BBB"}'), '%s', '%s', '%s', '%s', 'main', 1)\
+        INSERT INTO %s VALUES
+        (PARSE_JSON('{"id": 1, "name": "AAA"}'), '%s', '%s', '%s', '%s', 'main', 1),
+        (PARSE_JSON('{"id": 2, "name": "BBB"}'), '%s', '%s', '%s', '%s', 'main', 1)
         """,
         TABLE_NAME + "_dynamic",
         databaseName(),

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -441,9 +441,11 @@ public class TestIcebergConnector extends TestBase {
 
     // Insert data with database and table information
     sql(
-        "INSERT INTO %s VALUES "
-            + "(PARSE_JSON('{\"id\": 1, \"name\": \"AAA\"}'), '%s', '%s', '%s', '%s', 'main', 1), "
-            + "(PARSE_JSON('{\"id\": 2, \"name\": \"BBB\"}'), '%s', '%s', '%s', '%s', 'main', 1)",
+        """
+        INSERT INTO %s VALUES \
+        (PARSE_JSON('{"id": 1, "name": "AAA"}'), '%s', '%s', '%s', '%s', 'main', 1), \
+        (PARSE_JSON('{"id": 2, "name": "BBB"}'), '%s', '%s', '%s', '%s', 'main', 1)\
+        """,
         TABLE_NAME + "_dynamic",
         databaseName(),
         tableName(),

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestIcebergConnector.java
@@ -501,8 +501,11 @@ public class TestIcebergConnector extends TestBase {
     private int databaseFieldIndex = -1;
     private int tableFieldIndex = -1;
 
-    public SimpleRowDataTableRecordGenerator(RowType rowType, Map<String, String> writeProps) {
-      super(rowType, writeProps);
+    public SimpleRowDataTableRecordGenerator(
+        RowType rowType,
+        Map<String, String> writeProps,
+        org.apache.flink.configuration.Configuration flinkConfiguration) {
+      super(rowType, writeProps, flinkConfiguration);
     }
 
     @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -253,6 +253,7 @@ class TestVariantRowDataWrapper {
               variantKeyList.add(variantKeys.getString(k));
               rowDataKeyList.add(rowDataKeys.getString(k));
             }
+
             assertThat(variantKeyList).containsExactlyInAnyOrderElementsOf(rowDataKeyList);
 
             for (int k = 0; k < rowDataKeys.size(); k++) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -106,11 +106,11 @@ public class TestVariantRowDataWrapper {
     RowType rowType = dataGenerator.flinkRowType();
     Variant variant = dataGenerator.generateFlinkVariantData();
     RowData rowData = dataGenerator.generateFlinkRowData();
-    VariantRowDataWrapper variantRowDataWrapper = getVariantRowDataWrapper(rowType, variant);
+    VariantRowDataWrapper variantRowDataWrapper = variantRowDataWrapper(rowType, variant);
     compareData(rowType, variantRowDataWrapper, rowData);
   }
 
-  private static VariantRowDataWrapper getVariantRowDataWrapper(RowType rowType, Variant variant) {
+  private static VariantRowDataWrapper variantRowDataWrapper(RowType rowType, Variant variant) {
     VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType);
     return wrapper.wrap(variant);
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -20,89 +20,197 @@ package org.apache.iceberg.flink.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import org.apache.flink.table.data.ArrayData;
 import org.apache.flink.table.data.GenericArrayData;
 import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.DecimalType;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.LogicalTypeRoot;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.TimestampType;
+import org.apache.flink.table.types.logical.VarBinaryType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.types.variant.Variant;
+import org.apache.flink.types.variant.VariantBuilder;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
 
-public class TestVariantRowDataWrapper {
+@ExtendWith(ParameterizedTestExtension.class)
+class TestVariantRowDataWrapper {
+  @Parameter private DataGenerator data;
 
-  @Test
-  public void testPrimitives() {
-    testDataGenerator(new DataGenerators.Primitives());
+  @Parameters(name = "DataGenerator={0}")
+  public static Iterable<Object[]> parameters() {
+    return Lists.newArrayList(
+        new Object[] {new DataGenerators.Primitives()},
+        new Object[] {new DataGenerators.StructOfPrimitive()},
+        new Object[] {new DataGenerators.StructOfArray()},
+        new Object[] {new DataGenerators.StructOfMap()},
+        new Object[] {new DataGenerators.StructOfStruct()},
+        new Object[] {new DataGenerators.ArrayOfPrimitive()},
+        new Object[] {new DataGenerators.ArrayOfArray()},
+        new Object[] {new DataGenerators.ArrayOfMap()},
+        new Object[] {new DataGenerators.ArrayOfStruct()},
+        new Object[] {new DataGenerators.MapOfPrimitives()},
+        new Object[] {new DataGenerators.MapOfArray()},
+        new Object[] {new DataGenerators.MapOfMap()},
+        new Object[] {new DataGenerators.MapOfStruct()});
+  }
+
+  @TestTemplate
+  void testConversion() {
+    verifyConversion(data);
   }
 
   @Test
-  public void testStructOfPrimitive() {
-    testDataGenerator(new DataGenerators.StructOfPrimitive());
+  void testNullMissingField() {
+    RowType rowType = nullableRowType();
+    Variant variant = Variant.newBuilder().object().build();
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType).wrap(variant);
+
+    assertNulls(rowType, wrapper);
+    assertThat(wrapper.getVariant(7)).isNull();
   }
 
   @Test
-  public void testStructOfArray() {
-    testDataGenerator(new DataGenerators.StructOfArray());
+  void testNullFieldsExplicitNull() {
+    RowType rowType = nullableRowType();
+    VariantBuilder builder = Variant.newBuilder();
+    Variant variant =
+        builder
+            .object()
+            .add("string_field", builder.ofNull())
+            .add("binary_field", builder.ofNull())
+            .add("decimal_field", builder.ofNull())
+            .add("timestamp_field", builder.ofNull())
+            .add("array_field", builder.ofNull())
+            .add("map_field", builder.ofNull())
+            .add("row_field", builder.ofNull())
+            .add("variant_field", builder.ofNull())
+            .build();
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType).wrap(variant);
+
+    assertNulls(rowType, wrapper);
+    Variant variantField = wrapper.getVariant(7);
+    assertThat(variantField).isNotNull();
+    assertThat(variantField.isNull()).isTrue();
   }
 
   @Test
-  public void testStructOfMap() {
-    testDataGenerator(new DataGenerators.StructOfMap());
+  void testArrayWithNullElements() {
+    RowType rowType =
+        RowType.of(
+            new LogicalType[] {new ArrayType(true, new IntType(true))},
+            new String[] {"array_field"});
+
+    VariantBuilder builder = Variant.newBuilder();
+    Variant variant =
+        builder
+            .object()
+            .add(
+                "array_field",
+                builder.array().add(builder.of(1)).add(builder.ofNull()).add(builder.of(3)).build())
+            .build();
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType).wrap(variant);
+
+    ArrayData array = wrapper.getArray(0);
+    assertThat(array).isNotNull();
+    assertThat(array.size()).isEqualTo(3);
+    assertThat(array.isNullAt(0)).isFalse();
+    assertThat(array.getInt(0)).isEqualTo(1);
+    assertThat(array.isNullAt(1)).isTrue();
+    assertThat(array.isNullAt(2)).isFalse();
+    assertThat(array.getInt(2)).isEqualTo(3);
   }
 
   @Test
-  public void testStructOfStruct() {
-    testDataGenerator(new DataGenerators.StructOfStruct());
+  void testMapWithNullValues() {
+    RowType rowType =
+        RowType.of(
+            new LogicalType[] {new MapType(true, new VarCharType(false, 255), new IntType(true))},
+            new String[] {"map_field"});
+
+    VariantBuilder builder = Variant.newBuilder();
+    Variant variant =
+        builder
+            .object()
+            .add(
+                "map_field",
+                builder.object().add("a", builder.of(1)).add("b", builder.ofNull()).build())
+            .build();
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType).wrap(variant);
+
+    MapData map = wrapper.getMap(0);
+    assertThat(map).isNotNull();
+    assertThat(map.size()).isEqualTo(2);
+
+    ArrayData keys = map.keyArray();
+    ArrayData values = map.valueArray();
+    for (int i = 0; i < keys.size(); i++) {
+      String key = keys.getString(i).toString();
+      if ("b".equals(key)) {
+        assertThat(values.isNullAt(i)).isTrue();
+      } else {
+        assertThat(values.isNullAt(i)).isFalse();
+        assertThat(values.getInt(i)).isEqualTo(1);
+      }
+    }
   }
 
-  @Test
-  public void testArrayOfPrimitive() {
-    testDataGenerator(new DataGenerators.ArrayOfPrimitive());
+  private static RowType nullableRowType() {
+    return RowType.of(
+        new LogicalType[] {
+          new VarCharType(true, 255),
+          new VarBinaryType(true, 100),
+          new DecimalType(true, 10, 2),
+          new TimestampType(true, 6),
+          new ArrayType(true, new IntType(true)),
+          new MapType(true, new VarCharType(false, 255), new IntType(true)),
+          RowType.of(true, new LogicalType[] {new IntType(true)}, new String[] {"x"}),
+          new VariantType(true)
+        },
+        new String[] {
+          "string_field",
+          "binary_field",
+          "decimal_field",
+          "timestamp_field",
+          "array_field",
+          "map_field",
+          "row_field",
+          "variant_field"
+        });
   }
 
-  @Test
-  public void testArrayOfArray() {
-    testDataGenerator(new DataGenerators.ArrayOfArray());
+  private static void assertNulls(RowType rowType, VariantRowDataWrapper wrapper) {
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      assertThat(wrapper.isNullAt(i)).isTrue();
+    }
+
+    assertThat(wrapper.getString(0)).isNull();
+    assertThat(wrapper.getBinary(1)).isNull();
+    assertThat(wrapper.getDecimal(2, 10, 2)).isNull();
+    assertThat(wrapper.getTimestamp(3, 6)).isNull();
+    assertThat(wrapper.getArray(4)).isNull();
+    assertThat(wrapper.getMap(5)).isNull();
+    assertThat(wrapper.getRow(6, 1)).isNull();
   }
 
-  @Test
-  public void testArrayOfMap() {
-    testDataGenerator(new DataGenerators.ArrayOfMap());
-  }
-
-  @Test
-  public void testArrayOfStruct() {
-    testDataGenerator(new DataGenerators.ArrayOfStruct());
-  }
-
-  @Test
-  public void testMapOfPrimitives() {
-    testDataGenerator(new DataGenerators.MapOfPrimitives());
-  }
-
-  @Test
-  public void testMapOfArray() {
-    testDataGenerator(new DataGenerators.MapOfArray());
-  }
-
-  @Test
-  public void testMapOfMap() {
-    testDataGenerator(new DataGenerators.MapOfMap());
-  }
-
-  @Test
-  public void testMapOfStruct() {
-    testDataGenerator(new DataGenerators.MapOfStruct());
-  }
-
-  private static void testDataGenerator(DataGenerator dataGenerator) {
+  private static void verifyConversion(DataGenerator dataGenerator) {
     RowType rowType = dataGenerator.flinkRowType();
     Variant variant = dataGenerator.generateFlinkVariantData();
     RowData rowData = dataGenerator.generateFlinkRowData();
@@ -126,7 +234,7 @@ public class TestVariantRowDataWrapper {
       switch (logicalType.getTypeRoot()) {
         case ROW:
           compareData((RowType) logicalType, variantValue, rowDataValue);
-          return;
+          break;
         case MAP:
           MapType mapType = (MapType) logicalType;
           LogicalType valueType = mapType.getValueType();
@@ -135,15 +243,26 @@ public class TestVariantRowDataWrapper {
             GenericMapData mapVariantData = (GenericMapData) variantValue;
             GenericMapData mapRowData = (GenericMapData) rowDataValue;
 
-            ArrayData keys = mapRowData.keyArray();
-            for (int k = 0; k < keys.size(); k++) {
-              StringData key = keys.getString(k);
+            ArrayData rowDataKeys = mapRowData.keyArray();
+            ArrayData variantKeys = mapVariantData.keyArray();
+
+            assertThat(variantKeys.size()).isEqualTo(rowDataKeys.size());
+            List<StringData> variantKeyList = Lists.newArrayList();
+            List<StringData> rowDataKeyList = Lists.newArrayList();
+            for (int k = 0; k < rowDataKeys.size(); k++) {
+              variantKeyList.add(variantKeys.getString(k));
+              rowDataKeyList.add(rowDataKeys.getString(k));
+            }
+            assertThat(variantKeyList).containsExactlyInAnyOrderElementsOf(rowDataKeyList);
+
+            for (int k = 0; k < rowDataKeys.size(); k++) {
+              StringData key = rowDataKeys.getString(k);
               compareData((RowType) valueType, mapVariantData.get(key), mapRowData.get(key));
             }
           } else {
             assertThat(variantValue).isEqualTo(rowDataValue);
           }
-          return;
+          break;
         case ARRAY:
           ArrayType arrayType = (ArrayType) logicalType;
           LogicalType elementType = arrayType.getElementType();
@@ -163,7 +282,7 @@ public class TestVariantRowDataWrapper {
           } else {
             assertThat(variantValue).isEqualTo(rowDataValue);
           }
-          return;
+          break;
         default:
           assertThat(variantValue).isEqualTo(rowDataValue);
       }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestVariantRowDataWrapper.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.table.data.ArrayData;
+import org.apache.flink.table.data.GenericArrayData;
+import org.apache.flink.table.data.GenericMapData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.ArrayType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.LogicalTypeRoot;
+import org.apache.flink.table.types.logical.MapType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+import org.junit.jupiter.api.Test;
+
+public class TestVariantRowDataWrapper {
+
+  @Test
+  public void testPrimitives() {
+    testDataGenerator(new DataGenerators.Primitives());
+  }
+
+  @Test
+  public void testStructOfPrimitive() {
+    testDataGenerator(new DataGenerators.StructOfPrimitive());
+  }
+
+  @Test
+  public void testStructOfArray() {
+    testDataGenerator(new DataGenerators.StructOfArray());
+  }
+
+  @Test
+  public void testStructOfMap() {
+    testDataGenerator(new DataGenerators.StructOfMap());
+  }
+
+  @Test
+  public void testStructOfStruct() {
+    testDataGenerator(new DataGenerators.StructOfStruct());
+  }
+
+  @Test
+  public void testArrayOfPrimitive() {
+    testDataGenerator(new DataGenerators.ArrayOfPrimitive());
+  }
+
+  @Test
+  public void testArrayOfArray() {
+    testDataGenerator(new DataGenerators.ArrayOfArray());
+  }
+
+  @Test
+  public void testArrayOfMap() {
+    testDataGenerator(new DataGenerators.ArrayOfMap());
+  }
+
+  @Test
+  public void testArrayOfStruct() {
+    testDataGenerator(new DataGenerators.ArrayOfStruct());
+  }
+
+  @Test
+  public void testMapOfPrimitives() {
+    testDataGenerator(new DataGenerators.MapOfPrimitives());
+  }
+
+  @Test
+  public void testMapOfArray() {
+    testDataGenerator(new DataGenerators.MapOfArray());
+  }
+
+  @Test
+  public void testMapOfMap() {
+    testDataGenerator(new DataGenerators.MapOfMap());
+  }
+
+  @Test
+  public void testMapOfStruct() {
+    testDataGenerator(new DataGenerators.MapOfStruct());
+  }
+
+  private static void testDataGenerator(DataGenerator dataGenerator) {
+    RowType rowType = dataGenerator.flinkRowType();
+    Variant variant = dataGenerator.generateFlinkVariantData();
+    RowData rowData = dataGenerator.generateFlinkRowData();
+    VariantRowDataWrapper variantRowDataWrapper = getVariantRowDataWrapper(rowType, variant);
+    compareData(rowType, variantRowDataWrapper, rowData);
+  }
+
+  private static VariantRowDataWrapper getVariantRowDataWrapper(RowType rowType, Variant variant) {
+    VariantRowDataWrapper wrapper = new VariantRowDataWrapper(rowType);
+    return wrapper.wrap(variant);
+  }
+
+  private static void compareData(RowType rowType, Object variantRowDataWrapper, Object rowData) {
+    for (int i = 0; i < rowType.getFieldCount(); i++) {
+      LogicalType logicalType = rowType.getTypeAt(i);
+      RowData.FieldGetter fieldGetter = RowData.createFieldGetter(logicalType, i);
+
+      Object variantValue = fieldGetter.getFieldOrNull((RowData) variantRowDataWrapper);
+      Object rowDataValue = fieldGetter.getFieldOrNull((RowData) rowData);
+
+      switch (logicalType.getTypeRoot()) {
+        case ROW:
+          compareData((RowType) logicalType, variantValue, rowDataValue);
+          return;
+        case MAP:
+          MapType mapType = (MapType) logicalType;
+          LogicalType valueType = mapType.getValueType();
+
+          if (valueType.is(LogicalTypeRoot.ROW)) {
+            GenericMapData mapVariantData = (GenericMapData) variantValue;
+            GenericMapData mapRowData = (GenericMapData) rowDataValue;
+
+            ArrayData keys = mapRowData.keyArray();
+            for (int k = 0; k < keys.size(); k++) {
+              StringData key = keys.getString(k);
+              compareData((RowType) valueType, mapVariantData.get(key), mapRowData.get(key));
+            }
+          } else {
+            assertThat(variantValue).isEqualTo(rowDataValue);
+          }
+          return;
+        case ARRAY:
+          ArrayType arrayType = (ArrayType) logicalType;
+          LogicalType elementType = arrayType.getElementType();
+
+          if (elementType.is(LogicalTypeRoot.ROW)) {
+            GenericArrayData arrayVariantData = (GenericArrayData) variantValue;
+            GenericArrayData arrayRowData = (GenericArrayData) rowDataValue;
+
+            assertThat(arrayVariantData.size()).isEqualTo(arrayRowData.size());
+            for (int j = 0; j < arrayVariantData.size(); j++) {
+              ArrayData.ElementGetter elementGetter = ArrayData.createElementGetter(elementType);
+              compareData(
+                  (RowType) elementType,
+                  elementGetter.getElementOrNull(arrayVariantData, j),
+                  elementGetter.getElementOrNull(arrayRowData, j));
+            }
+          } else {
+            assertThat(variantValue).isEqualTo(rowDataValue);
+          }
+          return;
+        default:
+          assertThat(variantValue).isEqualTo(rowDataValue);
+      }
+    }
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -65,7 +65,8 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing column data. Expected column data of type VARIANT NOT NULL.");
+        .hasMessageContaining(
+            "Missing column data. Expected column data of type VARIANT NOT NULL.");
   }
 
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -21,11 +21,13 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
@@ -50,6 +52,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
   public static final String TEST_DB = "test_db";
   public static final String TEST_TABLE = "test_table";
   public static final String BRANCH = "main";
+  private static final Configuration FLINK_CONFIG = new Configuration();
 
   @Test
   public void testMissingRequiredFields() {
@@ -63,7 +66,10 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
 
-    assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
+    assertThatThrownBy(
+            () ->
+                new VariantAvroDynamicTableRecordGenerator(
+                    rowType, Collections.emptyMap(), FLINK_CONFIG))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Missing column data. Expected column data of type VARIANT NOT NULL.");
@@ -82,7 +88,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = createRowTypeWithRequiredFields();
     VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties);
+        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties, FLINK_CONFIG);
     generator.open(new DefaultOpenContext());
 
     RowData inputRecord =
@@ -101,7 +107,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
         .isEqualTo(TableIdentifier.of("test_db_override", "test_table_override"));
     assertThat(record.branch()).isNull();
     assertThat(record.spec()).isEqualTo(PartitionSpec.unpartitioned());
-    assertThat(record.writeParallelism()).isEqualTo(-1);
+    assertThat(record.writeParallelism()).isEqualTo(0);
   }
 
   @Test
@@ -113,7 +119,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = createRowTypeWithAllColumns();
     VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+        new VariantAvroDynamicTableRecordGenerator(rowType, Collections.emptyMap(), FLINK_CONFIG);
     generator.open(new DefaultOpenContext());
 
     RowData inputRecord =
@@ -157,7 +163,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = createRowTypeWithDbAndTable();
     VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+        new VariantAvroDynamicTableRecordGenerator(rowType, Collections.emptyMap(), FLINK_CONFIG);
     generator.open(new DefaultOpenContext());
 
     List<DynamicRecord> records = Lists.newArrayList();
@@ -248,7 +254,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = createRowTypeWithDbAndTable();
     VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+        new VariantAvroDynamicTableRecordGenerator(rowType, Collections.emptyMap(), FLINK_CONFIG);
     generator.open(new DefaultOpenContext());
 
     List<DynamicRecord> records = Lists.newArrayList();
@@ -318,7 +324,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     RowType rowType = createRowTypeWithAllColumns();
     VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+        new VariantAvroDynamicTableRecordGenerator(rowType, Collections.emptyMap(), FLINK_CONFIG);
     generator.open(new DefaultOpenContext());
 
     List<DynamicRecord> records = Lists.newArrayList();

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
+import org.apache.avro.SchemaParseException;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.configuration.Configuration;
@@ -38,6 +39,7 @@ import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
 import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.catalog.TableIdentifier;
@@ -45,6 +47,7 @@ import org.apache.iceberg.flink.DataGenerator;
 import org.apache.iceberg.flink.DataGenerators;
 import org.apache.iceberg.flink.FlinkCreateTableOptions;
 import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.flink.data.VariantRowDataWrapper;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
@@ -78,6 +81,61 @@ class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
+  void testNullRequiredColumnsSkipRecord() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaId = schema.getName() + ":v1";
+    RowType rowType = createRowTypeWithDbAndTable();
+
+    RowData nullData =
+        GenericRowData.of(
+            null,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    assertThat(runGenerate(rowType, Collections.emptyMap(), nullData)).isEmpty();
+
+    RowData nullSchema =
+        GenericRowData.of(
+            variantData,
+            null,
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    assertThat(runGenerate(rowType, Collections.emptyMap(), nullSchema)).isEmpty();
+
+    RowData nullSchemaId =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            null,
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    assertThat(runGenerate(rowType, Collections.emptyMap(), nullSchemaId)).isEmpty();
+  }
+
+  @Test
+  void testMalformedAvroSchemaThrows() {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    String schemaId = "TestSchema:v1";
+    RowType rowType = createRowTypeWithDbAndTable();
+
+    RowData malformed =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString("not-a-valid-avro-schema"),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+
+    assertThatThrownBy(() -> runGenerate(rowType, Collections.emptyMap(), malformed))
+        .isInstanceOf(SchemaParseException.class);
+  }
+
+  @Test
   void testWithWritePropertiesOverride() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
@@ -89,19 +147,13 @@ class TestVariantAvroDynamicTableRecordGenerator {
     writeProperties.put(FlinkCreateTableOptions.CATALOG_TABLE.key(), "test_table_override");
 
     RowType rowType = createRowTypeWithRequiredFields();
-    VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties, FLINK_CONFIG);
-    generator.open(new DefaultOpenContext());
-
     RowData inputRecord =
         GenericRowData.of(
             variantData,
             StringData.fromString(schema.toString()),
             StringData.fromString(schema.getName() + schemaVersion));
 
-    List<DynamicRecord> records = Lists.newArrayList();
-    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
-    generator.generate(inputRecord, collector);
+    List<DynamicRecord> records = runGenerate(rowType, writeProperties, inputRecord);
 
     assertThat(records).hasSize(1);
     DynamicRecord record = records.get(0);
@@ -124,10 +176,6 @@ class TestVariantAvroDynamicTableRecordGenerator {
     writeProperties.put(FlinkCreateTableOptions.CATALOG_TABLE.key(), "fallback_table");
 
     RowType rowType = createRowTypeWithDbAndTable();
-    VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties, FLINK_CONFIG);
-    generator.open(new DefaultOpenContext());
-
     RowData inputRecord =
         GenericRowData.of(
             variantData,
@@ -136,9 +184,7 @@ class TestVariantAvroDynamicTableRecordGenerator {
             null,
             null);
 
-    List<DynamicRecord> records = Lists.newArrayList();
-    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
-    generator.generate(inputRecord, collector);
+    List<DynamicRecord> records = runGenerate(rowType, writeProperties, inputRecord);
 
     assertThat(records).hasSize(1);
     DynamicRecord record = records.get(0);
@@ -147,17 +193,13 @@ class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
-  void testWithPartitionedTable() throws Exception {
+  void testBasicFields() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
     Schema schema = dataGenerator.avroSchema();
     String schemaVersion = "v1";
 
     RowType rowType = createRowTypeWithAllColumns();
-    VariantAvroDynamicTableRecordGenerator generator =
-        new VariantAvroDynamicTableRecordGenerator(rowType, Collections.emptyMap(), FLINK_CONFIG);
-    generator.open(new DefaultOpenContext());
-
     RowData inputRecord =
         GenericRowData.of(
             variantData,
@@ -167,17 +209,18 @@ class TestVariantAvroDynamicTableRecordGenerator {
             StringData.fromString(TEST_TABLE),
             StringData.fromString(BRANCH),
             StringData.fromString("row_id,string_field"),
-            1);
+            1,
+            StringData.fromString(DistributionMode.HASH.modeName()));
 
-    List<DynamicRecord> records = Lists.newArrayList();
-    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
-    generator.generate(inputRecord, collector);
+    List<DynamicRecord> records = runGenerate(rowType, Collections.emptyMap(), inputRecord);
 
     assertThat(records).hasSize(1);
     DynamicRecord record = records.get(0);
+    assertThat(record.rowData()).isInstanceOf(VariantRowDataWrapper.class);
     assertThat(record.tableIdentifier()).isEqualTo(TableIdentifier.of(TEST_DB, TEST_TABLE));
     assertThat(record.branch()).isEqualTo(BRANCH);
     assertThat(record.writeParallelism()).isEqualTo(1);
+    assertThat(record.distributionMode()).isEqualTo(DistributionMode.HASH);
 
     PartitionSpec expectedPartitionSpec =
         PartitionSpec.builderFor(AvroSchemaUtil.toIceberg(schema))
@@ -206,13 +249,7 @@ class TestVariantAvroDynamicTableRecordGenerator {
     ListCollector<DynamicRecord> collector = new ListCollector<>(records);
 
     // Generate first record with schema1
-    RowData inputRecord1 =
-        GenericRowData.of(
-            dataGenerator1.generateFlinkVariantData(),
-            StringData.fromString(schema1.toString()),
-            StringData.fromString(schemaId1),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE));
+    RowData inputRecord1 = inputRow(dataGenerator1.generateFlinkVariantData(), schema1, schemaId1);
     generator.generate(inputRecord1, collector);
 
     // Verify cache has been populated with first table and schema
@@ -226,22 +263,13 @@ class TestVariantAvroDynamicTableRecordGenerator {
 
     // Generate second record with same schema1 (should use cached schema)
     RowData inputRecord1Repeat =
-        GenericRowData.of(
-            dataGenerator1.generateFlinkVariantData(),
-            StringData.fromString(schema1.toString()),
-            StringData.fromString(schemaId1),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE));
+        inputRow(dataGenerator1.generateFlinkVariantData(), schema1, schemaId1);
     generator.generate(inputRecord1Repeat, collector);
 
     // Generate third record with different schema2 and different table
     RowData inputRecord2 =
-        GenericRowData.of(
-            dataGenerator2.generateFlinkVariantData(),
-            StringData.fromString(schema2.toString()),
-            StringData.fromString(schemaId2),
-            StringData.fromString(TEST_DB),
-            StringData.fromString("test_table2"));
+        inputRow(
+            dataGenerator2.generateFlinkVariantData(), schema2, schemaId2, TEST_DB, "test_table2");
     generator.generate(inputRecord2, collector);
 
     // Verify we now have two table cache items
@@ -301,13 +329,7 @@ class TestVariantAvroDynamicTableRecordGenerator {
         Variant.newBuilder().object().add("id", Variant.newBuilder().of(123L)).build();
 
     // Generate record with initial schema
-    RowData inputRecord1 =
-        GenericRowData.of(
-            initialVariantData,
-            StringData.fromString(initialSchema.toString()),
-            StringData.fromString(initialSchemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE));
+    RowData inputRecord1 = inputRow(initialVariantData, initialSchema, initialSchemaId);
     generator.generate(inputRecord1, collector);
 
     // Create variant data for evolved schema (id and name fields)
@@ -319,13 +341,7 @@ class TestVariantAvroDynamicTableRecordGenerator {
             .build();
 
     // Generate record with evolved schema
-    RowData inputRecord2 =
-        GenericRowData.of(
-            evolvedVariantData,
-            StringData.fromString(evolvedSchema.toString()),
-            StringData.fromString(evolvedSchemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE));
+    RowData inputRecord2 = inputRow(evolvedVariantData, evolvedSchema, evolvedSchemaId);
     generator.generate(inputRecord2, collector);
 
     assertThat(records).hasSize(2);
@@ -355,7 +371,7 @@ class TestVariantAvroDynamicTableRecordGenerator {
   void testPartitionSpecCaching() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
-    String avroSchema = dataGenerator.avroSchema().toString();
+    Schema avroSchema = dataGenerator.avroSchema();
     String schemaId = "TestSchema:1";
 
     RowType rowType = createRowTypeWithAllColumns();
@@ -367,42 +383,15 @@ class TestVariantAvroDynamicTableRecordGenerator {
     ListCollector<DynamicRecord> collector = new ListCollector<>(records);
 
     // Generate first record with partition on "row_id"
-    RowData inputRecord1 =
-        GenericRowData.of(
-            variantData,
-            StringData.fromString(avroSchema),
-            StringData.fromString(schemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE),
-            StringData.fromString(BRANCH),
-            StringData.fromString("row_id"),
-            1);
+    RowData inputRecord1 = inputRow(variantData, avroSchema, schemaId, BRANCH, "row_id", 1);
     generator.generate(inputRecord1, collector);
 
     // Generate second record with same partition spec (should use cached partition spec)
-    RowData inputRecord2 =
-        GenericRowData.of(
-            variantData,
-            StringData.fromString(avroSchema),
-            StringData.fromString(schemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE),
-            StringData.fromString(BRANCH),
-            StringData.fromString("row_id"),
-            1);
+    RowData inputRecord2 = inputRow(variantData, avroSchema, schemaId, BRANCH, "row_id", 1);
     generator.generate(inputRecord2, collector);
 
     // Generate third record with different partition spec
-    RowData inputRecord3 =
-        GenericRowData.of(
-            variantData,
-            StringData.fromString(avroSchema),
-            StringData.fromString(schemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE),
-            StringData.fromString(BRANCH),
-            StringData.fromString("string_field"),
-            1);
+    RowData inputRecord3 = inputRow(variantData, avroSchema, schemaId, BRANCH, "string_field", 1);
     generator.generate(inputRecord3, collector);
 
     assertThat(records).hasSize(3);
@@ -426,6 +415,49 @@ class TestVariantAvroDynamicTableRecordGenerator {
         generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
     assertThat(cacheItem.partitionSpec("row_id")).isNotNull();
     assertThat(cacheItem.partitionSpec("string_field")).isNotNull();
+  }
+
+  private static List<DynamicRecord> runGenerate(
+      RowType rowType, Map<String, String> writeProperties, RowData inputRow) throws Exception {
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties, FLINK_CONFIG);
+    generator.open(new DefaultOpenContext());
+    List<DynamicRecord> records = Lists.newArrayList();
+    generator.generate(inputRow, new ListCollector<>(records));
+    return records;
+  }
+
+  private static RowData inputRow(Variant data, Schema schema, String schemaId) {
+    return inputRow(data, schema, schemaId, TEST_DB, TEST_TABLE);
+  }
+
+  private static RowData inputRow(
+      Variant data, Schema schema, String schemaId, String database, String table) {
+    return GenericRowData.of(
+        data,
+        StringData.fromString(schema.toString()),
+        StringData.fromString(schemaId),
+        StringData.fromString(database),
+        StringData.fromString(table));
+  }
+
+  private static RowData inputRow(
+      Variant data,
+      Schema schema,
+      String schemaId,
+      String branch,
+      String partitionColumns,
+      int parallelism) {
+    return GenericRowData.of(
+        data,
+        StringData.fromString(schema.toString()),
+        StringData.fromString(schemaId),
+        StringData.fromString(TEST_DB),
+        StringData.fromString(TEST_TABLE),
+        StringData.fromString(branch),
+        StringData.fromString(partitionColumns),
+        parallelism,
+        StringData.fromString(DistributionMode.NONE.modeName()));
   }
 
   private static void addRequiredFields(List<LogicalType> types, List<String> names) {
@@ -481,6 +513,9 @@ class TestVariantAvroDynamicTableRecordGenerator {
 
     types.add(new IntType(false));
     names.add(FlinkWriteOptions.WRITE_PARALLELISM.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkWriteOptions.DISTRIBUTION_MODE.key());
 
     return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -25,12 +25,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.RowType;
 import org.apache.flink.table.types.logical.VarCharType;
@@ -47,15 +49,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
 
-public class TestVariantAvroDynamicTableRecordGenerator {
+class TestVariantAvroDynamicTableRecordGenerator {
 
-  public static final String TEST_DB = "test_db";
-  public static final String TEST_TABLE = "test_table";
-  public static final String BRANCH = "main";
+  private static final String TEST_DB = "test_db";
+  private static final String TEST_TABLE = "test_table";
+  private static final String BRANCH = "main";
   private static final Configuration FLINK_CONFIG = new Configuration();
 
   @Test
-  public void testMissingRequiredFields() {
+  void testMissingRequiredFields() {
     List<LogicalType> types = Lists.newArrayList();
     List<String> names = Lists.newArrayList();
 
@@ -76,7 +78,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
-  public void testWithWritePropertiesOverride() throws Exception {
+  void testWithWritePropertiesOverride() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
     Schema schema = dataGenerator.avroSchema();
@@ -111,7 +113,41 @@ public class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
-  public void testWithPartitionedTable() throws Exception {
+  void testNullCatalogColumnsFallBackToWriteProperties() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaVersion = "v1";
+
+    Map<String, String> writeProperties = Maps.newHashMap();
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_DATABASE.key(), "fallback_db");
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_TABLE.key(), "fallback_table");
+
+    RowType rowType = createRowTypeWithDbAndTable();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties, FLINK_CONFIG);
+    generator.open(new DefaultOpenContext());
+
+    RowData inputRecord =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schema.getName() + schemaVersion),
+            null,
+            null);
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+    generator.generate(inputRecord, collector);
+
+    assertThat(records).hasSize(1);
+    DynamicRecord record = records.get(0);
+    assertThat(record.tableIdentifier())
+        .isEqualTo(TableIdentifier.of("fallback_db", "fallback_table"));
+  }
+
+  @Test
+  void testWithPartitionedTable() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
     Schema schema = dataGenerator.avroSchema();
@@ -152,7 +188,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
-  public void testSchemaCaching() throws Exception {
+  void testSchemaCaching() throws Exception {
     DataGenerator dataGenerator1 = new DataGenerators.Primitives();
     DataGenerator dataGenerator2 = new DataGenerators.StructOfPrimitive();
 
@@ -226,14 +262,14 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     assertThat(records).hasSize(3);
     // Should emit DynamicRecord with same tableSchema instance.
-    assertThat(records.get(1).schema() == schemaCacheItem.tableSchema()).isTrue();
+    assertThat(records.get(1).schema()).isSameAs(schemaCacheItem.tableSchema());
   }
 
   @Test
-  public void testSchemaEvolution() throws Exception {
+  void testSchemaEvolution() throws Exception {
     // Create simple schema with one field
-    org.apache.avro.Schema initialSchema =
-        org.apache.avro.SchemaBuilder.builder()
+    Schema initialSchema =
+        SchemaBuilder.builder()
             .record("UserRecord")
             .namespace("test.schema")
             .fields()
@@ -242,8 +278,8 @@ public class TestVariantAvroDynamicTableRecordGenerator {
     String initialSchemaId = "UserRecord:v1";
 
     // Create evolved schema with additional field
-    org.apache.avro.Schema evolvedSchema =
-        org.apache.avro.SchemaBuilder.builder()
+    Schema evolvedSchema =
+        SchemaBuilder.builder()
             .record("UserRecord")
             .namespace("test.schema")
             .fields()
@@ -316,7 +352,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
   }
 
   @Test
-  public void testPartitionSpecCaching() throws Exception {
+  void testPartitionSpecCaching() throws Exception {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Variant variantData = dataGenerator.generateFlinkVariantData();
     String avroSchema = dataGenerator.avroSchema().toString();
@@ -380,7 +416,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
     assertThat(record2.spec().fields()).hasSize(1);
     assertThat(record1.spec().fields().get(0).name()).isEqualTo("row_id");
     assertThat(record2.spec().fields().get(0).name()).isEqualTo("row_id");
-    assertThat(record1.spec() == record2.spec()).isTrue();
+    assertThat(record1.spec()).isSameAs(record2.spec());
 
     // Verify third record has different partition spec (partitioned on string_field)
     assertThat(record3.spec().fields()).hasSize(1);
@@ -443,7 +479,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
     types.add(new VarCharType(false, 255));
     names.add(VariantAvroDynamicTableRecordGenerator.PARTITION_COLUMNS);
 
-    types.add(new org.apache.flink.table.types.logical.IntType(false));
+    types.add(new IntType(false));
     names.add(FlinkWriteOptions.WRITE_PARALLELISM.key());
 
     return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -1,0 +1,444 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.sink.dynamic;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.Schema;
+import org.apache.flink.api.common.functions.DefaultOpenContext;
+import org.apache.flink.api.common.functions.util.ListCollector;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.data.StringData;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.logical.VariantType;
+import org.apache.flink.types.variant.Variant;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.flink.DataGenerator;
+import org.apache.iceberg.flink.DataGenerators;
+import org.apache.iceberg.flink.FlinkCreateTableOptions;
+import org.apache.iceberg.flink.FlinkWriteOptions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestVariantAvroDynamicTableRecordGenerator {
+
+  public static final String TEST_DB = "test_db";
+  public static final String TEST_TABLE = "test_table";
+  public static final String BRANCH = "main";
+
+  @Test
+  public void testMissingRequiredFields() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    RowType rowType = RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+
+    assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing column data.Expected column data of type VARIANT NOT NULL.");
+  }
+
+  @Test
+  public void testWithWritePropertiesOverride() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaVersion = "v1";
+
+    Map<String, String> writeProperties = Maps.newHashMap();
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_DATABASE.key(), "test_db_override");
+    writeProperties.put(FlinkCreateTableOptions.CATALOG_TABLE.key(), "test_table_override");
+
+    RowType rowType = createRowTypeWithRequiredFields();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, writeProperties);
+    generator.open(new DefaultOpenContext());
+
+    RowData inputRecord =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schema.getName() + schemaVersion));
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+    generator.generate(inputRecord, collector);
+
+    assertThat(records).hasSize(1);
+    DynamicRecord record = records.get(0);
+    assertThat(record.tableIdentifier())
+        .isEqualTo(TableIdentifier.of("test_db_override", "test_table_override"));
+    assertThat(record.branch()).isNull();
+    assertThat(record.spec()).isEqualTo(PartitionSpec.unpartitioned());
+    assertThat(record.writeParallelism()).isEqualTo(-1);
+  }
+
+  @Test
+  public void testWithPartitionedTable() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    Schema schema = dataGenerator.avroSchema();
+    String schemaVersion = "v1";
+
+    RowType rowType = createRowTypeWithAllColumns();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    RowData inputRecord =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(schema.toString()),
+            StringData.fromString(schema.getName() + schemaVersion),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id,string_field"),
+            1);
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+    generator.generate(inputRecord, collector);
+
+    assertThat(records).hasSize(1);
+    DynamicRecord record = records.get(0);
+    assertThat(record.tableIdentifier()).isEqualTo(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(record.branch()).isEqualTo(BRANCH);
+    assertThat(record.writeParallelism()).isEqualTo(1);
+
+    PartitionSpec expectedPartitionSpec =
+        PartitionSpec.builderFor(AvroSchemaUtil.toIceberg(schema))
+            .identity("row_id")
+            .identity("string_field")
+            .build();
+    assertThat(record.spec()).isEqualTo(expectedPartitionSpec);
+  }
+
+  @Test
+  public void testSchemaCaching() throws Exception {
+    DataGenerator dataGenerator1 = new DataGenerators.Primitives();
+    DataGenerator dataGenerator2 = new DataGenerators.StructOfPrimitive();
+
+    Schema schema1 = AvroSchemaUtil.convert(dataGenerator1.icebergSchema(), "TestSchema1");
+    Schema schema2 = AvroSchemaUtil.convert(dataGenerator2.icebergSchema(), "TestSchema2");
+    String schemaId1 = schema1.getName() + ":1";
+    String schemaId2 = schema2.getName() + ":1";
+
+    RowType rowType = createRowTypeWithDbAndTable();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Generate first record with schema1
+    RowData inputRecord1 =
+        GenericRowData.of(
+            dataGenerator1.generateFlinkVariantData(),
+            StringData.fromString(schema1.toString()),
+            StringData.fromString(schemaId1),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1, collector);
+
+    // Verify cache has been populated with first table and schema
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem).isNotNull();
+    VariantAvroDynamicTableRecordGenerator.SchemaCacheItem schemaCacheItem =
+        cacheItem.schemaCacheItem(schemaId1);
+    assertThat(schemaCacheItem).isNotNull();
+    assertThat(schemaCacheItem.tableSchema().sameSchema(dataGenerator1.icebergSchema())).isTrue();
+
+    // Generate second record with same schema1 (should use cached schema)
+    RowData inputRecord1Repeat =
+        GenericRowData.of(
+            dataGenerator1.generateFlinkVariantData(),
+            StringData.fromString(schema1.toString()),
+            StringData.fromString(schemaId1),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1Repeat, collector);
+
+    // Generate third record with different schema2 and different table
+    RowData inputRecord2 =
+        GenericRowData.of(
+            dataGenerator2.generateFlinkVariantData(),
+            StringData.fromString(schema2.toString()),
+            StringData.fromString(schemaId2),
+            StringData.fromString(TEST_DB),
+            StringData.fromString("test_table2"));
+    generator.generate(inputRecord2, collector);
+
+    // Verify we now have two table cache items
+    assertThat(generator.tableCache()).hasSize(2);
+    assertThat(generator.tableCache()).containsKey(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(generator.tableCache()).containsKey(TableIdentifier.of(TEST_DB, "test_table2"));
+
+    // Verify second table cache item has different schema
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem2 =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, "test_table2"));
+    assertThat(cacheItem2).isNotNull();
+    assertThat(
+            cacheItem2
+                .schemaCacheItem(schemaId2)
+                .tableSchema()
+                .sameSchema(dataGenerator2.icebergSchema()))
+        .isTrue();
+
+    assertThat(records).hasSize(3);
+    // Should emit DynamicRecord with same tableSchema instance.
+    assertThat(records.get(1).schema() == schemaCacheItem.tableSchema()).isTrue();
+  }
+
+  @Test
+  public void testSchemaEvolution() throws Exception {
+    // Create simple schema with one field
+    org.apache.avro.Schema initialSchema =
+        org.apache.avro.SchemaBuilder.builder()
+            .record("UserRecord")
+            .namespace("test.schema")
+            .fields()
+            .requiredLong("id")
+            .endRecord();
+    String initialSchemaId = "UserRecord:v1";
+
+    // Create evolved schema with additional field
+    org.apache.avro.Schema evolvedSchema =
+        org.apache.avro.SchemaBuilder.builder()
+            .record("UserRecord")
+            .namespace("test.schema")
+            .fields()
+            .requiredLong("id")
+            .optionalString("name")
+            .endRecord();
+    String evolvedSchemaId = "UserRecord:v2";
+
+    RowType rowType = createRowTypeWithDbAndTable();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Create variant data for initial schema (only id field)
+    Variant initialVariantData =
+        Variant.newBuilder().object().add("id", Variant.newBuilder().of(123L)).build();
+
+    // Generate record with initial schema
+    RowData inputRecord1 =
+        GenericRowData.of(
+            initialVariantData,
+            StringData.fromString(initialSchema.toString()),
+            StringData.fromString(initialSchemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord1, collector);
+
+    // Create variant data for evolved schema (id and name fields)
+    Variant evolvedVariantData =
+        Variant.newBuilder()
+            .object()
+            .add("id", Variant.newBuilder().of(456L))
+            .add("name", Variant.newBuilder().of("name"))
+            .build();
+
+    // Generate record with evolved schema
+    RowData inputRecord2 =
+        GenericRowData.of(
+            evolvedVariantData,
+            StringData.fromString(evolvedSchema.toString()),
+            StringData.fromString(evolvedSchemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE));
+    generator.generate(inputRecord2, collector);
+
+    assertThat(records).hasSize(2);
+
+    // Verify all records were generated successfully
+    DynamicRecord record1 = records.get(0);
+    DynamicRecord record2 = records.get(1);
+
+    assertThat(record1.rowData().getLong(0)).isEqualTo(123L);
+    assertThat(record2.rowData().getLong(0)).isEqualTo(456L);
+    assertThat(record2.rowData().getString(1).toString()).isEqualTo("name");
+
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem).isNotNull();
+    VariantAvroDynamicTableRecordGenerator.SchemaCacheItem schemaCacheItem =
+        cacheItem.schemaCacheItem(initialSchemaId);
+    assertThat(schemaCacheItem.tableSchema().sameSchema(AvroSchemaUtil.toIceberg(initialSchema)))
+        .isTrue();
+
+    schemaCacheItem = cacheItem.schemaCacheItem(evolvedSchemaId);
+    assertThat(schemaCacheItem.tableSchema().sameSchema(AvroSchemaUtil.toIceberg(evolvedSchema)))
+        .isTrue();
+  }
+
+  @Test
+  public void testPartitionSpecCaching() throws Exception {
+    DataGenerator dataGenerator = new DataGenerators.Primitives();
+    Variant variantData = dataGenerator.generateFlinkVariantData();
+    String avroSchema = dataGenerator.avroSchema().toString();
+    String schemaId = "TestSchema:1";
+
+    RowType rowType = createRowTypeWithAllColumns();
+    VariantAvroDynamicTableRecordGenerator generator =
+        new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap());
+    generator.open(new DefaultOpenContext());
+
+    List<DynamicRecord> records = Lists.newArrayList();
+    ListCollector<DynamicRecord> collector = new ListCollector<>(records);
+
+    // Generate first record with partition on "row_id"
+    RowData inputRecord1 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id"),
+            1);
+    generator.generate(inputRecord1, collector);
+
+    // Generate second record with same partition spec (should use cached partition spec)
+    RowData inputRecord2 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("row_id"),
+            1);
+    generator.generate(inputRecord2, collector);
+
+    // Generate third record with different partition spec
+    RowData inputRecord3 =
+        GenericRowData.of(
+            variantData,
+            StringData.fromString(avroSchema),
+            StringData.fromString(schemaId),
+            StringData.fromString(TEST_DB),
+            StringData.fromString(TEST_TABLE),
+            StringData.fromString(BRANCH),
+            StringData.fromString("string_field"),
+            1);
+    generator.generate(inputRecord3, collector);
+
+    assertThat(records).hasSize(3);
+
+    DynamicRecord record1 = records.get(0);
+    DynamicRecord record2 = records.get(1);
+    DynamicRecord record3 = records.get(2);
+
+    // Verify first two records have same partition spec (partitioned on row_id)
+    assertThat(record1.spec().fields()).hasSize(1);
+    assertThat(record2.spec().fields()).hasSize(1);
+    assertThat(record1.spec().fields().get(0).name()).isEqualTo("row_id");
+    assertThat(record2.spec().fields().get(0).name()).isEqualTo("row_id");
+    assertThat(record1.spec() == record2.spec()).isTrue();
+
+    // Verify third record has different partition spec (partitioned on string_field)
+    assertThat(record3.spec().fields()).hasSize(1);
+    assertThat(record3.spec().fields().get(0).name()).isEqualTo("string_field");
+
+    VariantAvroDynamicTableRecordGenerator.SchemaAndPartitionSpecCacheItem cacheItem =
+        generator.tableCache().get(TableIdentifier.of(TEST_DB, TEST_TABLE));
+    assertThat(cacheItem.partitionSpec("row_id")).isNotNull();
+    assertThat(cacheItem.partitionSpec("string_field")).isNotNull();
+  }
+
+  private static void addRequiredFields(List<LogicalType> types, List<String> names) {
+    types.add(new VariantType(false));
+    names.add(VariantAvroDynamicTableRecordGenerator.DATA_COLUMN);
+    types.add(new VarCharType(false, Integer.MAX_VALUE));
+    names.add(VariantAvroDynamicTableRecordGenerator.AVRO_SCHEMA_COLUMN);
+    types.add(new VarCharType(false, 255));
+    names.add(VariantAvroDynamicTableRecordGenerator.AVRO_SCHEMA_ID_COLUMN);
+  }
+
+  private static RowType createRowTypeWithRequiredFields() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+
+  private static RowType createRowTypeWithDbAndTable() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+
+  private static RowType createRowTypeWithAllColumns() {
+    List<LogicalType> types = Lists.newArrayList();
+    List<String> names = Lists.newArrayList();
+
+    addRequiredFields(types, names);
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_DATABASE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkCreateTableOptions.CATALOG_TABLE.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(FlinkWriteOptions.BRANCH.key());
+
+    types.add(new VarCharType(false, 255));
+    names.add(VariantAvroDynamicTableRecordGenerator.PARTITION_COLUMNS);
+
+    types.add(new org.apache.flink.table.types.logical.IntType(false));
+    names.add(FlinkWriteOptions.WRITE_PARALLELISM.key());
+
+    return RowType.of(types.toArray(new LogicalType[0]), names.toArray(new String[0]));
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -65,7 +65,7 @@ public class TestVariantAvroDynamicTableRecordGenerator {
 
     assertThatThrownBy(() -> new VariantAvroDynamicTableRecordGenerator(rowType, Maps.newHashMap()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing column data.Expected column data of type VARIANT NOT NULL.");
+        .hasMessageContaining("Missing column data. Expected column data of type VARIANT NOT NULL.");
   }
 
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestVariantAvroDynamicTableRecordGenerator.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
-import org.apache.avro.SchemaParseException;
 import org.apache.flink.api.common.functions.DefaultOpenContext;
 import org.apache.flink.api.common.functions.util.ListCollector;
 import org.apache.flink.configuration.Configuration;
@@ -114,25 +113,6 @@ class TestVariantAvroDynamicTableRecordGenerator {
             StringData.fromString(TEST_DB),
             StringData.fromString(TEST_TABLE));
     assertThat(runGenerate(rowType, Collections.emptyMap(), nullSchemaId)).isEmpty();
-  }
-
-  @Test
-  void testMalformedAvroSchemaThrows() {
-    DataGenerator dataGenerator = new DataGenerators.Primitives();
-    Variant variantData = dataGenerator.generateFlinkVariantData();
-    String schemaId = "TestSchema:v1";
-    RowType rowType = createRowTypeWithDbAndTable();
-
-    RowData malformed =
-        GenericRowData.of(
-            variantData,
-            StringData.fromString("not-a-valid-avro-schema"),
-            StringData.fromString(schemaId),
-            StringData.fromString(TEST_DB),
-            StringData.fromString(TEST_TABLE));
-
-    assertThatThrownBy(() -> runGenerate(rowType, Collections.emptyMap(), malformed))
-        .isInstanceOf(SchemaParseException.class);
   }
 
   @Test


### PR DESCRIPTION
Resurrecting the closed PR, https://github.com/apache/iceberg/pull/15471 (Was Stale).

Re-adding the context here,

Added,

**VariantAvroDynamicTableRecordGenerator**: Custom Dynamic table record generator designed for deserializing the Variant with the schema provided and writing to Iceberg Tables matching with avro schema passed in SQL.

**VariantRowDataWrapper**: Wrapper class for variant row data that provides type-safe conversion and handling of variant data structures as RowData.


Changes allow to ingest data in Flink SQL using dynamic iceberg sink.

```
CREATE TABLE test_dynamic (
    data VARIANT,                    -- JSON payload 
    `catalog-database` STRING,       -- Target database
    `catalog-table` STRING,          -- Target table  
    avro_schema STRING,              -- Schema definition
    avro_schema_id STRING,       -- Schema versioning ,mainly used for caching instead of relying on full schema comparison.
    branch STRING,                   -- Iceberg branch
    `write-parallelism` INT          -- Performance tuning
  ) WITH ('use-dynamic-iceberg-sink'='true', ...)
```

 ```
 INSERT INTO test_dynamic VALUES
  (PARSE_JSON('{"id": 1, "name": "AAA"}'), 'db', 'table', '<avro-schema>', 'TestSchema:1', 'main', 1)
```

All comments in previous PR are resolved. Pulled and merged in changes from PR, https://github.com/apache/iceberg/pull/15780
