### PR TITLE
ORC: Push down timestamp_ns and timestamptz_ns predicates

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ExpressionToSearchArgument.java
@@ -301,6 +301,7 @@ class ExpressionToSearchArgument
       case DATE:
         return PredicateLeaf.Type.DATE;
       case TIMESTAMP:
+      case TIMESTAMP_NANO:
         return PredicateLeaf.Type.TIMESTAMP;
       case STRING:
         return PredicateLeaf.Type.STRING;
@@ -333,6 +334,12 @@ class ExpressionToSearchArgument
             Instant.ofEpochSecond(
                 Math.floorDiv(microsFromEpoch, 1_000_000),
                 Math.floorMod(microsFromEpoch, 1_000_000) * 1_000L));
+      case TIMESTAMP_NANO:
+        long nanosFromEpoch = (Long) icebergLiteral;
+        return Timestamp.from(
+            Instant.ofEpochSecond(
+                Math.floorDiv(nanosFromEpoch, 1_000_000_000),
+                Math.floorMod(nanosFromEpoch, 1_000_000_000)));
       case DECIMAL:
         return new HiveDecimalWritable(HiveDecimal.create((BigDecimal) icebergLiteral, false));
       default:

--- a/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestExpressionToSearchArgument.java
@@ -139,6 +139,37 @@ public class TestExpressionToSearchArgument {
   }
 
   @Test
+  public void testTimestampNanoTypes() {
+    OffsetDateTime epoch = Instant.ofEpochSecond(0).atOffset(ZoneOffset.UTC);
+    OffsetDateTime tsTzNsPredicate = OffsetDateTime.parse("2019-10-02T00:47:28.207366Z");
+    OffsetDateTime tsNsPredicate = OffsetDateTime.parse("1968-01-16T13:07:59.048625Z");
+
+    Schema schema =
+        new Schema(
+            required(1, "tsTzNs", Types.TimestampNanoType.withZone()),
+            required(2, "tsNs", Types.TimestampNanoType.withoutZone()));
+
+    Expression expr =
+        and(
+            equal("tsTzNs", ChronoUnit.MICROS.between(epoch, tsTzNsPredicate)),
+            equal("tsNs", ChronoUnit.MICROS.between(epoch, tsNsPredicate)));
+    Expression boundFilter = Binder.bind(schema.asStruct(), expr, true);
+
+    // timestamp_ns / timestamptz_ns push down as ORC TIMESTAMP predicates; ORC's java.sql.Timestamp
+    // carries nanosecond precision, so the bound is exact.
+    SearchArgument expected =
+        SearchArgumentFactory.newBuilder()
+            .startAnd()
+            .equals("`tsTzNs`", Type.TIMESTAMP, Timestamp.from(tsTzNsPredicate.toInstant()))
+            .equals("`tsNs`", Type.TIMESTAMP, Timestamp.from(tsNsPredicate.toInstant()))
+            .end()
+            .build();
+    SearchArgument actual =
+        ExpressionToSearchArgument.convert(boundFilter, ORCSchemaUtil.convert(schema));
+    assertThat(actual.toString()).isEqualTo(expected.toString());
+  }
+
+  @Test
   public void testTimezoneSensitiveTypes() {
     TimeZone currentTz = TimeZone.getDefault();
     try {

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDataReader.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.orc;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -166,5 +168,135 @@ public class TestOrcDataReader implements WithAssertions {
     assertThat(readRecords.get(0).get(0)).isEqualTo(3L);
     assertThat(readRecords.get(0).get(1)).isEqualTo("c");
     assertThat(readRecords.get(0).get(3)).isEqualTo(Arrays.asList(3, 4, 5));
+  }
+
+  @Test
+  public void testTimestampNanoFilterPushdownRespectsNanoseconds() throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "ts", Types.TimestampNanoType.withoutZone()));
+
+    // Five rows; ids 0..2 share the same microsecond, distinguished only by nanoseconds.
+    GenericRecord template = GenericRecord.create(schema);
+    List<Record> writeRecords =
+        Lists.newArrayList(
+            template.copy(
+                ImmutableMap.of(
+                    "id", 0L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000000"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 1L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000250"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 2L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000750"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 3L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000001500"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 4L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000003000"))));
+
+    OutputFile nanoFile =
+        Files.localOutput(File.createTempFile("ts-nano", ".orc", new File(temp.getPath())));
+    DataWriter<Record> nanoWriter =
+        ORC.writeData(nanoFile)
+            .schema(schema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try {
+      for (Record record : writeRecords) {
+        nanoWriter.write(record);
+      }
+    } finally {
+      nanoWriter.close();
+    }
+
+    // Filter at a sub-microsecond boundary (>= 500 ns within the first microsecond). If ORC honors
+    // nanosecond precision, only ids 2 (750 ns), 3 (1500 ns), 4 (3000 ns) remain. If it truncates
+    // to micros, ids 0/1/2 are indistinguishable and the result is wrong.
+    try (CloseableIterable<Record> reader =
+        ORC.read(nanoFile.toInputFile())
+            .project(schema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+            .filter(Expressions.greaterThanOrEqual("ts", "2024-01-01T00:00:00.000000500"))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .config(OrcConf.READER_USE_SELECTED.getAttribute(), String.valueOf(true))
+            .build()) {
+      List<Long> ids = Lists.newArrayList();
+      for (Record record : reader) {
+        ids.add((Long) record.getField("id"));
+      }
+      assertThat(ids).containsExactly(2L, 3L, 4L);
+    }
+  }
+
+  @Test
+  public void testTimestampTzNanoFilterAcrossTimezones() throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.required(2, "tsTz", Types.TimestampNanoType.withZone()));
+
+    // Each row is written in a DIFFERENT zone offset but the instants share the same UTC second and
+    // differ only by nanoseconds: id0 +0ns, id1 +500ns, id2 +750ns, id3 +1500ns, id4 +3000ns.
+    GenericRecord template = GenericRecord.create(schema);
+    List<Record> writeRecords =
+        Lists.newArrayList(
+            template.copy(
+                ImmutableMap.of(
+                    "id", 0L, "tsTz", OffsetDateTime.parse("2024-01-01T00:00:00.000000000+00:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 1L, "tsTz", OffsetDateTime.parse("2024-01-01T05:00:00.000000500+05:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 2L, "tsTz", OffsetDateTime.parse("2023-12-31T16:00:00.000000750-08:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 3L, "tsTz", OffsetDateTime.parse("2024-01-01T05:30:00.000001500+05:30"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id",
+                    4L,
+                    "tsTz",
+                    OffsetDateTime.parse("2024-01-01T00:00:00.000003000+00:00"))));
+
+    OutputFile tzFile =
+        Files.localOutput(File.createTempFile("ts-tz-nano", ".orc", new File(temp.getPath())));
+    DataWriter<Record> tzWriter =
+        ORC.writeData(tzFile)
+            .schema(schema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try {
+      for (Record record : writeRecords) {
+        tzWriter.write(record);
+      }
+    } finally {
+      tzWriter.close();
+    }
+
+    // Boundary expressed in +04:00 (== 2024-01-01T00:00:00.000000500Z). Comparison is by instant at
+    // nanosecond precision, so only ids 2 (750 ns), 3 (1500 ns), 4 (3000 ns) remain regardless of
+    // the zone each value was written in.
+    try (CloseableIterable<Record> reader =
+        ORC.read(tzFile.toInputFile())
+            .project(schema)
+            .createReaderFunc(fileSchema -> GenericOrcReader.buildReader(schema, fileSchema))
+            .filter(Expressions.greaterThan("tsTz", "2024-01-01T04:00:00.000000500+04:00"))
+            .config(OrcConf.ALLOW_SARG_TO_FILTER.getAttribute(), String.valueOf(true))
+            .config(OrcConf.READER_USE_SELECTED.getAttribute(), String.valueOf(true))
+            .build()) {
+      List<Long> ids = Lists.newArrayList();
+      for (Record record : reader) {
+        ids.add((Long) record.getField("id"));
+      }
+      assertThat(ids).containsExactly(2L, 3L, 4L);
+    }
   }
 }


### PR DESCRIPTION
## What

Pushes Iceberg `timestamp_ns` and `timestamptz_ns` predicates down into the ORC reader. Before this change, any filter on a nanosecond-timestamp column threw `UnsupportedOperationException: Type timestamp_ns not supported in ORC SearchArguments` and failed the read.

## Why

`ExpressionToSearchArgument` maps Iceberg types to an ORC `PredicateLeaf.Type` in `type()` and to predicate values in `literal()`, but `TIMESTAMP_NANO` was handled in neither switch, and it was also missing from `UNSUPPORTED_TYPES` (the set of types that degrade gracefully to `YES_NO_NULL`). So a nanosecond-timestamp predicate fell through to the `default:` branch and threw, crashing any filtered read of such a column. This affects both `timestamp_ns` and `timestamptz_ns` (both have type id `TIMESTAMP_NANO`) and every predicate kind, since they all call `type()`.

ORC 1.9.8 represents timestamp predicates with `java.sql.Timestamp`, which carries full nanosecond precision, and evaluates row-level filters at that precision, so the predicate can be pushed down exactly rather than skipped.

## Changes

`ExpressionToSearchArgument` now maps `TIMESTAMP_NANO` to `PredicateLeaf.Type.TIMESTAMP` and converts the nanos-from-epoch literal to a `java.sql.Timestamp`, mirroring the existing micros `TIMESTAMP` handling.

## Tests

- `TestExpressionToSearchArgument#testTimestampNanoTypes` asserts the converted `SearchArgument` for both `timestamp_ns` and `timestamptz_ns`.
- `TestOrcDataReader#testTimestampNanoFilterPushdownRespectsNanoseconds` writes rows that differ only by sub-microsecond nanoseconds and verifies that row-level SARG filtering returns exactly the rows past a sub-microsecond boundary, proving nanosecond precision is honored rather than truncated to micros.
- `TestOrcDataReader#testTimestampTzNanoFilterAcrossTimezones` writes `timestamptz_ns` values in several different zone offsets and filters with a boundary expressed in yet another zone, verifying the comparison is by instant at nanosecond precision.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Push down timestamp_ns and timestamptz_ns predicates into the ORC reader.
