### PR TITLE
Kafka Connect: Fix MongoDataConverter array conversion of timestamp and date types

### DIFF
--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/debezium/connector/mongodb/transforms/MongoDataConverter.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/debezium/connector/mongodb/transforms/MongoDataConverter.java
@@ -236,13 +236,13 @@ public class MongoDataConverter {
       long temp = arrValue.asInt64().getValue();
       list.add(temp);
     } else if (arrValue.getBsonType() == BsonType.DATE_TIME && valueType == BsonType.DATE_TIME) {
-      Date temp = new Date(arrValue.asInt64().getValue());
+      Date temp = new Date(arrValue.asDateTime().getValue());
       list.add(temp);
     } else if (arrValue.getBsonType() == BsonType.DECIMAL128 && valueType == BsonType.DECIMAL128) {
       String temp = arrValue.asDecimal128().getValue().toString();
       list.add(temp);
     } else if (arrValue.getBsonType() == BsonType.TIMESTAMP && valueType == BsonType.TIMESTAMP) {
-      Date temp = new Date(1000L * arrValue.asInt32().getValue());
+      Date temp = new Date(1000L * arrValue.asTimestamp().getTime());
       list.add(temp);
     } else if (arrValue.getBsonType() == BsonType.BOOLEAN && valueType == BsonType.BOOLEAN) {
       boolean temp = arrValue.asBoolean().getValue();

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/TestMongoArrayConverter.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/TestMongoArrayConverter.java
@@ -22,11 +22,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
 import java.util.Map.Entry;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.bson.BsonArray;
+import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
+import org.bson.BsonInt32;
+import org.bson.BsonTimestamp;
 import org.bson.BsonValue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -388,5 +394,61 @@ public class TestMongoArrayConverter {
         .isEqualTo(
             "Struct{" + "_id=1," + "a1=Struct{" + "_0=Struct{a=1}," + "_1=Struct{a=c}" + "}" + "}");
     // @formatter:on
+  }
+
+  @Test
+  @SuppressWarnings("JavaUtilDate")
+  public void shouldConvertArrayOfTimestamps() {
+    final MongoDataConverter converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+    final BsonDocument val =
+        new BsonDocument()
+            .append("_id", new BsonInt32(1))
+            .append(
+                "ts",
+                new BsonArray(Arrays.asList(new BsonTimestamp(60, 1), new BsonTimestamp(120, 1))));
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name("array");
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.addFieldSchema(entry, schemaBuilder);
+    }
+    final Schema finalSchema = schemaBuilder.build();
+    final Struct struct = new Struct(finalSchema);
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.convertRecord(entry, finalSchema, struct);
+    }
+
+    // BsonTimestamp.getTime() returns the seconds component; the scalar path multiplies by 1000
+    List<?> tsValues = (List<?>) struct.get("ts");
+    assertThat(tsValues).hasSize(2);
+    assertThat(tsValues.get(0)).isEqualTo(new Date(60_000L));
+    assertThat(tsValues.get(1)).isEqualTo(new Date(120_000L));
+  }
+
+  @Test
+  @SuppressWarnings("JavaUtilDate")
+  public void shouldConvertArrayOfDateTimes() {
+    final MongoDataConverter converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+    final BsonDocument val =
+        new BsonDocument()
+            .append("_id", new BsonInt32(1))
+            .append(
+                "dt",
+                new BsonArray(Arrays.asList(new BsonDateTime(1_000L), new BsonDateTime(2_000L))));
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name("array");
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.addFieldSchema(entry, schemaBuilder);
+    }
+    final Schema finalSchema = schemaBuilder.build();
+    final Struct struct = new Struct(finalSchema);
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.convertRecord(entry, finalSchema, struct);
+    }
+
+    // BsonDateTime.getValue() is epoch millis; the scalar path uses it directly
+    List<?> dtValues = (List<?>) struct.get("dt");
+    assertThat(dtValues).hasSize(2);
+    assertThat(dtValues.get(0)).isEqualTo(new Date(1_000L));
+    assertThat(dtValues.get(1)).isEqualTo(new Date(2_000L));
   }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/TestMongoArrayConverter.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/debezium/connector/mongodb/transforms/TestMongoArrayConverter.java
@@ -22,12 +22,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
-import java.util.List;
 import java.util.Map.Entry;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.assertj.core.api.InstanceOfAssertFactories;
 import org.bson.BsonArray;
 import org.bson.BsonDateTime;
 import org.bson.BsonDocument;
@@ -417,11 +418,9 @@ public class TestMongoArrayConverter {
       converter.convertRecord(entry, finalSchema, struct);
     }
 
-    // BsonTimestamp.getTime() returns the seconds component; the scalar path multiplies by 1000
-    List<?> tsValues = (List<?>) struct.get("ts");
-    assertThat(tsValues).hasSize(2);
-    assertThat(tsValues.get(0)).isEqualTo(new Date(60_000L));
-    assertThat(tsValues.get(1)).isEqualTo(new Date(120_000L));
+    assertThat(struct.get("ts"))
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .containsExactly(new Date(60_000L), new Date(120_000L));
   }
 
   @Test
@@ -445,10 +444,65 @@ public class TestMongoArrayConverter {
       converter.convertRecord(entry, finalSchema, struct);
     }
 
-    // BsonDateTime.getValue() is epoch millis; the scalar path uses it directly
-    List<?> dtValues = (List<?>) struct.get("dt");
-    assertThat(dtValues).hasSize(2);
-    assertThat(dtValues.get(0)).isEqualTo(new Date(1_000L));
-    assertThat(dtValues.get(1)).isEqualTo(new Date(2_000L));
+    assertThat(struct.get("dt"))
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .containsExactly(new Date(1_000L), new Date(2_000L));
+  }
+
+  @Test
+  @SuppressWarnings("JavaUtilDate")
+  public void shouldConvertNestedArrayOfTimestamps() {
+    final MongoDataConverter converter = new MongoDataConverter(ArrayEncoding.ARRAY);
+    final BsonDocument val =
+        new BsonDocument()
+            .append("_id", new BsonInt32(1))
+            .append(
+                "ts",
+                new BsonArray(
+                    Arrays.asList(
+                        new BsonArray(Collections.singletonList(new BsonTimestamp(60, 1))),
+                        new BsonArray(Collections.singletonList(new BsonTimestamp(120, 1))))));
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name("array");
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.addFieldSchema(entry, schemaBuilder);
+    }
+    final Schema finalSchema = schemaBuilder.build();
+    final Struct struct = new Struct(finalSchema);
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.convertRecord(entry, finalSchema, struct);
+    }
+
+    assertThat(struct.get("ts"))
+        .asInstanceOf(InstanceOfAssertFactories.LIST)
+        .containsExactly(
+            Collections.singletonList(new Date(60_000L)),
+            Collections.singletonList(new Date(120_000L)));
+  }
+
+  @Test
+  @SuppressWarnings("JavaUtilDate")
+  public void shouldConvertDocumentEncodedArrayOfTimestamps() {
+    final MongoDataConverter converter = new MongoDataConverter(ArrayEncoding.DOCUMENT);
+    final BsonDocument val =
+        new BsonDocument()
+            .append("_id", new BsonInt32(1))
+            .append(
+                "ts",
+                new BsonArray(Arrays.asList(new BsonTimestamp(60, 1), new BsonTimestamp(120, 1))));
+
+    final SchemaBuilder schemaBuilder = SchemaBuilder.struct().name("array");
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.addFieldSchema(entry, schemaBuilder);
+    }
+    final Schema finalSchema = schemaBuilder.build();
+    final Struct struct = new Struct(finalSchema);
+    for (Entry<String, BsonValue> entry : val.entrySet()) {
+      converter.convertRecord(entry, finalSchema, struct);
+    }
+
+    final Struct tsStruct = struct.getStruct("ts");
+    assertThat(tsStruct.get("_0")).isEqualTo(new Date(60_000L));
+    assertThat(tsStruct.get("_1")).isEqualTo(new Date(120_000L));
   }
 }


### PR DESCRIPTION
Closes #16603

### Problem

`MongoDataConverter` (used by `MongoDebeziumTransform`) read BSON array elements with the wrong accessors when `array.encoding=array` (the default): `DATE_TIME` elements were read with `asInt64()` and `TIMESTAMP` elements with `asInt32()`. Because those elements are actually `BsonDateTime`/`BsonTimestamp`, `BsonValue` throws `BsonInvalidOperationException`, so any MongoDB document containing an array of timestamps or date-times failed to convert. The scalar (non-array) paths already use the correct accessors.

### Solution

Read array `TIMESTAMP` and `DATE_TIME` elements with the same accessors as the scalar paths: `asTimestamp().getTime()` and `asDateTime().getValue()`.

This file lives under `org.debezium.connector.mongodb.transforms` and was adapted from Debezium; the fix intentionally diverges from the (buggy) upstream snapshot.

### Tests

`TestMongoArrayConverter` gains four temporal tests. `shouldConvertArrayOfTimestamps` and `shouldConvertArrayOfDateTimes` convert flat arrays of `BsonTimestamp` / `BsonDateTime` under `ArrayEncoding.ARRAY`, and `shouldConvertNestedArrayOfTimestamps` covers the recursive re-entry, where an array of arrays routes back through the same branches. All three fail before the change with `BsonInvalidOperationException` and pass after. `shouldConvertDocumentEncodedArrayOfTimestamps` pins the `ArrayEncoding.DOCUMENT` route, which reaches the scalar `TIMESTAMP` branch that had no coverage anywhere in the repo; it passes on both sides of the fix.

---
**AI Disclosure**
- Model: Claude Opus 4.8, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix MongoDataConverter reading BSON array timestamp and date elements with the wrong accessors.

