### PR TITLE
Spark: Deprecate SparkFilters in favor of SparkV2Filters

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -70,6 +70,13 @@ import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
 import org.apache.spark.sql.sources.StringStartsWith;
 
+/**
+ * Converts Spark DSv1 filters into Iceberg expressions.
+ *
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link SparkV2Filters} which converts
+ *     Spark DSv2 {@link org.apache.spark.sql.connector.expressions.filter.Predicate} instead.
+ */
+@Deprecated
 public class SparkFilters {
 
   private static final Pattern BACKTICKS_PATTERN = Pattern.compile("([`])(.|$)");

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class TestSparkFilters {
 
   @Test

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -70,6 +70,13 @@ import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
 import org.apache.spark.sql.sources.StringStartsWith;
 
+/**
+ * Converts Spark DSv1 filters into Iceberg expressions.
+ *
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link SparkV2Filters} which converts
+ *     Spark DSv2 {@link org.apache.spark.sql.connector.expressions.filter.Predicate} instead.
+ */
+@Deprecated
 public class SparkFilters {
 
   private static final Pattern BACKTICKS_PATTERN = Pattern.compile("([`])(.|$)");

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class TestSparkFilters {
 
   @Test

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkFilters.java
@@ -70,6 +70,13 @@ import org.apache.spark.sql.sources.Not;
 import org.apache.spark.sql.sources.Or;
 import org.apache.spark.sql.sources.StringStartsWith;
 
+/**
+ * Converts Spark DSv1 filters into Iceberg expressions.
+ *
+ * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link SparkV2Filters} which converts
+ *     Spark DSv2 {@link org.apache.spark.sql.connector.expressions.filter.Predicate} instead.
+ */
+@Deprecated
 public class SparkFilters {
 
   private static final Pattern BACKTICKS_PATTERN = Pattern.compile("([`])(.|$)");

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkFilters.java
@@ -44,6 +44,7 @@ import org.apache.spark.sql.sources.LessThanOrEqual;
 import org.apache.spark.sql.sources.Not;
 import org.junit.jupiter.api.Test;
 
+@SuppressWarnings("deprecation")
 public class TestSparkFilters {
 
   @Test


### PR DESCRIPTION
## Summary

`SparkFilters` converts the Spark DSv1 `Filter[]` API into Iceberg `Expression`s. It is no longer referenced by Iceberg's main source code in any supported Spark version (3.5, 4.0, 4.1) — all production call sites have already migrated to `SparkV2Filters`, which converts the DSv2 `Predicate[]` API. Only `TestSparkFilters` still references the class.

This PR:
- Adds `@Deprecated` and a Javadoc deprecation notice to `SparkFilters` in `spark/v3.5`, `spark/v4.0`, and `spark/v4.1`, with target removal in 1.12.0.
- Adds `@SuppressWarnings("deprecation")` to the matching `TestSparkFilters` so its existing tests continue to run cleanly until the class itself is removed.

No production code changes; no behavior changes.

## Test plan

- [ ] `./gradlew spotlessCheck` passes in CI
- [ ] Existing `TestSparkFilters` continues to pass for v3.5 / v4.0 / v4.1

Made with [Cursor](https://cursor.com)