### PR TITLE
Docs: Refresh FileIO concepts page

### DIFF
--- a/docs/docs/fileio.md
+++ b/docs/docs/fileio.md
@@ -22,20 +22,58 @@ title: "FileIO"
 
 ## Overview
 
-Iceberg comes with a flexible abstraction around reading and writing data and metadata files. The FileIO interface allows the Iceberg library to communicate with the underlying storage layer. FileIO is used for all metadata operations during the job planning and commit stages.
+Iceberg comes with a flexible abstraction around reading and writing data and metadata files. The FileIO interface allows the Iceberg library to communicate with the underlying storage layer, and is used for all metadata operations during job planning and commit. FileIO instances are passed across JVM boundaries by engines like Spark, so every implementation is required to be serializable.
 
 ## Iceberg Files
 
 The metadata for an Iceberg table tracks the absolute path for data files which allows greater abstraction over the physical layout. Additionally, changes to table state are performed by writing new metadata files and never involve renaming files. This allows a much smaller set of requirements for file operations. The essential functionality for a FileIO implementation is that it can read files, write files, and seek to any position within a stream.
 
+## Built-in implementations
+
+Iceberg ships with FileIO implementations for the storage systems most data platforms use. Each entry below names the implementation class, the storage system it talks to, and the operations it can perform efficiently.
+
+| Implementation | Storage | What it can do efficiently |
+| --- | --- | --- |
+| `HadoopFileIO` | Any Hadoop-compatible file system, including HDFS and the local file system | Single-file read, write, and delete; bulk delete; prefix listing |
+| `S3FileIO` | Amazon S3, via `s3://`, `s3a://`, `s3n://` | Single-file read, write, and delete; bulk delete; prefix listing; best-effort file recovery |
+| `GCSFileIO` | Google Cloud Storage, via `gs://` | Single-file read, write, and delete; bulk delete; prefix listing |
+| `ADLSFileIO` | Azure Data Lake Storage Gen2, via `abfs://`, `abfss://`, `wasb://`, `wasbs://` | Single-file read, write, and delete; bulk delete; prefix listing |
+| `OSSFileIO` | Aliyun Object Storage Service | Single-file read, write, and delete |
+| `EcsFileIO` | Dell EMC Enterprise Cloud Storage | Single-file read, write, and delete |
+
+`OSSFileIO` and `EcsFileIO` do not currently provide bulk delete or prefix listing. Table-maintenance operations that scan or remove many files at once, such as orphan-file cleanup and table purge, are therefore slower against those backends than against the other implementations.
+
+## Routing by URI scheme
+
+By default, the REST catalog uses `ResolvingFileIO`, which picks an implementation from the URI scheme of each file location:
+
+| URI scheme | Implementation |
+| --- | --- |
+| `s3`, `s3a`, `s3n` | `S3FileIO` |
+| `gs` | `GCSFileIO` |
+| `abfs`, `abfss`, `wasb`, `wasbs` | `ADLSFileIO` |
+| any other scheme | `HadoopFileIO` |
+
+Schemes that are not in this table, such as `oss://`, `ecs://`, or a bare `https://`, are not routed to `OSSFileIO` or `EcsFileIO`; they fall through to `HadoopFileIO`. To use `OSSFileIO` or `EcsFileIO`, set the catalog `io-impl` property to the implementation's fully qualified class name.
+
+## Choosing the FileIO
+
+Most users do not need to set anything. The REST catalog defaults to `ResolvingFileIO`, so writing to an `s3://` path automatically uses `S3FileIO`. The Hadoop and JDBC catalogs default to `HadoopFileIO`.
+
+To override the default, set the catalog property `io-impl` to the fully qualified class name of the FileIO implementation you want to use. Provider-specific tuning lives on the pages that own each backend:
+
+- [Catalog properties](catalog-properties.md) for the `io-impl` property and other catalog-wide knobs
+- [AWS](aws.md) for `S3FileIO` configuration and behavior
+- [Dell](dell.md) for the Dell EMC ECS catalog and FileIO
+
+## Encryption
+
+Iceberg supports table encryption by wrapping any FileIO with `EncryptingFileIO`, which preserves the capabilities of the wrapped FileIO so bulk delete and prefix listing continue to work when those are available on the underlying implementation. See the [Encryption](encryption.md) document for the full picture.
+
+## Implementing a custom FileIO
+
+The FileIO surface is intentionally small: read a file, write a file, delete a file. The interfaces live under the `org.apache.iceberg.io` package in the `iceberg-api` module. Once implemented, a custom FileIO is plugged in by setting the catalog `io-impl` property to its fully qualified class name. For a walkthrough, including the optional capability interfaces that enable bulk delete, prefix listing, best-effort recovery, and storage credentials, see the [Custom file IO implementation](custom-catalog.md#custom-file-io-implementation) section of the Java Custom Catalog guide.
+
 ## Usage in Processing Engines
 
-The responsibility of reading and writing data files lies with the processing engines and happens during task execution. However, after data files are written, processing engines use FileIO to write new Iceberg metadata files that capture the new state of the table.
-
-Different FileIO implementations are used depending on the type of storage. Iceberg comes with a set of FileIO implementations for popular storage providers.
-
-- Amazon S3
-- Google Cloud Storage
-- Object Service Storage (including https)
-- Dell Enterprise Cloud Storage
-- Hadoop (adapts any Hadoop FileSystem implementation)
+The responsibility for reading and writing data files lies with the processing engine and happens during task execution. Everything related to table metadata, including manifests, manifest lists, table metadata files, and the commit itself, goes through FileIO. Because engines distribute the FileIO instance to executors, every implementation is required to be serializable.

--- a/docs/docs/fileio.md
+++ b/docs/docs/fileio.md
@@ -22,20 +22,58 @@ title: "FileIO"
 
 ## Overview
 
-Iceberg comes with a flexible abstraction around reading and writing data and metadata files. The FileIO interface allows the Iceberg library to communicate with the underlying storage layer. FileIO is used for all metadata operations during the job planning and commit stages.
+Iceberg comes with a flexible abstraction around reading and writing data and metadata files. The FileIO interface allows the Iceberg library to communicate with the underlying storage layer, and is used for all metadata operations during job planning and commit. FileIO instances are passed across JVM boundaries by engines like Spark, so every implementation is required to be serializable.
 
 ## Iceberg Files
 
 The metadata for an Iceberg table tracks the absolute path for data files which allows greater abstraction over the physical layout. Additionally, changes to table state are performed by writing new metadata files and never involve renaming files. This allows a much smaller set of requirements for file operations. The essential functionality for a FileIO implementation is that it can read files, write files, and seek to any position within a stream.
 
+## Built-in implementations
+
+Iceberg ships with FileIO implementations for the storage systems most data platforms use. Each entry below names the implementation class, the storage system it talks to, and the operations it can perform efficiently.
+
+| Implementation | Storage | What it can do efficiently |
+| --- | --- | --- |
+| `HadoopFileIO` | Any Hadoop-compatible file system, including HDFS and the local file system | Single-file read, write, and delete; bulk delete; prefix listing |
+| `S3FileIO` | Amazon S3, via `s3://`, `s3a://`, `s3n://` | Single-file read, write, and delete; bulk delete; prefix listing; best-effort file recovery |
+| `GCSFileIO` | Google Cloud Storage, via `gs://` | Single-file read, write, and delete; bulk delete; prefix listing |
+| `ADLSFileIO` | Azure Data Lake Storage Gen2, via `abfs://`, `abfss://`, `wasb://`, `wasbs://` | Single-file read, write, and delete; bulk delete; prefix listing |
+| `OSSFileIO` | Aliyun Object Storage Service | Single-file read, write, and delete |
+| `EcsFileIO` | Dell Enterprise Object Storage (ECS) | Single-file read, write, and delete |
+
+`OSSFileIO` and `EcsFileIO` do not currently provide bulk delete or prefix listing. Table-maintenance operations that scan or remove many files at once, such as orphan-file cleanup and table purge, are therefore slower against those backends than against the other implementations.
+
+## Routing by URI scheme
+
+By default, the REST catalog uses `ResolvingFileIO`, which picks an implementation from the URI scheme of each file location:
+
+| URI scheme | Implementation |
+| --- | --- |
+| `s3`, `s3a`, `s3n` | `S3FileIO` |
+| `gs` | `GCSFileIO` |
+| `abfs`, `abfss`, `wasb`, `wasbs` | `ADLSFileIO` |
+| any other scheme | `HadoopFileIO` |
+
+Schemes that are not in this table, such as `oss://`, `ecs://`, or a bare `https://`, are not routed to `OSSFileIO` or `EcsFileIO`; they fall through to `HadoopFileIO`. To use `OSSFileIO` or `EcsFileIO`, set the catalog `io-impl` property to the implementation's fully qualified class name.
+
+## Choosing the FileIO
+
+Most users do not need to set anything. The REST catalog defaults to `ResolvingFileIO`, so writing to an `s3://` path automatically uses `S3FileIO`. The Hadoop and JDBC catalogs default to `HadoopFileIO`.
+
+To override the default, set the catalog property `io-impl` to the fully qualified class name of the FileIO implementation you want to use. Provider-specific tuning lives on the pages that own each backend:
+
+- [Catalog properties](catalog-properties.md) for the `io-impl` property and other catalog-wide knobs
+- [AWS](aws.md) for `S3FileIO` configuration and behavior
+- [Dell](dell.md) for the Dell EMC ECS catalog and FileIO
+
+## Encryption
+
+Iceberg supports table encryption by wrapping any FileIO with `EncryptingFileIO`, which preserves the capabilities of the wrapped FileIO so bulk delete and prefix listing continue to work when those are available on the underlying implementation. See the [Encryption](encryption.md) document for the full picture.
+
+## Implementing a custom FileIO
+
+The FileIO surface is intentionally small: read a file, write a file, delete a file. The interfaces live under the `org.apache.iceberg.io` package in the `iceberg-api` module. Once implemented, a custom FileIO is plugged in by setting the catalog `io-impl` property to its fully qualified class name. For a walkthrough, including the optional capability interfaces that enable bulk delete, prefix listing, best-effort recovery, and storage credentials, see the [Custom file IO implementation](custom-catalog.md#custom-file-io-implementation) section of the Java Custom Catalog guide.
+
 ## Usage in Processing Engines
 
-The responsibility of reading and writing data files lies with the processing engines and happens during task execution. However, after data files are written, processing engines use FileIO to write new Iceberg metadata files that capture the new state of the table.
-
-Different FileIO implementations are used depending on the type of storage. Iceberg comes with a set of FileIO implementations for popular storage providers.
-
-- Amazon S3
-- Google Cloud Storage
-- Object Service Storage (including https)
-- Dell Enterprise Cloud Storage
-- Hadoop (adapts any Hadoop FileSystem implementation)
+The responsibility for reading and writing data files lies with the processing engine and happens during task execution. Everything related to table metadata, including manifests, manifest lists, table metadata files, and the commit itself, goes through FileIO. Because engines distribute the FileIO instance to executors, every implementation is required to be serializable.


### PR DESCRIPTION
## Summary

Refreshes the FileIO concepts page (`docs/docs/fileio.md`) so it matches the FileIO surface actually shipping today, in response to issue #7966.

## What changed

- Replaces the inaccurate "Object Service Storage (including https)" entry with a six-row "Built-in implementations" table covering `HadoopFileIO`, `S3FileIO`, `GCSFileIO`, `ADLSFileIO`, `OSSFileIO`, and `EcsFileIO`, each with a plain-English summary of what it can do efficiently (single-file IO, bulk delete, prefix listing, best-effort recovery). Adds Azure / ADLS, which was missing entirely.
- Adds a "Routing by URI scheme" section documenting `ResolvingFileIO`'s scheme map (`s3/s3a/s3n` to `S3FileIO`, `gs` to `GCSFileIO`, `abfs/abfss/wasb/wasbs` to `ADLSFileIO`, anything else to `HadoopFileIO`), and notes that `oss://`, `ecs://`, and bare `https://` fall through to `HadoopFileIO`.
- Adds "Choosing the FileIO" with the per-catalog defaults that are actually in the code (REST to `ResolvingFileIO`; `HadoopCatalog` and `JdbcCatalog` to `HadoopFileIO`) and the `io-impl` catalog property.
- Adds short "Encryption" and "Implementing a custom FileIO" sections that link out to `encryption.md` and `custom-catalog.md` rather than duplicating their content.

Closes #7966

---
**AI Disclosure**
- Model: Claude Opus 4.7
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Refresh the FileIO concepts page so it matches the FileIO implementations shipping today.
