### PR TITLE
Core: Add unregister table to RCK

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -504,7 +504,7 @@ public class CatalogHandlers {
 
     TableMetadata metadata = ((BaseTable) table).operations().current();
 
-    // unregister without removing the underlying data and metadata files
+    // catalog implementations should preserve the table's metadata/data files
     boolean dropped = catalog.dropTable(ident, false /* do not purge */);
     if (!dropped) {
       throw new NoSuchTableException("Table does not exist: %s", ident);

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -95,11 +95,13 @@ import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
 import org.apache.iceberg.rest.responses.GetNamespaceResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
+import org.apache.iceberg.rest.responses.ImmutableUnregisterTableResponse;
 import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
+import org.apache.iceberg.rest.responses.UnregisterTableResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
@@ -486,6 +488,27 @@ public class CatalogHandlers {
     if (!dropped) {
       throw new NoSuchTableException("Table does not exist: %s", ident);
     }
+  }
+
+  public static UnregisterTableResponse unregisterTable(Catalog catalog, TableIdentifier ident) {
+    // capture the last metadata before dropping so it can be returned for re-registration
+    Table table = catalog.loadTable(ident);
+    if (!(table instanceof BaseTable)) {
+      throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");
+    }
+
+    TableMetadata metadata = ((BaseTable) table).operations().current();
+
+    // unregister without removing the underlying data and metadata files
+    boolean dropped = catalog.dropTable(ident, false /* do not purge */);
+    if (!dropped) {
+      throw new NoSuchTableException("Table does not exist: %s", ident);
+    }
+
+    return ImmutableUnregisterTableResponse.builder()
+        .metadataLocation(metadata.metadataFileLocation())
+        .metadata(metadata)
+        .build();
   }
 
   public static void purgeTable(Catalog catalog, TableIdentifier ident) {

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -492,6 +492,10 @@ public class CatalogHandlers {
   }
 
   public static UnregisterTableResponse unregisterTable(Catalog catalog, TableIdentifier ident) {
+    if (MetadataTableType.from(ident.name()) != null) {
+      throw new NoSuchTableException("Table does not exist: %s", ident);
+    }
+
     // capture the last metadata before dropping so it can be returned for re-registration
     Table table = catalog.loadTable(ident);
     if (!(table instanceof BaseTable)) {

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -507,7 +507,8 @@ public class CatalogHandlers {
     // catalog implementations should preserve the table's metadata/data files
     boolean dropped = catalog.dropTable(ident, false /* do not purge */);
     if (!dropped) {
-      throw new NoSuchTableException("Table does not exist: %s", ident);
+      throw new IllegalStateException(
+          String.format("Unregister failed. Table not dropped: %s", ident));
     }
 
     return ImmutableUnregisterTableResponse.builder()

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BaseTransaction;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.IncrementalAppendScan;
+import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.MetadataUpdate.UpgradeFormatVersion;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RetryableValidationException;

--- a/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
+++ b/core/src/main/java/org/apache/iceberg/rest/Endpoint.java
@@ -62,6 +62,8 @@ public class Endpoint {
       Endpoint.create("POST", ResourcePaths.V1_TABLE_RENAME);
   public static final Endpoint V1_REGISTER_TABLE =
       Endpoint.create("POST", ResourcePaths.V1_TABLE_REGISTER);
+  public static final Endpoint V1_UNREGISTER_TABLE =
+      Endpoint.create("POST", ResourcePaths.V1_TABLE_UNREGISTER);
   public static final Endpoint V1_REPORT_METRICS =
       Endpoint.create("POST", ResourcePaths.V1_TABLE_METRICS);
   public static final Endpoint V1_TABLE_CREDENTIALS =

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -247,10 +247,10 @@ public class RESTCatalog
   }
 
   /**
-   * Unregister a table from the catalog without removing its data or metadata files.
+   * Unregister a table from the catalog.
    *
    * <p>This is the opposite of {@link #registerTable(TableIdentifier, String)}. The underlying data
-   * and metadata files are left in place so that the table can be registered in another catalog.
+   * and metadata files should be left in place so that the table can be registered in another catalog.
    *
    * @param ident a table identifier
    * @return the last metadata location for the unregistered table

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -246,6 +246,19 @@ public class RESTCatalog
     return delegate.registerTable(ident, metadataFileLocation, overwrite);
   }
 
+  /**
+   * Unregister a table from the catalog without removing its data or metadata files.
+   *
+   * <p>This is the opposite of {@link #registerTable(TableIdentifier, String)}. The underlying data
+   * and metadata files are left in place so that the table can be registered in another catalog.
+   *
+   * @param ident a table identifier
+   * @return the last metadata location for the unregistered table
+   */
+  public String unregisterTable(TableIdentifier ident) {
+    return sessionCatalog.unregisterTable(context, ident);
+  }
+
   @Override
   public void createNamespace(Namespace ns, Map<String, String> props) {
     nsDelegate.createNamespace(ns, props);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTCatalog.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -250,12 +251,13 @@ public class RESTCatalog
    * Unregister a table from the catalog.
    *
    * <p>This is the opposite of {@link #registerTable(TableIdentifier, String)}. The underlying data
-   * and metadata files should be left in place so that the table can be registered in another catalog.
+   * and metadata files should be left in place so that the table can be registered in another
+   * catalog.
    *
    * @param ident a table identifier
-   * @return the last metadata location for the unregistered table
+   * @return the last metadata for the unregistered table
    */
-  public String unregisterTable(TableIdentifier ident) {
+  public TableMetadata unregisterTable(TableIdentifier ident) {
     return sessionCatalog.unregisterTable(context, ident);
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java
@@ -78,6 +78,7 @@ import org.apache.iceberg.rest.responses.FetchScanTasksResponseParser;
 import org.apache.iceberg.rest.responses.ImmutableLoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.ImmutableRemoteSignResponse;
+import org.apache.iceberg.rest.responses.ImmutableUnregisterTableResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponse;
 import org.apache.iceberg.rest.responses.LoadCredentialsResponseParser;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
@@ -89,6 +90,8 @@ import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponseParser;
 import org.apache.iceberg.rest.responses.RemoteSignResponse;
 import org.apache.iceberg.rest.responses.RemoteSignResponseParser;
+import org.apache.iceberg.rest.responses.UnregisterTableResponse;
+import org.apache.iceberg.rest.responses.UnregisterTableResponseParser;
 import org.apache.iceberg.util.JsonUtil;
 
 public class RESTSerializers {
@@ -149,6 +152,12 @@ public class RESTSerializers {
         .addDeserializer(ConfigResponse.class, new ConfigResponseDeserializer<>())
         .addSerializer(LoadTableResponse.class, new LoadTableResponseSerializer<>())
         .addDeserializer(LoadTableResponse.class, new LoadTableResponseDeserializer<>())
+        .addSerializer(UnregisterTableResponse.class, new UnregisterTableResponseSerializer<>())
+        .addSerializer(
+            ImmutableUnregisterTableResponse.class, new UnregisterTableResponseSerializer<>())
+        .addDeserializer(UnregisterTableResponse.class, new UnregisterTableResponseDeserializer<>())
+        .addDeserializer(
+            ImmutableUnregisterTableResponse.class, new UnregisterTableResponseDeserializer<>())
         .addSerializer(PlanTableScanRequest.class, new PlanTableScanRequestSerializer<>())
         .addDeserializer(PlanTableScanRequest.class, new PlanTableScanRequestDeserializer<>())
         .addSerializer(FetchScanTasksRequest.class, new FetchScanTasksRequestSerializer<>())
@@ -505,6 +514,24 @@ public class RESTSerializers {
     public void serialize(T request, JsonGenerator gen, SerializerProvider serializers)
         throws IOException {
       LoadTableResponseParser.toJson(request, gen);
+    }
+  }
+
+  static class UnregisterTableResponseSerializer<T extends UnregisterTableResponse>
+      extends JsonSerializer<T> {
+    @Override
+    public void serialize(T response, JsonGenerator gen, SerializerProvider serializers)
+        throws IOException {
+      UnregisterTableResponseParser.toJson(response, gen);
+    }
+  }
+
+  static class UnregisterTableResponseDeserializer<T extends UnregisterTableResponse>
+      extends JsonDeserializer<T> {
+    @Override
+    public T deserialize(JsonParser p, DeserializationContext context) throws IOException {
+      JsonNode jsonNode = p.getCodec().readTree(p);
+      return (T) UnregisterTableResponseParser.fromJson(jsonNode);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -736,14 +736,14 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
    * Unregister a table from the catalog without removing its data or metadata files.
    *
    * <p>This is the opposite of {@link #registerTable(SessionContext, TableIdentifier, String)}. On
-   * success, the table no longer exists in the catalog and the returned metadata location can be
-   * used to register the table in another catalog.
+   * success, the table no longer exists in the catalog and the returned metadata can be used to
+   * register the table in another catalog.
    *
    * @param context session context
    * @param identifier a table identifier
-   * @return the last metadata location for the unregistered table
+   * @return the last metadata for the unregistered table
    */
-  public String unregisterTable(SessionContext context, TableIdentifier identifier) {
+  public TableMetadata unregisterTable(SessionContext context, TableIdentifier identifier) {
     Endpoint.check(endpoints, Endpoint.V1_UNREGISTER_TABLE);
     checkIdentifierIsValid(identifier);
 
@@ -758,7 +758,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
                   UnregisterTableResponse.class,
                   mutationHeaders,
                   ErrorHandlers.tableErrorHandler());
-      return response.metadataLocation();
+      return response.metadata();
     } finally {
       invalidateTable(context, identifier);
     }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -96,6 +96,7 @@ import org.apache.iceberg.rest.responses.ListNamespacesResponse;
 import org.apache.iceberg.rest.responses.ListTablesResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.rest.responses.UnregisterTableResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
@@ -729,6 +730,38 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
 
     return new BaseTable(
         ops, fullTableName(ident), metricsReporter(paths.metrics(ident), tableClient));
+  }
+
+  /**
+   * Unregister a table from the catalog without removing its data or metadata files.
+   *
+   * <p>This is the opposite of {@link #registerTable(SessionContext, TableIdentifier, String)}. On
+   * success, the table no longer exists in the catalog and the returned metadata location can be
+   * used to register the table in another catalog.
+   *
+   * @param context session context
+   * @param identifier a table identifier
+   * @return the last metadata location for the unregistered table
+   */
+  public String unregisterTable(SessionContext context, TableIdentifier identifier) {
+    Endpoint.check(endpoints, Endpoint.V1_UNREGISTER_TABLE);
+    checkIdentifierIsValid(identifier);
+
+    try {
+      AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
+      UnregisterTableResponse response =
+          client
+              .withAuthSession(contextualSession)
+              .post(
+                  paths.unregister(identifier),
+                  null,
+                  UnregisterTableResponse.class,
+                  mutationHeaders,
+                  ErrorHandlers.tableErrorHandler());
+      return response.metadataLocation();
+    } finally {
+      invalidateTable(context, identifier);
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -38,6 +38,8 @@ public class ResourcePaths {
   public static final String V1_TABLE_REMOTE_SIGN =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign";
   public static final String V1_TABLE_REGISTER = "/v1/{prefix}/namespaces/{namespace}/register";
+  public static final String V1_TABLE_UNREGISTER =
+      "/v1/{prefix}/namespaces/{namespace}/tables/{table}/unregister";
   public static final String V1_TABLE_METRICS =
       "/v1/{prefix}/namespaces/{namespace}/tables/{table}/metrics";
   public static final String V1_TABLE_RENAME = "/v1/{prefix}/tables/rename";
@@ -115,6 +117,17 @@ public class ResourcePaths {
 
   public String register(Namespace ns) {
     return SLASH.join("v1", prefix, "namespaces", pathEncode(ns), "register");
+  }
+
+  public String unregister(TableIdentifier ident) {
+    return SLASH.join(
+        "v1",
+        prefix,
+        "namespaces",
+        pathEncode(ident.namespace()),
+        "tables",
+        RESTUtil.encodeString(ident.name()),
+        "unregister");
   }
 
   public String rename() {

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponse.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.rest.responses;
 
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.rest.RESTResponse;
 import org.immutables.value.Value;
 
@@ -36,6 +37,7 @@ public interface UnregisterTableResponse extends RESTResponse {
 
   @Override
   default void validate() {
-    // nothing to validate as it's not possible to create an invalid instance
+    Preconditions.checkArgument(metadataLocation() != null, "Invalid metadata location: null");
+    Preconditions.checkArgument(metadata() != null, "Invalid metadata: null");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponse.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.rest.RESTResponse;
+import org.immutables.value.Value;
+
+/**
+ * Represents the response when a table is successfully unregistered from a catalog.
+ *
+ * <p>The response carries the table's last metadata location and the corresponding table metadata
+ * so that the underlying (still present) files can be registered in another catalog.
+ */
+@Value.Immutable
+public interface UnregisterTableResponse extends RESTResponse {
+  String metadataLocation();
+
+  TableMetadata metadata();
+
+  @Override
+  default void validate() {
+    // nothing to validate as it's not possible to create an invalid instance
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/UnregisterTableResponseParser.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class UnregisterTableResponseParser {
+
+  private static final String METADATA_LOCATION = "metadata-location";
+  private static final String METADATA = "metadata";
+
+  private UnregisterTableResponseParser() {}
+
+  public static String toJson(UnregisterTableResponse response) {
+    return toJson(response, false);
+  }
+
+  public static String toJson(UnregisterTableResponse response, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(response, gen), pretty);
+  }
+
+  public static void toJson(UnregisterTableResponse response, JsonGenerator gen)
+      throws IOException {
+    Preconditions.checkArgument(null != response, "Invalid unregister table response: null");
+
+    gen.writeStartObject();
+
+    gen.writeStringField(METADATA_LOCATION, response.metadataLocation());
+
+    gen.writeFieldName(METADATA);
+    TableMetadataParser.toJson(response.metadata(), gen);
+
+    gen.writeEndObject();
+  }
+
+  public static UnregisterTableResponse fromJson(String json) {
+    return JsonUtil.parse(json, UnregisterTableResponseParser::fromJson);
+  }
+
+  public static UnregisterTableResponse fromJson(JsonNode json) {
+    Preconditions.checkArgument(
+        null != json, "Cannot parse unregister table response from null object");
+
+    String metadataLocation = JsonUtil.getString(METADATA_LOCATION, json);
+    TableMetadata metadata = TableMetadataParser.fromJson(JsonUtil.get(METADATA, json));
+
+    if (null == metadata.metadataFileLocation()) {
+      metadata = TableMetadata.buildFrom(metadata).withMetadataLocation(metadataLocation).build();
+    }
+
+    return ImmutableUnregisterTableResponse.builder()
+        .metadataLocation(metadataLocation)
+        .metadata(metadata)
+        .build();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
+++ b/core/src/test/java/org/apache/iceberg/rest/RESTCatalogAdapter.java
@@ -391,6 +391,16 @@ public class RESTCatalogAdapter extends BaseHTTPClient {
               });
         }
 
+      case UNREGISTER_TABLE:
+        {
+          return CatalogHandlers.withIdempotency(
+              httpRequest,
+              () ->
+                  castResponse(
+                      responseType,
+                      CatalogHandlers.unregisterTable(catalog, tableIdentFromPathVars(vars))));
+        }
+
       case UPDATE_TABLE:
         {
           return CatalogHandlers.withIdempotency(

--- a/core/src/test/java/org/apache/iceberg/rest/Route.java
+++ b/core/src/test/java/org/apache/iceberg/rest/Route.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
+import org.apache.iceberg.rest.responses.UnregisterTableResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
 
@@ -82,6 +83,11 @@ enum Route {
       ResourcePaths.V1_TABLE_REGISTER,
       RegisterTableRequest.class,
       LoadTableResponse.class),
+  UNREGISTER_TABLE(
+      HTTPRequest.HTTPMethod.POST,
+      ResourcePaths.V1_TABLE_UNREGISTER,
+      null,
+      UnregisterTableResponse.class),
   UPDATE_TABLE(
       HTTPRequest.HTTPMethod.POST,
       ResourcePaths.V1_TABLE,

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestUnregisterTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestUnregisterTableResponseParser.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest.responses;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestUnregisterTableResponseParser {
+
+  @Test
+  public void nullAndEmptyCheck() {
+    assertThatThrownBy(() -> UnregisterTableResponseParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid unregister table response: null");
+
+    assertThatThrownBy(() -> UnregisterTableResponseParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse unregister table response from null object");
+
+    assertThatThrownBy(() -> UnregisterTableResponseParser.fromJson("{}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing string: metadata-location");
+  }
+
+  @Test
+  public void missingFields() {
+    assertThatThrownBy(
+            () ->
+                UnregisterTableResponseParser.fromJson(
+                    "{\"metadata-location\": \"custom-location\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing field: metadata");
+  }
+
+  @Test
+  public void roundTripSerde() {
+    String uuid = "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b";
+    TableMetadata metadata =
+        TableMetadata.buildFromEmpty(1)
+            .assignUUID(uuid)
+            .setLocation("location")
+            .setCurrentSchema(
+                new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
+            .addPartitionSpec(PartitionSpec.unpartitioned())
+            .addSortOrder(SortOrder.unsorted())
+            .discardChanges()
+            .withMetadataLocation("metadata-location")
+            .build();
+
+    UnregisterTableResponse response =
+        ImmutableUnregisterTableResponse.builder()
+            .metadataLocation("metadata-location")
+            .metadata(metadata)
+            .build();
+
+    String expectedJson =
+        String.format(
+            "{\n"
+                + "  \"metadata-location\" : \"metadata-location\",\n"
+                + "  \"metadata\" : {\n"
+                + "    \"format-version\" : 1,\n"
+                + "    \"table-uuid\" : \"386b9f01-002b-4d8c-b77f-42c3fd3b7c9b\",\n"
+                + "    \"location\" : \"location\",\n"
+                + "    \"last-updated-ms\" : %s,\n"
+                + "    \"last-column-id\" : 1,\n"
+                + "    \"schema\" : {\n"
+                + "      \"type\" : \"struct\",\n"
+                + "      \"schema-id\" : 0,\n"
+                + "      \"fields\" : [ {\n"
+                + "        \"id\" : 1,\n"
+                + "        \"name\" : \"x\",\n"
+                + "        \"required\" : true,\n"
+                + "        \"type\" : \"long\"\n"
+                + "      } ]\n"
+                + "    },\n"
+                + "    \"current-schema-id\" : 0,\n"
+                + "    \"schemas\" : [ {\n"
+                + "      \"type\" : \"struct\",\n"
+                + "      \"schema-id\" : 0,\n"
+                + "      \"fields\" : [ {\n"
+                + "        \"id\" : 1,\n"
+                + "        \"name\" : \"x\",\n"
+                + "        \"required\" : true,\n"
+                + "        \"type\" : \"long\"\n"
+                + "      } ]\n"
+                + "    } ],\n"
+                + "    \"partition-spec\" : [ ],\n"
+                + "    \"default-spec-id\" : 0,\n"
+                + "    \"partition-specs\" : [ {\n"
+                + "      \"spec-id\" : 0,\n"
+                + "      \"fields\" : [ ]\n"
+                + "    } ],\n"
+                + "    \"last-partition-id\" : 999,\n"
+                + "    \"default-sort-order-id\" : 0,\n"
+                + "    \"sort-orders\" : [ {\n"
+                + "      \"order-id\" : 0,\n"
+                + "      \"fields\" : [ ]\n"
+                + "    } ],\n"
+                + "    \"properties\" : { },\n"
+                + "    \"current-snapshot-id\" : -1,\n"
+                + "    \"refs\" : { },\n"
+                + "    \"snapshots\" : [ ],\n"
+                + "    \"statistics\" : [ ],\n"
+                + "    \"partition-statistics\" : [ ],\n"
+                + "    \"snapshot-log\" : [ ],\n"
+                + "    \"metadata-log\" : [ ]\n"
+                + "  }\n"
+                + "}",
+            metadata.lastUpdatedMillis());
+
+    String json = UnregisterTableResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    // can't do an equality comparison because Schema doesn't implement equals/hashCode
+    assertThat(
+            UnregisterTableResponseParser.toJson(
+                UnregisterTableResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+}

--- a/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
@@ -19,9 +19,12 @@
 package org.apache.iceberg.rest;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.util.PropertyUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -107,6 +110,49 @@ public class RESTCompatibilityKitCatalogTests extends CatalogTests<RESTCatalog> 
     // https://jakarta.ee/specifications/servlet/6.0/jakarta-servlet-spec-6.0.html#uri-path-canonicalization
     // for additional details
     return false;
+  }
+
+  @Test
+  public void testUnregisterTable() {
+    if (requiresNamespaceCreate()) {
+      restCatalog.createNamespace(TABLE.namespace());
+    }
+
+    Table original =
+        restCatalog
+            .buildTable(TABLE, SCHEMA)
+            .withPartitionSpec(SPEC)
+            .withSortOrder(WRITE_ORDER)
+            .create();
+    original.newFastAppend().appendFile(FILE_A).commit();
+    original.newFastAppend().appendFile(FILE_B).commit();
+
+    String metadataLocation = restCatalog.unregisterTable(TABLE);
+
+    assertThat(metadataLocation).as("Returned metadata location must not be null").isNotNull();
+    assertThat(restCatalog.tableExists(TABLE))
+        .as("Table must not exist after being unregistered")
+        .isFalse();
+
+    // the underlying files are left in place, so the table can be registered again
+    Table registered = restCatalog.registerTable(TABLE, metadataLocation);
+    assertThat(registered.currentSnapshot())
+        .as("Current snapshot must match the unregistered table")
+        .isEqualTo(original.currentSnapshot());
+    assertFiles(registered, FILE_A, FILE_B);
+
+    assertThat(restCatalog.dropTable(TABLE)).isTrue();
+  }
+
+  @Test
+  public void testUnregisterMissingTable() {
+    if (requiresNamespaceCreate()) {
+      restCatalog.createNamespace(TABLE.namespace());
+    }
+
+    assertThatThrownBy(() -> restCatalog.unregisterTable(TABLE))
+        .isInstanceOf(NoSuchTableException.class)
+        .hasMessageContaining("Table does not exist");
   }
 
   @Disabled("RESTServerExtension isn’t configurable per test")

--- a/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/RESTCompatibilityKitCatalogTests.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.catalog.CatalogTests;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.util.PropertyUtil;
@@ -127,15 +128,15 @@ public class RESTCompatibilityKitCatalogTests extends CatalogTests<RESTCatalog> 
     original.newFastAppend().appendFile(FILE_A).commit();
     original.newFastAppend().appendFile(FILE_B).commit();
 
-    String metadataLocation = restCatalog.unregisterTable(TABLE);
+    TableMetadata metadata = restCatalog.unregisterTable(TABLE);
 
-    assertThat(metadataLocation).as("Returned metadata location must not be null").isNotNull();
+    assertThat(metadata).as("Returned metadata must not be null").isNotNull();
     assertThat(restCatalog.tableExists(TABLE))
         .as("Table must not exist after being unregistered")
         .isFalse();
 
     // the underlying files are left in place, so the table can be registered again
-    Table registered = restCatalog.registerTable(TABLE, metadataLocation);
+    Table registered = restCatalog.registerTable(TABLE, metadata.metadataFileLocation());
     assertThat(registered.currentSnapshot())
         .as("Current snapshot must match the unregistered table")
         .isEqualTo(original.currentSnapshot());


### PR DESCRIPTION
With the new [unregisterTable endpoint](https://github.com/apache/iceberg/pull/16400) added, one of the next steps is to add it to the REST Fixture.