### PR TITLE
Build: Replace deprecated Groovy space-assignment property syntax in build scripts

### DIFF
--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -52,7 +52,7 @@ project(":iceberg-aws-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/aws-bundle/build.gradle
+++ b/aws-bundle/build.gradle
@@ -52,7 +52,7 @@ project(":iceberg-aws-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // relocate AWS-specific versions
     relocate 'org.apache.http', 'org.apache.iceberg.aws.shaded.org.apache.http'

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -38,7 +38,7 @@ project(":iceberg-azure-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -41,7 +41,7 @@ project(":iceberg-azure-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // relocate Azure-specific versions
     relocate 'io.netty', 'org.apache.iceberg.azure.shaded.io.netty'

--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,7 @@ subprojects {
       } else {
         events "failed"
       }
-      exceptionFormat "full"
+      exceptionFormat = "full"
     }
 
     systemProperty 'project.version', project.version
@@ -306,7 +306,7 @@ project(':iceberg-bundled-guava') {
   shadowJar {
     archiveClassifier.set(null)
     configurations = [project.configurations.compileClasspath]
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {
@@ -471,7 +471,7 @@ project(':iceberg-data') {
   test {
     useJUnitPlatform()
     // Only for TestSplitScan as of Gradle 5.0+
-    maxHeapSize '1500m'
+    maxHeapSize = '1500m'
   }
 }
 
@@ -1168,7 +1168,7 @@ project(':iceberg-open-api') {
     archiveClassifier.set(null)
     configurations = [project.configurations.testFixturesRuntimeClasspath]
     from sourceSets.testFixtures.output
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the runtime Jar
     from(projectDir) {

--- a/build.gradle
+++ b/build.gradle
@@ -272,7 +272,7 @@ subprojects {
       } else {
         events "failed"
       }
-      exceptionFormat "full"
+      exceptionFormat = "full"
     }
 
     systemProperty 'project.version', project.version
@@ -327,7 +327,7 @@ project(':iceberg-bundled-guava') {
   shadowJar {
     archiveClassifier.set(null)
     configurations = [project.configurations.compileClasspath]
-    zip64 true
+    zip64 = true
 
     dependencies {
       exclude(dependency('org.slf4j:slf4j-api'))
@@ -486,7 +486,7 @@ project(':iceberg-data') {
   test {
     useJUnitPlatform()
     // Only for TestSplitScan as of Gradle 5.0+
-    maxHeapSize '1500m'
+    maxHeapSize = '1500m'
   }
 }
 
@@ -1188,7 +1188,7 @@ project(':iceberg-open-api') {
     archiveClassifier.set(null)
     configurations = [project.configurations.testFixturesRuntimeClasspath]
     from sourceSets.testFixtures.output
-    zip64 true
+    zip64 = true
 
     manifest {
       attributes 'Main-Class': 'org.apache.iceberg.rest.RESTCatalogServer'

--- a/deploy.gradle
+++ b/deploy.gradle
@@ -33,13 +33,13 @@ subprojects {
       task sourceJar(type: Jar, dependsOn: classes) {
         archiveClassifier.set('sources')
         from sourceSets.main.allSource
-        group 'build'
+        group = 'build'
       }
 
       task javadocJar(type: Jar, dependsOn: javadoc) {
         archiveClassifier.set('javadoc')
         from javadoc.destinationDir
-        group 'build'
+        group = 'build'
       }
 
       task testJar(type: Jar) {
@@ -123,8 +123,8 @@ subprojects {
       repositories {
         maven {
           credentials {
-            username project.hasProperty('mavenUser') ? "$mavenUser" : ""
-            password project.hasProperty('mavenPassword') ? "$mavenPassword" : ""
+            username = project.hasProperty('mavenUser') ? "$mavenUser" : ""
+            password = project.hasProperty('mavenPassword') ? "$mavenPassword" : ""
           }
           // upload to the releases repository using ./gradlew -Prelease publish
           def apacheSnapshotsRepoUrl = 'https://repository.apache.org/content/repositories/snapshots'

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -226,7 +226,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/flink/v1.20/build.gradle
+++ b/flink/v1.20/build.gradle
@@ -228,7 +228,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'

--- a/flink/v2.0/build.gradle
+++ b/flink/v2.0/build.gradle
@@ -226,7 +226,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -226,7 +226,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/flink/v2.1/build.gradle
+++ b/flink/v2.1/build.gradle
@@ -228,7 +228,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'

--- a/flink/v2.2/build.gradle
+++ b/flink/v2.2/build.gradle
@@ -228,7 +228,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'

--- a/flink/v2.3/build.gradle
+++ b/flink/v2.3/build.gradle
@@ -228,7 +228,7 @@ project(":iceberg-flink:iceberg-flink-runtime-${flinkMajorVersion}") {
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'org.apache.avro', 'org.apache.iceberg.shaded.org.apache.avro'

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -41,7 +41,7 @@ project(":iceberg-gcp-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -44,7 +44,7 @@ project(":iceberg-gcp-bundle") {
 
   shadowJar {
     archiveClassifier.set(null)
-    zip64 true
+    zip64 = true
 
     // relocate GCP-specific versions
     relocate 'com.fasterxml.jackson', 'org.apache.iceberg.gcp.shaded.com.fasterxml.jackson'

--- a/mr/build.gradle
+++ b/mr/build.gradle
@@ -76,7 +76,7 @@ project(':iceberg-mr') {
 
   test {
     // testJoinTables / testScanTable
-    maxHeapSize '2500m'
+    maxHeapSize = '2500m'
   }
 }
 

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // include the LICENSE and NOTICE files for the shaded Jar
     from(projectDir) {

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'

--- a/spark/v4.2/build.gradle
+++ b/spark/v4.2/build.gradle
@@ -117,7 +117,7 @@ project(":iceberg-spark:iceberg-spark-${sparkMajorVersion}_${scalaVersion}") {
 
   tasks.withType(Test) {
     // Vectorized reads need more memory
-    maxHeapSize '3160m'
+    maxHeapSize = '3160m'
   }
 }
 
@@ -272,7 +272,7 @@ project(":iceberg-spark:iceberg-spark-runtime-${sparkMajorVersion}_${scalaVersio
   shadowJar {
     configurations = [project.configurations.runtimeClasspath]
 
-    zip64 true
+    zip64 = true
 
     // Relocate dependencies to avoid conflicts
     relocate 'com.google.errorprone', 'org.apache.iceberg.shaded.com.google.errorprone'

--- a/tasks.gradle
+++ b/tasks.gradle
@@ -22,7 +22,7 @@ task aggregateJavadoc(type: Javadoc) {
   def javadocTasks = subprojects.findAll { it.name != 'iceberg-bom' }.javadoc
   dependsOn javadocTasks
   source javadocTasks.source
-  destinationDir project.rootProject.file("site/docs/javadoc/${getJavadocVersion()}")
+  destinationDir = project.rootProject.file("site/docs/javadoc/${getJavadocVersion()}")
   classpath = project.rootProject.files(javadocTasks.classpath)
 
   final JAVADOC_FIX_SEARCH_STR = '\n\n' +


### PR DESCRIPTION
Closes #15976

## Summary

Gradle deprecated the Groovy DSL "space-assignment" syntax for setting properties (e.g. `exceptionFormat "full"`) in favor of explicit assignment (`exceptionFormat = "full"`). It currently emits `Properties should be assigned using the 'propName = value' syntax ...` warnings and is scheduled for removal in Gradle 10. This migrates the remaining space-assignment usages across the build scripts so the build is quiet under `--warning-mode all` and ready for the eventual Gradle upgrade - the repository was already mostly migrated, and this completes it.

Issue: https://github.com/apache/iceberg/issues/15976

## What changed

Converted every remaining space-assignment property setter to `name = value` (25 occurrences across 15 build scripts), preserving the existing quote style:

- `exceptionFormat = "full"` and `maxHeapSize = '...'` in test / test-logging config (`build.gradle`, `mr/build.gradle`, `spark/v3.5|v4.0|v4.1|v4.2/build.gradle`).
- `zip64 = true` in every `shadowJar { }` block (`build.gradle` x2, the `aws-`/`azure-`/`gcp-bundle` builds, and every Spark and Flink runtime bundle).
- `group = 'build'` on the `sourceJar`/`javadocJar` tasks and `username =`/`password =` in the Maven `credentials { }` block (`deploy.gradle`).
- `destinationDir = ...` on the `aggregateJavadoc` task (`tasks.gradle`).

Genuine method calls that merely resemble the pattern were intentionally left unchanged - e.g. `events "passed", "failed"`, `systemProperty 'k', v`, `source javadocTasks.source`, and `configurations = [...]` (already correct). Unrelated deprecation categories (e.g. `JavaPluginConvention` from plugins, reserved configuration names) are out of scope for this issue.

## Tests

This is a build-script syntax migration with no runtime behavior change, so no unit tests apply. Verified by `./gradlew help --warning-mode all -DallModules=true` - configures every Spark/Flink/Kafka/Scala module with BUILD SUCCESSFUL and zero `propName = value` warnings remaining (a clean configure also proves each conversion targets a real settable property) - and by `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestTableMetadata.testJsonConversion" --warning-mode all`, confirming the converted `test`/`testLogging` config still runs at execution time. The `iceberg-flink-runtime-2.3` and `iceberg-spark-runtime-4.2_2.13` shadow JARs were reassembled after the `zip64` conversions.

---
**AI Disclosure**
- Model: Claude Opus 4.7, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Replace the deprecated Groovy space-assignment property syntax across the build scripts.
