### PR TITLE
Build: Ignore local warehouse directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ metastore_db/
 
 # Spark/metastore files
 spark-warehouse/
+warehouse/
 derby.log
 
 # jenv


### PR DESCRIPTION
## Summary

Adds the top-level `warehouse/` directory to `.gitignore`.

Iceberg local Spark/catalog experiments can create a `warehouse/` directory in the repository root containing generated table data and metadata files, such as Parquet data files, Avro manifest files, metadata JSON files, CRC files, and `version-hint.text`.

## Why

These files are local runtime artifacts and should not be committed. Because `warehouse/` was not ignored, a broad `git add .` could accidentally stage generated table files, leading to noisy commits or RAT/license check failures.

The repo already ignores related local runtime directories such as `spark-warehouse/` and `metastore_db/`. This adds the generic local warehouse path alongside those ignores.

## Testing

Manually verified that a generated file under `warehouse/` is ignored by Git after this change:

```bash
git check-ignore -v warehouse/repro/example.metadata.json