### PR TITLE
Docs: Replace Hadoop catalog examples with JDBC and REST catalog

### DIFF
--- a/docs/docs/spark-getting-started.md
+++ b/docs/docs/spark-getting-started.md
@@ -38,20 +38,43 @@ spark-shell --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionM
     <!-- markdown-link-check-disable-next-line -->
     If you want to include Iceberg in your Spark installation, add the [`iceberg-spark-runtime-{{ sparkVersionMajor }}` Jar](https://search.maven.org/remotecontent?filepath=org/apache/iceberg/iceberg-spark-runtime-{{ sparkVersionMajor }}/{{ icebergVersion }}/iceberg-spark-runtime-{{ sparkVersionMajor }}-{{ icebergVersion }}.jar) to Spark's `jars` folder.
 
-### Adding catalogs
+### Configuring catalogs
 
-Iceberg comes with [catalogs](spark-configuration.md#catalogs) that enable SQL commands to manage tables and load them by name. Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
+Iceberg uses [catalogs](https://iceberg.apache.org/concepts/catalog/) to track and manage table metadata and enable SQL operations. Iceberg provides several [catalog implementations](spark-configuration.md#catalogs), which can be configured using properties under `spark.sql.catalog.(catalog_name)`.
 
-This command creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog:
+The following command creates a JDBC-based catalog named `local` for tables under `$PWD/warehouse`, using SQLite as the catalog backend:
 
 ```sh
-spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMajor }}:{{ icebergVersion }}\
+spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMajor }}:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.53.1.0\
     --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
     --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
     --conf spark.sql.catalog.spark_catalog.type=hive \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.local.type=hadoop \
-    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse
+    --conf spark.sql.catalog.local.type=jdbc \
+    --conf spark.sql.catalog.local.jdbc-driver=org.sqlite.JDBC \
+    --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
+    --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
+    --conf spark.sql.defaultCatalog=local
+```
+
+You can also configure a REST-based catalog. The REST catalog provides a language-agnostic way to manage Iceberg tables through a RESTful service. The following example assumes a REST catalog server running at `localhost:8181` and a MinIO instance at `localhost:9000` for S3-compatible storage:
+
+```sh
+spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMajor }}:{{ icebergVersion }},org.apache.iceberg:iceberg-aws-bundle:{{ icebergVersion }}\
+    --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
+    --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
+    --conf spark.sql.catalog.spark_catalog.type=hive \
+    --conf spark.sql.catalog.rest=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.rest.type=rest \
+    --conf spark.sql.catalog.rest.uri=http://localhost:8181 \
+    --conf spark.sql.catalog.rest.warehouse=s3://warehouse/ \
+    --conf spark.sql.catalog.rest.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.rest.s3.endpoint=http://localhost:9000 \
+    --conf spark.sql.catalog.rest.s3.path-style-access=true \
+    --conf spark.sql.catalog.rest.s3.access-key-id=admin \
+    --conf spark.sql.catalog.rest.s3.secret-access-key=password \
+    --conf spark.sql.catalog.rest.client.region=us-east-1 \
+    --conf spark.sql.defaultCatalog=rest
 ```
 
 ### Creating a table
@@ -59,7 +82,7 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMaj
 To create your first Iceberg table in Spark, use the `spark-sql` shell or `spark.sql(...)` to run a [`CREATE TABLE`](spark-ddl.md#create-table) command:
 
 ```sql
--- local is the path-based catalog defined above
+-- local is the JDBC-based catalog defined above
 CREATE TABLE local.db.table (id bigint, data string) USING iceberg;
 CREATE TABLE source (id bigint, data string) USING parquet;
 CREATE TABLE updates (id bigint, data string) USING parquet;

--- a/site/docs/how-to-release.md
+++ b/site/docs/how-to-release.md
@@ -466,10 +466,12 @@ spark-runtime jar for the Spark installation):
 ```bash
 spark-shell \
     --conf spark.jars.repositories=${MAVEN_URL} \
-    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }} \
+    --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ icebergVersion }},org.xerial:sqlite-jdbc:3.53.1.0 \
     --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
     --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-    --conf spark.sql.catalog.local.type=hadoop \
+    --conf spark.sql.catalog.local.type=jdbc \
+    --conf spark.sql.catalog.local.jdbc-driver=org.sqlite.JDBC \
+    --conf spark.sql.catalog.local.uri=jdbc:sqlite:$PWD/iceberg_catalog_db.sqlite \
     --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
     --conf spark.sql.catalog.local.default-namespace=default \
     --conf spark.sql.defaultCatalog=local

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -25,8 +25,12 @@ highlight some powerful features. You can learn more about Iceberg's Spark runti
 - [Creating a table](#creating-a-table)
 - [Writing Data to a Table](#writing-data-to-a-table)
 - [Reading Data from a Table](#reading-data-from-a-table)
-- [Adding A Catalog](#adding-a-catalog)
-- [Next Steps](#next-steps)
+- [Configuring Catalogs](#configuring-catalogs)
+    - [Configuring REST Catalog](#configuring-rest-catalog)
+    - [Configuring JDBC Catalog](#configuring-jdbc-catalog)
+- [Next steps](#next-steps)
+    - [Adding Iceberg to Spark](#adding-iceberg-to-spark)
+    - [Learn More](#learn-more)
 
 ### Docker-Compose
 
@@ -284,43 +288,83 @@ To read a table, simply use the Iceberg table's name.
     df = spark.table("demo.nyc.taxis").show()
     ```
 
-### Adding A Catalog
+### Configuring Catalogs
 
-Iceberg has several catalog back-ends that can be used to track tables, like JDBC, Hive MetaStore and Glue.
-Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`. In this guide,
-we use JDBC, but you can follow these instructions to configure other catalog types. To learn more, check out
-the [Catalog](docs/latest/spark-configuration.md#catalogs) page in the Spark section.
+Iceberg provides several catalog implementations to manage tables and enable SQL operations.
+Catalogs are configured using properties under `spark.sql.catalog.(catalog_name)`.
+You can configure different catalog types, such as JDBC, Hive Metastore, Glue, and REST, to manage Iceberg tables in Spark.
 
-This configuration creates a path-based catalog named `local` for tables under `$PWD/warehouse` and adds support for Iceberg tables to Spark's built-in catalog.
+This guide covers the configuration of two popular catalog types: REST and JDBC.
+To learn more, check out the [Catalog](docs/latest/spark-configuration.md#catalogs) page in the Spark section.
+
+#### Configuring REST Catalog
+
+The REST catalog provides a language-agnostic way to manage Iceberg tables through a RESTful service. The following configuration creates a REST-based catalog named `rest`, using the `apache/iceberg-rest-fixture` container from the `docker-compose.yml` above as the REST server and MinIO for S3-compatible storage:
 
 === "CLI"
 
     ```sh
-    spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMajor }}:{{ icebergVersion }}\
-        --conf spark.sql.extensions=org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions \
-        --conf spark.sql.catalog.spark_catalog=org.apache.iceberg.spark.SparkSessionCatalog \
-        --conf spark.sql.catalog.spark_catalog.type=hive \
+    docker exec -it spark-iceberg spark-sql \
+        --conf spark.sql.catalog.rest=org.apache.iceberg.spark.SparkCatalog \
+        --conf spark.sql.catalog.rest.type=rest \
+        --conf spark.sql.catalog.rest.uri=http://rest:8181 \
+        --conf spark.sql.catalog.rest.warehouse=s3://warehouse/ \
+        --conf spark.sql.catalog.rest.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+        --conf spark.sql.catalog.rest.s3.endpoint=http://minio:9000 \
+        --conf spark.sql.catalog.rest.s3.path-style-access=true \
+        --conf spark.sql.defaultCatalog=rest
+    ```
+
+=== "spark-defaults.conf"
+
+    ```sh
+    docker exec spark-iceberg bash -c 'cat >> /opt/spark/conf/spark-defaults.conf <<EOF
+    spark.sql.catalog.rest                              org.apache.iceberg.spark.SparkCatalog
+    spark.sql.catalog.rest.type                         rest
+    spark.sql.catalog.rest.uri                          http://rest:8181
+    spark.sql.catalog.rest.warehouse                    s3://warehouse/
+    spark.sql.catalog.rest.io-impl                      org.apache.iceberg.aws.s3.S3FileIO
+    spark.sql.catalog.rest.s3.endpoint                  http://minio:9000
+    spark.sql.catalog.rest.s3.path-style-access         true
+    spark.sql.defaultCatalog                            rest
+    EOF'
+    ```
+
+#### Configuring JDBC Catalog
+
+The following configuration creates a JDBC-based catalog named `local` for tables under `/home/iceberg/warehouse`, using SQLite as the catalog backend.
+
+First, download the SQLite JDBC driver into the Spark jars directory:
+
+```sh
+docker exec spark-iceberg curl -sL -o /opt/spark/jars/sqlite-jdbc-3.53.1.0.jar \
+    https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.53.1.0/sqlite-jdbc-3.53.1.0.jar
+```
+
+Then start a Spark session with the JDBC catalog configuration:
+
+=== "CLI"
+
+    ```sh
+    docker exec -it spark-iceberg spark-sql \
         --conf spark.sql.catalog.local=org.apache.iceberg.spark.SparkCatalog \
-        --conf spark.sql.catalog.local.type=hadoop \
-        --conf spark.sql.catalog.local.warehouse=$PWD/warehouse \
+        --conf spark.sql.catalog.local.type=jdbc \
+        --conf spark.sql.catalog.local.uri=jdbc:sqlite:/home/iceberg/warehouse/iceberg_catalog_db.sqlite \
+        --conf spark.sql.catalog.local.warehouse=/home/iceberg/warehouse \
         --conf spark.sql.defaultCatalog=local
     ```
 
 === "spark-defaults.conf"
 
     ```sh
-    spark.jars.packages                                  org.apache.iceberg:iceberg-spark-runtime-{{ sparkVersionMajor }}:{{ icebergVersion }}
-    spark.sql.extensions                                 org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions
-    spark.sql.catalog.spark_catalog                      org.apache.iceberg.spark.SparkSessionCatalog
-    spark.sql.catalog.spark_catalog.type                 hive
+    docker exec spark-iceberg bash -c 'cat >> /opt/spark/conf/spark-defaults.conf <<EOF
     spark.sql.catalog.local                              org.apache.iceberg.spark.SparkCatalog
-    spark.sql.catalog.local.type                         hadoop
-    spark.sql.catalog.local.warehouse                    $PWD/warehouse
+    spark.sql.catalog.local.type                         jdbc
+    spark.sql.catalog.local.uri                          jdbc:sqlite:/home/iceberg/warehouse/iceberg_catalog_db.sqlite
+    spark.sql.catalog.local.warehouse                    /home/iceberg/warehouse
     spark.sql.defaultCatalog                             local
+    EOF'
     ```
-
-!!! note
-    If your Iceberg catalog is not set as the default catalog, you will have to switch to it by executing `USE local;`
 
 ### Next steps
 


### PR DESCRIPTION
## Problem

This PR replaces the use of Hadoop catalogs with REST and JDBC catalogs.

Closes #11284. I took over the task that was worked on #11845. The updates are mainly based on the PR.

## Solution

Replace Hadoop catalog examples with JDBC and REST catalog across three documentation files:

- site/docs/spark-quickstart.md
- docs/docs/spark-getting-started.md