### PR TITLE
Snowflake: Avoid mutating caller-supplied properties map during catalog initialization

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -124,14 +125,20 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     String uniqueId = UUID.randomUUID().toString().replace("-", "").substring(0, UNIQUE_ID_LENGTH);
     String uniqueAppIdentifier = APP_IDENTIFIER + "_" + uniqueId;
     String userAgentSuffix = IcebergBuild.fullVersion() + " " + uniqueAppIdentifier;
+    // Copy the caller-provided map so initialize does not mutate it (the caller may pass an
+    // immutable map) when adding the JDBC driver identifiers below.
+    Map<String, String> effectiveProperties = Maps.newHashMap(properties);
     // Populate application identifier in jdbc client
-    properties.put(JdbcCatalog.PROPERTY_PREFIX + JDBC_APPLICATION_PROPERTY, uniqueAppIdentifier);
+    effectiveProperties.put(
+        JdbcCatalog.PROPERTY_PREFIX + JDBC_APPLICATION_PROPERTY, uniqueAppIdentifier);
     // Adds application identifier to the user agent header of the JDBC requests.
-    properties.put(JdbcCatalog.PROPERTY_PREFIX + JDBC_USER_AGENT_SUFFIX_PROPERTY, userAgentSuffix);
+    effectiveProperties.put(
+        JdbcCatalog.PROPERTY_PREFIX + JDBC_USER_AGENT_SUFFIX_PROPERTY, userAgentSuffix);
 
-    JdbcClientPool connectionPool = new JdbcClientPool(uri, properties);
+    JdbcClientPool connectionPool = new JdbcClientPool(uri, effectiveProperties);
 
-    initialize(name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), properties);
+    initialize(
+        name, new JdbcSnowflakeClient(connectionPool), new FileIOFactory(), effectiveProperties);
   }
 
   /**

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/TestSnowflakeCatalog.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/TestSnowflakeCatalog.java
@@ -19,10 +19,12 @@
 package org.apache.iceberg.snowflake;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -294,5 +296,36 @@ public class TestSnowflakeCatalog {
     assertThat(catalog.namespaceExists(Namespace.of("DB_1", "SCHEMA_1"))).isTrue();
     assertThat(catalog.namespaceExists(Namespace.of("DB_1", "NONEXISTENT_SCHEMA"))).isFalse();
     assertThat(catalog.namespaceExists(Namespace.of("NONEXISTENT_DB", "SCHEMA_1"))).isFalse();
+  }
+
+  @Test
+  public void testInitializeWithImmutableProperties() throws IOException {
+    catalog = new SnowflakeCatalog();
+    // A caller may legitimately pass an immutable properties map (Map.of()/ImmutableMap.of() is an
+    // idiomatic, contract-legal pattern used throughout the codebase). Initialization must not
+    // require a mutable map.
+    assertThatCode(
+            () ->
+                catalog.initialize(
+                    TEST_CATALOG_NAME,
+                    ImmutableMap.of(
+                        CatalogProperties.URI, "jdbc:snowflake://acct.snowflakecomputing.com")))
+        .doesNotThrowAnyException();
+    catalog.close();
+  }
+
+  @Test
+  public void testInitializeDoesNotMutateCallerProperties() throws IOException {
+    catalog = new SnowflakeCatalog();
+    Map<String, String> callerProperties =
+        ImmutableMap.of(CatalogProperties.URI, "jdbc:snowflake://acct.snowflakecomputing.com");
+    Map<String, String> propertiesPassedToInitialize = Maps.newHashMap(callerProperties);
+
+    catalog.initialize(TEST_CATALOG_NAME, propertiesPassedToInitialize);
+
+    assertThat(propertiesPassedToInitialize)
+        .as("initialize must not mutate the caller-supplied properties map")
+        .isEqualTo(callerProperties);
+    catalog.close();
   }
 }


### PR DESCRIPTION
## Summary

`SnowflakeCatalog.initialize(String, Map)` adds the JDBC `application` and `user_agent_suffix` identifiers by calling `properties.put(...)` directly on the caller-supplied map. This has two problems: it throws `UnsupportedOperationException` when the caller passes an immutable map (for example `Map.of(...)` or `ImmutableMap.of(...)`, which is a contract-legal and idiomatic way to call `Catalog.initialize`), and even with a mutable map it silently pollutes the caller's map with the two derived JDBC properties.

Every other catalog (`JdbcCatalog`, `GlueCatalog`, `DynamoDbCatalog`, `HadoopCatalog`, `InMemoryCatalog`) treats the input properties as read-only and copies them. This change makes `SnowflakeCatalog` do the same: it builds a mutable copy with `Maps.newHashMap(properties)`, adds the JDBC identifiers to the copy, and passes the copy to the JDBC client pool and catalog initialization, leaving the caller's map untouched.

## Tests

Added two tests to `TestSnowflakeCatalog`: `testInitializeWithImmutableProperties` verifies that initializing with an immutable properties map no longer throws, and `testInitializeDoesNotMutateCallerProperties` verifies that a mutable caller map is left unmodified after `initialize`. Both fail before this change and pass after.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Stop SnowflakeCatalog.initialize from mutating the caller-supplied properties map.
