### PR TITLE
Core: Handle ExceptionInInitializerError & NoClassDefFoundError invoke-time failures in DynMethods callers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -50,25 +50,31 @@ public class InternalData {
     READ_BUILDERS.put(format, readBuilder);
   }
 
-  @SuppressWarnings("CatchBlockLogException")
   private static void registerSupportedFormats() {
     InternalData.register(
         FileFormat.AVRO,
         outputFile -> Avro.write(outputFile).createWriterFunc(InternalWriter::create),
         inputFile -> Avro.read(inputFile).createResolvingReader(InternalReader::create));
 
+    register("org.apache.iceberg.InternalParquet");
+  }
+
+  /**
+   * Invokes the static {@code register} method of the given class, tolerating the failure modes
+   * that occur when an optional module (like {@code iceberg-parquet}) is not on the classpath.
+   *
+   * <p>Besides {@link NoSuchMethodException}, invoking {@code register} can fail with {@link
+   * NoClassDefFoundError} when its body references a missing transitive dependency, or {@link
+   * ExceptionInInitializerError} when it triggers a failing static initializer.
+   */
+  @SuppressWarnings("CatchBlockLogException")
+  private static void register(String classToRegister) {
     try {
-      DynMethods.StaticMethod registerParquet =
-          DynMethods.builder("register")
-              .impl("org.apache.iceberg.InternalParquet")
-              .buildStaticChecked();
-
-      registerParquet.invoke();
-
+      DynMethods.builder("register").impl(classToRegister).buildStaticChecked().invoke();
     } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
-      // failing to load Parquet is normal and does not require a stack trace
+      // failing to load an optional format is normal and does not require a stack trace
       Throwable cause = e.getCause() != null ? e.getCause() : e;
-      LOG.info("Unable to register Parquet for metadata files: {}", cause.toString());
+      LOG.info("Cannot register {} for metadata files: {}", classToRegister, cause.toString());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -67,8 +67,8 @@ public class InternalData {
 
     } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
       // failing to load Parquet is normal and does not require a stack trace
-      String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
-      LOG.info("Unable to register Parquet for metadata files: {}", message);
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      LOG.info("Unable to register Parquet for metadata files: {}", cause.toString());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/InternalData.java
+++ b/core/src/main/java/org/apache/iceberg/InternalData.java
@@ -65,9 +65,10 @@ public class InternalData {
 
       registerParquet.invoke();
 
-    } catch (NoSuchMethodException e) {
+    } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
       // failing to load Parquet is normal and does not require a stack trace
-      LOG.info("Unable to register Parquet for metadata files: {}", e.getMessage());
+      String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+      LOG.info("Unable to register Parquet for metadata files: {}", message);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
+++ b/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
@@ -199,20 +199,33 @@ public final class FormatModelRegistry {
     return model;
   }
 
-  @SuppressWarnings("CatchBlockLogException")
   private static void registerSupportedFormats() {
     // Uses dynamic methods to call the `register` for the listed classes
     for (String classToRegister : CLASSES_TO_REGISTER) {
-      try {
-        DynMethods.builder("register").impl(classToRegister).buildStaticChecked().invoke();
-      } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
-        // failing to register a factory is normal and does not require a stack trace
-        Throwable cause = e.getCause() != null ? e.getCause() : e;
-        LOG.info(
-            "Unable to call register for ({}). Check for missing jars on the classpath: {}",
-            classToRegister,
-            cause.toString());
-      }
+      register(classToRegister);
+    }
+  }
+
+  /**
+   * Invokes the static {@code register} method of the given class, tolerating the failure modes
+   * that occur when an optional module (like {@code iceberg-parquet} or {@code iceberg-orc}) is not
+   * on the classpath.
+   *
+   * <p>Besides {@link NoSuchMethodException}, invoking {@code register} can fail with {@link
+   * NoClassDefFoundError} when its body references a missing transitive dependency, or {@link
+   * ExceptionInInitializerError} when it triggers a failing static initializer.
+   */
+  @SuppressWarnings("CatchBlockLogException")
+  private static void register(String classToRegister) {
+    try {
+      DynMethods.builder("register").impl(classToRegister).buildStaticChecked().invoke();
+    } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
+      // failing to register a factory is normal and does not require a stack trace
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      LOG.info(
+          "Unable to call register for ({}). Check for missing jars on the classpath: {}",
+          classToRegister,
+          cause.toString());
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
+++ b/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
@@ -205,12 +205,13 @@ public final class FormatModelRegistry {
     for (String classToRegister : CLASSES_TO_REGISTER) {
       try {
         DynMethods.builder("register").impl(classToRegister).buildStaticChecked().invoke();
-      } catch (NoSuchMethodException e) {
+      } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
         // failing to register a factory is normal and does not require a stack trace
+        String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
         LOG.info(
             "Unable to call register for ({}). Check for missing jars on the classpath: {}",
             classToRegister,
-            e.getMessage());
+            message);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
+++ b/core/src/main/java/org/apache/iceberg/formats/FormatModelRegistry.java
@@ -207,11 +207,11 @@ public final class FormatModelRegistry {
         DynMethods.builder("register").impl(classToRegister).buildStaticChecked().invoke();
       } catch (NoSuchMethodException | NoClassDefFoundError | ExceptionInInitializerError e) {
         // failing to register a factory is normal and does not require a stack trace
-        String message = e.getCause() != null ? e.getCause().getMessage() : e.getMessage();
+        Throwable cause = e.getCause() != null ? e.getCause() : e;
         LOG.info(
             "Unable to call register for ({}). Check for missing jars on the classpath: {}",
             classToRegister,
-            message);
+            cause.toString());
       }
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestInternalData.java
+++ b/core/src/test/java/org/apache/iceberg/TestInternalData.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -32,6 +34,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
@@ -153,6 +156,39 @@ public class TestInternalData {
         assertThat(customRow.get(1, String.class))
             .isEqualTo(expectedRecord.get(1, String.class)); // inner_name
       }
+    }
+  }
+
+  @Test
+  public void registerToleratesMissingClass() {
+    assertThatNoException().isThrownBy(() -> register("org.apache.iceberg.DoesNotExist"));
+  }
+
+  @Test
+  public void registerToleratesNoClassDefFoundErrorOnInvoke() {
+    assertThatNoException().isThrownBy(() -> register(ThrowsOnInvoke.class.getName()));
+  }
+
+  @Test
+  public void registerToleratesExceptionInInitializerErrorOnInvoke() {
+    assertThatNoException().isThrownBy(() -> register(ThrowsInitErrorOnInvoke.class.getName()));
+  }
+
+  private static void register(String className) throws ReflectiveOperationException {
+    Method register = InternalData.class.getDeclaredMethod("register", String.class);
+    register.setAccessible(true);
+    register.invoke(null, className);
+  }
+
+  public static class ThrowsOnInvoke {
+    public static void register() {
+      throw new NoClassDefFoundError("some/missing/TransitiveDependency");
+    }
+  }
+
+  public static class ThrowsInitErrorOnInvoke {
+    public static void register() {
+      throw new ExceptionInInitializerError(new RuntimeException("lazy init failed"));
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
+++ b/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
@@ -18,10 +18,12 @@
  */
 package org.apache.iceberg.formats;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.util.Pair;
@@ -84,6 +86,77 @@ class TestFormatModelRegistry {
             () -> FormatModelRegistry.register(new DummyParquetFormatModel(Object.class, null)))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot register class");
+  }
+
+  @Test
+  void registerDoesNotFailWhenClassThrowsNoClassDefFoundOnInvoke() {
+    assertThatNoException()
+        .isThrownBy(
+            () -> {
+              try {
+                DynMethods.StaticMethod method =
+                    DynMethods.builder("register").impl(ThrowsOnInvoke.class).buildStaticChecked();
+                method.invoke();
+              } catch (NoSuchMethodException
+                  | NoClassDefFoundError
+                  | ExceptionInInitializerError e) {
+                // same catch pattern used in InternalData.registerSupportedFormats and
+                // FormatModelRegistry.registerSupportedFormats
+              }
+            });
+  }
+
+  @Test
+  void registerDoesNotFailWhenClassThrowsInitErrorOnInvoke() {
+    assertThatNoException()
+        .isThrownBy(
+            () -> {
+              try {
+                DynMethods.StaticMethod method =
+                    DynMethods.builder("register")
+                        .impl(ThrowsInitErrorOnInvoke.class)
+                        .buildStaticChecked();
+                method.invoke();
+              } catch (NoSuchMethodException
+                  | NoClassDefFoundError
+                  | ExceptionInInitializerError e) {
+                // same catch pattern used in InternalData.registerSupportedFormats and
+                // FormatModelRegistry.registerSupportedFormats
+              }
+            });
+  }
+
+  @Test
+  void invokeCanThrowNoClassDefFoundError() throws NoSuchMethodException {
+    DynMethods.StaticMethod method =
+        DynMethods.builder("register").impl(ThrowsOnInvoke.class).buildStaticChecked();
+
+    assertThatThrownBy(method::invoke)
+        .isInstanceOf(NoClassDefFoundError.class)
+        .hasMessage("some/missing/TransitiveDependency");
+  }
+
+  @Test
+  void invokeCanThrowExceptionInInitializerError() throws NoSuchMethodException {
+    DynMethods.StaticMethod method =
+        DynMethods.builder("register").impl(ThrowsInitErrorOnInvoke.class).buildStaticChecked();
+
+    assertThatThrownBy(method::invoke)
+        .isInstanceOf(ExceptionInInitializerError.class)
+        .hasCauseInstanceOf(RuntimeException.class)
+        .hasMessage(null);
+  }
+
+  public static class ThrowsOnInvoke {
+    public static void register() {
+      throw new NoClassDefFoundError("some/missing/TransitiveDependency");
+    }
+  }
+
+  public static class ThrowsInitErrorOnInvoke {
+    public static void register() {
+      throw new ExceptionInInitializerError(new RuntimeException("lazy init failed"));
+    }
   }
 
   private static class DummyParquetFormatModel implements FormatModel<Object, Object> {

--- a/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
+++ b/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
@@ -22,8 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import java.lang.reflect.Method;
 import org.apache.iceberg.FileFormat;
-import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.util.Pair;
@@ -89,62 +89,27 @@ class TestFormatModelRegistry {
   }
 
   @Test
-  void registerDoesNotFailWhenClassThrowsNoClassDefFoundOnInvoke() {
-    assertThatNoException()
-        .isThrownBy(
-            () -> {
-              try {
-                DynMethods.StaticMethod method =
-                    DynMethods.builder("register").impl(ThrowsOnInvoke.class).buildStaticChecked();
-                method.invoke();
-              } catch (NoSuchMethodException
-                  | NoClassDefFoundError
-                  | ExceptionInInitializerError e) {
-                // same catch pattern used in InternalData.registerSupportedFormats and
-                // FormatModelRegistry.registerSupportedFormats
-              }
-            });
+  void registerToleratesMissingClass() {
+    assertThatNoException().isThrownBy(() -> register("org.apache.iceberg.formats.DoesNotExist"));
+    assertThat(FormatModelRegistry.models()).isEmpty();
   }
 
   @Test
-  void registerDoesNotFailWhenClassThrowsInitErrorOnInvoke() {
-    assertThatNoException()
-        .isThrownBy(
-            () -> {
-              try {
-                DynMethods.StaticMethod method =
-                    DynMethods.builder("register")
-                        .impl(ThrowsInitErrorOnInvoke.class)
-                        .buildStaticChecked();
-                method.invoke();
-              } catch (NoSuchMethodException
-                  | NoClassDefFoundError
-                  | ExceptionInInitializerError e) {
-                // same catch pattern used in InternalData.registerSupportedFormats and
-                // FormatModelRegistry.registerSupportedFormats
-              }
-            });
+  void registerToleratesNoClassDefFoundErrorOnInvoke() {
+    assertThatNoException().isThrownBy(() -> register(ThrowsOnInvoke.class.getName()));
+    assertThat(FormatModelRegistry.models()).isEmpty();
   }
 
   @Test
-  void invokeCanThrowNoClassDefFoundError() throws NoSuchMethodException {
-    DynMethods.StaticMethod method =
-        DynMethods.builder("register").impl(ThrowsOnInvoke.class).buildStaticChecked();
-
-    assertThatThrownBy(method::invoke)
-        .isInstanceOf(NoClassDefFoundError.class)
-        .hasMessage("some/missing/TransitiveDependency");
+  void registerToleratesExceptionInInitializerErrorOnInvoke() {
+    assertThatNoException().isThrownBy(() -> register(ThrowsInitErrorOnInvoke.class.getName()));
+    assertThat(FormatModelRegistry.models()).isEmpty();
   }
 
-  @Test
-  void invokeCanThrowExceptionInInitializerError() throws NoSuchMethodException {
-    DynMethods.StaticMethod method =
-        DynMethods.builder("register").impl(ThrowsInitErrorOnInvoke.class).buildStaticChecked();
-
-    assertThatThrownBy(method::invoke)
-        .isInstanceOf(ExceptionInInitializerError.class)
-        .hasCauseInstanceOf(RuntimeException.class)
-        .hasMessage(null);
+  private static void register(String className) throws ReflectiveOperationException {
+    Method register = FormatModelRegistry.class.getDeclaredMethod("register", String.class);
+    register.setAccessible(true);
+    register.invoke(null, className);
   }
 
   public static class ThrowsOnInvoke {


### PR DESCRIPTION
`DynMethods` use `Class.forName` which can throw `NoClassDefFoundError` or
`ExceptionInInitializerError` when a method is found but its body
references a missing transitive dependency or triggers a failing static
initializer. This causes `FormatModelRegistry.<clinit>` and `InternalData.<clinit>` to fail
permanently when optional modules like `iceberg-orc` or `iceberg-parquet` are absent (#16720).
This widens the catch blocks in `FormatModelRegistry.registerSupportedFormats()`
and `InternalData.registerSupportedFormats()` to handle these invoke-time
failures the same way as `NoSuchMethodException`

The initial version was created by Claude and tests were manually adjusted