### PR TITLE
OpenAPI: Require at least one level in CatalogObjectIdentifier

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -115,6 +115,7 @@ class CatalogObjectIdentifier(RootModel[list[str]]):
         ...,
         description='Reference to a catalog object (for example, table, view, or namespace) as an ordered list of hierarchical levels. The object kind is determined by context (e.g. the endpoint or a companion type discriminator), not by the identifier structure alone.',
         examples=[['accounting', 'tax', 'paid']],
+        min_length=1,
     )
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2326,6 +2326,7 @@ components:
       type: array
       items:
         type: string
+      minItems: 1
       example: [ "accounting", "tax", "paid" ]
 
     PrimitiveType:


### PR DESCRIPTION
## Summary

Add `minItems: 1` to the `CatalogObjectIdentifier` schema so the spec matches the Java implementation (`CatalogObjectIdentifier.of`), which rejects an empty levels array.