### PR TITLE
Kafka Connect: Make KafkaMetadataTransform configuration per-instance

### DIFF
--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
@@ -97,7 +97,7 @@ public class KafkaMetadataTransform implements Transformation<SinkRecord> {
   private static final String KEY_METADATA_FIELD_NAME = "field_name";
   private static final String KEY_METADATA_IS_NESTED = "nested";
   private static final String DEFAULT_METADATA_FIELD_NAME = "_kafka_metadata";
-  private static RecordAppender recordAppender;
+  private RecordAppender recordAppender;
 
   private static final ConfigDef CONFIG_DEF =
       new ConfigDef()

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
@@ -226,6 +226,39 @@ public class TestKafkaMetadataTransform {
   }
 
   @Test
+  @DisplayName("config must be per-instance, not leaked via a static field")
+  public void testConfigIsNotSharedAcrossInstances() {
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            null,
+            VALUE_MAP,
+            OFFSET,
+            TIMESTAMP,
+            TimestampType.CREATE_TIME);
+    try (KafkaMetadataTransform first = new KafkaMetadataTransform();
+        KafkaMetadataTransform second = new KafkaMetadataTransform()) {
+      first.configure(ImmutableMap.of("field_name", "aaa"));
+      // configuring a second, independently-configured instance must not affect the first
+      second.configure(ImmutableMap.of("field_name", "bbb"));
+
+      // the second (last-configured) instance works correctly today: it uses its own "bbb" prefix
+      Map<?, ?> secondValue = (Map<?, ?>) second.apply(record).value();
+      assertThat(secondValue.get("bbb_topic")).isEqualTo(TOPIC);
+      assertThat(secondValue.get("aaa_topic")).isNull();
+
+      // the first instance must also use its own "aaa" prefix, not the second's "bbb"; today this
+      // fails because recordAppender is static and the second configure() overwrote the first's
+      Map<?, ?> firstValue = (Map<?, ?>) first.apply(record).value();
+      assertThat(firstValue.get("aaa_topic")).isEqualTo(TOPIC);
+      assertThat(firstValue.get("bbb_topic")).isNull();
+    }
+  }
+
+  @Test
   @DisplayName("should append kafka metadata to maps as nested")
   public void testAppendToMapsNested() {
     SinkRecord record =

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
@@ -226,6 +226,39 @@ public class TestKafkaMetadataTransform {
   }
 
   @Test
+  @DisplayName("config must be per-instance, not leaked via a static field")
+  public void testConfigIsNotSharedAcrossInstances() {
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            null,
+            null,
+            null,
+            VALUE_MAP,
+            OFFSET,
+            TIMESTAMP,
+            TimestampType.CREATE_TIME);
+    try (KafkaMetadataTransform first = new KafkaMetadataTransform();
+        KafkaMetadataTransform second = new KafkaMetadataTransform()) {
+      first.configure(ImmutableMap.of("field_name", "aaa"));
+      // configuring a second, independently-configured instance must not affect the first
+      second.configure(ImmutableMap.of("field_name", "bbb"));
+
+      // the last-configured instance uses its own "bbb" prefix
+      Map<?, ?> secondValue = (Map<?, ?>) second.apply(record).value();
+      assertThat(secondValue.get("bbb_topic")).isEqualTo(TOPIC);
+      assertThat(secondValue.get("aaa_topic")).isNull();
+
+      // the earlier instance must still use its own "aaa" prefix: with a shared static appender the
+      // second configure() would have overwritten it, leaving "aaa_topic" null here
+      Map<?, ?> firstValue = (Map<?, ?>) first.apply(record).value();
+      assertThat(firstValue.get("aaa_topic")).isEqualTo(TOPIC);
+      assertThat(firstValue.get("bbb_topic")).isNull();
+    }
+  }
+
+  @Test
   @DisplayName("should append kafka metadata to maps as nested")
   public void testAppendToMapsNested() {
     SinkRecord record =


### PR DESCRIPTION
Closes #16601

### Problem

`KafkaMetadataTransform` held its configuration (`recordAppender`) in a `static` field, so every instance in a worker JVM shared one configuration and the last `configure()` call won. Two differently-configured instances (two connectors that use the SMT, or two transform aliases in one chain) would emit each other's metadata field names and structure. It is also a thread-safety hazard, since the field is mutated from each task's `configure()` and read from each task's `apply()`. The other SMTs in the module (`CopyValue`, `DebeziumTransform`) already use instance fields.

### Solution

Make `recordAppender` an instance field. All reads are in instance methods, so the change is minimal, and the appender is still built once per instance in `configure()`, so there is no added cost.

### Tests

Added `TestKafkaMetadataTransform.testConfigIsNotSharedAcrossInstances`: it configures two instances with different field names and verifies each instance uses its own configuration. It fails before the change and passes after.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Make KafkaMetadataTransform configuration per-instance instead of a shared static field.
