### PR TITLE
Spark: Bound file list cleanup to table location

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,12 +225,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      files = files.filter(isFileInLocation(files.col(FILE_PATH), location));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))
         .select(files.col(FILE_PATH))
         .as(Encoders.STRING());
+  }
+
+  private static Column isFileInLocation(Column filePath, String location) {
+    String locationPrefix = location.endsWith("/") ? location : location + "/";
+    return filePath.equalTo(location).or(filePath.startsWith(locationPrefix));
   }
 
   @Override

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1025,6 +1025,36 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assertThat(result4.orphanFilesCount()).as("Action should find nothing").isEqualTo(0L);
   }
 
+  @TestTemplate
+  public void testCompareToFileListDoesNotMatchSiblingLocationPrefix() {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+
+    List<FilePathLastModifiedRecord> siblingFiles =
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord(
+                table.location() + "-backup/data/file.parquet", new Timestamp(0L)));
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(siblingFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .compareToFileList(compareToFileList)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(s -> {})
+            .execute();
+
+    assertThat(result.orphanFileLocations()).as("Should ignore sibling paths").isEmpty();
+    assertThat(result.orphanFilesCount()).as("Should ignore sibling paths").isEqualTo(0L);
+  }
+
   protected long waitUntilAfter(long timestampMillis) {
     long current = System.currentTimeMillis();
     while (current <= timestampMillis) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,12 +225,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      files = files.filter(isFileInLocation(files.col(FILE_PATH), location));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))
         .select(files.col(FILE_PATH))
         .as(Encoders.STRING());
+  }
+
+  private static Column isFileInLocation(Column filePath, String location) {
+    String locationPrefix = location.endsWith("/") ? location : location + "/";
+    return filePath.equalTo(location).or(filePath.startsWith(locationPrefix));
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,12 +225,17 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      files = files.filter(isFileInLocation(files.col(FILE_PATH), location));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))
         .select(files.col(FILE_PATH))
         .as(Encoders.STRING());
+  }
+
+  private static Column isFileInLocation(Column filePath, String location) {
+    String locationPrefix = location.endsWith("/") ? location : location + "/";
+    return filePath.equalTo(location).or(filePath.startsWith(locationPrefix));
   }
 
   @Override


### PR DESCRIPTION
## Summary
- Bound `file_list_view` filtering to the exact table location or paths below `location/`
- Applied the same location-boundary filter to Spark 3.5, 4.0, and 4.1 action implementations
- Added a Spark 3.5 regression test that verifies a sibling path like `<table-location>-backup/...` is ignored

Fixes #16493.

## Validation
- `git diff --check`
- Attempted: `./gradlew :iceberg-spark:iceberg-spark-3.5_2.12:test --tests "org.apache.iceberg.spark.actions.TestRemoveOrphanFilesAction.testCompareToFileListDoesNotMatchSiblingLocationPrefix"`

The Gradle test is blocked locally because this machine has no Java Runtime installed.