### PR TITLE
Spark: Fix DELETE_GRANULARITY_DEFAULT and use it in SparkWriteConf

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -391,7 +391,7 @@ public class TableProperties {
   public static final long MAX_REF_AGE_MS_DEFAULT = Long.MAX_VALUE;
 
   public static final String DELETE_GRANULARITY = "write.delete.granularity";
-  public static final String DELETE_GRANULARITY_DEFAULT = DeleteGranularity.PARTITION.toString();
+  public static final String DELETE_GRANULARITY_DEFAULT = DeleteGranularity.FILE.toString();
 
   public static final String DELETE_ISOLATION_LEVEL = "write.delete.isolation-level";
   public static final String DELETE_ISOLATION_LEVEL_DEFAULT = "serializable";

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -742,7 +742,7 @@ public class SparkWriteConf {
         .enumConf(DeleteGranularity::fromString)
         .option(SparkWriteOptions.DELETE_GRANULARITY)
         .tableProperty(TableProperties.DELETE_GRANULARITY)
-        .defaultValue(DeleteGranularity.FILE)
+        .defaultValue(TableProperties.DELETE_GRANULARITY_DEFAULT)
         .parse();
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -756,7 +756,7 @@ public class SparkWriteConf {
         .enumConf(DeleteGranularity::fromString)
         .option(SparkWriteOptions.DELETE_GRANULARITY)
         .tableProperty(TableProperties.DELETE_GRANULARITY)
-        .defaultValue(DeleteGranularity.FILE)
+        .defaultValue(TableProperties.DELETE_GRANULARITY_DEFAULT)
         .parse();
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -731,7 +731,7 @@ public class SparkWriteConf {
         .enumConf(DeleteGranularity::fromString)
         .option(SparkWriteOptions.DELETE_GRANULARITY)
         .tableProperty(TableProperties.DELETE_GRANULARITY)
-        .defaultValue(DeleteGranularity.FILE)
+        .defaultValue(TableProperties.DELETE_GRANULARITY_DEFAULT)
         .parse();
   }
 


### PR DESCRIPTION
## Background

#11478 changed the effective default delete granularity from `PARTITION` to `FILE` for Spark writes, but introduced two inconsistencies:

1. `TableProperties.DELETE_GRANULARITY_DEFAULT` was left pointing to `DeleteGranularity.PARTITION`, making the constant misleading and effectively dead code.
2. All three Spark versions (`v3.5`, `v4.0`, `v4.1`) hardcoded `DeleteGranularity.FILE` directly in `SparkWriteConf` instead of referencing the constant.

## Changes

- Fix `TableProperties.DELETE_GRANULARITY_DEFAULT` to `DeleteGranularity.FILE` to correctly reflect the intended default
- Use `TableProperties.DELETE_GRANULARITY_DEFAULT` in `SparkWriteConf` for Spark v3.5, v4.0, and v4.1 to establish a single source of truth

## Test Plan

- [x] Existing unit tests for `SparkWriteConf` cover the default value resolution path
- [x] No behavior change — the effective default (`FILE`) remains the same; this only removes the inconsistency between the constant and its usage

Followup to #11478