### PR TITLE
Infra: skip actions for draft PRs

### DIFF
--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -28,6 +28,7 @@ on:
     tags:
       - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/api-binary-compatibility.yml'
       - '*.gradle'
@@ -44,6 +45,7 @@ concurrency:
 
 jobs:
   revapi:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -25,6 +25,7 @@ name: "ASF Allowlist Check"
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - ".github/**"
   push:
@@ -38,6 +39,7 @@ permissions:
 
 jobs:
   asf-allowlist-check:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -23,6 +23,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: [ "main" ]
   schedule:
     - cron: '16 4 * * 1'
@@ -32,6 +33,7 @@ permissions:
 
 jobs:
   analyze:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Analyze Actions
     runs-on: ubuntu-slim
     permissions:

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
@@ -50,6 +51,7 @@ jobs:
   #     Security tab for ongoing tracking.
   # ------------------------------------------------------------------
   cve-scan:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
       - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
       - '.github/ISSUE_TEMPLATE/**'
       - '.github/workflows/api-binary-compatibility.yml'
@@ -74,6 +75,7 @@ concurrency:
 
 jobs:
   delta-conversion-scala-2-12-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
@@ -103,6 +105,7 @@ jobs:
             **/build/testlogs
 
   delta-conversion-scala-2-13-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -19,6 +19,7 @@
 name: Docs Build CI
 on:
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - docs/**
       - site/**
@@ -30,6 +31,7 @@ permissions:
 
 jobs:
   build-docs:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 15

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -76,6 +77,7 @@ jobs:
 
   # Test all flink versions with scala 2.12 for general validation.
   flink-scala-2-12-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -75,6 +76,7 @@ concurrency:
 
 jobs:
   hive2-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -70,6 +71,7 @@ concurrency:
 
 jobs:
   core-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
@@ -99,6 +101,7 @@ jobs:
           **/build/testlogs
 
   build-checks:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
@@ -119,6 +122,7 @@ jobs:
     - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
 
   build-javadoc:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
@@ -139,6 +143,7 @@ jobs:
     - run: ./gradlew -Pquick=true javadoc
 
   check-runtime-deps:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -75,6 +76,7 @@ concurrency:
 jobs:
 
   kafka-connect-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15

--- a/.github/workflows/license-check.yml
+++ b/.github/workflows/license-check.yml
@@ -18,13 +18,16 @@
 #
 
 name: "Run License Check"
-on: pull_request
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
   contents: read
 
 jobs:
   rat:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/open-api.yml
+++ b/.github/workflows/open-api.yml
@@ -28,6 +28,7 @@ on:
     tags:
       - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths:
       - '.github/workflows/open-api.yml'
       - 'open-api/**'
@@ -41,6 +42,7 @@ concurrency:
 
 jobs:
   openapi-spec-validator:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-slim
 
     steps:

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, ready_for_review]
 
 concurrency:
   group: pr-title-${{ github.event.pull_request.number }}
@@ -28,6 +28,7 @@ permissions: {}
 
 jobs:
   check-pr-title:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-slim
     steps:
       - name: Check PR Title

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, reopened, ready_for_review]
+    types: [opened, edited, reopened]
 
 concurrency:
   group: pr-title-${{ github.event.pull_request.number }}
@@ -28,7 +28,6 @@ permissions: {}
 
 jobs:
   check-pr-title:
-    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-slim
     steps:
       - name: Check PR Title

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -28,6 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/workflows/api-binary-compatibility.yml'
@@ -74,6 +75,7 @@ concurrency:
 
 jobs:
   spark-tests:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -23,12 +23,14 @@ on:
   push:
     branches: ["main"]
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
     branches: ["**"]
 
 permissions: {}
 
 jobs:
   zizmor:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.draft == false }}
     name: Run zizmor 🌈
     runs-on: ubuntu-latest
     permissions: {}


### PR DESCRIPTION
ASF Infrastructure asked Iceberg to reduce GitHub Actions usage [1]. This change skips CI for draft PRs to help save resources.
 
The labeler and pr-tile-check workflows are intentionally left unchanged.

[1] https://lists.apache.org/thread/9gorr3b1c18f8yk2fys16knjmnrbkjff