### PR TITLE
CI: Limit CVE scan runs to relevant changes

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -27,7 +27,49 @@ on:
     - '2.*'
     tags:
     - 'apache-iceberg-**'
+    paths:
+    - '**'
+    - '!.github/**'
+    - '.github/workflows/cve-scan.yml'
+    - '!.baseline/**'
+    - '!.palantir/**'
+    - '!.gitignore'
+    - '!.asf.yaml'
+    - '!dev/**'
+    - '!docker/**'
+    - '!docs/**'
+    - '!examples/**'
+    - '!site/**'
+    - '!format/**'
+    - '!.gitattributes'
+    - '!**/README.md'
+    - '!AGENTS.md'
+    - '!CONTRIBUTING.md'
+    - '!**/LICENSE'
+    - '!**/NOTICE'
+    - '!doap.rdf'
   pull_request:
+    paths:
+    - '**'
+    - '!.github/**'
+    - '.github/workflows/cve-scan.yml'
+    - '!.baseline/**'
+    - '!.palantir/**'
+    - '!.gitignore'
+    - '!.asf.yaml'
+    - '!dev/**'
+    - '!docker/**'
+    - '!docs/**'
+    - '!examples/**'
+    - '!site/**'
+    - '!format/**'
+    - '!.gitattributes'
+    - '!**/README.md'
+    - '!AGENTS.md'
+    - '!CONTRIBUTING.md'
+    - '!**/LICENSE'
+    - '!**/NOTICE'
+    - '!doap.rdf'
 
 permissions:
   contents: read
@@ -150,7 +192,6 @@ jobs:
         scanners: 'vuln'
         severity: 'HIGH,CRITICAL'
         limit-severities-for-sarif: true
-        trivyignores: ${{ matrix.trivyignores || '' }}
         # Block PRs on CVE findings; on main/release branches report without failing
         exit-code: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         format: 'sarif'

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -45,6 +45,7 @@ on:
     - '!**/README.md'
     - '!AGENTS.md'
     - '!CONTRIBUTING.md'
+    - '!SECURITY-THREAT-MODEL.md'
     - '!**/LICENSE'
     - '!**/NOTICE'
     - '!doap.rdf'

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -68,6 +68,7 @@ on:
     - '!**/README.md'
     - '!AGENTS.md'
     - '!CONTRIBUTING.md'
+    - '!SECURITY-THREAT-MODEL.md'
     - '!**/LICENSE'
     - '!**/NOTICE'
     - '!doap.rdf'


### PR DESCRIPTION
## Summary

- Add path filters to the CVE scan workflow so docs, site, examples, metadata, and unrelated GitHub config changes do not run the scan
- Re-include `.github/workflows/cve-scan.yml` so workflow changes still trigger validation
- Remove the unused `trivyignores` input from the Trivy step

## Testing

- `actionlint .github/workflows/cve-scan.yml`
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/cve-scan.yml'))"`