### PR TITLE
Spark: Bound runaway serializable-isolation and concurrent-refresh tests

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -82,6 +82,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase {
 
+  // Bound the concurrency tests below so they fail fast instead of running until CI or
+  // disk limits are hit when the expected conflict never occurs.
+  protected static final int MAX_OPERATIONS = 20;
+  protected static final int OPERATION_TIMEOUT_MINUTES = 5;
+
   @Parameter(index = 3)
   protected FileFormat fileFormat;
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDelete.java
@@ -1078,7 +1078,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1102,7 +1102,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1128,13 +1128,14 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
             });
 
     try {
-      assertThatThrownBy(deleteFuture::get)
+      assertThatThrownBy(() -> deleteFuture.get(OPERATION_TIMEOUT_MINUTES, TimeUnit.MINUTES))
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Found conflicting files that can contain");
     } finally {
       shouldAppend.set(false);
+      deleteFuture.cancel(true);
       appendFuture.cancel(true);
     }
 
@@ -1180,7 +1181,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
     Future<?> deleteFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1204,7 +1205,7 @@ public abstract class TestDelete extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMerge.java
@@ -1563,7 +1563,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> mergeFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1592,7 +1592,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1617,13 +1617,14 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
             });
 
     try {
-      assertThatThrownBy(mergeFuture::get)
+      assertThatThrownBy(() -> mergeFuture.get(OPERATION_TIMEOUT_MINUTES, TimeUnit.MINUTES))
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Found conflicting files that can contain");
     } finally {
       shouldAppend.set(false);
+      mergeFuture.cancel(true);
       appendFuture.cancel(true);
     }
 
@@ -1669,7 +1670,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
     Future<?> mergeFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -1698,7 +1699,7 @@ public abstract class TestMerge extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestUpdate.java
@@ -648,7 +648,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Future<?> updateFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -672,7 +672,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < Integer.MAX_VALUE; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -698,13 +698,14 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
             });
 
     try {
-      assertThatThrownBy(updateFuture::get)
+      assertThatThrownBy(() -> updateFuture.get(OPERATION_TIMEOUT_MINUTES, TimeUnit.MINUTES))
           .isInstanceOf(ExecutionException.class)
           .cause()
           .isInstanceOf(ValidationException.class)
           .hasMessageContaining("Found conflicting files that can contain");
     } finally {
       shouldAppend.set(false);
+      updateFuture.cancel(true);
       appendFuture.cancel(true);
     }
 
@@ -741,7 +742,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
     Future<?> updateFuture =
         executorService.submit(
             () -> {
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)
@@ -765,7 +766,7 @@ public abstract class TestUpdate extends SparkRowLevelOperationsTestBase {
               record.set(0, 1); // id
               record.set(1, "hr"); // dep
 
-              for (int numOperations = 0; numOperations < 20; numOperations++) {
+              for (int numOperations = 0; numOperations < MAX_OPERATIONS; numOperations++) {
                 int currentNumOperations = numOperations;
                 Awaitility.await()
                     .pollInterval(10, TimeUnit.MILLISECONDS)


### PR DESCRIPTION
Closes #16359

## Summary

Several `spark-extensions` concurrency tests ran two worker threads in a barrier-synchronized loop bounded by `Integer.MAX_VALUE` while the main thread blocked on `assertThatThrownBy(<op>Future::get)` with no timeout, expecting a conflict exception. When that exception was never thrown, nothing bounded either thread — the append thread kept committing data files until CI hit its wall-clock limit or ran out of disk (as in #16303, where the runaway filled the GitHub Actions disk and was retriggered several times before the cause was found). This makes those tests fail fast instead of relying on external limits.

## What changed

- Bounded both worker loops with a shared `MAX_OPERATIONS = 20` constant — the same value the sibling `*WithSnapshotIsolation` tests already use with this identical harness — so the loop can no longer run unbounded.
- Wrapped the wait in `Future.get(OPERATION_TIMEOUT_MINUTES, TimeUnit.MINUTES)` (5 minutes) and cancelled the operation future in `finally`, so a stuck operation is interrupted and the wait can't block forever.
- Hoisted `MAX_OPERATIONS` and `OPERATION_TIMEOUT_MINUTES` into `SparkRowLevelOperationsTestBase` so these concurrency tests share one bound (the snapshot-isolation siblings now reference the same constant).

Affected methods in `spark/v4.1`: `testMergeWithSerializableIsolation`, `testDeleteWithSerializableIsolation`, `testUpdateWithSerializableIsolation`. The copy-on-write `testMergeWithConcurrentTableRefresh`, `testDeleteWithConcurrentTableRefresh` and `testUpdateWithConcurrentTableRefresh` exist only in `spark/v3.5` and `spark/v4.0`, so they are covered by the follow-up backport PR rather than here.

In a passing run the conflict still fires within the first couple of iterations, so behavior is unchanged; in a regression the bounded loop plus timeout make the test fail fast with a clear assertion instead of exhausting CI resources.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Bound the runaway serializable-isolation and concurrent-refresh Spark tests with iteration and time limits.

