### PR TITLE
Docs: Drop manual deploy step from release instructions

### DIFF
--- a/site/README.md
+++ b/site/README.md
@@ -174,22 +174,8 @@ make build OFFLINE=true
 
 ## Release process
 
-Deploying the docs is a two-step process:
-
-> [!WARNING]  
-> The `make release` directive is currently unavailable as we wanted to discuss the best way forward on how or if we should automate the release. It involves taking an existing snapshot of the versioned documentation, and potentially automerging the [`docs` branch](https://github.com/apache/iceberg/tree/docs) and the [`javadoc` branch](https://github.com/apache/iceberg/tree/javadoc) which are independent from the `main` branch. Once this is complete, we can create a pull request with an offline build of the documentation to verify everything renders correctly, and then have the release manager merge that PR to finalize the docs release. So the real process would be manually invoking a docs release action, then merging a pull request.
-
- 1. Release a new version by copying the current `/docs` directory to a new version directory in the `docs` branch and a new javadoc build in the `javadoc` branch.
-    ```sh
-    make release ICEBERG_VERSION=${ICEBERG_VERSION}
-    ```
- 1. Build and push the generated site to the `asf-site` branch of [remote repo](https://github.com/apache/iceberg). This requires committer write permission.
-    ```sh
-    # Default remote name is 'origin'
-    make deploy
-    # Or specify a different remote
-    make deploy remote_name=apache
-    ```
+For release documentation publishing steps, follow the
+[Documentation Release](docs/how-to-release.md#documentation-release) section of the release guide.
 
 ## Validate Links
 

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -364,7 +364,7 @@ to update the Iceberg version, the links to the new version's documentation, and
 Once this PR is merged, the [`site-ci`](https://github.com/apache/iceberg/blob/main/.github/workflows/site-ci.yml)
 GitHub Actions workflow is automatically triggered for any push to `main` that touches `docs/`, `site/`,
 or `format/`. The workflow runs `make deploy` to build and push the documentation site to the `asf-site`
-branch, which publishes the new version's docs and javadoc. 
+branch, which publishes the new version's docs and javadoc.
 
 The site will be updated automatically. Manually running `make deploy` is no longer required as part of the release.
 

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -356,14 +356,16 @@ cp -R apache-iceberg-1.8.0/site/docs/javadoc/1.8.0 1.8.0
 
 Once this is done, create a PR against the `javadoc` branch, similar to https://github.com/apache/iceberg/pull/12412.
 
-#### Release versioned docs and javadoc
-
-Please follow the instructions on the GitHub repository in the [`README.md` in the `site/`](https://github.com/apache/iceberg/tree/main/site) directory.
-
 #### Site update
 
 Submit a PR, following the approach in https://github.com/apache/iceberg/pull/12242,
 to update the Iceberg version, the links to the new version's documentation, and the release notes.
+
+Once this PR is merged, the [`site-ci`](https://github.com/apache/iceberg/blob/main/.github/workflows/site-ci.yml)
+GitHub Actions workflow is automatically triggered for any push to `main` that touches `docs/`, `site/`,
+or `format/`. The workflow runs `make deploy` to build and push the documentation site to the `asf-site`
+branch, which publishes the new version's docs and javadoc. Manually running `make deploy` is no longer
+required as part of the release.
 
 # How to Verify a Release
 

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -364,8 +364,9 @@ to update the Iceberg version, the links to the new version's documentation, and
 Once this PR is merged, the [`site-ci`](https://github.com/apache/iceberg/blob/main/.github/workflows/site-ci.yml)
 GitHub Actions workflow is automatically triggered for any push to `main` that touches `docs/`, `site/`,
 or `format/`. The workflow runs `make deploy` to build and push the documentation site to the `asf-site`
-branch, which publishes the new version's docs and javadoc. Manually running `make deploy` is no longer
-required as part of the release.
+branch, which publishes the new version's docs and javadoc. 
+
+The site will be updated automatically. Manually running `make deploy` is no longer required as part of the release.
 
 # How to Verify a Release
 


### PR DESCRIPTION
## Summary

The `Release versioned docs and javadoc` step in [`how-to-release.md`](https://iceberg.apache.org/how-to-release/#release-versioned-docs-and-javadoc) currently points release managers at `site/README.md`, which says to run `make deploy` manually to push the docs site to the `asf-site` branch.

That step is unnecessary: the [`site-ci`](https://github.com/apache/iceberg/blob/main/.github/workflows/site-ci.yml) GitHub Actions workflow already runs `make deploy` automatically on any push to `main` that touches `docs/`, `site/`, or `format/`. So once the `Site update` PR is merged, the new release's docs and javadoc are published without any manual deploy.

This PR removes the obsolete step and adds a short note under `Site update` explaining the auto-trigger, so release managers don't accidentally push to `asf-site` by hand.

## Test plan

- [ ] Verify `site-ci` triggers on the next merge to `main` that touches `site/docs/how-to-release.md` and updates the rendered page at https://iceberg.apache.org/how-to-release/.

🤖 Generated with [Claude Code](https://claude.com/claude-code)