### PR TITLE
OpenAPI: Fix schema of data-access object in REST spec

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2061,10 +2061,12 @@ components:
 
       required: false
       schema:
-        type: string
-        enum:
-          - vended-credentials
-          - remote-signing
+        type: array
+        items:
+          type: string
+          enum:
+            - vended-credentials
+            - remote-signing
       style: simple
       explode: false
       example: "vended-credentials,remote-signing"


### PR DESCRIPTION
The current spec defines this object as a single enum constant, not a comma-separated list of enum constants.

To achieve that, the schema must instead be of type `array`, and its elements must be enum constants. Then, the actual wire format (comma-separated) is achieved by setting the style to `simple` and `explode` to false (as is today).

The error has never been caught, likely because:

- We don't generate Python code for this specific object (only for requests and responses)
- CI only validates that the schema is structurally well-formed (which it is – only not what we wanted it to be). The example was wrong, but it wasn't being validated either.
- Most clients out there simply do not parse or validate the header value at all.

Note: the example was left as is (serialized string in wire format), not transformed into an array (internal representation). The OpenAPI spec is unclear about how such examples should be included:

- On one side, it states that "example ... SHOULD match the specified schema and encoding properties if present." (note the SHOULD)
- On the other side, the Style Examples table shows the serialized, comma-separated string as the canonical example of an array of strings when the style is `simple`.