### PR TITLE
AWS: Isolate S3 remote signer auth and HTTP state per catalog

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/signer/TestS3RestSigner.java
@@ -75,7 +75,6 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ObjectIdentifier;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.model.UploadPartRequest;
-import software.amazon.awssdk.utils.IoUtils;
 
 @Testcontainers
 public class TestS3RestSigner {
@@ -92,6 +91,7 @@ public class TestS3RestSigner {
       MinioUtil.createContainer(MinioUtil.LATEST_TAG, CREDENTIALS_PROVIDER.resolveCredentials());
 
   private static Server httpServer;
+  private static S3V4RestSignerClient signerClient;
   private static ValidatingSigner validatingSigner;
   private S3Client s3;
 
@@ -103,19 +103,18 @@ public class TestS3RestSigner {
       httpServer = initHttpServer();
     }
 
-    validatingSigner =
-        new ValidatingSigner(
-            ImmutableS3V4RestSignerClient.builder()
-                .properties(
-                    ImmutableMap.of(
-                        RESTCatalogProperties.SIGNER_URI,
-                        httpServer.getURI().toString(),
-                        RESTCatalogProperties.SIGNER_ENDPOINT,
-                        S3SignerServlet.S3_SIGNER_ENDPOINT,
-                        OAuth2Properties.CREDENTIAL,
-                        "catalog:12345"))
-                .build(),
-            new CustomAwsS3V4Signer());
+    signerClient =
+        ImmutableS3V4RestSignerClient.builder()
+            .properties(
+                ImmutableMap.of(
+                    RESTCatalogProperties.SIGNER_URI,
+                    httpServer.getURI().toString(),
+                    RESTCatalogProperties.SIGNER_ENDPOINT,
+                    S3SignerServlet.S3_SIGNER_ENDPOINT,
+                    OAuth2Properties.CREDENTIAL,
+                    "catalog:12345"))
+            .build();
+    validatingSigner = new ValidatingSigner(signerClient, new CustomAwsS3V4Signer());
   }
 
   @AfterAll
@@ -149,10 +148,9 @@ public class TestS3RestSigner {
       httpServer.stop();
     }
 
-    IoUtils.closeQuietlyV2(S3V4RestSignerClient.authManager, null);
-    IoUtils.closeQuietlyV2(S3V4RestSignerClient.httpClient, null);
-    S3V4RestSignerClient.authManager = null;
-    S3V4RestSignerClient.httpClient = null;
+    if (null != signerClient) {
+      signerClient.close();
+    }
   }
 
   @BeforeEach

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -98,19 +98,30 @@ public abstract class S3V4RestSignerClient
 
   private static final String SCOPE = "sign";
 
-  @SuppressWarnings({"immutables:incompat", "VisibilityModifier"})
-  @VisibleForTesting
-  static volatile AuthManager authManager;
+  @SuppressWarnings("immutables:incompat")
+  private volatile AuthManager authManager;
 
-  @SuppressWarnings({"immutables:incompat", "VisibilityModifier"})
-  @VisibleForTesting
-  static volatile RESTClient httpClient;
+  @SuppressWarnings("immutables:incompat")
+  private volatile RESTClient httpClient;
 
   public abstract Map<String, String> properties();
 
   @Value.Default
   public Supplier<Map<String, String>> requestPropertiesSupplier() {
     return Collections::emptyMap;
+  }
+
+  /**
+   * Supplies the {@link RESTClient} used to contact the signer service. Each signer instance owns
+   * its own client so that per-catalog configuration (custom headers, timeouts, ...) is never
+   * shared across catalogs. The client is built without a base URI because each request is sent to
+   * a fully resolved {@link #endpoint()}. Exposed as a settable default so tests can inject a mock
+   * client.
+   */
+  @Value.Default
+  Supplier<RESTClient> httpClientSupplier() {
+    return () ->
+        HTTPClient.builder(properties()).withHeaders(RESTUtil.configHeaders(properties())).build();
   }
 
   @Value.Lazy
@@ -175,11 +186,12 @@ public abstract class S3V4RestSignerClient
         OAuth2Properties.TOKEN_REFRESH_ENABLED_DEFAULT);
   }
 
-  private AuthManager authManager() {
+  @VisibleForTesting
+  AuthManager authManager() {
     if (null == authManager) {
-      synchronized (S3V4RestSignerClient.class) {
+      synchronized (this) {
         if (null == authManager) {
-          authManager = AuthManagers.loadAuthManager("s3-signer", properties());
+          this.authManager = AuthManagers.loadAuthManager("s3-signer", properties());
         }
       }
     }
@@ -187,16 +199,12 @@ public abstract class S3V4RestSignerClient
     return authManager;
   }
 
-  private RESTClient httpClient() {
+  @VisibleForTesting
+  RESTClient httpClient() {
     if (null == httpClient) {
-      synchronized (S3V4RestSignerClient.class) {
+      synchronized (this) {
         if (null == httpClient) {
-          // Don't include a base URI because this client may be used for contacting different
-          // catalogs.
-          httpClient =
-              HTTPClient.builder(properties())
-                  .withHeaders(RESTUtil.configHeaders(properties()))
-                  .build();
+          this.httpClient = httpClientSupplier().get();
         }
       }
     }
@@ -357,7 +365,12 @@ public abstract class S3V4RestSignerClient
   }
 
   @Override
-  public void close() throws Exception {}
+  public void close() {
+    IoUtils.closeQuietlyV2(httpClient, null);
+    IoUtils.closeQuietlyV2(authManager, null);
+    this.httpClient = null;
+    this.authManager = null;
+  }
 
   /**
    * Only add body for DeleteObjectsRequest. Refer to

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/signer/S3V4RestSignerClient.java
@@ -93,9 +93,6 @@ public abstract class S3V4RestSignerClient
   private static final String CACHE_CONTROL = "Cache-Control";
   private static final String CACHE_CONTROL_PRIVATE = "private";
 
-  private static final Cache<Key, SignedComponent> SIGNED_COMPONENT_CACHE =
-      Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.SECONDS).maximumSize(100).build();
-
   private static final String SCOPE = "sign";
 
   @SuppressWarnings("immutables:incompat")
@@ -103,6 +100,10 @@ public abstract class S3V4RestSignerClient
 
   @SuppressWarnings("immutables:incompat")
   private volatile RESTClient httpClient;
+
+  @SuppressWarnings("immutables:incompat")
+  private final Cache<Key, SignedComponent> signedComponentCache =
+      Caffeine.newBuilder().expireAfterWrite(30, TimeUnit.SECONDS).maximumSize(100).build();
 
   public abstract Map<String, String> properties();
 
@@ -210,6 +211,11 @@ public abstract class S3V4RestSignerClient
     }
 
     return httpClient;
+  }
+
+  @VisibleForTesting
+  Cache<Key, SignedComponent> signedComponentCache() {
+    return signedComponentCache;
   }
 
   @VisibleForTesting
@@ -324,7 +330,7 @@ public abstract class S3V4RestSignerClient
             .build();
 
     Key cacheKey = Key.from(remoteSigningRequest);
-    SignedComponent cachedSignedComponent = SIGNED_COMPONENT_CACHE.getIfPresent(cacheKey);
+    SignedComponent cachedSignedComponent = signedComponentCache().getIfPresent(cacheKey);
     SignedComponent signedComponent;
 
     if (null != cachedSignedComponent) {
@@ -350,7 +356,7 @@ public abstract class S3V4RestSignerClient
               .build();
 
       if (canBeCached(responseHeaders)) {
-        SIGNED_COMPONENT_CACHE.put(cacheKey, signedComponent);
+        signedComponentCache().put(cacheKey, signedComponent);
       }
     }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
@@ -27,81 +27,38 @@ import java.util.stream.Stream;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.auth.AuthManager;
 import org.apache.iceberg.rest.auth.AuthProperties;
 import org.apache.iceberg.rest.auth.AuthSession;
+import org.apache.iceberg.rest.auth.OAuth2Manager;
 import org.apache.iceberg.rest.auth.OAuth2Properties;
 import org.apache.iceberg.rest.auth.OAuth2Util;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mockito;
-import software.amazon.awssdk.utils.IoUtils;
 
 class TestS3V4RestSignerClient {
 
-  @BeforeAll
-  static void beforeAll() {
-    S3V4RestSignerClient.authManager = null;
-    S3V4RestSignerClient.httpClient = Mockito.mock(RESTClient.class);
-    when(S3V4RestSignerClient.httpClient.withAuthSession(Mockito.any()))
-        .thenReturn(S3V4RestSignerClient.httpClient);
-    when(S3V4RestSignerClient.httpClient.postForm(
-            Mockito.anyString(),
-            Mockito.eq(
-                Map.of(
-                    "grant_type",
-                    "client_credentials",
-                    "client_id",
-                    "user",
-                    "client_secret",
-                    "12345",
-                    "scope",
-                    "sign")),
-            Mockito.eq(OAuthTokenResponse.class),
-            Mockito.anyMap(),
-            Mockito.any()))
-        .thenReturn(
-            OAuthTokenResponse.builder().withToken("token").withTokenType("Bearer").build());
-    when(S3V4RestSignerClient.httpClient.postForm(
-            Mockito.anyString(),
-            Mockito.eq(
-                Map.of(
-                    "grant_type",
-                    "client_credentials",
-                    "client_id",
-                    "user",
-                    "client_secret",
-                    "12345",
-                    "scope",
-                    "custom")),
-            Mockito.eq(OAuthTokenResponse.class),
-            Mockito.anyMap(),
-            Mockito.any()))
-        .thenReturn(
-            OAuthTokenResponse.builder().withToken("token").withTokenType("Bearer").build());
-  }
-
-  @AfterAll
-  static void afterAll() {
-    S3V4RestSignerClient.httpClient = null;
-  }
-
-  @AfterEach
-  void afterEach() {
-    IoUtils.closeQuietlyV2(S3V4RestSignerClient.authManager, null);
-    S3V4RestSignerClient.authManager = null;
-  }
+  private static final Map<String, String> SIGNER_PROPERTIES =
+      Map.of(
+          RESTCatalogProperties.SIGNER_URI,
+          "https://signer.com",
+          RESTCatalogProperties.SIGNER_ENDPOINT,
+          "v1/sign/s3");
 
   @ParameterizedTest
   @MethodSource("validOAuth2Properties")
-  void authSessionOAuth2(Map<String, String> properties, String expectedScope, String expectedToken)
-      throws Exception {
+  void authSessionOAuth2(
+      Map<String, String> properties, String expectedScope, String expectedToken) {
+    RESTClient mockHttpClient = mockHttpClient();
     try (S3V4RestSignerClient client =
-            ImmutableS3V4RestSignerClient.builder().properties(properties).build();
+            ImmutableS3V4RestSignerClient.builder()
+                .properties(properties)
+                .httpClientSupplier(() -> mockHttpClient)
+                .build();
         AuthSession authSession = client.authSession()) {
       assertThat(client.optionalOAuthParams()).containsEntry(OAuth2Properties.SCOPE, expectedScope);
       if (expectedToken == null) {
@@ -189,8 +146,7 @@ class TestS3V4RestSignerClient {
   @ParameterizedTest
   @MethodSource("legacySignerProperties")
   void legacySignerProperties(
-      Map<String, String> properties, String expectedBaseSignerUri, String expectedEndpoint)
-      throws Exception {
+      Map<String, String> properties, String expectedBaseSignerUri, String expectedEndpoint) {
     try (S3V4RestSignerClient client =
         ImmutableS3V4RestSignerClient.builder().properties(properties).build()) {
       assertThat(client.baseSignerUri()).isEqualTo(expectedBaseSignerUri);
@@ -243,5 +199,105 @@ class TestS3V4RestSignerClient {
             Map.of(CatalogProperties.URI, "https://catalog.com"),
             "https://catalog.com",
             "https://catalog.com/" + S3V4RestSignerClient.S3_SIGNER_DEFAULT_ENDPOINT));
+  }
+
+  @Test
+  void httpClientNotSharedAcrossInstances() {
+    RESTClient firstHttpClient = Mockito.mock(RESTClient.class);
+    RESTClient secondHttpClient = Mockito.mock(RESTClient.class);
+    try (S3V4RestSignerClient first =
+            ImmutableS3V4RestSignerClient.builder()
+                .properties(SIGNER_PROPERTIES)
+                .httpClientSupplier(() -> firstHttpClient)
+                .build();
+        S3V4RestSignerClient second =
+            ImmutableS3V4RestSignerClient.builder()
+                .properties(SIGNER_PROPERTIES)
+                .httpClientSupplier(() -> secondHttpClient)
+                .build()) {
+      // each signer must use its own client, not the first one initialized in the JVM
+      assertThat(first.httpClient()).isSameAs(firstHttpClient);
+      assertThat(second.httpClient()).isSameAs(secondHttpClient);
+      assertThat(first.httpClient()).isNotSameAs(second.httpClient());
+    }
+  }
+
+  @Test
+  void authManagerNotSharedAcrossInstances() {
+    Map<String, String> oauth2Properties =
+        Map.of(
+            RESTCatalogProperties.SIGNER_URI,
+            "https://signer.com",
+            RESTCatalogProperties.SIGNER_ENDPOINT,
+            "v1/sign/s3",
+            AuthProperties.AUTH_TYPE,
+            AuthProperties.AUTH_TYPE_OAUTH2,
+            OAuth2Properties.TOKEN,
+            "token");
+    try (S3V4RestSignerClient noAuth =
+            ImmutableS3V4RestSignerClient.builder().properties(SIGNER_PROPERTIES).build();
+        S3V4RestSignerClient oauth2 =
+            ImmutableS3V4RestSignerClient.builder().properties(oauth2Properties).build()) {
+      AuthManager noAuthManager = noAuth.authManager();
+      AuthManager oauth2Manager = oauth2.authManager();
+      // a catalog configured for OAuth2 must not leak its auth manager into a catalog that
+      // configured no auth (and vice versa)
+      assertThat(noAuthManager).isNotSameAs(oauth2Manager);
+      assertThat(oauth2Manager).isInstanceOf(OAuth2Manager.class);
+      assertThat(noAuthManager).isNotInstanceOf(OAuth2Manager.class);
+    }
+  }
+
+  @Test
+  void closeReleasesHttpClient() throws Exception {
+    RESTClient mockHttpClient = Mockito.mock(RESTClient.class);
+    S3V4RestSignerClient client =
+        ImmutableS3V4RestSignerClient.builder()
+            .properties(SIGNER_PROPERTIES)
+            .httpClientSupplier(() -> mockHttpClient)
+            .build();
+    assertThat(client.httpClient()).isSameAs(mockHttpClient);
+    client.close();
+    Mockito.verify(mockHttpClient).close();
+  }
+
+  private static RESTClient mockHttpClient() {
+    RESTClient mock = Mockito.mock(RESTClient.class);
+    when(mock.withAuthSession(Mockito.any())).thenReturn(mock);
+    when(mock.postForm(
+            Mockito.anyString(),
+            Mockito.eq(
+                Map.of(
+                    "grant_type",
+                    "client_credentials",
+                    "client_id",
+                    "user",
+                    "client_secret",
+                    "12345",
+                    "scope",
+                    "sign")),
+            Mockito.eq(OAuthTokenResponse.class),
+            Mockito.anyMap(),
+            Mockito.any()))
+        .thenReturn(
+            OAuthTokenResponse.builder().withToken("token").withTokenType("Bearer").build());
+    when(mock.postForm(
+            Mockito.anyString(),
+            Mockito.eq(
+                Map.of(
+                    "grant_type",
+                    "client_credentials",
+                    "client_id",
+                    "user",
+                    "client_secret",
+                    "12345",
+                    "scope",
+                    "custom")),
+            Mockito.eq(OAuthTokenResponse.class),
+            Mockito.anyMap(),
+            Mockito.any()))
+        .thenReturn(
+            OAuthTokenResponse.builder().withToken("token").withTokenType("Bearer").build());
+    return mock;
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/signer/TestS3V4RestSignerClient.java
@@ -249,6 +249,18 @@ class TestS3V4RestSignerClient {
   }
 
   @Test
+  void signedComponentCacheNotSharedAcrossInstances() {
+    try (S3V4RestSignerClient first =
+            ImmutableS3V4RestSignerClient.builder().properties(SIGNER_PROPERTIES).build();
+        S3V4RestSignerClient second =
+            ImmutableS3V4RestSignerClient.builder().properties(SIGNER_PROPERTIES).build()) {
+      // each signer must keep its own signed-component cache so a signed URL minted for one
+      // catalog can never be served to another catalog
+      assertThat(first.signedComponentCache()).isNotSameAs(second.signedComponentCache());
+    }
+  }
+
+  @Test
   void closeReleasesHttpClient() throws Exception {
     RESTClient mockHttpClient = Mockito.mock(RESTClient.class);
     S3V4RestSignerClient client =


### PR DESCRIPTION
Closes #16460.

## Summary

`S3V4RestSignerClient` kept its `AuthManager` and `RESTClient` in process-wide `static volatile` fields, lazily initialized from the first catalog's properties. In a JVM that talks to more than one catalog the first catalog to initialize these fields won: any later catalog with a different auth type, different OAuth credentials, or different custom HTTP headers silently reused the first catalog's auth manager and HTTP client. That is the cross-catalog leakage reported in #16460. PR #14178 previously removed the base-URI pinning from the shared client but deliberately left the static fields in place; this change finishes the cleanup by making the auth/HTTP state per signer instance.

## What changed

The `authManager` and `httpClient` fields are now per-instance (double-checked locking on the instance rather than the class), so each signer owns its own auth manager and HTTP client.

The HTTP client is now built through a settable `httpClientSupplier()` default, which keeps per-catalog headers and timeouts isolated and provides a seam for injecting a mock client in tests. The previously empty `close()` now releases the per-instance auth manager and HTTP client via `IoUtils.closeQuietlyV2`.

The signed-component cache is per instance as well, so a signature obtained through one catalog's signer is never served to a signer configured for another catalog.

## Tests

Added regression tests in `TestS3V4RestSignerClient` showing two signer instances with different configuration no longer share state: distinct HTTP clients per instance, distinct auth managers of distinct types when auth differs, distinct signed-component caches, and that `close()` releases the HTTP client. Reworked the existing unit and integration tests to inject the HTTP client per instance and to release the signer through `close()` instead of nulling the removed static fields.

---
**AI Disclosure**
- Model: Claude Opus 4.7, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Move the S3 remote signer AuthManager and RESTClient out of process-wide statics so the state is isolated per catalog.

