### PR TITLE
implement cache expiration policy

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CatalogProperties.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogProperties.java
@@ -56,14 +56,18 @@ public class CatalogProperties {
    * <ul>
    *   <li>Zero - Caching and cache expiration are both disabled
    *   <li>Negative Values - Cache expiration is turned off and entries expire only on refresh etc
-   *   <li>Positive Values - Cache entries expire if not accessed via the cache after this many
-   *       milliseconds
+   *   <li>Positive Values - Cache entries expire this milliseconds based on the cache expiration
+   *       policy
    * </ul>
    */
   public static final String CACHE_EXPIRATION_INTERVAL_MS = "cache.expiration-interval-ms";
 
   public static final long CACHE_EXPIRATION_INTERVAL_MS_DEFAULT = TimeUnit.SECONDS.toMillis(30);
   public static final long CACHE_EXPIRATION_INTERVAL_MS_OFF = -1;
+
+  public static final String CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS =
+      "cache.expiration.expire-after-write-interval-ms";
+  public static final long CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT = 0;
 
   /**
    * Controls whether to use caching during manifest reads or not.

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -146,6 +146,7 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | clients                           | 2                  | client pool size                                       |
 | cache-enabled                     | true               | Whether to cache catalog entries |
 | cache.expiration-interval-ms      | 30000              | How long catalog entries are locally cached, in milliseconds; 0 disables caching, negative values disable expiration |
+| cache.expire-after-write-ms       | 0                  | Duration in milliseconds to expire a table from the cache after being created.tables will not refresh on write. 0 disables this policy. its disabled by default |
 | metrics-reporter-impl | org.apache.iceberg.metrics.LoggingMetricsReporter | Custom `MetricsReporter` implementation to use in a catalog. See the [Metrics reporting](metrics-reporting.md) section for additional details |
 | encryption.kms-impl               | null               | a custom `KeyManagementClient` implementation to use in a catalog for interactions with KMS (key management service). See the [Encryption](encryption.md) document for additional details |
 
@@ -235,9 +236,9 @@ Warn: Setting `iceberg.engine.hive.lock-enabled`=`false` will cause HiveCatalog 
 This should only be set to `false` if all following conditions are met:
 
 - [HIVE-26882](https://issues.apache.org/jira/browse/HIVE-26882)
-is available on the Hive Metastore server
+  is available on the Hive Metastore server
 - [HIVE-28121](https://issues.apache.org/jira/browse/HIVE-28121)
-is available on the Hive Metastore server, if it is backed by MySQL or MariaDB
+  is available on the Hive Metastore server, if it is backed by MySQL or MariaDB
 - All other HiveCatalogs committing to tables that this HiveCatalog commits to are also on Iceberg 1.3 or later
 - All other HiveCatalogs committing to tables that this HiveCatalog commits to have also disabled Hive locks on commit.
 

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -108,7 +108,8 @@ public class FlinkCatalog extends AbstractCatalog {
       CatalogLoader catalogLoader,
       Map<String, String> catalogProps,
       boolean cacheEnabled,
-      long cacheExpirationIntervalMs) {
+      long cacheExpirationIntervalMs,
+      long cacheExpireAfterWriteIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.catalogProps = catalogProps;
@@ -118,7 +119,8 @@ public class FlinkCatalog extends AbstractCatalog {
     Catalog originalCatalog = catalogLoader.loadCatalog();
     icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                originalCatalog, cacheExpirationIntervalMs, cacheExpireAfterWriteIntervalMs)
             : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -163,6 +163,12 @@ public class FlinkCatalogFactory implements CatalogFactory {
         "%s is not allowed to be 0.",
         CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     return new FlinkCatalog(
         name,
         defaultDatabase,
@@ -170,7 +176,8 @@ public class FlinkCatalogFactory implements CatalogFactory {
         catalogLoader,
         properties,
         cacheEnabled,
-        cacheExpirationIntervalMs);
+        cacheExpirationIntervalMs,
+        cacheExpireAfterWriteIntervalMs);
   }
 
   private static Configuration mergeHiveConf(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -108,7 +108,8 @@ public class FlinkCatalog extends AbstractCatalog {
       CatalogLoader catalogLoader,
       Map<String, String> catalogProps,
       boolean cacheEnabled,
-      long cacheExpirationIntervalMs) {
+      long cacheExpirationIntervalMs,
+      long cacheExpireAfterWriteIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.catalogProps = catalogProps;
@@ -118,7 +119,8 @@ public class FlinkCatalog extends AbstractCatalog {
     Catalog originalCatalog = catalogLoader.loadCatalog();
     icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                originalCatalog, cacheExpirationIntervalMs, cacheExpireAfterWriteIntervalMs)
             : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -165,6 +165,12 @@ public class FlinkCatalogFactory implements CatalogFactory {
         "%s is not allowed to be 0.",
         CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     return new FlinkCatalog(
         name,
         defaultDatabase,
@@ -172,7 +178,8 @@ public class FlinkCatalogFactory implements CatalogFactory {
         catalogLoader,
         properties,
         cacheEnabled,
-        cacheExpirationIntervalMs);
+        cacheExpirationIntervalMs,
+        cacheExpireAfterWriteIntervalMs);
   }
 
   private static Configuration mergeHiveConf(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -108,7 +108,8 @@ public class FlinkCatalog extends AbstractCatalog {
       CatalogLoader catalogLoader,
       Map<String, String> catalogProps,
       boolean cacheEnabled,
-      long cacheExpirationIntervalMs) {
+      long cacheExpirationIntervalMs,
+      long cacheExpireAfterWriteIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
     this.catalogProps = catalogProps;
@@ -118,7 +119,8 @@ public class FlinkCatalog extends AbstractCatalog {
     Catalog originalCatalog = catalogLoader.loadCatalog();
     icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(originalCatalog, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                originalCatalog, cacheExpirationIntervalMs, cacheExpireAfterWriteIntervalMs)
             : originalCatalog;
     asNamespaceCatalog =
         originalCatalog instanceof SupportsNamespaces ? (SupportsNamespaces) originalCatalog : null;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -165,6 +165,12 @@ public class FlinkCatalogFactory implements CatalogFactory {
         "%s is not allowed to be 0.",
         CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            properties,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     return new FlinkCatalog(
         name,
         defaultDatabase,
@@ -172,7 +178,8 @@ public class FlinkCatalogFactory implements CatalogFactory {
         catalogLoader,
         properties,
         cacheEnabled,
-        cacheExpirationIntervalMs);
+        cacheExpirationIntervalMs,
+        cacheExpireAfterWriteIntervalMs);
   }
 
   private static Configuration mergeHiveConf(

--- a/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.4/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -763,9 +763,15 @@ public class SparkCatalog extends BaseCatalog {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            options,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.
-    if (cacheExpirationIntervalMs == 0) {
+    if (cacheExpirationIntervalMs == 0 && cacheExpireAfterWriteIntervalMs == 0) {
       this.cacheEnabled = false;
     }
 
@@ -777,7 +783,11 @@ public class SparkCatalog extends BaseCatalog {
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                catalog,
+                cacheCaseSensitive,
+                cacheExpirationIntervalMs,
+                cacheExpireAfterWriteIntervalMs)
             : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -765,9 +765,15 @@ public class SparkCatalog extends BaseCatalog {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            options,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.
-    if (cacheExpirationIntervalMs == 0) {
+    if (cacheExpirationIntervalMs == 0 && cacheExpireAfterWriteIntervalMs == 0) {
       this.cacheEnabled = false;
     }
 
@@ -779,7 +785,11 @@ public class SparkCatalog extends BaseCatalog {
         new HadoopTables(SparkUtil.hadoopConfCatalogOverrides(SparkSession.active(), name));
     this.icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                catalog,
+                cacheCaseSensitive,
+                cacheExpirationIntervalMs,
+                cacheExpireAfterWriteIntervalMs)
             : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -764,9 +764,15 @@ public class SparkCatalog extends BaseCatalog {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            options,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.
-    if (cacheExpirationIntervalMs == 0) {
+    if (cacheExpirationIntervalMs == 0 && cacheExpireAfterWriteIntervalMs == 0) {
       this.cacheEnabled = false;
     }
 
@@ -779,7 +785,11 @@ public class SparkCatalog extends BaseCatalog {
             SparkUtil.hadoopConfCatalogOverrides(SparkSession.getActiveSession().get(), name));
     this.icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                catalog,
+                cacheCaseSensitive,
+                cacheExpirationIntervalMs,
+                cacheExpireAfterWriteIntervalMs)
             : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -764,9 +764,15 @@ public class SparkCatalog extends BaseCatalog {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
+    long cacheExpireAfterWriteIntervalMs =
+        PropertyUtil.propertyAsLong(
+            options,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS,
+            CatalogProperties.CACHE_EXPIRATION_EXPIRE_AFTER_WRITE_INTERVAL_MS_DEFAULT);
+
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.
-    if (cacheExpirationIntervalMs == 0) {
+    if (cacheExpirationIntervalMs == 0 && cacheExpireAfterWriteIntervalMs == 0) {
       this.cacheEnabled = false;
     }
 
@@ -779,7 +785,11 @@ public class SparkCatalog extends BaseCatalog {
             SparkUtil.hadoopConfCatalogOverrides(SparkSession.getActiveSession().get(), name));
     this.icebergCatalog =
         cacheEnabled
-            ? CachingCatalog.wrap(catalog, cacheCaseSensitive, cacheExpirationIntervalMs)
+            ? CachingCatalog.wrap(
+                catalog,
+                cacheCaseSensitive,
+                cacheExpirationIntervalMs,
+                cacheExpireAfterWriteIntervalMs)
             : catalog;
     if (catalog instanceof SupportsNamespaces) {
       this.asNamespaceCatalog = (SupportsNamespaces) catalog;


### PR DESCRIPTION
### Allow dual catalog cache expiration policies (expire-after-access and expire-after-write)
---
This change enhances Iceberg’s catalog-level cache by allowing `expire-after-access` and `expire-after-write` policies to be used concurrently. This provides more flexible and powerful cache-tuning strategies by enabling both time-since-last-access and time-since-creation eviction policies on the same cache.

This is achieved by introducing a new property, `cache.expiration.expire-after-write-interval-ms`, which works in conjunction with the existing `cache.expiration-interval-ms` (which controls `expire-after-access`).

This addresses the pain point described in Issue #14417, where long-running streaming jobs could prevent cache entries from ever expiring under a pure access-based policy. By combining both policies, users can ensure periodic data refreshes while still efficiently caching frequently accessed tables.

 ---
#### Background

In many scenarios, especially with long-running services, you want to balance performance with data freshness. For example:

- Performance: Caching is essential to avoid the high cost of reloading table metadata for every query.
- Freshness: Cached entries must be periodically refreshed to pick up new snapshots or to prevent issues with expired credentials.

Using `expire-after-access` alone is not sufficient for continuous workloads, as frequently accessed entries may never be evicted. Using` expire-after-write` alone can be inefficient if it evicts "hot" entries that are still in active use.

By using both, you can configure a "best-of-both-worlds" strategy:
- A shorter expire-after-access duration to quickly evict inactive tables.
- A longer expire-after-write duration to act as a safety net, ensuring that even "hot" tables are refreshed periodically (e.g., before underlying credentials expire).
 
 ---
#### What changed in this PR
##### ✅ New catalog property for dual-policy expiration
Two distinct properties now control cache expiration. An entry is evicted if either condition is met. If both are set to a non-positive value, caching is disabled.


| Property                          | Default            | Description                                            |
| --------------------------------- | ------------------ | ------------------------------------------------------ |
| cache.expire-after-write-ms       | 0                  | Duration in milliseconds to expire a table from the cache after being created.tables will not refresh on write. 0 disables this policy. its disabled by default |

##### ✅ CachingCatalog supports dual policies
`CachingCatalog.wrap(...)` has been updated to configure the underlying Caffeine cache with both expiration policies when both properties are provided.
##### ✅ Tests cover dual-policy scenarios
Tests have been added to validate that when both policies are active, an entry is evicted based on whichever condition is met first, and that each policy works correctly on its own.


#####
Followup: #14440 