### PR TITLE
Bug-16563: Imposed an ordering on the filter expressions while checking for equality and hashCode  of spark scans.

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatchQueryScan.java
@@ -79,8 +79,9 @@ class SparkBatchQueryScan extends SparkRuntimeFilterableScan {
         && Objects.equals(snapshot, that.snapshot)
         && Objects.equals(branch, that.branch)
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
-        && filtersDesc().equals(that.filtersDesc())
-        && runtimeFiltersDesc().equals(that.runtimeFiltersDesc());
+        && filtersDescForEqualsAndHashCode().equals(that.filtersDescForEqualsAndHashCode())
+        && runtimeFiltersDescForEqualsAndHashCode()
+            .equals(that.runtimeFiltersDescForEqualsAndHashCode());
   }
 
   @Override
@@ -91,8 +92,8 @@ class SparkBatchQueryScan extends SparkRuntimeFilterableScan {
         snapshot,
         branch,
         readSchema(),
-        filtersDesc(),
-        runtimeFiltersDesc());
+        filtersDescForEqualsAndHashCode(),
+        runtimeFiltersDescForEqualsAndHashCode());
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkCopyOnWriteScan.java
@@ -139,7 +139,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
         && Objects.equals(snapshot, that.snapshot)
         && Objects.equals(branch, that.branch)
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
-        && filtersDesc().equals(that.filtersDesc())
+        && filtersDescForEqualsAndHashCode().equals(that.filtersDescForEqualsAndHashCode())
         && Objects.equals(filteredLocations, that.filteredLocations);
   }
 
@@ -151,7 +151,7 @@ class SparkCopyOnWriteScan extends SparkPartitioningAwareScan<FileScanTask>
         snapshot,
         branch,
         readSchema(),
-        filtersDesc(),
+        filtersDescForEqualsAndHashCode(),
         filteredLocations);
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkIncrementalAppendScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkIncrementalAppendScan.java
@@ -65,8 +65,9 @@ class SparkIncrementalAppendScan extends SparkRuntimeFilterableScan {
         && startSnapshotId == that.startSnapshotId
         && Objects.equals(endSnapshotId, that.endSnapshotId)
         && readSchema().equals(that.readSchema()) // compare Spark schemas to ignore field ids
-        && filtersDesc().equals(that.filtersDesc())
-        && runtimeFiltersDesc().equals(that.runtimeFiltersDesc());
+        && filtersDescForEqualsAndHashCode().equals(that.filtersDescForEqualsAndHashCode())
+        && runtimeFiltersDescForEqualsAndHashCode()
+            .equals(that.runtimeFiltersDescForEqualsAndHashCode());
   }
 
   @Override
@@ -77,8 +78,8 @@ class SparkIncrementalAppendScan extends SparkRuntimeFilterableScan {
         startSnapshotId,
         endSnapshotId,
         readSchema(),
-        filtersDesc(),
-        runtimeFiltersDesc());
+        filtersDescForEqualsAndHashCode(),
+        runtimeFiltersDescForEqualsAndHashCode());
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -195,6 +195,6 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
   }
 
   protected String runtimeFiltersDesc() {
-    return Spark3Util.describe(runtimeFilters);
+    return createOrderedExprString(runtimeFilters.stream());
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkRuntimeFilterableScan.java
@@ -194,7 +194,11 @@ abstract class SparkRuntimeFilterableScan extends SparkPartitioningAwareScan<Par
     return filter;
   }
 
-  protected String runtimeFiltersDesc() {
+  protected String runtimeFiltersDescForEqualsAndHashCode() {
     return createOrderedExprString(runtimeFilters.stream());
+  }
+
+  protected String runtimeFiltersDesc() {
+    return Spark3Util.describe(runtimeFilters);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -165,8 +165,12 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
     return filters.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
   }
 
-  protected String filtersDesc() {
+  protected String filtersDescForEqualsAndHashCode() {
     return createOrderedExprString(filters.stream());
+  }
+
+  protected String filtersDesc() {
+    return Spark3Util.describe(filters);
   }
 
   protected Types.StructType groupingKeyType() {
@@ -428,6 +432,11 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
       flattened.addAll(rightResult);
       // sort the flattened stream back else otherwise the subtree may have ordering issue, when
       // calculating hashCode
+      // The transform to Pair for comparing is done for performance aspects, to evaluate the String
+      // representation only
+      // once for each Expression. Not using sorted(Comparator.comparing(Spark3Util::describe)) as
+      // it would result in
+      // String eval each comparison
       return flattened.stream()
           .map(expr -> Pair.of(Spark3Util.describe(expr), expr))
           .sorted((o1, o2) -> o1.getLeft().compareTo(o2.getLeft()))

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.BlobMetadata;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
@@ -32,8 +33,11 @@ import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
@@ -93,6 +97,7 @@ import org.apache.spark.sql.connector.read.colstats.ColumnStatistics;
 import org.apache.spark.sql.connector.read.streaming.MicroBatchStream;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -161,7 +166,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
   }
 
   protected String filtersDesc() {
-    return Spark3Util.describe(filters);
+    return createOrderedExprString(filters.stream());
   }
 
   protected Types.StructType groupingKeyType() {
@@ -382,6 +387,80 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
       return adjustedSplitSize;
     } else {
       return splitSize;
+    }
+  }
+
+  protected static String createOrderedExprString(Stream<Expression> exprStream) {
+    return exprStream
+        .flatMap(x -> ExpressionVisitors.visit(x, ExpressionFlattener.INSTANCE).stream())
+        .map(Spark3Util::describe)
+        .sorted()
+        .collect(Collectors.joining(", "));
+  }
+
+  private static class ExpressionFlattener
+      extends ExpressionVisitors.ExpressionVisitor<List<Expression>> {
+
+    private static final ExpressionFlattener INSTANCE = new ExpressionFlattener();
+
+    private ExpressionFlattener() {}
+
+    @Override
+    public List<Expression> alwaysTrue() {
+      return List.of(Expressions.alwaysTrue());
+    }
+
+    @Override
+    public List<Expression> alwaysFalse() {
+      return List.of(Expressions.alwaysFalse());
+    }
+
+    @Override
+    public List<Expression> not(List<Expression> result) {
+      // since its a list of expressions created by And, if more than 1, so it will already be
+      // sorted.
+      return List.of(Expressions.not(mergeExpressions(result)));
+    }
+
+    @Override
+    public List<Expression> and(List<Expression> leftResult, List<Expression> rightResult) {
+      List<Expression> flattened = Lists.newArrayList(leftResult);
+      flattened.addAll(rightResult);
+      // sort the flattened stream back else otherwise the subtree may have ordering issue, when
+      // calculating hashCode
+      return flattened.stream()
+          .map(expr -> Pair.of(Spark3Util.describe(expr), expr))
+          .sorted((o1, o2) -> o1.getLeft().compareTo(o2.getLeft()))
+          .map(Pair::getRight)
+          .toList();
+    }
+
+    @Override
+    public List<Expression> or(List<Expression> leftResult, List<Expression> rightResult) {
+      Expression leftMerged = mergeExpressions(leftResult);
+      Expression rightMerged = mergeExpressions(rightResult);
+      String leftMergedAsString = Spark3Util.describe(leftMerged);
+      String rightMergedAsString = Spark3Util.describe(rightMerged);
+      int leftCompRight = leftMergedAsString.compareTo(rightMergedAsString);
+      if (leftCompRight < 0) {
+        return List.of(Expressions.or(leftMerged, rightMerged));
+      } else {
+        return List.of(Expressions.or(rightMerged, leftMerged));
+      }
+    }
+
+    @Override
+    public <T> List<Expression> predicate(BoundPredicate<T> pred) {
+      return List.of(pred);
+    }
+
+    @Override
+    public <T> List<Expression> predicate(UnboundPredicate<T> pred) {
+      return List.of(pred);
+    }
+
+    private Expression mergeExpressions(List<Expression> toMerge) {
+      return toMerge.stream().reduce(Expressions.alwaysTrue(), Expressions::and);
     }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestFilteredScan.java
@@ -65,14 +65,17 @@ import org.apache.spark.sql.catalyst.expressions.UnsafeRow;
 import org.apache.spark.sql.connector.expressions.filter.Predicate;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.connector.read.Scan;
 import org.apache.spark.sql.connector.read.ScanBuilder;
 import org.apache.spark.sql.connector.read.SupportsPushDownV2Filters;
 import org.apache.spark.sql.sources.And;
 import org.apache.spark.sql.sources.EqualTo;
 import org.apache.spark.sql.sources.Filter;
 import org.apache.spark.sql.sources.GreaterThan;
+import org.apache.spark.sql.sources.In;
 import org.apache.spark.sql.sources.LessThan;
 import org.apache.spark.sql.sources.Not;
+import org.apache.spark.sql.sources.Or;
 import org.apache.spark.sql.sources.StringStartsWith;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.assertj.core.api.AbstractObjectAssert;
@@ -213,6 +216,56 @@ public class TestFilteredScan {
   }
 
   @TestTemplate
+  public void testSparkBatchScanEquality_Bug16563_nestedcase() {
+    // dynamic pruning runtime filters are always flatted And, so we need to test only for data
+    // filters here.
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
+
+    // set spark.sql.caseSensitive to false
+    String caseSensitivityBeforeTest =
+        org.apache.iceberg.spark.source.TestFilteredScan.spark
+            .conf()
+            .get("spark.sql.caseSensitive");
+    org.apache.iceberg.spark.source.TestFilteredScan.spark
+        .conf()
+        .set("spark.sql.caseSensitive", "false");
+    try {
+      Filter f1 = GreaterThan.apply("ID", 10);
+      Filter f2 = LessThan.apply("data", "abc");
+      Filter f3 = LessThan.apply("ts", "2017-12-22T00:00:00+00:00");
+      Filter f4 = GreaterThan.apply("ID", 12);
+      Filter f5 = GreaterThan.apply("data", "fxrj");
+      Filter f6 = GreaterThan.apply("ID", 7);
+
+      Filter or1ScanOne = Or.apply(f1, f2);
+      Filter or1ScanTwo = Or.apply(f2, f1);
+
+      Filter or2ScanOne = Or.apply(And.apply(f3, f4), Or.apply(f5, f6));
+      Filter or2ScanTwo = Or.apply(Or.apply(f6, f5), And.apply(f4, f3));
+
+      SparkScanBuilder builder1 =
+          new SparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      pushFilters(builder1, or1ScanOne, or2ScanOne);
+
+      SparkScanBuilder builder2 =
+          new SparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      pushFilters(builder2, or2ScanTwo, or1ScanTwo);
+
+      Scan scan1 = builder1.build();
+      Scan scan2 = builder2.build();
+
+      assertThat(scan1).as("is be equal to ").isEqualTo(scan2);
+      assertThat(scan1.hashCode()).as("is same as").isEqualTo(scan2.hashCode());
+    } finally {
+      // return global conf to previous state
+      org.apache.iceberg.spark.source.TestFilteredScan.spark
+          .conf()
+          .set("spark.sql.caseSensitive", caseSensitivityBeforeTest);
+    }
+  }
+
+  @TestTemplate
   public void testUnpartitionedCaseInsensitiveIDFilters() {
     CaseInsensitiveStringMap options =
         new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
@@ -267,6 +320,55 @@ public class TestFilteredScan {
             unpartitioned.toString(),
             vectorized,
             "ts < cast('2017-12-22 00:00:00+00:00' as timestamp)"));
+  }
+
+  @TestTemplate
+  public void testSparkBatchScanEquality_Bug16563() {
+    CaseInsensitiveStringMap options =
+        new CaseInsensitiveStringMap(ImmutableMap.of("path", unpartitioned.toString()));
+
+    // set spark.sql.caseSensitive to false
+    String caseSensitivityBeforeTest = TestFilteredScan.spark.conf().get("spark.sql.caseSensitive");
+    TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", "false");
+    try {
+      Filter f1 = GreaterThan.apply("ID", 10);
+      Filter f2 = LessThan.apply("data", "abc");
+
+      SparkScanBuilder builder1 =
+          new SparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      pushFilters(builder1, f1, f2);
+
+      SparkScanBuilder builder2 =
+          new SparkScanBuilder(spark, TABLES.load(options.get("path")), options);
+      pushFilters(builder2, f2, f1);
+
+      Scan scan1 = builder1.build();
+      Scan scan2 = builder2.build();
+
+      assertThat(scan1).as("is be equal to ").isEqualTo(scan2);
+      assertThat(scan1.hashCode()).as("is same as").isEqualTo(scan2.hashCode());
+
+      Filter runtimeFilter1 = In.apply("ID", new Object[] {10, 12, 13});
+      Filter runtimeFilter2 = In.apply("data", new Object[] {"abc", "def", "cde"});
+
+      ((SparkRuntimeFilterableScan) scan1)
+          .filter(
+              Arrays.stream(new Filter[] {runtimeFilter1, runtimeFilter2})
+                  .map(Filter::toV2)
+                  .toArray(Predicate[]::new));
+
+      ((SparkRuntimeFilterableScan) scan2)
+          .filter(
+              Arrays.stream(new Filter[] {runtimeFilter2, runtimeFilter1})
+                  .map(Filter::toV2)
+                  .toArray(Predicate[]::new));
+
+      assertThat(scan1).as("is be equal to ").isEqualTo(scan2);
+      assertThat(scan1.hashCode()).as("is same as").isEqualTo(scan2.hashCode());
+    } finally {
+      // return global conf to previous state
+      TestFilteredScan.spark.conf().set("spark.sql.caseSensitive", caseSensitivityBeforeTest);
+    }
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
+import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.BucketFunction;
 import org.apache.iceberg.spark.functions.DaysFunction;
@@ -1061,6 +1062,14 @@ public class TestSparkScan extends TestBaseWithCatalog {
         () -> {
           Predicate predicate1 = new Predicate("=", expressions(fieldRef("id"), intLit(2)));
           Predicate predicate2 = new Predicate("<", expressions(fieldRef("id"), intLit(10)));
+          String filter1Desc = Spark3Util.describe(SparkV2Filters.convert(predicate1));
+          String filter2Desc = Spark3Util.describe(SparkV2Filters.convert(predicate2));
+          String expectedFilterDesc;
+          if (filter1Desc.compareTo(filter2Desc) < 0) {
+            expectedFilterDesc = filter1Desc + ", " + filter2Desc;
+          } else {
+            expectedFilterDesc = filter2Desc + ", " + filter1Desc;
+          }
           pushFilters(builder, predicate1, predicate2);
 
           Scan scan = builder.buildCopyOnWriteScan();
@@ -1071,7 +1080,7 @@ public class TestSparkScan extends TestBaseWithCatalog {
           assertThat(description).contains("schemaId=" + table.schema().schemaId());
           assertThat(description).contains("snapshotId=" + table.currentSnapshot().snapshotId());
           assertThat(description).contains("branch=null");
-          assertThat(description).contains("filters=id = 2, id < 10");
+          assertThat(description).contains("filters=" + expectedFilterDesc);
           assertThat(description).contains("groupedBy=data");
         });
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -1064,12 +1064,7 @@ public class TestSparkScan extends TestBaseWithCatalog {
           Predicate predicate2 = new Predicate("<", expressions(fieldRef("id"), intLit(10)));
           String filter1Desc = Spark3Util.describe(SparkV2Filters.convert(predicate1));
           String filter2Desc = Spark3Util.describe(SparkV2Filters.convert(predicate2));
-          String expectedFilterDesc;
-          if (filter1Desc.compareTo(filter2Desc) < 0) {
-            expectedFilterDesc = filter1Desc + ", " + filter2Desc;
-          } else {
-            expectedFilterDesc = filter2Desc + ", " + filter1Desc;
-          }
+          String expectedFilterDesc = filter1Desc + ", " + filter2Desc;
           pushFilters(builder, predicate1, predicate2);
 
           Scan scan = builder.buildCopyOnWriteScan();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -46,7 +46,6 @@ import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.spark.SparkSQLProperties;
-import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.iceberg.spark.functions.BucketFunction;
 import org.apache.iceberg.spark.functions.DaysFunction;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkScan.java
@@ -1062,9 +1062,6 @@ public class TestSparkScan extends TestBaseWithCatalog {
         () -> {
           Predicate predicate1 = new Predicate("=", expressions(fieldRef("id"), intLit(2)));
           Predicate predicate2 = new Predicate("<", expressions(fieldRef("id"), intLit(10)));
-          String filter1Desc = Spark3Util.describe(SparkV2Filters.convert(predicate1));
-          String filter2Desc = Spark3Util.describe(SparkV2Filters.convert(predicate2));
-          String expectedFilterDesc = filter1Desc + ", " + filter2Desc;
           pushFilters(builder, predicate1, predicate2);
 
           Scan scan = builder.buildCopyOnWriteScan();
@@ -1075,7 +1072,7 @@ public class TestSparkScan extends TestBaseWithCatalog {
           assertThat(description).contains("schemaId=" + table.schema().schemaId());
           assertThat(description).contains("snapshotId=" + table.currentSnapshot().snapshotId());
           assertThat(description).contains("branch=null");
-          assertThat(description).contains("filters=" + expectedFilterDesc);
+          assertThat(description).contains("filters=id = 2, id < 10");
           assertThat(description).contains("groupedBy=data");
         });
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -27,6 +27,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -92,8 +93,32 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1' AND salary > 100.03" /* query predicate */,
         "isnotnull(salary) AND (salary > 100.03)" /* Spark post scan filter */,
-        "dep IS NOT NULL, salary IS NOT NULL, dep = 'd1', salary > 100.03" /* Iceberg scan filters */,
+        /* Iceberg scan filters */
+        new String[] {"dep IS NOT NULL", "salary IS NOT NULL", "dep = 'd1'", "salary > 100.03"},
         ImmutableList.of(row(2, new BigDecimal("100.05"), "d1")));
+  }
+
+  @TestTemplate
+  public void testNoFilterPushdownForComplexExpression() {
+    sql(
+        "CREATE TABLE %s (id INT, salary INT, dep STRING)"
+            + "USING iceberg "
+            + "PARTITIONED BY (dep)",
+        tableName);
+    configurePlanningMode(planningMode);
+
+    sql("INSERT INTO %s VALUES (10, 50, 'd1')", tableName);
+    sql("INSERT INTO %s VALUES (2, 25, 'd2')", tableName);
+    sql("INSERT INTO %s VALUES (3, 300, 'd3')", tableName);
+    sql("INSERT INTO %s VALUES (4, 400, 'd4')", tableName);
+    sql("INSERT INTO %s VALUES (5, 500, 'd5')", tableName);
+    sql("INSERT INTO %s VALUES (6, 600, null)", tableName);
+
+    checkFilters(
+        "log10(ifnull(id, 10)) = 1" /* query predicate */,
+        "LOG10(cast(coalesce(id, 10) as double)) = 1.0",
+        new String[] {} /* no Iceberg scan filters should be pushed */,
+        ImmutableList.of(row(10, 50, "d1")));
   }
 
   @TestTemplate
@@ -114,12 +139,12 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep IS NULL" /* query predicate */,
-        "dep IS NULL" /* Iceberg scan filters */,
+        new String[] {"dep IS NULL"} /* Iceberg scan filters */,
         ImmutableList.of(row(6, 600, null)));
 
     checkOnlyIcebergFilters(
         "dep IS NOT NULL" /* query predicate */,
-        "dep IS NOT NULL" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL"} /* Iceberg scan filters */,
         ImmutableList.of(
             row(1, 100, "d1"),
             row(2, 200, "d2"),
@@ -129,82 +154,88 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep = 'd3'" /* query predicate */,
-        "dep IS NOT NULL, dep = 'd3'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep = 'd3'"} /* Iceberg scan filters */,
         ImmutableList.of(row(3, 300, "d3")));
 
     checkOnlyIcebergFilters(
         "dep > 'd3'" /* query predicate */,
-        "dep IS NOT NULL, dep > 'd3'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep > 'd3'"} /* Iceberg scan filters */,
         ImmutableList.of(row(4, 400, "d4"), row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep >= 'd5'" /* query predicate */,
-        "dep IS NOT NULL, dep >= 'd5'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep >= 'd5'"} /* Iceberg scan filters */,
         ImmutableList.of(row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep < 'd2'" /* query predicate */,
-        "dep IS NOT NULL, dep < 'd2'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep < 'd2'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep <= 'd2'" /* query predicate */,
-        "dep IS NOT NULL, dep <= 'd2'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep <= 'd2'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkOnlyIcebergFilters(
         "dep <=> 'd3'" /* query predicate */,
-        "dep = 'd3'" /* Iceberg scan filters */,
+        new String[] {"dep = 'd3'"} /* Iceberg scan filters */,
         ImmutableList.of(row(3, 300, "d3")));
 
     checkOnlyIcebergFilters(
         "dep IN (null, 'd1')" /* query predicate */,
-        "dep IN ('d1')" /* Iceberg scan filters */,
+        new String[] {"dep IN ('d1')"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep NOT IN ('d2', 'd4')" /* query predicate */,
-        "(dep IS NOT NULL AND dep NOT IN ('d2', 'd4'))" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep NOT IN ('d2', 'd4')"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(3, 300, "d3"), row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep = 'd1' AND dep IS NOT NULL" /* query predicate */,
-        "dep = 'd1', dep IS NOT NULL" /* Iceberg scan filters */,
+        new String[] {"dep = 'd1'", "dep IS NOT NULL"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep = 'd1' OR dep = 'd2' OR dep = 'd3'" /* query predicate */,
-        "((dep = 'd1' OR dep = 'd2') OR dep = 'd3')" /* Iceberg scan filters */,
+        new String[] {"((dep = 'd1' OR dep = 'd2') OR dep = 'd3')"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2"), row(3, 300, "d3")));
 
     checkFilters(
         "dep = 'd1' AND id = 1" /* query predicate */,
         "isnotnull(id) AND (id = 1)" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1', id = 1" /* Iceberg scan filters */,
+        new String[] {
+          "dep IS NOT NULL", "id IS NOT NULL", "dep = 'd1'", "id = 1"
+        } /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep = 'd2' OR id = 1" /* query predicate */,
         "(dep = d2) OR (id = 1)" /* Spark post scan filter */,
-        "(dep = 'd2' OR id = 1)" /* Iceberg scan filters */,
+        new String[] {"(dep = 'd2' OR id = 1)"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkFilters(
         "dep LIKE 'd1%' AND id = 1" /* query predicate */,
         "isnotnull(id) AND (id = 1)" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IS NOT NULL, dep LIKE 'd1%', id = 1" /* Iceberg scan filters */,
+        new String[] {
+          "dep IS NOT NULL", "id IS NOT NULL", "dep LIKE 'd1%'", "id = 1"
+        } /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep NOT LIKE 'd5%' AND (id = 1 OR id = 5)" /* query predicate */,
         "(id = 1) OR (id = 5)" /* Spark post scan filter */,
-        "dep IS NOT NULL, NOT (dep LIKE 'd5%'), (id = 1 OR id = 5)" /* Iceberg scan filters */,
+        new String[] {
+          "dep IS NOT NULL", "NOT (dep LIKE 'd5%')", "(id = 1 OR id = 5)"
+        } /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep LIKE '%d5' AND id IN (1, 5)" /* query predicate */,
         "EndsWith(dep, d5) AND id IN (1,5)" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IN (1, 5)" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "id IN (1, 5)"} /* Iceberg scan filters */,
         ImmutableList.of(row(5, 500, "d5")));
   }
 
@@ -226,14 +257,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              "t IS NULL" /* Iceberg scan filters */,
+              new String[] {"t IS NULL"} /* Iceberg scan filters */,
               ImmutableList.of(row(3, 300, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-06-30T02:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-06-30T02:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1625018400000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625018400000000"} /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-06-30T01:00:00.001Z' differ,
@@ -241,7 +272,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T01:00:00.001Z'" /* query predicate */,
               "t < 2021-06-30 01:00:00.001" /* Spark post scan filter */,
-              "t IS NOT NULL, t < 1625014800001000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625014800001000"} /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
 
           // strict/inclusive projections for t <= TIMESTAMP '2021-06-30T01:00:00.000Z' differ,
@@ -249,7 +280,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t <= TIMESTAMP '2021-06-30T01:00:00.000Z'" /* query predicate */,
               "t <= 2021-06-30 01:00:00" /* Spark post scan filter */,
-              "t IS NOT NULL, t <= 1625014800000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t <= 1625014800000000"} /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
         });
   }
@@ -273,14 +304,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              "t IS NULL" /* Iceberg scan filters */,
+              new String[] {"t IS NULL"} /* Iceberg scan filters */,
               ImmutableList.of(row(4, 400, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-07-05T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-05T00:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1625443200000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625443200000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-15T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -290,7 +321,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-15T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -316,14 +347,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              "t IS NULL" /* Iceberg scan filters */,
+              new String[] {"t IS NULL"} /* Iceberg scan filters */,
               ImmutableList.of(row(4, 400, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-07-01T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-01T00:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1625097600000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625097600000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -333,7 +364,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -359,14 +390,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              "t IS NULL" /* Iceberg scan filters */,
+              new String[] {"t IS NULL"} /* Iceberg scan filters */,
               ImmutableList.of(row(3, 300, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2022-01-01T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2022-01-01T00:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1640995200000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1640995200000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -376,7 +407,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -398,7 +429,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1' AND id = 1" /* query predicate */,
         "id = 1" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "id IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -417,13 +448,13 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep LIKE 'd%'" /* query predicate */,
-        "dep IS NOT NULL, dep LIKE 'd%'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep LIKE 'd%'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkFilters(
         "dep = 'd1'" /* query predicate */,
         "dep = d1" /* Spark post scan filter */,
-        "dep IS NOT NULL" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -441,7 +472,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because all specs include identity(dep)
     checkOnlyIcebergFilters(
         "dep = 'd1'" /* query predicate */,
-        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -453,7 +484,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because all specs include identity(dep)
     checkOnlyIcebergFilters(
         "dep = 'd1'" /* query predicate */,
-        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
 
     table.updateSpec().removeField("sub_dep").removeField("dep").commit();
@@ -464,7 +495,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1'" /* query predicate */,
         "isnotnull(dep) AND (dep = d1)" /* Spark post scan filter */,
-        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
   }
 
@@ -482,7 +513,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because the current spec supports it
     checkOnlyIcebergFilters(
         "dep LIKE 'd1%'" /* query predicate */,
-        "dep IS NOT NULL, dep LIKE 'd1%'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep LIKE 'd1%'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -497,7 +528,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because both specs support it
     checkOnlyIcebergFilters(
         "dep LIKE 'd%'" /* query predicate */,
-        "dep IS NOT NULL, dep LIKE 'd%'" /* Iceberg scan filters */,
+        new String[] {"dep IS NOT NULL", "dep LIKE 'd%'"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     // the filter can't be pushed completely because the second spec is truncate(dep, 1) and
@@ -505,7 +536,9 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep LIKE 'd1%' AND id = 1" /* query predicate */,
         "(isnotnull(id) AND StartsWith(dep, d1)) AND (id = 1)" /* Spark post scan filter */,
-        "dep IS NOT NULL, id IS NOT NULL, dep LIKE 'd1%', id = 1" /* Iceberg scan filters */,
+        new String[] {
+          "dep IS NOT NULL", "id IS NOT NULL", "dep LIKE 'd1%'", "id = 1"
+        } /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -526,7 +559,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           // the filter can be pushed completely because the current spec supports it
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-01T00:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1625097600000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1625097600000000"} /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.000Z"))));
 
           Table table = validationCatalog.loadTable(tableIdent);
@@ -541,7 +574,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           // the filter can be pushed completely because both specs support it
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-06-01T00:00:00.000Z'" /* query predicate */,
-              "t IS NOT NULL, t < 1622505600000000" /* Iceberg scan filters */,
+              new String[] {"t IS NOT NULL", "t < 1622505600000000"} /* Iceberg scan filters */,
               ImmutableList.of(row(2, 200, timestamp("2021-05-30T01:00:00.000Z"))));
         });
   }
@@ -560,28 +593,28 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "salary = 100.5" /* query predicate */,
-        "salary IS NOT NULL, salary = 100.5" /* Iceberg scan filters */,
+        new String[] {"salary IS NOT NULL", "salary = 100.5"} /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100.5)));
 
     checkOnlyIcebergFilters(
         "salary = double('NaN')" /* query predicate */,
-        "salary IS NOT NULL, is_nan(salary)" /* Iceberg scan filters */,
+        new String[] {"salary IS NOT NULL", "is_nan(salary)"} /* Iceberg scan filters */,
         ImmutableList.of(row(2, Double.NaN)));
 
     checkOnlyIcebergFilters(
         "salary != double('NaN')" /* query predicate */,
-        "salary IS NOT NULL, NOT (is_nan(salary))" /* Iceberg scan filters */,
+        new String[] {"salary IS NOT NULL", "NOT (is_nan(salary))"} /* Iceberg scan filters */,
         ImmutableList.of(
             row(1, 100.5), row(3, Double.POSITIVE_INFINITY), row(4, Double.NEGATIVE_INFINITY)));
 
     checkOnlyIcebergFilters(
         "salary = double('infinity')" /* query predicate */,
-        "salary IS NOT NULL, salary = Infinity" /* Iceberg scan filters */,
+        new String[] {"salary IS NOT NULL", "salary = Infinity"} /* Iceberg scan filters */,
         ImmutableList.of(row(3, Double.POSITIVE_INFINITY)));
 
     checkOnlyIcebergFilters(
         "salary = double('-infinity')" /* query predicate */,
-        "salary IS NOT NULL, salary = -Infinity" /* Iceberg scan filters */,
+        new String[] {"salary IS NOT NULL", "salary = -Infinity"} /* Iceberg scan filters */,
         ImmutableList.of(row(4, Double.NEGATIVE_INFINITY)));
   }
 
@@ -607,7 +640,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IS NOT NULL",
               "isnotnull(data) AND isnotnull(try_variant_get(data, $.num, IntegerType, false, Some(UTC)))",
-              "data IS NOT NULL",
+              new String[] {"data IS NOT NULL"},
               ImmutableList.of(
                   row(1L, toSparkVariantRow("foo", 25)),
                   row(2L, toSparkVariantRow("bar", 30)),
@@ -616,45 +649,44 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IS NULL",
               "isnull(try_variant_get(data, $.num, IntegerType, false, Some(UTC)))",
-              "",
+              new String[] {""},
               ImmutableList.of(row(4L, null)));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') > 30",
               "isnotnull(data) AND (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) > 30)",
-              "data IS NOT NULL",
+              new String[] {"data IS NOT NULL"},
               ImmutableList.of(row(3L, toSparkVariantRow("baz", 35))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') = 30",
               "isnotnull(data) AND (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) = 30)",
-              "data IS NOT NULL",
+              new String[] {"data IS NOT NULL"},
               ImmutableList.of(row(2L, toSparkVariantRow("bar", 30))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IN (25, 35)",
               "try_variant_get(data, $.num, IntegerType, false, Some(UTC)) IN (25,35)",
-              "",
+              new String[] {""},
               ImmutableList.of(
                   row(1L, toSparkVariantRow("foo", 25)), row(3L, toSparkVariantRow("baz", 35))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') != 25",
               "isnotnull(data) AND NOT (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) = 25)",
-              "data IS NOT NULL",
+              new String[] {"data IS NOT NULL"},
               ImmutableList.of(
                   row(2L, toSparkVariantRow("bar", 30)), row(3L, toSparkVariantRow("baz", 35))));
         });
   }
 
   private void checkOnlyIcebergFilters(
-      String predicate, String icebergFilters, List<Object[]> expectedRows) {
-
+      String predicate, String[] icebergFilters, List<Object[]> expectedRows) {
     checkFilters(predicate, null, icebergFilters, expectedRows);
   }
 
   private void checkFilters(
-      String predicate, String sparkFilter, String icebergFilters, List<Object[]> expectedRows) {
+      String predicate, String sparkFilter, String[] icebergFilters, List<Object[]> expectedRows) {
 
     Action check =
         () -> {
@@ -674,9 +706,20 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
     }
 
-    assertThat(planAsString)
-        .as("Pushed filters must match")
-        .contains(", filters=" + icebergFilters + ",");
+    int startIndex = planAsString.indexOf("filters=");
+    int endIndex = planAsString.indexOf("runtimeFilters");
+    String filterStringFromPlan = planAsString.substring(startIndex, endIndex);
+    Arrays.stream(icebergFilters)
+        .forEach(
+            filter -> {
+              assertThat(filterStringFromPlan).as("Pushed filters must contain").contains(filter);
+            });
+    // This implies there should be no filter at all in Scan
+    if (icebergFilters.length == 0) {
+      assertThat(filterStringFromPlan.trim())
+          .as("Pushed filters must contain")
+          .isEqualTo("filters=,");
+    }
   }
 
   private Timestamp timestamp(String timestampAsString) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestFilterPushDown.java
@@ -27,7 +27,6 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.sql.Timestamp;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -93,8 +92,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1' AND salary > 100.03" /* query predicate */,
         "isnotnull(salary) AND (salary > 100.03)" /* Spark post scan filter */,
-        /* Iceberg scan filters */
-        new String[] {"dep IS NOT NULL", "salary IS NOT NULL", "dep = 'd1'", "salary > 100.03"},
+        "dep IS NOT NULL, salary IS NOT NULL, dep = 'd1', salary > 100.03" /* Iceberg scan filters */,
         ImmutableList.of(row(2, new BigDecimal("100.05"), "d1")));
   }
 
@@ -117,7 +115,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "log10(ifnull(id, 10)) = 1" /* query predicate */,
         "LOG10(cast(coalesce(id, 10) as double)) = 1.0",
-        new String[] {} /* no Iceberg scan filters should be pushed */,
+        "" /* no Iceberg scan filters should be pushed */,
         ImmutableList.of(row(10, 50, "d1")));
   }
 
@@ -139,12 +137,12 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep IS NULL" /* query predicate */,
-        new String[] {"dep IS NULL"} /* Iceberg scan filters */,
+        "dep IS NULL" /* Iceberg scan filters */,
         ImmutableList.of(row(6, 600, null)));
 
     checkOnlyIcebergFilters(
         "dep IS NOT NULL" /* query predicate */,
-        new String[] {"dep IS NOT NULL"} /* Iceberg scan filters */,
+        "dep IS NOT NULL" /* Iceberg scan filters */,
         ImmutableList.of(
             row(1, 100, "d1"),
             row(2, 200, "d2"),
@@ -154,88 +152,82 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep = 'd3'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep = 'd3'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep = 'd3'" /* Iceberg scan filters */,
         ImmutableList.of(row(3, 300, "d3")));
 
     checkOnlyIcebergFilters(
         "dep > 'd3'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep > 'd3'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep > 'd3'" /* Iceberg scan filters */,
         ImmutableList.of(row(4, 400, "d4"), row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep >= 'd5'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep >= 'd5'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep >= 'd5'" /* Iceberg scan filters */,
         ImmutableList.of(row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep < 'd2'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep < 'd2'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep < 'd2'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep <= 'd2'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep <= 'd2'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep <= 'd2'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkOnlyIcebergFilters(
         "dep <=> 'd3'" /* query predicate */,
-        new String[] {"dep = 'd3'"} /* Iceberg scan filters */,
+        "dep = 'd3'" /* Iceberg scan filters */,
         ImmutableList.of(row(3, 300, "d3")));
 
     checkOnlyIcebergFilters(
         "dep IN (null, 'd1')" /* query predicate */,
-        new String[] {"dep IN ('d1')"} /* Iceberg scan filters */,
+        "dep IN ('d1')" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep NOT IN ('d2', 'd4')" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep NOT IN ('d2', 'd4')"} /* Iceberg scan filters */,
+        "(dep IS NOT NULL AND dep NOT IN ('d2', 'd4'))" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(3, 300, "d3"), row(5, 500, "d5")));
 
     checkOnlyIcebergFilters(
         "dep = 'd1' AND dep IS NOT NULL" /* query predicate */,
-        new String[] {"dep = 'd1'", "dep IS NOT NULL"} /* Iceberg scan filters */,
+        "dep = 'd1', dep IS NOT NULL" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkOnlyIcebergFilters(
         "dep = 'd1' OR dep = 'd2' OR dep = 'd3'" /* query predicate */,
-        new String[] {"((dep = 'd1' OR dep = 'd2') OR dep = 'd3')"} /* Iceberg scan filters */,
+        "((dep = 'd1' OR dep = 'd2') OR dep = 'd3')" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2"), row(3, 300, "d3")));
 
     checkFilters(
         "dep = 'd1' AND id = 1" /* query predicate */,
         "isnotnull(id) AND (id = 1)" /* Spark post scan filter */,
-        new String[] {
-          "dep IS NOT NULL", "id IS NOT NULL", "dep = 'd1'", "id = 1"
-        } /* Iceberg scan filters */,
+        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1', id = 1" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep = 'd2' OR id = 1" /* query predicate */,
         "(dep = d2) OR (id = 1)" /* Spark post scan filter */,
-        new String[] {"(dep = 'd2' OR id = 1)"} /* Iceberg scan filters */,
+        "(dep = 'd2' OR id = 1)" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkFilters(
         "dep LIKE 'd1%' AND id = 1" /* query predicate */,
         "isnotnull(id) AND (id = 1)" /* Spark post scan filter */,
-        new String[] {
-          "dep IS NOT NULL", "id IS NOT NULL", "dep LIKE 'd1%'", "id = 1"
-        } /* Iceberg scan filters */,
+        "dep IS NOT NULL, id IS NOT NULL, dep LIKE 'd1%', id = 1" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep NOT LIKE 'd5%' AND (id = 1 OR id = 5)" /* query predicate */,
         "(id = 1) OR (id = 5)" /* Spark post scan filter */,
-        new String[] {
-          "dep IS NOT NULL", "NOT (dep LIKE 'd5%')", "(id = 1 OR id = 5)"
-        } /* Iceberg scan filters */,
+        "dep IS NOT NULL, NOT (dep LIKE 'd5%'), (id = 1 OR id = 5)" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     checkFilters(
         "dep LIKE '%d5' AND id IN (1, 5)" /* query predicate */,
         "EndsWith(dep, d5) AND id IN (1,5)" /* Spark post scan filter */,
-        new String[] {"dep IS NOT NULL", "id IN (1, 5)"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, id IN (1, 5)" /* Iceberg scan filters */,
         ImmutableList.of(row(5, 500, "d5")));
   }
 
@@ -257,14 +249,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              new String[] {"t IS NULL"} /* Iceberg scan filters */,
+              "t IS NULL" /* Iceberg scan filters */,
               ImmutableList.of(row(3, 300, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-06-30T02:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-06-30T02:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1625018400000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625018400000000" /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-06-30T01:00:00.001Z' differ,
@@ -272,7 +264,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T01:00:00.001Z'" /* query predicate */,
               "t < 2021-06-30 01:00:00.001" /* Spark post scan filter */,
-              new String[] {"t IS NOT NULL", "t < 1625014800001000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625014800001000" /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
 
           // strict/inclusive projections for t <= TIMESTAMP '2021-06-30T01:00:00.000Z' differ,
@@ -280,7 +272,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t <= TIMESTAMP '2021-06-30T01:00:00.000Z'" /* query predicate */,
               "t <= 2021-06-30 01:00:00" /* Spark post scan filter */,
-              new String[] {"t IS NOT NULL", "t <= 1625014800000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t <= 1625014800000000" /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.0Z"))));
         });
   }
@@ -304,14 +296,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              new String[] {"t IS NULL"} /* Iceberg scan filters */,
+              "t IS NULL" /* Iceberg scan filters */,
               ImmutableList.of(row(4, 400, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-07-05T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-05T00:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1625443200000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625443200000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-15T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -321,7 +313,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-15T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -347,14 +339,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              new String[] {"t IS NULL"} /* Iceberg scan filters */,
+              "t IS NULL" /* Iceberg scan filters */,
               ImmutableList.of(row(4, 400, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2021-07-01T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-01T00:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1625097600000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625097600000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -364,7 +356,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -390,14 +382,14 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
         () -> {
           checkOnlyIcebergFilters(
               "t IS NULL" /* query predicate */,
-              new String[] {"t IS NULL"} /* Iceberg scan filters */,
+              "t IS NULL" /* Iceberg scan filters */,
               ImmutableList.of(row(3, 300, null)));
 
           // strict/inclusive projections for t < TIMESTAMP '2022-01-01T00:00:00.000Z' are equal,
           // so this filter selects entire partitions and can be pushed down completely
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2022-01-01T00:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1640995200000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1640995200000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -407,7 +399,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "t < TIMESTAMP '2021-06-30T03:00:00.000Z'" /* query predicate */,
               "t < 2021-06-30 03:00:00" /* Spark post scan filter */,
-              new String[] {"t IS NOT NULL", "t < 1625022000000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625022000000000" /* Iceberg scan filters */,
               ImmutableList.of(
                   row(1, 100, timestamp("2021-06-30T01:00:00.000Z")),
                   row(2, 200, timestamp("2021-06-30T02:00:00.000Z"))));
@@ -429,7 +421,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1' AND id = 1" /* query predicate */,
         "id = 1" /* Spark post scan filter */,
-        new String[] {"dep IS NOT NULL", "id IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, id IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -448,13 +440,13 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "dep LIKE 'd%'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep LIKE 'd%'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep LIKE 'd%'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     checkFilters(
         "dep = 'd1'" /* query predicate */,
         "dep = d1" /* Spark post scan filter */,
-        new String[] {"dep IS NOT NULL"} /* Iceberg scan filters */,
+        "dep IS NOT NULL" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -472,7 +464,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because all specs include identity(dep)
     checkOnlyIcebergFilters(
         "dep = 'd1'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -484,7 +476,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because all specs include identity(dep)
     checkOnlyIcebergFilters(
         "dep = 'd1'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
 
     table.updateSpec().removeField("sub_dep").removeField("dep").commit();
@@ -495,7 +487,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep = 'd1'" /* query predicate */,
         "isnotnull(dep) AND (dep = d1)" /* Spark post scan filter */,
-        new String[] {"dep IS NOT NULL", "dep = 'd1'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep = 'd1'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1", "sd1")));
   }
 
@@ -513,7 +505,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because the current spec supports it
     checkOnlyIcebergFilters(
         "dep LIKE 'd1%'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep LIKE 'd1%'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep LIKE 'd1%'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
 
     Table table = validationCatalog.loadTable(tableIdent);
@@ -528,7 +520,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     // the filter can be pushed completely because both specs support it
     checkOnlyIcebergFilters(
         "dep LIKE 'd%'" /* query predicate */,
-        new String[] {"dep IS NOT NULL", "dep LIKE 'd%'"} /* Iceberg scan filters */,
+        "dep IS NOT NULL, dep LIKE 'd%'" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1"), row(2, 200, "d2")));
 
     // the filter can't be pushed completely because the second spec is truncate(dep, 1) and
@@ -536,9 +528,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
     checkFilters(
         "dep LIKE 'd1%' AND id = 1" /* query predicate */,
         "(isnotnull(id) AND StartsWith(dep, d1)) AND (id = 1)" /* Spark post scan filter */,
-        new String[] {
-          "dep IS NOT NULL", "id IS NOT NULL", "dep LIKE 'd1%'", "id = 1"
-        } /* Iceberg scan filters */,
+        "dep IS NOT NULL, id IS NOT NULL, dep LIKE 'd1%', id = 1" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100, "d1")));
   }
 
@@ -559,7 +549,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           // the filter can be pushed completely because the current spec supports it
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-07-01T00:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1625097600000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1625097600000000" /* Iceberg scan filters */,
               ImmutableList.of(row(1, 100, timestamp("2021-06-30T01:00:00.000Z"))));
 
           Table table = validationCatalog.loadTable(tableIdent);
@@ -574,7 +564,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           // the filter can be pushed completely because both specs support it
           checkOnlyIcebergFilters(
               "t < TIMESTAMP '2021-06-01T00:00:00.000Z'" /* query predicate */,
-              new String[] {"t IS NOT NULL", "t < 1622505600000000"} /* Iceberg scan filters */,
+              "t IS NOT NULL, t < 1622505600000000" /* Iceberg scan filters */,
               ImmutableList.of(row(2, 200, timestamp("2021-05-30T01:00:00.000Z"))));
         });
   }
@@ -593,28 +583,28 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
 
     checkOnlyIcebergFilters(
         "salary = 100.5" /* query predicate */,
-        new String[] {"salary IS NOT NULL", "salary = 100.5"} /* Iceberg scan filters */,
+        "salary IS NOT NULL, salary = 100.5" /* Iceberg scan filters */,
         ImmutableList.of(row(1, 100.5)));
 
     checkOnlyIcebergFilters(
         "salary = double('NaN')" /* query predicate */,
-        new String[] {"salary IS NOT NULL", "is_nan(salary)"} /* Iceberg scan filters */,
+        "salary IS NOT NULL, is_nan(salary)" /* Iceberg scan filters */,
         ImmutableList.of(row(2, Double.NaN)));
 
     checkOnlyIcebergFilters(
         "salary != double('NaN')" /* query predicate */,
-        new String[] {"salary IS NOT NULL", "NOT (is_nan(salary))"} /* Iceberg scan filters */,
+        "salary IS NOT NULL, NOT (is_nan(salary))" /* Iceberg scan filters */,
         ImmutableList.of(
             row(1, 100.5), row(3, Double.POSITIVE_INFINITY), row(4, Double.NEGATIVE_INFINITY)));
 
     checkOnlyIcebergFilters(
         "salary = double('infinity')" /* query predicate */,
-        new String[] {"salary IS NOT NULL", "salary = Infinity"} /* Iceberg scan filters */,
+        "salary IS NOT NULL, salary = Infinity" /* Iceberg scan filters */,
         ImmutableList.of(row(3, Double.POSITIVE_INFINITY)));
 
     checkOnlyIcebergFilters(
         "salary = double('-infinity')" /* query predicate */,
-        new String[] {"salary IS NOT NULL", "salary = -Infinity"} /* Iceberg scan filters */,
+        "salary IS NOT NULL, salary = -Infinity" /* Iceberg scan filters */,
         ImmutableList.of(row(4, Double.NEGATIVE_INFINITY)));
   }
 
@@ -640,7 +630,7 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IS NOT NULL",
               "isnotnull(data) AND isnotnull(try_variant_get(data, $.num, IntegerType, false, Some(UTC)))",
-              new String[] {"data IS NOT NULL"},
+              "data IS NOT NULL",
               ImmutableList.of(
                   row(1L, toSparkVariantRow("foo", 25)),
                   row(2L, toSparkVariantRow("bar", 30)),
@@ -649,44 +639,45 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IS NULL",
               "isnull(try_variant_get(data, $.num, IntegerType, false, Some(UTC)))",
-              new String[] {""},
+              "",
               ImmutableList.of(row(4L, null)));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') > 30",
               "isnotnull(data) AND (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) > 30)",
-              new String[] {"data IS NOT NULL"},
+              "data IS NOT NULL",
               ImmutableList.of(row(3L, toSparkVariantRow("baz", 35))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') = 30",
               "isnotnull(data) AND (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) = 30)",
-              new String[] {"data IS NOT NULL"},
+              "data IS NOT NULL",
               ImmutableList.of(row(2L, toSparkVariantRow("bar", 30))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') IN (25, 35)",
               "try_variant_get(data, $.num, IntegerType, false, Some(UTC)) IN (25,35)",
-              new String[] {""},
+              "",
               ImmutableList.of(
                   row(1L, toSparkVariantRow("foo", 25)), row(3L, toSparkVariantRow("baz", 35))));
 
           checkFilters(
               "try_variant_get(data, '$.num', 'int') != 25",
               "isnotnull(data) AND NOT (try_variant_get(data, $.num, IntegerType, false, Some(UTC)) = 25)",
-              new String[] {"data IS NOT NULL"},
+              "data IS NOT NULL",
               ImmutableList.of(
                   row(2L, toSparkVariantRow("bar", 30)), row(3L, toSparkVariantRow("baz", 35))));
         });
   }
 
   private void checkOnlyIcebergFilters(
-      String predicate, String[] icebergFilters, List<Object[]> expectedRows) {
+      String predicate, String icebergFilters, List<Object[]> expectedRows) {
+
     checkFilters(predicate, null, icebergFilters, expectedRows);
   }
 
   private void checkFilters(
-      String predicate, String sparkFilter, String[] icebergFilters, List<Object[]> expectedRows) {
+      String predicate, String sparkFilter, String icebergFilters, List<Object[]> expectedRows) {
 
     Action check =
         () -> {
@@ -706,20 +697,9 @@ public class TestFilterPushDown extends TestBaseWithCatalog {
       assertThat(planAsString).as("Should be no post scan filter").doesNotContain("Filter (");
     }
 
-    int startIndex = planAsString.indexOf("filters=");
-    int endIndex = planAsString.indexOf("runtimeFilters");
-    String filterStringFromPlan = planAsString.substring(startIndex, endIndex);
-    Arrays.stream(icebergFilters)
-        .forEach(
-            filter -> {
-              assertThat(filterStringFromPlan).as("Pushed filters must contain").contains(filter);
-            });
-    // This implies there should be no filter at all in Scan
-    if (icebergFilters.length == 0) {
-      assertThat(filterStringFromPlan.trim())
-          .as("Pushed filters must contain")
-          .isEqualTo("filters=,");
-    }
+    assertThat(planAsString)
+        .as("Pushed filters must match")
+        .contains(", filters=" + icebergFilters + ",");
   }
 
   private Timestamp timestamp(String timestampAsString) {


### PR DESCRIPTION
Impose order on filter expressions ( runtime as well as data) while checking for equality and hashCode of Spark Scans, so that structurally same scans do not mismatch. This is critical for re-use of exchange to happen , where the pushdown of filters may differ in order, due to spark code using Set type collection for collecting filters for pushdown, resulting in unpredictable ordering of filters when pushed.
The change involves flattening the expressions and then ordering them based, on each Predicate's string representation.

Once this code patch is reviewed, same modifications may be done in other spark versions too, if required backport for older versions.
