### PR TITLE
CI: Select PR matrices incrementally

### DIFF
--- a/.github/scripts/plan-pr-ci-test.sh
+++ b/.github/scripts/plan-pr-ci-test.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+plan_output=""
+
+run_plan() {
+  local name="$1"
+  shift
+  local changed_files
+
+  changed_files="$(mktemp)"
+  plan_output="$(mktemp)"
+  printf '%s\n' "$@" > "${changed_files}"
+
+  GITHUB_EVENT_NAME=pull_request \
+    CHANGED_FILES_FILE="${changed_files}" \
+    GITHUB_OUTPUT="${plan_output}" \
+    bash .github/scripts/plan-pr-ci.sh > "/tmp/${name}-plan.log" 2>&1
+
+  rm -f "${changed_files}"
+}
+
+output_value() {
+  local name="$1"
+  sed -n "s/^${name}=//p" "${plan_output}" | head -n 1
+}
+
+assert_equals() {
+  local expected="$1"
+  local actual="$2"
+  local message="$3"
+  if [[ "${expected}" != "${actual}" ]]; then
+    echo "Expected ${message} to be '${expected}', but was '${actual}'" >&2
+    exit 1
+  fi
+}
+
+assert_jq() {
+  local filter="$1"
+  local json="$2"
+  local message="$3"
+  if ! jq -e "${filter}" <<< "${json}" > /dev/null; then
+    echo "Failed assertion: ${message}" >&2
+    echo "${json}" >&2
+    exit 1
+  fi
+}
+
+assert_cve_consistent() {
+  if [[ "$(output_value run_cve)" == "true" ]]; then
+    assert_jq '.include | length > 0' "$(output_value cve_matrix)" "CVE matrix is non-empty when CVE runs"
+  fi
+}
+
+run_plan spark41 spark/v4.1/spark/src/main/java/Example.java
+assert_equals false "$(output_value full_matrix)" "Spark 4.1 full matrix"
+assert_equals true "$(output_value run_spark)" "Spark 4.1 Spark run"
+assert_equals false "$(output_value run_flink)" "Spark 4.1 Flink run"
+assert_jq '.jvm == [17]' "$(output_value jvm_matrix)" "Spark 4.1 uses primary JVM"
+assert_jq '.include | map(.spark) | unique == ["4.1"]' "$(output_value spark_matrix)" "Spark 4.1 matrix"
+assert_cve_consistent
+
+run_plan flink20 flink/v2.0/flink/src/main/java/Example.java
+assert_equals false "$(output_value full_matrix)" "Flink 2.0 full matrix"
+assert_equals true "$(output_value run_flink)" "Flink 2.0 Flink run"
+assert_equals false "$(output_value run_spark)" "Flink 2.0 Spark run"
+assert_jq '.jvm == [17]' "$(output_value jvm_matrix)" "Flink 2.0 uses primary JVM"
+assert_jq '.include | map(.flink) | unique == ["2.0"]' "$(output_value flink_matrix)" "Flink 2.0 matrix"
+assert_cve_consistent
+
+run_plan core core/src/main/java/org/apache/iceberg/Example.java
+assert_equals false "$(output_value full_matrix)" "Core full matrix"
+assert_equals true "$(output_value run_java)" "Core Java run"
+assert_equals true "$(output_value run_spark)" "Core Spark canary"
+assert_equals true "$(output_value run_flink)" "Core Flink canary"
+assert_equals false "$(output_value run_hive)" "Core Hive run"
+assert_jq '.include | map(.spark) | unique == ["4.1"]' "$(output_value spark_matrix)" "Core Spark canary version"
+assert_jq '.include | map(.flink) | unique == ["2.1"]' "$(output_value flink_matrix)" "Core Flink canary version"
+
+run_plan format format/spec.md
+assert_equals false "$(output_value full_matrix)" "Format full matrix"
+assert_equals true "$(output_value run_java)" "Format Java run"
+assert_equals true "$(output_value run_spark)" "Format Spark canary"
+assert_equals true "$(output_value run_flink)" "Format Flink canary"
+
+run_plan global gradle/libs.versions.toml
+assert_equals true "$(output_value full_matrix)" "Global full matrix"
+assert_equals true "$(output_value run_java)" "Global Java run"
+assert_equals true "$(output_value run_spark)" "Global Spark run"
+assert_equals true "$(output_value run_flink)" "Global Flink run"
+assert_equals true "$(output_value run_hive)" "Global Hive run"
+assert_equals true "$(output_value run_kafka)" "Global Kafka run"
+assert_equals true "$(output_value run_delta)" "Global Delta run"
+assert_equals true "$(output_value run_cve)" "Global CVE run"
+assert_jq '.jvm == [17,21]' "$(output_value jvm_matrix)" "Global JVM matrix"
+assert_cve_consistent
+
+run_plan docs docs/README.md
+assert_equals false "$(output_value full_matrix)" "Docs full matrix"
+assert_equals false "$(output_value run_java)" "Docs Java run"
+assert_equals false "$(output_value run_spark)" "Docs Spark run"
+assert_equals false "$(output_value run_flink)" "Docs Flink run"
+assert_equals false "$(output_value run_cve)" "Docs CVE run"
+
+run_plan unknown new-module/src/main/java/Example.java
+assert_equals true "$(output_value full_matrix)" "Unknown path full matrix"
+assert_equals true "$(output_value run_java)" "Unknown path Java run"
+assert_equals true "$(output_value run_spark)" "Unknown path Spark run"
+assert_equals true "$(output_value run_flink)" "Unknown path Flink run"
+assert_cve_consistent
+
+run_plan old_spark spark/v3.4/spark-runtime/src/main/java/Example.java
+assert_equals true "$(output_value full_matrix)" "Unknown Spark version full matrix"
+assert_equals true "$(output_value run_cve)" "Unknown Spark version CVE run"
+assert_cve_consistent
+
+echo "plan-pr-ci tests passed"

--- a/.github/scripts/plan-pr-ci.sh
+++ b/.github/scripts/plan-pr-ci.sh
@@ -1,0 +1,521 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+primary_jvm="${PRIMARY_JVM:-17}"
+
+gradle_property() {
+  local name="$1"
+  sed -n "s/^systemProp\\.${name}=//p" gradle.properties | head -n 1
+}
+
+known_spark_versions="$(gradle_property knownSparkVersions)"
+known_flink_versions="$(gradle_property knownFlinkVersions)"
+default_spark_version="$(gradle_property defaultSparkVersions)"
+default_flink_version="$(gradle_property defaultFlinkVersions)"
+
+IFS=',' read -r -a all_spark_versions <<< "${known_spark_versions}"
+IFS=',' read -r -a all_flink_versions <<< "${known_flink_versions}"
+
+changed_files=()
+read_changed_files() {
+  local file
+  while IFS= read -r file; do
+    if [[ -n "${file}" ]]; then
+      changed_files+=("${file}")
+    fi
+  done
+}
+
+if [[ -n "${CHANGED_FILES_FILE:-}" ]]; then
+  read_changed_files < "${CHANGED_FILES_FILE}"
+elif [[ "${GITHUB_EVENT_NAME:-}" == "pull_request" ]]; then
+  base_sha="${BASE_SHA:-}"
+  if [[ -n "${base_sha}" ]]; then
+    git fetch --no-tags --depth=1 origin "${base_sha}"
+    read_changed_files < <(git diff --name-only "${base_sha}" HEAD)
+  else
+    read_changed_files < <(git diff --name-only origin/main HEAD)
+  fi
+fi
+
+contains_file() {
+  local pattern="$1"
+  local file
+  if [[ ${#changed_files[@]} -eq 0 ]]; then
+    return 1
+  fi
+
+  for file in "${changed_files[@]}"; do
+    if [[ "${file}" =~ ${pattern} ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+add_unique() {
+  local name="$1"
+  local value="$2"
+  local existing
+  eval "existing=(\"\${${name}[@]:-}\")"
+  for existing in "${existing[@]}"; do
+    if [[ "${existing}" == "${value}" ]]; then
+      return
+    fi
+  done
+  eval "${name}+=(\"\${value}\")"
+}
+
+version_in_list() {
+  local version="$1"
+  shift
+  local known
+  for known in "$@"; do
+    if [[ "${known}" == "${version}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+docs_only_file() {
+  local file="$1"
+  case "${file}" in
+    .gitattributes|CONTRIBUTING.md|doap.rdf|README.md|LICENSE|NOTICE|docs/*|site/*|*/README.md|*/LICENSE|*/NOTICE)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+global_build_file() {
+  local file="$1"
+  case "${file}" in
+    .github/actions/*|.github/scripts/*|.github/workflows/*|build.gradle|settings.gradle|gradle.properties|baseline.gradle|deploy.gradle|jmh.gradle|runtime-deps.gradle|tasks.gradle|gradle/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+known_selective_file() {
+  local file="$1"
+  case "${file}" in
+    aliyun/*|api/*|arrow/*|aws/*|aws-bundle/*|azure/*|azure-bundle/*|bigquery/*|bom/*|bundled-guava/*|common/*|core/*|data/*|dell/*|delta-lake/*|flink/*|flink-runtime/*|format/*|gcp/*|gcp-bundle/*|hive-metastore/*|hive-runtime/*|hive3/*|hive3-orc-bundle/*|kafka-connect/*|mr/*|nessie/*|open-api/*|orc/*|parquet/*|pig/*|snowflake/*|spark/*)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+selected_spark_path_versions=()
+selected_flink_path_versions=()
+unknown_spark_version=false
+unknown_flink_version=false
+unknown_changed_files=()
+has_code_changes=false
+has_global_build_change=false
+
+for file in "${changed_files[@]:-}"; do
+  if docs_only_file "${file}"; then
+    continue
+  fi
+
+  has_code_changes=true
+
+  if global_build_file "${file}"; then
+    has_global_build_change=true
+    continue
+  fi
+
+  if [[ "${file}" =~ ^spark/v([^/]+)/ ]]; then
+    spark_version="${BASH_REMATCH[1]}"
+    if version_in_list "${spark_version}" "${all_spark_versions[@]}"; then
+      add_unique selected_spark_path_versions "${spark_version}"
+    else
+      unknown_spark_version=true
+    fi
+  fi
+
+  if [[ "${file}" =~ ^flink/v([^/]+)/ ]]; then
+    flink_version="${BASH_REMATCH[1]}"
+    if version_in_list "${flink_version}" "${all_flink_versions[@]}"; then
+      add_unique selected_flink_path_versions "${flink_version}"
+    else
+      unknown_flink_version=true
+    fi
+  fi
+
+  if ! known_selective_file "${file}"; then
+    unknown_changed_files+=("${file}")
+  fi
+done
+
+has_full_ci_label=false
+if [[ "${FULL_CI_LABEL:-false}" == "true" ]]; then
+  has_full_ci_label=true
+fi
+
+full_matrix=false
+full_matrix_reason=""
+if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+  full_matrix=true
+  full_matrix_reason="non-PR event"
+elif [[ "${has_full_ci_label}" == "true" ]]; then
+  full_matrix=true
+  full_matrix_reason="full-ci label"
+elif [[ ${#changed_files[@]} -eq 0 ]]; then
+  full_matrix=true
+  full_matrix_reason="no changed files detected"
+elif [[ "${has_global_build_change}" == "true" ]]; then
+  full_matrix=true
+  full_matrix_reason="global build or workflow change"
+elif [[ "${unknown_spark_version}" == "true" || "${unknown_flink_version}" == "true" ]]; then
+  full_matrix=true
+  full_matrix_reason="unknown Spark or Flink version path"
+elif [[ ${#unknown_changed_files[@]} -gt 0 ]]; then
+  full_matrix=true
+  full_matrix_reason="unknown changed path"
+fi
+
+is_upstream_canary_change=false
+if contains_file '^(api|common|core|data|parquet|orc|arrow|bundled-guava|format)/'; then
+  is_upstream_canary_change=true
+fi
+
+run_java=false
+run_spark=false
+run_flink=false
+run_hive=false
+run_kafka=false
+run_delta=false
+run_cve=false
+
+if [[ "${full_matrix}" == "true" ]]; then
+  run_java=true
+  run_spark=true
+  run_flink=true
+  run_hive=true
+  run_kafka=true
+  run_delta=true
+  run_cve=true
+elif [[ "${has_code_changes}" == "true" ]]; then
+  if [[ "${is_upstream_canary_change}" == "true" ]]; then
+    run_java=true
+    run_spark=true
+    run_flink=true
+  fi
+
+  if contains_file '^(aliyun|api|arrow|aws|aws-bundle|azure|azure-bundle|bigquery|bom|bundled-guava|common|core|data|dell|format|gcp|gcp-bundle|hive-metastore|hive-runtime|hive3|hive3-orc-bundle|nessie|orc|parquet|pig|snowflake)/'; then
+    run_java=true
+  fi
+
+  if contains_file '^spark/'; then
+    run_spark=true
+  fi
+
+  if contains_file '^(flink|flink-runtime)/'; then
+    run_flink=true
+  fi
+
+  if contains_file '^(mr|hive-metastore|hive-runtime|hive3|hive3-orc-bundle)/'; then
+    run_hive=true
+  fi
+
+  if contains_file '^kafka-connect/'; then
+    run_kafka=true
+  fi
+
+  if contains_file '^delta-lake/'; then
+    run_delta=true
+  fi
+
+  if contains_file '^(aws|aws-bundle|azure|azure-bundle|gcp|gcp-bundle|kafka-connect|open-api|spark|flink|flink-runtime)/'; then
+    run_cve=true
+  fi
+fi
+
+jvm_matrix() {
+  if [[ "${full_matrix}" == "true" ]]; then
+    jq -cn '{jvm: [17, 21]}'
+  else
+    jq -cn --argjson jvm "${primary_jvm}" '{jvm: [$jvm]}'
+  fi
+}
+
+spark_scala_versions() {
+  local spark_version="$1"
+  if [[ "${spark_version}" == "3.5" ]]; then
+    printf '%s\n' "2.12" "2.13"
+  else
+    printf '%s\n' "2.13"
+  fi
+}
+
+spark_cve_scala_version() {
+  local spark_version="$1"
+  if [[ "${spark_version}" == "3.5" ]]; then
+    printf '%s\n' "2.12"
+  else
+    printf '%s\n' "2.13"
+  fi
+}
+
+add_spark_rows() {
+  local spark_version="$1"
+  local scala_version
+  local test_group
+  local jvm
+  local -a jvms
+  if [[ "${full_matrix}" == "true" ]]; then
+    jvms=(17 21)
+  else
+    jvms=("${primary_jvm}")
+  fi
+
+  for jvm in "${jvms[@]}"; do
+    while IFS= read -r scala_version; do
+      for test_group in core extensions; do
+        spark_rows+=("${jvm}|${spark_version}|${scala_version}|${test_group}")
+      done
+    done < <(spark_scala_versions "${spark_version}")
+  done
+}
+
+spark_matrix() {
+  local spark_version
+  local -a selected_spark_versions=()
+  spark_rows=()
+
+  if [[ "${run_spark}" != "true" ]]; then
+    jq -cn '{include: []}'
+    return
+  fi
+
+  if [[ "${full_matrix}" == "true" ]]; then
+    selected_spark_versions=("${all_spark_versions[@]}")
+  elif [[ "${is_upstream_canary_change}" == "true" ]]; then
+    selected_spark_versions=("${default_spark_version}")
+  elif [[ ${#selected_spark_path_versions[@]} -gt 0 ]]; then
+    selected_spark_versions=("${selected_spark_path_versions[@]}")
+  else
+    selected_spark_versions=("${all_spark_versions[@]}")
+  fi
+
+  for spark_version in "${selected_spark_versions[@]}"; do
+    add_spark_rows "${spark_version}"
+  done
+
+  printf '%s\n' "${spark_rows[@]:-}" \
+    | jq -R 'select(length > 0) | split("|") | {jvm: .[0], spark: .[1], scala: .[2], tests: .[3]}' \
+    | jq -s -c '{include: .}'
+}
+
+flink_matrix() {
+  local flink_version
+  local jvm
+  local -a selected_flink_versions=()
+  local -a jvms=()
+  local -a flink_rows=()
+
+  if [[ "${run_flink}" != "true" ]]; then
+    jq -cn '{include: []}'
+    return
+  fi
+
+  if [[ "${full_matrix}" == "true" ]]; then
+    selected_flink_versions=("${all_flink_versions[@]}")
+    jvms=(17 21)
+  elif [[ "${is_upstream_canary_change}" == "true" ]]; then
+    selected_flink_versions=("${default_flink_version}")
+    jvms=("${primary_jvm}")
+  elif [[ ${#selected_flink_path_versions[@]} -gt 0 ]]; then
+    selected_flink_versions=("${selected_flink_path_versions[@]}")
+    jvms=("${primary_jvm}")
+  else
+    selected_flink_versions=("${all_flink_versions[@]}")
+    jvms=("${primary_jvm}")
+  fi
+
+  for jvm in "${jvms[@]}"; do
+    for flink_version in "${selected_flink_versions[@]}"; do
+      flink_rows+=("${jvm}|${flink_version}")
+    done
+  done
+
+  printf '%s\n' "${flink_rows[@]:-}" \
+    | jq -R 'select(length > 0) | split("|") | {jvm: .[0], flink: .[1]}' \
+    | jq -s -c '{include: .}'
+}
+
+add_cve_distribution() {
+  add_unique cve_distributions "$1"
+}
+
+select_cve_distributions() {
+  local spark_version
+  local flink_version
+  cve_distributions=()
+
+  if [[ "${run_cve}" != "true" ]]; then
+    return
+  fi
+
+  add_cve_distribution kafka-connect-runtime
+  add_cve_distribution aws-bundle
+  add_cve_distribution azure-bundle
+  add_cve_distribution gcp-bundle
+
+  for spark_version in "${all_spark_versions[@]}"; do
+    add_cve_distribution "spark-runtime-${spark_version}_$(spark_cve_scala_version "${spark_version}")"
+  done
+
+  for flink_version in "${all_flink_versions[@]}"; do
+    add_cve_distribution "flink-runtime-${flink_version}"
+  done
+
+  add_cve_distribution open-api-test-fixtures-runtime
+}
+
+cve_row() {
+  local distribution="$1"
+  local spark_version
+  local scala_version
+  local flink_version
+
+  case "${distribution}" in
+    kafka-connect-runtime)
+      printf '%s|%s|%s|%s\n' "${distribution}" "-DkafkaVersions=3 :iceberg-kafka-connect:iceberg-kafka-connect-runtime:distZip" "kafka-connect/kafka-connect-runtime/build/distributions" "true"
+      ;;
+    aws-bundle)
+      printf '%s|%s|%s|%s\n' "${distribution}" ":iceberg-aws-bundle:shadowJar" "aws-bundle/build/libs" "false"
+      ;;
+    azure-bundle)
+      printf '%s|%s|%s|%s\n' "${distribution}" ":iceberg-azure-bundle:shadowJar" "azure-bundle/build/libs" "false"
+      ;;
+    gcp-bundle)
+      printf '%s|%s|%s|%s\n' "${distribution}" ":iceberg-gcp-bundle:shadowJar" "gcp-bundle/build/libs" "false"
+      ;;
+    spark-runtime-*)
+      spark_version="${distribution#spark-runtime-}"
+      scala_version="${spark_version#*_}"
+      spark_version="${spark_version%_*}"
+      printf '%s|%s|%s|%s\n' "${distribution}" "-DsparkVersions=${spark_version} :iceberg-spark:iceberg-spark-runtime-${spark_version}_${scala_version}:shadowJar" "spark/v${spark_version}/spark-runtime/build/libs" "false"
+      ;;
+    flink-runtime-*)
+      flink_version="${distribution#flink-runtime-}"
+      printf '%s|%s|%s|%s\n' "${distribution}" "-DflinkVersions=${flink_version} :iceberg-flink:iceberg-flink-runtime-${flink_version}:shadowJar" "flink/v${flink_version}/flink-runtime/build/libs" "false"
+      ;;
+    open-api-test-fixtures-runtime)
+      printf '%s|%s|%s|%s\n' "${distribution}" ":iceberg-open-api:shadowJar" "open-api/build/libs" "false"
+      ;;
+    *)
+      echo "Unsupported CVE distribution: ${distribution}" >&2
+      return 1
+      ;;
+  esac
+}
+
+cve_matrix() {
+  local distribution
+  select_cve_distributions
+  if [[ ${#cve_distributions[@]} -eq 0 ]]; then
+    jq -cn '{include: []}'
+    return
+  fi
+
+  for distribution in "${cve_distributions[@]}"; do
+    cve_row "${distribution}"
+  done \
+    | jq -R 'select(length > 0) | split("|") | {distribution: .[0], "build-task": .[1], "scan-path": .[2], unpack: (.[3] == "true")}' \
+    | jq -s -c '{include: .}'
+}
+
+write_output() {
+  local name="$1"
+  local value="$2"
+  echo "${name}=${value}" >> "${GITHUB_OUTPUT}"
+}
+
+jvm_matrix_json="$(jvm_matrix)"
+spark_matrix_json="$(spark_matrix)"
+flink_matrix_json="$(flink_matrix)"
+cve_matrix_json="$(cve_matrix)"
+
+write_output full_matrix "${full_matrix}"
+write_output run_java "${run_java}"
+write_output run_spark "${run_spark}"
+write_output run_flink "${run_flink}"
+write_output run_hive "${run_hive}"
+write_output run_kafka "${run_kafka}"
+write_output run_delta "${run_delta}"
+write_output run_cve "${run_cve}"
+write_output jvm_matrix "${jvm_matrix_json}"
+write_output spark_matrix "${spark_matrix_json}"
+write_output flink_matrix "${flink_matrix_json}"
+write_output cve_matrix "${cve_matrix_json}"
+
+{
+  echo "full_matrix=${full_matrix}"
+  if [[ -n "${full_matrix_reason}" ]]; then
+    echo "full_matrix_reason=${full_matrix_reason}"
+  fi
+  echo "run_java=${run_java}"
+  echo "run_spark=${run_spark}"
+  echo "run_flink=${run_flink}"
+  echo "run_hive=${run_hive}"
+  echo "run_kafka=${run_kafka}"
+  echo "run_delta=${run_delta}"
+  echo "run_cve=${run_cve}"
+  echo "changed_files=${#changed_files[@]}"
+  if [[ ${#changed_files[@]} -gt 0 ]]; then
+    printf 'changed_file=%s\n' "${changed_files[@]}"
+  fi
+  if [[ ${#unknown_changed_files[@]} -gt 0 ]]; then
+    printf 'unknown_changed_file=%s\n' "${unknown_changed_files[@]}"
+  fi
+} >&2
+
+if [[ -n "${GITHUB_STEP_SUMMARY:-}" ]]; then
+  {
+    echo "### PR CI plan"
+    echo
+    echo "| Item | Value |"
+    echo "| --- | --- |"
+    echo "| Full matrix | ${full_matrix} |"
+    echo "| Full matrix reason | ${full_matrix_reason:-n/a} |"
+    echo "| Java | ${run_java} |"
+    echo "| Spark | ${run_spark} |"
+    echo "| Flink | ${run_flink} |"
+    echo "| Hive | ${run_hive} |"
+    echo "| Kafka | ${run_kafka} |"
+    echo "| Delta | ${run_delta} |"
+    echo "| CVE | ${run_cve} |"
+    echo "| Changed files | ${#changed_files[@]} |"
+  } >> "${GITHUB_STEP_SUMMARY}"
+fi

--- a/.github/workflows/api-binary-compatibility.yml
+++ b/.github/workflows/api-binary-compatibility.yml
@@ -61,7 +61,7 @@ jobs:
           java-version: 17
       - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
         with:
-          # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+          # Read-only: java-ci's build-checks (17) is the global canonical writer.
           cache-read-only: true
       - run: |
           echo "Using the old version tag, as per git describe, of $(git describe)";

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -50,28 +50,7 @@ on:
     - '!**/NOTICE'
     - '!doap.rdf'
   pull_request:
-    paths:
-    - '**'
-    - '!.github/**'
-    - '.github/workflows/cve-scan.yml'
-    - '!.baseline/**'
-    - '!.palantir/**'
-    - '!.gitignore'
-    - '!.asf.yaml'
-    - '!dev/**'
-    - '!docker/**'
-    - '!docs/**'
-    - '!examples/**'
-    - '!site/**'
-    - '!format/**'
-    - '!.gitattributes'
-    - '!**/README.md'
-    - '!AGENTS.md'
-    - '!CONTRIBUTING.md'
-    - '!SECURITY-THREAT-MODEL.md'
-    - '!**/LICENSE'
-    - '!**/NOTICE'
-    - '!doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -81,6 +60,20 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      run_cve: ${{ steps.plan.outputs.run_cve }}
+      cve_matrix: ${{ steps.plan.outputs.cve_matrix }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+      run: bash .github/scripts/plan-pr-ci.sh
 
   # ------------------------------------------------------------------
   # Trivy CVE scan — scans bundled jars for known vulnerabilities.
@@ -94,6 +87,8 @@ jobs:
   #     Security tab for ongoing tracking.
   # ------------------------------------------------------------------
   cve-scan:
+    needs: plan
+    if: needs.plan.outputs.run_cve == 'true'
     runs-on: ubuntu-24.04
     env:
       # Trivy scanner image, pinned by digest. Pulled from GHCR (ghcr.io), which serves the
@@ -105,66 +100,7 @@ jobs:
       security-events: write
     strategy:
       fail-fast: false
-      matrix:
-        include:
-        - distribution: kafka-connect-runtime
-          build-task: >-
-            -DkafkaVersions=3
-            :iceberg-kafka-connect:iceberg-kafka-connect-runtime:distZip
-          scan-path: kafka-connect/kafka-connect-runtime/build/distributions
-          unpack: true
-        - distribution: aws-bundle
-          build-task: :iceberg-aws-bundle:shadowJar
-          scan-path: aws-bundle/build/libs
-          unpack: false
-        - distribution: azure-bundle
-          build-task: :iceberg-azure-bundle:shadowJar
-          scan-path: azure-bundle/build/libs
-          unpack: false
-        - distribution: gcp-bundle
-          build-task: :iceberg-gcp-bundle:shadowJar
-          scan-path: gcp-bundle/build/libs
-          unpack: false
-        - distribution: spark-runtime-3.5_2.12
-          build-task: >-
-            -DsparkVersions=3.5
-            :iceberg-spark:iceberg-spark-runtime-3.5_2.12:shadowJar
-          scan-path: spark/v3.5/spark-runtime/build/libs
-          unpack: false
-        - distribution: spark-runtime-4.0_2.13
-          build-task: >-
-            -DsparkVersions=4.0
-            :iceberg-spark:iceberg-spark-runtime-4.0_2.13:shadowJar
-          scan-path: spark/v4.0/spark-runtime/build/libs
-          unpack: false
-        - distribution: spark-runtime-4.1_2.13
-          build-task: >-
-            -DsparkVersions=4.1
-            :iceberg-spark:iceberg-spark-runtime-4.1_2.13:shadowJar
-          scan-path: spark/v4.1/spark-runtime/build/libs
-          unpack: false
-        - distribution: flink-runtime-1.20
-          build-task: >-
-            -DflinkVersions=1.20
-            :iceberg-flink:iceberg-flink-runtime-1.20:shadowJar
-          scan-path: flink/v1.20/flink-runtime/build/libs
-          unpack: false
-        - distribution: flink-runtime-2.0
-          build-task: >-
-            -DflinkVersions=2.0
-            :iceberg-flink:iceberg-flink-runtime-2.0:shadowJar
-          scan-path: flink/v2.0/flink-runtime/build/libs
-          unpack: false
-        - distribution: flink-runtime-2.1
-          build-task: >-
-            -DflinkVersions=2.1
-            :iceberg-flink:iceberg-flink-runtime-2.1:shadowJar
-          scan-path: flink/v2.1/flink-runtime/build/libs
-          unpack: false
-        - distribution: open-api-test-fixtures-runtime
-          build-task: :iceberg-open-api:shadowJar
-          scan-path: open-api/build/libs
-          unpack: false
+      matrix: ${{ fromJson(needs.plan.outputs.cve_matrix) }}
     name: ${{ matrix.distribution }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -176,20 +112,43 @@ jobs:
         java-version: 21
     - uses: gradle/actions/setup-gradle@0723195856401067f7a2779048b490ace7a47d7c # v5.0.2
       with:
-        # Read-only: small job; restore opportunistically from other jobs' caches but never write.
+        # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - name: Build ${{ matrix.distribution }}
+      env:
+        BUILD_TASK: ${{ matrix.build-task }}
+        DISTRIBUTION: ${{ matrix.distribution }}
       run: |
+        case "${DISTRIBUTION}" in
+          kafka-connect-runtime|aws-bundle|azure-bundle|gcp-bundle|spark-runtime-*|flink-runtime-*|open-api-test-fixtures-runtime) ;;
+          *) echo "Unsupported CVE distribution: ${DISTRIBUTION}"; exit 1 ;;
+        esac
+
+        read -r -a build_task <<< "${BUILD_TASK}"
         ./gradlew -DsparkVersions= -DflinkVersions= \
-          ${{ matrix.build-task }} \
+          "${build_task[@]}" \
           -Pquick=true -x test -x javadoc
     - name: Prepare scan directory
+      env:
+        DISTRIBUTION: ${{ matrix.distribution }}
+        SCAN_PATH: ${{ matrix.scan-path }}
+        UNPACK: ${{ matrix.unpack }}
       run: |
+        case "${DISTRIBUTION}" in
+          kafka-connect-runtime|aws-bundle|azure-bundle|gcp-bundle|spark-runtime-*|flink-runtime-*|open-api-test-fixtures-runtime) ;;
+          *) echo "Unsupported CVE distribution: ${DISTRIBUTION}"; exit 1 ;;
+        esac
+
+        case "${UNPACK}" in
+          true|false) ;;
+          *) echo "Unsupported unpack value: ${UNPACK}"; exit 1 ;;
+        esac
+
         mkdir -p /tmp/cve-scan
-        if [ "${{ matrix.unpack }}" = "true" ]; then
-          unzip ${{ matrix.scan-path }}/*.zip -d /tmp/cve-scan
+        if [ "${UNPACK}" = "true" ]; then
+          unzip "${SCAN_PATH}"/*.zip -d /tmp/cve-scan
         else
-          cp ${{ matrix.scan-path }}/iceberg-${{ matrix.distribution }}-*.jar /tmp/cve-scan/
+          cp "${SCAN_PATH}"/iceberg-"${DISTRIBUTION}"-*.jar /tmp/cve-scan/
         fi
     - name: Pull Trivy image (with retry)
       # Pre-pull the scanner image so the action's docker run finds it locally and never hits
@@ -222,9 +181,11 @@ jobs:
         trivy-image: ${{ env.TRIVY_IMAGE }}
     - name: Print Trivy scan results
       if: always()
+      env:
+        DISTRIBUTION: ${{ matrix.distribution }}
       run: |
         if [ -f trivy-results.sarif ]; then
-          echo "## Trivy CVE Scan Results — ${{ matrix.distribution }}"
+          echo "## Trivy CVE Scan Results - ${DISTRIBUTION}"
           jq -r '.runs[].results[] | "- \(.ruleId): \(.message.text)"' trivy-results.sarif 2>/dev/null || echo "No findings or unable to parse SARIF."
         else
           echo "No SARIF file found — scan may have failed to install."

--- a/.github/workflows/delta-conversion-ci.yml
+++ b/.github/workflows/delta-conversion-ci.yml
@@ -28,42 +28,7 @@ on:
     tags:
       - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/api-binary-compatibility.yml'
-      - '.github/workflows/docs-ci.yml'
-      - '.github/workflows/flink-ci.yml'
-      - '.github/workflows/hive-ci.yml'
-      - '.github/workflows/java-ci.yml'
-      - '.github/workflows/jmh-benchmarks-ci.yml'
-      - '.github/workflows/kafka-connect-ci.yml'
-      - '.github/workflows/cve-scan.yml'
-      - '.github/workflows/labeler.yml'
-      - '.github/workflows/license-check.yml'
-      - '.github/workflows/open-api.yml'
-      - '.github/workflows/pr-title-check.yml'
-      - '.github/workflows/publish-snapshot.yml'
-      - '.github/workflows/recurring-jmh-benchmarks.yml'
-      - '.github/workflows/site-ci.yml'
-      - '.github/workflows/spark-ci.yml'
-      - '.github/workflows/stale.yml'
-      - '.gitignore'
-      - '.asf.yaml'
-      - 'dev/**'
-      - 'docker/**'
-      - 'mr/**'
-      - 'flink/**'
-      - 'kafka-connect/**'
-      - 'docs/**'
-      - 'site/**'
-      - 'open-api/**'
-      - 'format/**'
-      - '.gitattributes'
-      - '**/README.md'
-      - 'CONTRIBUTING.md'
-      - '**/LICENSE'
-      - '**/NOTICE'
-      - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -73,12 +38,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      jvm_matrix: ${{ steps.plan.outputs.jvm_matrix }}
+      run_delta: ${{ steps.plan.outputs.run_delta }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+        run: bash .github/scripts/plan-pr-ci.sh
+
   delta-conversion-scala-2-12-tests:
+    needs: plan
+    if: needs.plan.outputs.run_delta == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -103,11 +84,12 @@ jobs:
             **/build/testlogs
 
   delta-conversion-scala-2-13-tests:
+    needs: plan
+    if: needs.plan.outputs.run_delta == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -28,42 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-    - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/api-binary-compatibility.yml'
-    - '.github/workflows/delta-conversion-ci.yml'
-    - '.github/workflows/docs-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
-    - '.github/workflows/kafka-connect-ci.yml'
-    - '.github/workflows/cve-scan.yml'
-    - '.github/workflows/labeler.yml'
-    - '.github/workflows/license-check.yml'
-    - '.github/workflows/open-api.yml'
-    - '.github/workflows/pr-title-check.yml'
-    - '.github/workflows/publish-snapshot.yml'
-    - '.github/workflows/recurring-jmh-benchmarks.yml'
-    - '.github/workflows/site-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/stale.yml'
-    - '.gitignore'
-    - '.asf.yaml'
-    - 'dev/**'
-    - 'docker/**'
-    - 'mr/**'
-    - 'kafka-connect/**'
-    - 'spark/**'
-    - 'docs/**'
-    - 'site/**'
-    - 'open-api/**'
-    - 'format/**'
-    - '.gitattributes'
-    - '**/README.md'
-    - 'CONTRIBUTING.md'
-    - '**/LICENSE'
-    - '**/NOTICE'
-    - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -73,16 +38,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      run_flink: ${{ steps.plan.outputs.run_flink }}
+      flink_matrix: ${{ steps.plan.outputs.flink_matrix }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+      run: bash .github/scripts/plan-pr-ci.sh
 
   # Test all flink versions with scala 2.12 for general validation.
   flink-scala-2-12-tests:
+    needs: plan
+    if: needs.plan.outputs.run_flink == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
-        flink: ['1.20', '2.0', '2.1']
+      matrix: ${{ fromJson(needs.plan.outputs.flink_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -98,7 +77,18 @@ jobs:
         # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -DtestParallelism=auto
+    - env:
+        FLINK_VERSION: ${{ matrix.flink }}
+      run: |
+        case "${FLINK_VERSION}" in
+          1.20|2.0|2.1) ;;
+          *) echo "Unsupported Flink matrix row: ${FLINK_VERSION}"; exit 1 ;;
+        esac
+
+        ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions="${FLINK_VERSION}" \
+          ":iceberg-flink:iceberg-flink-${FLINK_VERSION}:check" \
+          ":iceberg-flink:iceberg-flink-runtime-${FLINK_VERSION}:check" \
+          -Pquick=true -x javadoc -DtestParallelism=auto
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:

--- a/.github/workflows/hive-ci.yml
+++ b/.github/workflows/hive-ci.yml
@@ -28,43 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-    - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/api-binary-compatibility.yml'
-    - '.github/workflows/delta-conversion-ci.yml'
-    - '.github/workflows/docs-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
-    - '.github/workflows/kafka-connect-ci.yml'
-    - '.github/workflows/cve-scan.yml'
-    - '.github/workflows/labeler.yml'
-    - '.github/workflows/license-check.yml'
-    - '.github/workflows/open-api.yml'
-    - '.github/workflows/pr-title-check.yml'
-    - '.github/workflows/publish-snapshot.yml'
-    - '.github/workflows/recurring-jmh-benchmarks.yml'
-    - '.github/workflows/site-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/stale.yml'
-    - '.gitignore'
-    - '.asf.yaml'
-    - 'dev/**'
-    - 'docker/**'
-    - 'arrow/**'
-    - 'spark/**'
-    - 'flink/**'
-    - 'kafka-connect/**'
-    - 'docs/**'
-    - 'site/**'
-    - 'open-api/**'
-    - 'format/**'
-    - '.gitattributes'
-    - '**/README.md'
-    - 'CONTRIBUTING.md'
-    - '**/LICENSE'
-    - '**/NOTICE'
-    - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -74,12 +38,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      jvm_matrix: ${{ steps.plan.outputs.jvm_matrix }}
+      run_hive: ${{ steps.plan.outputs.run_hive }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+      run: bash .github/scripts/plan-pr-ci.sh
+
   hive2-tests:
+    needs: plan
+    if: needs.plan.outputs.run_hive == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -28,38 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-    - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/api-binary-compatibility.yml'
-    - '.github/workflows/delta-conversion-ci.yml'
-    - '.github/workflows/docs-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
-    - '.github/workflows/kafka-connect-ci.yml'
-    - '.github/workflows/cve-scan.yml'
-    - '.github/workflows/labeler.yml'
-    - '.github/workflows/license-check.yml'
-    - '.github/workflows/open-api.yml'
-    - '.github/workflows/pr-title-check.yml'
-    - '.github/workflows/publish-snapshot.yml'
-    - '.github/workflows/recurring-jmh-benchmarks.yml'
-    - '.github/workflows/site-ci.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/stale.yml'
-    - '.gitignore'
-    - '.asf.yaml'
-    - 'dev/**'
-    - 'docker/**'
-    - 'docs/**'
-    - 'site/**'
-    - 'format/**'
-    - '.gitattributes'
-    - '**/README.md'
-    - 'CONTRIBUTING.md'
-    - '**/LICENSE'
-    - '**/NOTICE'
-    - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -69,12 +38,30 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      jvm_matrix: ${{ steps.plan.outputs.jvm_matrix }}
+      run_java: ${{ steps.plan.outputs.run_java }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+      run: bash .github/scripts/plan-pr-ci.sh
+    - name: Test CI planner
+      run: bash .github/scripts/plan-pr-ci-test.sh
+
   core-tests:
+    needs: plan
+    if: needs.plan.outputs.run_java == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -99,11 +86,12 @@ jobs:
           **/build/testlogs
 
   build-checks:
+    needs: plan
+    if: needs.plan.outputs.run_java == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -119,11 +107,12 @@ jobs:
     - run: ./gradlew -DallModules build -x test -x javadoc -x integrationTest
 
   build-javadoc:
+    needs: plan
+    if: needs.plan.outputs.run_java == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       with:
@@ -139,6 +128,8 @@ jobs:
     - run: ./gradlew -Pquick=true javadoc
 
   check-runtime-deps:
+    needs: plan
+    if: needs.plan.outputs.run_java == 'true'
     runs-on: ubuntu-24.04
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/kafka-connect-ci.yml
+++ b/.github/workflows/kafka-connect-ci.yml
@@ -28,42 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-    - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/api-binary-compatibility.yml'
-    - '.github/workflows/delta-conversion-ci.yml'
-    - '.github/workflows/docs-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
-    - '.github/workflows/labeler.yml'
-    - '.github/workflows/license-check.yml'
-    - '.github/workflows/open-api.yml'
-    - '.github/workflows/pr-title-check.yml'
-    - '.github/workflows/publish-snapshot.yml'
-    - '.github/workflows/recurring-jmh-benchmarks.yml'
-    - '.github/workflows/site-ci.yml'
-    - '.github/workflows/cve-scan.yml'
-    - '.github/workflows/spark-ci.yml'
-    - '.github/workflows/stale.yml'
-    - '.gitignore'
-    - '.asf.yaml'
-    - 'dev/**'
-    - 'docker/**'
-    - 'mr/**'
-    - 'flink/**'
-    - 'spark/**'
-    - 'docs/**'
-    - 'site/**'
-    - 'open-api/**'
-    - 'format/**'
-    - '.gitattributes'
-    - '**/README.md'
-    - 'CONTRIBUTING.md'
-    - '**/LICENSE'
-    - '**/NOTICE'
-    - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -73,13 +38,28 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      jvm_matrix: ${{ steps.plan.outputs.jvm_matrix }}
+      run_kafka: ${{ steps.plan.outputs.run_kafka }}
+    steps:
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+      run: bash .github/scripts/plan-pr-ci.sh
 
   kafka-connect-tests:
+    needs: plan
+    if: needs.plan.outputs.run_kafka == 'true'
     runs-on: ubuntu-24.04
     strategy:
       max-parallel: 15
-      matrix:
-        jvm: [17, 21]
+      matrix: ${{ fromJson(needs.plan.outputs.jvm_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:

--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -28,42 +28,7 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
-    paths-ignore:
-    - '.github/ISSUE_TEMPLATE/**'
-    - '.github/workflows/api-binary-compatibility.yml'
-    - '.github/workflows/delta-conversion-ci.yml'
-    - '.github/workflows/docs-ci.yml'
-    - '.github/workflows/flink-ci.yml'
-    - '.github/workflows/hive-ci.yml'
-    - '.github/workflows/java-ci.yml'
-    - '.github/workflows/jmh-benchmarks-ci.yml'
-    - '.github/workflows/kafka-connect-ci.yml'
-    - '.github/workflows/cve-scan.yml'
-    - '.github/workflows/labeler.yml'
-    - '.github/workflows/license-check.yml'
-    - '.github/workflows/open-api.yml'
-    - '.github/workflows/pr-title-check.yml'
-    - '.github/workflows/publish-snapshot.yml'
-    - '.github/workflows/recurring-jmh-benchmarks.yml'
-    - '.github/workflows/site-ci.yml'
-    - '.github/workflows/stale.yml'
-    - '.gitignore'
-    - '.asf.yaml'
-    - 'dev/**'
-    - 'docker/**'
-    - 'site/**'
-    - 'mr/**'
-    - 'flink/**'
-    - 'kafka-connect/**'
-    - 'docs/**'
-    - 'open-api/**'
-    - 'format/**'
-    - '.gitattributes'
-    - '**/README.md'
-    - 'CONTRIBUTING.md'
-    - '**/LICENSE'
-    - '**/NOTICE'
-    - 'doap.rdf'
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
   contents: read
@@ -73,27 +38,31 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      run_spark: ${{ steps.plan.outputs.run_spark }}
+      spark_matrix: ${{ steps.plan.outputs.spark_matrix }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - id: plan
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          FULL_CI_LABEL: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'full-ci') }}
+        run: bash .github/scripts/plan-pr-ci.sh
+
   spark-tests:
+    needs: plan
+    if: needs.plan.outputs.run_spark == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 90
     strategy:
       # 20 is the Apache infra policy ceiling (https://infra.apache.org/github-actions-policy.html).
       # Keep matrix <= 20 jobs; exceeding it queues a second wave and slows CI.
       max-parallel: 20
-      matrix:
-        jvm: [17, 21]
-        spark: ['3.5', '4.0', '4.1']
-        scala: ['2.12', '2.13']
-        # Split iceberg-spark (core) from iceberg-spark-extensions/-runtime
-        # so they run as concurrent jobs rather than serially in one job.
-        tests: [core, extensions]
-        exclude:
-          # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
-          # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
-          - spark: '4.0'
-            scala: '2.12'
-          - spark: '4.1'
-            scala: '2.12'
+      matrix: ${{ fromJson(needs.plan.outputs.spark_matrix) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -110,13 +79,22 @@ jobs:
           cache-read-only: true
       - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
       - name: Run tests
+        env:
+          SCALA_VERSION: ${{ matrix.scala }}
+          SPARK_VERSION: ${{ matrix.spark }}
+          TEST_GROUP: ${{ matrix.tests }}
         run: |
-          if [[ "${{ matrix.tests }}" == "core" ]]; then
-            projects=":iceberg-spark:iceberg-spark-${{ matrix.spark }}_${{ matrix.scala }}:check"
+          case "${SPARK_VERSION}:${SCALA_VERSION}:${TEST_GROUP}" in
+            3.5:2.12:core|3.5:2.12:extensions|3.5:2.13:core|3.5:2.13:extensions|4.0:2.13:core|4.0:2.13:extensions|4.1:2.13:core|4.1:2.13:extensions) ;;
+            *) echo "Unsupported Spark matrix row: ${SPARK_VERSION}:${SCALA_VERSION}:${TEST_GROUP}"; exit 1 ;;
+          esac
+
+          if [[ "${TEST_GROUP}" == "core" ]]; then
+            projects=":iceberg-spark:iceberg-spark-${SPARK_VERSION}_${SCALA_VERSION}:check"
           else
-            projects=":iceberg-spark:iceberg-spark-extensions-${{ matrix.spark }}_${{ matrix.scala }}:check :iceberg-spark:iceberg-spark-runtime-${{ matrix.spark }}_${{ matrix.scala }}:check"
+            projects=":iceberg-spark:iceberg-spark-extensions-${SPARK_VERSION}_${SCALA_VERSION}:check :iceberg-spark:iceberg-spark-runtime-${SPARK_VERSION}_${SCALA_VERSION}:check"
           fi
-          ./gradlew -DsparkVersions=${{ matrix.spark }} -DscalaVersion=${{ matrix.scala }} -DflinkVersions= -DkafkaVersions= \
+          ./gradlew -DsparkVersions="${SPARK_VERSION}" -DscalaVersion="${SCALA_VERSION}" -DflinkVersions= -DkafkaVersions= \
             $projects -Pquick=true -x javadoc -DtestParallelism=auto
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()


### PR DESCRIPTION
Mailing list discussion: https://lists.apache.org/thread/36vxlql61gojbg639c86mnz78n57kvgm

## Summary

- add a shared PR CI planner that uses changed files, `full-ci` labels, and global build/workflow changes to select PR matrices
- keep full Java/Spark/Flink/Hive/Kafka/Delta/CVE coverage for `main`, release branches, tags, `full-ci`, global build/workflow changes, and unknown changed code paths
- use Java 17 as the primary JVM for ordinary PRs, while full CI paths keep Java 17 and Java 21
- preserve the existing Gradle cache policy from #16356: only `java-ci.yml` `build-checks (17)` writes cache on `main`; all other Gradle jobs are read-only

## Selective PR behavior

- Spark-only changes run Spark CI, not Flink/Hive/Kafka CI
- `spark/v<known-version>/**` selects only that Spark version; unknown Spark version paths force full CI
- `flink/v<known-version>/**` selects only that Flink version; unknown Flink version paths force full CI
- API/Core/Data/file-format changes run Java checks plus latest Spark and latest Flink canaries
- Hive, Kafka Connect, and Delta jobs run only when their owned paths change or when full CI is selected

## CVE behavior

- CVE artifact-level selection is intentionally not included in this PR
- CVE-relevant PR changes still run the CVE workflow, but the workflow uses the full CVE distribution matrix when it runs
- docs-only PRs skip CVE, and global/unknown/full-ci paths force CVE along with the rest of the full matrix

## Maintainability guardrails

- the planner fails closed: unknown non-doc/code paths force full CI instead of silently skipping coverage
- Spark/Flink versions are read from `gradle.properties`; versioned paths are parsed generically rather than listed one by one
- the Java CI plan job runs `.github/scripts/plan-pr-ci-test.sh` to validate important routing cases
- the planner writes a GitHub step summary showing whether full CI was selected and which workflows will run

## Validation

- YAML parse for edited workflows
- `git diff --check origin/main...HEAD`
- `bash -n .github/scripts/plan-pr-ci.sh`
- `bash -n .github/scripts/plan-pr-ci-test.sh`
- `bash .github/scripts/plan-pr-ci-test.sh`
- synthetic planner checks for Spark 4.1, Flink 2.0, core/file-format canaries, global build changes, docs-only changes, unknown paths, and old Spark version paths
- `./gradlew -DallModules build -x test -x javadoc -x integrationTest`

Rebased on latest `origin/main` and pushed as single commit `ba49482fac`.
