### PR TITLE
Kafka Connect: Follow-up identifier field validations and error contract alignment

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -282,6 +282,10 @@ public class IcebergSinkConfig extends AbstractConfig {
     } else {
       throw new ConfigException("Must specify table name(s)");
     }
+    checkState(
+        !(schemaForceOptional() && tablesDefaultIdColumns() != null),
+        "iceberg.tables.schema-force-optional and iceberg.tables.default-id-columns are incompatible: "
+            + "schema-force-optional marks every field optional, but identifier fields must be required");
   }
 
   private void checkState(boolean condition, String msg) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
@@ -20,8 +20,10 @@ package org.apache.iceberg.connect.data;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
@@ -35,6 +37,7 @@ import org.apache.iceberg.exceptions.ForbiddenException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.Tasks;
 import org.apache.kafka.connect.errors.DataException;
@@ -93,7 +96,55 @@ class IcebergWriterFactory {
       structType = SchemaUtils.toIcebergType(sample.valueSchema(), config).asStructType();
     }
 
-    org.apache.iceberg.Schema schema = new org.apache.iceberg.Schema(structType.fields());
+    List<String> idColumns = config.tableConfig(tableName).idColumns();
+
+    if (!idColumns.isEmpty() && config.schemaForceOptional()) {
+      throw new DataException(
+          String.format(
+              "iceberg.tables.schema-force-optional is enabled for table %s but id-columns are configured. "
+                  + "schema-force-optional marks every field optional, which is incompatible with identifier fields that must be required. "
+                  + "Disable schema-force-optional or remove the id-columns configuration.",
+              tableName));
+    }
+
+    org.apache.iceberg.Schema initialSchema = new org.apache.iceberg.Schema(structType.fields());
+    Set<Integer> identifierFieldIds =
+        idColumns.stream()
+            .map(
+                name -> {
+                  if (name.contains(".")) {
+                    throw new DataException(
+                        String.format(
+                            "ID column '%s' for table %s must be a top-level column name, not a dotted path. "
+                                + "Nested identifier fields are not supported by the connector.",
+                            name, tableName));
+                  }
+                  NestedField field = initialSchema.findField(name);
+                  if (field == null) {
+                    throw new DataException(
+                        String.format(
+                            "ID column '%s' not found in schema for table %s. Available columns: %s",
+                            name,
+                            tableName,
+                            initialSchema.columns().stream()
+                                .map(NestedField::name)
+                                .collect(Collectors.toList())));
+                  }
+                  return field.fieldId();
+                })
+            .collect(Collectors.toSet());
+
+    org.apache.iceberg.Schema schema;
+    try {
+      schema = new org.apache.iceberg.Schema(structType.fields(), identifierFieldIds);
+    } catch (IllegalArgumentException e) {
+      throw new DataException(
+          String.format(
+              "Invalid identifier column configuration for table %s: %s",
+              tableName, e.getMessage()),
+          e);
+    }
+
     TableIdentifier identifier = TableIdentifier.parse(tableName);
 
     createNamespaceIfNotExist(catalog, identifier.namespace());

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterFactory.java
@@ -107,7 +107,6 @@ class IcebergWriterFactory {
               tableName));
     }
 
-    org.apache.iceberg.Schema initialSchema = new org.apache.iceberg.Schema(structType.fields());
     Set<Integer> identifierFieldIds =
         idColumns.stream()
             .map(
@@ -119,14 +118,14 @@ class IcebergWriterFactory {
                                 + "Nested identifier fields are not supported by the connector.",
                             name, tableName));
                   }
-                  NestedField field = initialSchema.findField(name);
+                  NestedField field = structType.field(name);
                   if (field == null) {
                     throw new DataException(
                         String.format(
                             "ID column '%s' not found in schema for table %s. Available columns: %s",
                             name,
                             tableName,
-                            initialSchema.columns().stream()
+                            structType.fields().stream()
                                 .map(NestedField::name)
                                 .collect(Collectors.toList())));
                   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 
 class RecordUtils {
 
@@ -122,7 +123,14 @@ class RecordUtils {
                   colName -> {
                     NestedField field = table.schema().findField(colName);
                     if (field == null) {
-                      throw new IllegalArgumentException("ID column not found: " + colName);
+                      throw new DataException(
+                          String.format(
+                              "ID column '%s' not found in schema for table %s. Available columns: %s",
+                              colName,
+                              tableReference.identifier().name(),
+                              table.schema().columns().stream()
+                                  .map(NestedField::name)
+                                  .collect(Collectors.toList())));
                     }
                     return field.fieldId();
                   })

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
@@ -30,6 +30,22 @@ import org.junit.jupiter.api.Test;
 public class TestIcebergSinkConfig {
 
   @Test
+  public void testSchemaForceOptionalIncompatibleWithDefaultIdColumns() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            "topics", "source-topic",
+            "iceberg.catalog.type", "rest",
+            "iceberg.tables", "db.landing",
+            "iceberg.tables.schema-force-optional", "true",
+            "iceberg.tables.default-id-columns", "id");
+    assertThatThrownBy(() -> new IcebergSinkConfig(props))
+        .isInstanceOf(ConfigException.class)
+        .hasMessageContaining("schema-force-optional")
+        .hasMessageContaining("default-id-columns")
+        .hasMessageContaining("incompatible");
+  }
+
+  @Test
   public void testGetVersion() {
     String version = IcebergSinkConfig.version();
     assertThat(version).isNotNull();

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
@@ -137,4 +137,145 @@ public class TestIcebergWriterFactory {
         .hasMessageContaining("id-columns")
         .hasMessageContaining("foo.bar");
   }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTableRejectsDottedPathIdColumn() {
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.partitionBy()).thenReturn(ImmutableList.of());
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("user.id"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of());
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.schemaForceOptional()).thenReturn(false);
+
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.valueSchema()).thenReturn(valueSchema);
+    when(record.value()).thenReturn(new Struct(valueSchema).put("id", 1L));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.autoCreateTable("foo.bar", record))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("user.id")
+        .hasMessageContaining("top-level")
+        .hasMessageContaining("foo.bar");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTableRejectsMissingIdColumn() {
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.partitionBy()).thenReturn(ImmutableList.of());
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("missing_col"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of());
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.schemaForceOptional()).thenReturn(false);
+
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.valueSchema()).thenReturn(valueSchema);
+    when(record.value()).thenReturn(new Struct(valueSchema).put("id", 1L));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.autoCreateTable("foo.bar", record))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("missing_col")
+        .hasMessageContaining("Available columns")
+        .hasMessageContaining("foo.bar");
+  }
+
+  // Exercises the try/catch around new Schema(..., identifierFieldIds): an optional Kafka field
+  // produces an optional Iceberg field, which Schema.validateIdentifierField rejects with
+  // IllegalArgumentException. The catch must re-wrap it as DataException.
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTableRejectsOptionalIdColumnAsDataException() {
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.partitionBy()).thenReturn(ImmutableList.of());
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("id"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of());
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.schemaForceOptional()).thenReturn(false);
+
+    // OPTIONAL_INT64_SCHEMA produces an optional Iceberg field, which is invalid as an identifier
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("id", org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+            .build();
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.valueSchema()).thenReturn(valueSchema);
+    when(record.value()).thenReturn(new Struct(valueSchema).put("id", 1L));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.autoCreateTable("foo.bar", record))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("foo.bar")
+        .cause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not a required field");
+  }
+
+  // Exercises the try/catch around new Schema(..., identifierFieldIds): a FLOAT64 Kafka field
+  // produces an Iceberg DoubleType, which Schema.validateIdentifierField rejects.
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTableRejectsDoubleIdColumnAsDataException() {
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.partitionBy()).thenReturn(ImmutableList.of());
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("score"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of());
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.schemaForceOptional()).thenReturn(false);
+
+    // FLOAT64_SCHEMA (required) produces an Iceberg DoubleType, banned as an identifier field
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("score", org.apache.kafka.connect.data.Schema.FLOAT64_SCHEMA)
+            .build();
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.valueSchema()).thenReturn(valueSchema);
+    when(record.value()).thenReturn(new Struct(valueSchema).put("score", 1.0));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.autoCreateTable("foo.bar", record))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("foo.bar")
+        .cause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("float or double");
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestIcebergWriterFactory.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -41,7 +42,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StringType;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.sink.SinkRecord;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.ArgumentCaptor;
@@ -95,5 +100,41 @@ public class TestIcebergWriterFactory {
     assertThat(capturedArguments.get(0)).isEqualTo(Namespace.of("foo1"));
     assertThat(capturedArguments.get(1)).isEqualTo(Namespace.of("foo1", "foo2"));
     assertThat(capturedArguments.get(2)).isEqualTo(Namespace.of("foo1", "foo2", "foo3"));
+  }
+
+  // schema-force-optional=true with id-columns configured: Kafka field is required but the config
+  // flag forces every Iceberg field optional, so the combination is rejected at the connector
+  // layer.
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testAutoCreateTableRejectsIdColumnsWithSchemaForceOptional() {
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(SupportsNamespaces.class));
+    when(catalog.loadTable(any())).thenThrow(new NoSuchTableException("no such table"));
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.partitionBy()).thenReturn(ImmutableList.of());
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("id"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.autoCreateProps()).thenReturn(ImmutableMap.of());
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.schemaForceOptional()).thenReturn(true);
+
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("id", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
+
+    SinkRecord record = mock(SinkRecord.class);
+    when(record.valueSchema()).thenReturn(valueSchema);
+    when(record.value()).thenReturn(new Struct(valueSchema).put("id", 1L));
+
+    IcebergWriterFactory factory = new IcebergWriterFactory(catalog, config);
+
+    assertThatThrownBy(() -> factory.autoCreateTable("foo.bar", record))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("schema-force-optional")
+        .hasMessageContaining("id-columns")
+        .hasMessageContaining("foo.bar");
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
@@ -19,19 +19,72 @@
 package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.LocationProviders;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.connect.IcebergSinkConfig;
+import org.apache.iceberg.connect.TableSinkConfig;
+import org.apache.iceberg.connect.events.TableReference;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.kafka.connect.data.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.types.Types;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.apache.kafka.connect.errors.DataException;
 import org.junit.jupiter.api.Test;
 
 public class TestRecordUtils {
 
   @Test
+  public void testCreateTableWriterMissingIdColumnThrowsDataException() {
+    Schema icebergSchema =
+        new Schema(
+            ImmutableList.of(Types.NestedField.required(1, "id", Types.LongType.get())),
+            ImmutableSet.of(1));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(icebergSchema);
+    when(table.spec()).thenReturn(PartitionSpec.unpartitioned());
+    when(table.io()).thenReturn(new InMemoryFileIO());
+    when(table.locationProvider())
+        .thenReturn(LocationProviders.locationsFor("file", ImmutableMap.of()));
+    when(table.encryption()).thenReturn(PlaintextEncryptionManager.instance());
+    when(table.properties()).thenReturn(ImmutableMap.of());
+
+    TableSinkConfig tableConfig = mock(TableSinkConfig.class);
+    when(tableConfig.idColumns()).thenReturn(ImmutableList.of("missing_column"));
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.tableConfig(any())).thenReturn(tableConfig);
+    when(config.writeProps()).thenReturn(ImmutableMap.of());
+
+    TableReference tableReference =
+        TableReference.of("test_catalog", TableIdentifier.of("name"), UUID.randomUUID());
+
+    assertThatThrownBy(() -> RecordUtils.createTableWriter(table, tableReference, config))
+        .isInstanceOf(DataException.class)
+        .hasMessageContaining("ID column 'missing_column' not found in schema")
+        .hasMessageContaining("Available columns:");
+  }
+
+  @Test
   public void testExtractFromRecordValueStruct() {
-    Schema valSchema = SchemaBuilder.struct().field("key", Schema.INT64_SCHEMA).build();
+    org.apache.kafka.connect.data.Schema valSchema =
+        SchemaBuilder.struct()
+            .field("key", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
     Struct val = new Struct(valSchema).put("key", 123L);
     Object result = RecordUtils.extractFromRecordValue(val, "key");
     assertThat(result).isEqualTo(123L);
@@ -39,9 +92,14 @@ public class TestRecordUtils {
 
   @Test
   public void testExtractFromRecordValueStructNested() {
-    Schema idSchema = SchemaBuilder.struct().field("key", Schema.INT64_SCHEMA).build();
-    Schema dataSchema = SchemaBuilder.struct().field("id", idSchema).build();
-    Schema valSchema = SchemaBuilder.struct().field("data", dataSchema).build();
+    org.apache.kafka.connect.data.Schema idSchema =
+        SchemaBuilder.struct()
+            .field("key", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
+    org.apache.kafka.connect.data.Schema dataSchema =
+        SchemaBuilder.struct().field("id", idSchema).build();
+    org.apache.kafka.connect.data.Schema valSchema =
+        SchemaBuilder.struct().field("data", dataSchema).build();
 
     Struct id = new Struct(idSchema).put("key", 123L);
     Struct data = new Struct(dataSchema).put("id", id);
@@ -53,7 +111,10 @@ public class TestRecordUtils {
 
   @Test
   public void testExtractFromRecordValueStructNull() {
-    Schema valSchema = SchemaBuilder.struct().field("key", Schema.INT64_SCHEMA).build();
+    org.apache.kafka.connect.data.Schema valSchema =
+        SchemaBuilder.struct()
+            .field("key", org.apache.kafka.connect.data.Schema.INT64_SCHEMA)
+            .build();
     Struct val = new Struct(valSchema).put("key", 123L);
 
     Object result = RecordUtils.extractFromRecordValue(val, "");


### PR DESCRIPTION
Kafka Connect: Follow-up identifier field validations and error contract alignment
    
      * Reject the combination of `schema-force-optional=true` and `id-columns` at
        two levels:
        - At startup with `ConfigException` when `default-id-columns` is set globally.
        - At runtime with `DataException` for per-table `id-columns` overrides.
      * Align `RecordUtils.createTableWriter` to throw `DataException` (with
        consistent message format) instead of `IllegalArgumentException` when a
        configured `id-column` is missing from an existing table schema.
    
    Signed-off-by: elbehery [elbeherymustafa@gmail.com]

cc @laskoviymishka 