### PR TITLE
REST: introduce FileIOBuilder to pass storage credentials at construction time

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/FileIOBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/rest/FileIOBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.catalog.SessionCatalog.SessionContext;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.StorageCredential;
+
+@FunctionalInterface
+public interface FileIOBuilder {
+  FileIO build(
+      SessionContext context, Map<String, String> properties, List<StorageCredential> credentials);
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -87,7 +87,7 @@ public class RESTCatalog
    */
   protected RESTSessionCatalog newSessionCatalog(
       Function<Map<String, String>, RESTClient> clientBuilder) {
-    return new RESTSessionCatalog(clientBuilder, null);
+    return new RESTSessionCatalog(clientBuilder, (FileIOBuilder) null);
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -155,7 +155,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
           .build();
 
   private final Function<Map<String, String>, RESTClient> clientBuilder;
-  private final BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder;
+  private final FileIOBuilder ioBuilder;
   private FileIOTracker fileIOTracker = null;
   private AuthSession catalogAuth = null;
   private AuthManager authManager;
@@ -181,15 +181,35 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                 .uri(config.get(CatalogProperties.URI))
                 .withHeaders(RESTUtil.configHeaders(config))
                 .build(),
-        null);
+        (FileIOBuilder) null);
   }
 
   public RESTSessionCatalog(
-      Function<Map<String, String>, RESTClient> clientBuilder,
-      BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder) {
+      Function<Map<String, String>, RESTClient> clientBuilder, FileIOBuilder ioBuilder) {
     Preconditions.checkNotNull(clientBuilder, "Invalid client builder: null");
     this.clientBuilder = clientBuilder;
     this.ioBuilder = ioBuilder;
+  }
+
+  /**
+   * @deprecated Use {@link #RESTSessionCatalog(Function, FileIOBuilder)} instead.
+   */
+  @Deprecated
+  public RESTSessionCatalog(
+      Function<Map<String, String>, RESTClient> clientBuilder,
+      BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder) {
+    this(
+        clientBuilder,
+        ioBuilder == null
+            ? null
+            : (context, properties, credentials) -> {
+              FileIO fileIO = ioBuilder.apply(context, properties);
+              if (!credentials.isEmpty()
+                  && fileIO instanceof SupportsStorageCredentials ioWithCredentials) {
+                ioWithCredentials.setCredentials(credentials);
+              }
+              return fileIO;
+            });
   }
 
   @Override
@@ -1186,25 +1206,16 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
   private FileIO newFileIO(
       SessionContext context, Map<String, String> properties, List<Credential> storageCredentials) {
+    List<StorageCredential> credentials =
+        storageCredentials.stream()
+            .map(c -> StorageCredential.create(c.prefix(), c.config()))
+            .collect(Collectors.toList());
+
     if (null != ioBuilder) {
-      FileIO fileIO = ioBuilder.apply(context, properties);
-      if (!storageCredentials.isEmpty()
-          && fileIO instanceof SupportsStorageCredentials ioWithCredentials) {
-        ioWithCredentials.setCredentials(
-            storageCredentials.stream()
-                .map(c -> StorageCredential.create(c.prefix(), c.config()))
-                .collect(Collectors.toList()));
-      }
-      return fileIO;
+      return ioBuilder.build(context, properties, credentials);
     } else {
       String ioImpl = properties.getOrDefault(CatalogProperties.FILE_IO_IMPL, DEFAULT_FILE_IO_IMPL);
-      return CatalogUtil.loadFileIO(
-          ioImpl,
-          properties,
-          conf,
-          storageCredentials.stream()
-              .map(c -> StorageCredential.create(c.prefix(), c.config()))
-              .collect(Collectors.toList()));
+      return CatalogUtil.loadFileIO(ioImpl, properties, conf, credentials);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -547,7 +547,8 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
   public void tableCacheWithMultiSessions() {
     RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
 
-    RESTSessionCatalog sessionCatalog = new RESTSessionCatalog(config -> adapter, null);
+    RESTSessionCatalog sessionCatalog =
+        new RESTSessionCatalog(config -> adapter, (FileIOBuilder) null);
     sessionCatalog.initialize("test_session_catalog", Map.of());
 
     SessionCatalog.SessionContext otherSessionContext =

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -90,7 +90,6 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
-import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.CommitReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -3821,7 +3820,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           }
         };
 
-    AtomicReference<FileIO> createdFileIO = new AtomicReference<>();
+    AtomicReference<List<StorageCredential>> capturedCredentials = new AtomicReference<>();
 
     try (RESTCatalog catalog =
         catalog(
@@ -3829,22 +3828,18 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             clientBuilder ->
                 new RESTSessionCatalog(
                     clientBuilder,
-                    (context, config) -> {
-                      TestCatalogUtil.TestFileIOWithStorageCredentials fileIO =
-                          new TestCatalogUtil.TestFileIOWithStorageCredentials();
-                      createdFileIO.set(fileIO);
-                      return fileIO;
-                    }))) {
+                    (FileIOBuilder)
+                        (context, config, credentials) -> {
+                          capturedCredentials.set(credentials);
+                          return new TestCatalogUtil.TestFileIONoArg();
+                        }))) {
       catalog.createNamespace(NS);
       catalog.createTable(TABLE, SCHEMA);
       catalog.loadTable(TABLE);
 
-      assertThat(createdFileIO.get()).isInstanceOf(SupportsStorageCredentials.class);
-      List<StorageCredential> creds =
-          ((SupportsStorageCredentials) createdFileIO.get()).credentials();
-      assertThat(creds).hasSize(1);
-      assertThat(creds.get(0).prefix()).isEqualTo("s3://test-bucket/");
-      assertThat(creds.get(0).config())
+      assertThat(capturedCredentials.get()).hasSize(1);
+      assertThat(capturedCredentials.get().get(0).prefix()).isEqualTo("s3://test-bucket/");
+      assertThat(capturedCredentials.get().get(0).config())
           .containsEntry("s3.access-key-id", "test-access-key")
           .containsEntry("s3.secret-access-key", "test-secret-key");
     } catch (IOException e) {


### PR DESCRIPTION
## Problem

The existing `BiFunction<SessionContext, Map<String, String>, FileIO> ioBuilder` applied storage credentials post-construction via `SupportsStorageCredential.setCredentials` method
which does not work for engines (e.g. Trino) that need all inputs available at build time.

## Technical solution

Introduce a `FileIOBuilder` functional interface that receives `SessionContext`, fileIO properties, and `List<StorageCredential>` all at once. Deprecate the `BiFunction` constructor with a wrapper that preserves the old two-step behavior for existing callers.

## Related issues and PRs

This contribution is attempting to adjust the previous changes performed in https://github.com/apache/iceberg/pull/15752 for configuring `StorageCredentials` in the `ioBuilder`.

Issue discovered while developing https://github.com/trinodb/trino/pull/29590
The Trino PR makes use of this contribution for ensuring the accuracy of these changes on https://github.com/trinodb/trino project within the Iceberg connector.


UPDATE 27.05.2026

I've created an alternative in trinodb/trino which works without any changes on apache/iceberg 1.11.0

https://github.com/trinodb/trino/pull/29641
By making Trino's `ForwardingFileIO` to implement `SupportsStorageCredentials` (as well as providing a hook to update the underlying `TrinoFileSystem`'s storage credentials, the PR adds the functionality of updating storage credentials for the Trino Iceberg REST catalog integration.

