### PR TITLE
Core: Allow v3 unknown to primitive type promotion

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -445,6 +445,9 @@ public class TypeUtil {
     }
 
     switch (from.typeId()) {
+      case UNKNOWN:
+        return true;
+
       case INTEGER:
         return to.typeId() == Type.TypeID.LONG;
 

--- a/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
@@ -87,6 +87,44 @@ public class TestReadabilityChecks {
     }
   }
 
+  @Test
+  public void testUnknownTypeReadCompatibility() {
+    Schema write = new Schema(required(1, "from_field", Types.UnknownType.get()));
+    List<String> primitiveErrors =
+        CheckCompatibility.writeCompatibilityErrors(
+            new Schema(required(1, "to_field", Types.IntegerType.get())), write);
+    assertThat(primitiveErrors).isEmpty();
+
+    List<String> structErrors =
+        CheckCompatibility.writeCompatibilityErrors(
+            new Schema(
+                required(
+                    1,
+                    "to_field",
+                    Types.StructType.of(required(2, "nested", Types.IntegerType.get())))),
+            write);
+    assertThat(structErrors).hasSize(1);
+    assertThat(structErrors.get(0)).contains("cannot be read as a struct");
+
+    List<String> listErrors =
+        CheckCompatibility.writeCompatibilityErrors(
+            new Schema(required(1, "to_field", Types.ListType.ofRequired(2, Types.IntegerType.get()))),
+            write);
+    assertThat(listErrors).hasSize(1);
+    assertThat(listErrors.get(0)).contains("cannot be read as a list");
+
+    List<String> mapErrors =
+        CheckCompatibility.writeCompatibilityErrors(
+            new Schema(
+                required(
+                    1,
+                    "to_field",
+                    Types.MapType.ofRequired(2, 3, Types.StringType.get(), Types.IntegerType.get()))),
+            write);
+    assertThat(mapErrors).hasSize(1);
+    assertThat(mapErrors.get(0)).contains("cannot be read as a map");
+  }
+
   private void testDisallowPrimitiveToMap(PrimitiveType from, Schema fromSchema) {
     Schema mapSchema =
         new Schema(

--- a/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestReadabilityChecks.java
@@ -89,16 +89,16 @@ public class TestReadabilityChecks {
 
   @Test
   public void testUnknownTypeReadCompatibility() {
-    Schema write = new Schema(required(1, "from_field", Types.UnknownType.get()));
+    Schema write = new Schema(optional(1, "from_field", Types.UnknownType.get()));
     List<String> primitiveErrors =
         CheckCompatibility.writeCompatibilityErrors(
-            new Schema(required(1, "to_field", Types.IntegerType.get())), write);
+            new Schema(optional(1, "to_field", Types.IntegerType.get())), write);
     assertThat(primitiveErrors).isEmpty();
 
     List<String> structErrors =
         CheckCompatibility.writeCompatibilityErrors(
             new Schema(
-                required(
+                optional(
                     1,
                     "to_field",
                     Types.StructType.of(required(2, "nested", Types.IntegerType.get())))),
@@ -108,7 +108,8 @@ public class TestReadabilityChecks {
 
     List<String> listErrors =
         CheckCompatibility.writeCompatibilityErrors(
-            new Schema(required(1, "to_field", Types.ListType.ofRequired(2, Types.IntegerType.get()))),
+            new Schema(
+                optional(1, "to_field", Types.ListType.ofRequired(2, Types.IntegerType.get()))),
             write);
     assertThat(listErrors).hasSize(1);
     assertThat(listErrors.get(0)).contains("cannot be read as a list");
@@ -116,10 +117,11 @@ public class TestReadabilityChecks {
     List<String> mapErrors =
         CheckCompatibility.writeCompatibilityErrors(
             new Schema(
-                required(
+                optional(
                     1,
                     "to_field",
-                    Types.MapType.ofRequired(2, 3, Types.StringType.get(), Types.IntegerType.get()))),
+                    Types.MapType.ofRequired(
+                        2, 3, Types.StringType.get(), Types.IntegerType.get()))),
             write);
     assertThat(mapErrors).hasSize(1);
     assertThat(mapErrors.get(0)).contains("cannot be read as a map");

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -2493,7 +2493,8 @@ public class TestSchemaUpdate {
         new Schema(
             required(1, "id", Types.LongType.get()), optional(2, "unk", Types.UnknownType.get()));
     Schema expected =
-        new Schema(required(1, "id", Types.LongType.get()), optional(2, "unk", Types.IntegerType.get()));
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "unk", Types.IntegerType.get()));
 
     Schema actual =
         new SchemaUpdate(schema, schema.highestFieldId())

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -2488,6 +2488,22 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateUnknownToInteger() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "unk", Types.UnknownType.get()));
+    Schema expected =
+        new Schema(required(1, "id", Types.LongType.get()), optional(2, "unk", Types.IntegerType.get()));
+
+    Schema actual =
+        new SchemaUpdate(schema, schema.highestFieldId())
+            .updateColumn("unk", Types.IntegerType.get())
+            .apply();
+
+    assertThat(actual.asStruct()).isEqualTo(expected.asStruct());
+  }
+
+  @Test
   public void testAddUnknownNonNullDefault() {
     Schema schema = new Schema(required(1, "id", Types.LongType.get()));
 


### PR DESCRIPTION
### Motivation

The v3 spec requires `unknown` to be promotable to any primitive type. However, it's not included in `TypeUtil.isPromotionAllowed`, which blocked schema evolution and read-compatibility paths that should allow `unknown` columns to become concrete primitive columns.

### Description

- Add an `UNKNOWN` case to `TypeUtil.isPromotionAllowed` so `unknown` can be promoted to primitive target types.
- Add a read-compatibility test that verifies `unknown` to `int` is allowed while `unknown` to struct, list, and map remains rejected.
- Add a schema evolution test that verifies `SchemaUpdate.updateColumn("unk", Types.IntegerType.get())` succeeds when the current type is `unknown`.

---

Co-authored-by: @codex
