### PR TITLE
ci: only run site-ci deploy job for apache/iceberg

### DIFF
--- a/.github/workflows/site-ci.yml
+++ b/.github/workflows/site-ci.yml
@@ -32,6 +32,7 @@ permissions:
 
 jobs:
   deploy:
+    if: github.repository == 'apache/iceberg'
     runs-on: ubuntu-slim
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
Adds `if: github.repository == 'apache/iceberg'` to the `deploy` job so it is skipped when triggered from other repos (forks).

## Testing

Manually triggered on my fork based on this branch, and it skipped
https://github.com/kevinjqliu/iceberg/actions/runs/26303866004