### PR TITLE
AWS: Unset environment variables in test without credentials

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -87,6 +87,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junitpioneer.jupiter.ClearEnvironmentVariable;
 import org.mockito.Mockito;
 import org.testcontainers.containers.MinIOContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -955,6 +956,9 @@ public class TestS3FileIO {
   }
 
   @Test
+  @ClearEnvironmentVariable(key = "AWS_PROFILE")
+  @ClearEnvironmentVariable(key = "AWS_ACCESS_KEY_ID")
+  @ClearEnvironmentVariable(key = "AWS_SECRET_ACCESS_KEY")
   public void noStorageCredentialConfiguredWithoutCredentialsInProperties() {
     S3FileIO fileIO = new S3FileIO();
     fileIO.initialize(ImmutableMap.of("client.region", "us-east-1"));

--- a/build.gradle
+++ b/build.gradle
@@ -565,6 +565,7 @@ project(':iceberg-aws') {
     testImplementation libs.jetty.servlet
     testImplementation libs.jetty.compression.server
     testImplementation libs.jetty.compression.gzip
+    testImplementation libs.junit.pioneer
     testImplementation libs.mockito.junit.jupiter
   }
 


### PR DESCRIPTION
This test fails if the machine has AWS environment variables.

This PR introduces the `@ClearEnvironmentVariable` annotation to clear the value of a specific environment variable during a test execution. After the annotated method is executed, the initial default value is restored.