### PR TITLE
API: Single-value binary serialization for geometry and geography

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
@@ -131,6 +132,12 @@ public class Conversions {
         variantMetadata.writeTo(variantBuffer, 0);
         variantValue.writeTo(variantBuffer, variantMetadata.sizeInBytes());
         return variantBuffer;
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // Geometry and geography lower/upper bounds are single points encoded as an
+        // x:y:z:m concatenation of 8-byte little-endian IEEE 754 doubles. See the
+        // Bound Serialization section of the Iceberg spec.
+        return ((GeospatialBound) value).toByteBuffer();
       case UNKNOWN:
         // underlying type not known
         return null;
@@ -196,6 +203,9 @@ public class Conversions {
         return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
       case VARIANT:
         return Variant.from(tmp);
+      case GEOMETRY:
+      case GEOGRAPHY:
+        return GeospatialBound.fromByteBuffer(tmp);
       case UNKNOWN:
         // underlying type not known
         return null;

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -27,6 +27,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.primitives.Bytes;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.BooleanType;
 import org.apache.iceberg.types.Types.DateType;
@@ -196,66 +198,41 @@ public class TestConversions {
 
   @Test
   public void testByteBufferConversionsForGeometry() {
-    // geometry and geography lower/upper bounds are points encoded as an x:y:z:m concatenation
-    // of 8-byte little-endian IEEE 754 doubles. x and y are mandatory; the encoding is x:y when
-    // both z and m are unset, x:y:z when only m is unset, and x:y:NaN:m when only z is unset.
+    // geometry/geography bounds are a single point encoded as 8-byte little-endian IEEE 754
+    // doubles in X, Y[, Z][, M] order:
+    //   x:y       (16B) when z and m are unset
+    //   x:y:z     (24B) when only m is unset
+    //   x:y:NaN:m (32B) when only z is unset -- z slot is filled with NaN
+    //   x:y:z:m   (32B) when all are set
+    byte[] x = {0, 0, 0, 0, 0, 0, 36, 64}; // 10.0
+    byte[] y = {0, 0, 0, 0, 0, 0, 42, 64}; // 13.0
+    byte[] z = {0, 0, 0, 0, 0, 0, 46, 64}; // 15.0
+    byte[] m = {0, 0, 0, 0, 0, 0, 52, 64}; // 20.0
+    byte[] nan = {0, 0, 0, 0, 0, 0, -8, 127};
 
-    // x=10.0 -> 0, 0, 0, 0, 0, 0, 36, 64 (little-endian IEEE 754)
-    // y=13.0 -> 0, 0, 0, 0, 0, 0, 42, 64
-    // z=15.0 -> 0, 0, 0, 0, 0, 0, 46, 64
-    // m=20.0 -> 0, 0, 0, 0, 0, 0, 52, 64
-    // NaN    -> 0, 0, 0, 0, 0, 0, -8, 127
-
-    byte[] xyBytes = new byte[] {0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 42, 64};
-    byte[] xyzBytes =
-        new byte[] {
-          0, 0, 0, 0, 0, 0, 36, 64,
-          0, 0, 0, 0, 0, 0, 42, 64,
-          0, 0, 0, 0, 0, 0, 46, 64
-        };
-    byte[] xymBytes =
-        new byte[] {
-          0, 0, 0, 0, 0, 0, 36, 64,
-          0, 0, 0, 0, 0, 0, 42, 64,
-          0, 0, 0, 0, 0, 0, -8, 127,
-          0, 0, 0, 0, 0, 0, 52, 64
-        };
-    byte[] xyzmBytes =
-        new byte[] {
-          0, 0, 0, 0, 0, 0, 36, 64,
-          0, 0, 0, 0, 0, 0, 42, 64,
-          0, 0, 0, 0, 0, 0, 46, 64,
-          0, 0, 0, 0, 0, 0, 52, 64
-        };
-
-    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.crs84(), xyBytes);
-    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeometryType.crs84(), xyzBytes);
-    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeometryType.crs84(), xymBytes);
-    assertConversion(
-        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeometryType.crs84(), xyzmBytes);
-
-    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeographyType.crs84(), xyBytes);
-    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeographyType.crs84(), xyzBytes);
-    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeographyType.crs84(), xymBytes);
-    assertConversion(
-        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeographyType.crs84(), xyzmBytes);
+    for (Type type : ImmutableList.of(GeometryType.crs84(), GeographyType.crs84())) {
+      assertConversion(GeospatialBound.createXY(10.0, 13.0), type, Bytes.concat(x, y));
+      assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), type, Bytes.concat(x, y, z));
+      assertConversion(
+          GeospatialBound.createXYM(10.0, 13.0, 20.0), type, Bytes.concat(x, y, nan, m));
+      assertConversion(
+          GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), type, Bytes.concat(x, y, z, m));
+    }
 
     // a non-default CRS must not change the binary encoding
-    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.of("EPSG:3857"), xyBytes);
+    assertConversion(
+        GeospatialBound.createXY(10.0, 13.0), GeometryType.of("EPSG:3857"), Bytes.concat(x, y));
   }
 
   @Test
   public void testNullByteBufferConversionsForGeometry() {
-    // Null is handled by the shared guards in toByteBuffer / fromByteBuffer before the type
-    // switch, so this does not exercise the GEOMETRY / GEOGRAPHY arms (those are covered by
-    // testByteBufferConversionsForGeometry). It pins the null contract for geo types so a future
-    // change to the guards cannot silently alter null handling.
+    // Null is handled by the shared guards in toByteBuffer / fromByteBuffer before the type switch,
+    // so this pins the null contract for geo types rather than exercising the GEOMETRY / GEOGRAPHY
+    // arms (those are covered by testByteBufferConversionsForGeometry).
     assertThat(Conversions.toByteBuffer(GeometryType.crs84(), null)).isNull();
     assertThat(Conversions.toByteBuffer(GeographyType.crs84(), null)).isNull();
-    GeospatialBound geometryBound = Conversions.fromByteBuffer(GeometryType.crs84(), null);
-    GeospatialBound geographyBound = Conversions.fromByteBuffer(GeographyType.crs84(), null);
-    assertThat(geometryBound).isNull();
-    assertThat(geographyBound).isNull();
+    assertThat((Object) Conversions.fromByteBuffer(GeometryType.crs84(), null)).isNull();
+    assertThat((Object) Conversions.fromByteBuffer(GeographyType.crs84(), null)).isNull();
   }
 
   private <T> void assertConversion(T value, Type type, byte[] expectedBinary) {

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -26,6 +26,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.BooleanType;
 import org.apache.iceberg.types.Types.DateType;
@@ -33,6 +34,8 @@ import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.FixedType;
 import org.apache.iceberg.types.Types.FloatType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StringType;
@@ -189,6 +192,70 @@ public class TestConversions {
     assertConversion(new BigDecimal("0.011"), DecimalType.of(10, 3), new byte[] {11});
     assertThat(Literal.of(new BigDecimal("0.011")).toByteBuffer().array())
         .isEqualTo(new byte[] {11});
+  }
+
+  @Test
+  public void testByteBufferConversionsForGeometry() {
+    // geometry and geography lower/upper bounds are points encoded as an x:y:z:m concatenation
+    // of 8-byte little-endian IEEE 754 doubles. x and y are mandatory; the encoding is x:y when
+    // both z and m are unset, x:y:z when only m is unset, and x:y:NaN:m when only z is unset.
+
+    // x=10.0 -> 0, 0, 0, 0, 0, 0, 36, 64 (little-endian IEEE 754)
+    // y=13.0 -> 0, 0, 0, 0, 0, 0, 42, 64
+    // z=15.0 -> 0, 0, 0, 0, 0, 0, 46, 64
+    // m=20.0 -> 0, 0, 0, 0, 0, 0, 52, 64
+    // NaN    -> 0, 0, 0, 0, 0, 0, -8, 127
+
+    byte[] xyBytes = new byte[] {0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 42, 64};
+    byte[] xyzBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, 46, 64
+        };
+    byte[] xymBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, -8, 127,
+          0, 0, 0, 0, 0, 0, 52, 64
+        };
+    byte[] xyzmBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, 46, 64,
+          0, 0, 0, 0, 0, 0, 52, 64
+        };
+
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.crs84(), xyBytes);
+    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeometryType.crs84(), xyzBytes);
+    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeometryType.crs84(), xymBytes);
+    assertConversion(
+        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeometryType.crs84(), xyzmBytes);
+
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeographyType.crs84(), xyBytes);
+    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeographyType.crs84(), xyzBytes);
+    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeographyType.crs84(), xymBytes);
+    assertConversion(
+        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeographyType.crs84(), xyzmBytes);
+
+    // a non-default CRS must not change the binary encoding
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.of("EPSG:3857"), xyBytes);
+  }
+
+  @Test
+  public void testNullByteBufferConversionsForGeometry() {
+    // Null is handled by the shared guards in toByteBuffer / fromByteBuffer before the type
+    // switch, so this does not exercise the GEOMETRY / GEOGRAPHY arms (those are covered by
+    // testByteBufferConversionsForGeometry). It pins the null contract for geo types so a future
+    // change to the guards cannot silently alter null handling.
+    assertThat(Conversions.toByteBuffer(GeometryType.crs84(), null)).isNull();
+    assertThat(Conversions.toByteBuffer(GeographyType.crs84(), null)).isNull();
+    GeospatialBound geometryBound = Conversions.fromByteBuffer(GeometryType.crs84(), null);
+    GeospatialBound geographyBound = Conversions.fromByteBuffer(GeographyType.crs84(), null);
+    assertThat(geometryBound).isNull();
+    assertThat(geographyBound).isNull();
   }
 
   private <T> void assertConversion(T value, Type type, byte[] expectedBinary) {

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -204,24 +204,31 @@ public class TestConversions {
     //   x:y:z     (24B) when only m is unset
     //   x:y:NaN:m (32B) when only z is unset -- z slot is filled with NaN
     //   x:y:z:m   (32B) when all are set
-    byte[] x = {0, 0, 0, 0, 0, 0, 36, 64}; // 10.0
-    byte[] y = {0, 0, 0, 0, 0, 0, 42, 64}; // 13.0
-    byte[] z = {0, 0, 0, 0, 0, 0, 46, 64}; // 15.0
-    byte[] m = {0, 0, 0, 0, 0, 0, 52, 64}; // 20.0
-    byte[] nan = {0, 0, 0, 0, 0, 0, -8, 127};
+    byte[] xBytes = {0, 0, 0, 0, 0, 0, 36, 64}; // 10.0
+    byte[] yBytes = {0, 0, 0, 0, 0, 0, 42, 64}; // 13.0
+    byte[] zBytes = {0, 0, 0, 0, 0, 0, 46, 64}; // 15.0
+    byte[] mBytes = {0, 0, 0, 0, 0, 0, 52, 64}; // 20.0
+    byte[] nanBytes = {0, 0, 0, 0, 0, 0, -8, 127};
 
     for (Type type : ImmutableList.of(GeometryType.crs84(), GeographyType.crs84())) {
-      assertConversion(GeospatialBound.createXY(10.0, 13.0), type, Bytes.concat(x, y));
-      assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), type, Bytes.concat(x, y, z));
+      assertConversion(GeospatialBound.createXY(10.0, 13.0), type, Bytes.concat(xBytes, yBytes));
       assertConversion(
-          GeospatialBound.createXYM(10.0, 13.0, 20.0), type, Bytes.concat(x, y, nan, m));
+          GeospatialBound.createXYZ(10.0, 13.0, 15.0), type, Bytes.concat(xBytes, yBytes, zBytes));
       assertConversion(
-          GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), type, Bytes.concat(x, y, z, m));
+          GeospatialBound.createXYM(10.0, 13.0, 20.0),
+          type,
+          Bytes.concat(xBytes, yBytes, nanBytes, mBytes));
+      assertConversion(
+          GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0),
+          type,
+          Bytes.concat(xBytes, yBytes, zBytes, mBytes));
     }
 
     // a non-default CRS must not change the binary encoding
     assertConversion(
-        GeospatialBound.createXY(10.0, 13.0), GeometryType.of("EPSG:3857"), Bytes.concat(x, y));
+        GeospatialBound.createXY(10.0, 13.0),
+        GeometryType.of("EPSG:3857"),
+        Bytes.concat(xBytes, yBytes));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Hook `GeospatialBound` into `Conversions.toByteBuffer` / `fromByteBuffer` so that v3 single-value binary serialization for `geometry` and `geography` actually round-trips through Iceberg's central type conversion API.

The encoding itself is already implemented in `GeospatialBound` per the [Bound Serialization](https://iceberg.apache.org/spec/#bound-serialization) section of the spec (Appendix D): an x:y:z:m concatenation of 8-byte little-endian IEEE 754 doubles, with x:y when both z and m are unset, x:y:z when only m is unset, and x:y:NaN:m when only z is unset.

Today `Conversions.toByteBuffer(GeometryType, ...)` and `fromByteBuffer(GeometryType, ...)` fall through to the `default` case and throw `UnsupportedOperationException`, so any caller that goes through `Conversions` (manifest writers/readers, `ContentFileParser`, metric helpers, etc.) cannot handle geo lower/upper bounds. This PR adds the missing cases. It is purely additive — no behavior changes for non-geo types and no downstream code is silently activated, since the file readers/writers and evaluators still need their own follow-ups.

## Test plan

- [x] New `testByteBufferConversionsForGeometry` covers `geometry` and `geography` × {XY (16B), XYZ (24B), XYM (32B with NaN-Z slot), XYZM (32B)} round-trips with explicit byte layouts, plus a non-default CRS to confirm the encoding is CRS-independent.
- [x] New `testNullByteBufferConversionsForGeometry` covers null in both directions for both types.
- [x] `./gradlew :iceberg-api:test --tests "org.apache.iceberg.types.*" --tests "org.apache.iceberg.geospatial.*"` — all green, no regressions in `TestGeospatialBound` / `TestBoundingBox`.
- [x] `./gradlew :iceberg-api:checkstyleMain :iceberg-api:checkstyleTest :iceberg-api:spotlessCheck` — clean.