### PR TITLE
Arrow: Cap heap allocations in vectorized Parquet decoders

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/BaseVectorizedParquetValuesReader.java
@@ -188,6 +188,17 @@ public class BaseVectorizedParquetValuesReader extends ValuesReader {
           return;
         case PACKED:
           int numGroups = header >>> 1;
+          Preconditions.checkArgument(
+              numGroups >= 0 && numGroups <= Integer.MAX_VALUE / 8,
+              "Invalid PACKED group count %s, must be in [0, %s]",
+              numGroups,
+              Integer.MAX_VALUE / 8);
+          long requiredBytes = (long) numGroups * bitWidth;
+          Preconditions.checkArgument(
+              requiredBytes <= inputStream.available(),
+              "PACKED run needs %s bytes but only %s available",
+              requiredBytes,
+              inputStream.available());
           this.currentCount = numGroups * 8;
           if (this.packedValuesBuffer.length < this.currentCount) {
             this.packedValuesBuffer = new int[this.currentCount];

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedByteStreamSplitValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedByteStreamSplitValuesReader.java
@@ -49,8 +49,18 @@ public class VectorizedByteStreamSplitValuesReader extends ValuesReader
   }
 
   @Override
-  public void initFromPage(int ignoredValueCount, ByteBufferInputStream in) {
+  public void initFromPage(int valueCount, ByteBufferInputStream in) {
+    Preconditions.checkArgument(valueCount >= 0, "valueCount must be >= 0, but is %s", valueCount);
     this.totalBytesInStream = in.available();
+    // valueCount counts every row in the page including nulls, but BYTE_STREAM_SPLIT only encodes
+    // the non-null values, so the byte count is an upper bound rather than an exact match.
+    Preconditions.checkArgument(
+        (long) totalBytesInStream <= (long) valueCount * elementSizeInBytes,
+        "Page size %s bytes exceeds bound %s (= valueCount %s * elementSize %s)",
+        totalBytesInStream,
+        (long) valueCount * elementSizeInBytes,
+        valueCount,
+        elementSizeInBytes);
     this.dataStream = in;
   }
 
@@ -80,7 +90,13 @@ public class VectorizedByteStreamSplitValuesReader extends ValuesReader
 
   @Override
   public Binary readBinary(int len) {
+    Preconditions.checkArgument(len >= 0, "Length must be >= 0, but is %s", len);
     ensureDecoded();
+    Preconditions.checkArgument(
+        len <= decodedDataStream.remaining(),
+        "Length %s exceeds %s bytes remaining in the decoded stream",
+        len,
+        decodedDataStream.remaining());
     byte[] bytes = new byte[len];
     decodedDataStream.get(bytes);
     return Binary.fromConstantByteArray(bytes);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaByteArrayValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaByteArrayValuesReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.arrow.vectorized.parquet;
 
 import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.api.Binary;
@@ -59,6 +60,13 @@ public class VectorizedDeltaByteArrayValuesReader extends ValuesReader
   @Override
   public Binary readBinary(int len) {
     int prefixLength = prefixLengths[currentRow];
+    Preconditions.checkArgument(
+        prefixLength >= 0 && prefixLength <= previous.length(),
+        "Invalid prefixLength %s for previous value of length %s",
+        prefixLength,
+        previous.length());
+    Preconditions.checkArgument(
+        len >= prefixLength, "Total length %s is less than prefixLength %s", len, prefixLength);
     Binary suffix = suffixReader.readBinary(len - prefixLength);
     this.currentRow++;
 
@@ -69,7 +77,13 @@ public class VectorizedDeltaByteArrayValuesReader extends ValuesReader
 
     byte[] prefixBytes = previous.getBytes();
     byte[] suffixBytes = suffix.getBytes();
-    byte[] out = new byte[prefixLength + suffixBytes.length];
+    long totalLen = (long) prefixLength + suffixBytes.length;
+    Preconditions.checkArgument(
+        totalLen <= Integer.MAX_VALUE,
+        "Combined length overflow: prefix=%s + suffix=%s",
+        prefixLength,
+        suffixBytes.length);
+    byte[] out = new byte[(int) totalLen];
     System.arraycopy(prefixBytes, 0, out, 0, prefixLength);
     System.arraycopy(suffixBytes, 0, out, prefixLength, suffixBytes.length);
     this.previous = Binary.fromConstantByteArray(out);

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaEncodedValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaEncodedValuesReader.java
@@ -41,6 +41,11 @@ import org.apache.parquet.io.ParquetDecodingException;
 public class VectorizedDeltaEncodedValuesReader extends ValuesReader
     implements VectorizedValuesReader {
 
+  // Hard cap on the number of values per DELTA_BINARY_PACKED block. Standard Parquet writers use
+  // 128; 1 << 20 is ~8000x that and still bounds `unpackedValuesBuffer` to a few MB even at the
+  // most miniBlocksPerBlock-skewed shape, so legitimate files are unaffected.
+  private static final int MAX_BLOCK_SIZE_IN_VALUES = 1 << 20;
+
   // header data
   private int blockSizeInValues;
   private int miniBlocksPerBlock;
@@ -78,12 +83,27 @@ public class VectorizedDeltaEncodedValuesReader extends ValuesReader
     // Read the header
     this.blockSizeInValues = BytesUtils.readUnsignedVarInt(this.inputStream);
     this.miniBlocksPerBlock = BytesUtils.readUnsignedVarInt(this.inputStream);
+    Preconditions.checkArgument(
+        blockSizeInValues > 0 && blockSizeInValues <= MAX_BLOCK_SIZE_IN_VALUES,
+        "blockSizeInValues must be in (0, %s], but is %s",
+        MAX_BLOCK_SIZE_IN_VALUES,
+        blockSizeInValues);
+    Preconditions.checkArgument(
+        miniBlocksPerBlock > 0 && miniBlocksPerBlock <= blockSizeInValues,
+        "miniBlocksPerBlock must be in (0, blockSizeInValues=%s], but is %s",
+        blockSizeInValues,
+        miniBlocksPerBlock);
     double miniSize = (double) blockSizeInValues / miniBlocksPerBlock;
     Preconditions.checkArgument(
         miniSize % 8 == 0, "miniBlockSize must be multiple of 8, but it's " + miniSize);
     this.miniBlockSizeInValues = (int) miniSize;
     // True value count. May be less than valueCount because of nulls
     this.totalValueCount = BytesUtils.readUnsignedVarInt(this.inputStream);
+    Preconditions.checkArgument(
+        totalValueCount >= 0 && totalValueCount <= valueCount,
+        "totalValueCount must be in [0, valueCount=%s], but is %s",
+        valueCount,
+        totalValueCount);
     this.bitWidths = new int[miniBlocksPerBlock];
     this.unpackedValuesBuffer = new long[miniBlockSizeInValues];
     // read the first value

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaLengthByteArrayValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaLengthByteArrayValuesReader.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.arrow.vectorized.parquet;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.parquet.bytes.ByteBufferInputStream;
 import org.apache.parquet.column.values.ValuesReader;
 import org.apache.parquet.io.api.Binary;
@@ -55,6 +56,12 @@ public class VectorizedDeltaLengthByteArrayValuesReader extends ValuesReader
 
   @Override
   public Binary readBinary(int len) {
+    Preconditions.checkArgument(len >= 0, "Length must be >= 0, but is %s", len);
+    Preconditions.checkArgument(
+        len <= dataStream.available(),
+        "Length %s exceeds %s bytes available in the data stream",
+        len,
+        dataStream.available());
     try {
       ByteBuffer buffer = dataStream.slice(len);
       this.currentRow++;

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestBaseVectorizedParquetValuesReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestBaseVectorizedParquetValuesReader.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.junit.jupiter.api.Test;
+
+class TestBaseVectorizedParquetValuesReader extends VectorizedParquetDecoderTestBase {
+
+  /** Constructs a reader with fixed bitWidth, no length prefix, and no validity vector. */
+  private static BaseVectorizedParquetValuesReader fixedWidthReader(int bitWidth) {
+    return new BaseVectorizedParquetValuesReader(bitWidth, 0, false, false);
+  }
+
+  @Test
+  void rejectsOverflowingPackedGroupCount() throws IOException {
+    int badNumGroups = Integer.MAX_VALUE / 8 + 1;
+    int header = (badNumGroups << 1) | 1; // PACKED with overflowing numGroups
+    byte[] page = page(out -> BytesUtils.writeUnsignedVarInt(header, out));
+
+    BaseVectorizedParquetValuesReader reader = fixedWidthReader(1);
+    reader.initFromPage(0, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(reader::readInteger)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid PACKED group count");
+  }
+
+  @Test
+  void rejectsPackedRunNeedingMoreBytesThanAvailable() throws IOException {
+    int numGroups = 100;
+    int header = (numGroups << 1) | 1; // PACKED, 100 groups => needs 100 * bitWidth bytes
+    byte[] page = page(out -> BytesUtils.writeUnsignedVarInt(header, out));
+
+    BaseVectorizedParquetValuesReader reader = fixedWidthReader(8);
+    reader.initFromPage(0, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(reader::readInteger)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("PACKED run needs");
+  }
+
+  @Test
+  void decodesSinglePackedGroupOfZeros() throws IOException {
+    // bitWidth = 1, numGroups = 1 -> 8 packed values in 1 byte. All-zero byte unpacks to 8 zeros.
+    int header = (1 << 1) | 1; // = 3
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(header, out);
+              out.write(0x00);
+            });
+
+    BaseVectorizedParquetValuesReader reader = fixedWidthReader(1);
+    reader.initFromPage(0, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    for (int i = 0; i < 8; i++) {
+      assertThat(reader.readInteger()).as("value %d", i).isEqualTo(0);
+    }
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedByteStreamSplitValuesReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedByteStreamSplitValuesReader.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.junit.jupiter.api.Test;
+
+class TestVectorizedByteStreamSplitValuesReader extends VectorizedParquetDecoderTestBase {
+
+  @Test
+  void rejectsNegativeValueCount() {
+    byte[] page = new byte[0];
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    assertThatThrownBy(
+            () -> reader.initFromPage(-1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("valueCount must be >= 0");
+  }
+
+  @Test
+  void acceptsPageSmallerThanValueCountTimesElementSize() {
+    // valueCount=4 means 4 logical rows, but BYTE_STREAM_SPLIT only encodes non-null values, so
+    // a page covering 2 nulls + 2 non-null floats is 8 bytes — legitimate, not a size mismatch.
+    byte[] page = new byte[8];
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    reader.initFromPage(4, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+  }
+
+  @Test
+  void rejectsPageSizeMismatchWithOversizedPage() {
+    // valueCount=2, elementSize=4 => bound is 8 bytes, but page has 1024 (an attacker-shaped page)
+    byte[] page = new byte[1024];
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    assertThatThrownBy(
+            () -> reader.initFromPage(2, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds bound");
+  }
+
+  @Test
+  void rejectsNegativeLengthInReadBinary() {
+    // valueCount=1, elementSize=4 => 4 raw bytes.
+    byte[] page = new byte[4];
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Length must be >= 0");
+  }
+
+  @Test
+  void rejectsLengthExceedingDecodedStream() {
+    byte[] page = new byte[4];
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(1024 * 1024))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds 4 bytes remaining");
+  }
+
+  @Test
+  void decodesIntegersRoundTrip() {
+    // BYTE_STREAM_SPLIT: for 4-byte ints, bytes are interleaved by position.
+    // Values: 0x01020304, 0x05060708 stored little-endian:
+    //   stream 0 (LSB): 0x04, 0x08
+    //   stream 1:       0x03, 0x07
+    //   stream 2:       0x02, 0x06
+    //   stream 3 (MSB): 0x01, 0x05
+    byte[] page = {0x04, 0x08, 0x03, 0x07, 0x02, 0x06, 0x01, 0x05};
+
+    VectorizedByteStreamSplitValuesReader reader = new VectorizedByteStreamSplitValuesReader(4);
+    reader.initFromPage(2, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    int first = reader.readInteger();
+    int second = reader.readInteger();
+    int firstLittleEndian =
+        ByteBuffer.wrap(new byte[] {0x04, 0x03, 0x02, 0x01})
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .getInt();
+    int secondLittleEndian =
+        ByteBuffer.wrap(new byte[] {0x08, 0x07, 0x06, 0x05})
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .getInt();
+    assertThat(first).isEqualTo(firstLittleEndian);
+    assertThat(second).isEqualTo(secondLittleEndian);
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaByteArrayValuesReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaByteArrayValuesReader.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.io.api.Binary;
+import org.junit.jupiter.api.Test;
+
+class TestVectorizedDeltaByteArrayValuesReader extends VectorizedParquetDecoderTestBase {
+
+  /** Builds a single-value DELTA_BINARY_PACKED page encoding only the given firstValue. */
+  private static byte[] singleValueDeltaBinaryPacked(long firstValue) {
+    return page(
+        out -> {
+          BytesUtils.writeUnsignedVarInt(128, out); // blockSize
+          BytesUtils.writeUnsignedVarInt(4, out); // miniBlocksPerBlock
+          BytesUtils.writeUnsignedVarInt(1, out); // totalValueCount
+          BytesUtils.writeZigZagVarLong(firstValue, out);
+        });
+  }
+
+  /** Builds a single-value DELTA_LENGTH_BYTE_ARRAY page encoding the given suffix. */
+  private static byte[] singleValueDeltaLengthByteArray(byte[] suffix) {
+    return concat(singleValueDeltaBinaryPacked(suffix.length), suffix);
+  }
+
+  @Test
+  void rejectsPrefixLengthLargerThanPreviousValue() throws IOException {
+    // Row 0: prefixLength = 5, but previous is Binary.EMPTY (length 0) => first guard fails.
+    byte[] page =
+        concat(
+            singleValueDeltaBinaryPacked(5L), // prefixLengths[0] = 5
+            singleValueDeltaLengthByteArray(new byte[] {'x', 'y'})); // suffix length = 2
+
+    VectorizedDeltaByteArrayValuesReader reader = new VectorizedDeltaByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(7))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid prefixLength 5 for previous value of length 0");
+  }
+
+  @Test
+  void rejectsTotalLengthShorterThanPrefix() throws IOException {
+    // Row 0: prefixLength = 0 (passes first guard since 0 <= 0), then call readBinary(-1).
+    // The -1 fails the len >= prefixLength guard (-1 < 0) BEFORE suffixReader is touched.
+    byte[] page =
+        concat(
+            singleValueDeltaBinaryPacked(0L),
+            singleValueDeltaLengthByteArray(new byte[] {'a', 'b'}));
+
+    VectorizedDeltaByteArrayValuesReader reader = new VectorizedDeltaByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Total length -1 is less than prefixLength 0");
+  }
+
+  @Test
+  void decodesSingleValueRoundTrip() throws IOException {
+    byte[] page =
+        concat(
+            singleValueDeltaBinaryPacked(0L), // prefixLength = 0
+            singleValueDeltaLengthByteArray(new byte[] {'h', 'i'}));
+
+    VectorizedDeltaByteArrayValuesReader reader = new VectorizedDeltaByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    Binary value = reader.readBinary(2);
+    assertThat(value.getBytes()).containsExactly('h', 'i');
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaEncodedValuesReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaEncodedValuesReader.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.junit.jupiter.api.Test;
+
+class TestVectorizedDeltaEncodedValuesReader extends VectorizedParquetDecoderTestBase {
+
+  @Test
+  void rejectsZeroBlockSize() {
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(0, out); // blockSizeInValues = 0
+              BytesUtils.writeUnsignedVarInt(4, out);
+              BytesUtils.writeUnsignedVarInt(1, out);
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    assertThatThrownBy(
+            () -> reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("blockSizeInValues must be in");
+  }
+
+  @Test
+  void rejectsZeroMiniBlocksPerBlock() {
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(128, out);
+              BytesUtils.writeUnsignedVarInt(0, out); // miniBlocksPerBlock = 0
+              BytesUtils.writeUnsignedVarInt(1, out);
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    assertThatThrownBy(
+            () -> reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("miniBlocksPerBlock");
+  }
+
+  @Test
+  void rejectsMiniBlocksPerBlockExceedingBlockSize() {
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(128, out);
+              BytesUtils.writeUnsignedVarInt(200, out); // > blockSize
+              BytesUtils.writeUnsignedVarInt(1, out);
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    assertThatThrownBy(
+            () -> reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("miniBlocksPerBlock");
+  }
+
+  @Test
+  void rejectsTotalValueCountAboveCallerValueCount() {
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(128, out);
+              BytesUtils.writeUnsignedVarInt(4, out);
+              BytesUtils.writeUnsignedVarInt(100, out); // totalValueCount = 100
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    assertThatThrownBy(
+            () ->
+                reader.initFromPage(
+                    50, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)))) // valueCount = 50
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("totalValueCount must be in [0, valueCount=50]");
+  }
+
+  @Test
+  void rejectsBlockSizeAboveCap() {
+    // 1 << 21 = 2 MiB values per block, well above the (1 << 20) cap.
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(1 << 21, out);
+              BytesUtils.writeUnsignedVarInt(4, out);
+              BytesUtils.writeUnsignedVarInt(1, out);
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    assertThatThrownBy(
+            () -> reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("blockSizeInValues must be in");
+  }
+
+  @Test
+  void decodesSingleValuePage() throws IOException {
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(128, out); // blockSize
+              BytesUtils.writeUnsignedVarInt(4, out); // miniBlocksPerBlock
+              BytesUtils.writeUnsignedVarInt(1, out); // totalValueCount
+              BytesUtils.writeZigZagVarLong(42L, out); // firstValue
+            });
+
+    VectorizedDeltaEncodedValuesReader reader = new VectorizedDeltaEncodedValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+    assertThat(reader.totalValueCount()).isEqualTo(1);
+    assertThat(reader.readInteger()).isEqualTo(42);
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaLengthByteArrayValuesReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedDeltaLengthByteArrayValuesReader.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.parquet.bytes.ByteBufferInputStream;
+import org.apache.parquet.bytes.BytesUtils;
+import org.apache.parquet.io.api.Binary;
+import org.junit.jupiter.api.Test;
+
+class TestVectorizedDeltaLengthByteArrayValuesReader extends VectorizedParquetDecoderTestBase {
+
+  /** Builds a minimal valid DELTA_LENGTH_BYTE_ARRAY page encoding a single binary value. */
+  private static byte[] singleValuePage(byte[] suffix) {
+    byte[] lengthHeader =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(128, out); // blockSize
+              BytesUtils.writeUnsignedVarInt(4, out); // miniBlocksPerBlock
+              BytesUtils.writeUnsignedVarInt(1, out); // totalValueCount
+              BytesUtils.writeZigZagVarLong(suffix.length, out); // firstValue = length
+            });
+    return concat(lengthHeader, suffix);
+  }
+
+  @Test
+  void rejectsNegativeLength() throws IOException {
+    byte[] page = singleValuePage(new byte[] {'a', 'b', 'c'});
+
+    VectorizedDeltaLengthByteArrayValuesReader reader =
+        new VectorizedDeltaLengthByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(-1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Length must be >= 0");
+  }
+
+  @Test
+  void rejectsLengthExceedingAvailable() throws IOException {
+    // Page carries only 3 suffix bytes; an attacker-shaped len asks for 1 MB.
+    byte[] page = singleValuePage(new byte[] {'a', 'b', 'c'});
+
+    VectorizedDeltaLengthByteArrayValuesReader reader =
+        new VectorizedDeltaLengthByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThatThrownBy(() -> reader.readBinary(1024 * 1024))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("exceeds 3 bytes available");
+  }
+
+  @Test
+  void surfacesInnerLengthReaderGuardOnMalformedLengthHeader() {
+    // Inner DELTA_BINARY_PACKED has blockSizeInValues = 0, which must be rejected by the inner
+    // reader's guard — proves the composition propagates hardening, not just the outer reader's.
+    byte[] page =
+        page(
+            out -> {
+              BytesUtils.writeUnsignedVarInt(0, out); // blockSize = 0
+              BytesUtils.writeUnsignedVarInt(4, out);
+              BytesUtils.writeUnsignedVarInt(1, out);
+              BytesUtils.writeZigZagVarLong(0L, out);
+            });
+
+    VectorizedDeltaLengthByteArrayValuesReader reader =
+        new VectorizedDeltaLengthByteArrayValuesReader();
+    assertThatThrownBy(
+            () -> reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("blockSizeInValues must be in");
+  }
+
+  @Test
+  void decodesSingleValueRoundTrip() throws IOException {
+    byte[] suffix = new byte[] {'a', 'b', 'c'};
+    byte[] page = singleValuePage(suffix);
+
+    VectorizedDeltaLengthByteArrayValuesReader reader =
+        new VectorizedDeltaLengthByteArrayValuesReader();
+    reader.initFromPage(1, ByteBufferInputStream.wrap(ByteBuffer.wrap(page)));
+
+    assertThat(reader.lengthForCurrentRow()).isEqualTo(3);
+    Binary value = reader.readBinary(3);
+    assertThat(value.getBytes()).containsExactly('a', 'b', 'c');
+  }
+}

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDecoderTestBase.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDecoderTestBase.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+/**
+ * Shared helpers for hardening tests of the vectorized Parquet value decoders in this package.
+ * Subclasses use these primitives to assemble forged or hand-built encoded pages without each test
+ * class re-deriving the same boilerplate.
+ */
+abstract class VectorizedParquetDecoderTestBase {
+
+  @FunctionalInterface
+  protected interface PageWriter {
+    void write(ByteArrayOutputStream out) throws IOException;
+  }
+
+  /** Builds a page by composing writes into a {@link ByteArrayOutputStream}. */
+  protected static byte[] page(PageWriter body) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    try {
+      body.write(out);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+    return out.toByteArray();
+  }
+
+  /** Concatenates the given byte arrays in order. */
+  protected static byte[] concat(byte[]... parts) {
+    int total = 0;
+    for (byte[] part : parts) {
+      total += part.length;
+    }
+    byte[] result = new byte[total];
+    int pos = 0;
+    for (byte[] part : parts) {
+      System.arraycopy(part, 0, result, pos, part.length);
+      pos += part.length;
+    }
+    return result;
+  }
+}


### PR DESCRIPTION
Closes #16458

## Summary

Five vectorized Parquet decoders in `iceberg-arrow` allocated heap arrays whose size came directly from the file bytes — varint headers in DELTA_BINARY_PACKED, the available-byte count in BYTE_STREAM_SPLIT, packed-group counts in the RLE/PACKED reader, and prefix-length entries in DELTA_BYTE_ARRAY. A crafted page could force a multi-hundred-MB allocation before any row-batch or page-size limit applied. Maintainers downgraded the report from security to a normal hardening task and invited a fix.

This PR adds tight bound checks before each allocation, so a malformed page now fails with a descriptive `IllegalArgumentException` instead of allocating gigabytes of heap. Bounds come from each encoding's own math, not from arbitrary tuning knobs, so spec-conformant pages are unaffected.

## What changed

`BaseVectorizedParquetValuesReader`: PACKED group count fits in `int` (avoids `numGroups * 8` overflow) and the run cannot claim more bytes than the page still has.

`VectorizedDeltaEncodedValuesReader`: `blockSizeInValues` is in `(0, 1 << 20]` — the upper bound is ~8000× the parquet-mr default of 128, well clear of any legitimate writer. `miniBlocksPerBlock` is in `(0, blockSize]`. `totalValueCount` is in `[0, valueCount]` (it is the file-declared non-null count, which can never exceed the caller's total).

`VectorizedByteStreamSplitValuesReader`: page size is at most `valueCount * elementSizeInBytes` - valueCount counts every row including nulls, while the encoding only stores non-null values, so the product is an upper bound rather than an exact match. The previously-ignored `valueCount` parameter is now used for validation. `readBinary(int len)` enforces `0 <= len <= decodedDataStream.remaining()` before allocating.

`VectorizedDeltaByteArrayValuesReader`: prefix length fits in the previous value (spec invariant), total length is at least the prefix length, and the combined `prefix + suffix` length does not overflow `int`.

`VectorizedDeltaLengthByteArrayValuesReader`: `readBinary(int len)` enforces `0 <= len <= dataStream.available()` before allocating.

## Tests

One new test class per modified reader (`Test*ValuesReader`), plus an abstract `VectorizedParquetDecoderTestBase` that owns the shared forged-page helpers (`page`, `concat`). Each test class covers every new guard via a hand-built malformed page, plus a positive round-trip to confirm spec-conformant pages still decode correctly.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Cap the heap allocations sized directly from file bytes in five vectorized Parquet decoders.

