### PR TITLE
Azure: Retry transient Azurite image-fetch failures in integration tests

### DIFF
--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/AzuriteContainer.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/AzuriteContainer.java
@@ -26,16 +26,29 @@ import com.azure.storage.file.datalake.DataLakeServiceClientBuilder;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.ContainerFetchException;
+import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
 public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AzuriteContainer.class);
 
   private static final int DEFAULT_PORT = 10000; // default blob service port
   private static final String DEFAULT_IMAGE = "mcr.microsoft.com/azure-storage/azurite";
   private static final String DEFAULT_TAG = "3.35.0";
   private static final String LOG_WAIT_REGEX =
       "Azurite Blob service is successfully listening at .*";
+
+  // Pulling the Azurite image from mcr.microsoft.com intermittently fails with a transient
+  // ContainerFetchException/404 (registry rate-limiting or CDN inconsistency); retry the fetch a
+  // few times before giving up. See https://github.com/apache/iceberg/issues/16530.
+  private static final int MAX_START_ATTEMPTS = 5;
+  private static final Duration START_RETRY_BASE_BACKOFF = Duration.ofSeconds(2);
 
   public static final String ACCOUNT = "account";
   public static final String KEY = "key";
@@ -51,6 +64,67 @@ public class AzuriteContainer extends GenericContainer<AzuriteContainer> {
     this.addEnv("AZURITE_ACCOUNTS", ACCOUNT + ":" + KEY);
     this.withCommand("azurite", "--blobHost", "0.0.0.0", "--skipApiVersionCheck");
     this.setWaitStrategy(new LogMessageWaitStrategy().withRegEx(LOG_WAIT_REGEX));
+  }
+
+  @Override
+  public void start() {
+    startWithRetry(super::start, MAX_START_ATTEMPTS, START_RETRY_BASE_BACKOFF);
+  }
+
+  // Retries transient image-fetch failures with exponential backoff (baseBackoff doubled each
+  // attempt). Exponential rather than fixed because the failure is often registry rate-limiting or
+  // CDN inconsistency, which a tight fixed interval would repeatedly hit. Genuine launch failures
+  // (e.g. a wait-strategy timeout) are not retried so real problems still surface immediately.
+  static void startWithRetry(Runnable start, int maxAttempts, Duration baseBackoff) {
+    RuntimeException lastFailure = null;
+    Duration backoff = baseBackoff;
+    for (int attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        start.run();
+        return;
+      } catch (ContainerFetchException | ContainerLaunchException e) {
+        if (!isImageFetchFailure(e)) {
+          throw e;
+        }
+
+        lastFailure = e;
+        if (attempt < maxAttempts) {
+          LOG.warn(
+              "Failed to fetch Azurite image (attempt {}/{}), retrying in {}",
+              attempt,
+              maxAttempts,
+              backoff,
+              e);
+          sleep(backoff);
+          backoff = backoff.multipliedBy(2);
+        }
+      }
+    }
+
+    throw lastFailure;
+  }
+
+  private static boolean isImageFetchFailure(Throwable throwable) {
+    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+      if (cause instanceof ContainerFetchException) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static void sleep(Duration backoff) {
+    if (backoff.isZero() || backoff.isNegative()) {
+      return;
+    }
+
+    try {
+      Thread.sleep(backoff.toMillis());
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException("Interrupted while waiting to retry Azurite container start", e);
+    }
   }
 
   public void createStorageContainer() {

--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestAzuriteContainer.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestAzuriteContainer.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.azure.adlsv2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Duration;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.ContainerFetchException;
+import org.testcontainers.containers.ContainerLaunchException;
+
+public class TestAzuriteContainer {
+
+  private static final int MAX_ATTEMPTS = 5;
+
+  @Test
+  public void succeedsWithoutRetryWhenStartSucceeds() {
+    AtomicInteger calls = new AtomicInteger();
+
+    AzuriteContainer.startWithRetry(calls::incrementAndGet, MAX_ATTEMPTS, Duration.ZERO);
+
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void retriesUntilStartSucceeds() {
+    AtomicInteger calls = new AtomicInteger();
+    Runnable start =
+        () -> {
+          if (calls.incrementAndGet() < 3) {
+            throw new ContainerFetchException("transient", new RuntimeException("404"));
+          }
+        };
+
+    AzuriteContainer.startWithRetry(start, MAX_ATTEMPTS, Duration.ZERO);
+
+    assertThat(calls.get()).isEqualTo(3);
+  }
+
+  @Test
+  public void rethrowsLastFailureAfterExhaustingAttempts() {
+    AtomicInteger calls = new AtomicInteger();
+    Runnable start =
+        () -> {
+          calls.incrementAndGet();
+          throw new ContainerFetchException("always", new RuntimeException("404"));
+        };
+
+    assertThatThrownBy(() -> AzuriteContainer.startWithRetry(start, MAX_ATTEMPTS, Duration.ZERO))
+        .isInstanceOf(ContainerFetchException.class);
+    assertThat(calls.get()).isEqualTo(MAX_ATTEMPTS);
+  }
+
+  @Test
+  public void doesNotRetryNonImageFetchFailures() {
+    AtomicInteger calls = new AtomicInteger();
+    ContainerLaunchException launchFailure =
+        new ContainerLaunchException("wait strategy timed out");
+    Runnable start =
+        () -> {
+          calls.incrementAndGet();
+          throw launchFailure;
+        };
+
+    assertThatThrownBy(() -> AzuriteContainer.startWithRetry(start, MAX_ATTEMPTS, Duration.ZERO))
+        .isSameAs(launchFailure);
+    assertThat(calls.get()).isEqualTo(1);
+  }
+
+  @Test
+  public void retriesFetchFailureWrappedInLaunchException() {
+    AtomicInteger calls = new AtomicInteger();
+    Runnable start =
+        () -> {
+          if (calls.incrementAndGet() < 2) {
+            throw new ContainerLaunchException(
+                "startup failed",
+                new ContainerFetchException("transient", new RuntimeException("404")));
+          }
+        };
+
+    AzuriteContainer.startWithRetry(start, MAX_ATTEMPTS, Duration.ZERO);
+
+    assertThat(calls.get()).isEqualTo(2);
+  }
+}

--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestAzuriteContainer.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestAzuriteContainer.java
@@ -58,14 +58,16 @@ public class TestAzuriteContainer {
   @Test
   public void rethrowsLastFailureAfterExhaustingAttempts() {
     AtomicInteger calls = new AtomicInteger();
+    ContainerFetchException fetchFailure =
+        new ContainerFetchException("transient", new RuntimeException("404"));
     Runnable start =
         () -> {
           calls.incrementAndGet();
-          throw new ContainerFetchException("always", new RuntimeException("404"));
+          throw fetchFailure;
         };
 
     assertThatThrownBy(() -> AzuriteContainer.startWithRetry(start, MAX_ATTEMPTS, Duration.ZERO))
-        .isInstanceOf(ContainerFetchException.class);
+        .isSameAs(fetchFailure);
     assertThat(calls.get()).isEqualTo(MAX_ATTEMPTS);
   }
 


### PR DESCRIPTION
## Summary

Closes #16530.

The `iceberg-azure` integration tests (`TestADLSFileIO`, `TestADLSInputStream`, `TestADLSOutputStream`) start a shared Azurite container in `AzuriteTestBase.@BeforeAll`. They intermittently fail at startup with a `ContainerFetchException` caused by a `NotFoundException` (HTTP 404) while testcontainers pulls `mcr.microsoft.com/azure-storage/azurite:3.35.0`. The image tag is already pinned, so this is a transient registry/CDN failure (rate-limiting or CDN inconsistency), not a missing image — re-running usually succeeds, which is exactly what makes these tests flaky.

## What changed

`AzuriteContainer` now overrides `start()` to retry transient image-fetch failures before giving up: up to 5 attempts with exponential backoff (2s → 4s → 8s → 16s). Each retry re-invokes `start()`, which re-triggers the image pull, because testcontainers' `RemoteDockerImage` does not cache a failed resolution.

Notably, testcontainers' own `withStartupAttempts(...)` does not help here: in testcontainers 2.0.5 the image is fetched (`getDockerImageName()` → `RemoteDockerImage`) *before* the `startupAttempts` retry loop in `GenericContainer.doStart()`, so a fetch failure short-circuits that loop. Retrying `start()` itself is what actually re-attempts the pull.

The retry is deliberately narrow: it only retries when the failure (or its cause chain) is a `ContainerFetchException`. Genuine launch failures — e.g. a wait-strategy timeout surfaced as a `ContainerLaunchException` without a fetch cause — are rethrown immediately so real problems are never masked.

## Tests

- New `TestAzuriteContainer` exercises the retry helper without Docker: succeeds without retry, retries until success, rethrows after exhausting attempts, does not retry non-fetch launch failures, and retries a fetch failure wrapped in a `ContainerLaunchException`.
- Confirmed the existing Azurite integration tests still pass through the overridden `start()` (`TestADLSFileIO`, `TestADLSInputStream`, `TestADLSOutputStream`) with Docker.

## Note

This reduces the flakiness by tolerating transient fetch hiccups; it cannot mask a registry outage that persists across all retries.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Retry transient Azurite container image-fetch failures in the Azure integration tests.
