### PR TITLE
Core: Validate non-string elements in JsonUtil.getStringArray

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequestParser.java
@@ -133,7 +133,7 @@ public class RemoteSignRequestParser {
         .forEach(
             entry -> {
               String key = entry.getKey();
-              List<String> values = Arrays.asList(JsonUtil.getStringArray(entry.getValue()));
+              List<String> values = Arrays.asList(JsonUtil.getStringArray(key, headersNode));
               headers.put(key, values);
             });
     return headers;

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -272,7 +272,10 @@ public class JsonUtil {
     ArrayNode arrayNode = (ArrayNode) node;
     String[] arr = new String[arrayNode.size()];
     for (int i = 0; i < arr.length; i++) {
-      arr[i] = arrayNode.get(i).asText();
+      JsonNode element = arrayNode.get(i);
+      Preconditions.checkArgument(
+          element.isTextual(), "Cannot parse string from non-text value: %s", element);
+      arr[i] = element.asText();
     }
     return arr;
   }

--- a/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/JsonUtil.java
@@ -280,6 +280,10 @@ public class JsonUtil {
     return arr;
   }
 
+  public static String[] getStringArray(String property, JsonNode node) {
+    return getStringList(property, node).toArray(new String[0]);
+  }
+
   public static List<String> getStringList(String property, JsonNode node) {
     Preconditions.checkArgument(node.has(property), "Cannot parse missing list: %s", property);
     return ImmutableList.<String>builder()

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionParser.java
@@ -96,8 +96,7 @@ public class ViewVersionParser {
 
     String defaultCatalog = JsonUtil.getStringOrNull(DEFAULT_CATALOG, node);
 
-    Namespace defaultNamespace =
-        Namespace.of(JsonUtil.getStringArray(JsonUtil.get(DEFAULT_NAMESPACE, node)));
+    Namespace defaultNamespace = Namespace.of(JsonUtil.getStringArray(DEFAULT_NAMESPACE, node));
 
     return ImmutableViewVersion.builder()
         .versionId(versionId)

--- a/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
@@ -451,6 +451,33 @@ public class TestJsonUtil {
   }
 
   @Test
+  public void getStringArrayWithProperty() throws JsonProcessingException {
+    assertThatThrownBy(() -> JsonUtil.getStringArray("items", JsonUtil.mapper().readTree("{}")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing list: items");
+
+    assertThatThrownBy(
+            () -> JsonUtil.getStringArray("items", JsonUtil.mapper().readTree("{\"items\": null}")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse JSON array from non-array value: items: null");
+
+    assertThatThrownBy(
+            () ->
+                JsonUtil.getStringArray(
+                    "items", JsonUtil.mapper().readTree("{\"items\": [\"23\", 45]}")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string from non-text value in items: 45");
+
+    assertThat(
+            JsonUtil.getStringArray(
+                "items", JsonUtil.mapper().readTree("{\"items\": [\"23\", \"45\"]}")))
+        .containsExactly("23", "45");
+
+    assertThat(JsonUtil.getStringArray("items", JsonUtil.mapper().readTree("{\"items\": []}")))
+        .isEmpty();
+  }
+
+  @Test
   public void getStringList() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getStringList("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestJsonUtil.java
@@ -431,6 +431,26 @@ public class TestJsonUtil {
   }
 
   @Test
+  public void getStringArray() throws JsonProcessingException {
+    assertThatThrownBy(() -> JsonUtil.getStringArray(JsonUtil.mapper().readTree("null")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string array from non-array: null");
+
+    assertThatThrownBy(() -> JsonUtil.getStringArray(JsonUtil.mapper().readTree("23")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string array from non-array: 23");
+
+    assertThatThrownBy(() -> JsonUtil.getStringArray(JsonUtil.mapper().readTree("[\"23\", 45]")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse string from non-text value: 45");
+
+    assertThat(JsonUtil.getStringArray(JsonUtil.mapper().readTree("[\"23\", \"45\"]")))
+        .containsExactly("23", "45");
+
+    assertThat(JsonUtil.getStringArray(JsonUtil.mapper().readTree("[]"))).isEmpty();
+  }
+
+  @Test
   public void getStringList() throws JsonProcessingException {
     assertThatThrownBy(() -> JsonUtil.getStringList("items", JsonUtil.mapper().readTree("{}")))
         .isInstanceOf(IllegalArgumentException.class)

--- a/core/src/test/java/org/apache/iceberg/view/TestViewVersionParser.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewVersionParser.java
@@ -127,7 +127,7 @@ public class TestViewVersionParser {
                     "{\"version-id\":1,\"timestamp-ms\":12345,\"schema-id\":1,"
                         + "\"summary\":{\"operation\":\"create\"},\"representations\":[]}"))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot parse missing field: default-namespace");
+        .hasMessage("Cannot parse missing list: default-namespace");
   }
 
   @Test


### PR DESCRIPTION
## Summary

`JsonUtil.getStringArray(JsonNode)` calls `asText()` on each element without verifying that it is actually a JSON string. Non-textual elements are silently coerced (e.g. `45` becomes `"45"`, `true` becomes `"true"`), masking malformed inputs instead of surfacing them.

This change adds an `isTextual()` check per element, mirroring the validation already performed by `JsonStringArrayIterator` (used by `getStringList`, `getStringSet`, and `getStringListOrNull`).

## Why this is safe

There are three callers of `JsonUtil.getStringArray` today, and all three expect arrays of JSON strings; none rely on the coercion behavior:

1. `ViewVersionParser.fromJson` (`core/src/main/java/org/apache/iceberg/view/ViewVersionParser.java:100`) — parses the `default-namespace` field of a view version. The Iceberg view spec defines this as a list of strings; only string levels are valid.
2. `RESTSerializers.NamespaceDeserializer.deserialize` (`core/src/main/java/org/apache/iceberg/rest/RESTSerializers.java:262`) — deserializes a `Namespace` from a REST payload. The REST OpenAPI spec defines a Namespace as `array<string>`; non-string elements would be a protocol violation.
3. `RemoteSignRequestParser.headersFromJson` (`core/src/main/java/org/apache/iceberg/rest/requests/RemoteSignRequestParser.java:136`) — parses HTTP header values, which are by definition strings.

In every case, a non-string element indicates malformed input. Failing fast with `Cannot parse string from non-text value: <element>` is strictly more useful than silently coercing.

## Test plan

- [x] New unit tests in `TestJsonUtil.getStringArray` covering: `null` node, non-array node, array containing a non-string element, valid string array, and empty array.
- [x] Existing `TestJsonUtil`, `TestViewVersionParser`, `TestRemoteSignRequestParser` continue to pass.