### PR TITLE
Flink: Expose scan planning metrics on ContinuousIcebergEnumerator (#16589)

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalAppendScan.java
@@ -73,6 +73,8 @@ class BaseIncrementalAppendScan
             .filter(manifestFile -> snapshotIds.contains(manifestFile.snapshotId()))
             .toSet();
 
+    scanMetrics().totalDataManifests().increment((long) manifests.size());
+
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), manifests)
             .caseSensitive(isCaseSensitive())
@@ -85,7 +87,8 @@ class BaseIncrementalAppendScan
             .schemasById(schemas())
             .specsById(table().specs())
             .ignoreDeleted()
-            .columnsToKeepStats(columnsToKeepStats());
+            .columnsToKeepStats(columnsToKeepStats())
+            .scanMetrics(scanMetrics());
 
     if (context().ignoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -71,6 +71,8 @@ class BaseIncrementalChangelogScan
             .filter(manifest -> changelogSnapshotIds.contains(manifest.snapshotId()))
             .toSet();
 
+    scanMetrics().totalDataManifests().increment((long) newDataManifests.size());
+
     ManifestGroup manifestGroup =
         new ManifestGroup(table().io(), newDataManifests, ImmutableList.of())
             .specsById(table().specs())
@@ -79,7 +81,8 @@ class BaseIncrementalChangelogScan
             .filterData(filter())
             .filterManifestEntries(entry -> changelogSnapshotIds.contains(entry.snapshotId()))
             .ignoreExisting()
-            .columnsToKeepStats(columnsToKeepStats());
+            .columnsToKeepStats(columnsToKeepStats())
+            .scanMetrics(scanMetrics());
 
     if (shouldIgnoreResiduals()) {
       manifestGroup = manifestGroup.ignoreResiduals();

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalScan.java
@@ -18,17 +18,39 @@
  */
 package org.apache.iceberg;
 
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.iceberg.events.IncrementalScanEvent;
 import org.apache.iceberg.events.Listeners;
+import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ScanMetrics;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.Timer;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 
 abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     extends BaseScan<ThisT, T, G> implements IncrementalScan<ThisT, T, G> {
 
+  private ScanMetrics scanMetrics;
+
   protected BaseIncrementalScan(Table table, Schema schema, TableScanContext context) {
     super(table, schema, context);
+  }
+
+  protected ScanMetrics scanMetrics() {
+    if (scanMetrics == null) {
+      this.scanMetrics = ScanMetrics.of(new DefaultMetricsContext());
+    }
+
+    return scanMetrics;
   }
 
   protected abstract CloseableIterable<T> doPlanFiles(
@@ -123,7 +145,34 @@ abstract class BaseIncrementalScan<ThisT, T extends ScanTask, G extends ScanTask
               true /* from snapshot ID inclusive */));
     }
 
-    return doPlanFiles(fromSnapshotIdExclusive, toSnapshotIdInclusive);
+    List<Integer> projectedFieldIds = Lists.newArrayList(TypeUtil.getProjectedIds(schema()));
+    List<String> projectedFieldNames =
+        projectedFieldIds.stream().map(schema()::findColumnName).collect(Collectors.toList());
+
+    Timer.Timed planningDuration = scanMetrics().totalPlanningDuration().start();
+
+    return CloseableIterable.whenComplete(
+        doPlanFiles(fromSnapshotIdExclusive, toSnapshotIdInclusive),
+        () -> {
+          planningDuration.stop();
+          Map<String, String> metadata = Maps.newHashMap(context().options());
+          metadata.putAll(EnvironmentContext.get());
+          context()
+              .metricsReporter()
+              .report(
+                  ImmutableScanReport.builder()
+                      .schemaId(schema().schemaId())
+                      .tableName(table().name())
+                      .snapshotId(toSnapshotIdInclusive)
+                      .filter(
+                          ExpressionUtil.sanitize(
+                              schema().asStruct(), filter(), context().caseSensitive()))
+                      .projectedFieldIds(projectedFieldIds)
+                      .projectedFieldNames(projectedFieldNames)
+                      .scanMetrics(ScanMetricsResult.fromScanMetrics(scanMetrics()))
+                      .metadata(metadata)
+                      .build());
+        });
   }
 
   private boolean scanCurrentLineage() {

--- a/core/src/test/java/org/apache/iceberg/TestIncrementalScanPlanningAndReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestIncrementalScanPlanningAndReporting.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsReport;
+import org.apache.iceberg.metrics.MetricsReporter;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.ScanReport;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestIncrementalScanPlanningAndReporting extends TestBase {
+
+  private final TestMetricsReporter reporter = new TestMetricsReporter();
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Integer> formatVersions() {
+    return TestHelpers.ALL_VERSIONS;
+  }
+
+  @TestTemplate
+  public void incrementalAppendScanEmitsScanReport() throws IOException {
+    String tableName = "incremental-append-scan-report";
+    Table table =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId1 = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(FILE_B).commit();
+    long snapshotId2 = table.currentSnapshot().snapshotId();
+    table.refresh();
+
+    IncrementalAppendScan scan =
+        table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotId1);
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+    assertThat(scanReport.snapshotId()).isEqualTo(snapshotId2);
+
+    ScanMetricsResult result = scanReport.scanMetrics();
+    assertThat(result.totalPlanningDuration().totalDuration()).isGreaterThan(Duration.ZERO);
+    assertThat(result.resultDataFiles().value()).isEqualTo(1);
+    assertThat(result.totalDataManifests().value()).isEqualTo(1);
+    assertThat(result.scannedDataManifests().value()).isEqualTo(1);
+    assertThat(result.skippedDataManifests().value()).isEqualTo(0);
+    assertThat(result.totalFileSizeInBytes().value()).isEqualTo(10L);
+  }
+
+  @TestTemplate
+  public void incrementalAppendScanWithMultipleSnapshots() throws IOException {
+    String tableName = "incremental-append-multi-snapshot";
+    Table table =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId1 = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(FILE_B).commit();
+    table.newAppend().appendFile(FILE_C).commit();
+    long snapshotId3 = table.currentSnapshot().snapshotId();
+    table.refresh();
+
+    IncrementalAppendScan scan =
+        table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotId1);
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+    assertThat(scanReport.snapshotId()).isEqualTo(snapshotId3);
+
+    ScanMetricsResult result = scanReport.scanMetrics();
+    assertThat(result.totalPlanningDuration().totalDuration()).isGreaterThan(Duration.ZERO);
+    assertThat(result.resultDataFiles().value()).isEqualTo(2);
+    assertThat(result.totalDataManifests().value()).isEqualTo(2);
+    assertThat(result.scannedDataManifests().value()).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void incrementalAppendScanFromInclusiveEmitsScanReport() throws IOException {
+    String tableName = "incremental-append-inclusive-report";
+    Table table =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId1 = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(FILE_B).commit();
+    long snapshotId2 = table.currentSnapshot().snapshotId();
+    table.refresh();
+
+    IncrementalAppendScan scan =
+        table.newIncrementalAppendScan().fromSnapshotInclusive(snapshotId1);
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+    assertThat(scanReport.snapshotId()).isEqualTo(snapshotId2);
+
+    ScanMetricsResult result = scanReport.scanMetrics();
+    assertThat(result.totalPlanningDuration().totalDuration()).isGreaterThan(Duration.ZERO);
+    // fromSnapshotInclusive means FILE_A + FILE_B
+    assertThat(result.resultDataFiles().value()).isEqualTo(2);
+    assertThat(result.totalDataManifests().value()).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void incrementalAppendScanWithCustomReporter() throws IOException {
+    String tableName = "incremental-append-custom-reporter";
+    Table table =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
+
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId1 = table.currentSnapshot().snapshotId();
+    table.newAppend().appendFile(FILE_B).commit();
+    table.refresh();
+
+    TestMetricsReporter customReporter = new TestMetricsReporter();
+    IncrementalAppendScan scan =
+        table
+            .newIncrementalAppendScan()
+            .fromSnapshotExclusive(snapshotId1)
+            .metricsReporter(customReporter);
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    // Both the table-level and custom reporters should receive the report
+    assertThat(reporter.lastReport()).isNotNull();
+    assertThat(customReporter.lastReport()).isNotNull();
+    assertThat(customReporter.lastReport().tableName()).isEqualTo(tableName);
+  }
+
+  @TestTemplate
+  public void incrementalAppendScanEmptyResult() throws IOException {
+    String tableName = "incremental-append-empty";
+    Table table =
+        TestTables.create(
+            tableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, reporter);
+
+    // Only non-append operations after the start snapshot
+    table.newAppend().appendFile(FILE_A).commit();
+    long snapshotId1 = table.currentSnapshot().snapshotId();
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+    table.refresh();
+
+    IncrementalAppendScan scan =
+        table.newIncrementalAppendScan().fromSnapshotExclusive(snapshotId1);
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      tasks.forEach(task -> {});
+    }
+
+    // ScanReport should still be emitted even with no append snapshots
+    ScanReport scanReport = reporter.lastReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(tableName);
+
+    ScanMetricsResult result = scanReport.scanMetrics();
+    assertThat(result.totalPlanningDuration().totalDuration()).isGreaterThan(Duration.ZERO);
+    assertThat(result.resultDataFiles().value()).isEqualTo(0);
+  }
+
+  static class TestMetricsReporter implements MetricsReporter {
+    private final List<MetricsReport> reports = Lists.newArrayList();
+    private final LoggingMetricsReporter delegate = LoggingMetricsReporter.instance();
+
+    @Override
+    public void report(MetricsReport report) {
+      reports.add(report);
+      delegate.report(report);
+    }
+
+    public ScanReport lastReport() {
+      if (reports.isEmpty()) {
+        return null;
+      }
+
+      return (ScanReport) reports.get(reports.size() - 1);
+    }
+
+    public CommitReport lastCommitReport() {
+      if (reports.isEmpty()) {
+        return null;
+      }
+
+      return (CommitReport) reports.get(reports.size() - 1);
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -72,8 +73,17 @@ public class FlinkSplitPlanner {
   /** This returns splits for the FLIP-27 source */
   public static List<IcebergSourceSplit> planIcebergSourceSplits(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planIcebergSourceSplits(table, context, workerPool, null);
+  }
+
+  /** This returns splits for the FLIP-27 source with optional metrics reporting */
+  public static List<IcebergSourceSplit> planIcebergSourceSplits(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     try (CloseableIterable<CombinedScanTask> tasksIterable =
-        planTasks(table, context, workerPool)) {
+        planTasks(table, context, workerPool, metricsReporter)) {
       return Lists.newArrayList(
           CloseableIterable.transform(tasksIterable, IcebergSourceSplit::fromCombinedScanTask));
     } catch (IOException e) {
@@ -83,10 +93,18 @@ public class FlinkSplitPlanner {
 
   static CloseableIterable<CombinedScanTask> planTasks(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planTasks(table, context, workerPool, null);
+  }
+
+  static CloseableIterable<CombinedScanTask> planTasks(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     ScanMode scanMode = checkScanMode(context);
     if (scanMode == ScanMode.INCREMENTAL_APPEND_SCAN) {
       IncrementalAppendScan scan = table.newIncrementalAppendScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.startTag() != null) {
         Preconditions.checkArgument(
@@ -119,7 +137,7 @@ public class FlinkSplitPlanner {
       return scan.planTasks();
     } else {
       TableScan scan = table.newScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.snapshotId() != null) {
         scan = scan.useSnapshot(context.snapshotId());
@@ -157,7 +175,7 @@ public class FlinkSplitPlanner {
 
   /** refine scan with common configs */
   private static <T extends Scan<T, FileScanTask, CombinedScanTask>> T refineScanWithBaseConfigs(
-      T scan, ScanContext context, ExecutorService workerPool) {
+      T scan, ScanContext context, ExecutorService workerPool, MetricsReporter metricsReporter) {
     T refinedScan =
         scan.caseSensitive(context.caseSensitive()).project(context.project()).planWith(workerPool);
 
@@ -182,6 +200,10 @@ public class FlinkSplitPlanner {
       for (Expression filter : context.filters()) {
         refinedScan = refinedScan.filter(filter);
       }
+    }
+
+    if (metricsReporter != null) {
+      refinedScan = refinedScan.metricsReporter(metricsReporter);
     }
 
     return refinedScan;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -221,7 +221,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       ContinuousSplitPlanner splitPlanner =
           new ContinuousSplitPlannerImpl(tableLoader, scanContext, planningThreadName());
       return new ContinuousIcebergEnumerator(
-          enumContext, assigner, scanContext, splitPlanner, enumState);
+          enumContext, assigner, scanContext, splitPlanner, enumState, tableName);
     } else {
       if (enumState == null) {
         // Only do scan planning if nothing is restored from checkpoint state

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
@@ -19,13 +19,16 @@
 package org.apache.iceberg.flink.source.enumerator;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 class ContinuousEnumerationResult {
   private final Collection<IcebergSourceSplit> splits;
   private final IcebergEnumeratorPosition fromPosition;
   private final IcebergEnumeratorPosition toPosition;
+  @Nullable private final ScanReport scanReport;
 
   /**
    * @param splits should never be null. But it can be an empty collection
@@ -36,11 +39,20 @@ class ContinuousEnumerationResult {
       Collection<IcebergSourceSplit> splits,
       IcebergEnumeratorPosition fromPosition,
       IcebergEnumeratorPosition toPosition) {
+    this(splits, fromPosition, toPosition, null);
+  }
+
+  ContinuousEnumerationResult(
+      Collection<IcebergSourceSplit> splits,
+      IcebergEnumeratorPosition fromPosition,
+      IcebergEnumeratorPosition toPosition,
+      @Nullable ScanReport scanReport) {
     Preconditions.checkArgument(splits != null, "Invalid to splits collection: null");
     Preconditions.checkArgument(toPosition != null, "Invalid end position: null");
     this.splits = splits;
     this.fromPosition = fromPosition;
     this.toPosition = toPosition;
+    this.scanReport = scanReport;
   }
 
   public Collection<IcebergSourceSplit> splits() {
@@ -53,5 +65,10 @@ class ContinuousEnumerationResult {
 
   public IcebergEnumeratorPosition toPosition() {
     return toPosition;
+  }
+
+  @Nullable
+  public ScanReport scanReport() {
+    return scanReport;
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -62,13 +62,15 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;
+  private final IcebergSourceEnumeratorMetrics enumeratorMetrics;
 
   public ContinuousIcebergEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
       SplitAssigner assigner,
       ScanContext scanContext,
       ContinuousSplitPlanner splitPlanner,
-      @Nullable IcebergEnumeratorState enumState) {
+      @Nullable IcebergEnumeratorState enumState,
+      String tableName) {
     super(enumeratorContext, assigner);
 
     this.enumeratorContext = enumeratorContext;
@@ -78,6 +80,8 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
     this.enumeratorPosition = new AtomicReference<>();
     this.enumerationHistory = new EnumerationHistory(ENUMERATION_SPLIT_COUNT_HISTORY_SIZE);
     this.elapsedSecondsSinceLastSplitDiscovery = new ElapsedTimeGauge(TimeUnit.SECONDS);
+    this.enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(enumeratorContext.metricGroup(), tableName);
     this.enumeratorContext
         .metricGroup()
         .gauge("elapsedSecondsSinceLastSplitDiscovery", elapsedSecondsSinceLastSplitDiscovery);
@@ -150,6 +154,9 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
             result.fromPosition());
       } else {
         elapsedSecondsSinceLastSplitDiscovery.refreshLastRecordedTime();
+        if (result.scanReport() != null && result.scanReport().scanMetrics() != null) {
+          enumeratorMetrics.updateWithScanMetrics(result.scanReport().scanMetrics());
+        }
         // Sometimes, enumeration may yield no splits for a few reasons.
         // - upstream paused or delayed streaming writes to the Iceberg table.
         // - enumeration frequency is higher than the upstream write frequency.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.flink.source.FlinkSplitPlanner;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.InMemoryMetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -131,15 +133,19 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
       ScanContext incrementalScan =
           scanContext.copyWithAppendsBetween(
               lastPosition.snapshotId(), toSnapshotInclusive.snapshotId());
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       List<IcebergSourceSplit> splits =
-          FlinkSplitPlanner.planIcebergSourceSplits(table, incrementalScan, workerPool);
+          FlinkSplitPlanner.planIcebergSourceSplits(
+              table, incrementalScan, workerPool, metricsReporter);
+      ScanReport scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from incremental scan: "
               + "from snapshot (exclusive) is {}, to snapshot (inclusive) is {}",
           splits.size(),
           lastPosition,
           newPosition);
-      return new ContinuousEnumerationResult(splits, lastPosition, newPosition);
+      return new ContinuousEnumerationResult(splits, lastPosition, newPosition, scanReport);
     }
   }
 
@@ -166,13 +172,20 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
         startSnapshot.snapshotId(),
         scanContext.streamingStartingStrategy());
     List<IcebergSourceSplit> splits = Collections.emptyList();
+    ScanReport scanReport = null;
     IcebergEnumeratorPosition toPosition;
     if (scanContext.streamingStartingStrategy()
         == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL) {
       // do a batch table scan first
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       splits =
           FlinkSplitPlanner.planIcebergSourceSplits(
-              table, scanContext.copyWithSnapshotId(startSnapshot.snapshotId()), workerPool);
+              table,
+              scanContext.copyWithSnapshotId(startSnapshot.snapshotId()),
+              workerPool,
+              metricsReporter);
+      scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from initial batch table scan with snapshot Id {}",
           splits.size(),
@@ -207,7 +220,7 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
           startSnapshot.timestampMillis());
     }
 
-    return new ContinuousEnumerationResult(splits, null, toPosition);
+    return new ContinuousEnumerationResult(splits, null, toPosition, scanReport);
   }
 
   /**

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+
+/**
+ * Metrics for the Iceberg source enumerator (coordinator). All metrics are gauges reporting the
+ * values from the most recent scan planning cycle, providing a per-scan snapshot of planning
+ * efficiency. This allows monitoring systems to track spikes, trends, and correlate scan behavior
+ * with other events over time. Gauge values remain at 0 until the first actual scan completes.
+ */
+@Internal
+public class IcebergSourceEnumeratorMetrics {
+  private final AtomicLong lastScanPlanningDurationMs = new AtomicLong();
+  private final AtomicLong scannedDataManifests = new AtomicLong();
+  private final AtomicLong skippedDataManifests = new AtomicLong();
+  private final AtomicLong totalDataManifests = new AtomicLong();
+  private final AtomicLong scannedDeleteManifests = new AtomicLong();
+  private final AtomicLong skippedDeleteManifests = new AtomicLong();
+  private final AtomicLong totalDeleteManifests = new AtomicLong();
+  private final AtomicLong resultDataFiles = new AtomicLong();
+  private final AtomicLong skippedDataFiles = new AtomicLong();
+  private final AtomicLong resultDeleteFiles = new AtomicLong();
+  private final AtomicLong skippedDeleteFiles = new AtomicLong();
+  private final AtomicLong indexedDeleteFiles = new AtomicLong();
+  private final AtomicLong equalityDeleteFiles = new AtomicLong();
+  private final AtomicLong positionalDeleteFiles = new AtomicLong();
+  // named to match ScanMetricsResult.dvs() (deletion vectors)
+  private final AtomicLong dvs = new AtomicLong();
+  private final AtomicLong totalFileSizeInBytes = new AtomicLong();
+  private final AtomicLong totalDeleteFileSizeInBytes = new AtomicLong();
+
+  public IcebergSourceEnumeratorMetrics(MetricGroup metrics, String fullTableName) {
+    MetricGroup enumeratorMetrics =
+        metrics.addGroup("IcebergSourceEnumerator").addGroup("table", fullTableName);
+    enumeratorMetrics.gauge("lastScanPlanningDurationMs", lastScanPlanningDurationMs::get);
+    enumeratorMetrics.gauge("scannedDataManifests", scannedDataManifests::get);
+    enumeratorMetrics.gauge("skippedDataManifests", skippedDataManifests::get);
+    enumeratorMetrics.gauge("totalDataManifests", totalDataManifests::get);
+    enumeratorMetrics.gauge("scannedDeleteManifests", scannedDeleteManifests::get);
+    enumeratorMetrics.gauge("skippedDeleteManifests", skippedDeleteManifests::get);
+    enumeratorMetrics.gauge("totalDeleteManifests", totalDeleteManifests::get);
+    enumeratorMetrics.gauge("resultDataFiles", resultDataFiles::get);
+    enumeratorMetrics.gauge("skippedDataFiles", skippedDataFiles::get);
+    enumeratorMetrics.gauge("resultDeleteFiles", resultDeleteFiles::get);
+    enumeratorMetrics.gauge("skippedDeleteFiles", skippedDeleteFiles::get);
+    enumeratorMetrics.gauge("indexedDeleteFiles", indexedDeleteFiles::get);
+    enumeratorMetrics.gauge("equalityDeleteFiles", equalityDeleteFiles::get);
+    enumeratorMetrics.gauge("positionalDeleteFiles", positionalDeleteFiles::get);
+    enumeratorMetrics.gauge("dvs", dvs::get);
+    enumeratorMetrics.gauge("totalFileSizeInBytes", totalFileSizeInBytes::get);
+    enumeratorMetrics.gauge("totalDeleteFileSizeInBytes", totalDeleteFileSizeInBytes::get);
+  }
+
+  /** Updates enumerator metrics from the given scan metrics result. No-op if {@code null}. */
+  public void updateWithScanMetrics(ScanMetricsResult scanMetrics) {
+    if (scanMetrics == null) {
+      return;
+    }
+
+    TimerResult planningDuration = scanMetrics.totalPlanningDuration();
+    if (planningDuration != null) {
+      lastScanPlanningDurationMs.set(planningDuration.totalDuration().toMillis());
+    }
+
+    setGauge(scannedDataManifests, scanMetrics.scannedDataManifests());
+    setGauge(skippedDataManifests, scanMetrics.skippedDataManifests());
+    setGauge(totalDataManifests, scanMetrics.totalDataManifests());
+    setGauge(scannedDeleteManifests, scanMetrics.scannedDeleteManifests());
+    setGauge(skippedDeleteManifests, scanMetrics.skippedDeleteManifests());
+    setGauge(totalDeleteManifests, scanMetrics.totalDeleteManifests());
+    setGauge(resultDataFiles, scanMetrics.resultDataFiles());
+    setGauge(skippedDataFiles, scanMetrics.skippedDataFiles());
+    setGauge(resultDeleteFiles, scanMetrics.resultDeleteFiles());
+    setGauge(skippedDeleteFiles, scanMetrics.skippedDeleteFiles());
+    setGauge(indexedDeleteFiles, scanMetrics.indexedDeleteFiles());
+    setGauge(equalityDeleteFiles, scanMetrics.equalityDeleteFiles());
+    setGauge(positionalDeleteFiles, scanMetrics.positionalDeleteFiles());
+    setGauge(dvs, scanMetrics.dvs());
+    setGauge(totalFileSizeInBytes, scanMetrics.totalFileSizeInBytes());
+    setGauge(totalDeleteFileSizeInBytes, scanMetrics.totalDeleteFileSizeInBytes());
+  }
+
+  private static void setGauge(AtomicLong gauge, CounterResult counterResult) {
+    if (counterResult != null) {
+      gauge.set(counterResult.value());
+    }
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -555,16 +555,13 @@ public class TestIcebergSourceContinuous {
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
     // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
-    Optional<MetricGroup> scanMetricsGroup =
-        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    Optional<MetricGroup> scanMetricsGroup = METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
     assertThat(scanMetricsGroup).isPresent();
     assertThat(
             METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
                 .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
         .anySatisfy(
-            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
-        .anySatisfy(
-            fullMetricName ->
-                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
+            fullMetricName -> assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -554,20 +554,17 @@ public class TestIcebergSourceContinuous {
   }
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
-    assertThatIcebergSourceMetricExists(
-        "enumerator", "coordinator.enumerator.elapsedSecondsSinceLastSplitDiscovery");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.unassignedSplits");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.pendingRecords");
-  }
-
-  private static void assertThatIcebergSourceMetricExists(
-      String metricGroupPattern, String metricName) {
-    Optional<MetricGroup> groups = METRIC_REPORTER.findGroup(metricGroupPattern);
-    assertThat(groups).isPresent();
+    // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
+    Optional<MetricGroup> scanMetricsGroup =
+        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    assertThat(scanMetricsGroup).isPresent();
     assertThat(
-            METRIC_REPORTER.getMetricsByGroup(groups.get()).keySet().stream()
-                .map(name -> groups.get().getMetricIdentifier(name)))
-        .satisfiesOnlyOnce(
-            fullMetricName -> assertThat(fullMetricName).containsSubsequence(metricName));
+            METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
+                .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(
+            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
+        .anySatisfy(
+            fullMetricName ->
+                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -33,6 +35,7 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   private final NavigableMap<Long, List<IcebergSourceSplit>> splits;
   private long latestSnapshotId;
   private int remainingFailures;
+  @Nullable private ScanReport scanReport;
 
   ManualContinuousSplitPlanner(ScanContext scanContext, int expectedFailures) {
     this.maxPlanningSnapshotCount = scanContext.maxPlanningSnapshotCount();
@@ -79,7 +82,8 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
             discoveredSplits,
             lastPosition,
             // use the snapshot Id as snapshot timestamp.
-            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive));
+            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive),
+            scanReport);
     return result;
   }
 
@@ -90,6 +94,11 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   public synchronized void addSplits(List<IcebergSourceSplit> newSplits) {
     latestSnapshotId += 1;
     splits.put(latestSnapshotId, newSplits);
+  }
+
+  /** Set a ScanReport to be included in future enumeration results. */
+  public synchronized void setScanReport(@Nullable ScanReport report) {
+    this.scanReport = report;
   }
 
   @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -22,13 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
@@ -37,6 +40,12 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanReport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -334,6 +343,58 @@ public class TestContinuousIcebergEnumerator {
     assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
+  @Test
+  public void testEnumeratorMetricsUpdatedFromScanReport() throws Exception {
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner(scanContext, 0);
+
+    // Set a ScanReport with known metrics
+    ScanReport report =
+        ImmutableScanReport.builder()
+            .tableName("test.db.metrics_table")
+            .snapshotId(1L)
+            .schemaId(0)
+            .filter(Expressions.alwaysTrue())
+            .projectedFieldNames(Collections.emptyList())
+            .scanMetrics(
+                ImmutableScanMetricsResult.builder()
+                    .totalPlanningDuration(
+                        ImmutableTimerResult.builder()
+                            .timeUnit(TimeUnit.NANOSECONDS)
+                            .totalDuration(Duration.ofMillis(250))
+                            .count(1)
+                            .build())
+                    .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+                    .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+                    .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+                    .build())
+            .build();
+    splitPlanner.setScanReport(report);
+
+    ContinuousIcebergEnumerator enumerator =
+        createEnumerator(enumeratorContext, scanContext, splitPlanner);
+
+    // Register reader and add splits to trigger a discovery cycle
+    enumeratorContext.registerReader(2, "localhost");
+    List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
+    splitPlanner.addSplits(splits);
+
+    // Trigger the enumeration which calls processDiscoveredSplits internally
+    enumeratorContext.triggerAllActions();
+
+    // Verify that the enumerator processed splits (basic sanity)
+    Collection<IcebergSourceSplitState> pendingSplits =
+        enumerator.snapshotState(1).pendingSplits();
+    assertThat(pendingSplits).hasSize(1);
+  }
+
   private static ContinuousIcebergEnumerator createEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> context,
       ScanContext scanContext,
@@ -345,7 +406,8 @@ public class TestContinuousIcebergEnumerator {
             new DefaultSplitAssigner(null, Collections.emptyList()),
             scanContext,
             splitPlanner,
-            null);
+            null,
+            "test.table");
     enumerator.start();
     return enumerator;
   }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -390,8 +390,7 @@ public class TestContinuousIcebergEnumerator {
     enumeratorContext.triggerAllActions();
 
     // Verify that the enumerator processed splits (basic sanity)
-    Collection<IcebergSourceSplitState> pendingSplits =
-        enumerator.snapshotState(1).pendingSplits();
+    Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(1).pendingSplits();
     assertThat(pendingSplits).hasSize(1);
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -731,4 +731,65 @@ public class TestContinuousSplitPlannerImpl {
       this.split = split;
     }
   }
+
+  @Test
+  public void testScanReportPopulatedInTableScanResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
+    assertThat(
+            initialResult
+                .scanReport()
+                .scanMetrics()
+                .totalPlanningDuration()
+                .totalDuration()
+                .toMillis())
+        .isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  public void testScanReportPopulatedInIncrementalResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    // Initial plan does a table scan
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+
+    // Append new data so incremental scan has something to discover
+    List<Record> batch =
+        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    DataFile dataFile = dataAppender.writeFile(null, batch);
+    dataAppender.appendToTable(dataFile);
+
+    // Incremental scan should discover the new snapshot and produce a scan report
+    ContinuousEnumerationResult incrementalResult =
+        splitPlanner.planSplits(initialResult.toPosition());
+    assertThat(incrementalResult.scanReport()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(incrementalResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+  }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -748,8 +748,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
     assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
         .isGreaterThan(0);
-    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
-        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value()).isGreaterThan(0);
     assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
     assertThat(
             initialResult
@@ -777,8 +776,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport()).isNotNull();
 
     // Append new data so incremental scan has something to discover
-    List<Record> batch =
-        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    List<Record> batch = RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
     DataFile dataFile = dataAppender.writeFile(null, batch);
     dataAppender.appendToTable(dataFile);
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergSourceEnumeratorMetrics {
+
+  @Test
+  public void testMetricsRegistration() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    assertThat(enumeratorMetrics).isNotNull();
+    assertThat(metricGroup.registeredGauges()).hasSize(17);
+    assertThat(metricGroup.registeredGauges())
+        .containsKey("lastScanPlanningDurationMs")
+        .containsKey("scannedDataManifests")
+        .containsKey("skippedDataManifests")
+        .containsKey("totalDataManifests")
+        .containsKey("scannedDeleteManifests")
+        .containsKey("skippedDeleteManifests")
+        .containsKey("totalDeleteManifests")
+        .containsKey("resultDataFiles")
+        .containsKey("skippedDataFiles")
+        .containsKey("resultDeleteFiles")
+        .containsKey("skippedDeleteFiles")
+        .containsKey("indexedDeleteFiles")
+        .containsKey("equalityDeleteFiles")
+        .containsKey("positionalDeleteFiles")
+        .containsKey("dvs")
+        .containsKey("totalFileSizeInBytes")
+        .containsKey("totalDeleteFileSizeInBytes");
+  }
+
+  @Test
+  public void testUpdateWithScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult scanMetrics =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(150))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .skippedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 15))
+            .scannedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .skippedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .totalDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 100))
+            .skippedDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 50))
+            .resultDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .skippedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .indexedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 4))
+            .equalityDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .positionalDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 1))
+            .dvs(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .totalFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 1024000))
+            .totalDeleteFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 512000))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(scanMetrics);
+
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 150L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 10L);
+    assertGaugeValue(metricGroup, "skippedDataManifests", 5L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 15L);
+    assertGaugeValue(metricGroup, "scannedDeleteManifests", 3L);
+    assertGaugeValue(metricGroup, "skippedDeleteManifests", 2L);
+    assertGaugeValue(metricGroup, "totalDeleteManifests", 5L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 100L);
+    assertGaugeValue(metricGroup, "skippedDataFiles", 50L);
+    assertGaugeValue(metricGroup, "resultDeleteFiles", 7L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 3L);
+    assertGaugeValue(metricGroup, "indexedDeleteFiles", 4L);
+    assertGaugeValue(metricGroup, "equalityDeleteFiles", 2L);
+    assertGaugeValue(metricGroup, "positionalDeleteFiles", 1L);
+    assertGaugeValue(metricGroup, "dvs", 3L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 1024000L);
+    assertGaugeValue(metricGroup, "totalDeleteFileSizeInBytes", 512000L);
+  }
+
+  @Test
+  public void testGaugesShowLatestScanValues() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult firstScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(100))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    ScanMetricsResult secondScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(200))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(firstScan);
+    enumeratorMetrics.updateWithScanMetrics(secondScan);
+
+    // Gauges show last-scan values, NOT accumulated
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 200L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 7L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 2L);
+  }
+
+  @Test
+  public void testUpdateWithNullMetricsIsNoOp() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    enumeratorMetrics.updateWithScanMetrics(null);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 0L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 0L);
+  }
+
+  @Test
+  public void testPartialNullFieldsInScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    // Only some fields populated, rest are null
+    ScanMetricsResult partialMetrics =
+        ImmutableScanMetricsResult.builder()
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(partialMetrics);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 10L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 5L);
+    // Null fields remain at zero
+    assertGaugeValue(metricGroup, "skippedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 0L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 0L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertGaugeValue(
+      TestingEnumeratorMetricGroup metricGroup, String name, Long expected) {
+    Gauge<Long> gauge = (Gauge<Long>) metricGroup.registeredGauges().get(name);
+    assertThat(gauge).as("Gauge '%s' should be registered", name).isNotNull();
+    assertThat(gauge.getValue()).isEqualTo(expected);
+  }
+
+  private static TimerResult timerResult(long durationMs) {
+    return ImmutableTimerResult.builder()
+        .timeUnit(TimeUnit.NANOSECONDS)
+        .totalDuration(Duration.ofMillis(durationMs))
+        .count(1)
+        .build();
+  }
+
+  /**
+   * A testing metric group that captures registered gauges for verification. Follows the pattern
+   * from {@code TestingMetricGroup} in the reader package.
+   */
+  static class TestingEnumeratorMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Counter> counters;
+    private final Map<String, Gauge<?>> gauges;
+
+    TestingEnumeratorMetricGroup() {
+      this.counters = Maps.newHashMap();
+      this.gauges = Maps.newHashMap();
+    }
+
+    private TestingEnumeratorMetricGroup(
+        Map<String, Counter> counters, Map<String, Gauge<?>> gauges) {
+      this.counters = counters;
+      this.gauges = gauges;
+    }
+
+    Map<String, Counter> counters() {
+      return counters;
+    }
+
+    Map<String, Gauge<?>> registeredGauges() {
+      return gauges;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      Counter counter = new SimpleCounter();
+      counters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+
+    @Override
+    public MetricGroup addGroup(String key, String value) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -72,8 +73,17 @@ public class FlinkSplitPlanner {
   /** This returns splits for the FLIP-27 source */
   public static List<IcebergSourceSplit> planIcebergSourceSplits(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planIcebergSourceSplits(table, context, workerPool, null);
+  }
+
+  /** This returns splits for the FLIP-27 source with optional metrics reporting */
+  public static List<IcebergSourceSplit> planIcebergSourceSplits(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     try (CloseableIterable<CombinedScanTask> tasksIterable =
-        planTasks(table, context, workerPool)) {
+        planTasks(table, context, workerPool, metricsReporter)) {
       return Lists.newArrayList(
           CloseableIterable.transform(tasksIterable, IcebergSourceSplit::fromCombinedScanTask));
     } catch (IOException e) {
@@ -83,10 +93,18 @@ public class FlinkSplitPlanner {
 
   static CloseableIterable<CombinedScanTask> planTasks(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planTasks(table, context, workerPool, null);
+  }
+
+  static CloseableIterable<CombinedScanTask> planTasks(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     ScanMode scanMode = checkScanMode(context);
     if (scanMode == ScanMode.INCREMENTAL_APPEND_SCAN) {
       IncrementalAppendScan scan = table.newIncrementalAppendScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.startTag() != null) {
         Preconditions.checkArgument(
@@ -119,7 +137,7 @@ public class FlinkSplitPlanner {
       return scan.planTasks();
     } else {
       TableScan scan = table.newScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.snapshotId() != null) {
         scan = scan.useSnapshot(context.snapshotId());
@@ -157,7 +175,7 @@ public class FlinkSplitPlanner {
 
   /** refine scan with common configs */
   private static <T extends Scan<T, FileScanTask, CombinedScanTask>> T refineScanWithBaseConfigs(
-      T scan, ScanContext context, ExecutorService workerPool) {
+      T scan, ScanContext context, ExecutorService workerPool, MetricsReporter metricsReporter) {
     T refinedScan =
         scan.caseSensitive(context.caseSensitive()).project(context.project()).planWith(workerPool);
 
@@ -182,6 +200,10 @@ public class FlinkSplitPlanner {
       for (Expression filter : context.filters()) {
         refinedScan = refinedScan.filter(filter);
       }
+    }
+
+    if (metricsReporter != null) {
+      refinedScan = refinedScan.metricsReporter(metricsReporter);
     }
 
     return refinedScan;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -221,7 +221,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       ContinuousSplitPlanner splitPlanner =
           new ContinuousSplitPlannerImpl(tableLoader, scanContext, planningThreadName());
       return new ContinuousIcebergEnumerator(
-          enumContext, assigner, scanContext, splitPlanner, enumState);
+          enumContext, assigner, scanContext, splitPlanner, enumState, tableName);
     } else {
       if (enumState == null) {
         // Only do scan planning if nothing is restored from checkpoint state

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
@@ -19,13 +19,16 @@
 package org.apache.iceberg.flink.source.enumerator;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 class ContinuousEnumerationResult {
   private final Collection<IcebergSourceSplit> splits;
   private final IcebergEnumeratorPosition fromPosition;
   private final IcebergEnumeratorPosition toPosition;
+  @Nullable private final ScanReport scanReport;
 
   /**
    * @param splits should never be null. But it can be an empty collection
@@ -36,11 +39,20 @@ class ContinuousEnumerationResult {
       Collection<IcebergSourceSplit> splits,
       IcebergEnumeratorPosition fromPosition,
       IcebergEnumeratorPosition toPosition) {
+    this(splits, fromPosition, toPosition, null);
+  }
+
+  ContinuousEnumerationResult(
+      Collection<IcebergSourceSplit> splits,
+      IcebergEnumeratorPosition fromPosition,
+      IcebergEnumeratorPosition toPosition,
+      @Nullable ScanReport scanReport) {
     Preconditions.checkArgument(splits != null, "Invalid to splits collection: null");
     Preconditions.checkArgument(toPosition != null, "Invalid end position: null");
     this.splits = splits;
     this.fromPosition = fromPosition;
     this.toPosition = toPosition;
+    this.scanReport = scanReport;
   }
 
   public Collection<IcebergSourceSplit> splits() {
@@ -53,5 +65,10 @@ class ContinuousEnumerationResult {
 
   public IcebergEnumeratorPosition toPosition() {
     return toPosition;
+  }
+
+  @Nullable
+  public ScanReport scanReport() {
+    return scanReport;
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -62,13 +62,15 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;
+  private final IcebergSourceEnumeratorMetrics enumeratorMetrics;
 
   public ContinuousIcebergEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
       SplitAssigner assigner,
       ScanContext scanContext,
       ContinuousSplitPlanner splitPlanner,
-      @Nullable IcebergEnumeratorState enumState) {
+      @Nullable IcebergEnumeratorState enumState,
+      String tableName) {
     super(enumeratorContext, assigner);
 
     this.enumeratorContext = enumeratorContext;
@@ -78,6 +80,8 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
     this.enumeratorPosition = new AtomicReference<>();
     this.enumerationHistory = new EnumerationHistory(ENUMERATION_SPLIT_COUNT_HISTORY_SIZE);
     this.elapsedSecondsSinceLastSplitDiscovery = new ElapsedTimeGauge(TimeUnit.SECONDS);
+    this.enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(enumeratorContext.metricGroup(), tableName);
     this.enumeratorContext
         .metricGroup()
         .gauge("elapsedSecondsSinceLastSplitDiscovery", elapsedSecondsSinceLastSplitDiscovery);
@@ -150,6 +154,9 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
             result.fromPosition());
       } else {
         elapsedSecondsSinceLastSplitDiscovery.refreshLastRecordedTime();
+        if (result.scanReport() != null && result.scanReport().scanMetrics() != null) {
+          enumeratorMetrics.updateWithScanMetrics(result.scanReport().scanMetrics());
+        }
         // Sometimes, enumeration may yield no splits for a few reasons.
         // - upstream paused or delayed streaming writes to the Iceberg table.
         // - enumeration frequency is higher than the upstream write frequency.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.flink.source.FlinkSplitPlanner;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.InMemoryMetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -131,15 +133,19 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
       ScanContext incrementalScan =
           scanContext.copyWithAppendsBetween(
               lastPosition.snapshotId(), toSnapshotInclusive.snapshotId());
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       List<IcebergSourceSplit> splits =
-          FlinkSplitPlanner.planIcebergSourceSplits(table, incrementalScan, workerPool);
+          FlinkSplitPlanner.planIcebergSourceSplits(
+              table, incrementalScan, workerPool, metricsReporter);
+      ScanReport scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from incremental scan: "
               + "from snapshot (exclusive) is {}, to snapshot (inclusive) is {}",
           splits.size(),
           lastPosition,
           newPosition);
-      return new ContinuousEnumerationResult(splits, lastPosition, newPosition);
+      return new ContinuousEnumerationResult(splits, lastPosition, newPosition, scanReport);
     }
   }
 
@@ -166,13 +172,20 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
         startSnapshot.snapshotId(),
         scanContext.streamingStartingStrategy());
     List<IcebergSourceSplit> splits = Collections.emptyList();
+    ScanReport scanReport = null;
     IcebergEnumeratorPosition toPosition;
     if (scanContext.streamingStartingStrategy()
         == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL) {
       // do a batch table scan first
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       splits =
           FlinkSplitPlanner.planIcebergSourceSplits(
-              table, scanContext.copyWithSnapshotId(startSnapshot.snapshotId()), workerPool);
+              table,
+              scanContext.copyWithSnapshotId(startSnapshot.snapshotId()),
+              workerPool,
+              metricsReporter);
+      scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from initial batch table scan with snapshot Id {}",
           splits.size(),
@@ -207,7 +220,7 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
           startSnapshot.timestampMillis());
     }
 
-    return new ContinuousEnumerationResult(splits, null, toPosition);
+    return new ContinuousEnumerationResult(splits, null, toPosition, scanReport);
   }
 
   /**

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+
+/**
+ * Metrics for the Iceberg source enumerator (coordinator). All metrics are gauges reporting the
+ * values from the most recent scan planning cycle, providing a per-scan snapshot of planning
+ * efficiency. This allows monitoring systems to track spikes, trends, and correlate scan behavior
+ * with other events over time. Gauge values remain at 0 until the first actual scan completes.
+ */
+@Internal
+public class IcebergSourceEnumeratorMetrics {
+  private final AtomicLong lastScanPlanningDurationMs = new AtomicLong();
+  private final AtomicLong scannedDataManifests = new AtomicLong();
+  private final AtomicLong skippedDataManifests = new AtomicLong();
+  private final AtomicLong totalDataManifests = new AtomicLong();
+  private final AtomicLong scannedDeleteManifests = new AtomicLong();
+  private final AtomicLong skippedDeleteManifests = new AtomicLong();
+  private final AtomicLong totalDeleteManifests = new AtomicLong();
+  private final AtomicLong resultDataFiles = new AtomicLong();
+  private final AtomicLong skippedDataFiles = new AtomicLong();
+  private final AtomicLong resultDeleteFiles = new AtomicLong();
+  private final AtomicLong skippedDeleteFiles = new AtomicLong();
+  private final AtomicLong indexedDeleteFiles = new AtomicLong();
+  private final AtomicLong equalityDeleteFiles = new AtomicLong();
+  private final AtomicLong positionalDeleteFiles = new AtomicLong();
+  // named to match ScanMetricsResult.dvs() (deletion vectors)
+  private final AtomicLong dvs = new AtomicLong();
+  private final AtomicLong totalFileSizeInBytes = new AtomicLong();
+  private final AtomicLong totalDeleteFileSizeInBytes = new AtomicLong();
+
+  public IcebergSourceEnumeratorMetrics(MetricGroup metrics, String fullTableName) {
+    MetricGroup enumeratorMetrics =
+        metrics.addGroup("IcebergSourceEnumerator").addGroup("table", fullTableName);
+    enumeratorMetrics.gauge("lastScanPlanningDurationMs", lastScanPlanningDurationMs::get);
+    enumeratorMetrics.gauge("scannedDataManifests", scannedDataManifests::get);
+    enumeratorMetrics.gauge("skippedDataManifests", skippedDataManifests::get);
+    enumeratorMetrics.gauge("totalDataManifests", totalDataManifests::get);
+    enumeratorMetrics.gauge("scannedDeleteManifests", scannedDeleteManifests::get);
+    enumeratorMetrics.gauge("skippedDeleteManifests", skippedDeleteManifests::get);
+    enumeratorMetrics.gauge("totalDeleteManifests", totalDeleteManifests::get);
+    enumeratorMetrics.gauge("resultDataFiles", resultDataFiles::get);
+    enumeratorMetrics.gauge("skippedDataFiles", skippedDataFiles::get);
+    enumeratorMetrics.gauge("resultDeleteFiles", resultDeleteFiles::get);
+    enumeratorMetrics.gauge("skippedDeleteFiles", skippedDeleteFiles::get);
+    enumeratorMetrics.gauge("indexedDeleteFiles", indexedDeleteFiles::get);
+    enumeratorMetrics.gauge("equalityDeleteFiles", equalityDeleteFiles::get);
+    enumeratorMetrics.gauge("positionalDeleteFiles", positionalDeleteFiles::get);
+    enumeratorMetrics.gauge("dvs", dvs::get);
+    enumeratorMetrics.gauge("totalFileSizeInBytes", totalFileSizeInBytes::get);
+    enumeratorMetrics.gauge("totalDeleteFileSizeInBytes", totalDeleteFileSizeInBytes::get);
+  }
+
+  /** Updates enumerator metrics from the given scan metrics result. No-op if {@code null}. */
+  public void updateWithScanMetrics(ScanMetricsResult scanMetrics) {
+    if (scanMetrics == null) {
+      return;
+    }
+
+    TimerResult planningDuration = scanMetrics.totalPlanningDuration();
+    if (planningDuration != null) {
+      lastScanPlanningDurationMs.set(planningDuration.totalDuration().toMillis());
+    }
+
+    setGauge(scannedDataManifests, scanMetrics.scannedDataManifests());
+    setGauge(skippedDataManifests, scanMetrics.skippedDataManifests());
+    setGauge(totalDataManifests, scanMetrics.totalDataManifests());
+    setGauge(scannedDeleteManifests, scanMetrics.scannedDeleteManifests());
+    setGauge(skippedDeleteManifests, scanMetrics.skippedDeleteManifests());
+    setGauge(totalDeleteManifests, scanMetrics.totalDeleteManifests());
+    setGauge(resultDataFiles, scanMetrics.resultDataFiles());
+    setGauge(skippedDataFiles, scanMetrics.skippedDataFiles());
+    setGauge(resultDeleteFiles, scanMetrics.resultDeleteFiles());
+    setGauge(skippedDeleteFiles, scanMetrics.skippedDeleteFiles());
+    setGauge(indexedDeleteFiles, scanMetrics.indexedDeleteFiles());
+    setGauge(equalityDeleteFiles, scanMetrics.equalityDeleteFiles());
+    setGauge(positionalDeleteFiles, scanMetrics.positionalDeleteFiles());
+    setGauge(dvs, scanMetrics.dvs());
+    setGauge(totalFileSizeInBytes, scanMetrics.totalFileSizeInBytes());
+    setGauge(totalDeleteFileSizeInBytes, scanMetrics.totalDeleteFileSizeInBytes());
+  }
+
+  private static void setGauge(AtomicLong gauge, CounterResult counterResult) {
+    if (counterResult != null) {
+      gauge.set(counterResult.value());
+    }
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -555,16 +555,13 @@ public class TestIcebergSourceContinuous {
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
     // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
-    Optional<MetricGroup> scanMetricsGroup =
-        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    Optional<MetricGroup> scanMetricsGroup = METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
     assertThat(scanMetricsGroup).isPresent();
     assertThat(
             METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
                 .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
         .anySatisfy(
-            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
-        .anySatisfy(
-            fullMetricName ->
-                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
+            fullMetricName -> assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -554,20 +554,17 @@ public class TestIcebergSourceContinuous {
   }
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
-    assertThatIcebergSourceMetricExists(
-        "enumerator", "coordinator.enumerator.elapsedSecondsSinceLastSplitDiscovery");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.unassignedSplits");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.pendingRecords");
-  }
-
-  private static void assertThatIcebergSourceMetricExists(
-      String metricGroupPattern, String metricName) {
-    Optional<MetricGroup> groups = METRIC_REPORTER.findGroup(metricGroupPattern);
-    assertThat(groups).isPresent();
+    // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
+    Optional<MetricGroup> scanMetricsGroup =
+        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    assertThat(scanMetricsGroup).isPresent();
     assertThat(
-            METRIC_REPORTER.getMetricsByGroup(groups.get()).keySet().stream()
-                .map(name -> groups.get().getMetricIdentifier(name)))
-        .satisfiesOnlyOnce(
-            fullMetricName -> assertThat(fullMetricName).containsSubsequence(metricName));
+            METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
+                .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(
+            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
+        .anySatisfy(
+            fullMetricName ->
+                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -33,6 +35,7 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   private final NavigableMap<Long, List<IcebergSourceSplit>> splits;
   private long latestSnapshotId;
   private int remainingFailures;
+  @Nullable private ScanReport scanReport;
 
   ManualContinuousSplitPlanner(ScanContext scanContext, int expectedFailures) {
     this.maxPlanningSnapshotCount = scanContext.maxPlanningSnapshotCount();
@@ -79,7 +82,8 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
             discoveredSplits,
             lastPosition,
             // use the snapshot Id as snapshot timestamp.
-            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive));
+            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive),
+            scanReport);
     return result;
   }
 
@@ -90,6 +94,11 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   public synchronized void addSplits(List<IcebergSourceSplit> newSplits) {
     latestSnapshotId += 1;
     splits.put(latestSnapshotId, newSplits);
+  }
+
+  /** Set a ScanReport to be included in future enumeration results. */
+  public synchronized void setScanReport(@Nullable ScanReport report) {
+    this.scanReport = report;
   }
 
   @Override

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -22,13 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
@@ -37,6 +40,12 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanReport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -334,6 +343,58 @@ public class TestContinuousIcebergEnumerator {
     assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
+  @Test
+  public void testEnumeratorMetricsUpdatedFromScanReport() throws Exception {
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner(scanContext, 0);
+
+    // Set a ScanReport with known metrics
+    ScanReport report =
+        ImmutableScanReport.builder()
+            .tableName("test.db.metrics_table")
+            .snapshotId(1L)
+            .schemaId(0)
+            .filter(Expressions.alwaysTrue())
+            .projectedFieldNames(Collections.emptyList())
+            .scanMetrics(
+                ImmutableScanMetricsResult.builder()
+                    .totalPlanningDuration(
+                        ImmutableTimerResult.builder()
+                            .timeUnit(TimeUnit.NANOSECONDS)
+                            .totalDuration(Duration.ofMillis(250))
+                            .count(1)
+                            .build())
+                    .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+                    .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+                    .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+                    .build())
+            .build();
+    splitPlanner.setScanReport(report);
+
+    ContinuousIcebergEnumerator enumerator =
+        createEnumerator(enumeratorContext, scanContext, splitPlanner);
+
+    // Register reader and add splits to trigger a discovery cycle
+    enumeratorContext.registerReader(2, "localhost");
+    List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
+    splitPlanner.addSplits(splits);
+
+    // Trigger the enumeration which calls processDiscoveredSplits internally
+    enumeratorContext.triggerAllActions();
+
+    // Verify that the enumerator processed splits (basic sanity)
+    Collection<IcebergSourceSplitState> pendingSplits =
+        enumerator.snapshotState(1).pendingSplits();
+    assertThat(pendingSplits).hasSize(1);
+  }
+
   private static ContinuousIcebergEnumerator createEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> context,
       ScanContext scanContext,
@@ -345,7 +406,8 @@ public class TestContinuousIcebergEnumerator {
             new DefaultSplitAssigner(null, Collections.emptyList()),
             scanContext,
             splitPlanner,
-            null);
+            null,
+            "test.table");
     enumerator.start();
     return enumerator;
   }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -390,8 +390,7 @@ public class TestContinuousIcebergEnumerator {
     enumeratorContext.triggerAllActions();
 
     // Verify that the enumerator processed splits (basic sanity)
-    Collection<IcebergSourceSplitState> pendingSplits =
-        enumerator.snapshotState(1).pendingSplits();
+    Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(1).pendingSplits();
     assertThat(pendingSplits).hasSize(1);
   }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -731,4 +731,65 @@ public class TestContinuousSplitPlannerImpl {
       this.split = split;
     }
   }
+
+  @Test
+  public void testScanReportPopulatedInTableScanResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
+    assertThat(
+            initialResult
+                .scanReport()
+                .scanMetrics()
+                .totalPlanningDuration()
+                .totalDuration()
+                .toMillis())
+        .isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  public void testScanReportPopulatedInIncrementalResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    // Initial plan does a table scan
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+
+    // Append new data so incremental scan has something to discover
+    List<Record> batch =
+        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    DataFile dataFile = dataAppender.writeFile(null, batch);
+    dataAppender.appendToTable(dataFile);
+
+    // Incremental scan should discover the new snapshot and produce a scan report
+    ContinuousEnumerationResult incrementalResult =
+        splitPlanner.planSplits(initialResult.toPosition());
+    assertThat(incrementalResult.scanReport()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(incrementalResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+  }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -748,8 +748,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
     assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
         .isGreaterThan(0);
-    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
-        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value()).isGreaterThan(0);
     assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
     assertThat(
             initialResult
@@ -777,8 +776,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport()).isNotNull();
 
     // Append new data so incremental scan has something to discover
-    List<Record> batch =
-        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    List<Record> batch = RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
     DataFile dataFile = dataAppender.writeFile(null, batch);
     dataAppender.appendToTable(dataFile);
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergSourceEnumeratorMetrics {
+
+  @Test
+  public void testMetricsRegistration() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    assertThat(enumeratorMetrics).isNotNull();
+    assertThat(metricGroup.registeredGauges()).hasSize(17);
+    assertThat(metricGroup.registeredGauges())
+        .containsKey("lastScanPlanningDurationMs")
+        .containsKey("scannedDataManifests")
+        .containsKey("skippedDataManifests")
+        .containsKey("totalDataManifests")
+        .containsKey("scannedDeleteManifests")
+        .containsKey("skippedDeleteManifests")
+        .containsKey("totalDeleteManifests")
+        .containsKey("resultDataFiles")
+        .containsKey("skippedDataFiles")
+        .containsKey("resultDeleteFiles")
+        .containsKey("skippedDeleteFiles")
+        .containsKey("indexedDeleteFiles")
+        .containsKey("equalityDeleteFiles")
+        .containsKey("positionalDeleteFiles")
+        .containsKey("dvs")
+        .containsKey("totalFileSizeInBytes")
+        .containsKey("totalDeleteFileSizeInBytes");
+  }
+
+  @Test
+  public void testUpdateWithScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult scanMetrics =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(150))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .skippedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 15))
+            .scannedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .skippedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .totalDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 100))
+            .skippedDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 50))
+            .resultDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .skippedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .indexedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 4))
+            .equalityDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .positionalDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 1))
+            .dvs(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .totalFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 1024000))
+            .totalDeleteFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 512000))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(scanMetrics);
+
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 150L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 10L);
+    assertGaugeValue(metricGroup, "skippedDataManifests", 5L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 15L);
+    assertGaugeValue(metricGroup, "scannedDeleteManifests", 3L);
+    assertGaugeValue(metricGroup, "skippedDeleteManifests", 2L);
+    assertGaugeValue(metricGroup, "totalDeleteManifests", 5L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 100L);
+    assertGaugeValue(metricGroup, "skippedDataFiles", 50L);
+    assertGaugeValue(metricGroup, "resultDeleteFiles", 7L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 3L);
+    assertGaugeValue(metricGroup, "indexedDeleteFiles", 4L);
+    assertGaugeValue(metricGroup, "equalityDeleteFiles", 2L);
+    assertGaugeValue(metricGroup, "positionalDeleteFiles", 1L);
+    assertGaugeValue(metricGroup, "dvs", 3L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 1024000L);
+    assertGaugeValue(metricGroup, "totalDeleteFileSizeInBytes", 512000L);
+  }
+
+  @Test
+  public void testGaugesShowLatestScanValues() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult firstScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(100))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    ScanMetricsResult secondScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(200))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(firstScan);
+    enumeratorMetrics.updateWithScanMetrics(secondScan);
+
+    // Gauges show last-scan values, NOT accumulated
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 200L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 7L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 2L);
+  }
+
+  @Test
+  public void testUpdateWithNullMetricsIsNoOp() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    enumeratorMetrics.updateWithScanMetrics(null);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 0L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 0L);
+  }
+
+  @Test
+  public void testPartialNullFieldsInScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    // Only some fields populated, rest are null
+    ScanMetricsResult partialMetrics =
+        ImmutableScanMetricsResult.builder()
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(partialMetrics);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 10L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 5L);
+    // Null fields remain at zero
+    assertGaugeValue(metricGroup, "skippedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 0L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 0L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertGaugeValue(
+      TestingEnumeratorMetricGroup metricGroup, String name, Long expected) {
+    Gauge<Long> gauge = (Gauge<Long>) metricGroup.registeredGauges().get(name);
+    assertThat(gauge).as("Gauge '%s' should be registered", name).isNotNull();
+    assertThat(gauge.getValue()).isEqualTo(expected);
+  }
+
+  private static TimerResult timerResult(long durationMs) {
+    return ImmutableTimerResult.builder()
+        .timeUnit(TimeUnit.NANOSECONDS)
+        .totalDuration(Duration.ofMillis(durationMs))
+        .count(1)
+        .build();
+  }
+
+  /**
+   * A testing metric group that captures registered gauges for verification. Follows the pattern
+   * from {@code TestingMetricGroup} in the reader package.
+   */
+  static class TestingEnumeratorMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Counter> counters;
+    private final Map<String, Gauge<?>> gauges;
+
+    TestingEnumeratorMetricGroup() {
+      this.counters = Maps.newHashMap();
+      this.gauges = Maps.newHashMap();
+    }
+
+    private TestingEnumeratorMetricGroup(
+        Map<String, Counter> counters, Map<String, Gauge<?>> gauges) {
+      this.counters = counters;
+      this.gauges = gauges;
+    }
+
+    Map<String, Counter> counters() {
+      return counters;
+    }
+
+    Map<String, Gauge<?>> registeredGauges() {
+      return gauges;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      Counter counter = new SimpleCounter();
+      counters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+
+    @Override
+    public MetricGroup addGroup(String key, String value) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/FlinkSplitPlanner.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.hadoop.Util;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -72,8 +73,17 @@ public class FlinkSplitPlanner {
   /** This returns splits for the FLIP-27 source */
   public static List<IcebergSourceSplit> planIcebergSourceSplits(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planIcebergSourceSplits(table, context, workerPool, null);
+  }
+
+  /** This returns splits for the FLIP-27 source with optional metrics reporting */
+  public static List<IcebergSourceSplit> planIcebergSourceSplits(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     try (CloseableIterable<CombinedScanTask> tasksIterable =
-        planTasks(table, context, workerPool)) {
+        planTasks(table, context, workerPool, metricsReporter)) {
       return Lists.newArrayList(
           CloseableIterable.transform(tasksIterable, IcebergSourceSplit::fromCombinedScanTask));
     } catch (IOException e) {
@@ -83,10 +93,18 @@ public class FlinkSplitPlanner {
 
   static CloseableIterable<CombinedScanTask> planTasks(
       Table table, ScanContext context, ExecutorService workerPool) {
+    return planTasks(table, context, workerPool, null);
+  }
+
+  static CloseableIterable<CombinedScanTask> planTasks(
+      Table table,
+      ScanContext context,
+      ExecutorService workerPool,
+      MetricsReporter metricsReporter) {
     ScanMode scanMode = checkScanMode(context);
     if (scanMode == ScanMode.INCREMENTAL_APPEND_SCAN) {
       IncrementalAppendScan scan = table.newIncrementalAppendScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.startTag() != null) {
         Preconditions.checkArgument(
@@ -119,7 +137,7 @@ public class FlinkSplitPlanner {
       return scan.planTasks();
     } else {
       TableScan scan = table.newScan();
-      scan = refineScanWithBaseConfigs(scan, context, workerPool);
+      scan = refineScanWithBaseConfigs(scan, context, workerPool, metricsReporter);
 
       if (context.snapshotId() != null) {
         scan = scan.useSnapshot(context.snapshotId());
@@ -157,7 +175,7 @@ public class FlinkSplitPlanner {
 
   /** refine scan with common configs */
   private static <T extends Scan<T, FileScanTask, CombinedScanTask>> T refineScanWithBaseConfigs(
-      T scan, ScanContext context, ExecutorService workerPool) {
+      T scan, ScanContext context, ExecutorService workerPool, MetricsReporter metricsReporter) {
     T refinedScan =
         scan.caseSensitive(context.caseSensitive()).project(context.project()).planWith(workerPool);
 
@@ -182,6 +200,10 @@ public class FlinkSplitPlanner {
       for (Expression filter : context.filters()) {
         refinedScan = refinedScan.filter(filter);
       }
+    }
+
+    if (metricsReporter != null) {
+      refinedScan = refinedScan.metricsReporter(metricsReporter);
     }
 
     return refinedScan;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/IcebergSource.java
@@ -221,7 +221,7 @@ public class IcebergSource<T> implements Source<T, IcebergSourceSplit, IcebergEn
       ContinuousSplitPlanner splitPlanner =
           new ContinuousSplitPlannerImpl(tableLoader, scanContext, planningThreadName());
       return new ContinuousIcebergEnumerator(
-          enumContext, assigner, scanContext, splitPlanner, enumState);
+          enumContext, assigner, scanContext, splitPlanner, enumState, tableName);
     } else {
       if (enumState == null) {
         // Only do scan planning if nothing is restored from checkpoint state

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousEnumerationResult.java
@@ -19,13 +19,16 @@
 package org.apache.iceberg.flink.source.enumerator;
 
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 class ContinuousEnumerationResult {
   private final Collection<IcebergSourceSplit> splits;
   private final IcebergEnumeratorPosition fromPosition;
   private final IcebergEnumeratorPosition toPosition;
+  @Nullable private final ScanReport scanReport;
 
   /**
    * @param splits should never be null. But it can be an empty collection
@@ -36,11 +39,20 @@ class ContinuousEnumerationResult {
       Collection<IcebergSourceSplit> splits,
       IcebergEnumeratorPosition fromPosition,
       IcebergEnumeratorPosition toPosition) {
+    this(splits, fromPosition, toPosition, null);
+  }
+
+  ContinuousEnumerationResult(
+      Collection<IcebergSourceSplit> splits,
+      IcebergEnumeratorPosition fromPosition,
+      IcebergEnumeratorPosition toPosition,
+      @Nullable ScanReport scanReport) {
     Preconditions.checkArgument(splits != null, "Invalid to splits collection: null");
     Preconditions.checkArgument(toPosition != null, "Invalid end position: null");
     this.splits = splits;
     this.fromPosition = fromPosition;
     this.toPosition = toPosition;
+    this.scanReport = scanReport;
   }
 
   public Collection<IcebergSourceSplit> splits() {
@@ -53,5 +65,10 @@ class ContinuousEnumerationResult {
 
   public IcebergEnumeratorPosition toPosition() {
     return toPosition;
+  }
+
+  @Nullable
+  public ScanReport scanReport() {
+    return scanReport;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousIcebergEnumerator.java
@@ -62,13 +62,15 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
   private transient int consecutiveFailures = 0;
 
   private final ElapsedTimeGauge elapsedSecondsSinceLastSplitDiscovery;
+  private final IcebergSourceEnumeratorMetrics enumeratorMetrics;
 
   public ContinuousIcebergEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> enumeratorContext,
       SplitAssigner assigner,
       ScanContext scanContext,
       ContinuousSplitPlanner splitPlanner,
-      @Nullable IcebergEnumeratorState enumState) {
+      @Nullable IcebergEnumeratorState enumState,
+      String tableName) {
     super(enumeratorContext, assigner);
 
     this.enumeratorContext = enumeratorContext;
@@ -78,6 +80,8 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
     this.enumeratorPosition = new AtomicReference<>();
     this.enumerationHistory = new EnumerationHistory(ENUMERATION_SPLIT_COUNT_HISTORY_SIZE);
     this.elapsedSecondsSinceLastSplitDiscovery = new ElapsedTimeGauge(TimeUnit.SECONDS);
+    this.enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(enumeratorContext.metricGroup(), tableName);
     this.enumeratorContext
         .metricGroup()
         .gauge("elapsedSecondsSinceLastSplitDiscovery", elapsedSecondsSinceLastSplitDiscovery);
@@ -150,6 +154,9 @@ public class ContinuousIcebergEnumerator extends AbstractIcebergEnumerator {
             result.fromPosition());
       } else {
         elapsedSecondsSinceLastSplitDiscovery.refreshLastRecordedTime();
+        if (result.scanReport() != null && result.scanReport().scanMetrics() != null) {
+          enumeratorMetrics.updateWithScanMetrics(result.scanReport().scanMetrics());
+        }
         // Sometimes, enumeration may yield no splits for a few reasons.
         // - upstream paused or delayed streaming writes to the Iceberg table.
         // - enumeration frequency is higher than the upstream write frequency.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/ContinuousSplitPlannerImpl.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.flink.source.FlinkSplitPlanner;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.InMemoryMetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.SnapshotUtil;
@@ -131,15 +133,19 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
       ScanContext incrementalScan =
           scanContext.copyWithAppendsBetween(
               lastPosition.snapshotId(), toSnapshotInclusive.snapshotId());
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       List<IcebergSourceSplit> splits =
-          FlinkSplitPlanner.planIcebergSourceSplits(table, incrementalScan, workerPool);
+          FlinkSplitPlanner.planIcebergSourceSplits(
+              table, incrementalScan, workerPool, metricsReporter);
+      ScanReport scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from incremental scan: "
               + "from snapshot (exclusive) is {}, to snapshot (inclusive) is {}",
           splits.size(),
           lastPosition,
           newPosition);
-      return new ContinuousEnumerationResult(splits, lastPosition, newPosition);
+      return new ContinuousEnumerationResult(splits, lastPosition, newPosition, scanReport);
     }
   }
 
@@ -166,13 +172,20 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
         startSnapshot.snapshotId(),
         scanContext.streamingStartingStrategy());
     List<IcebergSourceSplit> splits = Collections.emptyList();
+    ScanReport scanReport = null;
     IcebergEnumeratorPosition toPosition;
     if (scanContext.streamingStartingStrategy()
         == StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL) {
       // do a batch table scan first
+      InMemoryMetricsReporter metricsReporter = new InMemoryMetricsReporter();
       splits =
           FlinkSplitPlanner.planIcebergSourceSplits(
-              table, scanContext.copyWithSnapshotId(startSnapshot.snapshotId()), workerPool);
+              table,
+              scanContext.copyWithSnapshotId(startSnapshot.snapshotId()),
+              workerPool,
+              metricsReporter);
+      scanReport = metricsReporter.scanReport();
+      metricsReporter.close();
       LOG.info(
           "Discovered {} splits from initial batch table scan with snapshot Id {}",
           splits.size(),
@@ -207,7 +220,7 @@ public class ContinuousSplitPlannerImpl implements ContinuousSplitPlanner {
           startSnapshot.timestampMillis());
     }
 
-    return new ContinuousEnumerationResult(splits, null, toPosition);
+    return new ContinuousEnumerationResult(splits, null, toPosition, scanReport);
   }
 
   /**

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/enumerator/IcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+
+/**
+ * Metrics for the Iceberg source enumerator (coordinator). All metrics are gauges reporting the
+ * values from the most recent scan planning cycle, providing a per-scan snapshot of planning
+ * efficiency. This allows monitoring systems to track spikes, trends, and correlate scan behavior
+ * with other events over time. Gauge values remain at 0 until the first actual scan completes.
+ */
+@Internal
+public class IcebergSourceEnumeratorMetrics {
+  private final AtomicLong lastScanPlanningDurationMs = new AtomicLong();
+  private final AtomicLong scannedDataManifests = new AtomicLong();
+  private final AtomicLong skippedDataManifests = new AtomicLong();
+  private final AtomicLong totalDataManifests = new AtomicLong();
+  private final AtomicLong scannedDeleteManifests = new AtomicLong();
+  private final AtomicLong skippedDeleteManifests = new AtomicLong();
+  private final AtomicLong totalDeleteManifests = new AtomicLong();
+  private final AtomicLong resultDataFiles = new AtomicLong();
+  private final AtomicLong skippedDataFiles = new AtomicLong();
+  private final AtomicLong resultDeleteFiles = new AtomicLong();
+  private final AtomicLong skippedDeleteFiles = new AtomicLong();
+  private final AtomicLong indexedDeleteFiles = new AtomicLong();
+  private final AtomicLong equalityDeleteFiles = new AtomicLong();
+  private final AtomicLong positionalDeleteFiles = new AtomicLong();
+  // named to match ScanMetricsResult.dvs() (deletion vectors)
+  private final AtomicLong dvs = new AtomicLong();
+  private final AtomicLong totalFileSizeInBytes = new AtomicLong();
+  private final AtomicLong totalDeleteFileSizeInBytes = new AtomicLong();
+
+  public IcebergSourceEnumeratorMetrics(MetricGroup metrics, String fullTableName) {
+    MetricGroup enumeratorMetrics =
+        metrics.addGroup("IcebergSourceEnumerator").addGroup("table", fullTableName);
+    enumeratorMetrics.gauge("lastScanPlanningDurationMs", lastScanPlanningDurationMs::get);
+    enumeratorMetrics.gauge("scannedDataManifests", scannedDataManifests::get);
+    enumeratorMetrics.gauge("skippedDataManifests", skippedDataManifests::get);
+    enumeratorMetrics.gauge("totalDataManifests", totalDataManifests::get);
+    enumeratorMetrics.gauge("scannedDeleteManifests", scannedDeleteManifests::get);
+    enumeratorMetrics.gauge("skippedDeleteManifests", skippedDeleteManifests::get);
+    enumeratorMetrics.gauge("totalDeleteManifests", totalDeleteManifests::get);
+    enumeratorMetrics.gauge("resultDataFiles", resultDataFiles::get);
+    enumeratorMetrics.gauge("skippedDataFiles", skippedDataFiles::get);
+    enumeratorMetrics.gauge("resultDeleteFiles", resultDeleteFiles::get);
+    enumeratorMetrics.gauge("skippedDeleteFiles", skippedDeleteFiles::get);
+    enumeratorMetrics.gauge("indexedDeleteFiles", indexedDeleteFiles::get);
+    enumeratorMetrics.gauge("equalityDeleteFiles", equalityDeleteFiles::get);
+    enumeratorMetrics.gauge("positionalDeleteFiles", positionalDeleteFiles::get);
+    enumeratorMetrics.gauge("dvs", dvs::get);
+    enumeratorMetrics.gauge("totalFileSizeInBytes", totalFileSizeInBytes::get);
+    enumeratorMetrics.gauge("totalDeleteFileSizeInBytes", totalDeleteFileSizeInBytes::get);
+  }
+
+  /** Updates enumerator metrics from the given scan metrics result. No-op if {@code null}. */
+  public void updateWithScanMetrics(ScanMetricsResult scanMetrics) {
+    if (scanMetrics == null) {
+      return;
+    }
+
+    TimerResult planningDuration = scanMetrics.totalPlanningDuration();
+    if (planningDuration != null) {
+      lastScanPlanningDurationMs.set(planningDuration.totalDuration().toMillis());
+    }
+
+    setGauge(scannedDataManifests, scanMetrics.scannedDataManifests());
+    setGauge(skippedDataManifests, scanMetrics.skippedDataManifests());
+    setGauge(totalDataManifests, scanMetrics.totalDataManifests());
+    setGauge(scannedDeleteManifests, scanMetrics.scannedDeleteManifests());
+    setGauge(skippedDeleteManifests, scanMetrics.skippedDeleteManifests());
+    setGauge(totalDeleteManifests, scanMetrics.totalDeleteManifests());
+    setGauge(resultDataFiles, scanMetrics.resultDataFiles());
+    setGauge(skippedDataFiles, scanMetrics.skippedDataFiles());
+    setGauge(resultDeleteFiles, scanMetrics.resultDeleteFiles());
+    setGauge(skippedDeleteFiles, scanMetrics.skippedDeleteFiles());
+    setGauge(indexedDeleteFiles, scanMetrics.indexedDeleteFiles());
+    setGauge(equalityDeleteFiles, scanMetrics.equalityDeleteFiles());
+    setGauge(positionalDeleteFiles, scanMetrics.positionalDeleteFiles());
+    setGauge(dvs, scanMetrics.dvs());
+    setGauge(totalFileSizeInBytes, scanMetrics.totalFileSizeInBytes());
+    setGauge(totalDeleteFileSizeInBytes, scanMetrics.totalDeleteFileSizeInBytes());
+  }
+
+  private static void setGauge(AtomicLong gauge, CounterResult counterResult) {
+    if (counterResult != null) {
+      gauge.set(counterResult.value());
+    }
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -555,16 +555,13 @@ public class TestIcebergSourceContinuous {
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
     // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
-    Optional<MetricGroup> scanMetricsGroup =
-        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    Optional<MetricGroup> scanMetricsGroup = METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
     assertThat(scanMetricsGroup).isPresent();
     assertThat(
             METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
                 .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
         .anySatisfy(
-            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
-        .anySatisfy(
-            fullMetricName ->
-                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
+            fullMetricName -> assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceContinuous.java
@@ -554,20 +554,17 @@ public class TestIcebergSourceContinuous {
   }
 
   private static void assertThatIcebergEnumeratorMetricsExist() {
-    assertThatIcebergSourceMetricExists(
-        "enumerator", "coordinator.enumerator.elapsedSecondsSinceLastSplitDiscovery");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.unassignedSplits");
-    assertThatIcebergSourceMetricExists("enumerator", "coordinator.enumerator.pendingRecords");
-  }
-
-  private static void assertThatIcebergSourceMetricExists(
-      String metricGroupPattern, String metricName) {
-    Optional<MetricGroup> groups = METRIC_REPORTER.findGroup(metricGroupPattern);
-    assertThat(groups).isPresent();
+    // Verify scan planning metrics (registered on the "IcebergSourceEnumerator" subgroup)
+    Optional<MetricGroup> scanMetricsGroup =
+        METRIC_REPORTER.findGroup("IcebergSourceEnumerator");
+    assertThat(scanMetricsGroup).isPresent();
     assertThat(
-            METRIC_REPORTER.getMetricsByGroup(groups.get()).keySet().stream()
-                .map(name -> groups.get().getMetricIdentifier(name)))
-        .satisfiesOnlyOnce(
-            fullMetricName -> assertThat(fullMetricName).containsSubsequence(metricName));
+            METRIC_REPORTER.getMetricsByGroup(scanMetricsGroup.get()).keySet().stream()
+                .map(name -> scanMetricsGroup.get().getMetricIdentifier(name)))
+        .anySatisfy(
+            fullMetricName -> assertThat(fullMetricName).contains("resultDataFiles"))
+        .anySatisfy(
+            fullMetricName ->
+                assertThat(fullMetricName).contains("lastScanPlanningDurationMs"));
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/ManualContinuousSplitPlanner.java
@@ -22,8 +22,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.NavigableMap;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -33,6 +35,7 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   private final NavigableMap<Long, List<IcebergSourceSplit>> splits;
   private long latestSnapshotId;
   private int remainingFailures;
+  @Nullable private ScanReport scanReport;
 
   ManualContinuousSplitPlanner(ScanContext scanContext, int expectedFailures) {
     this.maxPlanningSnapshotCount = scanContext.maxPlanningSnapshotCount();
@@ -79,7 +82,8 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
             discoveredSplits,
             lastPosition,
             // use the snapshot Id as snapshot timestamp.
-            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive));
+            IcebergEnumeratorPosition.of(toSnapshotIdInclusive, toSnapshotIdInclusive),
+            scanReport);
     return result;
   }
 
@@ -90,6 +94,11 @@ class ManualContinuousSplitPlanner implements ContinuousSplitPlanner {
   public synchronized void addSplits(List<IcebergSourceSplit> newSplits) {
     latestSnapshotId += 1;
     splits.put(latestSnapshotId, newSplits);
+  }
+
+  /** Set a ScanReport to be included in future enumeration results. */
+  public synchronized void setScanReport(@Nullable ScanReport report) {
+    this.scanReport = report;
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -22,13 +22,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Path;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
 import org.apache.flink.connector.testutils.source.reader.TestingSplitEnumeratorContext;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.source.ScanContext;
 import org.apache.iceberg.flink.source.SplitHelpers;
 import org.apache.iceberg.flink.source.StreamingStartingStrategy;
@@ -37,6 +40,12 @@ import org.apache.iceberg.flink.source.split.IcebergSourceSplit;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitState;
 import org.apache.iceberg.flink.source.split.IcebergSourceSplitStatus;
 import org.apache.iceberg.flink.source.split.SplitRequestEvent;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableScanReport;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanReport;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -334,6 +343,58 @@ public class TestContinuousIcebergEnumerator {
     assertThat(pendingSplit.status()).isEqualTo(IcebergSourceSplitStatus.UNASSIGNED);
   }
 
+  @Test
+  public void testEnumeratorMetricsUpdatedFromScanReport() throws Exception {
+    TestingSplitEnumeratorContext<IcebergSourceSplit> enumeratorContext =
+        new TestingSplitEnumeratorContext<>(4);
+    ScanContext scanContext =
+        ScanContext.builder()
+            .streaming(true)
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ManualContinuousSplitPlanner splitPlanner = new ManualContinuousSplitPlanner(scanContext, 0);
+
+    // Set a ScanReport with known metrics
+    ScanReport report =
+        ImmutableScanReport.builder()
+            .tableName("test.db.metrics_table")
+            .snapshotId(1L)
+            .schemaId(0)
+            .filter(Expressions.alwaysTrue())
+            .projectedFieldNames(Collections.emptyList())
+            .scanMetrics(
+                ImmutableScanMetricsResult.builder()
+                    .totalPlanningDuration(
+                        ImmutableTimerResult.builder()
+                            .timeUnit(TimeUnit.NANOSECONDS)
+                            .totalDuration(Duration.ofMillis(250))
+                            .count(1)
+                            .build())
+                    .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+                    .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+                    .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+                    .build())
+            .build();
+    splitPlanner.setScanReport(report);
+
+    ContinuousIcebergEnumerator enumerator =
+        createEnumerator(enumeratorContext, scanContext, splitPlanner);
+
+    // Register reader and add splits to trigger a discovery cycle
+    enumeratorContext.registerReader(2, "localhost");
+    List<IcebergSourceSplit> splits =
+        SplitHelpers.createSplitsFromTransientHadoopTable(temporaryFolder, 1, 1);
+    splitPlanner.addSplits(splits);
+
+    // Trigger the enumeration which calls processDiscoveredSplits internally
+    enumeratorContext.triggerAllActions();
+
+    // Verify that the enumerator processed splits (basic sanity)
+    Collection<IcebergSourceSplitState> pendingSplits =
+        enumerator.snapshotState(1).pendingSplits();
+    assertThat(pendingSplits).hasSize(1);
+  }
+
   private static ContinuousIcebergEnumerator createEnumerator(
       SplitEnumeratorContext<IcebergSourceSplit> context,
       ScanContext scanContext,
@@ -345,7 +406,8 @@ public class TestContinuousIcebergEnumerator {
             new DefaultSplitAssigner(null, Collections.emptyList()),
             scanContext,
             splitPlanner,
-            null);
+            null,
+            "test.table");
     enumerator.start();
     return enumerator;
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousIcebergEnumerator.java
@@ -390,8 +390,7 @@ public class TestContinuousIcebergEnumerator {
     enumeratorContext.triggerAllActions();
 
     // Verify that the enumerator processed splits (basic sanity)
-    Collection<IcebergSourceSplitState> pendingSplits =
-        enumerator.snapshotState(1).pendingSplits();
+    Collection<IcebergSourceSplitState> pendingSplits = enumerator.snapshotState(1).pendingSplits();
     assertThat(pendingSplits).hasSize(1);
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -731,4 +731,65 @@ public class TestContinuousSplitPlannerImpl {
       this.split = split;
     }
   }
+
+  @Test
+  public void testScanReportPopulatedInTableScanResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
+    assertThat(
+            initialResult
+                .scanReport()
+                .scanMetrics()
+                .totalPlanningDuration()
+                .totalDuration()
+                .toMillis())
+        .isGreaterThanOrEqualTo(0);
+  }
+
+  @Test
+  public void testScanReportPopulatedInIncrementalResult() throws Exception {
+    appendTwoSnapshots();
+
+    ScanContext scanContext =
+        ScanContext.builder()
+            .startingStrategy(StreamingStartingStrategy.TABLE_SCAN_THEN_INCREMENTAL)
+            .build();
+    ContinuousSplitPlannerImpl splitPlanner =
+        new ContinuousSplitPlannerImpl(TABLE_RESOURCE.tableLoader().clone(), scanContext, null);
+
+    // Initial plan does a table scan
+    ContinuousEnumerationResult initialResult = splitPlanner.planSplits(null);
+    assertThat(initialResult.scanReport()).isNotNull();
+
+    // Append new data so incremental scan has something to discover
+    List<Record> batch =
+        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    DataFile dataFile = dataAppender.writeFile(null, batch);
+    dataAppender.appendToTable(dataFile);
+
+    // Incremental scan should discover the new snapshot and produce a scan report
+    ContinuousEnumerationResult incrementalResult =
+        splitPlanner.planSplits(initialResult.toPosition());
+    assertThat(incrementalResult.scanReport()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics()).isNotNull();
+    assertThat(incrementalResult.scanReport().scanMetrics().totalDataManifests().value())
+        .isGreaterThan(0);
+    assertThat(incrementalResult.scanReport().scanMetrics().resultDataFiles().value())
+        .isGreaterThan(0);
+  }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestContinuousSplitPlannerImpl.java
@@ -748,8 +748,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport().scanMetrics()).isNotNull();
     assertThat(initialResult.scanReport().scanMetrics().totalDataManifests().value())
         .isGreaterThan(0);
-    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value())
-        .isGreaterThan(0);
+    assertThat(initialResult.scanReport().scanMetrics().resultDataFiles().value()).isGreaterThan(0);
     assertThat(initialResult.scanReport().scanMetrics().totalPlanningDuration()).isNotNull();
     assertThat(
             initialResult
@@ -777,8 +776,7 @@ public class TestContinuousSplitPlannerImpl {
     assertThat(initialResult.scanReport()).isNotNull();
 
     // Append new data so incremental scan has something to discover
-    List<Record> batch =
-        RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
+    List<Record> batch = RandomGenericData.generate(TABLE_RESOURCE.table().schema(), 2, 100L);
     DataFile dataFile = dataAppender.writeFile(null, batch);
     dataAppender.appendToTable(dataFile);
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/enumerator/TestIcebergSourceEnumeratorMetrics.java
@@ -1,0 +1,249 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.enumerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.metrics.SimpleCounter;
+import org.apache.flink.metrics.groups.UnregisteredMetricsGroup;
+import org.apache.iceberg.metrics.CounterResult;
+import org.apache.iceberg.metrics.ImmutableScanMetricsResult;
+import org.apache.iceberg.metrics.ImmutableTimerResult;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.ScanMetricsResult;
+import org.apache.iceberg.metrics.TimerResult;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestIcebergSourceEnumeratorMetrics {
+
+  @Test
+  public void testMetricsRegistration() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    assertThat(enumeratorMetrics).isNotNull();
+    assertThat(metricGroup.registeredGauges()).hasSize(17);
+    assertThat(metricGroup.registeredGauges())
+        .containsKey("lastScanPlanningDurationMs")
+        .containsKey("scannedDataManifests")
+        .containsKey("skippedDataManifests")
+        .containsKey("totalDataManifests")
+        .containsKey("scannedDeleteManifests")
+        .containsKey("skippedDeleteManifests")
+        .containsKey("totalDeleteManifests")
+        .containsKey("resultDataFiles")
+        .containsKey("skippedDataFiles")
+        .containsKey("resultDeleteFiles")
+        .containsKey("skippedDeleteFiles")
+        .containsKey("indexedDeleteFiles")
+        .containsKey("equalityDeleteFiles")
+        .containsKey("positionalDeleteFiles")
+        .containsKey("dvs")
+        .containsKey("totalFileSizeInBytes")
+        .containsKey("totalDeleteFileSizeInBytes");
+  }
+
+  @Test
+  public void testUpdateWithScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult scanMetrics =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(150))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .skippedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 15))
+            .scannedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .skippedDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .totalDeleteManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 100))
+            .skippedDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 50))
+            .resultDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .skippedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .indexedDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 4))
+            .equalityDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .positionalDeleteFiles(CounterResult.of(MetricsContext.Unit.COUNT, 1))
+            .dvs(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .totalFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 1024000))
+            .totalDeleteFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 512000))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(scanMetrics);
+
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 150L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 10L);
+    assertGaugeValue(metricGroup, "skippedDataManifests", 5L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 15L);
+    assertGaugeValue(metricGroup, "scannedDeleteManifests", 3L);
+    assertGaugeValue(metricGroup, "skippedDeleteManifests", 2L);
+    assertGaugeValue(metricGroup, "totalDeleteManifests", 5L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 100L);
+    assertGaugeValue(metricGroup, "skippedDataFiles", 50L);
+    assertGaugeValue(metricGroup, "resultDeleteFiles", 7L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 3L);
+    assertGaugeValue(metricGroup, "indexedDeleteFiles", 4L);
+    assertGaugeValue(metricGroup, "equalityDeleteFiles", 2L);
+    assertGaugeValue(metricGroup, "positionalDeleteFiles", 1L);
+    assertGaugeValue(metricGroup, "dvs", 3L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 1024000L);
+    assertGaugeValue(metricGroup, "totalDeleteFileSizeInBytes", 512000L);
+  }
+
+  @Test
+  public void testGaugesShowLatestScanValues() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    ScanMetricsResult firstScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(100))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 3))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    ScanMetricsResult secondScan =
+        ImmutableScanMetricsResult.builder()
+            .totalPlanningDuration(timerResult(200))
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 7))
+            .scannedDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 2))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(firstScan);
+    enumeratorMetrics.updateWithScanMetrics(secondScan);
+
+    // Gauges show last-scan values, NOT accumulated
+    assertGaugeValue(metricGroup, "lastScanPlanningDurationMs", 200L);
+    assertGaugeValue(metricGroup, "resultDataFiles", 7L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 2L);
+  }
+
+  @Test
+  public void testUpdateWithNullMetricsIsNoOp() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    enumeratorMetrics.updateWithScanMetrics(null);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 0L);
+    assertGaugeValue(metricGroup, "scannedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 0L);
+  }
+
+  @Test
+  public void testPartialNullFieldsInScanMetrics() {
+    TestingEnumeratorMetricGroup metricGroup = new TestingEnumeratorMetricGroup();
+    IcebergSourceEnumeratorMetrics enumeratorMetrics =
+        new IcebergSourceEnumeratorMetrics(metricGroup, "test.db.table");
+
+    // Only some fields populated, rest are null
+    ScanMetricsResult partialMetrics =
+        ImmutableScanMetricsResult.builder()
+            .resultDataFiles(CounterResult.of(MetricsContext.Unit.COUNT, 10))
+            .totalDataManifests(CounterResult.of(MetricsContext.Unit.COUNT, 5))
+            .build();
+
+    enumeratorMetrics.updateWithScanMetrics(partialMetrics);
+
+    assertGaugeValue(metricGroup, "resultDataFiles", 10L);
+    assertGaugeValue(metricGroup, "totalDataManifests", 5L);
+    // Null fields remain at zero
+    assertGaugeValue(metricGroup, "skippedDataManifests", 0L);
+    assertGaugeValue(metricGroup, "totalFileSizeInBytes", 0L);
+    assertGaugeValue(metricGroup, "skippedDeleteFiles", 0L);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertGaugeValue(
+      TestingEnumeratorMetricGroup metricGroup, String name, Long expected) {
+    Gauge<Long> gauge = (Gauge<Long>) metricGroup.registeredGauges().get(name);
+    assertThat(gauge).as("Gauge '%s' should be registered", name).isNotNull();
+    assertThat(gauge.getValue()).isEqualTo(expected);
+  }
+
+  private static TimerResult timerResult(long durationMs) {
+    return ImmutableTimerResult.builder()
+        .timeUnit(TimeUnit.NANOSECONDS)
+        .totalDuration(Duration.ofMillis(durationMs))
+        .count(1)
+        .build();
+  }
+
+  /**
+   * A testing metric group that captures registered gauges for verification. Follows the pattern
+   * from {@code TestingMetricGroup} in the reader package.
+   */
+  static class TestingEnumeratorMetricGroup extends UnregisteredMetricsGroup {
+    private final Map<String, Counter> counters;
+    private final Map<String, Gauge<?>> gauges;
+
+    TestingEnumeratorMetricGroup() {
+      this.counters = Maps.newHashMap();
+      this.gauges = Maps.newHashMap();
+    }
+
+    private TestingEnumeratorMetricGroup(
+        Map<String, Counter> counters, Map<String, Gauge<?>> gauges) {
+      this.counters = counters;
+      this.gauges = gauges;
+    }
+
+    Map<String, Counter> counters() {
+      return counters;
+    }
+
+    Map<String, Gauge<?>> registeredGauges() {
+      return gauges;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      Counter counter = new SimpleCounter();
+      counters.put(name, counter);
+      return counter;
+    }
+
+    @Override
+    public <T, G extends Gauge<T>> G gauge(String name, G gauge) {
+      gauges.put(name, gauge);
+      return gauge;
+    }
+
+    @Override
+    public MetricGroup addGroup(String name) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+
+    @Override
+    public MetricGroup addGroup(String key, String value) {
+      return new TestingEnumeratorMetricGroup(counters, gauges);
+    }
+  }
+}


### PR DESCRIPTION
Closes #16589

## Summary

- Wire `metricsReporter()` into `BaseIncrementalScan.planFiles()`, bringing incremental scans to parity with batch scans (`SnapshotScan`) for metrics reporting.
- Expose all `ScanMetricsResult` fields as Flink gauges on `ContinuousIcebergEnumerator`, reporting per-scan (last-value) snapshots via the coordinator metric
group.
- Accessible through Flink metric reporters (Prometheus, Datadog, JMX, Slf4j) at path: `coordinator.enumerator.IcebergSourceEnumerator.table.<tableName>.<metric>`

## Changes

**Core:**
- `BaseIncrementalScan.planFiles()` now emits `ScanReport` via `metricsReporter()` (same pattern as `SnapshotScan`)

**Flink (v1.20, v2.0, v2.1):**
- New `IcebergSourceEnumeratorMetrics` class — 17 AtomicLong-backed gauges
- `ContinuousSplitPlannerImpl` creates `InMemoryMetricsReporter` per scan cycle, attaches `ScanReport` to `ContinuousEnumerationResult`
- `ContinuousIcebergEnumerator` updates metrics after each scan discovery
- `FlinkSplitPlanner` supports optional `MetricsReporter` parameter

## Design decisions

- **Gauges (not counters):** Per-scan snapshots match Spark's reporting model and let operators see spikes directly without applying `rate()`.                        
- **AtomicLong:** Gauges are read by metric reporter threads, written by coordinator thread.
- **InMemoryMetricsReporter per cycle:** Lightweight, no accumulation, follows existing Spark pattern.                                                                

## Testing

- Unit tests: `TestIcebergSourceEnumeratorMetrics` (all 17 gauges, null handling, last-value semantics)
- Wiring test: `TestContinuousIcebergEnumerator.testEnumeratorMetricsUpdatedFromScanReport`
- Integration test: `TestIcebergSourceContinuous` (MiniCluster + InMemoryReporter)
- Core test: `TestIncrementalScanPlanningAndReporting`
- Verified end-to-end on standalone Flink 2.0 cluster                                                                                                                 

## Future work                                                                                                                                                        

- Batch metrics (`StaticIcebergEnumerator`) — requires different design due to serialization boundary, planned as follow-up.