### PR TITLE
Data: Add TCK for Writer builder in FileFormat API

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -69,6 +70,7 @@ import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
@@ -197,51 +199,9 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterEngineWriteGenericRead(FileFormat fileFormat, DataGenerator dataGenerator)
       throws IOException {
     Schema schema = dataGenerator.schema();
-    FileWriterBuilder<DataWriter<T>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, engineType(), encryptedFile);
-
-    DataWriter<T> writer = writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
-
     List<Record> genericRecords = dataGenerator.generateRecords();
     List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
-
-    try (writer) {
-      engineRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
-
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(engineRecords.size());
-    assertThat(dataFile.format()).isEqualTo(fileFormat);
-
-    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
-  }
-
-  /** Write with engine type T without explicit engineSchema, read with Generic Record */
-  @ParameterizedTest
-  @FieldSource("FORMAT_AND_GENERATOR")
-  void testDataWriterEngineWriteWithoutEngineSchema(
-      FileFormat fileFormat, DataGenerator dataGenerator) throws IOException {
-    Schema schema = dataGenerator.schema();
-    FileWriterBuilder<DataWriter<T>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, engineType(), encryptedFile);
-
-    DataWriter<T> writer = writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
-
-    List<Record> genericRecords = dataGenerator.generateRecords();
-    List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
-
-    try (writer) {
-      engineRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
-
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(engineRecords.size());
-    assertThat(dataFile.format()).isEqualTo(fileFormat);
-
+    writeEngineRecords(fileFormat, schema, engineRecords);
     readAndAssertGenericRecords(fileFormat, schema, genericRecords);
   }
 
@@ -274,34 +234,10 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterEngineWriteEngineRead(FileFormat fileFormat, DataGenerator dataGenerator)
       throws IOException {
     Schema schema = dataGenerator.schema();
-    FileWriterBuilder<DataWriter<T>, Object> writerBuilder =
-        FormatModelRegistry.dataWriteBuilder(fileFormat, engineType(), encryptedFile);
-
-    DataWriter<T> writer = writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned()).build();
-
     List<Record> genericRecords = dataGenerator.generateRecords();
     List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
-
-    try (writer) {
-      engineRecords.forEach(writer::write);
-    }
-
-    DataFile dataFile = writer.toDataFile();
-
-    assertThat(dataFile).isNotNull();
-    assertThat(dataFile.recordCount()).isEqualTo(engineRecords.size());
-    assertThat(dataFile.format()).isEqualTo(fileFormat);
-
-    InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
-    List<T> readRecords;
-    try (CloseableIterable<T> reader =
-        FormatModelRegistry.readBuilder(fileFormat, engineType(), inputFile)
-            .project(schema)
-            .build()) {
-      readRecords = ImmutableList.copyOf(reader);
-    }
-
-    assertEquals(schema, engineRecords, readRecords);
+    writeEngineRecords(fileFormat, schema, engineRecords);
+    readAndAssertEngineRecords(fileFormat, schema, genericRecords, Function.identity());
   }
 
   /** Write with engine type T, read with Generic Record */
@@ -1662,6 +1598,69 @@ public abstract class BaseFormatModelTests<T> {
     assertEquals(icebergSchema, convertToEngineRecords(genericRecords, icebergSchema), readRecords);
   }
 
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterOverwrite(FileFormat fileFormat) throws IOException {
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+    List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
+
+    writeEngineRecords(fileFormat, schema, engineRecords);
+    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
+
+    assertThatThrownBy(() -> writeEngineRecords(fileFormat, schema, engineRecords))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Already exists");
+
+    genericRecords = dataGenerator.generateRecords();
+    writeEngineRecords(fileFormat, schema, convertToEngineRecords(genericRecords, schema), true);
+    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterSet(FileFormat fileFormat) throws IOException {
+    writeAndAssertDataWriterWithConfig(
+        fileFormat,
+        (writerBuilder, format) ->
+            writerBuilder.set(compressionProperty(format), compressionValue(format)),
+        format ->
+            assertThat(actualCompressionCodec(format)).isEqualTo(expectedCompressionCodec(format)));
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterSetAll(FileFormat fileFormat) throws IOException {
+    writeAndAssertDataWriterWithConfig(
+        fileFormat,
+        (writerBuilder, format) ->
+            writerBuilder.setAll(Map.of(compressionProperty(format), compressionValue(format))),
+        format ->
+            assertThat(actualCompressionCodec(format)).isEqualTo(expectedCompressionCodec(format)));
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMeta(FileFormat fileFormat) throws IOException {
+    writeAndAssertDataWriterWithConfig(
+        fileFormat,
+        (writerBuilder, format) -> writerBuilder.meta("tck.meta.key", "tck-meta-value"),
+        format ->
+            assertThat(fileMetadataValue(format, "tck.meta.key")).isEqualTo("tck-meta-value"));
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testDataWriterMetaMap(FileFormat fileFormat) throws IOException {
+    writeAndAssertDataWriterWithConfig(
+        fileFormat,
+        (writerBuilder, format) -> writerBuilder.meta(Map.of("tck.meta.key", "tck-meta-value")),
+        format ->
+            assertThat(fileMetadataValue(format, "tck.meta.key")).isEqualTo("tck-meta-value"));
+  }
+
   private void readAndAssertGenericRecords(
       FileFormat fileFormat, Schema schema, List<Record> expected) throws IOException {
     InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
@@ -2205,13 +2204,7 @@ public abstract class BaseFormatModelTests<T> {
     }
 
     InputFile inputFile = outputFile.toInputFile();
-    OrcFile.ReaderOptions readerOptions =
-        OrcFile.readerOptions(conf)
-            .useUTCTimestamp(true)
-            .filesystem(OrcWritingTestUtils.inputFileSystem(inputFile))
-            .maxLength(inputFile.getLength());
-
-    try (Reader reader = OrcFile.createReader(hadoopPath, readerOptions)) {
+    try (Reader reader = newOrcReader(inputFile, conf)) {
       assertThat(TestORCSchemaUtil.hasIds(reader.getSchema())).isFalse();
     }
   }
@@ -2256,5 +2249,168 @@ public abstract class BaseFormatModelTests<T> {
     assertThat(readRecords).hasSize(expectedGenericRecords.size());
     assertEquals(
         readSchema, convertToEngineRecords(expectedGenericRecords, readSchema), readRecords);
+  }
+
+  private DataFile writeEngineRecords(FileFormat fileFormat, Schema schema, List<T> records)
+      throws IOException {
+    return writeEngineRecords(fileFormat, schema, records, false);
+  }
+
+  private DataFile writeEngineRecords(
+      FileFormat fileFormat, Schema schema, List<T> records, boolean overwrite) throws IOException {
+    FileWriterBuilder<DataWriter<T>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, engineType(), encryptedFile);
+
+    writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned());
+
+    if (overwrite) {
+      writerBuilder.overwrite();
+    }
+
+    DataWriter<T> writer = writerBuilder.build();
+
+    try (writer) {
+      records.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(records.size());
+    assertThat(dataFile.format()).isEqualTo(fileFormat);
+
+    return dataFile;
+  }
+
+  private static Reader newOrcReader(InputFile inputFile, Configuration conf) throws IOException {
+    Path hadoopPath = new Path(inputFile.location());
+    OrcFile.ReaderOptions readerOptions =
+        OrcFile.readerOptions(conf)
+            .useUTCTimestamp(true)
+            .filesystem(OrcWritingTestUtils.inputFileSystem(inputFile))
+            .maxLength(inputFile.getLength());
+
+    return OrcFile.createReader(hadoopPath, readerOptions);
+  }
+
+  private static String compressionProperty(FileFormat fileFormat) {
+    return switch (fileFormat) {
+      case AVRO -> TableProperties.AVRO_COMPRESSION;
+      case PARQUET -> TableProperties.PARQUET_COMPRESSION;
+      case ORC -> TableProperties.ORC_COMPRESSION;
+      default ->
+          throw new UnsupportedOperationException(
+              "No compression property defined for format: " + fileFormat);
+    };
+  }
+
+  private static String compressionValue(FileFormat fileFormat) {
+    return switch (fileFormat) {
+      case AVRO, PARQUET -> "uncompressed";
+      case ORC -> "none";
+      default ->
+          throw new UnsupportedOperationException(
+              "No compression value defined for format: " + fileFormat);
+    };
+  }
+
+  private static String expectedCompressionCodec(FileFormat fileFormat) {
+    return switch (fileFormat) {
+      case AVRO -> "null";
+      case PARQUET -> "UNCOMPRESSED";
+      case ORC -> "NONE";
+      default ->
+          throw new UnsupportedOperationException(
+              "No expected compression codec defined for format: " + fileFormat);
+    };
+  }
+
+  private String actualCompressionCodec(FileFormat fileFormat) throws IOException {
+    InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
+
+    return switch (fileFormat) {
+      case AVRO -> avroMetadataValue(inputFile, "avro.codec");
+      case PARQUET -> parquetCompressionCodec(inputFile);
+      case ORC -> orcCompressionCodec(inputFile);
+      default -> throw new UnsupportedOperationException("Unsupported file format: " + fileFormat);
+    };
+  }
+
+  private static String orcCompressionCodec(InputFile inputFile) throws IOException {
+    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
+      return reader.getCompressionKind().name();
+    }
+  }
+
+  private static String avroMetadataValue(InputFile inputFile, String key) throws IOException {
+    try (DataFileStream<GenericData.Record> reader =
+        new DataFileStream<>(inputFile.newStream(), new GenericDatumReader<>())) {
+      return reader.getMetaString(key);
+    }
+  }
+
+  private static String parquetCompressionCodec(InputFile inputFile) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
+      return reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name();
+    }
+  }
+
+  private String fileMetadataValue(FileFormat fileFormat, String key) throws IOException {
+    InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
+
+    return switch (fileFormat) {
+      case AVRO -> avroMetadataValue(inputFile, key);
+      case PARQUET -> parquetMetadataValue(inputFile, key);
+      case ORC -> orcMetadataValue(inputFile, key);
+      default -> throw new UnsupportedOperationException("Unsupported file format: " + fileFormat);
+    };
+  }
+
+  private static String parquetMetadataValue(InputFile inputFile, String key) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
+      return reader.getFooter().getFileMetaData().getKeyValueMetaData().get(key);
+    }
+  }
+
+  private static String orcMetadataValue(InputFile inputFile, String key) throws IOException {
+    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
+      ByteBuffer metadataValue = reader.getMetadataValue(key).duplicate();
+      byte[] bytes = new byte[metadataValue.remaining()];
+      metadataValue.get(bytes);
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  @FunctionalInterface
+  private interface DataWriterEffectAssertion {
+    void accept(FileFormat fileFormat) throws IOException;
+  }
+
+  private void writeAndAssertDataWriterWithConfig(
+      FileFormat fileFormat,
+      BiConsumer<FileWriterBuilder<DataWriter<T>, Object>, FileFormat> configureWriter,
+      DataWriterEffectAssertion assertWriterEffect)
+      throws IOException {
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+    List<Record> genericRecords = dataGenerator.generateRecords();
+    List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
+
+    FileWriterBuilder<DataWriter<T>, Object> writerBuilder =
+        FormatModelRegistry.dataWriteBuilder(fileFormat, engineType(), encryptedFile);
+    writerBuilder.schema(schema).spec(PartitionSpec.unpartitioned());
+    configureWriter.accept(writerBuilder, fileFormat);
+
+    DataWriter<T> writer = writerBuilder.build();
+
+    try (writer) {
+      engineRecords.forEach(writer::write);
+    }
+
+    DataFile dataFile = writer.toDataFile();
+    assertThat(dataFile).isNotNull();
+    assertThat(dataFile.recordCount()).isEqualTo(genericRecords.size());
+    assertThat(dataFile.format()).isEqualTo(fileFormat);
+    assertWriterEffect.accept(fileFormat);
+    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -1565,7 +1565,9 @@ public abstract class BaseFormatModelTests<T> {
     List<Record> genericRecords = dataGenerator.generateRecords();
 
     // Write the file WITHOUT Iceberg field IDs (as an external writer would).
-    writeRecordsWithoutFieldIds(fileFormat, icebergSchema, genericRecords);
+    FileFormatTestSupport.forFormat(fileFormat)
+        .writeRecordsWithoutFieldIds(
+            encryptedFile.encryptingOutputFile(), icebergSchema, genericRecords);
 
     NameMapping nameMapping = MappingUtil.create(icebergSchema);
 
@@ -1594,10 +1596,6 @@ public abstract class BaseFormatModelTests<T> {
     writeEngineRecords(fileFormat, schema, engineRecords);
     readAndAssertGenericRecords(fileFormat, schema, genericRecords);
 
-    assertThatThrownBy(() -> writeEngineRecords(fileFormat, schema, engineRecords))
-        .isInstanceOf(AlreadyExistsException.class)
-        .hasMessageContaining("Already exists");
-
     genericRecords = dataGenerator.generateRecords(20);
     writeEngineRecords(
         fileFormat, schema, convertToEngineRecords(genericRecords, schema), true /* overwrite */);
@@ -1606,11 +1604,28 @@ public abstract class BaseFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testDataWriterOverwriteNone(FileFormat fileFormat) throws IOException {
+    DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
+    Schema schema = dataGenerator.schema();
+
+    List<Record> genericRecords = dataGenerator.generateRecords();
+    List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
+
+    writeEngineRecords(fileFormat, schema, engineRecords);
+    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
+
+    assertThatThrownBy(() -> writeEngineRecords(fileFormat, schema, engineRecords))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("Already exists");
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testDataWriterSet(FileFormat fileFormat) throws IOException {
     writeAndAssertDataWriterWithConfig(
         fileFormat,
-        (writerBuilder, format) -> testPropertyToSet(format).forEach(writerBuilder::set),
-        format -> assertThat(checkTestProperty(format)).isTrue());
+        (writerBuilder, format) -> testPropertiesToSet(format).forEach(writerBuilder::set),
+        format -> assertThat(checkTestProperties(format)).isTrue());
   }
 
   @ParameterizedTest
@@ -1618,8 +1633,8 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterSetAll(FileFormat fileFormat) throws IOException {
     writeAndAssertDataWriterWithConfig(
         fileFormat,
-        (writerBuilder, format) -> writerBuilder.setAll(testPropertyToSet(format)),
-        format -> assertThat(checkTestProperty(format)).isTrue());
+        (writerBuilder, format) -> writerBuilder.setAll(testPropertiesToSet(format)),
+        format -> assertThat(checkTestProperties(format)).isTrue());
   }
 
   @ParameterizedTest
@@ -1637,9 +1652,13 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterMetaMap(FileFormat fileFormat) throws IOException {
     writeAndAssertDataWriterWithConfig(
         fileFormat,
-        (writerBuilder, format) -> writerBuilder.meta(Map.of("tck.meta.key", "tck-meta-value")),
-        format ->
-            assertThat(fileMetadataValue(format, "tck.meta.key")).isEqualTo("tck-meta-value"));
+        (writerBuilder, format) ->
+            writerBuilder.meta(
+                Map.of("tck.meta.key", "tck-meta-value", "tck.meta.key2", "tck-meta-value2")),
+        format -> {
+          assertThat(fileMetadataValue(format, "tck.meta.key")).isEqualTo("tck-meta-value");
+          assertThat(fileMetadataValue(format, "tck.meta.key2")).isEqualTo("tck-meta-value2");
+        });
   }
 
   private void readAndAssertGenericRecords(
@@ -1717,7 +1736,7 @@ public abstract class BaseFormatModelTests<T> {
   private DataFile writeRecordsForSplit(FileFormat fileFormat, Schema schema, List<Record> records)
       throws IOException {
 
-    String splitSizeProperty = splitSizeProperty(fileFormat);
+    String splitSizeProperty = FileFormatTestSupport.forFormat(fileFormat).splitSizeProperty();
     DataWriter<Record> writer =
         FormatModelRegistry.dataWriteBuilder(fileFormat, Record.class, encryptedFile)
             .schema(schema)
@@ -1741,10 +1760,6 @@ public abstract class BaseFormatModelTests<T> {
 
     assertThat(dataFile.format()).isEqualTo(fileFormat);
     return dataFile;
-  }
-
-  private static String splitSizeProperty(FileFormat fileFormat) {
-    return FileFormatTestSupport.forFormat(fileFormat).splitSizeProperty();
   }
 
   private static void assertCounts(
@@ -2084,12 +2099,6 @@ public abstract class BaseFormatModelTests<T> {
     return result;
   }
 
-  private void writeRecordsWithoutFieldIds(
-      FileFormat fileFormat, Schema schema, List<Record> records) throws IOException {
-    FileFormatTestSupport.forFormat(fileFormat)
-        .writeRecordsWithoutFieldIds(encryptedFile.encryptingOutputFile(), schema, records);
-  }
-
   private void runTypePromotionCheck(
       FileFormat fileFormat, Type fromType, Type toType, Function<Object, Object> promoteValue)
       throws IOException {
@@ -2134,7 +2143,7 @@ public abstract class BaseFormatModelTests<T> {
 
   private DataFile writeEngineRecords(FileFormat fileFormat, Schema schema, List<T> records)
       throws IOException {
-    return writeEngineRecords(fileFormat, schema, records, false);
+    return writeEngineRecords(fileFormat, schema, records, false /* overwrite */);
   }
 
   private DataFile writeEngineRecords(
@@ -2162,13 +2171,13 @@ public abstract class BaseFormatModelTests<T> {
     return dataFile;
   }
 
-  private static Map<String, String> testPropertyToSet(FileFormat fileFormat) {
-    return FileFormatTestSupport.forFormat(fileFormat).testPropertyToSet();
+  private static Map<String, String> testPropertiesToSet(FileFormat fileFormat) {
+    return FileFormatTestSupport.forFormat(fileFormat).testPropertiesToSet();
   }
 
-  private boolean checkTestProperty(FileFormat fileFormat) throws IOException {
+  private boolean checkTestProperties(FileFormat fileFormat) throws IOException {
     return FileFormatTestSupport.forFormat(fileFormat)
-        .checkTestProperty(encryptedFile.encryptingOutputFile().toInputFile());
+        .checkTestProperties(encryptedFile.encryptingOutputFile().toInputFile());
   }
 
   private String fileMetadataValue(FileFormat fileFormat, String key) throws IOException {

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -1604,7 +1604,7 @@ public abstract class BaseFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
-  void testDataWriterOverwriteNone(FileFormat fileFormat) throws IOException {
+  void testDataWriterNoOverwriteFailsIfFileExists(FileFormat fileFormat) throws IOException {
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
 

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -205,6 +205,18 @@ public abstract class BaseFormatModelTests<T> {
     readAndAssertGenericRecords(fileFormat, schema, genericRecords);
   }
 
+  /** Write with engine type T without explicit engineSchema, read with Generic Record */
+  @ParameterizedTest
+  @FieldSource("FORMAT_AND_GENERATOR")
+  void testDataWriterEngineWriteWithoutEngineSchema(
+      FileFormat fileFormat, DataGenerator dataGenerator) throws IOException {
+    Schema schema = dataGenerator.schema();
+    List<Record> genericRecords = dataGenerator.generateRecords();
+    List<T> engineRecords = convertToEngineRecords(genericRecords, schema);
+    writeEngineRecords(fileFormat, schema, engineRecords);
+    readAndAssertGenericRecords(fileFormat, schema, genericRecords);
+  }
+
   /** Write with Generic Record, read with engine type T */
   @ParameterizedTest
   @FieldSource("FORMAT_AND_GENERATOR")
@@ -1614,7 +1626,7 @@ public abstract class BaseFormatModelTests<T> {
         .isInstanceOf(AlreadyExistsException.class)
         .hasMessageContaining("Already exists");
 
-    genericRecords = dataGenerator.generateRecords();
+    genericRecords = dataGenerator.generateRecords(20);
     writeEngineRecords(fileFormat, schema, convertToEngineRecords(genericRecords, schema), true);
     readAndAssertGenericRecords(fileFormat, schema, genericRecords);
   }

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -21,13 +21,6 @@ package org.apache.iceberg.data;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.apache.iceberg.TestBase.SCHEMA;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_CASE_SENSITIVE;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_COLUMN_LEVEL_METRICS;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_COLUMN_METRICS_TRUNCATE_BINARY;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_FILTER;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_READER_DEFAULT;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_REUSE_CONTAINERS;
-import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_SPLIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -121,6 +114,29 @@ public abstract class BaseFormatModelTests<T> {
                   Arrays.stream(DataGenerators.ALL)
                       .map(generator -> Arguments.of(format, generator)))
           .toList();
+
+  static final String FEATURE_FILTER = "filter";
+  static final String FEATURE_CASE_SENSITIVE = "caseSensitive";
+  static final String FEATURE_SPLIT = "split";
+  static final String FEATURE_READER_DEFAULT = "readerDefault";
+  static final String FEATURE_REUSE_CONTAINERS = "reuseContainers";
+  static final String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
+  static final String FEATURE_COLUMN_METRICS_TRUNCATE_BINARY = "columnMetricsTruncateBinary";
+
+  private static final Map<FileFormat, String[]> MISSING_FEATURES =
+      Map.of(
+          FileFormat.AVRO,
+          new String[] {
+            FEATURE_FILTER,
+            FEATURE_CASE_SENSITIVE,
+            FEATURE_SPLIT,
+            FEATURE_COLUMN_LEVEL_METRICS,
+            FEATURE_COLUMN_METRICS_TRUNCATE_BINARY
+          },
+          FileFormat.ORC,
+          new String[] {
+            FEATURE_REUSE_CONTAINERS, FEATURE_COLUMN_METRICS_TRUNCATE_BINARY, FEATURE_READER_DEFAULT
+          });
 
   private InMemoryFileIO fileIO;
   private EncryptedOutputFile encryptedFile;
@@ -1583,7 +1599,8 @@ public abstract class BaseFormatModelTests<T> {
         .hasMessageContaining("Already exists");
 
     genericRecords = dataGenerator.generateRecords(20);
-    writeEngineRecords(fileFormat, schema, convertToEngineRecords(genericRecords, schema), true);
+    writeEngineRecords(
+        fileFormat, schema, convertToEngineRecords(genericRecords, schema), true /* overwrite */);
     readAndAssertGenericRecords(fileFormat, schema, genericRecords);
   }
 
@@ -1674,13 +1691,14 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private static void assumeSupports(FileFormat fileFormat, String feature) {
-    assumeThat(supportsFeature(fileFormat, feature)).isTrue();
+    assumeThat(MISSING_FEATURES.getOrDefault(fileFormat, new String[] {})).doesNotContain(feature);
   }
 
   /**
    * Returns whether the given file format supports the specified feature.
    *
-   * <p>The check is based on {@link FileFormatTestSupport#supportsFeature(String)}.
+   * <p>The check is based on {@link #MISSING_FEATURES}. Features not listed as missing for a format
+   * are treated as supported.
    *
    * <p>Prefer this method over {@link #assumeSupports(FileFormat, String)} when only part of a test
    * should be skipped conditionally. Unlike {@code assumeSupports}, this method does not abort the
@@ -1692,7 +1710,8 @@ public abstract class BaseFormatModelTests<T> {
    * @return {@code true} if the feature is supported by the format; {@code false} otherwise
    */
   private static boolean supportsFeature(FileFormat fileFormat, String feature) {
-    return FileFormatTestSupport.forFormat(fileFormat).supportsFeature(feature);
+    String[] missing = MISSING_FEATURES.getOrDefault(fileFormat, new String[] {});
+    return !Arrays.asList(missing).contains(feature);
   }
 
   private DataFile writeRecordsForSplit(FileFormat fileFormat, Schema schema, List<Record> records)

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -21,6 +21,13 @@ package org.apache.iceberg.data;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_PATH;
 import static org.apache.iceberg.MetadataColumns.DELETE_FILE_POS;
 import static org.apache.iceberg.TestBase.SCHEMA;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_CASE_SENSITIVE;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_COLUMN_LEVEL_METRICS;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_COLUMN_METRICS_TRUNCATE_BINARY;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_FILTER;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_READER_DEFAULT;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_REUSE_CONTAINERS;
+import static org.apache.iceberg.data.FileFormatTestSupport.FEATURE_SPLIT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -28,9 +35,7 @@ import static org.junit.jupiter.api.Assumptions.assumeFalse;
 
 import java.io.File;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -40,14 +45,6 @@ import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.IntStream;
-import org.apache.avro.file.DataFileStream;
-import org.apache.avro.file.DataFileWriter;
-import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
-import org.apache.avro.io.DatumWriter;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
@@ -62,8 +59,6 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestTables;
-import org.apache.iceberg.avro.AvroTestHelpers;
-import org.apache.iceberg.data.orc.GenericOrcWriter;
 import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
@@ -83,15 +78,8 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
-import org.apache.iceberg.orc.ORCSchemaUtil;
-import org.apache.iceberg.orc.OrcRowWriter;
-import org.apache.iceberg.orc.OrcWritingTestUtils;
-import org.apache.iceberg.orc.TestORCSchemaUtil;
-import org.apache.iceberg.parquet.ParquetFileTestUtils;
-import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -99,14 +87,6 @@ import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.orc.OrcFile;
-import org.apache.orc.Reader;
-import org.apache.orc.TypeDescription;
-import org.apache.orc.Writer;
-import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
-import org.apache.parquet.avro.AvroParquetWriter;
-import org.apache.parquet.hadoop.ParquetFileReader;
-import org.apache.parquet.hadoop.ParquetWriter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
@@ -132,8 +112,7 @@ public abstract class BaseFormatModelTests<T> {
 
   @TempDir private File tableDir;
 
-  private static final FileFormat[] FILE_FORMATS =
-      new FileFormat[] {FileFormat.AVRO, FileFormat.PARQUET, FileFormat.ORC};
+  private static final FileFormat[] FILE_FORMATS = FileFormatTestSupport.formats();
 
   private static final List<Arguments> FORMAT_AND_GENERATOR =
       Arrays.stream(FILE_FORMATS)
@@ -142,29 +121,6 @@ public abstract class BaseFormatModelTests<T> {
                   Arrays.stream(DataGenerators.ALL)
                       .map(generator -> Arguments.of(format, generator)))
           .toList();
-
-  static final String FEATURE_FILTER = "filter";
-  static final String FEATURE_CASE_SENSITIVE = "caseSensitive";
-  static final String FEATURE_SPLIT = "split";
-  static final String FEATURE_READER_DEFAULT = "readerDefault";
-  static final String FEATURE_REUSE_CONTAINERS = "reuseContainers";
-  static final String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
-  static final String FEATURE_COLUMN_METRICS_TRUNCATE_BINARY = "columnMetricsTruncateBinary";
-
-  private static final Map<FileFormat, String[]> MISSING_FEATURES =
-      Map.of(
-          FileFormat.AVRO,
-          new String[] {
-            FEATURE_FILTER,
-            FEATURE_CASE_SENSITIVE,
-            FEATURE_SPLIT,
-            FEATURE_COLUMN_LEVEL_METRICS,
-            FEATURE_COLUMN_METRICS_TRUNCATE_BINARY
-          },
-          FileFormat.ORC,
-          new String[] {
-            FEATURE_REUSE_CONTAINERS, FEATURE_COLUMN_METRICS_TRUNCATE_BINARY, FEATURE_READER_DEFAULT
-          });
 
   private InMemoryFileIO fileIO;
   private EncryptedOutputFile encryptedFile;
@@ -1722,14 +1678,13 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private static void assumeSupports(FileFormat fileFormat, String feature) {
-    assumeThat(MISSING_FEATURES.getOrDefault(fileFormat, new String[] {})).doesNotContain(feature);
+    assumeThat(supportsFeature(fileFormat, feature)).isTrue();
   }
 
   /**
    * Returns whether the given file format supports the specified feature.
    *
-   * <p>The check is based on {@link #MISSING_FEATURES}. Features not listed as missing for a format
-   * are treated as supported.
+   * <p>The check is based on {@link FileFormatTestSupport#supportsFeature(String)}.
    *
    * <p>Prefer this method over {@link #assumeSupports(FileFormat, String)} when only part of a test
    * should be skipped conditionally. Unlike {@code assumeSupports}, this method does not abort the
@@ -1741,8 +1696,7 @@ public abstract class BaseFormatModelTests<T> {
    * @return {@code true} if the feature is supported by the format; {@code false} otherwise
    */
   private static boolean supportsFeature(FileFormat fileFormat, String feature) {
-    String[] missing = MISSING_FEATURES.getOrDefault(fileFormat, new String[] {});
-    return !Arrays.asList(missing).contains(feature);
+    return FileFormatTestSupport.forFormat(fileFormat).supportsFeature(feature);
   }
 
   private DataFile writeRecordsForSplit(FileFormat fileFormat, Schema schema, List<Record> records)
@@ -1775,13 +1729,7 @@ public abstract class BaseFormatModelTests<T> {
   }
 
   private static String splitSizeProperty(FileFormat fileFormat) {
-    return switch (fileFormat) {
-      case PARQUET -> TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
-      case ORC -> TableProperties.ORC_STRIPE_SIZE_BYTES;
-      default ->
-          throw new UnsupportedOperationException(
-              "No split size property defined for format: " + fileFormat);
-    };
+    return FileFormatTestSupport.forFormat(fileFormat).splitSizeProperty();
   }
 
   private static void assertCounts(
@@ -2123,102 +2071,8 @@ public abstract class BaseFormatModelTests<T> {
 
   private void writeRecordsWithoutFieldIds(
       FileFormat fileFormat, Schema schema, List<Record> records) throws IOException {
-    switch (fileFormat) {
-      case PARQUET -> writeParquetWithoutFieldIds(schema, records);
-      case AVRO -> writeAvroWithoutFieldIds(schema, records);
-      case ORC -> writeOrcWithoutFieldIds(schema, records);
-      default -> throw new UnsupportedOperationException("Unsupported file format: " + fileFormat);
-    }
-  }
-
-  private void writeAvroWithoutFieldIds(Schema schema, List<Record> records) throws IOException {
-    org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);
-
-    OutputFile outputFile = encryptedFile.encryptingOutputFile();
-    DatumWriter<GenericData.Record> datumWriter = new GenericDatumWriter<>(avroSchemaWithoutIds);
-    try (OutputStream out = outputFile.create();
-        DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(datumWriter)) {
-      writer.create(avroSchemaWithoutIds, out);
-      for (Record record : records) {
-        GenericData.Record avroRecord = new GenericData.Record(avroSchemaWithoutIds);
-        for (Types.NestedField field : schema.columns()) {
-          avroRecord.put(field.name(), record.getField(field.name()));
-        }
-
-        writer.append(avroRecord);
-      }
-    }
-
-    try (DataFileStream<GenericData.Record> reader =
-        new DataFileStream<>(outputFile.toInputFile().newStream(), new GenericDatumReader<>())) {
-      assertThat(AvroTestHelpers.hasIds(reader.getSchema())).isFalse();
-    }
-  }
-
-  private void writeParquetWithoutFieldIds(Schema schema, List<Record> records) throws IOException {
-    org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);
-
-    OutputFile outputFile = encryptedFile.encryptingOutputFile();
-
-    try (ParquetWriter<GenericData.Record> writer =
-        AvroParquetWriter.<GenericData.Record>builder(ParquetFileTestUtils.file(outputFile))
-            .withDataModel(GenericData.get())
-            .withSchema(avroSchemaWithoutIds)
-            .withConf(new Configuration())
-            .build()) {
-      for (Record record : records) {
-        GenericData.Record avroRecord = new GenericData.Record(avroSchemaWithoutIds);
-        for (Types.NestedField field : schema.columns()) {
-          avroRecord.put(field.name(), record.getField(field.name()));
-        }
-
-        writer.write(avroRecord);
-      }
-    }
-
-    try (ParquetFileReader reader =
-        ParquetFileReader.open(ParquetFileTestUtils.file(outputFile.toInputFile()))) {
-      assertThat(ParquetSchemaUtil.hasIds(reader.getFooter().getFileMetaData().getSchema()))
-          .isFalse();
-    }
-  }
-
-  private void writeOrcWithoutFieldIds(Schema schema, List<Record> records) throws IOException {
-    TypeDescription typeWithIds = ORCSchemaUtil.convert(schema);
-    TypeDescription typeWithoutIds = TestORCSchemaUtil.removeIds(typeWithIds);
-
-    OutputFile outputFile = encryptedFile.encryptingOutputFile();
-    Path hadoopPath = new Path(outputFile.location());
-
-    Configuration conf = new Configuration();
-    OrcFile.WriterOptions options =
-        OrcFile.writerOptions(conf)
-            .useUTCTimestamp(true)
-            .setSchema(typeWithoutIds)
-            .fileSystem(OrcWritingTestUtils.outputFileSystem(outputFile));
-
-    OrcRowWriter<Record> rowWriter = GenericOrcWriter.buildWriter(schema, typeWithIds);
-
-    try (Writer orcWriter = OrcFile.createWriter(hadoopPath, options)) {
-      VectorizedRowBatch batch = typeWithoutIds.createRowBatch();
-      for (Record record : records) {
-        rowWriter.write(record, batch);
-        if (batch.size == batch.getMaxSize()) {
-          orcWriter.addRowBatch(batch);
-          batch.reset();
-        }
-      }
-
-      if (batch.size > 0) {
-        orcWriter.addRowBatch(batch);
-        batch.reset();
-      }
-    }
-
-    InputFile inputFile = outputFile.toInputFile();
-    try (Reader reader = newOrcReader(inputFile, conf)) {
-      assertThat(TestORCSchemaUtil.hasIds(reader.getSchema())).isFalse();
-    }
+    FileFormatTestSupport.forFormat(fileFormat)
+        .writeRecordsWithoutFieldIds(encryptedFile.encryptingOutputFile(), schema, records);
   }
 
   private void runTypePromotionCheck(
@@ -2293,103 +2147,26 @@ public abstract class BaseFormatModelTests<T> {
     return dataFile;
   }
 
-  private static Reader newOrcReader(InputFile inputFile, Configuration conf) throws IOException {
-    Path hadoopPath = new Path(inputFile.location());
-    OrcFile.ReaderOptions readerOptions =
-        OrcFile.readerOptions(conf)
-            .useUTCTimestamp(true)
-            .filesystem(OrcWritingTestUtils.inputFileSystem(inputFile))
-            .maxLength(inputFile.getLength());
-
-    return OrcFile.createReader(hadoopPath, readerOptions);
-  }
-
   private static String compressionProperty(FileFormat fileFormat) {
-    return switch (fileFormat) {
-      case AVRO -> TableProperties.AVRO_COMPRESSION;
-      case PARQUET -> TableProperties.PARQUET_COMPRESSION;
-      case ORC -> TableProperties.ORC_COMPRESSION;
-      default ->
-          throw new UnsupportedOperationException(
-              "No compression property defined for format: " + fileFormat);
-    };
+    return FileFormatTestSupport.forFormat(fileFormat).compressionProperty();
   }
 
   private static String compressionValue(FileFormat fileFormat) {
-    return switch (fileFormat) {
-      case AVRO, PARQUET -> "uncompressed";
-      case ORC -> "none";
-      default ->
-          throw new UnsupportedOperationException(
-              "No compression value defined for format: " + fileFormat);
-    };
+    return FileFormatTestSupport.forFormat(fileFormat).compressionValue();
   }
 
   private static String expectedCompressionCodec(FileFormat fileFormat) {
-    return switch (fileFormat) {
-      case AVRO -> "null";
-      case PARQUET -> "UNCOMPRESSED";
-      case ORC -> "NONE";
-      default ->
-          throw new UnsupportedOperationException(
-              "No expected compression codec defined for format: " + fileFormat);
-    };
+    return FileFormatTestSupport.forFormat(fileFormat).expectedCompressionCodec();
   }
 
   private String actualCompressionCodec(FileFormat fileFormat) throws IOException {
-    InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
-
-    return switch (fileFormat) {
-      case AVRO -> avroMetadataValue(inputFile, "avro.codec");
-      case PARQUET -> parquetCompressionCodec(inputFile);
-      case ORC -> orcCompressionCodec(inputFile);
-      default -> throw new UnsupportedOperationException("Unsupported file format: " + fileFormat);
-    };
-  }
-
-  private static String orcCompressionCodec(InputFile inputFile) throws IOException {
-    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
-      return reader.getCompressionKind().name();
-    }
-  }
-
-  private static String avroMetadataValue(InputFile inputFile, String key) throws IOException {
-    try (DataFileStream<GenericData.Record> reader =
-        new DataFileStream<>(inputFile.newStream(), new GenericDatumReader<>())) {
-      return reader.getMetaString(key);
-    }
-  }
-
-  private static String parquetCompressionCodec(InputFile inputFile) throws IOException {
-    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
-      return reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name();
-    }
+    return FileFormatTestSupport.forFormat(fileFormat)
+        .actualCompressionCodec(encryptedFile.encryptingOutputFile().toInputFile());
   }
 
   private String fileMetadataValue(FileFormat fileFormat, String key) throws IOException {
-    InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
-
-    return switch (fileFormat) {
-      case AVRO -> avroMetadataValue(inputFile, key);
-      case PARQUET -> parquetMetadataValue(inputFile, key);
-      case ORC -> orcMetadataValue(inputFile, key);
-      default -> throw new UnsupportedOperationException("Unsupported file format: " + fileFormat);
-    };
-  }
-
-  private static String parquetMetadataValue(InputFile inputFile, String key) throws IOException {
-    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
-      return reader.getFooter().getFileMetaData().getKeyValueMetaData().get(key);
-    }
-  }
-
-  private static String orcMetadataValue(InputFile inputFile, String key) throws IOException {
-    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
-      ByteBuffer metadataValue = reader.getMetadataValue(key).duplicate();
-      byte[] bytes = new byte[metadataValue.remaining()];
-      metadataValue.get(bytes);
-      return new String(bytes, StandardCharsets.UTF_8);
-    }
+    return FileFormatTestSupport.forFormat(fileFormat)
+        .metadataValue(encryptedFile.encryptingOutputFile().toInputFile(), key);
   }
 
   @FunctionalInterface

--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -1592,10 +1592,8 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterSet(FileFormat fileFormat) throws IOException {
     writeAndAssertDataWriterWithConfig(
         fileFormat,
-        (writerBuilder, format) ->
-            writerBuilder.set(compressionProperty(format), compressionValue(format)),
-        format ->
-            assertThat(actualCompressionCodec(format)).isEqualTo(expectedCompressionCodec(format)));
+        (writerBuilder, format) -> testPropertyToSet(format).forEach(writerBuilder::set),
+        format -> assertThat(checkTestProperty(format)).isTrue());
   }
 
   @ParameterizedTest
@@ -1603,10 +1601,8 @@ public abstract class BaseFormatModelTests<T> {
   void testDataWriterSetAll(FileFormat fileFormat) throws IOException {
     writeAndAssertDataWriterWithConfig(
         fileFormat,
-        (writerBuilder, format) ->
-            writerBuilder.setAll(Map.of(compressionProperty(format), compressionValue(format))),
-        format ->
-            assertThat(actualCompressionCodec(format)).isEqualTo(expectedCompressionCodec(format)));
+        (writerBuilder, format) -> writerBuilder.setAll(testPropertyToSet(format)),
+        format -> assertThat(checkTestProperty(format)).isTrue());
   }
 
   @ParameterizedTest
@@ -2147,21 +2143,13 @@ public abstract class BaseFormatModelTests<T> {
     return dataFile;
   }
 
-  private static String compressionProperty(FileFormat fileFormat) {
-    return FileFormatTestSupport.forFormat(fileFormat).compressionProperty();
+  private static Map<String, String> testPropertyToSet(FileFormat fileFormat) {
+    return FileFormatTestSupport.forFormat(fileFormat).testPropertyToSet();
   }
 
-  private static String compressionValue(FileFormat fileFormat) {
-    return FileFormatTestSupport.forFormat(fileFormat).compressionValue();
-  }
-
-  private static String expectedCompressionCodec(FileFormat fileFormat) {
-    return FileFormatTestSupport.forFormat(fileFormat).expectedCompressionCodec();
-  }
-
-  private String actualCompressionCodec(FileFormat fileFormat) throws IOException {
+  private boolean checkTestProperty(FileFormat fileFormat) throws IOException {
     return FileFormatTestSupport.forFormat(fileFormat)
-        .actualCompressionCodec(encryptedFile.encryptingOutputFile().toInputFile());
+        .checkTestProperty(encryptedFile.encryptingOutputFile().toInputFile());
   }
 
   private String fileMetadataValue(FileFormat fileFormat, String key) throws IOException {

--- a/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.data;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.avro.AvroFormat;
@@ -55,20 +56,14 @@ public interface FileFormatTestSupport {
 
   FileFormat format();
 
-  default boolean supportsFeature(String feature) {
-    return true;
-  }
+  boolean supportsFeature(String feature);
 
   void writeRecordsWithoutFieldIds(OutputFile outputFile, Schema schema, List<Record> records)
       throws IOException;
 
-  String compressionProperty();
+  Map<String, String> testPropertyToSet();
 
-  String compressionValue();
-
-  String expectedCompressionCodec();
-
-  String actualCompressionCodec(InputFile inputFile) throws IOException;
+  boolean checkTestProperty(InputFile inputFile) throws IOException;
 
   String metadataValue(InputFile inputFile, String key) throws IOException;
 

--- a/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
@@ -32,14 +32,6 @@ import org.apache.iceberg.io.OutputFile;
 
 public interface FileFormatTestSupport {
 
-  String FEATURE_FILTER = "filter";
-  String FEATURE_CASE_SENSITIVE = "caseSensitive";
-  String FEATURE_SPLIT = "split";
-  String FEATURE_READER_DEFAULT = "readerDefault";
-  String FEATURE_REUSE_CONTAINERS = "reuseContainers";
-  String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
-  String FEATURE_COLUMN_METRICS_TRUNCATE_BINARY = "columnMetricsTruncateBinary";
-
   FileFormatTestSupport[] ALL =
       new FileFormatTestSupport[] {new AvroFormat(), new OrcFormat(), new ParquetFormat()};
 
@@ -55,8 +47,6 @@ public interface FileFormatTestSupport {
   }
 
   FileFormat format();
-
-  boolean supportsFeature(String feature);
 
   void writeRecordsWithoutFieldIds(OutputFile outputFile, Schema schema, List<Record> records)
       throws IOException;

--- a/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
@@ -51,9 +51,9 @@ public interface FileFormatTestSupport {
   void writeRecordsWithoutFieldIds(OutputFile outputFile, Schema schema, List<Record> records)
       throws IOException;
 
-  Map<String, String> testPropertyToSet();
+  Map<String, String> testPropertiesToSet();
 
-  boolean checkTestProperty(InputFile inputFile) throws IOException;
+  boolean checkTestProperties(InputFile inputFile) throws IOException;
 
   String metadataValue(InputFile inputFile, String key) throws IOException;
 

--- a/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
+++ b/data/src/test/java/org/apache/iceberg/data/FileFormatTestSupport.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.avro.AvroFormat;
+import org.apache.iceberg.data.orc.OrcFormat;
+import org.apache.iceberg.data.parquet.ParquetFormat;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+
+public interface FileFormatTestSupport {
+
+  String FEATURE_FILTER = "filter";
+  String FEATURE_CASE_SENSITIVE = "caseSensitive";
+  String FEATURE_SPLIT = "split";
+  String FEATURE_READER_DEFAULT = "readerDefault";
+  String FEATURE_REUSE_CONTAINERS = "reuseContainers";
+  String FEATURE_COLUMN_LEVEL_METRICS = "columnLevelMetrics";
+  String FEATURE_COLUMN_METRICS_TRUNCATE_BINARY = "columnMetricsTruncateBinary";
+
+  FileFormatTestSupport[] ALL =
+      new FileFormatTestSupport[] {new AvroFormat(), new OrcFormat(), new ParquetFormat()};
+
+  static FileFormat[] formats() {
+    return Arrays.stream(ALL).map(FileFormatTestSupport::format).toArray(FileFormat[]::new);
+  }
+
+  static FileFormatTestSupport forFormat(FileFormat format) {
+    return Arrays.stream(ALL)
+        .filter(testSupportFormat -> testSupportFormat.format() == format)
+        .findFirst()
+        .orElseThrow(() -> new UnsupportedOperationException("Unsupported file format: " + format));
+  }
+
+  FileFormat format();
+
+  default boolean supportsFeature(String feature) {
+    return true;
+  }
+
+  void writeRecordsWithoutFieldIds(OutputFile outputFile, Schema schema, List<Record> records)
+      throws IOException;
+
+  String compressionProperty();
+
+  String compressionValue();
+
+  String expectedCompressionCodec();
+
+  String actualCompressionCodec(InputFile inputFile) throws IOException;
+
+  String metadataValue(InputFile inputFile, String key) throws IOException;
+
+  String splitSizeProperty();
+}

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -47,19 +47,6 @@ public class AvroFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public boolean supportsFeature(String feature) {
-    return switch (feature) {
-      case FEATURE_FILTER,
-              FEATURE_CASE_SENSITIVE,
-              FEATURE_SPLIT,
-              FEATURE_COLUMN_LEVEL_METRICS,
-              FEATURE_COLUMN_METRICS_TRUNCATE_BINARY ->
-          false;
-      default -> true;
-    };
-  }
-
-  @Override
   public void writeRecordsWithoutFieldIds(
       OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
     org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);
@@ -85,29 +72,25 @@ public class AvroFormat implements FileFormatTestSupport {
 
   @Override
   public Map<String, String> testPropertyToSet() {
-    return Map.of(TableProperties.AVRO_COMPRESSION, "uncompressed");
+    return Map.of(TableProperties.AVRO_COMPRESSION, "snappy");
   }
 
   @Override
   public boolean checkTestProperty(InputFile inputFile) throws IOException {
-    return "null".equals(avroMetadataValue(inputFile, "avro.codec"));
+    return "snappy".equals(metadataValue(inputFile, "avro.codec"));
   }
 
   @Override
   public String metadataValue(InputFile inputFile, String key) throws IOException {
-    return avroMetadataValue(inputFile, key);
+    try (DataFileStream<GenericData.Record> reader =
+        new DataFileStream<>(inputFile.newStream(), new GenericDatumReader<>())) {
+      return reader.getMetaString(key);
+    }
   }
 
   @Override
   public String splitSizeProperty() {
     throw new UnsupportedOperationException(
         "No split size property defined for format: " + format());
-  }
-
-  private static String avroMetadataValue(InputFile inputFile, String key) throws IOException {
-    try (DataFileStream<GenericData.Record> reader =
-        new DataFileStream<>(inputFile.newStream(), new GenericDatumReader<>())) {
-      return reader.getMetaString(key);
-    }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -83,23 +84,13 @@ public class AvroFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public String compressionProperty() {
-    return TableProperties.AVRO_COMPRESSION;
+  public Map<String, String> testPropertyToSet() {
+    return Map.of(TableProperties.AVRO_COMPRESSION, "uncompressed");
   }
 
   @Override
-  public String compressionValue() {
-    return "uncompressed";
-  }
-
-  @Override
-  public String expectedCompressionCodec() {
-    return "null";
-  }
-
-  @Override
-  public String actualCompressionCodec(InputFile inputFile) throws IOException {
-    return avroMetadataValue(inputFile, "avro.codec");
+  public boolean checkTestProperty(InputFile inputFile) throws IOException {
+    return "null".equals(avroMetadataValue(inputFile, "avro.codec"));
   }
 
   @Override

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -71,12 +71,13 @@ public class AvroFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public Map<String, String> testPropertyToSet() {
-    return Map.of(TableProperties.AVRO_COMPRESSION, "snappy");
+  public Map<String, String> testPropertiesToSet() {
+    return Map.of(
+        TableProperties.AVRO_COMPRESSION_LEVEL, "1", TableProperties.AVRO_COMPRESSION, "snappy");
   }
 
   @Override
-  public boolean checkTestProperty(InputFile inputFile) throws IOException {
+  public boolean checkTestProperties(InputFile inputFile) throws IOException {
     return "snappy".equals(metadataValue(inputFile, "avro.codec"));
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.avro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import org.apache.avro.file.DataFileStream;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.io.DatumWriter;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.avro.AvroTestHelpers;
+import org.apache.iceberg.data.FileFormatTestSupport;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.types.Types;
+
+public class AvroFormat implements FileFormatTestSupport {
+  @Override
+  public FileFormat format() {
+    return FileFormat.AVRO;
+  }
+
+  @Override
+  public boolean supportsFeature(String feature) {
+    return switch (feature) {
+      case FEATURE_FILTER,
+              FEATURE_CASE_SENSITIVE,
+              FEATURE_SPLIT,
+              FEATURE_COLUMN_LEVEL_METRICS,
+              FEATURE_COLUMN_METRICS_TRUNCATE_BINARY ->
+          false;
+      default -> true;
+    };
+  }
+
+  @Override
+  public void writeRecordsWithoutFieldIds(
+      OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
+    org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);
+    DatumWriter<GenericData.Record> datumWriter = new GenericDatumWriter<>(avroSchemaWithoutIds);
+    try (OutputStream out = outputFile.create();
+        DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(datumWriter)) {
+      writer.create(avroSchemaWithoutIds, out);
+      for (Record record : records) {
+        GenericData.Record avroRecord = new GenericData.Record(avroSchemaWithoutIds);
+        for (Types.NestedField field : schema.columns()) {
+          avroRecord.put(field.name(), record.getField(field.name()));
+        }
+
+        writer.append(avroRecord);
+      }
+    }
+
+    try (DataFileStream<GenericData.Record> reader =
+        new DataFileStream<>(outputFile.toInputFile().newStream(), new GenericDatumReader<>())) {
+      assertThat(AvroTestHelpers.hasIds(reader.getSchema())).isFalse();
+    }
+  }
+
+  @Override
+  public String compressionProperty() {
+    return TableProperties.AVRO_COMPRESSION;
+  }
+
+  @Override
+  public String compressionValue() {
+    return "uncompressed";
+  }
+
+  @Override
+  public String expectedCompressionCodec() {
+    return "null";
+  }
+
+  @Override
+  public String actualCompressionCodec(InputFile inputFile) throws IOException {
+    return avroMetadataValue(inputFile, "avro.codec");
+  }
+
+  @Override
+  public String metadataValue(InputFile inputFile, String key) throws IOException {
+    return avroMetadataValue(inputFile, key);
+  }
+
+  @Override
+  public String splitSizeProperty() {
+    throw new UnsupportedOperationException(
+        "No split size property defined for format: " + format());
+  }
+
+  private static String avroMetadataValue(InputFile inputFile, String key) throws IOException {
+    try (DataFileStream<GenericData.Record> reader =
+        new DataFileStream<>(inputFile.newStream(), new GenericDatumReader<>())) {
+      return reader.getMetaString(key);
+    }
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -73,15 +73,15 @@ public class AvroFormat implements FileFormatTestSupport {
   @Override
   public Map<String, String> testPropertiesToSet() {
     // Avro currently has only two configurable writer properties: compression codec and
-    // compression level. The compression level cannot be verified from file metadata, so this
-    // test sets the compression codec as the second property and verifies it to confirm that the
-    // multi-property setAll path takes effect.
+    // compression level.
     return Map.of(
         TableProperties.AVRO_COMPRESSION_LEVEL, "1", TableProperties.AVRO_COMPRESSION, "snappy");
   }
 
   @Override
   public boolean checkTestProperties(InputFile inputFile) throws IOException {
+    // Only the compression codec round-trips into the file metadata; the compression level is not
+    // persisted and cannot be read back.
     return "snappy".equals(metadataValue(inputFile, "avro.codec"));
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/AvroFormat.java
@@ -72,6 +72,10 @@ public class AvroFormat implements FileFormatTestSupport {
 
   @Override
   public Map<String, String> testPropertiesToSet() {
+    // Avro currently has only two configurable writer properties: compression codec and
+    // compression level. The compression level cannot be verified from file metadata, so this
+    // test sets the compression codec as the second property and verifies it to confirm that the
+    // multi-property setAll path takes effect.
     return Map.of(
         TableProperties.AVRO_COMPRESSION_LEVEL, "1", TableProperties.AVRO_COMPRESSION, "snappy");
   }

--- a/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
@@ -38,14 +38,11 @@ import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcRowWriter;
 import org.apache.iceberg.orc.OrcWritingTestUtils;
 import org.apache.iceberg.orc.TestORCSchemaUtil;
+import org.apache.orc.OrcConf;
 import org.apache.orc.OrcFile;
-import org.apache.orc.OrcProto;
 import org.apache.orc.Reader;
-import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
-import org.apache.orc.impl.OrcIndex;
-import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 
 public class OrcFormat implements FileFormatTestSupport {
@@ -94,17 +91,14 @@ public class OrcFormat implements FileFormatTestSupport {
   @Override
   public Map<String, String> testPropertiesToSet() {
     return Map.of(
-        TableProperties.ORC_COMPRESSION,
-        "snappy",
-        TableProperties.ORC_BLOOM_FILTER_COLUMNS,
-        "col_a");
+        TableProperties.ORC_COMPRESSION, "snappy", OrcConf.ROW_INDEX_STRIDE.getAttribute(), "8192");
   }
 
   @Override
   public boolean checkTestProperties(InputFile inputFile) throws IOException {
     try (Reader reader = newOrcReader(inputFile, new Configuration())) {
       return "SNAPPY".equals(reader.getCompressionKind().name())
-          && hasBloomFilter(inputFile, "col_a");
+          && reader.getRowIndexStride() == 8192;
     }
   }
 
@@ -132,27 +126,5 @@ public class OrcFormat implements FileFormatTestSupport {
             .maxLength(inputFile.getLength());
 
     return OrcFile.createReader(hadoopPath, readerOptions);
-  }
-
-  private static boolean hasBloomFilter(InputFile inputFile, String columnName) throws IOException {
-    try (Reader reader = newOrcReader(inputFile, new Configuration());
-        RecordReader rows = reader.rows()) {
-      if (!(rows instanceof RecordReaderImpl)) {
-        throw new IllegalStateException(
-            "Expected RecordReaderImpl to access row index, but got: " + rows.getClass().getName());
-      }
-
-      TypeDescription column = reader.getSchema().findSubtype(columnName);
-      int columnId = column.getId();
-      boolean[] readColumns = new boolean[reader.getSchema().getMaximumId() + 1];
-      readColumns[columnId] = true;
-
-      OrcIndex indices = ((RecordReaderImpl) rows).readRowIndex(0, null, readColumns);
-      OrcProto.BloomFilterIndex[] bloomFilterIndex = indices.getBloomFilterIndex();
-      return bloomFilterIndex != null
-          && columnId < bloomFilterIndex.length
-          && bloomFilterIndex[columnId] != null
-          && bloomFilterIndex[columnId].getBloomFilterCount() > 0;
-    }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.FileFormat;
@@ -98,24 +99,14 @@ public class OrcFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public String compressionProperty() {
-    return TableProperties.ORC_COMPRESSION;
+  public Map<String, String> testPropertyToSet() {
+    return Map.of(TableProperties.ORC_COMPRESSION, "none");
   }
 
   @Override
-  public String compressionValue() {
-    return "none";
-  }
-
-  @Override
-  public String expectedCompressionCodec() {
-    return "NONE";
-  }
-
-  @Override
-  public String actualCompressionCodec(InputFile inputFile) throws IOException {
+  public boolean checkTestProperty(InputFile inputFile) throws IOException {
     try (Reader reader = newOrcReader(inputFile, new Configuration())) {
-      return reader.getCompressionKind().name();
+      return "NONE".equals(reader.getCompressionKind().name());
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
@@ -51,17 +51,6 @@ public class OrcFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public boolean supportsFeature(String feature) {
-    return switch (feature) {
-      case FEATURE_REUSE_CONTAINERS,
-              FEATURE_COLUMN_METRICS_TRUNCATE_BINARY,
-              FEATURE_READER_DEFAULT ->
-          false;
-      default -> true;
-    };
-  }
-
-  @Override
   public void writeRecordsWithoutFieldIds(
       OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
     TypeDescription typeWithIds = ORCSchemaUtil.convert(schema);

--- a/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
@@ -39,9 +39,13 @@ import org.apache.iceberg.orc.OrcRowWriter;
 import org.apache.iceberg.orc.OrcWritingTestUtils;
 import org.apache.iceberg.orc.TestORCSchemaUtil;
 import org.apache.orc.OrcFile;
+import org.apache.orc.OrcProto;
 import org.apache.orc.Reader;
+import org.apache.orc.RecordReader;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
+import org.apache.orc.impl.OrcIndex;
+import org.apache.orc.impl.RecordReaderImpl;
 import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
 
 public class OrcFormat implements FileFormatTestSupport {
@@ -88,14 +92,19 @@ public class OrcFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public Map<String, String> testPropertyToSet() {
-    return Map.of(TableProperties.ORC_COMPRESSION, "none");
+  public Map<String, String> testPropertiesToSet() {
+    return Map.of(
+        TableProperties.ORC_COMPRESSION,
+        "snappy",
+        TableProperties.ORC_BLOOM_FILTER_COLUMNS,
+        "col_a");
   }
 
   @Override
-  public boolean checkTestProperty(InputFile inputFile) throws IOException {
+  public boolean checkTestProperties(InputFile inputFile) throws IOException {
     try (Reader reader = newOrcReader(inputFile, new Configuration())) {
-      return "NONE".equals(reader.getCompressionKind().name());
+      return "SNAPPY".equals(reader.getCompressionKind().name())
+          && hasBloomFilter(inputFile, "col_a");
     }
   }
 
@@ -123,5 +132,27 @@ public class OrcFormat implements FileFormatTestSupport {
             .maxLength(inputFile.getLength());
 
     return OrcFile.createReader(hadoopPath, readerOptions);
+  }
+
+  private static boolean hasBloomFilter(InputFile inputFile, String columnName) throws IOException {
+    try (Reader reader = newOrcReader(inputFile, new Configuration());
+        RecordReader rows = reader.rows()) {
+      if (!(rows instanceof RecordReaderImpl)) {
+        throw new IllegalStateException(
+            "Expected RecordReaderImpl to access row index, but got: " + rows.getClass().getName());
+      }
+
+      TypeDescription column = reader.getSchema().findSubtype(columnName);
+      int columnId = column.getId();
+      boolean[] readColumns = new boolean[reader.getSchema().getMaximumId() + 1];
+      readColumns[columnId] = true;
+
+      OrcIndex indices = ((RecordReaderImpl) rows).readRowIndex(0, null, readColumns);
+      OrcProto.BloomFilterIndex[] bloomFilterIndex = indices.getBloomFilterIndex();
+      return bloomFilterIndex != null
+          && columnId < bloomFilterIndex.length
+          && bloomFilterIndex[columnId] != null
+          && bloomFilterIndex[columnId].getBloomFilterCount() > 0;
+    }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/orc/OrcFormat.java
@@ -1,0 +1,147 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.orc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.FileFormatTestSupport;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.orc.ORCSchemaUtil;
+import org.apache.iceberg.orc.OrcRowWriter;
+import org.apache.iceberg.orc.OrcWritingTestUtils;
+import org.apache.iceberg.orc.TestORCSchemaUtil;
+import org.apache.orc.OrcFile;
+import org.apache.orc.Reader;
+import org.apache.orc.TypeDescription;
+import org.apache.orc.Writer;
+import org.apache.orc.storage.ql.exec.vector.VectorizedRowBatch;
+
+public class OrcFormat implements FileFormatTestSupport {
+  @Override
+  public FileFormat format() {
+    return FileFormat.ORC;
+  }
+
+  @Override
+  public boolean supportsFeature(String feature) {
+    return switch (feature) {
+      case FEATURE_REUSE_CONTAINERS,
+              FEATURE_COLUMN_METRICS_TRUNCATE_BINARY,
+              FEATURE_READER_DEFAULT ->
+          false;
+      default -> true;
+    };
+  }
+
+  @Override
+  public void writeRecordsWithoutFieldIds(
+      OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
+    TypeDescription typeWithIds = ORCSchemaUtil.convert(schema);
+    TypeDescription typeWithoutIds = TestORCSchemaUtil.removeIds(typeWithIds);
+    Path hadoopPath = new Path(outputFile.location());
+
+    Configuration conf = new Configuration();
+    OrcFile.WriterOptions options =
+        OrcFile.writerOptions(conf)
+            .useUTCTimestamp(true)
+            .setSchema(typeWithoutIds)
+            .fileSystem(OrcWritingTestUtils.outputFileSystem(outputFile));
+
+    OrcRowWriter<Record> rowWriter = GenericOrcWriter.buildWriter(schema, typeWithIds);
+
+    try (Writer orcWriter = OrcFile.createWriter(hadoopPath, options)) {
+      VectorizedRowBatch batch = typeWithoutIds.createRowBatch();
+      for (Record record : records) {
+        rowWriter.write(record, batch);
+        if (batch.size == batch.getMaxSize()) {
+          orcWriter.addRowBatch(batch);
+          batch.reset();
+        }
+      }
+
+      if (batch.size > 0) {
+        orcWriter.addRowBatch(batch);
+        batch.reset();
+      }
+    }
+
+    try (Reader reader = newOrcReader(outputFile.toInputFile(), conf)) {
+      assertThat(TestORCSchemaUtil.hasIds(reader.getSchema())).isFalse();
+    }
+  }
+
+  @Override
+  public String compressionProperty() {
+    return TableProperties.ORC_COMPRESSION;
+  }
+
+  @Override
+  public String compressionValue() {
+    return "none";
+  }
+
+  @Override
+  public String expectedCompressionCodec() {
+    return "NONE";
+  }
+
+  @Override
+  public String actualCompressionCodec(InputFile inputFile) throws IOException {
+    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
+      return reader.getCompressionKind().name();
+    }
+  }
+
+  @Override
+  public String metadataValue(InputFile inputFile, String key) throws IOException {
+    try (Reader reader = newOrcReader(inputFile, new Configuration())) {
+      ByteBuffer metadataValue = reader.getMetadataValue(key).duplicate();
+      byte[] bytes = new byte[metadataValue.remaining()];
+      metadataValue.get(bytes);
+      return new String(bytes, StandardCharsets.UTF_8);
+    }
+  }
+
+  @Override
+  public String splitSizeProperty() {
+    return TableProperties.ORC_STRIPE_SIZE_BYTES;
+  }
+
+  private static Reader newOrcReader(InputFile inputFile, Configuration conf) throws IOException {
+    Path hadoopPath = new Path(inputFile.location());
+    OrcFile.ReaderOptions readerOptions =
+        OrcFile.readerOptions(conf)
+            .useUTCTimestamp(true)
+            .filesystem(OrcWritingTestUtils.inputFileSystem(inputFile))
+            .maxLength(inputFile.getLength());
+
+    return OrcFile.createReader(hadoopPath, readerOptions);
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -95,21 +95,18 @@ public class ParquetFormat implements FileFormatTestSupport {
           "GZIP"
               .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
 
-      return compressionMatches && hasExpectedDataPages(reader, "col_a", 2, 5);
+      return compressionMatches && hasExpectedDataPages(reader, 2, 5);
     }
   }
 
   private boolean hasExpectedDataPages(
-      ParquetFileReader reader, String columnName, int expectedPageCount, int expectedRowsPerPage)
-      throws IOException {
+      ParquetFileReader reader, int expectedPageCount, int expectedRowsPerPage) throws IOException {
     int pageCount = 0;
     PageReadStore rowGroup;
 
     while ((rowGroup = reader.readNextRowGroup()) != null) {
       PageReader pageReader =
-          rowGroup.getPageReader(
-              reader.getFileMetaData().getSchema().getColumnDescription(new String[] {columnName}));
-
+          rowGroup.getPageReader(reader.getFileMetaData().getSchema().getColumns().get(0));
       DataPage page;
       while ((page = pageReader.readPage()) != null) {
         pageCount += 1;

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -75,12 +75,16 @@ public class ParquetFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public Map<String, String> testPropertyToSet() {
-    return Map.of(TableProperties.PARQUET_COMPRESSION, "uncompressed");
+  public Map<String, String> testPropertiesToSet() {
+    return Map.of(
+        TableProperties.PARQUET_COMPRESSION,
+        "uncompressed",
+        TableProperties.PARQUET_COMPRESSION_LEVEL,
+        "1");
   }
 
   @Override
-  public boolean checkTestProperty(InputFile inputFile) throws IOException {
+  public boolean checkTestProperties(InputFile inputFile) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
       return "UNCOMPRESSED"
           .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.avro.generic.GenericData;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.avro.AvroTestHelpers;
+import org.apache.iceberg.data.FileFormatTestSupport;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.ParquetFileTestUtils;
+import org.apache.iceberg.parquet.ParquetSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+
+public class ParquetFormat implements FileFormatTestSupport {
+  @Override
+  public FileFormat format() {
+    return FileFormat.PARQUET;
+  }
+
+  @Override
+  public void writeRecordsWithoutFieldIds(
+      OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
+    org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);
+
+    try (ParquetWriter<GenericData.Record> writer =
+        AvroParquetWriter.<GenericData.Record>builder(ParquetFileTestUtils.file(outputFile))
+            .withDataModel(GenericData.get())
+            .withSchema(avroSchemaWithoutIds)
+            .withConf(new Configuration())
+            .build()) {
+      for (Record record : records) {
+        GenericData.Record avroRecord = new GenericData.Record(avroSchemaWithoutIds);
+        for (Types.NestedField field : schema.columns()) {
+          avroRecord.put(field.name(), record.getField(field.name()));
+        }
+
+        writer.write(avroRecord);
+      }
+    }
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetFileTestUtils.file(outputFile.toInputFile()))) {
+      assertThat(ParquetSchemaUtil.hasIds(reader.getFooter().getFileMetaData().getSchema()))
+          .isFalse();
+    }
+  }
+
+  @Override
+  public String compressionProperty() {
+    return TableProperties.PARQUET_COMPRESSION;
+  }
+
+  @Override
+  public String compressionValue() {
+    return "uncompressed";
+  }
+
+  @Override
+  public String expectedCompressionCodec() {
+    return "UNCOMPRESSED";
+  }
+
+  @Override
+  public String actualCompressionCodec(InputFile inputFile) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
+      return reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name();
+    }
+  }
+
+  @Override
+  public String metadataValue(InputFile inputFile, String key) throws IOException {
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
+      return reader.getFooter().getFileMetaData().getKeyValueMetaData().get(key);
+    }
+  }
+
+  @Override
+  public String splitSizeProperty() {
+    return TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+  }
+}

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -37,10 +37,11 @@ import org.apache.iceberg.parquet.ParquetFileTestUtils;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.avro.AvroParquetWriter;
+import org.apache.parquet.column.page.DataPage;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
-import org.apache.parquet.hadoop.metadata.BlockMetaData;
-import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
 public class ParquetFormat implements FileFormatTestSupport {
   @Override
@@ -81,8 +82,10 @@ public class ParquetFormat implements FileFormatTestSupport {
     return Map.of(
         TableProperties.PARQUET_COMPRESSION,
         "gzip",
-        TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "col_a",
-        "false");
+        TableProperties.PARQUET_PAGE_ROW_LIMIT,
+        "5",
+        TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT,
+        "1");
   }
 
   @Override
@@ -91,20 +94,33 @@ public class ParquetFormat implements FileFormatTestSupport {
       boolean compressionMatches =
           "GZIP"
               .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
-      boolean foundColA = false;
-      boolean colAStatsDisabled = true;
 
-      for (BlockMetaData block : reader.getFooter().getBlocks()) {
-        for (ColumnChunkMetaData column : block.getColumns()) {
-          if ("col_a".equals(column.getPath().toDotString())) {
-            foundColA = true;
-            colAStatsDisabled &= column.getStatistics().isEmpty();
-          }
+      return compressionMatches && hasExpectedDataPages(reader, "col_a", 2, 5);
+    }
+  }
+
+  private boolean hasExpectedDataPages(
+      ParquetFileReader reader, String columnName, int expectedPageCount, int expectedRowsPerPage)
+      throws IOException {
+    int pageCount = 0;
+    PageReadStore rowGroup;
+
+    while ((rowGroup = reader.readNextRowGroup()) != null) {
+      PageReader pageReader =
+          rowGroup.getPageReader(
+              reader.getFileMetaData().getSchema().getColumnDescription(new String[] {columnName}));
+
+      DataPage page;
+      while ((page = pageReader.readPage()) != null) {
+        pageCount += 1;
+
+        if (page.getValueCount() != expectedRowsPerPage) {
+          return false;
         }
       }
-
-      return compressionMatches && foundColA && colAStatsDisabled;
     }
+
+    return pageCount == expectedPageCount;
   }
 
   @Override

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -39,6 +39,8 @@ import org.apache.iceberg.types.Types;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 
 public class ParquetFormat implements FileFormatTestSupport {
   @Override
@@ -78,16 +80,30 @@ public class ParquetFormat implements FileFormatTestSupport {
   public Map<String, String> testPropertiesToSet() {
     return Map.of(
         TableProperties.PARQUET_COMPRESSION,
-        "uncompressed",
-        TableProperties.PARQUET_COMPRESSION_LEVEL,
-        "1");
+        "gzip",
+        TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "col_a",
+        "false");
   }
 
   @Override
   public boolean checkTestProperties(InputFile inputFile) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
-      return "UNCOMPRESSED"
-          .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
+      boolean compressionMatches =
+          "GZIP"
+              .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
+      boolean foundColA = false;
+      boolean colAStatsDisabled = true;
+
+      for (BlockMetaData block : reader.getFooter().getBlocks()) {
+        for (ColumnChunkMetaData column : block.getColumns()) {
+          if ("col_a".equals(column.getPath().toDotString())) {
+            foundColA = true;
+            colAStatsDisabled &= column.getStatistics().isEmpty();
+          }
+        }
+      }
+
+      return compressionMatches && foundColA && colAStatsDisabled;
     }
   }
 

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -95,11 +95,11 @@ public class ParquetFormat implements FileFormatTestSupport {
           "GZIP"
               .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
 
-      return compressionMatches && hasExpectedDataPages(reader, 1);
+      return compressionMatches && hasExpectedRowsPerPage(reader, 1);
     }
   }
 
-  private boolean hasExpectedDataPages(ParquetFileReader reader, int expectedRowsPerPage)
+  private boolean hasExpectedRowsPerPage(ParquetFileReader reader, int expectedRowsPerPage)
       throws IOException {
     PageReadStore rowGroup;
 

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -83,7 +83,7 @@ public class ParquetFormat implements FileFormatTestSupport {
         TableProperties.PARQUET_COMPRESSION,
         "gzip",
         TableProperties.PARQUET_PAGE_ROW_LIMIT,
-        "5",
+        "1",
         TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT,
         "1");
   }
@@ -95,29 +95,24 @@ public class ParquetFormat implements FileFormatTestSupport {
           "GZIP"
               .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
 
-      return compressionMatches && hasExpectedDataPages(reader, 2, 5);
+      return compressionMatches && hasExpectedDataPages(reader, 1);
     }
   }
 
-  private boolean hasExpectedDataPages(
-      ParquetFileReader reader, int expectedPageCount, int expectedRowsPerPage) throws IOException {
-    int pageCount = 0;
+  private boolean hasExpectedDataPages(ParquetFileReader reader, int expectedRowsPerPage)
+      throws IOException {
     PageReadStore rowGroup;
 
     while ((rowGroup = reader.readNextRowGroup()) != null) {
       PageReader pageReader =
           rowGroup.getPageReader(reader.getFileMetaData().getSchema().getColumns().get(0));
-      DataPage page;
-      while ((page = pageReader.readPage()) != null) {
-        pageCount += 1;
-
-        if (page.getValueCount() != expectedRowsPerPage) {
-          return false;
-        }
+      DataPage page = pageReader.readPage();
+      if (page != null) {
+        return page.getValueCount() == expectedRowsPerPage;
       }
     }
 
-    return pageCount == expectedPageCount;
+    return false;
   }
 
   @Override

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -47,11 +47,6 @@ public class ParquetFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public boolean supportsFeature(String feature) {
-    return true;
-  }
-
-  @Override
   public void writeRecordsWithoutFieldIds(
       OutputFile outputFile, Schema schema, List<Record> records) throws IOException {
     org.apache.avro.Schema avroSchemaWithoutIds = AvroTestHelpers.removeIds(schema);

--- a/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/ParquetFormat.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import org.apache.avro.generic.GenericData;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.FileFormat;
@@ -43,6 +44,11 @@ public class ParquetFormat implements FileFormatTestSupport {
   @Override
   public FileFormat format() {
     return FileFormat.PARQUET;
+  }
+
+  @Override
+  public boolean supportsFeature(String feature) {
+    return true;
   }
 
   @Override
@@ -74,24 +80,15 @@ public class ParquetFormat implements FileFormatTestSupport {
   }
 
   @Override
-  public String compressionProperty() {
-    return TableProperties.PARQUET_COMPRESSION;
+  public Map<String, String> testPropertyToSet() {
+    return Map.of(TableProperties.PARQUET_COMPRESSION, "uncompressed");
   }
 
   @Override
-  public String compressionValue() {
-    return "uncompressed";
-  }
-
-  @Override
-  public String expectedCompressionCodec() {
-    return "UNCOMPRESSED";
-  }
-
-  @Override
-  public String actualCompressionCodec(InputFile inputFile) throws IOException {
+  public boolean checkTestProperty(InputFile inputFile) throws IOException {
     try (ParquetFileReader reader = ParquetFileReader.open(ParquetFileTestUtils.file(inputFile))) {
-      return reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name();
+      return "UNCOMPRESSED"
+          .equals(reader.getFooter().getBlocks().get(0).getColumns().get(0).getCodec().name());
     }
   }
 


### PR DESCRIPTION
Add TCK coverage for the missing parts of the Writer builder in the File Format API:

* set(...)
* setAll(...)
* meta(key, value)
* meta(Map)
* overwrite()

withFileEncryptionKey(...) and withAADPrefix(...) are Parquet-only and related to encryption. They will be covered in a follow-up PR.

