### PR TITLE
Core: v4 table metadata location should be optional

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Files.java
+++ b/api/src/main/java/org/apache/iceberg/Files.java
@@ -40,6 +40,9 @@ public class Files {
   }
 
   public static OutputFile localOutput(String file) {
+    if (file.startsWith("file:")) {
+      return localOutput(new File(file.replaceFirst("file:", "")));
+    }
     return localOutput(Paths.get(file).toAbsolutePath().toFile());
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -313,10 +313,16 @@ public class TableMetadata implements Serializable {
         SUPPORTED_TABLE_FORMAT_VERSION);
     Preconditions.checkArgument(
         formatVersion == 1 || uuid != null, "UUID is required in format v%s", formatVersion);
+    boolean locationOptional = formatVersion >= MIN_FORMAT_VERSION_OPTIONAL_LOCATION;
     Preconditions.checkArgument(
-        formatVersion >= MIN_FORMAT_VERSION_OPTIONAL_LOCATION || location != null,
+        locationOptional || location != null,
         "Table location is required in format v%s",
         formatVersion);
+    Preconditions.checkArgument(
+        !locationOptional || location == null || LocationUtil.hasScheme(location),
+        "Invalid table location in format v%s, must be absolute: %s",
+        formatVersion,
+        location);
     Preconditions.checkArgument(
         formatVersion > 1 || lastSequenceNumber == 0,
         "Sequence number must be 0 in v1: %s",

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -58,6 +58,7 @@ public class TableMetadata implements Serializable {
   static final int SUPPORTED_TABLE_FORMAT_VERSION = 4;
   static final int MIN_FORMAT_VERSION_ROW_LINEAGE = 3;
   static final int MIN_FORMAT_VERSION_PARQUET_MANIFESTS = 4;
+  static final int MIN_FORMAT_VERSION_OPTIONAL_LOCATION = 4;
   static final int INITIAL_SPEC_ID = 0;
   static final int INITIAL_SORT_ORDER_ID = 1;
   static final int INITIAL_SCHEMA_ID = 0;
@@ -312,6 +313,10 @@ public class TableMetadata implements Serializable {
         SUPPORTED_TABLE_FORMAT_VERSION);
     Preconditions.checkArgument(
         formatVersion == 1 || uuid != null, "UUID is required in format v%s", formatVersion);
+    Preconditions.checkArgument(
+        formatVersion >= MIN_FORMAT_VERSION_OPTIONAL_LOCATION || location != null,
+        "Table location is required in format v%s",
+        formatVersion);
     Preconditions.checkArgument(
         formatVersion > 1 || lastSequenceNumber == 0,
         "Sequence number must be 0 in v1: %s",

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -319,9 +319,7 @@ public class TableMetadata implements Serializable {
         "Table location is required in format v%s",
         formatVersion);
     Preconditions.checkArgument(
-        !locationOptional
-            || location == null
-            || LocationUtil.hasScheme(location),
+        !locationOptional || location == null || LocationUtil.hasScheme(location),
         "Invalid table location in format v%s, must be absolute: %s",
         formatVersion,
         location);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -319,7 +319,10 @@ public class TableMetadata implements Serializable {
         "Table location is required in format v%s",
         formatVersion);
     Preconditions.checkArgument(
-        !locationOptional || location == null || LocationUtil.hasScheme(location),
+        !locationOptional
+            || location == null
+            || LocationUtil.hasScheme(location)
+            || location.startsWith("/"),
         "Invalid table location in format v%s, must be absolute: %s",
         formatVersion,
         location);

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -321,8 +321,7 @@ public class TableMetadata implements Serializable {
     Preconditions.checkArgument(
         !locationOptional
             || location == null
-            || LocationUtil.hasScheme(location)
-            || location.startsWith("/"),
+            || LocationUtil.hasScheme(location),
         "Invalid table location in format v%s, must be absolute: %s",
         formatVersion,
         location);

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -167,7 +167,9 @@ public class TableMetadataParser {
 
     generator.writeNumberField(FORMAT_VERSION, metadata.formatVersion());
     generator.writeStringField(TABLE_UUID, metadata.uuid());
-    generator.writeStringField(LOCATION, metadata.location());
+    if (metadata.location() != null) {
+      generator.writeStringField(LOCATION, metadata.location());
+    }
     if (metadata.formatVersion() > 1) {
       generator.writeNumberField(LAST_SEQUENCE_NUMBER, metadata.lastSequenceNumber());
     }
@@ -347,7 +349,11 @@ public class TableMetadataParser {
         formatVersion);
 
     String uuid = JsonUtil.getStringOrNull(TABLE_UUID, node);
-    String location = JsonUtil.getString(LOCATION, node);
+    // location is required in v1-v3 but optional in v4 and later
+    String location =
+        formatVersion >= TableMetadata.MIN_FORMAT_VERSION_OPTIONAL_LOCATION
+            ? JsonUtil.getStringOrNull(LOCATION, node)
+            : JsonUtil.getString(LOCATION, node);
     long lastSequenceNumber;
     if (formatVersion > 1) {
       lastSequenceNumber = JsonUtil.getLong(LAST_SEQUENCE_NUMBER, node);

--- a/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/LocationUtil.java
@@ -65,7 +65,7 @@ public class LocationUtil {
    * file:}), per <a href="https://datatracker.ietf.org/doc/html/rfc3986#section-3.1">RFC 3986
    * section 3.1</a>.
    */
-  private static boolean hasScheme(String location) {
+  public static boolean hasScheme(String location) {
     for (int i = 0; i < location.length(); i += 1) {
       char ch = location.charAt(i);
       if (ch == ':') {

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -1222,8 +1222,8 @@ public class TestRemoveSnapshots extends TestBase {
         .as("Should contain only the statistics file of snapshot2")
         .isEqualTo(Lists.newArrayList(statisticsFile2.snapshotId()));
 
-    assertThat(new File(statsFileLocation1)).doesNotExist();
-    assertThat(new File(statsFileLocation2)).exists();
+    assertThat(new File(URI.create(statsFileLocation1))).doesNotExist();
+    assertThat(new File(URI.create(statsFileLocation2))).exists();
   }
 
   @TestTemplate
@@ -1260,7 +1260,7 @@ public class TestRemoveSnapshots extends TestBase {
         .as("Should contain only the statistics file of snapshot2")
         .isEqualTo(Lists.newArrayList(statisticsFile2.snapshotId()));
     // the reused stats file should exist.
-    assertThat(new File(statsFileLocation1)).exists();
+    assertThat(new File(URI.create(statsFileLocation1))).exists();
   }
 
   @TestTemplate
@@ -1291,8 +1291,8 @@ public class TestRemoveSnapshots extends TestBase {
         .as("Should contain only the statistics file of snapshot2")
         .isEqualTo(Lists.newArrayList(statisticsFile2.snapshotId()));
 
-    assertThat(new File(statsFileLocation1)).doesNotExist();
-    assertThat(new File(statsFileLocation2)).exists();
+    assertThat(new File(URI.create(statsFileLocation1))).doesNotExist();
+    assertThat(new File(URI.create(statsFileLocation2))).exists();
   }
 
   @TestTemplate
@@ -1326,7 +1326,7 @@ public class TestRemoveSnapshots extends TestBase {
         .as("Should contain only the statistics file of snapshot2")
         .isEqualTo(Lists.newArrayList(statisticsFile2.snapshotId()));
     // the reused stats file should exist.
-    assertThat(new File(statsFileLocation1)).exists();
+    assertThat(new File(URI.create(statsFileLocation1))).exists();
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
+++ b/core/src/test/java/org/apache/iceberg/TestRemoveSnapshots.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.times;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.net.URI;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -413,7 +414,7 @@ public class TestRemoveSnapshots extends TestBase {
 
     long t3 = waitUntilAfter(table.currentSnapshot().timestampMillis());
 
-    assertThat(listManifestFiles(new File(table.location()))).hasSize(3);
+    assertThat(listManifestFiles(new File(URI.create(table.location())))).hasSize(3);
 
     // Retain last 2 snapshots, which means 1 is deleted.
     Transaction tx = table.newTransaction();
@@ -422,7 +423,7 @@ public class TestRemoveSnapshots extends TestBase {
 
     assertThat(table.snapshots()).hasSize(2);
     assertThat(table.snapshot(firstSnapshotId)).isNull();
-    assertThat(listManifestLists(new File(table.location()))).hasSize(2);
+    assertThat(listManifestLists(new File(URI.create(table.location())))).hasSize(2);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
+++ b/core/src/test/java/org/apache/iceberg/TestSequenceNumberForV2Table.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
@@ -316,7 +317,9 @@ public class TestSequenceNumberForV2Table extends TestBase {
     V2Assert.assertEquals(
         "Last sequence number should be 1", 1, readMetadata().lastSequenceNumber());
     V2Assert.assertEquals(
-        "Should be 1 manifest list", 1, listManifestLists(new File(table.location())).size());
+        "Should be 1 manifest list",
+        1,
+        listManifestLists(new File(URI.create(table.location()))).size());
 
     table.newAppend().appendFile(FILE_B).commit();
     Snapshot snap2 = table.currentSnapshot();
@@ -328,7 +331,9 @@ public class TestSequenceNumberForV2Table extends TestBase {
     V2Assert.assertEquals(
         "Last sequence number should be 2", 2, readMetadata().lastSequenceNumber());
     V2Assert.assertEquals(
-        "Should be 2 manifest lists", 2, listManifestLists(new File(table.location())).size());
+        "Should be 2 manifest lists",
+        2,
+        listManifestLists(new File(URI.create(table.location()))).size());
 
     Transaction txn = table.newTransaction();
     txn.expireSnapshots().expireSnapshotId(commitId1).commit();
@@ -338,7 +343,7 @@ public class TestSequenceNumberForV2Table extends TestBase {
     V2Assert.assertEquals(
         "Should be 1 manifest list as 1 was deleted",
         1,
-        listManifestLists(new File(table.location())).size());
+        listManifestLists(new File(URI.create(table.location()))).size());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1133,6 +1133,64 @@ public class TestTableMetadata {
         .hasMessageStartingWith("Cannot read unsupported version");
   }
 
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3})
+  public void testLocationRequiredBeforeV4(int formatVersion) {
+    assertThatThrownBy(
+            () ->
+                TableMetadata.newTableMetadata(
+                    TEST_SCHEMA,
+                    PartitionSpec.unpartitioned(),
+                    SortOrder.unsorted(),
+                    null,
+                    ImmutableMap.of(),
+                    formatVersion))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Table location is required in format v%s", formatVersion);
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {1, 2, 3})
+  public void testParserRequiresLocationBeforeV4(int formatVersion) {
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            TEST_LOCATION,
+            ImmutableMap.of(),
+            formatVersion);
+    // drop the location field to simulate a v1-v3 metadata file that omits the required location
+    String withoutLocation =
+        TableMetadataParser.toJson(metadata)
+            .replaceFirst("\"location\"\\s*:\\s*\"[^\"]*\"\\s*,", "");
+
+    assertThatThrownBy(() -> TableMetadataParser.fromJson(withoutLocation))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(LOCATION);
+  }
+
+  @Test
+  public void testLocationOptionalInV4() {
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            null,
+            ImmutableMap.of(),
+            4);
+    assertThat(metadata.location()).isNull();
+
+    // location must be omitted from the serialized metadata, not written as a JSON null
+    String json = TableMetadataParser.toJson(metadata);
+    assertThat(json).doesNotContain("\"location\"");
+
+    // and the round trip must succeed with a null location
+    TableMetadata parsed = TableMetadataParser.fromJson(json);
+    assertThat(parsed.location()).isNull();
+  }
+
   @Test
   public void testParserV2PartitionSpecsValidation() throws Exception {
     String unsupportedVersion =
@@ -1311,7 +1369,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
     assertThat(meta.sortOrder().isUnsorted()).isTrue();
     assertThat(meta.replaceSortOrder(SortOrder.unsorted()))
         .as("Should detect identical unsorted order")
@@ -1326,7 +1384,7 @@ public class TestTableMetadata {
 
     TableMetadata sortedByX =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), order, null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), order, TEST_LOCATION, ImmutableMap.of());
     assertThat(sortedByX.sortOrders()).hasSize(1);
     assertThat(sortedByX.sortOrder().orderId()).isEqualTo(1);
     assertThat(sortedByX.sortOrder().fields()).hasSize(1);
@@ -1363,7 +1421,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
     assertThat(meta.statisticsFiles()).as("Should default to no statistics files").isEmpty();
   }
 
@@ -1373,7 +1431,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
 
     TableMetadata withStatistics =
         TableMetadata.buildFrom(meta)
@@ -1411,7 +1469,7 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.buildFrom(
                 TableMetadata.newTableMetadata(
-                    schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of()))
+                    schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of()))
             .setStatistics(
                 new GenericStatisticsFile(
                     43, "/some/path/to/stats/file", 128, 27, ImmutableList.of()))
@@ -1440,7 +1498,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
     assertThat(meta.partitionStatisticsFiles())
         .as("Should default to no partition statistics files")
         .isEmpty();
@@ -1452,7 +1510,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
 
     TableMetadata withPartitionStatistics =
         TableMetadata.buildFrom(meta)
@@ -1502,7 +1560,7 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.buildFrom(
                 TableMetadata.newTableMetadata(
-                    schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of()))
+                    schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of()))
             .setPartitionStatistics(
                 ImmutableGenericPartitionStatisticsFile.builder()
                     .snapshotId(43)
@@ -1559,7 +1617,7 @@ public class TestTableMetadata {
 
     TableMetadata meta =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
 
     Schema newSchema =
         new Schema(
@@ -1576,7 +1634,7 @@ public class TestTableMetadata {
         new Schema(0, Types.NestedField.required(1, "y", Types.LongType.get(), "comment"));
     TableMetadata freshTable =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), TEST_LOCATION, ImmutableMap.of());
     assertThat(freshTable.currentSchemaId()).isEqualTo(TableMetadata.INITIAL_SCHEMA_ID);
     assertSameSchemaList(ImmutableList.of(schema), freshTable.schemas());
     assertThat(freshTable.schema().asStruct()).isEqualTo(schema.asStruct());
@@ -1644,7 +1702,7 @@ public class TestTableMetadata {
         TableMetadata.newTableMetadata(
             schema,
             PartitionSpec.unpartitioned(),
-            null,
+            TEST_LOCATION,
             ImmutableMap.of(TableProperties.FORMAT_VERSION, "2", "key", "val"));
 
     assertThat(meta.formatVersion()).isEqualTo(2);
@@ -1730,7 +1788,7 @@ public class TestTableMetadata {
         TableMetadata.newTableMetadata(
             schema,
             PartitionSpec.unpartitioned(),
-            null,
+            TEST_LOCATION,
             ImmutableMap.of(
                 TableProperties.FORMAT_VERSION, String.valueOf(baseFormatVersion), "key", "val"));
 
@@ -1759,7 +1817,7 @@ public class TestTableMetadata {
         TableMetadata.newTableMetadata(
             schema,
             PartitionSpec.unpartitioned(),
-            null,
+            TEST_LOCATION,
             ImmutableMap.of(
                 TableProperties.FORMAT_VERSION, String.valueOf(baseFormatVersion), "key", "val"));
 
@@ -1964,7 +2022,10 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.buildFrom(
                 TableMetadata.newTableMetadata(
-                    TestBase.SCHEMA, PartitionSpec.unpartitioned(), null, ImmutableMap.of()))
+                    TestBase.SCHEMA,
+                    PartitionSpec.unpartitioned(),
+                    TEST_LOCATION,
+                    ImmutableMap.of()))
             .removeSpecs(Sets.newHashSet())
             .build();
 
@@ -1980,7 +2041,10 @@ public class TestTableMetadata {
     TableMetadata meta =
         TableMetadata.buildFrom(
                 TableMetadata.newTableMetadata(
-                    TestBase.SCHEMA, PartitionSpec.unpartitioned(), null, ImmutableMap.of()))
+                    TestBase.SCHEMA,
+                    PartitionSpec.unpartitioned(),
+                    TEST_LOCATION,
+                    ImmutableMap.of()))
             .removeSchemas(Sets.newHashSet())
             .build();
 

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -36,6 +36,7 @@ import static org.assertj.core.api.Assertions.entry;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.File;
 import java.io.IOException;
 import java.io.StringWriter;
@@ -1151,7 +1152,7 @@ public class TestTableMetadata {
 
   @ParameterizedTest
   @ValueSource(ints = {1, 2, 3})
-  public void testParserRequiresLocationBeforeV4(int formatVersion) {
+  public void testParserRequiresLocationBeforeV4(int formatVersion) throws Exception {
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             TEST_SCHEMA,
@@ -1161,9 +1162,9 @@ public class TestTableMetadata {
             ImmutableMap.of(),
             formatVersion);
     // drop the location field to simulate a v1-v3 metadata file that omits the required location
-    String withoutLocation =
-        TableMetadataParser.toJson(metadata)
-            .replaceFirst("\"location\"\\s*:\\s*\"[^\"]*\"\\s*,", "");
+    ObjectNode node = (ObjectNode) JsonUtil.mapper().readTree(TableMetadataParser.toJson(metadata));
+    node.remove(LOCATION);
+    String withoutLocation = JsonUtil.mapper().writeValueAsString(node);
 
     assertThatThrownBy(() -> TableMetadataParser.fromJson(withoutLocation))
         .isInstanceOf(IllegalArgumentException.class)
@@ -1189,6 +1190,21 @@ public class TestTableMetadata {
     // and the round trip must succeed with a null location
     TableMetadata parsed = TableMetadataParser.fromJson(json);
     assertThat(parsed.location()).isNull();
+  }
+
+  @Test
+  public void testV4LocationMustBeAbsolute() {
+    assertThatThrownBy(
+            () ->
+                TableMetadata.newTableMetadata(
+                    TEST_SCHEMA,
+                    PartitionSpec.unpartitioned(),
+                    SortOrder.unsorted(),
+                    "relative/path",
+                    ImmutableMap.of(),
+                    4))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid table location in format v4, must be absolute: relative/path");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -133,7 +133,8 @@ public class TestTables {
     }
 
     TableMetadata metadata =
-        newTableMetadata(schema, spec, sortOrder, temp.toString(), properties, formatVersion);
+        newTableMetadata(
+            schema, spec, sortOrder, temp.toURI().toString(), properties, formatVersion);
 
     if (metaTemp != null) {
       metadata =
@@ -164,7 +165,7 @@ public class TestTables {
     }
 
     TableMetadata metadata =
-        newTableMetadata(schema, spec, sortOrder, temp.toString(), ImmutableMap.of(), 1);
+        newTableMetadata(schema, spec, sortOrder, temp.toURI().toString(), ImmutableMap.of(), 1);
 
     return Transactions.createTableTransaction(name, ops, metadata);
   }
@@ -206,7 +207,7 @@ public class TestTables {
       metadata = current.buildReplacement(schema, spec, sortOrder, current.location(), properties);
       return Transactions.replaceTableTransaction(name, ops, metadata);
     } else {
-      metadata = newTableMetadata(schema, spec, sortOrder, temp.toString(), properties);
+      metadata = newTableMetadata(schema, spec, sortOrder, temp.toURI().toString(), properties);
       return Transactions.createTableTransaction(name, ops, metadata);
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -390,7 +390,8 @@ public class TestTables {
 
     @Override
     public void deleteFile(String path) {
-      if (!new File(path).delete()) {
+      String localPath = path.startsWith("file:") ? path.replaceFirst("file:", "") : path;
+      if (!new File(localPath).delete()) {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -146,7 +146,7 @@ public class TestLoadTableResponseParser {
     TableMetadata metadata =
         TableMetadata.buildFromEmpty(formatVersion)
             .assignUUID(uuid)
-            .setLocation("location")
+            .setLocation("/location")
             .setCurrentSchema(
                 new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
             .addPartitionSpec(PartitionSpec.unpartitioned())
@@ -164,7 +164,7 @@ public class TestLoadTableResponseParser {
                 + "  \"metadata\" : {\n"
                 + "    \"format-version\" : %s,\n"
                 + "    \"table-uuid\" : \"386b9f01-002b-4d8c-b77f-42c3fd3b7c9b\",\n"
-                + "    \"location\" : \"location\",\n"
+                + "    \"location\" : \"/location\",\n"
                 + "    \"last-sequence-number\" : 0,\n"
                 + "    \"last-updated-ms\" : %d,\n"
                 + "    \"last-column-id\" : 1,\n"

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -146,7 +146,7 @@ public class TestLoadTableResponseParser {
     TableMetadata metadata =
         TableMetadata.buildFromEmpty(formatVersion)
             .assignUUID(uuid)
-            .setLocation("location")
+            .setLocation("file:/location")
             .setCurrentSchema(
                 new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
             .addPartitionSpec(PartitionSpec.unpartitioned())
@@ -164,7 +164,7 @@ public class TestLoadTableResponseParser {
                 + "  \"metadata\" : {\n"
                 + "    \"format-version\" : %s,\n"
                 + "    \"table-uuid\" : \"386b9f01-002b-4d8c-b77f-42c3fd3b7c9b\",\n"
-                + "    \"location\" : \"location\",\n"
+                + "    \"location\" : \"file:/location\",\n"
                 + "    \"last-sequence-number\" : 0,\n"
                 + "    \"last-updated-ms\" : %d,\n"
                 + "    \"last-column-id\" : 1,\n"

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -146,7 +146,7 @@ public class TestLoadTableResponseParser {
     TableMetadata metadata =
         TableMetadata.buildFromEmpty(formatVersion)
             .assignUUID(uuid)
-            .setLocation("/location")
+            .setLocation("location")
             .setCurrentSchema(
                 new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
             .addPartitionSpec(PartitionSpec.unpartitioned())
@@ -164,7 +164,7 @@ public class TestLoadTableResponseParser {
                 + "  \"metadata\" : {\n"
                 + "    \"format-version\" : %s,\n"
                 + "    \"table-uuid\" : \"386b9f01-002b-4d8c-b77f-42c3fd3b7c9b\",\n"
-                + "    \"location\" : \"/location\",\n"
+                + "    \"location\" : \"location\",\n"
                 + "    \"last-sequence-number\" : 0,\n"
                 + "    \"last-updated-ms\" : %d,\n"
                 + "    \"last-column-id\" : 1,\n"

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -146,7 +146,7 @@ public class TestLoadTableResponseParser {
     TableMetadata metadata =
         TableMetadata.buildFromEmpty(formatVersion)
             .assignUUID(uuid)
-            .setLocation("file:/location")
+            .setLocation("file://location")
             .setCurrentSchema(
                 new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
             .addPartitionSpec(PartitionSpec.unpartitioned())
@@ -164,7 +164,7 @@ public class TestLoadTableResponseParser {
                 + "  \"metadata\" : {\n"
                 + "    \"format-version\" : %s,\n"
                 + "    \"table-uuid\" : \"386b9f01-002b-4d8c-b77f-42c3fd3b7c9b\",\n"
-                + "    \"location\" : \"file:/location\",\n"
+                + "    \"location\" : \"file://location\",\n"
                 + "    \"last-sequence-number\" : 0,\n"
                 + "    \"last-updated-ms\" : %d,\n"
                 + "    \"last-column-id\" : 1,\n"

--- a/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestHashWriter.java
@@ -53,7 +53,7 @@ public class TestHashWriter {
     Schema schema = new Schema(Types.NestedField.required(1, "col1", Types.StringType.get()));
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, icebergTblProperties);
+            schema, PartitionSpec.unpartitioned(), "file:///tmp/table", icebergTblProperties);
 
     JsonGenerator generator = JsonUtil.factory().createGenerator(hashWriter);
     TableMetadataParser.toJson(tableMetadata, generator);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -170,6 +170,8 @@ class TestIcebergCommitter extends TestBase {
 
     String tablePath = warehouse.concat("/test");
     assertThat(new File(tablePath).mkdir()).as("Should create the table path correctly.").isTrue();
+    // v4 table metadata requires an absolute (scheme-qualified) location
+    String tableLocation = "file:" + tablePath;
 
     Map<String, String> props =
         ImmutableMap.of(
@@ -179,8 +181,8 @@ class TestIcebergCommitter extends TestBase {
             flinkManifestFolder.getAbsolutePath(),
             IcebergCommitter.MAX_CONTINUOUS_EMPTY_COMMITS,
             "1");
-    table = SimpleDataUtil.createTable(tablePath, props, false);
-    tableLoader = TableLoader.fromHadoopTable(tablePath);
+    table = SimpleDataUtil.createTable(tableLocation, props, false);
+    tableLoader = TableLoader.fromHadoopTable(tableLocation);
   }
 
   @TestTemplate

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -170,6 +170,8 @@ class TestIcebergCommitter extends TestBase {
 
     String tablePath = warehouse.concat("/test");
     assertThat(new File(tablePath).mkdir()).as("Should create the table path correctly.").isTrue();
+    // v4 table metadata requires an absolute (scheme-qualified) location
+    String tableLocation = "file:" + tablePath;
 
     Map<String, String> props =
         ImmutableMap.of(
@@ -179,8 +181,8 @@ class TestIcebergCommitter extends TestBase {
             flinkManifestFolder.getAbsolutePath(),
             IcebergCommitter.MAX_CONTINUOUS_EMPTY_COMMITS,
             "1");
-    table = SimpleDataUtil.createTable(tablePath, props, false);
-    tableLoader = TableLoader.fromHadoopTable(tablePath);
+    table = SimpleDataUtil.createTable(tableLocation, props, false);
+    tableLoader = TableLoader.fromHadoopTable(tableLocation);
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -170,6 +170,8 @@ class TestIcebergCommitter extends TestBase {
 
     String tablePath = warehouse.concat("/test");
     assertThat(new File(tablePath).mkdir()).as("Should create the table path correctly.").isTrue();
+    // v4 table metadata requires an absolute (scheme-qualified) location
+    String tableLocation = "file:" + tablePath;
 
     Map<String, String> props =
         ImmutableMap.of(
@@ -179,8 +181,8 @@ class TestIcebergCommitter extends TestBase {
             flinkManifestFolder.getAbsolutePath(),
             IcebergCommitter.MAX_CONTINUOUS_EMPTY_COMMITS,
             "1");
-    table = SimpleDataUtil.createTable(tablePath, props, false);
-    tableLoader = TableLoader.fromHadoopTable(tablePath);
+    table = SimpleDataUtil.createTable(tableLocation, props, false);
+    tableLoader = TableLoader.fromHadoopTable(tableLocation);
   }
 
   @TestTemplate

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -1253,7 +1253,7 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
     Schema schema = new Schema(Types.NestedField.required(1, "col1", Types.StringType.get()));
     TableMetadata tableMetadata =
         TableMetadata.newTableMetadata(
-            schema, PartitionSpec.unpartitioned(), null, ImmutableMap.of());
+            schema, PartitionSpec.unpartitioned(), "file:///tmp/table", ImmutableMap.of());
 
     HMSTablePropertyHelper.setMetadataHash(tableMetadata, hiveTblProperties);
 

--- a/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
+++ b/nessie/src/test/java/org/apache/iceberg/nessie/TestNessieIcebergClient.java
@@ -593,6 +593,6 @@ public class TestNessieIcebergClient extends BaseTestIceberg {
   private static TableMetadata newTableMetadata() {
     Schema schema = new Schema(required(1, "id", Types.LongType.get()));
     return TableMetadata.newTableMetadata(
-        schema, PartitionSpec.unpartitioned(), SortOrder.unsorted(), null, Map.of());
+        schema, PartitionSpec.unpartitioned(), SortOrder.unsorted(), "file:///tmp/table", Map.of());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -738,7 +738,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .isEqualTo(false);
     Table table =
         TABLES.create(
-            SCHEMA, PartitionSpec.unpartitioned(), properties, tableDir.getAbsolutePath());
+            SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
@@ -749,7 +749,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .write()
         .format("iceberg")
         .mode("append")
-        .save(tableDir.getAbsolutePath());
+        .save(tableLocation);
 
     List<String> validFiles =
         spark

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -736,20 +736,14 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")
         .isEqualTo(false);
-    Table table =
-        TABLES.create(
-            SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    df.select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(tableLocation);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
     List<String> validFiles =
         spark

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -53,7 +53,8 @@ class TestTables {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
-    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString(), properties));
+    ops.commit(
+        null, TableMetadata.newTableMetadata(schema, spec, temp.toURI().toString(), properties));
     return new TestTable(ops, name);
   }
 
@@ -196,12 +197,13 @@ class TestTables {
 
     @Override
     public OutputFile newOutputFile(String path) {
-      return Files.localOutput(new File(path));
+      return Files.localOutput(path);
     }
 
     @Override
     public void deleteFile(String path) {
-      if (!new File(path).delete()) {
+      String localPath = path.startsWith("file:") ? path.replaceFirst("file:", "") : path;
+      if (!new File(localPath).delete()) {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -738,7 +738,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .isEqualTo(false);
     Table table =
         TABLES.create(
-            SCHEMA, PartitionSpec.unpartitioned(), properties, tableDir.getAbsolutePath());
+            SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
@@ -749,7 +749,7 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
         .write()
         .format("iceberg")
         .mode("append")
-        .save(tableDir.getAbsolutePath());
+        .save(tableLocation);
 
     List<String> validFiles =
         spark

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -736,20 +736,14 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")
         .isEqualTo(false);
-    Table table =
-        TABLES.create(
-            SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    df.select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(tableLocation);
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
     List<String> validFiles =
         spark

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -53,7 +53,8 @@ class TestTables {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
-    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString(), properties));
+    ops.commit(
+        null, TableMetadata.newTableMetadata(schema, spec, temp.toURI().toString(), properties));
     return new TestTable(ops, name);
   }
 
@@ -196,12 +197,13 @@ class TestTables {
 
     @Override
     public OutputFile newOutputFile(String path) {
-      return Files.localOutput(new File(path));
+      return Files.localOutput(path);
     }
 
     @Override
     public void deleteFile(String path) {
-      if (!new File(path).delete()) {
+      String localPath = path.startsWith("file:") ? path.replaceFirst("file:", "") : path;
+      if (!new File(localPath).delete()) {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -737,20 +737,14 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")
         .isEqualTo(false);
-    Table table =
-        TABLES.create(
-            SCHEMA, PartitionSpec.unpartitioned(), properties, tableDir.getAbsolutePath());
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
 
     List<ThreeColumnRecord> records =
         Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    df.select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(tableDir.getAbsolutePath());
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
 
     List<String> validFiles =
         spark

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestTables.java
@@ -53,7 +53,8 @@ class TestTables {
     if (ops.current() != null) {
       throw new AlreadyExistsException("Table %s already exists at location: %s", name, temp);
     }
-    ops.commit(null, TableMetadata.newTableMetadata(schema, spec, temp.toString(), properties));
+    ops.commit(
+        null, TableMetadata.newTableMetadata(schema, spec, temp.toURI().toString(), properties));
     return new TestTable(ops, name);
   }
 
@@ -196,12 +197,13 @@ class TestTables {
 
     @Override
     public OutputFile newOutputFile(String path) {
-      return Files.localOutput(new File(path));
+      return Files.localOutput(path);
     }
 
     @Override
     public void deleteFile(String path) {
-      if (!new File(path).delete()) {
+      String localPath = path.startsWith("file:") ? path.replaceFirst("file:", "") : path;
+      if (!new File(localPath).delete()) {
         throw new RuntimeIOException("Failed to delete file: " + path);
       }
     }


### PR DESCRIPTION
As part of the new relative paths spec, the field `location` on v4 table metadata has been made optional. 

This ensures that location is mandatory on v1-v3 and optional on v4. There's a few tests where we're (incorrectly) allowing an optional location on non-v4, so there's some test changes in here.