### PR TITLE
Infra: Add `.claude/` to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ derby.log
 
 # git hooks like pre-commit
 .githooks/
+
+# claude code
+.claude/


### PR DESCRIPTION
The .claude/ directory is used by Claude Code (https://claude.ai/claude-code) to store local project configuration and session data. This directory is user-specific and should not be committed to the repository. 

Fix #16532 