### PR TITLE
API, Core: Implement filter() for partition statistics scan API

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionStatisticsScan.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionStatisticsScan.java
@@ -43,6 +43,17 @@ public interface PartitionStatisticsScan {
   PartitionStatisticsScan filter(Expression filter);
 
   /**
+   * Create a new scan from this that will configure whether column name matches in filter
+   * expressions are case-sensitive. Default is true.
+   *
+   * @param caseSensitive whether column name matches in filter expressions should be case-sensitive
+   * @return a new scan based on this with the given case sensitivity
+   */
+  default PartitionStatisticsScan caseSensitive(boolean caseSensitive) {
+    throw new UnsupportedOperationException("caseSensitive is not supported");
+  }
+
+  /**
    * Create a new scan from this with the schema as its projection.
    *
    * @param schema a projection schema

--- a/core/src/main/java/org/apache/iceberg/BasePartitionStatisticsScan.java
+++ b/core/src/main/java/org/apache/iceberg/BasePartitionStatisticsScan.java
@@ -18,10 +18,16 @@
  */
 package org.apache.iceberg;
 
+import java.util.Collections;
 import java.util.Optional;
+import java.util.Set;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.Evaluator;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
@@ -30,6 +36,8 @@ public class BasePartitionStatisticsScan implements PartitionStatisticsScan {
   private final Table table;
   private Long snapshotId;
   private Schema projection;
+  private Expression filter = Expressions.alwaysTrue();
+  private boolean caseSensitive = true;
 
   public BasePartitionStatisticsScan(Table table) {
     this.table = table;
@@ -46,7 +54,15 @@ public class BasePartitionStatisticsScan implements PartitionStatisticsScan {
 
   @Override
   public PartitionStatisticsScan filter(Expression newFilter) {
-    throw new UnsupportedOperationException("Filtering is not supported");
+    Preconditions.checkArgument(newFilter != null, "Invalid filter: null");
+    this.filter = newFilter;
+    return this;
+  }
+
+  @Override
+  public PartitionStatisticsScan caseSensitive(boolean newCaseSensitive) {
+    this.caseSensitive = newCaseSensitive;
+    return this;
   }
 
   @Override
@@ -77,16 +93,43 @@ public class BasePartitionStatisticsScan implements PartitionStatisticsScan {
 
     Types.StructType partitionType = Partitioning.partitionType(table);
     Schema schema = PartitionStatistics.schema(partitionType, TableUtil.formatVersion(table));
-    Schema readSchema =
-        projection == null ? schema : TypeUtil.select(schema, TypeUtil.getProjectedIds(projection));
+    Schema readSchema = readSchema(schema);
 
     FileFormat fileFormat = FileFormat.fromFileName(statsFile.get().path());
     Preconditions.checkNotNull(
         fileFormat != null, "Unable to determine format of file: %s", statsFile.get().path());
 
-    return InternalData.read(fileFormat, table.io().newInputFile(statsFile.get().path()))
-        .project(readSchema)
-        .setRootType(BasePartitionStatistics.class)
-        .build();
+    CloseableIterable<PartitionStatistics> result =
+        InternalData.read(fileFormat, table.io().newInputFile(statsFile.get().path()))
+            .project(readSchema)
+            .setRootType(BasePartitionStatistics.class)
+            .build();
+
+    if (filter != Expressions.alwaysTrue()) {
+      Evaluator evaluator = new Evaluator(readSchema.asStruct(), filter, caseSensitive);
+      result = CloseableIterable.filter(result, evaluator::eval);
+    }
+
+    return result;
+  }
+
+  /**
+   * Resolves the schema to read. When a projection is set, all columns referenced by the filter are
+   * added to the result not just the projected fields.
+   */
+  private Schema readSchema(Schema schema) {
+    if (projection == null) {
+      return schema;
+    }
+
+    Set<Integer> fieldIdsToRead = Sets.newHashSet();
+
+    fieldIdsToRead.addAll(TypeUtil.getProjectedIds(projection));
+
+    fieldIdsToRead.addAll(
+        Binder.boundReferences(
+            schema.asStruct(), Collections.singletonList(filter), caseSensitive));
+
+    return TypeUtil.select(schema, fieldIdsToRead);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/PartitionStatisticsScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/PartitionStatisticsScanTestBase.java
@@ -27,6 +27,8 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -555,6 +557,313 @@ public abstract class PartitionStatisticsScanTestBase extends PartitionStatistic
               assertThat(stats.lastUpdatedSnapshotId()).isNull();
               assertThat(stats.dvCount()).isNull();
             });
+  }
+
+  @Test
+  public void testNullFilter() throws Exception {
+    Table testTable =
+        TestTables.create(
+            tempDir("scan_filter_null"), "scan_filter_null", SCHEMA, SPEC, 2, fileFormatProperty);
+
+    assertThatThrownBy(() -> testTable.newPartitionStatisticsScan().filter(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid filter");
+  }
+
+  @Test
+  public void testAlwaysTrueFilter() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_always_true");
+
+    List<PartitionStatistics> partitionStats;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable.newPartitionStatisticsScan().filter(Expressions.alwaysTrue()).scan()) {
+      partitionStats = Lists.newArrayList(recordIterator);
+    }
+
+    assertThat(partitionStats).hasSize(2);
+  }
+
+  @Test
+  public void testAlwaysFalseFilter() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_always_false");
+
+    List<PartitionStatistics> partitionStats;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable.newPartitionStatisticsScan().filter(Expressions.alwaysFalse()).scan()) {
+      partitionStats = Lists.newArrayList(recordIterator);
+    }
+
+    assertThat(partitionStats).isEmpty();
+  }
+
+  @Test
+  public void testFilterOnPartitionColumn() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_partition_col");
+
+    List<PartitionStatistics> results;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable
+            .newPartitionStatisticsScan()
+            .filter(
+                Expressions.and(
+                    Expressions.equal("partition.c2", "foo"),
+                    Expressions.equal("partition.c3", "A")))
+            .scan()) {
+      results = Lists.newArrayList(recordIterator);
+    }
+
+    Types.StructType partitionType = Partitioning.partitionType(testTable);
+
+    assertThat(results)
+        .extracting(PartitionStatistics::partition)
+        .containsExactlyInAnyOrder(partitionRecord(partitionType, "foo", "A"));
+  }
+
+  @Test
+  public void testFilterOnStatsField() throws Exception {
+    Table testTable = tableWithUnevenPartitions("scan_filter_stats_field");
+
+    List<PartitionStatistics> results;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable
+            .newPartitionStatisticsScan()
+            .filter(Expressions.greaterThan("data_file_count", 2))
+            .scan()) {
+      results = Lists.newArrayList(recordIterator);
+    }
+
+    Types.StructType partitionType = Partitioning.partitionType(testTable);
+
+    assertThat(results)
+        .extracting(PartitionStatistics::partition, PartitionStatistics::dataFileCount)
+        .containsExactlyInAnyOrder(Tuple.tuple(partitionRecord(partitionType, "foo", "A"), 3));
+  }
+
+  @Test
+  public void testFilterOnUnknownColumnFails() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_unknown_col");
+
+    assertThatThrownBy(
+            () ->
+                testTable
+                    .newPartitionStatisticsScan()
+                    .filter(Expressions.equal("does_not_exist", 1))
+                    .scan())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'does_not_exist'");
+  }
+
+  @Test
+  public void testFilterOnUnknownPartitionSubFieldFails() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_unknown_partition");
+
+    assertThatThrownBy(
+            () ->
+                testTable
+                    .newPartitionStatisticsScan()
+                    .filter(Expressions.equal("partition.no_such_col", "foo"))
+                    .scan())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'partition.no_such_col'");
+  }
+
+  @Test
+  public void testFilterDvCountOnV2Stats() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_v2_dvcount");
+
+    assertThatThrownBy(
+            () ->
+                testTable
+                    .newPartitionStatisticsScan()
+                    .filter(Expressions.isNull("dv_count"))
+                    .scan())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'dv_count'");
+  }
+
+  @Test
+  public void testFilterColumnIncludedInProjection() throws Exception {
+    Table testTable = tableWithUnevenPartitions("scan_filter_in_projection");
+
+    Schema projection =
+        new Schema(
+            PartitionStatistics.EMPTY_PARTITION_FIELD,
+            PartitionStatistics.DATA_FILE_COUNT,
+            PartitionStatistics.DATA_RECORD_COUNT);
+
+    List<PartitionStatistics> results;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable
+            .newPartitionStatisticsScan()
+            .filter(Expressions.greaterThan("data_file_count", 2L))
+            .project(projection)
+            .scan()) {
+      results = Lists.newArrayList(recordIterator);
+    }
+
+    long expectedDataRecordCount = 0L;
+    try (CloseableIterable<FileScanTask> tasks = testTable.newScan().planFiles()) {
+      for (FileScanTask task : tasks) {
+        if ("A".equals(task.file().partition().get(1, String.class))) {
+          expectedDataRecordCount += task.file().recordCount();
+        }
+      }
+    }
+
+    Types.StructType partitionType = Partitioning.partitionType(testTable);
+
+    assertThat(results)
+        .extracting(
+            PartitionStatistics::partition,
+            PartitionStatistics::dataFileCount,
+            PartitionStatistics::dataRecordCount)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple(partitionRecord(partitionType, "foo", "A"), 3, expectedDataRecordCount));
+
+    assertThat(results)
+        .allSatisfy(
+            stats -> {
+              assertThat(stats.specId()).isNull();
+              assertThat(stats.totalDataFileSizeInBytes()).isNull();
+              assertThat(stats.positionDeleteRecordCount()).isNull();
+              assertThat(stats.positionDeleteFileCount()).isNull();
+              assertThat(stats.equalityDeleteRecordCount()).isNull();
+              assertThat(stats.equalityDeleteFileCount()).isNull();
+              assertThat(stats.totalRecords()).isNull();
+              assertThat(stats.lastUpdatedAt()).isNull();
+              assertThat(stats.lastUpdatedSnapshotId()).isNull();
+              assertThat(stats.dvCount()).isNull();
+            });
+  }
+
+  @Test
+  public void testFilterColumnNotInProjection() throws Exception {
+    Table testTable = tableWithUnevenPartitions("scan_filter_outside_projection");
+
+    Schema projection =
+        new Schema(
+            PartitionStatistics.EMPTY_PARTITION_FIELD, PartitionStatistics.DATA_RECORD_COUNT);
+
+    List<PartitionStatistics> results;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable
+            .newPartitionStatisticsScan()
+            .filter(Expressions.greaterThan("data_file_count", 2L))
+            .project(projection)
+            .scan()) {
+      results = Lists.newArrayList(recordIterator);
+    }
+
+    long expectedDataRecordCount = 0L;
+    try (CloseableIterable<FileScanTask> tasks = testTable.newScan().planFiles()) {
+      for (FileScanTask task : tasks) {
+        if ("A".equals(task.file().partition().get(1, String.class))) {
+          expectedDataRecordCount += task.file().recordCount();
+        }
+      }
+    }
+
+    Types.StructType partitionType = Partitioning.partitionType(testTable);
+
+    assertThat(results)
+        .extracting(
+            PartitionStatistics::partition,
+            PartitionStatistics::dataFileCount,
+            PartitionStatistics::dataRecordCount)
+        .containsExactlyInAnyOrder(
+            Tuple.tuple(partitionRecord(partitionType, "foo", "A"), 3, expectedDataRecordCount));
+
+    assertThat(results)
+        .allSatisfy(
+            stats -> {
+              assertThat(stats.specId()).isNull();
+              assertThat(stats.totalDataFileSizeInBytes()).isNull();
+              assertThat(stats.positionDeleteRecordCount()).isNull();
+              assertThat(stats.positionDeleteFileCount()).isNull();
+              assertThat(stats.equalityDeleteRecordCount()).isNull();
+              assertThat(stats.equalityDeleteFileCount()).isNull();
+              assertThat(stats.totalRecords()).isNull();
+              assertThat(stats.lastUpdatedAt()).isNull();
+              assertThat(stats.lastUpdatedSnapshotId()).isNull();
+              assertThat(stats.dvCount()).isNull();
+            });
+  }
+
+  @Test
+  public void testCaseSensitiveFilterFailsOnUppercaseRef() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_case_sensitive");
+
+    assertThatThrownBy(
+            () ->
+                testTable
+                    .newPartitionStatisticsScan()
+                    .filter(Expressions.greaterThan("DATA_RECORD_COUNT", 0L))
+                    .scan())
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot find field 'DATA_RECORD_COUNT'");
+  }
+
+  @Test
+  public void testCaseInsensitiveFilterMatchesUppercaseRef() throws Exception {
+    Table testTable = tableWithTwoPartitions("scan_filter_case_insensitive");
+
+    List<PartitionStatistics> results;
+    try (CloseableIterable<PartitionStatistics> recordIterator =
+        testTable
+            .newPartitionStatisticsScan()
+            .filter(Expressions.equal("partition.C3", "B"))
+            .caseSensitive(false)
+            .scan()) {
+      results = Lists.newArrayList(recordIterator);
+    }
+
+    Types.StructType partitionType = Partitioning.partitionType(testTable);
+
+    assertThat(results)
+        .extracting(PartitionStatistics::partition)
+        .containsExactlyInAnyOrder(partitionRecord(partitionType, "foo", "B"));
+  }
+
+  private Table tableWithTwoPartitions(String name) throws IOException {
+    Table testTable = TestTables.create(tempDir(name), name, SCHEMA, SPEC, 2, fileFormatProperty);
+
+    DataFile dataFile1 =
+        FileGenerationUtil.generateDataFile(testTable, TestHelpers.Row.of("foo", "A"));
+    DataFile dataFile2 =
+        FileGenerationUtil.generateDataFile(testTable, TestHelpers.Row.of("foo", "B"));
+    testTable.newAppend().appendFile(dataFile1).appendFile(dataFile2).commit();
+
+    long snapshotId = testTable.currentSnapshot().snapshotId();
+    testTable
+        .updatePartitionStatistics()
+        .setPartitionStatistics(
+            PartitionStatsHandler.computeAndWriteStatsFile(testTable, snapshotId))
+        .commit();
+    return testTable;
+  }
+
+  private Table tableWithUnevenPartitions(String name) throws IOException {
+    Table testTable = TestTables.create(tempDir(name), name, SCHEMA, SPEC, 2, fileFormatProperty);
+
+    for (int i = 0; i < 3; i++) {
+      testTable
+          .newAppend()
+          .appendFile(
+              FileGenerationUtil.generateDataFile(testTable, TestHelpers.Row.of("foo", "A")))
+          .commit();
+    }
+    testTable
+        .newAppend()
+        .appendFile(FileGenerationUtil.generateDataFile(testTable, TestHelpers.Row.of("foo", "B")))
+        .commit();
+
+    long snapshotId = testTable.currentSnapshot().snapshotId();
+    testTable
+        .updatePartitionStatistics()
+        .setPartitionStatistics(
+            PartitionStatsHandler.computeAndWriteStatsFile(testTable, snapshotId))
+        .commit();
+    return testTable;
   }
 
   private static void computeAndValidatePartitionStats(


### PR DESCRIPTION
Also implement caseSensitive(), that we can use when binding the unbound field name to the schema.

Used Claude Opus 4.7 to generate the tests, that I reviewed, cleaned up, and adjusted to my taste.