### PR TITLE
Build: Clean up shaded-jar LICENSE/NOTICE and add missing third-party notices

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -24,3 +24,17 @@ the following copyright notice:
 | See the License for the specific language governing permissions and
 | limitations under the License.
 
+--------------------------------------------------------------------------------
+
+This project includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This project includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+

--- a/aws-bundle/NOTICE
+++ b/aws-bundle/NOTICE
@@ -337,3 +337,43 @@ This product bundles Netty with the following in its NOTICE file:
 
 This product bundles AWS Analytics Accelerator S3 with the following in its NOTICE file:
 | Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+--------------------------------------------------------------------------------
+
+This product bundles AWS Common Runtime (CRT) for Java with the following in its NOTICE file:
+| AWS Crt Java
+| Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+| SPDX-License-Identifier: Apache-2.0.
+|
+| ** XXHash - https://xxhash.com/
+| Copyright (c) 2012-2021 Yann Collet
+| All rights reserved.
+|
+| BSD 2-Clause License (https://www.opensource.org/licenses/bsd-license.php)
+|
+| Redistribution and use in source and binary forms, with or without modification,
+| are permitted provided that the following conditions are met:
+|
+| * Redistributions of source code must retain the above copyright notice, this
+|   list of conditions and the following disclaimer.
+|
+| * Redistributions in binary form must reproduce the above copyright notice, this
+|   list of conditions and the following disclaimer in the documentation and/or
+|   other materials provided with the distribution.
+|
+| THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+| ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+| WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+| DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+| ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+| (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+| LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+| ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+| (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+| SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+--------------------------------------------------------------------------------
+
+This product bundles AWS EventStream for Java with the following in its NOTICE file:
+| AWS EventStream for Java
+| Copyright 2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -60,6 +60,10 @@ project(":iceberg-aws-bundle") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // relocate AWS-specific versions
     relocate 'org.apache.http', 'org.apache.iceberg.aws.shaded.org.apache.http'
     relocate 'io.netty', 'org.apache.iceberg.aws.shaded.io.netty'

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -54,21 +54,6 @@ project(":iceberg-aws-bundle") {
     archiveClassifier.set(null)
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // relocate AWS-specific versions
     relocate 'org.apache.http', 'org.apache.iceberg.aws.shaded.org.apache.http'
     relocate 'io.netty', 'org.apache.iceberg.aws.shaded.io.netty'

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -64,6 +64,11 @@ project(":iceberg-aws-bundle") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // relocate AWS-specific versions
     relocate 'org.apache.http', 'org.apache.iceberg.aws.shaded.org.apache.http'
     relocate 'io.netty', 'org.apache.iceberg.aws.shaded.io.netty'

--- a/azure-bundle/NOTICE
+++ b/azure-bundle/NOTICE
@@ -307,3 +307,10 @@ This product bundles Netty with the following in its NOTICE file:
 |     * license/LICENSE.brotli4j.txt (Apache License 2.0)
 |   * HOMEPAGE:
 |     * https://github.com/hyperxpro/Brotli4j
+
+--------------------------------------------------------------------------------
+
+This product bundles Project Reactor (reactor-core, reactor-netty-core and
+reactor-netty-http), which is available under the Apache License, Version 2.0,
+with the following copyright notice:
+| Copyright (c) 2011-2025 VMware, Inc. or its affiliates. All Rights Reserved.

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -49,6 +49,10 @@ project(":iceberg-azure-bundle") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // relocate Azure-specific versions
     relocate 'io.netty', 'org.apache.iceberg.azure.shaded.io.netty'
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.azure.shaded.com.fasterxml.jackson'

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -43,21 +43,6 @@ project(":iceberg-azure-bundle") {
     archiveClassifier.set(null)
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // relocate Azure-specific versions
     relocate 'io.netty', 'org.apache.iceberg.azure.shaded.io.netty'
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.azure.shaded.com.fasterxml.jackson'

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -53,6 +53,11 @@ project(":iceberg-azure-bundle") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // relocate Azure-specific versions
     relocate 'io.netty', 'org.apache.iceberg.azure.shaded.io.netty'
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.azure.shaded.com.fasterxml.jackson'

--- a/build.gradle
+++ b/build.gradle
@@ -287,6 +287,26 @@ subprojects {
       scalaCompileOptions.additionalParameters.add("-release:17")
     }
   }
+
+  plugins.withId('com.gradleup.shadow') {
+    tasks.named('shadowJar').configure { jar ->
+      // keep Iceberg's aggregated LICENSE/NOTICE at the jar root
+      jar.from(project.projectDir) {
+        include 'LICENSE'
+        include 'NOTICE'
+      }
+
+      // drop LICENSE/NOTICE that shaded dependencies put under META-INF/
+      jar.exclude 'META-INF/LICENSE*'
+      jar.exclude 'META-INF/NOTICE*'
+
+      // drop a second root LICENSE/NOTICE that came out of a dependency jar.
+      // entries copied from projectDir have a real File; archive entries do not,
+      // so `it.file in bundledNotices` keeps the Iceberg pair and drops the rest.
+      def bundledNotices = [project.file('LICENSE'), project.file('NOTICE')]
+      jar.exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+    }
+  }
 }
 
 project(':iceberg-bundled-guava') {
@@ -308,21 +328,6 @@ project(':iceberg-bundled-guava') {
     archiveClassifier.set(null)
     configurations = [project.configurations.compileClasspath]
     zip64 true
-
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
 
     dependencies {
       exclude(dependency('org.slf4j:slf4j-api'))
@@ -1177,12 +1182,6 @@ project(':iceberg-open-api') {
     configurations = [project.configurations.testFixturesRuntimeClasspath]
     from sourceSets.testFixtures.output
     zip64 true
-
-    // include the LICENSE and NOTICE files for the runtime Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
 
     manifest {
       attributes 'Main-Class': 'org.apache.iceberg.rest.RESTCatalogServer'

--- a/build.gradle
+++ b/build.gradle
@@ -315,6 +315,15 @@ project(':iceberg-bundled-guava') {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     dependencies {
       exclude(dependency('org.slf4j:slf4j-api'))
       exclude(dependency('org.checkerframework:checker-qual'))

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -235,6 +235,10 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -239,6 +239,11 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -229,21 +229,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -490,6 +517,30 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v1.20/flink-runtime/LICENSE
+++ b/flink/v1.20/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -519,6 +546,30 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v1.20/flink-runtime/NOTICE
+++ b/flink/v1.20/flink-runtime/NOTICE
@@ -389,3 +389,19 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | 
 | See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
 | and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/flink/v1.20/flink-runtime/NOTICE
+++ b/flink/v1.20/flink-runtime/NOTICE
@@ -7,6 +7,38 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+This product includes code from Kite, developed at Cloudera, Inc. with
+the following in its NOTICE file:
+| Copyright 2013 Cloudera Inc.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -235,6 +235,10 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -239,6 +239,11 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -229,21 +229,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.0/flink-runtime/LICENSE
+++ b/flink/v2.0/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -490,6 +517,30 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v2.0/flink-runtime/LICENSE
+++ b/flink/v2.0/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -519,6 +546,30 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v2.0/flink-runtime/NOTICE
+++ b/flink/v2.0/flink-runtime/NOTICE
@@ -389,3 +389,19 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | 
 | See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
 | and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/flink/v2.0/flink-runtime/NOTICE
+++ b/flink/v2.0/flink-runtime/NOTICE
@@ -7,6 +7,38 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+This product includes code from Kite, developed at Cloudera, Inc. with
+the following in its NOTICE file:
+| Copyright 2013 Cloudera Inc.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -235,6 +235,10 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -239,6 +239,11 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -229,21 +229,6 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'
     relocate 'org.apache.parquet', 'org.apache.iceberg.shaded.org.apache.parquet'

--- a/flink/v2.1/flink-runtime/LICENSE
+++ b/flink/v2.1/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -490,6 +517,31 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+* Binary variant accessor utility methods in BinaryVariantAccessorUtils.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v2.1/flink-runtime/LICENSE
+++ b/flink/v2.1/flink-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://avro.apache.org/
@@ -307,7 +309,12 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
 
 Copyright: 2014-2020 The Apache Software Foundation.
 Project URL: https://parquet.apache.org/
@@ -418,6 +425,26 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 
 --------------------------------------------------------------------------------
 
+This product includes code from Cloudera Kite.
+
+* SchemaVisitor and visit methods
+
+Copyright: 2013-2017 Cloudera Inc.
+Project URL: https://kitesdk.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto.
+
+* Retry wait and jitter logic in Tasks.java
+
+Copyright: 2016 Facebook and contributors
+Project URL: https://prestodb.io/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
 This product bundles Google Guava.
 
 Copyright: 2006-2020 The Guava Authors
@@ -519,6 +546,30 @@ This product bundles Project Nessie.
 
 Copyright: Copyright 2015-2025 Dremio Corporation
 Project URL: https://projectnessie.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Apache Flink.
+
+* Primary key validation logic in FlinkSchemaUtil.java
+* Avro to RowData conversion logic in AvroToRowDataConverters.java
+* RowData to Avro conversion logic in RowDataToAvroConverters.java
+* Avro schema conversion logic in AvroSchemaConverter.java
+* Joda optional dependency encapsulation in JodaConverter.java
+
+Copyright: 1999-2022 The Apache Software Foundation.
+Project URL: https://flink.apache.org/
+License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake.
+
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
+
+Copyright: 2020 The Delta Lake Project Authors.
+Project URL: https://delta.io/
 License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2.0
 
 --------------------------------------------------------------------------------

--- a/flink/v2.1/flink-runtime/NOTICE
+++ b/flink/v2.1/flink-runtime/NOTICE
@@ -389,3 +389,19 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | 
 | See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
 | and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/flink/v2.1/flink-runtime/NOTICE
+++ b/flink/v2.1/flink-runtime/NOTICE
@@ -7,6 +7,38 @@ The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
+This product includes code from Kite, developed at Cloudera, Inc. with
+the following in its NOTICE file:
+| Copyright 2013 Cloudera Inc.
+|
+| Licensed under the Apache License, Version 2.0 (the "License");
+| you may not use this file except in compliance with the License.
+| You may obtain a copy of the License at
+|
+|   http://www.apache.org/licenses/LICENSE-2.0
+|
+| Unless required by applicable law or agreed to in writing, software
+| distributed under the License is distributed on an "AS IS" BASIS,
+| WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+| See the License for the specific language governing permissions and
+| limitations under the License.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -52,6 +52,10 @@ project(":iceberg-gcp-bundle") {
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // relocate GCP-specific versions
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.gcp.shaded.com.fasterxml.jackson'
     relocate 'com.google.common', 'org.apache.iceberg.gcp.shaded.com.google.common'

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -56,6 +56,11 @@ project(":iceberg-gcp-bundle") {
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // relocate GCP-specific versions
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.gcp.shaded.com.fasterxml.jackson'
     relocate 'com.google.common', 'org.apache.iceberg.gcp.shaded.com.google.common'

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -46,21 +46,6 @@ project(":iceberg-gcp-bundle") {
     archiveClassifier.set(null)
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // relocate GCP-specific versions
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.gcp.shaded.com.fasterxml.jackson'
     relocate 'com.google.common', 'org.apache.iceberg.gcp.shaded.com.google.common'

--- a/open-api/NOTICE
+++ b/open-api/NOTICE
@@ -26,6 +26,20 @@ the following copyright notice:
 
 --------------------------------------------------------------------------------
 
+This project includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This project includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This binary artifact contains code from the following projects:
 
 --------------------------------------------------------------------------------
@@ -76,7 +90,7 @@ This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
 
 Apache Avro
-Copyright 2009-2024 The Apache Software Foundation
+Copyright 2009-2025 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (https://www.apache.org/).
@@ -153,6 +167,12 @@ This software uses the SSL libraries from the Jetty project written
 by mortbay.org.
 Hadoop Yarn Server Web Proxy uses the BouncyCastle Java
 cryptography APIs written by the Legion of the Bouncy Castle Inc.
+
+Apache Hadoop Third-party Libs
+Copyright 2020 and onwards The Apache Software Foundation.
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
 
 --------------------------------------------------------------------------------
 
@@ -251,3 +271,37 @@ for non-commercial or commercial purposes and without fee is
 granted provided that the copyright notice appears in all copies.
 
 --------------------------------------------------------------------------------
+
+# Notices for Eclipse Project for JAF
+
+This content is produced and maintained by the Eclipse Project for JAF project.
+
+* Project home: https://projects.eclipse.org/projects/ee4j.jaf
+
+## Copyright
+
+All content is the property of the respective authors or their employers. For
+more information regarding authorship of content, please consult the listed
+source code repository logs.
+
+## Declared Project Licenses
+
+This program and the accompanying materials are made available under the terms
+of the Eclipse Distribution License v. 1.0,
+which is available at http://www.eclipse.org/org/documents/edl-v10.php.
+
+SPDX-License-Identifier: BSD-3-Clause
+
+## Source Code
+
+The project maintains the following source code repositories:
+
+* https://github.com/eclipse-ee4j/jaf
+
+## Third-party Content
+
+This project leverages the following third party content.
+
+JUnit (4.12)
+
+* License: Eclipse Public License

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -280,6 +280,10 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -284,6 +284,11 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -274,21 +274,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v3.5/spark-runtime/LICENSE
+++ b/spark/v3.5/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -930,6 +938,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v3.5/spark-runtime/LICENSE
+++ b/spark/v3.5/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -959,6 +967,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v3.5/spark-runtime/NOTICE
+++ b/spark/v3.5/spark-runtime/NOTICE
@@ -391,3 +391,19 @@ This product bundles Eclipse MicroProfile OpenAPI with the following in its NOTI
 | PackageCopyrightText: <text>
 | Arthur De Magalhaes arthurdm@ca.ibm.com
 | </text>
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/spark/v3.5/spark-runtime/NOTICE
+++ b/spark/v3.5/spark-runtime/NOTICE
@@ -25,6 +25,20 @@ the following in its NOTICE file:
 
 --------------------------------------------------------------------------------
 
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -280,6 +280,10 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -284,6 +284,11 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -274,21 +274,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.0/spark-runtime/LICENSE
+++ b/spark/v4.0/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -930,6 +938,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v4.0/spark-runtime/LICENSE
+++ b/spark/v4.0/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -959,6 +967,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v4.0/spark-runtime/NOTICE
+++ b/spark/v4.0/spark-runtime/NOTICE
@@ -391,3 +391,19 @@ This product bundles Jackson JSON Processor with the following in its NOTICE fil
 | 
 | See FastDoubleParser-NOTICE for details of other source code included in FastDoubleParser
 | and the licenses and copyrights that apply to that code.
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/spark/v4.0/spark-runtime/NOTICE
+++ b/spark/v4.0/spark-runtime/NOTICE
@@ -25,6 +25,20 @@ the following in its NOTICE file:
 
 --------------------------------------------------------------------------------
 
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -280,6 +280,10 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
       include 'NOTICE'
     }
 
+    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
+    exclude 'META-INF/LICENSE*'
+    exclude 'META-INF/NOTICE*'
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -284,6 +284,11 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
     exclude 'META-INF/LICENSE*'
     exclude 'META-INF/NOTICE*'
 
+    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
+    // bundled ones above, so drop every root copy that is not read from the project directory
+    def bundledNotices = [file('LICENSE'), file('NOTICE')]
+    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
+
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -274,21 +274,6 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
 
     zip64 true
 
-    // include the LICENSE and NOTICE files for the shaded Jar
-    from(projectDir) {
-      include 'LICENSE'
-      include 'NOTICE'
-    }
-
-    // exclude dependency-provided LICENSE/NOTICE files in favor of the bundled Iceberg ones
-    exclude 'META-INF/LICENSE*'
-    exclude 'META-INF/NOTICE*'
-
-    // dependencies that ship a root LICENSE/NOTICE would place a second copy next to the
-    // bundled ones above, so drop every root copy that is not read from the project directory
-    def bundledNotices = [file('LICENSE'), file('NOTICE')]
-    exclude { it.relativePath.pathString in ['LICENSE', 'NOTICE'] && !(it.file in bundledNotices) }
-
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'
     relocate 'com.google.flatbuffers', 'org.apache.iceberg.shaded.com.google.flatbuffers'

--- a/spark/v4.1/spark-runtime/LICENSE
+++ b/spark/v4.1/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -930,6 +938,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v4.1/spark-runtime/LICENSE
+++ b/spark/v4.1/spark-runtime/LICENSE
@@ -203,7 +203,9 @@
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Avro.
+This product bundles and includes code from Apache Avro.
+
+* Conversion in DecimalWriter is based on Avro's Conversions.DecimalConversion.
 
 Copyright: Copyright 2010-2019 The Apache Software Foundation
 Project URL: https://avro.apache.org/
@@ -307,7 +309,13 @@ License: BSD 2-Clause
 
 --------------------------------------------------------------------------------
 
-This product bundles Apache Parquet.
+This product bundles and includes code from Apache Parquet.
+
+* DynMethods.java
+* DynConstructors.java
+* IOUtil.java readFully
+* ByteBufferInputStream implementations
+* implementation of VectorizedByteStreamSplitValuesReader
 
 Copyright: 2014-2024 The Apache Software Foundation
 Project URL: https://parquet.apache.org/
@@ -959,6 +967,7 @@ License: Apache License, Version 2.0 - https://www.apache.org/licenses/LICENSE-2
 This product includes code from Delta Lake.
 
 * AssignmentAlignmentSupport is an independent development but UpdateExpressionsSupport in Delta was used as a reference.
+* RoaringPositionBitmap is a Java implementation of RoaringBitmapArray in Delta.
 
 Copyright: 2020 The Delta Lake Project Authors.
 Project URL: https://delta.io/

--- a/spark/v4.1/spark-runtime/NOTICE
+++ b/spark/v4.1/spark-runtime/NOTICE
@@ -391,3 +391,19 @@ This product bundles Eclipse MicroProfile OpenAPI with the following in its NOTI
 | PackageCopyrightText: <text>
 | Arthur De Magalhaes arthurdm@ca.ibm.com
 | </text>
+
+--------------------------------------------------------------------------------
+
+This product bundles Apache DataSketches Memory with the following in its NOTICE file:
+| Apache DataSketches Memory
+| Copyright 2024 - The Apache Software Foundation
+|
+| Copyright 2015-2018 Yahoo Inc.
+| Copyright 2019-2020 Verizon Media
+| Copyright 2021 Yahoo Inc.
+|
+| This product includes software developed at
+| The Apache Software Foundation (http://www.apache.org/).
+|
+| Prior to moving to ASF, the software for this project was developed at
+| Yahoo Inc. (https://developer.yahoo.com).

--- a/spark/v4.1/spark-runtime/NOTICE
+++ b/spark/v4.1/spark-runtime/NOTICE
@@ -25,6 +25,20 @@ the following in its NOTICE file:
 
 --------------------------------------------------------------------------------
 
+This product includes code from Presto, developed at Facebook, with the
+following copyright notice:
+
+| Copyright 2016 Facebook and contributors.
+
+--------------------------------------------------------------------------------
+
+This product includes code from Delta Lake, developed at The Delta Lake Project,
+with the following copyright notice:
+
+| Copyright (2021) The Delta Lake Project Authors.
+
+--------------------------------------------------------------------------------
+
 This product bundles Airlift Aircompressor with the following in its NOTICE file:
 | Snappy Copyright Notices
 | =========================


### PR DESCRIPTION
Closes #16396
Closes #17406

Follow-up to the LICENSE/NOTICE findings from the 1.11.0 RC4 vote thread: https://lists.apache.org/thread/ddw8cvyrvypoolmzhd673s5wglhdpd5f

## Strip duplicate license metadata from shaded jars

The shaded jars add Iceberg's own LICENSE/NOTICE at the jar root via `from(projectDir)`, but the shadow plugin also merges the `META-INF/LICENSE*` / `META-INF/NOTICE*` files of the shaded dependencies. This excludes those from `iceberg-aws-bundle`, `iceberg-azure-bundle`, `iceberg-gcp-bundle`, `iceberg-flink-runtime` (1.20/2.0/2.1), `iceberg-spark-runtime` (3.5/4.0/4.1) and `iceberg-bundled-guava`.

Nothing is lost: each jar-root `LICENSE`/`NOTICE` already aggregates every shaded dependency's attribution, while shadow collapses the dependencies' own `META-INF/NOTICE` files into a single arbitrary entry. The glob stays narrow, so required root-level texts such as Eclipse Collections' `LICENSE-EPL-1.0.txt` are untouched.

## Keep a single root LICENSE/NOTICE

Every shaded jar also carried two root `LICENSE` and two root `NOTICE` entries: the module's own aggregated pair copied from `projectDir`, plus one merged out of a shaded dependency. In the Spark and Flink runtimes that second pair is the repo-root `LICENSE`/`NOTICE` that `deploy.gradle` injects into every `iceberg-*` module jar; in `iceberg-aws-bundle` it is analyticsaccelerator-s3's own pair.

A plain `exclude 'LICENSE'` does not work here. Task-level `CopySpec` patterns are inherited by the `from(projectDir) { include 'LICENSE'; include 'NOTICE' }` child spec, so the pattern removes the module's aggregated pair as well and the jar ships with no LICENSE or NOTICE at all. Shadow filters dependency-jar entries through that same root pattern set, and it is the only hook that reaches them, since `eachFile` and `duplicatesStrategy` never see archive contents. The `Spec` form of `exclude` can tell the two apart: entries read out of a dependency jar have no backing `File`, entries copied from the project directory do.

Deduping on its own would have removed live attributions, because the surviving per-module file was not a superset of the repo-root one. `flink-runtime/LICENSE` listed only "code from Apache Commons", yet the jar ships `util/Tasks` (Presto), `deletes/RoaringPositionBitmap` (Delta Lake), `common/DynMethods` (Parquet), `avro/ValueWriters` (Avro) and the Kite-derived schema visitors. The runtime `LICENSE`/`NOTICE` files therefore gain the source-derived entries for the code each jar actually contains, taken from the root files: Avro, Parquet and HttpComponents for Spark, and Avro, Parquet, Kite, Presto, Delta Lake and Flink for Flink. Entries covering code that does not ship in these jars, namely the gradle wrapper and the hive-metastore test sources behind the iBATIS and Hive entries, are not copied.

## Add missing third-party NOTICE attributions

Per Apache License 2.0 §4(d):

- Root `NOTICE`: Presto and Delta Lake, for the code already listed under those projects in the root `LICENSE`. Presto's only notice file covers its t-digest module, which Iceberg does not include, so a minimal copyright attribution is added.
- `aws-bundle/NOTICE`: AWS Common Runtime (CRT) for Java and AWS EventStream for Java, whose notices differ from the AWS SDK notice already present.
- `azure-bundle/NOTICE`: the Project Reactor copyright (reactor-core/reactor-netty ship no NOTICE file, so a copyright line is added rather than copied text).
- `spark-runtime/NOTICE` (3.5/4.0/4.1) and `flink-runtime/NOTICE` (1.20/2.0/2.1): Apache DataSketches Memory, whose NOTICE carries Yahoo Inc. / Verizon Media copyrights beyond the generic ASF boilerplate.

## Tests

Rebuilt `iceberg-aws-bundle`, `iceberg-azure-bundle`, `iceberg-gcp-bundle`, `iceberg-bundled-guava`, `iceberg-spark-runtime-4.1_2.13` and `iceberg-flink-runtime-2.1` with `--no-build-cache` and inspected them with `unzip`:

- exactly one root `LICENSE` and one root `NOTICE` in each, both the module's aggregated pair
- no `META-INF/LICENSE*` or `META-INF/NOTICE*` entries left
- the back-filled attributions present when `LICENSE`/`NOTICE` is read out of the jar rather than from the source tree
- `THIRD-PARTY-NOTICES`, Eclipse Collections' `LICENSE-EPL-1.0.txt` / `LICENSE-EDL-1.0.txt` / `about.html`, `META-INF/licenses/org.projectnessie.*` and `META-INF/FastDoubleParser-*` all retained
- as a negative control, the literal `exclude 'LICENSE'` / `exclude 'NOTICE'` was built first and produced a jar carrying neither file

All six engine build files were configuration-checked with `-DsparkVersions=3.5,4.0,4.1 -DflinkVersions=1.20,2.0,2.1`. `spotlessCheck` and `checkRuntimeDeps` green. No Java sources changed.

---
**AI Disclosure**
- Model: Claude Opus 4.7, Claude Opus 4.8, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Strip the duplicate license metadata from shaded jars and add the missing third-party notices, then extend the same exclude to the Spark runtime jars and, per review feedback, dedupe the root LICENSE/NOTICE pair and back-fill the runtime attributions that the removed copy had been carrying.
