### PR TITLE
Avro: Encode non-zone timestamps with local-timestamp logical types

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -153,15 +153,17 @@ public class AvroSchemaUtil {
 
   public static boolean isTimestamptz(Schema schema) {
     LogicalType logicalType = schema.getLogicalType();
+    if (logicalType instanceof LogicalTypes.LocalTimestampMillis
+        || logicalType instanceof LogicalTypes.LocalTimestampMicros
+        || logicalType instanceof LogicalTypes.LocalTimestampNanos) {
+      return false;
+    }
     if (logicalType instanceof LogicalTypes.TimestampMillis
         || logicalType instanceof LogicalTypes.TimestampMicros
         || logicalType instanceof LogicalTypes.TimestampNanos) {
-      // timestamptz is adjusted to UTC
       Object value = schema.getObjectProp(ADJUST_TO_UTC_PROP);
 
       if (value == null) {
-        // not all avro timestamp logical types will have the adjust_to_utc prop, default to
-        // timestamp without timezone
         return false;
       } else if (value instanceof Boolean) {
         return (Boolean) value;

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -82,9 +82,11 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
           return ValueWriters.longs();
 
         case "timestamp-micros":
+        case "local-timestamp-micros":
           return ValueWriters.longs();
 
         case "timestamp-nanos":
+        case "local-timestamp-nanos":
           return ValueWriters.longs();
 
         case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -182,13 +182,14 @@ public class GenericAvroReader<T>
             return ValueReaders.longs();
 
           case "timestamp-millis":
-            // adjust to microseconds
+          case "local-timestamp-millis":
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
           case "timestamp-nanos":
-            // both are handled in memory as long values, using the type to track units
+          case "local-timestamp-micros":
+          case "local-timestamp-nanos":
             return ValueReaders.longs();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -178,13 +178,14 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
             return ValueReaders.longs();
 
           case "timestamp-millis":
-            // adjust to microseconds
+          case "local-timestamp-millis":
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
           case "timestamp-nanos":
-            // both are handled in memory as long values, using the type to track units
+          case "local-timestamp-micros":
+          case "local-timestamp-nanos":
             return ValueReaders.longs();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -191,25 +191,29 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
         || logical instanceof LogicalTypes.TimeMicros) {
       return Types.TimeType.get();
 
-    } else if (logical instanceof LogicalTypes.TimestampMillis
-        || logical instanceof LogicalTypes.TimestampMicros) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
-        return Types.TimestampType.withZone();
-      } else {
-        return Types.TimestampType.withoutZone();
-      }
-
-    } else if (logical instanceof LogicalTypes.TimestampNanos) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
-        return Types.TimestampNanoType.withZone();
-      } else {
-        return Types.TimestampNanoType.withoutZone();
-      }
-
     } else if (LogicalTypes.uuid().getName().equals(name)) {
       return Types.UUIDType.get();
     }
 
+    return timestampType(primitive, logical);
+  }
+
+  private static Type timestampType(Schema primitive, LogicalType logical) {
+    if (logical instanceof LogicalTypes.TimestampMillis
+        || logical instanceof LogicalTypes.TimestampMicros) {
+      return AvroSchemaUtil.isTimestamptz(primitive)
+          ? Types.TimestampType.withZone()
+          : Types.TimestampType.withoutZone();
+    } else if (logical instanceof LogicalTypes.LocalTimestampMillis
+        || logical instanceof LogicalTypes.LocalTimestampMicros) {
+      return Types.TimestampType.withoutZone();
+    } else if (logical instanceof LogicalTypes.TimestampNanos) {
+      return AvroSchemaUtil.isTimestamptz(primitive)
+          ? Types.TimestampNanoType.withZone()
+          : Types.TimestampNanoType.withoutZone();
+    } else if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      return Types.TimestampNanoType.withoutZone();
+    }
     return null;
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -43,11 +43,11 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   private static final Schema TIME_SCHEMA =
       LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMP_SCHEMA =
-      LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+      LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMPTZ_SCHEMA =
       LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMP_NANO_SCHEMA =
-      LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+      LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMPTZ_NANO_SCHEMA =
       LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema STRING_SCHEMA = Schema.create(Schema.Type.STRING);
@@ -56,9 +56,7 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   private static final Schema BINARY_SCHEMA = Schema.create(Schema.Type.BYTES);
 
   static {
-    TIMESTAMP_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     TIMESTAMPTZ_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
-    TIMESTAMP_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     TIMESTAMPTZ_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
   }
 

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -140,16 +140,25 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
             }
             return GenericReaders.timestamps();
 
+          case "local-timestamp-micros":
+            return GenericReaders.timestamps();
+
           case "timestamp-nanos":
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
 
+          case "local-timestamp-nanos":
+            return GenericReaders.timestampNanos();
+
           case "timestamp-millis":
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
+            return GenericReaders.timestampMillis();
+
+          case "local-timestamp-millis":
             return GenericReaders.timestampMillis();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -124,10 +124,16 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
             }
             return GenericWriters.timestamps();
 
+          case "local-timestamp-micros":
+            return GenericWriters.timestamps();
+
           case "timestamp-nanos":
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericWriters.timestamptzNanos();
             }
+            return GenericWriters.timestampNanos();
+
+          case "local-timestamp-nanos":
             return GenericWriters.timestampNanos();
 
           case "decimal":

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -148,16 +148,25 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
             }
             return GenericReaders.timestamps();
 
+          case "local-timestamp-micros":
+            return GenericReaders.timestamps();
+
           case "timestamp-nanos":
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
 
+          case "local-timestamp-nanos":
+            return GenericReaders.timestampNanos();
+
           case "timestamp-millis":
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
+            return GenericReaders.timestampMillis();
+
+          case "local-timestamp-millis":
             return GenericReaders.timestampMillis();
 
           case "decimal":

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -72,8 +72,7 @@ public class TestSchemaConversions {
             LogicalTypes.timeMicros().addToSchema(Schema.create(Schema.Type.LONG)),
             addAdjustToUtc(
                 LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)), true),
-            addAdjustToUtc(
-                LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)), false),
+            LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG)),
             Schema.create(Schema.Type.STRING),
             LogicalTypes.uuid().addToSchema(Schema.createFixed("uuid_fixed", null, null, 16)),
             Schema.createFixed("fixed_12", null, null, 12),
@@ -96,14 +95,49 @@ public class TestSchemaConversions {
 
   @Test
   public void testAvroToIcebergTimestampTypeWithoutAdjustToUTC() {
-    // Not included in the primitives test because there is not a way to round trip the
-    // avro<->iceberg conversion
-    // This is because iceberg types can only can encode adjust-to-utc=true|false but not a missing
-    // adjust-to-utc
     Type expectedIcebergType = Types.TimestampType.withoutZone();
     Schema avroType = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
 
     assertThat(AvroSchemaUtil.convert(avroType)).isEqualTo(expectedIcebergType);
+  }
+
+  @Test
+  public void testAvroLegacyTimestampMicrosWithAdjustToUtcFalse() {
+    Schema avroType =
+        addAdjustToUtc(
+            LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)), false);
+    assertThat(AvroSchemaUtil.convert(avroType)).isEqualTo(Types.TimestampType.withoutZone());
+  }
+
+  @Test
+  public void testAvroLegacyTimestampNanosWithAdjustToUtcFalse() {
+    Schema avroType =
+        addAdjustToUtc(
+            LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG)), false);
+    assertThat(AvroSchemaUtil.convert(avroType)).isEqualTo(Types.TimestampNanoType.withoutZone());
+  }
+
+  @Test
+  public void testAvroLocalTimestampLogicalTypes() {
+    Schema millis =
+        LogicalTypes.localTimestampMillis().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema micros =
+        LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema nanos = LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+
+    assertThat(AvroSchemaUtil.convert(millis)).isEqualTo(Types.TimestampType.withoutZone());
+    assertThat(AvroSchemaUtil.convert(micros)).isEqualTo(Types.TimestampType.withoutZone());
+    assertThat(AvroSchemaUtil.convert(nanos)).isEqualTo(Types.TimestampNanoType.withoutZone());
+  }
+
+  @Test
+  public void testIcebergTimestampNanosToAvro() {
+    assertThat(AvroSchemaUtil.convert(Types.TimestampNanoType.withZone()))
+        .isEqualTo(
+            addAdjustToUtc(
+                LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG)), true));
+    assertThat(AvroSchemaUtil.convert(Types.TimestampNanoType.withoutZone()))
+        .isEqualTo(LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG)));
   }
 
   private Schema addAdjustToUtc(Schema schema, boolean adjustToUTC) {
@@ -152,9 +186,7 @@ public class TestSchemaConversions {
             optionalField(
                 29,
                 "timestamp",
-                addAdjustToUtc(
-                    LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG)),
-                    false)),
+                LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG))),
             optionalField(30, "string", Schema.create(Schema.Type.STRING)),
             optionalField(
                 31,

--- a/data/src/test/java/org/apache/iceberg/data/avro/TestTimestampLogicalTypeRoundTrip.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/TestTimestampLogicalTypeRoundTrip.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data.avro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.apache.avro.LogicalType;
+import org.apache.avro.LogicalTypes;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.avro.Avro;
+import org.apache.iceberg.avro.AvroIterable;
+import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestTimestampLogicalTypeRoundTrip {
+
+  @TempDir private Path temp;
+
+  private static final Schema TS_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "ts", Types.TimestampType.withoutZone()),
+          Types.NestedField.required(2, "tstz", Types.TimestampType.withZone()),
+          Types.NestedField.required(3, "ts_ns", Types.TimestampNanoType.withoutZone()),
+          Types.NestedField.required(4, "tstz_ns", Types.TimestampNanoType.withZone()));
+
+  @Test
+  void writerEmitsLocalTimestampForNonZoneTypes() {
+    org.apache.avro.Schema avro = AvroSchemaUtil.convert(TS_SCHEMA, "test");
+    assertThat(logicalTypeOf(avro, "ts")).isInstanceOf(LogicalTypes.LocalTimestampMicros.class);
+    assertThat(logicalTypeOf(avro, "tstz")).isInstanceOf(LogicalTypes.TimestampMicros.class);
+    assertThat(logicalTypeOf(avro, "ts_ns")).isInstanceOf(LogicalTypes.LocalTimestampNanos.class);
+    assertThat(logicalTypeOf(avro, "tstz_ns")).isInstanceOf(LogicalTypes.TimestampNanos.class);
+  }
+
+  @Test
+  void roundTripsAllFourTimestampTypes() throws IOException {
+    LocalDateTime localTs = LocalDateTime.of(2026, 5, 27, 12, 34, 56, 123_456_000);
+    OffsetDateTime utcTs = OffsetDateTime.of(localTs, ZoneOffset.UTC);
+    LocalDateTime localTsNanos = LocalDateTime.of(2026, 5, 27, 12, 34, 56, 123_456_789);
+    OffsetDateTime utcTsNanos = OffsetDateTime.of(localTsNanos, ZoneOffset.UTC);
+
+    Record record = GenericRecord.create(TS_SCHEMA);
+    record.setField("ts", localTs);
+    record.setField("tstz", utcTs);
+    record.setField("ts_ns", localTsNanos);
+    record.setField("tstz_ns", utcTsNanos);
+
+    List<Record> written = ImmutableList.of(record);
+    File file = temp.resolve("timestamps-" + System.nanoTime() + ".avro").toFile();
+
+    try (org.apache.iceberg.io.FileAppender<Record> writer =
+        Avro.write(Files.localOutput(file))
+            .schema(TS_SCHEMA)
+            .createWriterFunc(DataWriter::create)
+            .named("test")
+            .build()) {
+      writer.add(record);
+    }
+
+    List<Record> read;
+    try (AvroIterable<Record> reader =
+        Avro.read(Files.localInput(file))
+            .project(TS_SCHEMA)
+            .createResolvingReader(PlannedDataReader::create)
+            .build()) {
+      read = Lists.newArrayList(reader);
+    }
+
+    assertThat(read).hasSize(1);
+    Record actual = read.get(0);
+    assertThat(actual.getField("ts")).isEqualTo(localTs);
+    assertThat(actual.getField("tstz")).isEqualTo(utcTs);
+    assertThat(actual.getField("ts_ns")).isEqualTo(localTsNanos);
+    assertThat(actual.getField("tstz_ns")).isEqualTo(utcTsNanos);
+    assertThat(written.get(0)).isEqualTo(actual);
+  }
+
+  @Test
+  void readsLegacyAdjustToUtcFalseEncoding() {
+    assertThat(AvroSchemaUtil.convert(legacyStamped(LogicalTypes.timestampMicros(), false)))
+        .isEqualTo(Types.TimestampType.withoutZone());
+    assertThat(AvroSchemaUtil.convert(legacyStamped(LogicalTypes.timestampNanos(), false)))
+        .isEqualTo(Types.TimestampNanoType.withoutZone());
+    assertThat(AvroSchemaUtil.convert(legacyStamped(LogicalTypes.timestampMicros(), true)))
+        .isEqualTo(Types.TimestampType.withZone());
+    assertThat(AvroSchemaUtil.convert(legacyStamped(LogicalTypes.timestampNanos(), true)))
+        .isEqualTo(Types.TimestampNanoType.withZone());
+  }
+
+  private static LogicalType logicalTypeOf(org.apache.avro.Schema record, String fieldName) {
+    org.apache.avro.Schema field = record.getField(fieldName).schema();
+    if (field.getType() == org.apache.avro.Schema.Type.UNION) {
+      for (org.apache.avro.Schema branch : field.getTypes()) {
+        if (branch.getType() != org.apache.avro.Schema.Type.NULL) {
+          return branch.getLogicalType();
+        }
+      }
+    }
+    return field.getLogicalType();
+  }
+
+  private static org.apache.avro.Schema legacyStamped(
+      LogicalType logicalType, boolean adjustToUtc) {
+    org.apache.avro.Schema stamped =
+        logicalType.addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+    stamped.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, adjustToUtc);
+    return stamped;
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
@@ -122,9 +122,11 @@ public class FlinkAvroWriter implements MetricsAwareDatumWriter<RowData> {
             return FlinkValueWriters.timeMicros();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueWriters.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueWriters.timestampNanos();
 
           case "decimal":

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -138,12 +138,15 @@ public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRow
             return FlinkValueReaders.timeMicros();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             return FlinkValueReaders.timestampMills();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueReaders.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueReaders.timestampNanos();
 
           case "decimal":

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -60,6 +60,72 @@ import org.joda.time.Days;
  */
 public class DataGenerators {
 
+  private static org.apache.avro.Schema rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema schema) {
+    switch (schema.getType()) {
+      case UNION:
+        List<org.apache.avro.Schema> rewritten =
+            schema.getTypes().stream()
+                .map(DataGenerators::rewriteLocalTimestampForFlink)
+                .collect(Collectors.toList());
+        return org.apache.avro.Schema.createUnion(rewritten);
+      case ARRAY:
+        return org.apache.avro.Schema.createArray(
+            rewriteLocalTimestampForFlink(schema.getElementType()));
+      case MAP:
+        return org.apache.avro.Schema.createMap(
+            rewriteLocalTimestampForFlink(schema.getValueType()));
+      case RECORD:
+        List<org.apache.avro.Schema.Field> fields =
+            schema.getFields().stream()
+                .map(
+                    f ->
+                        new org.apache.avro.Schema.Field(
+                            f.name(),
+                            rewriteLocalTimestampForFlink(f.schema()),
+                            f.doc(),
+                            f.defaultVal()))
+                .collect(Collectors.toList());
+        org.apache.avro.Schema record =
+            org.apache.avro.Schema.createRecord(
+                schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError(), fields);
+        schema.getObjectProps().forEach(record::addProp);
+        return record;
+      default:
+        return rewriteLocalTimestampPrimitive(schema);
+    }
+  }
+
+  private static org.apache.avro.Schema rewriteLocalTimestampPrimitive(
+      org.apache.avro.Schema schema) {
+    org.apache.avro.LogicalType logical = schema.getLogicalType();
+    if (logical instanceof LogicalTypes.LocalTimestampMicros) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampMicros()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampNanos()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    return schema;
+  }
+
+  private static org.apache.avro.Schema.Field rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema.Field field) {
+    org.apache.avro.Schema rewritten = rewriteLocalTimestampForFlink(field.schema());
+    if (rewritten == field.schema()) {
+      return field;
+    }
+    return new org.apache.avro.Schema.Field(
+        field.name(), rewritten, field.doc(), field.defaultVal());
+  }
+
   public static class Primitives implements DataGenerator {
     private static final DateTime JODA_DATETIME_EPOC =
         new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
@@ -134,6 +200,8 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = rewriteLocalTimestampForFlink(updatedField);
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
@@ -580,7 +648,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {
@@ -867,7 +935,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
@@ -122,9 +122,11 @@ public class FlinkAvroWriter implements MetricsAwareDatumWriter<RowData> {
             return FlinkValueWriters.timeMicros();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueWriters.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueWriters.timestampNanos();
 
           case "decimal":

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -138,12 +138,15 @@ public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRow
             return FlinkValueReaders.timeMicros();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             return FlinkValueReaders.timestampMills();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueReaders.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueReaders.timestampNanos();
 
           case "decimal":

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -60,6 +60,72 @@ import org.joda.time.Days;
  */
 public class DataGenerators {
 
+  private static org.apache.avro.Schema rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema schema) {
+    switch (schema.getType()) {
+      case UNION:
+        List<org.apache.avro.Schema> rewritten =
+            schema.getTypes().stream()
+                .map(DataGenerators::rewriteLocalTimestampForFlink)
+                .collect(Collectors.toList());
+        return org.apache.avro.Schema.createUnion(rewritten);
+      case ARRAY:
+        return org.apache.avro.Schema.createArray(
+            rewriteLocalTimestampForFlink(schema.getElementType()));
+      case MAP:
+        return org.apache.avro.Schema.createMap(
+            rewriteLocalTimestampForFlink(schema.getValueType()));
+      case RECORD:
+        List<org.apache.avro.Schema.Field> fields =
+            schema.getFields().stream()
+                .map(
+                    f ->
+                        new org.apache.avro.Schema.Field(
+                            f.name(),
+                            rewriteLocalTimestampForFlink(f.schema()),
+                            f.doc(),
+                            f.defaultVal()))
+                .collect(Collectors.toList());
+        org.apache.avro.Schema record =
+            org.apache.avro.Schema.createRecord(
+                schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError(), fields);
+        schema.getObjectProps().forEach(record::addProp);
+        return record;
+      default:
+        return rewriteLocalTimestampPrimitive(schema);
+    }
+  }
+
+  private static org.apache.avro.Schema rewriteLocalTimestampPrimitive(
+      org.apache.avro.Schema schema) {
+    org.apache.avro.LogicalType logical = schema.getLogicalType();
+    if (logical instanceof LogicalTypes.LocalTimestampMicros) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampMicros()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampNanos()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    return schema;
+  }
+
+  private static org.apache.avro.Schema.Field rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema.Field field) {
+    org.apache.avro.Schema rewritten = rewriteLocalTimestampForFlink(field.schema());
+    if (rewritten == field.schema()) {
+      return field;
+    }
+    return new org.apache.avro.Schema.Field(
+        field.name(), rewritten, field.doc(), field.defaultVal());
+  }
+
   public static class Primitives implements DataGenerator {
     private static final DateTime JODA_DATETIME_EPOC =
         new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
@@ -134,6 +200,8 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = rewriteLocalTimestampForFlink(updatedField);
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
@@ -580,7 +648,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {
@@ -867,7 +935,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
@@ -122,9 +122,11 @@ public class FlinkAvroWriter implements MetricsAwareDatumWriter<RowData> {
             return FlinkValueWriters.timeMicros();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueWriters.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueWriters.timestampNanos();
 
           case "decimal":

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -138,12 +138,15 @@ public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRow
             return FlinkValueReaders.timeMicros();
 
           case "timestamp-millis":
+          case "local-timestamp-millis":
             return FlinkValueReaders.timestampMills();
 
           case "timestamp-micros":
+          case "local-timestamp-micros":
             return FlinkValueReaders.timestampMicros();
 
           case "timestamp-nanos":
+          case "local-timestamp-nanos":
             return FlinkValueReaders.timestampNanos();
 
           case "decimal":

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -60,6 +60,72 @@ import org.joda.time.Days;
  */
 public class DataGenerators {
 
+  private static org.apache.avro.Schema rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema schema) {
+    switch (schema.getType()) {
+      case UNION:
+        List<org.apache.avro.Schema> rewritten =
+            schema.getTypes().stream()
+                .map(DataGenerators::rewriteLocalTimestampForFlink)
+                .collect(Collectors.toList());
+        return org.apache.avro.Schema.createUnion(rewritten);
+      case ARRAY:
+        return org.apache.avro.Schema.createArray(
+            rewriteLocalTimestampForFlink(schema.getElementType()));
+      case MAP:
+        return org.apache.avro.Schema.createMap(
+            rewriteLocalTimestampForFlink(schema.getValueType()));
+      case RECORD:
+        List<org.apache.avro.Schema.Field> fields =
+            schema.getFields().stream()
+                .map(
+                    f ->
+                        new org.apache.avro.Schema.Field(
+                            f.name(),
+                            rewriteLocalTimestampForFlink(f.schema()),
+                            f.doc(),
+                            f.defaultVal()))
+                .collect(Collectors.toList());
+        org.apache.avro.Schema record =
+            org.apache.avro.Schema.createRecord(
+                schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError(), fields);
+        schema.getObjectProps().forEach(record::addProp);
+        return record;
+      default:
+        return rewriteLocalTimestampPrimitive(schema);
+    }
+  }
+
+  private static org.apache.avro.Schema rewriteLocalTimestampPrimitive(
+      org.apache.avro.Schema schema) {
+    org.apache.avro.LogicalType logical = schema.getLogicalType();
+    if (logical instanceof LogicalTypes.LocalTimestampMicros) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampMicros()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      org.apache.avro.Schema rewritten =
+          LogicalTypes.timestampNanos()
+              .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG));
+      rewritten.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      return rewritten;
+    }
+    return schema;
+  }
+
+  private static org.apache.avro.Schema.Field rewriteLocalTimestampForFlink(
+      org.apache.avro.Schema.Field field) {
+    org.apache.avro.Schema rewritten = rewriteLocalTimestampForFlink(field.schema());
+    if (rewritten == field.schema()) {
+      return field;
+    }
+    return new org.apache.avro.Schema.Field(
+        field.name(), rewritten, field.doc(), field.defaultVal());
+  }
+
   public static class Primitives implements DataGenerator {
     private static final DateTime JODA_DATETIME_EPOC =
         new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeZone.UTC);
@@ -134,6 +200,8 @@ public class DataGenerators {
                               .addToSchema(
                                   org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT));
                       updatedField = new org.apache.avro.Schema.Field("time_field", fieldSchema);
+                    } else {
+                      updatedField = rewriteLocalTimestampForFlink(updatedField);
                     }
 
                     return new org.apache.avro.Schema.Field(updatedField, updatedField.schema());
@@ -580,7 +648,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {
@@ -867,7 +935,7 @@ public class DataGenerators {
     private final RowType flinkRowType = FlinkSchemaUtil.convert(icebergSchema);
 
     private final org.apache.avro.Schema avroSchema =
-        AvroSchemaUtil.convert(icebergSchema, "table");
+        rewriteLocalTimestampForFlink(AvroSchemaUtil.convert(icebergSchema, "table"));
 
     @Override
     public Schema icebergSchema() {

--- a/format/spec.md
+++ b/format/spec.md
@@ -1485,9 +1485,9 @@ Maps with non-string keys must use an array representation with the `map` logica
 |**`decimal(P,S)`**|`{ "type": "fixed",`<br />&nbsp;&nbsp;`"size": minBytesRequired(P),`<br />&nbsp;&nbsp;`"logicalType": "decimal",`<br />&nbsp;&nbsp;`"precision": P,`<br />&nbsp;&nbsp;`"scale": S }`|Stored as fixed using the minimum number of bytes for the given precision.|
 |**`date`**|`{ "type": "int",`<br />&nbsp;&nbsp;`"logicalType": "date" }`|Stores days from 1970-01-01.|
 |**`time`**|`{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "time-micros" }`|Stores microseconds from midnight.|
-|**`timestamp`**      | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "timestamp-micros",`<br />&nbsp;&nbsp;`"adjust-to-utc": false }` | Stores microseconds from 1970-01-01 00:00:00.000000. [1]            |
+|**`timestamp`**      | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "local-timestamp-micros" }`                                     | Stores microseconds from 1970-01-01 00:00:00.000000. [1]            |
 |**`timestamptz`**    | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "timestamp-micros",`<br />&nbsp;&nbsp;`"adjust-to-utc": true }`  | Stores microseconds from 1970-01-01 00:00:00.000000 UTC. [1]        |
-|**`timestamp_ns`**   | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "timestamp-nanos",`<br />&nbsp;&nbsp;`"adjust-to-utc": false }`  | Stores nanoseconds from 1970-01-01 00:00:00.000000000. [1], [2]     |
+|**`timestamp_ns`**   | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "local-timestamp-nanos" }`                                      | Stores nanoseconds from 1970-01-01 00:00:00.000000000. [1], [2]     |
 |**`timestamptz_ns`** | `{ "type": "long",`<br />&nbsp;&nbsp;`"logicalType": "timestamp-nanos",`<br />&nbsp;&nbsp;`"adjust-to-utc": true }`   | Stores nanoseconds from 1970-01-01 00:00:00.000000000 UTC. [1], [2] |
 |**`string`**|`string`||
 |**`uuid`**|`{ "type": "fixed",`<br />&nbsp;&nbsp;`"size": 16,`<br />&nbsp;&nbsp;`"logicalType": "uuid" }`||
@@ -1502,7 +1502,7 @@ Maps with non-string keys must use an array representation with the `map` logica
 
 Notes:
 
-1. Avro type annotation `adjust-to-utc` is an Iceberg convention; default value is `false` if not present.
+1. Non-zone timestamp types are written using Avro's `local-timestamp-{micros,nanos}` logical types. Zone-adjusted timestamp types are written using `timestamp-{micros,nanos}` with `adjust-to-utc: true`. Readers must also accept legacy files that encode non-zone timestamps as `timestamp-{micros,nanos}` with `adjust-to-utc: false`.
 2. Avro logical type `timestamp-nanos` is an Iceberg convention; the Avro specification does not define this type.
 
 **Field IDs**

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -123,7 +123,7 @@ public class SparkAvroWriter implements MetricsAwareDatumWriter<InternalRow> {
             return ValueWriters.ints();
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueWriters.longs();
 
           case "decimal":

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -136,12 +136,12 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
-            // adjust to microseconds
+          case "local-timestamp-millis":
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueReaders.longs();
 
           case "decimal":

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -128,7 +128,7 @@ public class SparkAvroWriter implements MetricsAwareDatumWriter<InternalRow> {
             return ValueWriters.ints();
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueWriters.longs();
 
           case "decimal":

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -142,12 +142,12 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
-            // adjust to microseconds
+          case "local-timestamp-millis":
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueReaders.longs();
 
           case "decimal":

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkAvroWriter.java
@@ -128,7 +128,7 @@ public class SparkAvroWriter implements MetricsAwareDatumWriter<InternalRow> {
             return ValueWriters.ints();
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueWriters.longs();
 
           case "decimal":

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkPlannedAvroReader.java
@@ -142,12 +142,12 @@ public class SparkPlannedAvroReader implements DatumReader<InternalRow>, Support
             return ValueReaders.ints();
 
           case "timestamp-millis":
-            // adjust to microseconds
+          case "local-timestamp-millis":
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
 
           case "timestamp-micros":
-            // Spark uses the same representation
+          case "local-timestamp-micros":
             return ValueReaders.longs();
 
           case "decimal":


### PR DESCRIPTION
Closes #12751

Switches Iceberg's Avro encoding for non-zone timestamp types
(`timestamp`, `timestamp_ns`) to the Avro-spec-correct
`local-timestamp-{micros,nanos}` logical types, instead of overloading
`timestamp-{micros,nanos}` with the Iceberg-private
`adjust-to-utc=false` convention.

The zone-adjusted variants (`timestamptz`, `timestamptz_ns`) continue
to use `timestamp-{micros,nanos}` with `adjust-to-utc=true`.

## Why

Per the Avro spec, `timestamp-{millis,micros,nanos}` is an instant on
the global timeline (UTC), while `local-timestamp-{millis,micros,nanos}`
is the timezone-free local timestamp. 

Iceberg's writer mapped both the
zone and non-zone Iceberg types to `timestamp-*` and disambiguated with
the `adjust-to-utc` property, which the spec footnote already calls
out as an Iceberg-only convention.