### PR TITLE
Core: Skip testAddManyFilesWithConsistentOrdering if WORKER_THREAD_POOL_SIZE < 3

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
+++ b/core/src/test/java/org/apache/iceberg/TestMergeAppend.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ThreadPools;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -90,6 +91,11 @@ public class TestMergeAppend extends TestBase {
     assertThat(listManifestFiles()).as("Table should start empty").isEmpty();
 
     int multiplier = 3;
+    assumeThat(ThreadPools.WORKER_THREAD_POOL_SIZE)
+        .as(
+            "Worker thread pool size should be at least 3 to test manifest file ordering with multiple threads")
+        .isGreaterThanOrEqualTo(multiplier);
+
     int groupSize = SnapshotProducer.MIN_FILE_GROUP_SIZE;
     List<DataFile> dataFiles = Lists.newArrayList();
 


### PR DESCRIPTION
The test fails if `WORKER_THREAD_POOL_SIZE` < 3.

```
Expected size: 3 but was: 2 in:
[GenericManifestFile{content=DATA, path=/var/folders/9s/_zwn4r_n2_9bp0krllp1pl3c0000gp/T/junit-2351142152275179508/metadata/4d4b563b-9372-4561-b141-f9434d3e5473-m1.avro, length=1517389, partition_spec_id=0, added_snapshot_id=1, added_data_files_count=15000, added_rows_count=1507481968, existing_data_files_count=0, existing_rows_count=0, deleted_data_files_count=0, deleted_rows_count=0, partitions=[GenericPartitionFieldSummary{contains_null=false, contains_nan=false, lower_bound=[0, 0, 0, 0], upper_bound=[1, 0, 0, 0]}], key_metadata=null, sequence_number=0, min_sequence_number=0, first_row_id=null},
    GenericManifestFile{content=DATA, path=/var/folders/9s/_zwn4r_n2_9bp0krllp1pl3c0000gp/T/junit-2351142152275179508/metadata/4d4b563b-9372-4561-b141-f9434d3e5473-m0.avro, length=1516450, partition_spec_id=0, added_snapshot_id=1, added_data_files_count=15000, added_rows_count=1507482102, existing_data_files_count=0, existing_rows_count=0, deleted_data_files_count=0, deleted_rows_count=0, partitions=[GenericPartitionFieldSummary{contains_null=false, contains_nan=false, lower_bound=[0, 0, 0, 0], upper_bound=[1, 0, 0, 0]}], key_metadata=null, sequence_number=0, min_sequence_number=0, first_row_id=null}]
java.lang.AssertionError: 
Expected size: 3 but was: 2 in:
[GenericManifestFile{content=DATA, path=/var/folders/9s/_zwn4r_n2_9bp0krllp1pl3c0000gp/T/junit-2351142152275179508/metadata/4d4b563b-9372-4561-b141-f9434d3e5473-m1.avro, length=1517389, partition_spec_id=0, added_snapshot_id=1, added_data_files_count=15000, added_rows_count=1507481968, existing_data_files_count=0, existing_rows_count=0, deleted_data_files_count=0, deleted_rows_count=0, partitions=[GenericPartitionFieldSummary{contains_null=false, contains_nan=false, lower_bound=[0, 0, 0, 0], upper_bound=[1, 0, 0, 0]}], key_metadata=null, sequence_number=0, min_sequence_number=0, first_row_id=null},
    GenericManifestFile{content=DATA, path=/var/folders/9s/_zwn4r_n2_9bp0krllp1pl3c0000gp/T/junit-2351142152275179508/metadata/4d4b563b-9372-4561-b141-f9434d3e5473-m0.avro, length=1516450, partition_spec_id=0, added_snapshot_id=1, added_data_files_count=15000, added_rows_count=1507482102, existing_data_files_count=0, existing_rows_count=0, deleted_data_files_count=0, deleted_rows_count=0, partitions=[GenericPartitionFieldSummary{contains_null=false, contains_nan=false, lower_bound=[0, 0, 0, 0], upper_bound=[1, 0, 0, 0]}], key_metadata=null, sequence_number=0, min_sequence_number=0, first_row_id=null}]
	at org.apache.iceberg.TestMergeAppend.testAddManyFilesWithConsistentOrdering(TestMergeAppend.java:110)
	at java.base/java.lang.reflect.Method.invoke(Method.java:580)
	at java.base/java.util.Optional.ifPresent(Optional.java:178)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.accept(ForEachOps.java:184)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1708)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ForEachOps$ForEachOp.evaluateSequential(ForEachOps.java:151)
	at java.base/java.util.stream.ForEachOps$ForEachOp$OfRef.evaluateSequential(ForEachOps.java:174)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.forEach(ReferencePipeline.java:596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
```