### PR TITLE
Kafka Connect: Fix invalid decimal type inferred for some BigDecimal values

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -306,7 +306,15 @@ class SchemaUtils {
         return BooleanType.get();
       } else if (value instanceof BigDecimal) {
         BigDecimal bigDecimal = (BigDecimal) value;
-        return DecimalType.of(bigDecimal.precision(), bigDecimal.scale());
+        int scale = bigDecimal.scale();
+        int precision = bigDecimal.precision();
+        // BigDecimal may use a negative scale (e.g. "1E+2" has scale -2)
+        if (scale < 0) {
+          precision -= scale;
+          scale = 0;
+        }
+        // a value < 1 may have precision < scale (e.g. "0.001"); widen precision to the scale
+        return DecimalType.of(Math.max(precision, scale), scale);
       } else if (value instanceof Integer || value instanceof Long) {
         return LongType.get();
       } else if (value instanceof Float || value instanceof Double) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SchemaUtils.java
@@ -72,6 +72,8 @@ class SchemaUtils {
 
   private static final Pattern TRANSFORM_REGEX = Pattern.compile("(\\w+)\\((.+)\\)");
 
+  private static final int MAX_DECIMAL_PRECISION = 38;
+
   static PrimitiveType needsDataTypeUpdate(Type currentIcebergType, Schema valueSchema) {
     if (currentIcebergType.typeId() == TypeID.FLOAT && valueSchema.type() == Schema.Type.FLOAT64) {
       return DoubleType.get();
@@ -305,16 +307,7 @@ class SchemaUtils {
       } else if (value instanceof Boolean) {
         return BooleanType.get();
       } else if (value instanceof BigDecimal) {
-        BigDecimal bigDecimal = (BigDecimal) value;
-        int scale = bigDecimal.scale();
-        int precision = bigDecimal.precision();
-        // BigDecimal may use a negative scale (e.g. "1E+2" has scale -2)
-        if (scale < 0) {
-          precision -= scale;
-          scale = 0;
-        }
-        // a value < 1 may have precision < scale (e.g. "0.001"); widen precision to the scale
-        return DecimalType.of(Math.max(precision, scale), scale);
+        return inferDecimalType((BigDecimal) value);
       } else if (value instanceof Integer || value instanceof Long) {
         return LongType.get();
       } else if (value instanceof Float || value instanceof Double) {
@@ -355,6 +348,31 @@ class SchemaUtils {
       } else {
         return null;
       }
+    }
+
+    /**
+     * BigDecimal does not satisfy Iceberg's 0 &lt;= scale &lt;= precision &lt;= 38 invariant: a
+     * value &lt; 1 has a precision smaller than its scale ("0.001" is precision 1, scale 3), and an
+     * exponential value has a negative scale ("1E+2" is scale -2). Both are normalized here, the
+     * same way Spark normalizes a BigDecimal in Decimal.set. A value that needs more than 38 digits
+     * cannot be represented, so its type is reported as unknown.
+     */
+    private static Type inferDecimalType(BigDecimal value) {
+      // widened to long because the subtraction below overflows int for a pathological scale,
+      // e.g. new BigDecimal(BigInteger.ONE, Integer.MIN_VALUE)
+      long scale = value.scale();
+      long precision = value.precision();
+      if (scale < 0) {
+        precision -= scale;
+        scale = 0;
+      }
+
+      precision = Math.max(precision, scale);
+      if (precision > MAX_DECIMAL_PRECISION) {
+        return null;
+      }
+
+      return DecimalType.of((int) precision, (int) scale);
     }
 
     private int nextId() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
@@ -340,4 +340,19 @@ public class TestSchemaUtils {
     Schema uuidSchema = SchemaBuilder.string().name("uuid").build();
     assertThat(SchemaUtils.toIcebergType(uuidSchema, config)).isInstanceOf(UUIDType.class);
   }
+
+  @Test
+  public void testInferIcebergTypeSmallDecimal() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+
+    // BigDecimal("0.001") has precision 1, smaller than its scale 3;
+    // Iceberg requires scale <= precision, so precision is widened to the scale
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("0.001"), config))
+        .isEqualTo(DecimalType.of(3, 3));
+
+    // BigDecimal("1E+2") has a negative scale (-2); normalized to scale 0,
+    // the same decimal(3, 0) as new BigDecimal("100")
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E+2"), config))
+        .isEqualTo(DecimalType.of(3, 0));
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -354,5 +355,26 @@ public class TestSchemaUtils {
     // the same decimal(3, 0) as new BigDecimal("100")
     assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E+2"), config))
         .isEqualTo(DecimalType.of(3, 0));
+  }
+
+  @Test
+  public void testInferIcebergTypeDecimalOutOfRange() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+
+    // the widest values that can still be represented
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E+37"), config))
+        .isEqualTo(DecimalType.of(38, 0));
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E-38"), config))
+        .isEqualTo(DecimalType.of(38, 38));
+
+    // one digit past the limit on either branch: no type can be inferred
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E+38"), config)).isNull();
+    assertThat(SchemaUtils.inferIcebergType(new BigDecimal("1E-39"), config)).isNull();
+
+    // a scale of Integer.MIN_VALUE must not overflow the precision normalization. it is built
+    // here rather than parsed from "1E+2147483648", which only yields this scale on Java 21+
+    // (Java 17 rejects that exponent with a NumberFormatException)
+    BigDecimal minScale = new BigDecimal(BigInteger.ONE, Integer.MIN_VALUE);
+    assertThat(SchemaUtils.inferIcebergType(minScale, config)).isNull();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
@@ -41,6 +42,7 @@ import org.apache.iceberg.connect.TableSinkConfig;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
@@ -233,6 +235,26 @@ public class TestSinkWriter {
 
     List<IcebergWriterResult> writerResults = sinkWriterTest(value, config);
     assertThat(writerResults).hasSize(0);
+  }
+
+  @Test
+  public void testEvolveAddsFractionalDecimalColumn() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.tables()).thenReturn(ImmutableList.of(TABLE_IDENTIFIER.toString()));
+    when(config.evolveSchemaEnabled()).thenReturn(true);
+
+    // a new column whose value is a fractional decimal < 1: BigDecimal("0.001") has precision 1
+    // and scale 3, so before the fix the column evolves to a malformed decimal(1, 3) and the
+    // write below fails; after the fix it evolves to decimal(3, 3) and the record is written.
+    Map<String, Object> value = ImmutableMap.of("amount", new BigDecimal("0.001"));
+
+    List<IcebergWriterResult> writerResults = sinkWriterTest(value, config);
+    assertThat(writerResults).isNotEmpty();
+
+    // the column evolved to a valid decimal that can hold 0.001 (scale <= precision)
+    Type added = catalog.loadTable(TABLE_IDENTIFIER).schema().findType("amount");
+    assertThat(added).isEqualTo(Types.DecimalType.of(3, 3));
   }
 
   private List<IcebergWriterResult> sinkWriterTest(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
@@ -42,7 +42,6 @@ import org.apache.iceberg.connect.TableSinkConfig;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
@@ -245,16 +244,37 @@ public class TestSinkWriter {
     when(config.evolveSchemaEnabled()).thenReturn(true);
 
     // a new column whose value is a fractional decimal < 1: BigDecimal("0.001") has precision 1
-    // and scale 3, so before the fix the column evolves to a malformed decimal(1, 3) and the
-    // write below fails; after the fix it evolves to decimal(3, 3) and the record is written.
+    // and scale 3. DecimalType.of validates only precision <= 38, so before the fix the column
+    // evolved to a malformed decimal(1, 3) without error and the write below failed in the
+    // Parquet writer; after the fix it evolves to decimal(3, 3) and the record is written.
     Map<String, Object> value = ImmutableMap.of("amount", new BigDecimal("0.001"));
 
     List<IcebergWriterResult> writerResults = sinkWriterTest(value, config);
     assertThat(writerResults).isNotEmpty();
 
     // the column evolved to a valid decimal that can hold 0.001 (scale <= precision)
-    Type added = catalog.loadTable(TABLE_IDENTIFIER).schema().findType("amount");
-    assertThat(added).isEqualTo(Types.DecimalType.of(3, 3));
+    Types.NestedField added = catalog.loadTable(TABLE_IDENTIFIER).schema().findField("amount");
+    assertThat(added).isNotNull();
+    assertThat(added.type()).isEqualTo(Types.DecimalType.of(3, 3));
+  }
+
+  @Test
+  public void testEvolveAddsExponentialDecimalColumn() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.tables()).thenReturn(ImmutableList.of(TABLE_IDENTIFIER.toString()));
+    when(config.evolveSchemaEnabled()).thenReturn(true);
+
+    // BigDecimal("1E+2") has a negative scale (-2), which is normalized to decimal(3, 0), the
+    // same type inferred for new BigDecimal("100"); the value is rescaled when it is written
+    Map<String, Object> value = ImmutableMap.of("amount", new BigDecimal("1E+2"));
+
+    List<IcebergWriterResult> writerResults = sinkWriterTest(value, config);
+    assertThat(writerResults).isNotEmpty();
+
+    Types.NestedField added = catalog.loadTable(TABLE_IDENTIFIER).schema().findField("amount");
+    assertThat(added).isNotNull();
+    assertThat(added.type()).isEqualTo(Types.DecimalType.of(3, 0));
   }
 
   private List<IcebergWriterResult> sinkWriterTest(


### PR DESCRIPTION
Closes #16605

### Problem

`SchemaUtils.inferIcebergType` inferred a decimal column type directly from a `BigDecimal`'s precision and scale. Iceberg requires `0 <= scale <= precision <= 38`, but a `BigDecimal` does not guarantee that: a value < 1 (e.g. `0.001`) has precision 1 and scale 3, and an exponential-form value (e.g. `1E+2`) has a negative scale. `DecimalType.of` only validates `precision <= 38`, so these malformed types were built silently and then failed downstream at write time.

### Solution

Normalize precision and scale before building the type: rescale a negative scale to 0, and widen precision to at least the scale. Valid inputs are unchanged (e.g. `12.345` stays `decimal(5, 3)`); `0.001` becomes `decimal(3, 3)` and `1E+2` becomes `decimal(3, 0)`. A value needing more than 38 digits cannot be represented at all, so no type is inferred for it and the existing "cannot infer" path applies, rather than an `IllegalArgumentException` escaping inference. The normalization runs in `long` so a pathological scale cannot overflow it.

### Tests

- `TestSchemaUtils.testInferIcebergTypeSmallDecimal` (unit): asserts the inferred type is valid for both the small-fraction and the negative-scale cases.
- `TestSchemaUtils.testInferIcebergTypeDecimalOutOfRange` (unit): `1E+37` and `1E-38` still infer as `decimal(38, 0)` and `decimal(38, 38)`; `1E+38`, `1E-39` and a scale of `Integer.MIN_VALUE` infer no type.
- `TestSinkWriter.testEvolveAddsFractionalDecimalColumn` (end-to-end): with schema evolution enabled, writes a schemaless record with a fractional decimal for a new column. Before the change the write fails with `DataException` caused by `Invalid DECIMAL scale: 3 cannot be greater than precision: 1`; after the change the record is written and the column is `decimal(3, 3)`.
- `TestSinkWriter.testEvolveAddsExponentialDecimalColumn` (end-to-end): the same for `1E+2`, which fails before the change and evolves to `decimal(3, 0)` after it.

---
**AI Disclosure**
- Model: Claude Opus 4.8, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix the invalid decimal type inferred for BigDecimal values whose scale exceeds their precision, then bound the inferred precision and address review feedback.
