### PR TITLE
Core: Fix flaky test by ensuring generateContentLength returns positive value

### DIFF
--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -276,7 +276,7 @@ public class FileGenerationUtil {
   }
 
   private static long generateContentLength() {
-    return random().nextInt(10_000);
+    return 1 + random().nextInt(10_000);
   }
 
   private static Pair<ByteBuffer, ByteBuffer> generateBounds(PrimitiveType type, MetricsMode mode) {

--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -268,7 +268,7 @@ public class FileGenerationUtil {
   }
 
   private static long generateFileSize() {
-    return random().nextInt(50_000);
+    return 1 + random().nextInt(50_000);
   }
 
   private static long generateContentOffset() {


### PR DESCRIPTION
  generateContentLength() used random().nextInt(10_000) which could return 0.
  When a DV's contentSizeInBytes is 0, SnapshotSummary skips writing the
  "added-files-size" field due to the setIf(addedSize > 0, ...) guard,
  causing testFileSizeSummaryWithDVs to fail with hasSize(19) vs actual 18.

  Fix by returning 1 + random().nextInt(10_000) to guarantee a positive value.