### PR TITLE
Core: Fix SerializableTable.sortOrders() throwing on historical sort orders with dropped fields (#16519)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -58,6 +58,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
   private final int defaultSpecId;
   private final Map<Integer, String> specAsJsonMap;
   private final String sortOrderAsJson;
+  private final int defaultSortOrderId;
   private final Map<Integer, String> sortOrderAsJsonMap;
   private final FileIO io;
   private final EncryptionManager encryption;
@@ -83,6 +84,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
     Map<Integer, PartitionSpec> specs = table.specs();
     specs.forEach((specId, spec) -> specAsJsonMap.put(specId, PartitionSpecParser.toJson(spec)));
     this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
+    this.defaultSortOrderId = table.sortOrder().orderId();
     this.sortOrderAsJsonMap = Maps.newHashMap();
     table
         .sortOrders()
@@ -253,7 +255,8 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
           ImmutableMap.Builder<Integer, SortOrder> sortOrders =
               ImmutableMap.builderWithExpectedSize(sortOrderAsJsonMap.size());
           sortOrderAsJsonMap.forEach(
-              (id, json) -> sortOrders.put(id, SortOrderParser.fromJson(schema(), json)));
+              (id, json) ->
+                  sortOrders.put(id, SortOrderParser.fromJson(schema(), json, defaultSortOrderId)));
           this.lazySortOrders = sortOrders.build();
         } else if (lazySortOrders == null) {
           this.lazySortOrders = lazyTable.sortOrders();

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -112,6 +112,10 @@ public class SortOrderParser {
     return fromJson(json).bind(schema);
   }
 
+  public static SortOrder fromJson(Schema schema, String json, int defaultSortOderId) {
+    return JsonUtil.parse(json, node -> fromJson(schema, node, defaultSortOderId));
+  }
+
   public static SortOrder fromJson(Schema schema, JsonNode json, int defaultSortOrderId) {
     UnboundSortOrder unboundSortOrder = fromJson(json);
 

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -112,8 +112,8 @@ public class SortOrderParser {
     return fromJson(json).bind(schema);
   }
 
-  public static SortOrder fromJson(Schema schema, String json, int defaultSortOderId) {
-    return JsonUtil.parse(json, node -> fromJson(schema, node, defaultSortOderId));
+  public static SortOrder fromJson(Schema schema, String json, int defaultSortOrderId) {
+    return JsonUtil.parse(json, node -> fromJson(schema, node, defaultSortOrderId));
   }
 
   public static SortOrder fromJson(Schema schema, JsonNode json, int defaultSortOrderId) {

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -80,6 +80,27 @@ public class TestTableSerialization extends HadoopTableTestBase {
   }
 
   @Test
+  public void testSerializableTableSortOrdersWithDroppedColumn() {
+    // add an extra column and establish sort order 1 on id + ts
+    table.updateSchema().addColumn("ts", Types.LongType.get()).commit();
+    table.replaceSortOrder().asc("id").asc("ts").commit();
+    table.newAppend().appendFile(FILE_A).commit();
+
+    // switch to sort order 2 using only "id", then drop "ts"
+    // historical sort order 1 still references the dropped "ts" field
+    table.replaceSortOrder().asc("id").commit();
+    table.updateSchema().deleteColumn("ts").commit();
+
+    // SerializableTable.copyOf captures all sort orders at construction time
+    Table serialized = SerializableTable.copyOf(table);
+
+    // sortOrders() must return all historical orders without throwing a ValidationException,
+    // even though sort order 1 references the now-dropped "ts" field
+    assertThat(serialized.sortOrders()).hasSize(3); // unsorted(0), order-1(id+ts), order-2(id)
+    assertThat(serialized.sortOrder().fields()).hasSize(1); // current default is order-2
+  }
+
+  @Test
   public void testSerializableTableWithSnapshot() throws IOException, ClassNotFoundException {
     table.newAppend().appendFile(FILE_A).commit();
     TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -80,24 +80,19 @@ public class TestTableSerialization extends HadoopTableTestBase {
   }
 
   @Test
-  public void testSerializableTableSortOrdersWithDroppedColumn() {
-    // add an extra column and establish sort order 1 on id + ts
+  public void testSerializableTableSortOrdersWithDroppedColumn()
+      throws IOException, ClassNotFoundException {
     table.updateSchema().addColumn("ts", Types.LongType.get()).commit();
     table.replaceSortOrder().asc("id").asc("ts").commit();
-    table.newAppend().appendFile(FILE_A).commit();
 
-    // switch to sort order 2 using only "id", then drop "ts"
-    // historical sort order 1 still references the dropped "ts" field
+    // historical sort order 1 still references "ts" after the column is dropped
     table.replaceSortOrder().asc("id").commit();
     table.updateSchema().deleteColumn("ts").commit();
 
-    // SerializableTable.copyOf captures all sort orders at construction time
-    Table serialized = SerializableTable.copyOf(table);
-
-    // sortOrders() must return all historical orders without throwing a ValidationException,
-    // even though sort order 1 references the now-dropped "ts" field
-    assertThat(serialized.sortOrders()).hasSize(3); // unsorted(0), order-1(id+ts), order-2(id)
-    assertThat(serialized.sortOrder().fields()).hasSize(1); // current default is order-2
+    TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));
+    Table serializableTable = SerializableTable.copyOf(table);
+    TestHelpers.assertSerializedAndLoadedMetadata(
+        serializableTable, TestHelpers.KryoHelpers.roundTripSerialize(serializableTable));
   }
 
   @Test


### PR DESCRIPTION
## Background

After upgraded Apache Iceberg runtime from 1.10.1 to 1.11.0, the write from spark on my workload started to fail when the table has a historical sort order that references a column that has since been dropped from the schema. This is introduced by https://github.com/apache/iceberg/pull/15150. This is also reported by @aihuaxu via https://github.com/apache/iceberg/issues/16519

## Change
`SerializableTable.sortOrders()` strict binds every sort order against the current schema, which fails when a historical sort order references a field dropped by schema evolution. This PR fixes it to only strict bind the default sort order. 

## Test Plan
I added the new test case added by @aihuaxu from https://github.com/apache/iceberg/issues/16519 as well as the local reproducible that I wrote to validate the issue is resolved by this PR.
