### PR TITLE
Core: Retry transient REST response-body read failures

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -32,8 +32,10 @@ import javax.net.ssl.HostnameVerifier;
 import org.apache.hc.client5.http.auth.AuthScope;
 import org.apache.hc.client5.http.auth.CredentialsProvider;
 import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.classic.ExecChain;
 import org.apache.hc.client5.http.classic.methods.HttpUriRequestBase;
 import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.ChainElement;
 import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
@@ -43,14 +45,18 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.client5.http.protocol.HttpClientContext;
 import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
 import org.apache.hc.client5.http.ssl.HostnameVerificationPolicy;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
 import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+import org.apache.hc.core5.http.HttpException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.http.ParseException;
 import org.apache.hc.core5.http.impl.EnglishReasonPhraseCatalog;
+import org.apache.hc.core5.http.io.entity.BufferedHttpEntity;
 import org.apache.hc.core5.http.io.entity.EntityUtils;
 import org.apache.hc.core5.http.io.entity.StringEntity;
 import org.apache.hc.core5.http.protocol.HttpContext;
@@ -127,6 +133,13 @@ public class HTTPClient extends BaseHTTPClient {
     int maxRetries = PropertyUtil.propertyAsInt(properties, REST_MAX_RETRIES, 5);
     clientBuilder.setRetryStrategy(new ExponentialHttpRequestRetryStrategy(maxRetries));
 
+    // Buffer the response body inside the retry-aware exec chain so that transient wire failures
+    // while reading the body (e.g. MalformedChunkCodingException on a chunked/gzip stream) are
+    // retried like any other transient IOException, instead of escaping the retry strategy in the
+    // response handler. See https://github.com/apache/iceberg/issues/15030.
+    clientBuilder.addExecInterceptorAfter(
+        ChainElement.RETRY.name(), "BUFFER_RESPONSE_BODY", HTTPClient::bufferResponseBody);
+
     String userAgent = PropertyUtil.propertyAsString(properties, REST_USER_AGENT, null);
     if (userAgent != null) {
       clientBuilder.setUserAgent(userAgent);
@@ -162,6 +175,28 @@ public class HTTPClient extends BaseHTTPClient {
   public HTTPClient withAuthSession(AuthSession session) {
     Preconditions.checkNotNull(session, "Invalid auth session: null");
     return new HTTPClient(this, session);
+  }
+
+  /**
+   * Reads the full response body into memory while still inside the retry-aware exec chain.
+   *
+   * <p>The body is otherwise read lazily in the response handler, which runs outside the exec
+   * chain, so a transient failure while reading it (e.g. {@code MalformedChunkCodingException} on a
+   * chunked/gzip stream) would escape the retry strategy and fail the request. Buffering here
+   * surfaces such failures as retryable {@link IOException}s handled by the configured retry
+   * strategy. The entity is wrapped transparently (preserving content type and encoding), so the
+   * body is still parsed exactly once by the response handler.
+   */
+  private static ClassicHttpResponse bufferResponseBody(
+      ClassicHttpRequest request, ExecChain.Scope scope, ExecChain chain)
+      throws IOException, HttpException {
+    ClassicHttpResponse response = chain.proceed(request, scope);
+    HttpEntity entity = response.getEntity();
+    if (entity != null) {
+      response.setEntity(new BufferedHttpEntity(entity));
+    }
+
+    return response;
   }
 
   private static String extractResponseBodyAsString(ClassicHttpResponse response) {

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -33,15 +33,22 @@ import static org.mockserver.model.HttpResponse.response;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.net.SocketTimeoutException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.security.KeyStore;
 import java.security.cert.CertificateException;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
@@ -586,6 +593,110 @@ public class TestHTTPClient {
 
     // No exception should be thrown, and the second request should succeed
     doExecuteRequest(method, path, loadTableRequestBody, errorHandler, headers -> {});
+  }
+
+  @Test
+  public void testRetriesTransientResponseBodyFailure() throws Exception {
+    Item expected = new Item(0L, "load table");
+    AtomicInteger connections = new AtomicInteger();
+    List<byte[]> responses =
+        List.of(malformedChunkedResponse(), validJsonResponse(MAPPER.writeValueAsString(expected)));
+
+    try (ServerSocket server = startServer(responses, connections);
+        HTTPClient client = clientFor(server)) {
+      Item response =
+          client.get(
+              "v1/namespaces/ns/tables/table",
+              ImmutableMap.of(),
+              Item.class,
+              ImmutableMap.of(),
+              error -> {},
+              headers -> {});
+      assertThat(response).isEqualTo(expected);
+    }
+
+    // The idempotent GET fails reading the body on the first connection and is retried on a fresh
+    // connection, so the server is hit exactly twice.
+    assertThat(connections).hasValue(2);
+  }
+
+  private static HTTPClient clientFor(ServerSocket server) {
+    return HTTPClient.builder(ImmutableMap.of())
+        .uri(String.format("http://127.0.0.1:%d", server.getLocalPort()))
+        .withAuthSession(AuthSession.EMPTY)
+        .build();
+  }
+
+  /**
+   * Starts a daemon HTTP server on an ephemeral port that replies to each accepted connection with
+   * the next scripted raw response, then returns the (caller-closed) server socket. Used to
+   * reproduce wire-level faults (such as a malformed chunked body) that MockServer cannot emit.
+   */
+  private static ServerSocket startServer(List<byte[]> responses, AtomicInteger connections)
+      throws IOException {
+    ServerSocket server = new ServerSocket(0);
+    Thread serverThread =
+        new Thread(() -> responses.forEach(response -> reply(server, response, connections)));
+    serverThread.setDaemon(true);
+    serverThread.start();
+    return server;
+  }
+
+  private static void reply(ServerSocket server, byte[] response, AtomicInteger connections) {
+    try (Socket socket = server.accept()) {
+      connections.incrementAndGet();
+      drainRequest(socket.getInputStream());
+      socket.getOutputStream().write(response);
+    } catch (IOException e) {
+      // The server socket was closed after the test finished, or the client hung up; nothing to do.
+    }
+  }
+
+  /** Consumes a bodyless HTTP request by reading up to the end of the request headers. */
+  private static void drainRequest(InputStream in) throws IOException {
+    int[] tail = {0, 0, 0, 0};
+    int next;
+    while ((next = in.read()) != -1) {
+      tail[0] = tail[1];
+      tail[1] = tail[2];
+      tail[2] = tail[3];
+      tail[3] = next;
+      if (tail[0] == '\r' && tail[1] == '\n' && tail[2] == '\r' && tail[3] == '\n') {
+        break;
+      }
+    }
+  }
+
+  /**
+   * A 200 response whose chunked body is not terminated by a CRLF, which the client decodes into a
+   * {@code MalformedChunkCodingException} while reading the body — the transient wire fault
+   * reported in iceberg#15030.
+   */
+  private static byte[] malformedChunkedResponse() {
+    String raw =
+        "HTTP/1.1 200 OK\r\n"
+            + "Content-Type: application/json\r\n"
+            + "Transfer-Encoding: chunked\r\n"
+            + "\r\n"
+            + "5\r\nhelloXX";
+    return raw.getBytes(StandardCharsets.US_ASCII);
+  }
+
+  private static byte[] validJsonResponse(String json) {
+    byte[] body = json.getBytes(StandardCharsets.UTF_8);
+    byte[] head =
+        ("HTTP/1.1 200 OK\r\n"
+                + "Content-Type: application/json\r\n"
+                + "Content-Length: "
+                + body.length
+                + "\r\n"
+                + "Connection: close\r\n"
+                + "\r\n")
+            .getBytes(StandardCharsets.US_ASCII);
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    out.writeBytes(head);
+    out.writeBytes(body);
+    return out.toByteArray();
   }
 
   public static void testHttpMethodOnSuccess(HttpMethod method) throws JsonProcessingException {


### PR DESCRIPTION
Closes #15030.

## Summary

The Iceberg REST catalog client occasionally fails with an unrecoverable `RESTException: Failed to convert HTTP response body to string` caused by `MalformedChunkCodingException` while reading a chunked/gzip response body. The failure is transient (restarting the affected process — e.g. a Kafka Connect sink — recovers), so it should be retried rather than surfaced as fatal.

The client already retries idempotent requests on transient `IOException`s via `ExponentialHttpRequestRetryStrategy`, and `MalformedChunkCodingException` is not in its non-retriable set. The gap is structural: Apache HttpClient5's retry runs in the `HttpRequestRetryExec` chain element, which only covers connecting and reading the response headers. The response body is read later, in the response handler (outside the exec chain), so a body-read failure bypasses the retry entirely.

## What changed

Added an exec-chain interceptor, registered immediately inside `HttpRequestRetryExec`, that fully buffers the response entity (`BufferedHttpEntity`). Because the body is now read inside the retry-aware part of the chain, a transient body-read `IOException` is surfaced to the existing retry strategy and retried like any other transient failure — same idempotency check, same non-retriable classification, same exponential backoff, and a fresh connection per attempt. The entity is wrapped transparently (content type and encoding preserved), so the body is still parsed exactly once by the response handler and no other code paths change.

Non-idempotent requests (e.g. commits) are not retried on a body-read failure: the retry strategy only retries idempotent methods on transient `IOException`s. This change makes idempotent body-read failures retryable while leaving non-idempotent requests unaffected — matching how the strategy already treats connection- and header-level `IOException`s.

## Tests

Added a test in `TestHTTPClient` that uses a small raw-socket server (MockServer cannot emit a malformed chunked response) returning a malformed chunked body on the first connection and a valid response on the second, asserting that an idempotent GET transparently retries on a fresh connection and succeeds.

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Retry transient REST response-body read failures in the REST catalog client.
