### PR TITLE
Build: Print failed test summary after suite completes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -274,6 +274,27 @@ subprojects {
       exceptionFormat "full"
     }
 
+    def failedTests = []
+    addTestListener(new TestListener() {
+      void afterTest(TestDescriptor descriptor, TestResult result) {
+        if (result.resultType == TestResult.ResultType.FAILURE) {
+          failedTests << "${descriptor.className}.${descriptor.name}"
+        }
+      }
+      
+      void afterSuite(TestDescriptor descriptor, TestResult result) {
+        if (descriptor.parent == null && !failedTests.isEmpty()) {
+          println "\nFailures:"
+          failedTests.each { testName ->
+            println "  ${testName}"
+          }
+        }
+      }
+      
+      void beforeTest(TestDescriptor descriptor) {}
+      void beforeSuite(TestDescriptor descriptor) {}
+    })
+
     systemProperty 'project.version', project.version
   }
 


### PR DESCRIPTION
https://github.com/apache/iceberg/actions/runs/26280375822/job/77354779601

We can't quickly identify `TestADLSOutputStream` without scrolling or searching by keyword.

This change will print the names of failed tests after the suite completes, as shown below: 
```
...
TestPropertiesSerDesUtil > testPropertiesSerDes() PASSED

TestExceptionCode > testExceptionCode() STARTED

TestExceptionCode > testExceptionCode() PASSED

Failures:
  org.apache.iceberg.dell.ecs.TestEcsCatalog.testListTablesAndNamespaces()

25 tests completed, 1 failed

> Task :iceberg-dell:test FAILED

[Incubating] Problems report is available at: file:///Users/yuya.ebihara/iceberg/build/reports/problems/problems-report.html
```