### PR TITLE
Revapi: Fix order in the revapi file

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -404,6 +404,119 @@ acceptedBreaks:
       old: "method org.apache.iceberg.orc.ORC.WriteBuilder org.apache.iceberg.orc.ORC.WriteBuilder::config(java.lang.String,\
         \ java.lang.String)"
       justification: "Removing deprecations for 1.2.0"
+  "1.10.0":
+    org.apache.iceberg:iceberg-api:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.encryption.EncryptingFileIO"
+      new: "class org.apache.iceberg.encryption.EncryptingFileIO"
+      justification: "New method for Manifest List reading"
+    org.apache.iceberg:iceberg-core:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.avro.SupportsIndexProjection"
+      new: "class org.apache.iceberg.avro.SupportsIndexProjection"
+      justification: "Serialization across versions is not guaranteed"
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.hadoop.SerializableConfiguration"
+      new: "class org.apache.iceberg.hadoop.SerializableConfiguration"
+      justification: "Serialization across versions is not guaranteed"
+    - code: "java.class.noLongerInheritsFromClass"
+      old: "class org.apache.iceberg.rest.auth.OAuth2Manager"
+      new: "class org.apache.iceberg.rest.auth.OAuth2Manager"
+      justification: "Removing deprecations for 1.11.0"
+    - code: "java.class.nowImplementsInterface"
+      old: "class org.apache.iceberg.rest.auth.OAuth2Manager"
+      new: "class org.apache.iceberg.rest.auth.OAuth2Manager"
+      justification: "Removing deprecations for 1.11.0"
+    - code: "java.class.removed"
+      old: "class org.apache.iceberg.PartitionStatsUtil"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.class.removed"
+      old: "class org.apache.iceberg.rest.auth.RefreshingAuthManager"
+      justification: "Removing deprecations for 1.11.0"
+    - code: "java.field.constantValueChanged"
+      old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN"
+      new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN"
+      justification: "Plan API is table scoped and path constant value should include\
+        \ namespace. No actual breakage because it never worked before with incorrect\
+        \ value."
+    - code: "java.field.constantValueChanged"
+      old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT"
+      new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT"
+      justification: "Plan API is table scoped and path constant value should include\
+        \ namespace. No actual breakage because it never worked before with incorrect\
+        \ value."
+    - code: "java.field.constantValueChanged"
+      old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_TASKS"
+      new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_TASKS"
+      justification: "Plan API is table scoped and path constant value should include\
+        \ namespace. No actual breakage because it never worked before with incorrect\
+        \ value."
+    - code: "java.method.removed"
+      old: "method java.lang.String org.apache.iceberg.RewriteTablePathUtil::stagingPath(java.lang.String,\
+        \ java.lang.String)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.DataFile>\
+        \ org.apache.iceberg.RewriteTablePathUtil::rewriteDataManifest(org.apache.iceberg.ManifestFile,\
+        \ org.apache.iceberg.io.OutputFile, org.apache.iceberg.io.FileIO, int, java.util.Map<java.lang.Integer,\
+        \ org.apache.iceberg.PartitionSpec>, java.lang.String, java.lang.String) throws\
+        \ java.io.IOException"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.DeleteFile>\
+        \ org.apache.iceberg.RewriteTablePathUtil::rewriteDeleteManifest(org.apache.iceberg.ManifestFile,\
+        \ org.apache.iceberg.io.OutputFile, org.apache.iceberg.io.FileIO, int, java.util.Map<java.lang.Integer,\
+        \ org.apache.iceberg.PartitionSpec>, java.lang.String, java.lang.String, java.lang.String)\
+        \ throws java.io.IOException"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.Schema org.apache.iceberg.PartitionStatsHandler::schema(org.apache.iceberg.types.Types.StructType)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.TableMetadata org.apache.iceberg.TableMetadataParser::read(org.apache.iceberg.io.FileIO,\
+        \ org.apache.iceberg.io.InputFile)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.encryption.EncryptionManager org.apache.iceberg.encryption.EncryptionUtil::createEncryptionManager(java.util.Map<java.lang.String,\
+        \ java.lang.String>, org.apache.iceberg.encryption.KeyManagementClient)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::exchangeToken(org.apache.iceberg.rest.RESTClient,\
+        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
+        \ java.lang.String, java.lang.String, java.lang.String)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::exchangeToken(org.apache.iceberg.rest.RESTClient,\
+        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
+        \ java.lang.String, java.lang.String, java.lang.String, java.lang.String)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::fetchToken(org.apache.iceberg.rest.RESTClient,\
+        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::fetchToken(org.apache.iceberg.rest.RESTClient,\
+        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
+        \ java.lang.String)"
+      justification: "Removing deprecated code for 1.11.0"
+    - code: "java.method.visibilityReduced"
+      old: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
+      new: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
+      justification: "Changing deprecated code"
+    - code: "java.method.visibilityReduced"
+      old: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
+      new: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
+      justification: "Changing deprecated code"
+    - code: "java.method.visibilityReduced"
+      old: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>,\
+        \ org.apache.iceberg.Snapshot)"
+      new: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>,\
+        \ org.apache.iceberg.Snapshot)"
+      justification: "Changing deprecated code"
+    org.apache.iceberg:iceberg-data:
+    - code: "java.class.removed"
+      old: "class org.apache.iceberg.data.PartitionStatsHandler"
+      justification: "Removing deprecated code for 1.11.0"
   "1.2.0":
     org.apache.iceberg:iceberg-api:
     - code: "java.field.constantValueChanged"
@@ -1363,111 +1476,6 @@ acceptedBreaks:
       old: "method org.apache.iceberg.parquet.ParquetValueWriters.StructWriter<org.apache.iceberg.data.Record>\
         \ org.apache.iceberg.data.parquet.GenericParquetWriter::createStructWriter(java.util.List<org.apache.iceberg.parquet.ParquetValueWriter<?>>)"
       justification: "Removing deprecations for 1.10.0"
-  "1.10.0":
-    org.apache.iceberg:iceberg-api:
-      - code: "java.class.defaultSerializationChanged"
-        old: "class org.apache.iceberg.encryption.EncryptingFileIO"
-        new: "class org.apache.iceberg.encryption.EncryptingFileIO"
-        justification: "New method for Manifest List reading"
-    org.apache.iceberg:iceberg-core:
-      - code: "java.class.defaultSerializationChanged"
-        old: "class org.apache.iceberg.avro.SupportsIndexProjection"
-        new: "class org.apache.iceberg.avro.SupportsIndexProjection"
-        justification: "Serialization across versions is not guaranteed"
-      - code: "java.class.defaultSerializationChanged"
-        old: "class org.apache.iceberg.hadoop.SerializableConfiguration"
-        new: "class org.apache.iceberg.hadoop.SerializableConfiguration"
-        justification: "Serialization across versions is not guaranteed"
-      - code: "java.class.noLongerInheritsFromClass"
-        old: "class org.apache.iceberg.rest.auth.OAuth2Manager"
-        new: "class org.apache.iceberg.rest.auth.OAuth2Manager"
-        justification: "Removing deprecations for 1.11.0"
-      - code: "java.class.nowImplementsInterface"
-        old: "class org.apache.iceberg.rest.auth.OAuth2Manager"
-        new: "class org.apache.iceberg.rest.auth.OAuth2Manager"
-        justification: "Removing deprecations for 1.11.0"
-      - code: "java.class.removed"
-        old: "class org.apache.iceberg.rest.auth.RefreshingAuthManager"
-        justification: "Removing deprecations for 1.11.0"
-      - code: "java.field.constantValueChanged"
-        old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN"
-        new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN"
-        justification: "Plan API is table scoped and path constant value should include namespace. No actual breakage because it never worked before with incorrect value."
-      - code: "java.field.constantValueChanged"
-        old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT"
-        new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_SUBMIT"
-        justification: "Plan API is table scoped and path constant value should include namespace. No actual breakage because it never worked before with incorrect value."
-      - code: "java.field.constantValueChanged"
-        old: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_TASKS"
-        new: "field org.apache.iceberg.rest.ResourcePaths.V1_TABLE_SCAN_PLAN_TASKS"
-        justification: "Plan API is table scoped and path constant value should include namespace. No actual breakage because it never worked before with incorrect value."
-      - code: "java.class.removed"
-        old: "class org.apache.iceberg.PartitionStatsUtil"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method java.lang.String org.apache.iceberg.RewriteTablePathUtil::stagingPath(java.lang.String,\
-        \ java.lang.String)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.DataFile>\
-        \ org.apache.iceberg.RewriteTablePathUtil::rewriteDataManifest(org.apache.iceberg.ManifestFile,\
-        \ org.apache.iceberg.io.OutputFile, org.apache.iceberg.io.FileIO, int, java.util.Map<java.lang.Integer,\
-        \ org.apache.iceberg.PartitionSpec>, java.lang.String, java.lang.String) throws\
-        \ java.io.IOException"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.DeleteFile>\
-        \ org.apache.iceberg.RewriteTablePathUtil::rewriteDeleteManifest(org.apache.iceberg.ManifestFile,\
-        \ org.apache.iceberg.io.OutputFile, org.apache.iceberg.io.FileIO, int, java.util.Map<java.lang.Integer,\
-        \ org.apache.iceberg.PartitionSpec>, java.lang.String, java.lang.String, java.lang.String)\
-        \ throws java.io.IOException"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.Schema org.apache.iceberg.PartitionStatsHandler::schema(org.apache.iceberg.types.Types.StructType)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.TableMetadata org.apache.iceberg.TableMetadataParser::read(org.apache.iceberg.io.FileIO,\
-        \ org.apache.iceberg.io.InputFile)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.encryption.EncryptionManager org.apache.iceberg.encryption.EncryptionUtil::createEncryptionManager(java.util.Map<java.lang.String,\
-        \ java.lang.String>, org.apache.iceberg.encryption.KeyManagementClient)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::exchangeToken(org.apache.iceberg.rest.RESTClient,\
-        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
-        \ java.lang.String, java.lang.String, java.lang.String)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::exchangeToken(org.apache.iceberg.rest.RESTClient,\
-        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
-        \ java.lang.String, java.lang.String, java.lang.String, java.lang.String)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::fetchToken(org.apache.iceberg.rest.RESTClient,\
-        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.removed"
-        old: "method org.apache.iceberg.rest.responses.OAuthTokenResponse org.apache.iceberg.rest.auth.OAuth2Util::fetchToken(org.apache.iceberg.rest.RESTClient,\
-        \ java.util.Map<java.lang.String, java.lang.String>, java.lang.String, java.lang.String,\
-        \ java.lang.String)"
-        justification: "Removing deprecated code for 1.11.0"
-      - code: "java.method.visibilityReduced"
-        old: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>, org.apache.iceberg.Snapshot)"
-        new: "method void org.apache.iceberg.PartitionStats::liveEntry(org.apache.iceberg.ContentFile<?>, org.apache.iceberg.Snapshot)"
-        justification: "Changing deprecated code"
-      - code: "java.method.visibilityReduced"
-        old: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
-        new: "method void org.apache.iceberg.PartitionStats::appendStats(org.apache.iceberg.PartitionStats)"
-        justification: "Changing deprecated code"
-      - code: "java.method.visibilityReduced"
-        old: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
-        new: "method void org.apache.iceberg.PartitionStats::deletedEntry(org.apache.iceberg.Snapshot)"
-        justification: "Changing deprecated code"
-    org.apache.iceberg:iceberg-data:
-      - code: "java.class.removed"
-        old: "class org.apache.iceberg.data.PartitionStatsHandler"
-        justification: "Removing deprecated code for 1.11.0"
   apache-iceberg-0.14.0:
     org.apache.iceberg:iceberg-api:
     - code: "java.class.defaultSerializationChanged"


### PR DESCRIPTION
When running revapi, it reorders the versions. To avoid noise in other PRs, ran revapi on a clean main.