### PR TITLE
Docs: Document Kafka Connect control topic purpose and retention

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -238,6 +238,8 @@ This assumes the source topic already exists and is named `events`.
 
 #### Control topic
 
+The connector uses a control topic to coordinate commits across its tasks; it is internal to the connector and does not hold your table data. On each commit cycle (`iceberg.control.commit.interval-ms`, default 5 minutes) the coordinator publishes a `StartCommit` event, each worker replies with `DataWritten` events — carrying the metadata of the data and delete files it wrote to storage (file paths, record counts, column statistics), not the rows themselves — followed by a `DataComplete` event, and the coordinator concludes the round with `CommitToTable` and `CommitComplete` events. The committed position of each commit is persisted in the destination table's snapshot, so once a commit completes its control-topic events are no longer read.
+
 If your Kafka cluster has `auto.create.topics.enable` set to `true` (the default), then the control topic will be
 automatically created. If not, then you will need to create the topic first. The default topic name is `control-iceberg`:
 ```bash
@@ -246,9 +248,27 @@ bin/kafka-topics.sh  \
   --bootstrap-server ${CONNECT_BOOTSTRAP_SERVERS} \
   --create \
   --topic control-iceberg \
-  --partitions 1
+  --partitions 1 \
+  --config retention.ms=3600000
 ```
 *NOTE: Clusters running on Confluent Cloud have `auto.create.topics.enable` set to `false` by default.*
+
+##### Control topic retention
+
+Control-topic events are only needed until their commit completes, but the connector never deletes them itself. An auto-created control topic inherits the broker's default topic configuration — `cleanup.policy=delete` with the broker's default `retention.ms` — and if that default is very large or unlimited (`-1`), the topic keeps every coordination event and grows without bound. Configure a finite `retention.ms` that comfortably exceeds both `iceberg.control.commit.interval-ms` and `iceberg.control.commit.timeout-ms` (leaving some margin for a coordinator restart) so Kafka can age out old events; for the default 5-minute commit interval, one hour is a reasonable starting point.
+
+Set the retention when creating the topic with `--config retention.ms=3600000` (as shown above), or update an existing control topic:
+```bash
+bin/kafka-configs.sh \
+  --command-config command-config.props \
+  --bootstrap-server ${CONNECT_BOOTSTRAP_SERVERS} \
+  --alter \
+  --entity-type topics \
+  --entity-name control-iceberg \
+  --add-config retention.ms=3600000
+```
+
+A single control topic may be shared by multiple connectors — each task only acts on the events tagged with its own group id — but every connector writes its events to that one topic, so size the retention accordingly. Use the default `cleanup.policy=delete` (with retention) rather than log compaction: the control topic is an append-only coordination log, not keyed state.
 
 #### Iceberg catalog configuration
 

--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -240,6 +240,8 @@ This assumes the source topic already exists and is named `events`.
 
 #### Control topic
 
+The connector uses a control topic to coordinate commits across its tasks; it is internal to the connector and does not hold your table data. On each commit cycle (`iceberg.control.commit.interval-ms`, default 5 minutes) the coordinator publishes a `StartCommit` event, each worker replies with `DataWritten` events (which carry the metadata of the data and delete files it wrote to storage, such as file paths, record counts and column statistics, rather than the rows themselves), followed by a `DataComplete` event, and the coordinator concludes the round with `CommitToTable` and `CommitComplete` events. The committed position of each commit is persisted in the destination table's snapshot, so once a commit completes its control-topic events are no longer read.
+
 If your Kafka cluster has `auto.create.topics.enable` set to `true` (the default), then the control topic will be
 automatically created. If not, then you will need to create the topic first. The default topic name is `control-iceberg`:
 ```bash
@@ -248,9 +250,27 @@ bin/kafka-topics.sh  \
   --bootstrap-server ${CONNECT_BOOTSTRAP_SERVERS} \
   --create \
   --topic control-iceberg \
-  --partitions 1
+  --partitions 1 \
+  --config retention.ms=3600000
 ```
 *NOTE: Clusters running on Confluent Cloud have `auto.create.topics.enable` set to `false` by default.*
+
+##### Control topic retention
+
+Control-topic events are only needed until their commit completes, but the connector never deletes them itself. An auto-created control topic inherits the broker's default topic configuration (`cleanup.policy=delete` with the broker's default `retention.ms`), and if that default is very large or unlimited (`-1`), the topic keeps every coordination event and grows without bound. Configure a finite `retention.ms` that comfortably exceeds both `iceberg.control.commit.interval-ms` and `iceberg.control.commit.timeout-ms` (leaving some margin for a coordinator restart) so Kafka can age out old events; for the default 5-minute commit interval, one hour is a reasonable starting point.
+
+Set the retention when creating the topic with `--config retention.ms=3600000` (as shown above), or update an existing control topic:
+```bash
+bin/kafka-configs.sh \
+  --command-config command-config.props \
+  --bootstrap-server ${CONNECT_BOOTSTRAP_SERVERS} \
+  --alter \
+  --entity-type topics \
+  --entity-name control-iceberg \
+  --add-config retention.ms=3600000
+```
+
+A single control topic may be shared by multiple connectors (each task only acts on the events tagged with its own group id), but every connector writes its events to that one topic, so size the retention accordingly. Use the default `cleanup.policy=delete` (with retention) rather than log compaction: events are keyed by a per-producer id only to preserve their relative order, so compaction would keep just the latest record per producer and discard the rest of the coordination log.
 
 #### Iceberg catalog configuration
 


### PR DESCRIPTION
## Summary

Users have reported confusion about the Kafka Connect sink's control topic growing without bound (#15844, https://github.com/apache/iceberg/issues/15844). The docs explain how to *create* the control topic but never describe what it is for, how its events are used, or that it should have a finite retention — so on brokers with a large or unlimited default `retention.ms`, the topic accumulates coordination events indefinitely. This documents the behavior and the recommended configuration.

## What changed

Expanded the "Control topic" section of `docs/docs/kafka-connect.md`:

- Added a paragraph on the control topic's purpose and the per-commit event flow (`StartCommit` / `DataWritten` / `DataComplete` / `CommitToTable` / `CommitComplete`), noting that `DataWritten` carries data/delete file metadata rather than rows, and that the durable commit position lives in the table snapshot — so control-topic events are transient.
- Added `--config retention.ms=3600000` to the topic-creation example.
- Added a "Control topic retention" subsection: why an auto-created topic grows under broker defaults, how to size `retention.ms` relative to the commit interval/timeout, how to set it on an existing topic, multi-connector sizing, and using `cleanup.policy=delete` rather than compaction.

Closes #15844

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Document the Kafka Connect control topic purpose, event lifecycle, and retention settings.
