### PR TITLE
Docs: Document adaptive split sizing configurations

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -207,6 +207,8 @@ val spark = SparkSession.builder()
 | spark.sql.iceberg.executor-cache.locality.enabled      | false                                                          | Enables locality-aware executor cache usage                                                                                     |
 | spark.sql.iceberg.merge-schema                         | false                                                          | Enables modifying the table schema to match the write schema. Only adds columns missing columns                                 |
 | spark.sql.iceberg.report-column-stats                  | true                                                           | Report Puffin Table Statistics if available to Spark's Cost Based Optimizer. CBO must be enabled for this to be effective       |
+| spark.sql.iceberg.read.adaptive-split-size.enabled     | Table default                                                  | Enables adaptive split sizing for read operations. When enabled, split size is automatically adjusted based on scan size and parallelism |
+| spark.sql.iceberg.read.adaptive-split-size.parallelism | max(spark.default.parallelism, spark.sql.shuffle.partitions)                                    | Overrides the parallelism used for adaptive split sizing. Must be greater than 0                                                |
 | spark.sql.iceberg.async-micro-batch-planning-enabled   | false                                                          | Enables asynchronous microbatch planning to reduce planning latency by pre-fetching file scan tasks                             |
 
 ### Read options


### PR DESCRIPTION
Documenting the adaptive split sizing configurations that were added in #16088 but were missed to be documented.

Closes https://github.com/apache/iceberg/issues/16556


