### PR TITLE
REST: Allow struct default values in schema fields

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -28,6 +28,7 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
@@ -883,7 +884,14 @@ public class Types {
     }
 
     private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
-      if (type.isNestedType() && defaultValue != null) {
+      if (type.isStructType() && defaultValue != null) {
+        Preconditions.checkArgument(
+            isEmptyStructDefault(defaultValue),
+            "Invalid default value for %s: %s (must be null or empty struct)",
+            type,
+            defaultValue);
+        return defaultValue;
+      } else if (type.isNestedType() && defaultValue != null) {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
       } else if (defaultValue != null) {
@@ -894,6 +902,11 @@ public class Types {
       }
 
       return null;
+    }
+
+    private static boolean isEmptyStructDefault(Literal<?> defaultValue) {
+      Object value = defaultValue.value();
+      return value instanceof StructLike structLike && structLike.size() == 0;
     }
 
     public boolean isOptional() {

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -23,8 +23,10 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
@@ -197,7 +199,12 @@ public class SchemaParser {
 
   private static Literal<?> defaultFromJson(String defaultField, Type type, JsonNode json) {
     if (json.has(defaultField)) {
-      Object value = SingleValueParser.fromJson(type, json.get(defaultField));
+      JsonNode defaultValue = json.get(defaultField);
+      if (type.isStructType() && !defaultValue.isNull()) {
+        return structDefaultFromJson(type, defaultValue);
+      }
+
+      Object value = SingleValueParser.fromJson(type, defaultValue);
       if (type instanceof Types.TimestampNanoType) {
         // Call Expressions.nanos instead of Expressions.lit to prevent overflow
         // https://github.com/apache/iceberg/issues/13160
@@ -208,6 +215,17 @@ public class SchemaParser {
     }
 
     return null;
+  }
+
+  private static Literal<?> structDefaultFromJson(Type type, JsonNode defaultValue) {
+    Preconditions.checkArgument(
+        defaultValue.isObject(), "Cannot parse default as a %s value: %s", type, defaultValue);
+    Preconditions.checkArgument(
+        defaultValue.size() == 0,
+        "Cannot parse default as a %s value: %s, non-null struct defaults must be empty",
+        type,
+        defaultValue);
+    return StructDefaultLiteral.get();
   }
 
   private static Types.NestedField.Builder fieldBuilder(boolean isRequired, String name) {
@@ -301,5 +319,51 @@ public class SchemaParser {
 
   public static Schema fromJson(String json) {
     return SCHEMA_CACHE.get(json, jsonKey -> JsonUtil.parse(json, SchemaParser::fromJson));
+  }
+
+  private static class StructDefaultLiteral implements Literal<StructLike> {
+    private static final StructDefaultLiteral INSTANCE = new StructDefaultLiteral();
+
+    private StructDefaultLiteral() {}
+
+    private static StructDefaultLiteral get() {
+      return INSTANCE;
+    }
+
+    @Override
+    public StructLike value() {
+      return EmptyStructLike.get();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T> Literal<T> to(Type type) {
+      if (type.isStructType()) {
+        return (Literal<T>) this;
+      }
+
+      return null;
+    }
+
+    @Override
+    public Comparator<StructLike> comparator() {
+      throw new UnsupportedOperationException("Struct defaults do not support comparison");
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      return other instanceof StructDefaultLiteral structDefaultLiteral
+          && Objects.equals(value(), structDefaultLiteral.value());
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(value());
+    }
+
+    @Override
+    public String toString() {
+      return value().toString();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -154,5 +155,47 @@ public class TestSchemaParser extends DataTestBase {
         .isEqualTo(defaultValue.value());
     assertThat(serialized.findField("col_with_default").writeDefault())
         .isEqualTo(defaultValue.value());
+  }
+
+  @Test
+  public void testStructDefaultValues() {
+    String schemaJson =
+        "{\"type\":\"struct\",\"schema-id\":0,\"fields\":["
+            + "{\"id\":1,\"name\":\"col\",\"required\":false,"
+            + "\"type\":{\"type\":\"struct\",\"fields\":["
+            + "{\"id\":2,\"name\":\"a\",\"required\":false,\"type\":\"string\","
+            + "\"initial-default\":\"test\",\"write-default\":\"test\"},"
+            + "{\"id\":3,\"name\":\"b\",\"required\":false,\"type\":\"int\"}]},"
+            + "\"initial-default\":{},\"write-default\":{}},"
+            + "{\"id\":4,\"name\":\"col2\",\"required\":false,\"type\":\"int\","
+            + "\"initial-default\":34,\"write-default\":35}]}";
+
+    Schema schema = SchemaParser.fromJson(schemaJson);
+    Types.NestedField col = schema.findField("col");
+    Types.StructType colType = col.type().asStructType();
+
+    assertThat(col.initialDefault()).isInstanceOf(StructLike.class);
+    assertThat(col.writeDefault()).isInstanceOf(StructLike.class);
+    assertThat(colType.field("a").initialDefault()).isEqualTo("test");
+    assertThat(colType.field("a").writeDefault()).isEqualTo("test");
+    assertThat(schema.findField("col2").initialDefault()).isEqualTo(34);
+    assertThat(schema.findField("col2").writeDefault()).isEqualTo(35);
+
+    String serializedJson = SchemaParser.toJson(schema);
+    assertThat(serializedJson).contains("\"initial-default\":{}");
+    assertThat(serializedJson).contains("\"write-default\":{}");
+    assertThat(SchemaParser.fromJson(serializedJson).sameSchema(schema)).isTrue();
+  }
+
+  @Test
+  public void testInvalidPrimitiveDefaultValue() {
+    String schemaJson =
+        "{\"type\":\"struct\",\"schema-id\":0,\"fields\":["
+            + "{\"id\":1,\"name\":\"col\",\"required\":false,\"type\":\"int\","
+            + "\"initial-default\":\"not-an-int\"}]}";
+
+    assertThatThrownBy(() -> SchemaParser.fromJson(schemaJson))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse default as a int value: \"not-an-int\"");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestCreateTableRequest.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.SortOrderParser;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -167,6 +168,32 @@ public class TestCreateTableRequest extends RequestResponseTestBase<CreateTableR
 
     assertEquals(
         deserialize(jsonOnlyRequiredFieldsMissingDefaults), reqOnlyRequiredFieldsMissingDefaults);
+  }
+
+  @Test
+  public void testDeserializeStructDefaultValues() throws JsonProcessingException {
+    String json =
+        "{\"stage-create\":true,\"name\":\"tbl\",\"schema\":{\"type\":\"struct\",\"fields\":["
+            + "{\"name\":\"col\",\"id\":1,\"type\":{\"type\":\"struct\",\"fields\":["
+            + "{\"name\":\"a\",\"id\":2,\"type\":\"string\",\"required\":false,"
+            + "\"initial-default\":\"test\",\"write-default\":\"test\"},"
+            + "{\"name\":\"b\",\"id\":3,\"type\":\"int\",\"required\":false}]},"
+            + "\"required\":false,\"initial-default\":{},\"write-default\":{}},"
+            + "{\"name\":\"col2\",\"id\":4,\"type\":\"int\",\"required\":false}],"
+            + "\"schema-id\":0},\"partition-spec\":{\"spec-id\":0,\"type\":\"struct\","
+            + "\"fields\":[]},\"write-order\":{\"order-id\":0,\"fields\":[]},"
+            + "\"properties\":{\"format-version\":\"3\"}}";
+
+    CreateTableRequest request = deserialize(json);
+    Schema schema = request.schema();
+    Types.NestedField col = schema.findField("col");
+    Types.StructType colType = col.type().asStructType();
+
+    assertThat(col.initialDefault()).isInstanceOf(StructLike.class);
+    assertThat(col.writeDefault()).isInstanceOf(StructLike.class);
+    assertThat(colType.field("a").initialDefault()).isEqualTo("test");
+    assertThat(colType.field("a").writeDefault()).isEqualTo("test");
+    assertThat(request.stageCreate()).isTrue();
   }
 
   @Test

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -993,6 +993,22 @@ class PrimitiveTypeValue(
     )
 
 
+class StructDefaultValue(RootModel[dict[str, object]]):
+    """
+    Empty object marker for a non-null struct default. Nested field defaults are stored on the struct's fields.
+    """
+
+    root: dict[str, object] = Field(..., max_length=0)
+
+
+class DefaultValue(RootModel[PrimitiveTypeValue | StructDefaultValue]):
+    """
+    A schema field default value. Primitive fields use primitive type values. Struct fields use an empty object (`{}`) to represent a non-null default that applies nested field defaults.
+    """
+
+    root: PrimitiveTypeValue | StructDefaultValue
+
+
 class FileFormat(RootModel[Literal['avro', 'orc', 'parquet', 'puffin']]):
     root: Literal['avro', 'orc', 'parquet', 'puffin']
 
@@ -1316,8 +1332,8 @@ class StructField(BaseModel):
     type: Type
     required: bool
     doc: str | None = None
-    initial_default: PrimitiveTypeValue | None = Field(None, alias='initial-default')
-    write_default: PrimitiveTypeValue | None = Field(None, alias='write-default')
+    initial_default: DefaultValue | None = Field(None, alias='initial-default')
+    write_default: DefaultValue | None = Field(None, alias='write-default')
 
 
 class StructType(BaseModel):

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -993,20 +993,10 @@ class PrimitiveTypeValue(
     )
 
 
-class StructDefaultValue(RootModel[dict[str, object]]):
+class StructDefaultValue(BaseModel):
     """
     Empty object marker for a non-null struct default. Nested field defaults are stored on the struct's fields.
     """
-
-    root: dict[str, object] = Field(..., max_length=0)
-
-
-class DefaultValue(RootModel[PrimitiveTypeValue | StructDefaultValue]):
-    """
-    A schema field default value. Primitive fields use primitive type values. Struct fields use an empty object (`{}`) to represent a non-null default that applies nested field defaults.
-    """
-
-    root: PrimitiveTypeValue | StructDefaultValue
 
 
 class FileFormat(RootModel[Literal['avro', 'orc', 'parquet', 'puffin']]):
@@ -1169,6 +1159,13 @@ class ValueMap(BaseModel):
     )
     values: list[PrimitiveTypeValue] | None = Field(
         None, description="List of primitive type values, matched to 'keys' by index"
+    )
+
+
+class DefaultValue(RootModel[PrimitiveTypeValue | StructDefaultValue]):
+    root: PrimitiveTypeValue | StructDefaultValue = Field(
+        ...,
+        description='A schema field default value. Primitive fields use primitive type values. Struct fields use an empty object (`{}`) to represent a non-null default that applies nested field defaults.',
     )
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2355,9 +2355,9 @@ components:
         doc:
           type: string
         initial-default:
-          $ref: "#/components/schemas/PrimitiveTypeValue"
+          $ref: "#/components/schemas/DefaultValue"
         write-default:
-          $ref: "#/components/schemas/PrimitiveTypeValue"
+          $ref: "#/components/schemas/DefaultValue"
 
     StructType:
       type: object
@@ -4566,6 +4566,23 @@ components:
         - $ref: '#/components/schemas/TimestampTzNanoTypeValue'
         - $ref: '#/components/schemas/FixedTypeValue'
         - $ref: '#/components/schemas/BinaryTypeValue'
+
+    DefaultValue:
+      description:
+        A schema field default value. Primitive fields use primitive type values. Struct fields
+        use an empty object (`{}`) to represent a non-null default that applies nested field
+        defaults.
+      oneOf:
+        - $ref: '#/components/schemas/PrimitiveTypeValue'
+        - $ref: '#/components/schemas/StructDefaultValue'
+
+    StructDefaultValue:
+      type: object
+      maxProperties: 0
+      description:
+        Empty object marker for a non-null struct default. Nested field defaults are stored on the
+        struct's fields.
+      example: {}
 
     FileFormat:
       type: string


### PR DESCRIPTION
Fixes #16596.

This updates REST/OpenAPI schema field default handling so `initial-default` and `write-default` can represent valid Iceberg struct defaults such as `{}`.

The change keeps expression literal values restricted to primitive values while allowing schema field defaults to use the broader default-value representation required by the Iceberg v3 spec.

Added regression coverage for:
- struct field defaults represented as `{}`
- nested field defaults inside that struct
- round-tripping schema/default JSON
- REST create-table/schema parsing with struct defaults

Validation:
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :iceberg-core:test --tests org.apache.iceberg.TestSchemaParser --tests org.apache.iceberg.rest.requests.TestCreateTableRequest --stacktrace
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew :iceberg-open-api:check --stacktrace
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew spotlessApply
- JAVA_HOME=/opt/homebrew/Cellar/openjdk@17/17.0.19/libexec/openjdk.jdk/Contents/Home ./gradlew spotlessCheck