### PR TITLE
Core: Add table-name filter for MetricsReporter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -293,7 +293,7 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
 
   protected MetricsReporter metricsReporter() {
     if (metricsReporter == null) {
-      metricsReporter = CatalogUtil.loadMetricsReporter(properties());
+      metricsReporter = CatalogUtil.loadMetricsReporter(name(), properties());
     }
 
     return metricsReporter;

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -34,6 +34,25 @@ public class CatalogProperties {
   public static final String METRICS_REPORTER_IMPL = "metrics-reporter-impl";
 
   /**
+   * Java regex applied to {@code tableName()} of {@link org.apache.iceberg.metrics.ScanReport} and
+   * {@link org.apache.iceberg.metrics.CommitReport}. When set, only reports whose table name
+   * matches the pattern are forwarded to the configured {@link
+   * org.apache.iceberg.metrics.MetricsReporter}. Empty values are treated as not set.
+   */
+  public static final String METRICS_REPORTER_TABLE_NAME_INCLUDE =
+      "metrics-reporter.table-name.include";
+
+  /**
+   * Java regex applied to {@code tableName()} of {@link org.apache.iceberg.metrics.ScanReport} and
+   * {@link org.apache.iceberg.metrics.CommitReport}. When set, reports whose table name matches the
+   * pattern are dropped before reaching the configured {@link
+   * org.apache.iceberg.metrics.MetricsReporter}. When both include and exclude are set, exclude
+   * wins. Empty values are treated as not set.
+   */
+  public static final String METRICS_REPORTER_TABLE_NAME_EXCLUDE =
+      "metrics-reporter.table-name.exclude";
+
+  /**
    * Controls whether the catalog will cache table entries upon load.
    *
    * <p>If {@link #CACHE_EXPIRATION_INTERVAL_MS} is set to zero, this value will be ignored and the

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -60,6 +60,37 @@ public class CatalogProperties {
       "metrics-reporter.table-name.exclude";
 
   /**
+   * Comma-separated list of Java regexes applied to the namespace of the table a {@link
+   * org.apache.iceberg.metrics.ScanReport} or {@link org.apache.iceberg.metrics.CommitReport} was
+   * produced for. When set, only reports for tables whose namespace matches at least one pattern
+   * are forwarded to the configured {@link org.apache.iceberg.metrics.MetricsReporter}.
+   *
+   * <p>The namespace is the dot-joined form of the table's namespace levels, with the catalog name
+   * removed, so {@code db} matches a table reported as {@code prod.db.table} in a catalog named
+   * {@code prod}. Filtering on the namespace is less prone to unintended matches than filtering on
+   * the table name, because a namespace is part of the table's identity rather than a naming
+   * convention.
+   *
+   * <p>Each pattern is matched against the entire namespace rather than any substring of it. Empty
+   * values are treated as not set.
+   */
+  public static final String METRICS_REPORTER_NAMESPACE_INCLUDE =
+      "metrics-reporter.namespace.include";
+
+  /**
+   * Comma-separated list of Java regexes applied to the namespace of the table a {@link
+   * org.apache.iceberg.metrics.ScanReport} or {@link org.apache.iceberg.metrics.CommitReport} was
+   * produced for. When set, reports for tables whose namespace matches any pattern are dropped
+   * before reaching the configured {@link org.apache.iceberg.metrics.MetricsReporter}. An exclude
+   * match wins over an include match.
+   *
+   * <p>Each pattern is matched against the entire namespace rather than any substring of it. Empty
+   * values are treated as not set.
+   */
+  public static final String METRICS_REPORTER_NAMESPACE_EXCLUDE =
+      "metrics-reporter.namespace.exclude";
+
+  /**
    * Controls whether the catalog will cache table entries upon load.
    *
    * <p>If {@link #CACHE_EXPIRATION_INTERVAL_MS} is set to zero, this value will be ignored and the

--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -34,20 +34,27 @@ public class CatalogProperties {
   public static final String METRICS_REPORTER_IMPL = "metrics-reporter-impl";
 
   /**
-   * Java regex applied to {@code tableName()} of {@link org.apache.iceberg.metrics.ScanReport} and
-   * {@link org.apache.iceberg.metrics.CommitReport}. When set, only reports whose table name
-   * matches the pattern are forwarded to the configured {@link
-   * org.apache.iceberg.metrics.MetricsReporter}. Empty values are treated as not set.
+   * Comma-separated list of Java regexes applied to {@code tableName()} of {@link
+   * org.apache.iceberg.metrics.ScanReport} and {@link org.apache.iceberg.metrics.CommitReport}.
+   * When set, only reports whose table name matches at least one pattern are forwarded to the
+   * configured {@link org.apache.iceberg.metrics.MetricsReporter}.
+   *
+   * <p>Each pattern is matched against the entire table name rather than any substring of it, so
+   * {@code prod\..*} matches {@code prod.db.table} but not {@code production.db.table}. Empty
+   * values are treated as not set.
    */
   public static final String METRICS_REPORTER_TABLE_NAME_INCLUDE =
       "metrics-reporter.table-name.include";
 
   /**
-   * Java regex applied to {@code tableName()} of {@link org.apache.iceberg.metrics.ScanReport} and
-   * {@link org.apache.iceberg.metrics.CommitReport}. When set, reports whose table name matches the
-   * pattern are dropped before reaching the configured {@link
-   * org.apache.iceberg.metrics.MetricsReporter}. When both include and exclude are set, exclude
-   * wins. Empty values are treated as not set.
+   * Comma-separated list of Java regexes applied to {@code tableName()} of {@link
+   * org.apache.iceberg.metrics.ScanReport} and {@link org.apache.iceberg.metrics.CommitReport}.
+   * When set, reports whose table name matches any pattern are dropped before reaching the
+   * configured {@link org.apache.iceberg.metrics.MetricsReporter}. An exclude match wins over an
+   * include match.
+   *
+   * <p>Each pattern is matched against the entire table name rather than any substring of it. Empty
+   * values are treated as not set.
    */
   public static final String METRICS_REPORTER_TABLE_NAME_EXCLUDE =
       "metrics-reporter.table-name.exclude";

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.apache.iceberg.metrics.FilteringMetricsReporter;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -514,37 +515,38 @@ public class CatalogUtil {
    */
   public static MetricsReporter loadMetricsReporter(Map<String, String> properties) {
     String impl = properties.get(CatalogProperties.METRICS_REPORTER_IMPL);
-    if (impl == null) {
-      return LoggingMetricsReporter.instance();
-    }
-
-    LOG.info("Loading custom MetricsReporter implementation: {}", impl);
-    DynConstructors.Ctor<MetricsReporter> ctor;
-    try {
-      ctor =
-          DynConstructors.builder(MetricsReporter.class)
-              .loader(CatalogUtil.class.getClassLoader())
-              .impl(impl)
-              .buildChecked();
-    } catch (NoSuchMethodException e) {
-      throw new IllegalArgumentException(
-          String.format("Cannot initialize MetricsReporter, missing no-arg constructor: %s", impl),
-          e);
-    }
-
     MetricsReporter reporter;
-    try {
-      reporter = ctor.newInstance();
-    } catch (ClassCastException e) {
-      throw new IllegalArgumentException(
-          String.format(
-              "Cannot initialize MetricsReporter, %s does not implement MetricsReporter.", impl),
-          e);
+    if (impl == null) {
+      reporter = LoggingMetricsReporter.instance();
+    } else {
+      LOG.info("Loading custom MetricsReporter implementation: {}", impl);
+      DynConstructors.Ctor<MetricsReporter> ctor;
+      try {
+        ctor =
+            DynConstructors.builder(MetricsReporter.class)
+                .loader(CatalogUtil.class.getClassLoader())
+                .impl(impl)
+                .buildChecked();
+      } catch (NoSuchMethodException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot initialize MetricsReporter, missing no-arg constructor: %s", impl),
+            e);
+      }
+
+      try {
+        reporter = ctor.newInstance();
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Cannot initialize MetricsReporter, %s does not implement MetricsReporter.", impl),
+            e);
+      }
+
+      reporter.initialize(properties);
     }
 
-    reporter.initialize(properties);
-
-    return reporter;
+    return FilteringMetricsReporter.wrap(reporter, properties);
   }
 
   public static String fullTableName(String catalogName, TableIdentifier identifier) {

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -514,6 +514,24 @@ public class CatalogUtil {
    *     loaded class cannot be cast to the given interface type
    */
   public static MetricsReporter loadMetricsReporter(Map<String, String> properties) {
+    return loadMetricsReporter(null, properties);
+  }
+
+  /**
+   * Load a custom {@link MetricsReporter} implementation.
+   *
+   * <p>The implementation must have a no-arg constructor.
+   *
+   * @param catalogName name of the catalog the reporter is loaded for, used to derive a table's
+   *     namespace when filtering by namespace is configured
+   * @param properties catalog properties which contains class name of a custom {@link
+   *     MetricsReporter} implementation
+   * @return An initialized {@link MetricsReporter}.
+   * @throws IllegalArgumentException if class path not found or right constructor not found or the
+   *     loaded class cannot be cast to the given interface type
+   */
+  public static MetricsReporter loadMetricsReporter(
+      String catalogName, Map<String, String> properties) {
     String impl = properties.get(CatalogProperties.METRICS_REPORTER_IMPL);
     MetricsReporter reporter;
     if (impl == null) {
@@ -546,7 +564,7 @@ public class CatalogUtil {
       reporter.initialize(properties);
     }
 
-    return FilteringMetricsReporter.wrap(reporter, properties);
+    return FilteringMetricsReporter.wrap(reporter, catalogName, properties);
   }
 
   public static String fullTableName(String catalogName, TableIdentifier identifier) {

--- a/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import org.apache.iceberg.CatalogProperties;
+
+/**
+ * A {@link MetricsReporter} wrapper that drops {@link ScanReport} and {@link CommitReport}
+ * instances whose {@code tableName()} does not pass the configured include / exclude patterns
+ * before forwarding to a delegate reporter.
+ *
+ * <p>The patterns are Java regular expressions sourced from the catalog properties {@link
+ * CatalogProperties#METRICS_REPORTER_TABLE_NAME_INCLUDE} and {@link
+ * CatalogProperties#METRICS_REPORTER_TABLE_NAME_EXCLUDE}. When both are set, {@code exclude} wins
+ * over {@code include} (an explicit deny overrides an include). When neither is set, {@link
+ * #wrap(MetricsReporter, Map)} returns the delegate unchanged.
+ *
+ * <p>{@link MetricsReport} subtypes other than {@link ScanReport} and {@link CommitReport} are
+ * forwarded to the delegate without filtering, since they do not expose a {@code tableName()}.
+ */
+public class FilteringMetricsReporter implements MetricsReporter {
+
+  private final MetricsReporter delegate;
+  private final Pattern include;
+  private final Pattern exclude;
+
+  private FilteringMetricsReporter(MetricsReporter delegate, Pattern include, Pattern exclude) {
+    this.delegate = delegate;
+    this.include = include;
+    this.exclude = exclude;
+  }
+
+  /**
+   * Wraps the given delegate in a {@code FilteringMetricsReporter} when either include or exclude
+   * is configured in {@code properties}; otherwise returns the delegate unchanged so the default
+   * case incurs no runtime overhead.
+   *
+   * @param delegate the underlying reporter that receives forwarded reports
+   * @param properties catalog properties; consulted for the table-name include / exclude regex
+   * @return either the delegate unchanged, or a new filtering wrapper around it
+   */
+  public static MetricsReporter wrap(MetricsReporter delegate, Map<String, String> properties) {
+    Pattern include =
+        compileIfPresent(
+            properties.get(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE),
+            CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE);
+    Pattern exclude =
+        compileIfPresent(
+            properties.get(CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE),
+            CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE);
+    if (include == null && exclude == null) {
+      return delegate;
+    }
+    return new FilteringMetricsReporter(delegate, include, exclude);
+  }
+
+  private static Pattern compileIfPresent(String value, String propertyName) {
+    if (value == null || value.isEmpty()) {
+      return null;
+    }
+    try {
+      return Pattern.compile(value);
+    } catch (PatternSyntaxException e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid regex for %s: %s", propertyName, value), e);
+    }
+  }
+
+  @Override
+  public void report(MetricsReport report) {
+    String tableName = extractTableName(report);
+    if (tableName == null) {
+      delegate.report(report);
+      return;
+    }
+    if (exclude != null && exclude.matcher(tableName).matches()) {
+      return;
+    }
+    if (include != null && !include.matcher(tableName).matches()) {
+      return;
+    }
+    delegate.report(report);
+  }
+
+  private static String extractTableName(MetricsReport report) {
+    if (report instanceof ScanReport) {
+      return ((ScanReport) report).tableName();
+    }
+    if (report instanceof CommitReport) {
+      return ((CommitReport) report).tableName();
+    }
+    return null;
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
@@ -18,35 +18,42 @@
  */
 package org.apache.iceberg.metrics;
 
+import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 /**
  * A {@link MetricsReporter} wrapper that drops {@link ScanReport} and {@link CommitReport}
- * instances whose {@code tableName()} does not pass the configured include / exclude patterns
- * before forwarding to a delegate reporter.
+ * instances whose {@code tableName()} does not pass the configured include / exclude filters before
+ * forwarding to a delegate reporter.
  *
- * <p>The patterns are Java regular expressions sourced from the catalog properties {@link
+ * <p>The filters come from the catalog properties {@link
  * CatalogProperties#METRICS_REPORTER_TABLE_NAME_INCLUDE} and {@link
- * CatalogProperties#METRICS_REPORTER_TABLE_NAME_EXCLUDE}. When both are set, {@code exclude} wins
- * over {@code include} (an explicit deny overrides an include). When neither is set, {@link
- * #wrap(MetricsReporter, Map)} returns the delegate unchanged.
+ * CatalogProperties#METRICS_REPORTER_TABLE_NAME_EXCLUDE}, each holding a comma-separated list of
+ * Java regular expressions. An exclude match wins over an include match. When neither is set,
+ * {@link #wrap(MetricsReporter, Map)} returns the delegate unchanged so the default path incurs no
+ * overhead.
+ *
+ * <p>Patterns are matched against the entire table name rather than any substring of it, so {@code
+ * prod\..*} matches {@code prod.db.table} but not {@code production.db.table}.
  *
  * <p>{@link MetricsReport} subtypes other than {@link ScanReport} and {@link CommitReport} are
- * forwarded to the delegate without filtering, since they do not expose a {@code tableName()}.
+ * forwarded without filtering, since they do not identify a table.
  */
 public class FilteringMetricsReporter implements MetricsReporter {
 
   private final MetricsReporter delegate;
-  private final Pattern include;
-  private final Pattern exclude;
+  private final List<Pattern> tableNameInclude;
+  private final List<Pattern> tableNameExclude;
 
-  private FilteringMetricsReporter(MetricsReporter delegate, Pattern include, Pattern exclude) {
+  private FilteringMetricsReporter(
+      MetricsReporter delegate, List<Pattern> tableNameInclude, List<Pattern> tableNameExclude) {
     this.delegate = delegate;
-    this.include = include;
-    this.exclude = exclude;
+    this.tableNameInclude = tableNameInclude;
+    this.tableNameExclude = tableNameExclude;
   }
 
   /**
@@ -55,59 +62,89 @@ public class FilteringMetricsReporter implements MetricsReporter {
    * case incurs no runtime overhead.
    *
    * @param delegate the underlying reporter that receives forwarded reports
-   * @param properties catalog properties; consulted for the table-name include / exclude regex
+   * @param properties catalog properties; consulted for the table-name include / exclude filters
    * @return either the delegate unchanged, or a new filtering wrapper around it
    */
   public static MetricsReporter wrap(MetricsReporter delegate, Map<String, String> properties) {
-    Pattern include =
-        compileIfPresent(
-            properties.get(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE),
-            CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE);
-    Pattern exclude =
-        compileIfPresent(
-            properties.get(CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE),
-            CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE);
-    if (include == null && exclude == null) {
+    List<Pattern> tableNameInclude =
+        compilePatterns(properties, CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE);
+    List<Pattern> tableNameExclude =
+        compilePatterns(properties, CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE);
+
+    if (tableNameInclude.isEmpty() && tableNameExclude.isEmpty()) {
       return delegate;
     }
-    return new FilteringMetricsReporter(delegate, include, exclude);
+
+    return new FilteringMetricsReporter(delegate, tableNameInclude, tableNameExclude);
   }
 
-  private static Pattern compileIfPresent(String value, String propertyName) {
-    if (value == null || value.isEmpty()) {
-      return null;
+  private static List<Pattern> compilePatterns(
+      Map<String, String> properties, String propertyName) {
+    String value = properties.get(propertyName);
+    if (value == null || value.trim().isEmpty()) {
+      return ImmutableList.of();
     }
-    try {
-      return Pattern.compile(value);
-    } catch (PatternSyntaxException e) {
-      throw new IllegalArgumentException(
-          String.format("Invalid regex for %s: %s", propertyName, value), e);
+
+    ImmutableList.Builder<Pattern> patterns = ImmutableList.builder();
+    for (String pattern : value.split(",", -1)) {
+      String trimmed = pattern.trim();
+      if (trimmed.isEmpty()) {
+        continue;
+      }
+
+      try {
+        patterns.add(Pattern.compile(trimmed));
+      } catch (PatternSyntaxException e) {
+        throw new IllegalArgumentException(
+            String.format("Invalid regex for %s: %s", propertyName, trimmed), e);
+      }
     }
+
+    return patterns.build();
   }
 
   @Override
   public void report(MetricsReport report) {
-    String tableName = extractTableName(report);
+    String tableName = tableName(report);
     if (tableName == null) {
       delegate.report(report);
       return;
     }
-    if (exclude != null && exclude.matcher(tableName).matches()) {
+
+    if (!passes(tableName, tableNameInclude, tableNameExclude)) {
       return;
     }
-    if (include != null && !include.matcher(tableName).matches()) {
-      return;
-    }
+
     delegate.report(report);
   }
 
-  private static String extractTableName(MetricsReport report) {
+  private static boolean passes(String value, List<Pattern> include, List<Pattern> exclude) {
+    if (matchesAny(value, exclude)) {
+      return false;
+    }
+
+    return include.isEmpty() || matchesAny(value, include);
+  }
+
+  private static boolean matchesAny(String value, List<Pattern> patterns) {
+    for (Pattern pattern : patterns) {
+      if (pattern.matcher(value).matches()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  private static String tableName(MetricsReport report) {
     if (report instanceof ScanReport) {
       return ((ScanReport) report).tableName();
     }
+
     if (report instanceof CommitReport) {
       return ((CommitReport) report).tableName();
     }
+
     return null;
   }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
@@ -51,8 +51,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
  *
  * <p>{@link MetricsReport} subtypes other than {@link ScanReport} and {@link CommitReport} are
  * forwarded without filtering, since they do not identify a table.
+ *
+ * <p>Reports carry the table name as a single flattened string, so the namespace is recovered by
+ * dropping the catalog prefix and the last dot-separated element. A table name that itself contains
+ * a dot is therefore attributed to a namespace one level deeper than it belongs to; filter on the
+ * table-name level for those.
  */
 public class FilteringMetricsReporter implements MetricsReporter {
+
+  private static final List<String> SEPARATORS = ImmutableList.of(".", "/");
 
   private final MetricsReporter delegate;
   private final String catalogName;
@@ -131,7 +138,7 @@ public class FilteringMetricsReporter implements MetricsReporter {
     }
 
     ImmutableList.Builder<Pattern> patterns = ImmutableList.builder();
-    for (String pattern : value.split(",", -1)) {
+    for (String pattern : splitPatterns(value)) {
       String trimmed = pattern.trim();
       if (trimmed.isEmpty()) {
         continue;
@@ -146,6 +153,46 @@ public class FilteringMetricsReporter implements MetricsReporter {
     }
 
     return patterns.build();
+  }
+
+  /**
+   * Splits a comma-separated list of regular expressions, ignoring commas that belong to a pattern
+   * rather than separating two of them: bounded quantifiers such as {@code x{1,3}} and character
+   * classes such as {@code [,;]} both contain commas that are part of the regex.
+   */
+  private static List<String> splitPatterns(String value) {
+    ImmutableList.Builder<String> parts = ImmutableList.builder();
+    StringBuilder current = new StringBuilder();
+    int braceDepth = 0;
+    boolean inCharClass = false;
+    boolean escaped = false;
+
+    for (char c : value.toCharArray()) {
+      if (escaped) {
+        escaped = false;
+      } else if (c == '\\') {
+        escaped = true;
+      } else if (inCharClass) {
+        if (c == ']') {
+          inCharClass = false;
+        }
+      } else if (c == '[') {
+        inCharClass = true;
+      } else if (c == '{') {
+        braceDepth++;
+      } else if (c == '}') {
+        braceDepth = Math.max(0, braceDepth - 1);
+      } else if (c == ',' && braceDepth == 0) {
+        parts.add(current.toString());
+        current.setLength(0);
+        continue;
+      }
+
+      current.append(c);
+    }
+
+    parts.add(current.toString());
+    return parts.build();
   }
 
   @Override
@@ -195,19 +242,22 @@ public class FilteringMetricsReporter implements MetricsReporter {
    * expected catalog prefix.
    */
   private String namespace(String tableName) {
-    String prefix;
-    if (catalogName.contains("/") || catalogName.contains(":")) {
-      // URI-like catalog names are joined with /, as in thrift://host:port/db.table
-      prefix = catalogName.endsWith("/") ? catalogName : catalogName + "/";
-    } else {
-      prefix = catalogName + ".";
+    // CatalogUtil#fullTableName joins a URI-like catalog name with / and any other name with .,
+    // while RESTSessionCatalog always joins with ., so accept either rather than deciding from the
+    // catalog name which one the report must have used.
+    String withoutCatalog = null;
+    for (String separator : SEPARATORS) {
+      String prefix = catalogName.endsWith(separator) ? catalogName : catalogName + separator;
+      if (tableName.startsWith(prefix)) {
+        withoutCatalog = tableName.substring(prefix.length());
+        break;
+      }
     }
 
-    if (!tableName.startsWith(prefix)) {
+    if (withoutCatalog == null) {
       return null;
     }
 
-    String withoutCatalog = tableName.substring(prefix.length());
     int lastDot = withoutCatalog.lastIndexOf('.');
     return lastDot < 0 ? "" : withoutCatalog.substring(0, lastDot);
   }

--- a/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/FilteringMetricsReporter.java
@@ -27,18 +27,27 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 /**
  * A {@link MetricsReporter} wrapper that drops {@link ScanReport} and {@link CommitReport}
- * instances whose {@code tableName()} does not pass the configured include / exclude filters before
- * forwarding to a delegate reporter.
+ * instances that do not pass the configured namespace and table-name filters before forwarding to a
+ * delegate reporter.
  *
- * <p>The filters come from the catalog properties {@link
- * CatalogProperties#METRICS_REPORTER_TABLE_NAME_INCLUDE} and {@link
- * CatalogProperties#METRICS_REPORTER_TABLE_NAME_EXCLUDE}, each holding a comma-separated list of
- * Java regular expressions. An exclude match wins over an include match. When neither is set,
- * {@link #wrap(MetricsReporter, Map)} returns the delegate unchanged so the default path incurs no
+ * <p>Filtering happens on two levels, either of which may be configured on its own:
+ *
+ * <ul>
+ *   <li>namespace, via {@link CatalogProperties#METRICS_REPORTER_NAMESPACE_INCLUDE} and {@link
+ *       CatalogProperties#METRICS_REPORTER_NAMESPACE_EXCLUDE}
+ *   <li>table name, via {@link CatalogProperties#METRICS_REPORTER_TABLE_NAME_INCLUDE} and {@link
+ *       CatalogProperties#METRICS_REPORTER_TABLE_NAME_EXCLUDE}
+ * </ul>
+ *
+ * <p>Each property holds a comma-separated list of Java regular expressions. A report is forwarded
+ * unless a filter drops it, and the levels are applied independently: an exclude match on either
+ * level drops the report, and when a level has an include list configured the report must match it.
+ * An exclude match always wins over an include match. When no property is set, {@link
+ * #wrap(MetricsReporter, String, Map)} returns the delegate unchanged so the default path incurs no
  * overhead.
  *
- * <p>Patterns are matched against the entire table name rather than any substring of it, so {@code
- * prod\..*} matches {@code prod.db.table} but not {@code production.db.table}.
+ * <p>Patterns are matched against the entire namespace or table name rather than any substring of
+ * it, so {@code prod\..*} matches {@code prod.db.table} but not {@code production.db.table}.
  *
  * <p>{@link MetricsReport} subtypes other than {@link ScanReport} and {@link CommitReport} are
  * forwarded without filtering, since they do not identify a table.
@@ -46,36 +55,72 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 public class FilteringMetricsReporter implements MetricsReporter {
 
   private final MetricsReporter delegate;
+  private final String catalogName;
+  private final List<Pattern> namespaceInclude;
+  private final List<Pattern> namespaceExclude;
   private final List<Pattern> tableNameInclude;
   private final List<Pattern> tableNameExclude;
 
   private FilteringMetricsReporter(
-      MetricsReporter delegate, List<Pattern> tableNameInclude, List<Pattern> tableNameExclude) {
+      MetricsReporter delegate,
+      String catalogName,
+      List<Pattern> namespaceInclude,
+      List<Pattern> namespaceExclude,
+      List<Pattern> tableNameInclude,
+      List<Pattern> tableNameExclude) {
     this.delegate = delegate;
+    this.catalogName = catalogName;
+    this.namespaceInclude = namespaceInclude;
+    this.namespaceExclude = namespaceExclude;
     this.tableNameInclude = tableNameInclude;
     this.tableNameExclude = tableNameExclude;
   }
 
   /**
-   * Wraps the given delegate in a {@code FilteringMetricsReporter} when either include or exclude
-   * is configured in {@code properties}; otherwise returns the delegate unchanged so the default
-   * case incurs no runtime overhead.
+   * Wraps the given delegate in a {@code FilteringMetricsReporter} when any of the namespace or
+   * table-name filters is configured in {@code properties}; otherwise returns the delegate
+   * unchanged so the default case incurs no runtime overhead.
    *
    * @param delegate the underlying reporter that receives forwarded reports
-   * @param properties catalog properties; consulted for the table-name include / exclude filters
+   * @param catalogName name of the catalog the reports originate from, used to derive a table's
+   *     namespace from the reported table name. When null, namespace filters cannot be applied and
+   *     configuring them is rejected.
+   * @param properties catalog properties; consulted for the namespace and table-name filters
    * @return either the delegate unchanged, or a new filtering wrapper around it
    */
-  public static MetricsReporter wrap(MetricsReporter delegate, Map<String, String> properties) {
+  public static MetricsReporter wrap(
+      MetricsReporter delegate, String catalogName, Map<String, String> properties) {
+    List<Pattern> namespaceInclude =
+        compilePatterns(properties, CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE);
+    List<Pattern> namespaceExclude =
+        compilePatterns(properties, CatalogProperties.METRICS_REPORTER_NAMESPACE_EXCLUDE);
     List<Pattern> tableNameInclude =
         compilePatterns(properties, CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE);
     List<Pattern> tableNameExclude =
         compilePatterns(properties, CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE);
 
-    if (tableNameInclude.isEmpty() && tableNameExclude.isEmpty()) {
+    if (namespaceInclude.isEmpty()
+        && namespaceExclude.isEmpty()
+        && tableNameInclude.isEmpty()
+        && tableNameExclude.isEmpty()) {
       return delegate;
     }
 
-    return new FilteringMetricsReporter(delegate, tableNameInclude, tableNameExclude);
+    if (catalogName == null && !(namespaceInclude.isEmpty() && namespaceExclude.isEmpty())) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot filter metrics by namespace without a catalog name: %s, %s",
+              CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE,
+              CatalogProperties.METRICS_REPORTER_NAMESPACE_EXCLUDE));
+    }
+
+    return new FilteringMetricsReporter(
+        delegate,
+        catalogName,
+        namespaceInclude,
+        namespaceExclude,
+        tableNameInclude,
+        tableNameExclude);
   }
 
   private static List<Pattern> compilePatterns(
@@ -115,6 +160,13 @@ public class FilteringMetricsReporter implements MetricsReporter {
       return;
     }
 
+    if (!namespaceInclude.isEmpty() || !namespaceExclude.isEmpty()) {
+      String namespace = namespace(tableName);
+      if (namespace == null || !passes(namespace, namespaceInclude, namespaceExclude)) {
+        return;
+      }
+    }
+
     delegate.report(report);
   }
 
@@ -134,6 +186,30 @@ public class FilteringMetricsReporter implements MetricsReporter {
     }
 
     return false;
+  }
+
+  /**
+   * Derives the namespace of a reported table by removing the catalog name prefix and the table
+   * name, mirroring how {@code CatalogUtil#fullTableName} builds the reported name. Returns an
+   * empty string for a table directly under the catalog, or null when the name does not carry the
+   * expected catalog prefix.
+   */
+  private String namespace(String tableName) {
+    String prefix;
+    if (catalogName.contains("/") || catalogName.contains(":")) {
+      // URI-like catalog names are joined with /, as in thrift://host:port/db.table
+      prefix = catalogName.endsWith("/") ? catalogName : catalogName + "/";
+    } else {
+      prefix = catalogName + ".";
+    }
+
+    if (!tableName.startsWith(prefix)) {
+      return null;
+    }
+
+    String withoutCatalog = tableName.substring(prefix.length());
+    int lastDot = withoutCatalog.lastIndexOf('.');
+    return lastDot < 0 ? "" : withoutCatalog.substring(0, lastDot);
   }
 
   private static String tableName(MetricsReport report) {

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.apache.iceberg.metrics.FilteringMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.MetricsReporters;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -169,6 +170,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private FileIO io = null;
   private MetricsReporter reporter = null;
   private ExecutorService metricsExecutor = null;
+  private Map<String, String> reporterFilterProperties = ImmutableMap.of();
   private boolean reportingViaRestEnabled;
   private Integer pageSize = null;
   private CloseableGroup closeables = null;
@@ -274,6 +276,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                 .toUpperCase(Locale.US));
 
     this.reporter = CatalogUtil.loadMetricsReporter(mergedProps);
+    this.reporterFilterProperties = mergedProps;
     this.closeables.addCloseable(reporter);
 
     this.reportingViaRestEnabled =
@@ -666,11 +669,13 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     }
   }
 
-  private MetricsReporter metricsReporter(String metricsEndpoint, RESTClient restClient) {
+  @VisibleForTesting
+  MetricsReporter metricsReporter(String metricsEndpoint, RESTClient restClient) {
     if (reportingViaRestEnabled && endpoints.contains(Endpoint.V1_REPORT_METRICS)) {
       RESTMetricsReporter restMetricsReporter =
           new RESTMetricsReporter(restClient, metricsEndpoint, Map::of, metricsExecutor);
-      return MetricsReporters.combine(reporter, restMetricsReporter);
+      return MetricsReporters.combine(
+          reporter, FilteringMetricsReporter.wrap(restMetricsReporter, reporterFilterProperties));
     } else {
       return this.reporter;
     }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -171,6 +171,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private MetricsReporter reporter = null;
   private ExecutorService metricsExecutor = null;
   private Map<String, String> reporterFilterProperties = ImmutableMap.of();
+  private String reporterCatalogName = null;
   private boolean reportingViaRestEnabled;
   private Integer pageSize = null;
   private CloseableGroup closeables = null;
@@ -275,7 +276,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                     RESTCatalogProperties.SNAPSHOT_LOADING_MODE_DEFAULT.name())
                 .toUpperCase(Locale.US));
 
-    this.reporter = CatalogUtil.loadMetricsReporter(mergedProps);
+    // name() is only available after super.initialize below, so use the name argument here
+    this.reporter = CatalogUtil.loadMetricsReporter(name, mergedProps);
+    this.reporterCatalogName = name;
     this.reporterFilterProperties = mergedProps;
     this.closeables.addCloseable(reporter);
 
@@ -675,7 +678,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       RESTMetricsReporter restMetricsReporter =
           new RESTMetricsReporter(restClient, metricsEndpoint, Map::of, metricsExecutor);
       return MetricsReporters.combine(
-          reporter, FilteringMetricsReporter.wrap(restMetricsReporter, reporterFilterProperties));
+          reporter,
+          FilteringMetricsReporter.wrap(
+              restMetricsReporter, reporterCatalogName, reporterFilterProperties));
     } else {
       return this.reporter;
     }

--- a/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestCatalogUtil.java
@@ -43,6 +43,7 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.io.SupportsStorageCredentials;
+import org.apache.iceberg.metrics.FilteringMetricsReporter;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -264,6 +265,28 @@ public class TestCatalogUtil {
                         TestFileIONotImpl.class.getName())))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("does not implement MetricsReporter");
+  }
+
+  @Test
+  public void loadMetricsReporter_wrappedWhenTableNameFilterPresent() {
+    MetricsReporter metricsReporter =
+        CatalogUtil.loadMetricsReporter(
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_IMPL,
+                TestMetricsReporterDefault.class.getName(),
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE,
+                "prod\\..*"));
+    assertThat(metricsReporter).isInstanceOf(FilteringMetricsReporter.class);
+  }
+
+  @Test
+  public void loadMetricsReporter_notWrappedWhenFilterAbsent() {
+    MetricsReporter metricsReporter =
+        CatalogUtil.loadMetricsReporter(
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_IMPL,
+                TestMetricsReporterDefault.class.getName()));
+    assertThat(metricsReporter).isInstanceOf(TestMetricsReporterDefault.class);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.regex.PatternSyntaxException;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class TestFilteringMetricsReporter {
+
+  private static final ScanReport SCAN_PROD = newScanReport("prod_db.orders");
+  private static final ScanReport SCAN_TMP = newScanReport("prod_db.tmp_staging");
+  private static final ScanReport SCAN_DEV = newScanReport("dev_db.orders");
+  private static final CommitReport COMMIT_PROD = newCommitReport("prod_db.orders");
+
+  @Test
+  public void wrapReturnsDelegateWhenNoPropertiesSet() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped = FilteringMetricsReporter.wrap(delegate, ImmutableMap.of());
+    assertThat(wrapped).isSameAs(delegate);
+  }
+
+  @Test
+  public void wrapReturnsDelegateWhenPropertiesAreEmpty() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "",
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ""));
+    assertThat(wrapped).isSameAs(delegate);
+  }
+
+  @Test
+  public void includeOnlyForwardsMatchingTableNames() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod_db\\..*"));
+
+    wrapped.report(SCAN_PROD);
+    wrapped.report(SCAN_DEV);
+    wrapped.report(COMMIT_PROD);
+
+    assertThat(delegate.reports).containsExactly(SCAN_PROD, COMMIT_PROD);
+  }
+
+  @Test
+  public void excludeOnlyDropsMatchingTableNames() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*"));
+
+    wrapped.report(SCAN_PROD);
+    wrapped.report(SCAN_TMP);
+
+    assertThat(delegate.reports).containsExactly(SCAN_PROD);
+  }
+
+  @Test
+  public void excludeWinsOverInclude() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod_db\\..*",
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*"));
+
+    wrapped.report(SCAN_PROD);
+    wrapped.report(SCAN_TMP);
+    wrapped.report(SCAN_DEV);
+
+    assertThat(delegate.reports).containsExactly(SCAN_PROD);
+  }
+
+  @Test
+  public void unknownReportSubtypeIsForwardedWithoutFiltering() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "no_such\\..*"));
+
+    MetricsReport unknown = new MetricsReport() {};
+    wrapped.report(unknown);
+
+    assertThat(delegate.reports).containsExactly(unknown);
+  }
+
+  @Test
+  public void wrapThrowsClearErrorForInvalidRegex() {
+    assertThatThrownBy(
+            () ->
+                FilteringMetricsReporter.wrap(
+                    new CapturingMetricsReporter(),
+                    ImmutableMap.of(
+                        CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "[invalid")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE)
+        .hasMessageContaining("[invalid")
+        .hasCauseInstanceOf(PatternSyntaxException.class);
+  }
+
+  @Test
+  public void closeIsDelegated() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate, ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, ".*"));
+
+    wrapped.close();
+
+    assertThat(delegate.closed).isTrue();
+  }
+
+  private static ScanReport newScanReport(String tableName) {
+    return ImmutableScanReport.builder()
+        .tableName(tableName)
+        .snapshotId(1L)
+        .filter(Expressions.alwaysTrue())
+        .schemaId(1)
+        .projectedFieldIds(ImmutableList.of())
+        .projectedFieldNames(ImmutableList.of())
+        .scanMetrics(ImmutableScanMetricsResult.builder().build())
+        .metadata(ImmutableMap.of())
+        .build();
+  }
+
+  private static CommitReport newCommitReport(String tableName) {
+    return ImmutableCommitReport.builder()
+        .tableName(tableName)
+        .snapshotId(1L)
+        .sequenceNumber(1L)
+        .operation("append")
+        .commitMetrics(ImmutableCommitMetricsResult.builder().build())
+        .metadata(ImmutableMap.of())
+        .build();
+  }
+
+  private static class CapturingMetricsReporter implements MetricsReporter {
+    private final List<MetricsReport> reports = Lists.newArrayList();
+    private boolean closed = false;
+
+    @Override
+    public void report(MetricsReport report) {
+      reports.add(report);
+    }
+
+    @Override
+    public void close() {
+      this.closed = true;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.regex.PatternSyntaxException;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -131,6 +132,28 @@ public class TestFilteringMetricsReporter {
   }
 
   @Test
+  public void loadMetricsReporterFiltersThroughUserConfiguredReporter() {
+    StaticCapturingReporter.REPORTS.clear();
+    MetricsReporter reporter =
+        CatalogUtil.loadMetricsReporter(
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_IMPL,
+                StaticCapturingReporter.class.getName(),
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE,
+                "prod_db\\..*"));
+
+    reporter.report(SCAN_PROD);
+    reporter.report(SCAN_DEV);
+    reporter.report(COMMIT_PROD);
+
+    assertThat(StaticCapturingReporter.REPORTS)
+        .as(
+            "Reports configured via metrics-reporter-impl receive only table names that pass the"
+                + " include filter")
+        .containsExactly(SCAN_PROD, COMMIT_PROD);
+  }
+
+  @Test
   public void closeIsDelegated() {
     CapturingMetricsReporter delegate = new CapturingMetricsReporter();
     MetricsReporter wrapped =
@@ -178,6 +201,20 @@ public class TestFilteringMetricsReporter {
     @Override
     public void close() {
       this.closed = true;
+    }
+  }
+
+  /**
+   * Public no-arg reporter usable via {@code metrics-reporter-impl}. Captured reports live on a
+   * static list so the test can inspect what reached the underlying reporter after CatalogUtil
+   * instantiated it via reflection.
+   */
+  public static class StaticCapturingReporter implements MetricsReporter {
+    static final List<MetricsReport> REPORTS = Lists.newCopyOnWriteArrayList();
+
+    @Override
+    public void report(MetricsReport report) {
+      REPORTS.add(report);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
@@ -339,6 +339,58 @@ public class TestFilteringMetricsReporter {
   }
 
   @Test
+  public void namespaceFilterHandlesUriStyleCatalogNamesJoinedWithADot() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "thrift://localhost:9083",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "db"));
+
+    // RESTSessionCatalog joins the catalog name with a dot even when it looks like a URI
+    ScanReport report = newScanReport("thrift://localhost:9083.db.orders");
+    wrapped.report(report);
+    wrapped.report(newScanReport("thrift://localhost:9083.other.orders"));
+
+    assertThat(delegate.reports).containsExactly(report);
+  }
+
+  @Test
+  public void patternsMayContainBoundedQuantifiers() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            null,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE,
+                "prod_db\\.table_[0-9]{1,3}, prod_db\\.orders"));
+
+    ScanReport shard = newScanReport("prod_db.table_42");
+    wrapped.report(shard);
+    wrapped.report(SCAN_PROD);
+    wrapped.report(newScanReport("prod_db.table_1234"));
+
+    assertThat(delegate.reports).containsExactly(shard, SCAN_PROD);
+  }
+
+  @Test
+  public void patternsMayContainCharacterClassesWithCommas() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            null,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, "prod_db\\.[a-z,]+"));
+
+    wrapped.report(SCAN_PROD);
+    wrapped.report(SCAN_DEV);
+
+    assertThat(delegate.reports).containsExactly(SCAN_DEV);
+  }
+
+  @Test
   public void namespaceFilterDropsReportsWithoutExpectedCatalogPrefix() {
     CapturingMetricsReporter delegate = new CapturingMetricsReporter();
     MetricsReporter wrapped =

--- a/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
@@ -41,7 +41,7 @@ public class TestFilteringMetricsReporter {
   @Test
   public void wrapReturnsDelegateWhenNoPropertiesSet() {
     CapturingMetricsReporter delegate = new CapturingMetricsReporter();
-    MetricsReporter wrapped = FilteringMetricsReporter.wrap(delegate, ImmutableMap.of());
+    MetricsReporter wrapped = FilteringMetricsReporter.wrap(delegate, null, ImmutableMap.of());
     assertThat(wrapped).isSameAs(delegate);
   }
 
@@ -51,6 +51,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "",
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ""));
@@ -63,6 +64,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod_db\\..*"));
 
     wrapped.report(SCAN_PROD);
@@ -78,6 +80,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*"));
 
     wrapped.report(SCAN_PROD);
@@ -92,6 +95,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod_db\\..*",
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*"));
@@ -109,6 +113,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "no_such\\..*"));
 
     MetricsReport unknown = new MetricsReport() {};
@@ -123,6 +128,7 @@ public class TestFilteringMetricsReporter {
             () ->
                 FilteringMetricsReporter.wrap(
                     new CapturingMetricsReporter(),
+                    null,
                     ImmutableMap.of(
                         CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "[invalid")))
         .isInstanceOf(IllegalArgumentException.class)
@@ -158,7 +164,9 @@ public class TestFilteringMetricsReporter {
     CapturingMetricsReporter delegate = new CapturingMetricsReporter();
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
-            delegate, ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, ".*"));
+            delegate,
+            null,
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, ".*"));
 
     wrapped.close();
 
@@ -171,6 +179,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE,
                 "prod_db\\..*, analytics_db\\..*"));
@@ -189,6 +198,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(
                 CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*,dev_db\\..*"));
 
@@ -205,6 +215,7 @@ public class TestFilteringMetricsReporter {
     MetricsReporter wrapped =
         FilteringMetricsReporter.wrap(
             delegate,
+            null,
             ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod\\..*"));
 
     ScanReport prod = newScanReport("prod.orders");
@@ -215,6 +226,157 @@ public class TestFilteringMetricsReporter {
     wrapped.report(newScanReport("staging.prod.orders"));
 
     assertThat(delegate.reports).containsExactly(prod);
+  }
+
+  @Test
+  public void namespaceIncludeFiltersOnNamespaceOnly() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "cat",
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "prod,analytics"));
+
+    ScanReport prod = newScanReport("cat.prod.orders");
+    ScanReport analytics = newScanReport("cat.analytics.events");
+    wrapped.report(prod);
+    wrapped.report(analytics);
+    wrapped.report(newScanReport("cat.staging.orders"));
+    // a namespace that only shares a prefix must not match
+    wrapped.report(newScanReport("cat.production.orders"));
+
+    assertThat(delegate.reports).containsExactly(prod, analytics);
+  }
+
+  @Test
+  public void namespaceExcludeDropsMatchingNamespaces() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "cat",
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_NAMESPACE_EXCLUDE, "staging,sandbox"));
+
+    ScanReport prod = newScanReport("cat.prod.orders");
+    wrapped.report(prod);
+    wrapped.report(newScanReport("cat.staging.orders"));
+    wrapped.report(newScanReport("cat.sandbox.orders"));
+
+    assertThat(delegate.reports).containsExactly(prod);
+  }
+
+  @Test
+  public void namespaceAndTableNameFiltersCombine() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "cat",
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "prod",
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.bench_.*"));
+
+    ScanReport prod = newScanReport("cat.prod.orders");
+    wrapped.report(prod);
+    // in the included namespace, but excluded by table name
+    wrapped.report(newScanReport("cat.prod.bench_scratch"));
+    // outside the included namespace
+    wrapped.report(newScanReport("cat.staging.orders"));
+
+    assertThat(delegate.reports).containsExactly(prod);
+  }
+
+  @Test
+  public void namespaceFilterHandlesMultiLevelAndEmptyNamespaces() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "cat",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "a\\.b"));
+
+    ScanReport nested = newScanReport("cat.a.b.orders");
+    wrapped.report(nested);
+    wrapped.report(newScanReport("cat.a.orders"));
+    // table directly under the catalog has an empty namespace
+    wrapped.report(newScanReport("cat.orders"));
+
+    assertThat(delegate.reports).containsExactly(nested);
+  }
+
+  @Test
+  public void namespaceFilterHandlesCatalogNameContainingDots() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "my.cat",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "db"));
+
+    ScanReport report = newScanReport("my.cat.db.orders");
+    wrapped.report(report);
+    wrapped.report(newScanReport("my.cat.other.orders"));
+
+    assertThat(delegate.reports).containsExactly(report);
+  }
+
+  @Test
+  public void namespaceFilterHandlesUriStyleCatalogNames() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "thrift://localhost:9083",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "db"));
+
+    ScanReport report = newScanReport("thrift://localhost:9083/db.orders");
+    wrapped.report(report);
+    wrapped.report(newScanReport("thrift://localhost:9083/other.orders"));
+
+    assertThat(delegate.reports).containsExactly(report);
+  }
+
+  @Test
+  public void namespaceFilterDropsReportsWithoutExpectedCatalogPrefix() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            "cat",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, ".*"));
+
+    // the namespace cannot be derived, so the report cannot be shown to pass the filter
+    wrapped.report(newScanReport("other.db.orders"));
+
+    assertThat(delegate.reports).isEmpty();
+  }
+
+  @Test
+  public void namespaceFilterWithoutCatalogNameIsRejected() {
+    assertThatThrownBy(
+            () ->
+                FilteringMetricsReporter.wrap(
+                    new CapturingMetricsReporter(),
+                    null,
+                    ImmutableMap.of(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE, "prod")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CatalogProperties.METRICS_REPORTER_NAMESPACE_INCLUDE);
+  }
+
+  @Test
+  public void wrapThrowsClearErrorForInvalidNamespaceRegex() {
+    assertThatThrownBy(
+            () ->
+                FilteringMetricsReporter.wrap(
+                    new CapturingMetricsReporter(),
+                    "cat",
+                    ImmutableMap.of(
+                        CatalogProperties.METRICS_REPORTER_NAMESPACE_EXCLUDE, "[invalid")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CatalogProperties.METRICS_REPORTER_NAMESPACE_EXCLUDE)
+        .hasMessageContaining("[invalid");
   }
 
   private static ScanReport newScanReport(String tableName) {

--- a/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestFilteringMetricsReporter.java
@@ -165,6 +165,58 @@ public class TestFilteringMetricsReporter {
     assertThat(delegate.closed).isTrue();
   }
 
+  @Test
+  public void includeAcceptsCommaSeparatedPatterns() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE,
+                "prod_db\\..*, analytics_db\\..*"));
+
+    ScanReport analytics = newScanReport("analytics_db.events");
+    wrapped.report(SCAN_PROD);
+    wrapped.report(analytics);
+    wrapped.report(SCAN_DEV);
+
+    assertThat(delegate.reports).containsExactly(SCAN_PROD, analytics);
+  }
+
+  @Test
+  public void excludeAcceptsCommaSeparatedPatterns() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(
+                CatalogProperties.METRICS_REPORTER_TABLE_NAME_EXCLUDE, ".*\\.tmp_.*,dev_db\\..*"));
+
+    wrapped.report(SCAN_PROD);
+    wrapped.report(SCAN_TMP);
+    wrapped.report(SCAN_DEV);
+
+    assertThat(delegate.reports).containsExactly(SCAN_PROD);
+  }
+
+  @Test
+  public void patternsMatchWholeNameNotSubstring() {
+    CapturingMetricsReporter delegate = new CapturingMetricsReporter();
+    MetricsReporter wrapped =
+        FilteringMetricsReporter.wrap(
+            delegate,
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod\\..*"));
+
+    ScanReport prod = newScanReport("prod.orders");
+    // names that a substring match would wrongly accept
+    wrapped.report(prod);
+    wrapped.report(newScanReport("production.orders"));
+    wrapped.report(newScanReport("prod_sandbox.orders"));
+    wrapped.report(newScanReport("staging.prod.orders"));
+
+    assertThat(delegate.reports).containsExactly(prod);
+  }
+
   private static ScanReport newScanReport(String tableName) {
     return ImmutableScanReport.builder()
         .tableName(tableName)

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -93,6 +94,10 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.StorageCredential;
 import org.apache.iceberg.io.SupportsStorageCredentials;
 import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -3988,6 +3993,49 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
       catalog.close();
       overwriteCatalog.close();
     }
+  }
+
+  @Test
+  public void metricsFilterAppliesToRestMetricsReporter() throws Exception {
+    RESTCatalog catalog =
+        initCatalog(
+            "withFilter",
+            ImmutableMap.of(CatalogProperties.METRICS_REPORTER_TABLE_NAME_INCLUDE, "prod_db\\..*"));
+
+    String metricsEndpoint = "/v1/prefix/namespaces/x/tables/y/metrics";
+    RESTClient mockClient = mock(RESTClient.class);
+    MetricsReporter combined =
+        catalog.sessionCatalog().metricsReporter(metricsEndpoint, mockClient);
+
+    ScanReport excluded = scanReport("dev_db.scratch");
+    ScanReport included = scanReport("prod_db.orders");
+
+    combined.report(excluded);
+    combined.report(included);
+
+    // RESTMetricsReporter.report() submits to its executor and waits for completion via
+    // Tasks.range(1).run(...), so by the time both report() calls above have returned, all
+    // resulting client.post() invocations have already happened. The included report should
+    // produce exactly one post; the excluded one should produce none because the
+    // FilteringMetricsReporter wrapping the RESTMetricsReporter drops it before it reaches the
+    // REST client.
+    verify(mockClient, times(1))
+        .post(eq(metricsEndpoint), any(RESTRequest.class), any(), any(Supplier.class), any());
+
+    catalog.close();
+  }
+
+  private static ScanReport scanReport(String tableName) {
+    return ImmutableScanReport.builder()
+        .tableName(tableName)
+        .snapshotId(1L)
+        .filter(Expressions.alwaysTrue())
+        .schemaId(1)
+        .projectedFieldIds(ImmutableList.of())
+        .projectedFieldNames(ImmutableList.of())
+        .scanMetrics(ImmutableScanMetricsResult.builder().build())
+        .metadata(ImmutableMap.of())
+        .build();
   }
 
   private RESTCatalog catalog(RESTCatalogAdapter adapter) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -4013,13 +4013,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     combined.report(excluded);
     combined.report(included);
 
-    // RESTMetricsReporter.report() submits to its executor and waits for completion via
-    // Tasks.range(1).run(...), so by the time both report() calls above have returned, all
-    // resulting client.post() invocations have already happened. The included report should
-    // produce exactly one post; the excluded one should produce none because the
-    // FilteringMetricsReporter wrapping the RESTMetricsReporter drops it before it reaches the
-    // REST client.
-    verify(mockClient, times(1))
+    // RESTMetricsReporter dispatches each report to a single-threaded executor asynchronously, so
+    // the resulting client.post() happens off-thread. The excluded report is submitted first and
+    // dropped by the FilteringMetricsReporter before it reaches the REST client; the included one
+    // is submitted next and produces exactly one post. Because the executor is single-threaded and
+    // FIFO, observing the included post (waited for via timeout) guarantees the excluded report has
+    // already been processed, so times(1) confirms the filter suppressed it.
+    verify(mockClient, timeout(5000).times(1))
         .post(eq(metricsEndpoint), any(RESTRequest.class), any(), any(Supplier.class), any());
 
     catalog.close();

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -34,6 +34,10 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | cache-enabled                     | true               | Whether to cache catalog entries |
 | cache.expiration-interval-ms      | 30000              | How long catalog entries are locally cached, in milliseconds; 0 disables caching, negative values disable expiration |
 | metrics-reporter-impl | org.apache.iceberg.metrics.LoggingMetricsReporter | Custom `MetricsReporter` implementation to use in a catalog. See the [Metrics reporting](metrics-reporting.md) section for additional details |
+| metrics-reporter.namespace.include | null | Comma-separated Java regexes; when set, only reports for tables whose namespace matches one of them are reported. See the [Metrics reporting](metrics-reporting.md) section for additional details |
+| metrics-reporter.namespace.exclude | null | Comma-separated Java regexes; reports for tables whose namespace matches one of them are dropped, and an exclude match wins over an include match |
+| metrics-reporter.table-name.include | null | Comma-separated Java regexes; when set, only reports whose table name matches one of them are reported |
+| metrics-reporter.table-name.exclude | null | Comma-separated Java regexes; reports whose table name matches one of them are dropped, and an exclude match wins over an include match |
 | unique-table-location             | false              | Whether to use a unique location for new tables |
 | encryption.kms-impl               | null               | a custom `KeyManagementClient` implementation to use in a catalog for interactions with KMS (key management service). See the [Encryption](encryption.md) document for additional details |
 

--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -147,6 +147,27 @@ public class InMemoryMetricsReporter implements MetricsReporter {
 
 The [catalog property](catalog-properties.md) `metrics-reporter-impl` allows registering a given [`MetricsReporter`](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java) by specifying its fully-qualified class name, e.g. `metrics-reporter-impl=org.apache.iceberg.metrics.InMemoryMetricsReporter`.
 
+### Table-name filtering
+
+Reports forwarded to the configured `MetricsReporter` can be filtered by table name using two additional catalog properties. Both accept Java regular expressions matched against `ScanReport.tableName()` and `CommitReport.tableName()`:
+
+| Property | Effect |
+|---|---|
+| `metrics-reporter.table-name.include` | Forward only reports whose table name matches; drop the rest. |
+| `metrics-reporter.table-name.exclude` | Drop reports whose table name matches; forward the rest. |
+
+When both are set, `exclude` wins over `include` (an explicit deny overrides an include). When neither is set, behavior is identical to today (every report is forwarded, with no runtime overhead). Empty values are treated as not set to avoid accidentally silencing all metrics on misconfiguration.
+
+For example, to forward metrics only for tables in the `prod_db` namespace while still dropping any temporary tables under it:
+
+```
+metrics-reporter-impl=org.apache.iceberg.metrics.LoggingMetricsReporter
+metrics-reporter.table-name.include=prod_db\..*
+metrics-reporter.table-name.exclude=.*\.tmp_.*
+```
+
+The filter applies uniformly to all `MetricsReporter` implementations (`LoggingMetricsReporter`, `RESTMetricsReporter`, and custom user-supplied ones). Reports whose subtype does not expose a table name (i.e. anything other than `ScanReport` and `CommitReport`) are forwarded without filtering.
+
 ### Via the Java API during Scan planning
 
 Independently of the [`MetricsReporter`](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java) being registered at the catalog level via the `metrics-reporter-impl` property, it is also possible to supply additional reporters during scan planning as shown below:

--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -147,28 +147,36 @@ public class InMemoryMetricsReporter implements MetricsReporter {
 
 The [catalog property](catalog-properties.md) `metrics-reporter-impl` allows registering a given [`MetricsReporter`](https://github.com/apache/iceberg/blob/main/api/src/main/java/org/apache/iceberg/metrics/MetricsReporter.java) by specifying its fully-qualified class name, e.g. `metrics-reporter-impl=org.apache.iceberg.metrics.InMemoryMetricsReporter`.
 
-### Table-name filtering
+### Filtering which tables are reported
 
-Reports forwarded to the configured `MetricsReporter` can be filtered by table name using two additional catalog properties. Both accept a comma-separated list of Java regular expressions matched against `ScanReport.tableName()` and `CommitReport.tableName()`:
+Reports forwarded to the configured `MetricsReporter` can be filtered on two levels, either of which may be used on its own:
 
 | Property | Effect |
 |---|---|
+| `metrics-reporter.namespace.include` | Forward only reports for tables whose namespace matches; drop the rest. |
+| `metrics-reporter.namespace.exclude` | Drop reports for tables whose namespace matches; forward the rest. |
 | `metrics-reporter.table-name.include` | Forward only reports whose table name matches; drop the rest. |
 | `metrics-reporter.table-name.exclude` | Drop reports whose table name matches; forward the rest. |
 
-Patterns are matched against the **entire** table name rather than any substring of it. This matters in practice: `prod\..*` matches `prod.db.table` but not `production.db.table` or `prod_sandbox.db.table`, which a substring match would wrongly accept.
+Each property accepts a comma-separated list of Java regular expressions. Namespace patterns are matched against the table's namespace levels joined by dots, with the catalog name removed; table-name patterns are matched against `ScanReport.tableName()` and `CommitReport.tableName()`, which include the catalog name.
 
-When both are set, `exclude` wins over `include` (an explicit deny overrides an include). When neither is set, behavior is identical to today (every report is forwarded, with no runtime overhead). Empty values are treated as not set to avoid accidentally silencing all metrics on misconfiguration.
+Patterns are matched against the **entire** namespace or table name rather than any substring of it. This matters in practice: `prod\..*` matches `prod.db.table` but not `production.db.table` or `prod_sandbox.db.table`, which a substring match would wrongly accept.
 
-For example, to forward metrics for the `prod_db` and `analytics_db` databases while still dropping any temporary tables under them:
+An `exclude` match always wins over an `include` match, and the two levels are applied independently — a report must survive both to be forwarded. When no property is set, behavior is identical to today: every report is forwarded, and no wrapper is instantiated. Empty values are treated as not set, to avoid accidentally silencing all metrics on misconfiguration.
+
+Filtering by namespace is less error-prone than filtering by table name, because a namespace is part of a table's identity rather than a naming convention: a table added to an included namespace later is picked up automatically, and no table outside that namespace can match by accident. Table-name patterns remain available for cases a namespace cannot express, such as excluding a few noisy tables inside an otherwise interesting namespace.
+
+For example, to report on the `prod` and `analytics` namespaces while dropping benchmark tables anywhere:
 
 ```
 metrics-reporter-impl=org.apache.iceberg.metrics.LoggingMetricsReporter
-metrics-reporter.table-name.include=prod_db\..*,analytics_db\..*
-metrics-reporter.table-name.exclude=.*\.tmp_.*
+metrics-reporter.namespace.include=prod,analytics
+metrics-reporter.table-name.exclude=.*\.bench_.*
 ```
 
-The filter applies uniformly to all `MetricsReporter` implementations (`LoggingMetricsReporter`, `RESTMetricsReporter`, and custom user-supplied ones). Reports whose subtype does not expose a table name (i.e. anything other than `ScanReport` and `CommitReport`) are forwarded without filtering.
+The filter applies uniformly to all `MetricsReporter` implementations (`LoggingMetricsReporter`, `RESTMetricsReporter`, and custom user-supplied ones). Reports whose subtype does not identify a table (i.e. anything other than `ScanReport` and `CommitReport`) are forwarded without filtering.
+
+Namespace filtering requires the catalog name, which the catalog supplies when it loads the reporter. Configuring a namespace filter where no catalog name is available fails at initialization with a clear error rather than silently dropping reports.
 
 ### Via the Java API during Scan planning
 

--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -149,20 +149,22 @@ The [catalog property](catalog-properties.md) `metrics-reporter-impl` allows reg
 
 ### Table-name filtering
 
-Reports forwarded to the configured `MetricsReporter` can be filtered by table name using two additional catalog properties. Both accept Java regular expressions matched against `ScanReport.tableName()` and `CommitReport.tableName()`:
+Reports forwarded to the configured `MetricsReporter` can be filtered by table name using two additional catalog properties. Both accept a comma-separated list of Java regular expressions matched against `ScanReport.tableName()` and `CommitReport.tableName()`:
 
 | Property | Effect |
 |---|---|
 | `metrics-reporter.table-name.include` | Forward only reports whose table name matches; drop the rest. |
 | `metrics-reporter.table-name.exclude` | Drop reports whose table name matches; forward the rest. |
 
+Patterns are matched against the **entire** table name rather than any substring of it. This matters in practice: `prod\..*` matches `prod.db.table` but not `production.db.table` or `prod_sandbox.db.table`, which a substring match would wrongly accept.
+
 When both are set, `exclude` wins over `include` (an explicit deny overrides an include). When neither is set, behavior is identical to today (every report is forwarded, with no runtime overhead). Empty values are treated as not set to avoid accidentally silencing all metrics on misconfiguration.
 
-For example, to forward metrics only for tables in the `prod_db` namespace while still dropping any temporary tables under it:
+For example, to forward metrics for the `prod_db` and `analytics_db` databases while still dropping any temporary tables under them:
 
 ```
 metrics-reporter-impl=org.apache.iceberg.metrics.LoggingMetricsReporter
-metrics-reporter.table-name.include=prod_db\..*
+metrics-reporter.table-name.include=prod_db\..*,analytics_db\..*
 metrics-reporter.table-name.exclude=.*\.tmp_.*
 ```
 


### PR DESCRIPTION
Closes #16573.

Adds an optional filtering layer above any `MetricsReporter` implementation that drops `ScanReport` and `CommitReport` instances whose `tableName()` does not pass the configured include / exclude regex. The filter applies uniformly to `LoggingMetricsReporter`, `RESTMetricsReporter`, and custom user-supplied reporters. The proposal surfaced in the dev@ DISCUSS thread for #16250 (per-table cardinality of the OTel reporter) and is intentionally scoped as cross-reporter, not OTel-specific.

## Design

`CatalogUtil.loadMetricsReporter` wraps the resolved reporter in a `FilteringMetricsReporter` when either of the new properties is set. When neither is set, the resolved reporter is returned unchanged — no wrapper instantiated, no runtime overhead on the default path. `MetricsReport` subtypes that do not expose a table name (anything other than `ScanReport` / `CommitReport`) are forwarded without filtering.

## Configuration

Two new catalog properties:

```
metrics-reporter.table-name.include=prod_db\..*
metrics-reporter.table-name.exclude=.*\.tmp_.*
```

Values are Java regex patterns matched against the table name. When both are set, `exclude` wins over `include` (an explicit deny overrides an include). Empty values are treated as not set to avoid accidentally silencing all metrics on misconfiguration. Invalid regex values fail fast at catalog initialization with a clear error pointing at the offending property.

Behavior:

- `include` only: forward reports whose table name matches; drop others.
- `exclude` only: drop reports whose table name matches; forward others.
- Both set: drop if `exclude` matches; otherwise forward only if `include` matches.
- Neither set: forward everything (current behavior).

This mirrors the existing `route-regex` pattern used in `iceberg-kafka-connect` (`IcebergSinkConfig`), where a user-supplied regex from configuration is compiled via `Pattern.compile()` and matched against incoming data. Same trust model: catalog property = admin-controlled.

## Design choice — where the filter wrap lives in REST catalog flow

The REST catalog adds an additional `RESTMetricsReporter` per-table inside `RESTSessionCatalog.metricsReporter(...)`, separate from the user's `metrics-reporter-impl`. To make the table-name filter apply uniformly to both reporters, three shapes were considered:

**A. Wrap inside `RESTSessionCatalog.metricsReporter(...)`** (chosen). The `RESTMetricsReporter` is wrapped with `FilteringMetricsReporter` using the catalog properties stored at init, then combined with the user reporter. Smallest local change. Keeps `MetricsReporters` and `FilteringMetricsReporter` mutually unaware. The additional wrap lives next to the existing `combine(reporter, restMetricsReporter)` line, which is itself REST-specific wiring.

**B. Make `MetricsReporters.combine()` aware of `FilteringMetricsReporter`**. Detect when one input is a filtering wrapper and "lift" it to wrap the composite. Avoids touching REST catalog code; would apply uniformly to any future combine site. But couples a generic utility to a specific reporter implementation and changes `combine()` semantics for all callers.

**C. Wrap at the scan/commit framework layer** (`TableScanContext` / `BaseTable.combineMetricsReporter`). Apply the filter wrap on the final composed reporter at the point it's used. Catalog-agnostic. But touches scan/commit framework code for what is logically a catalog-level concern, and requires plumbing filter properties down to that layer.

Option A was preferred because the `combine(reporter, restMetricsReporter)` line in `RESTSessionCatalog` is already REST-specific wiring (no other catalog does this combine), so the additional wrap lives in the same conceptual location rather than introducing knowledge of filtering elsewhere. Happy to revisit if reviewers prefer one of the other shapes.

## Disclosure

Per the project's [AI-assisted contribution guidelines](https://iceberg.apache.org/contribute/#guidelines-for-ai-assisted-contributions), I used Claude Code to help draft this work. I reviewed every change by hand and ran the full test/lint loop locally before opening this PR. The design and motivation discussion is in #16573.

cc @ebyhr @jbonofre — happy to address any feedback.
