### PR TITLE
Arrow: Support reading Parquet UINT32 as long in vectorized reader

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.arrow.vectorized.parquet.VectorizedColumnIterator;
 import org.apache.iceberg.parquet.ParquetUtil;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.Dictionary;
@@ -587,12 +588,16 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
       int bitWidth = intLogicalType.getBitWidth();
 
       if (bitWidth == 8 || bitWidth == 16 || bitWidth == 32) {
-        // Iceberg has no unsigned integer type. Reading UINT32 into a 32-bit signed value would
-        // silently produce negative results for inputs above Integer.MAX_VALUE. UINT8 and UINT16
-        // both fit losslessly in a signed int32 and are allowed, matching the policy in
-        // BaseParquetReaders for the non-vectorized path.
-        Preconditions.checkArgument(
-            intLogicalType.isSigned() || bitWidth < 32, "Cannot read UINT32 as an int value");
+        // Iceberg has no unsigned integer type. UINT8 and UINT16 fit losslessly in a signed int32
+        // and are always allowed. UINT32 is only allowed when the Iceberg field expects a long
+        // (the existing IntAccessor widens int to long on read, matching the non-vectorized
+        // IntAsLongReader). Reading UINT32 into a 32-bit signed value would silently produce
+        // negative results for inputs above Integer.MAX_VALUE, so it is rejected.
+        if (bitWidth == 32 && !intLogicalType.isSigned()) {
+          Preconditions.checkArgument(
+              icebergField.type().typeId() == Type.TypeID.LONG,
+              "Cannot read UINT32 as an int value");
+        }
         Field intField =
             new Field(
                 icebergField.name(),

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -598,6 +598,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
               icebergField.type().typeId() == Type.TypeID.LONG,
               "Cannot read UINT32 as an int value");
         }
+
         Field intField =
             new Field(
                 icebergField.name(),

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -436,6 +436,31 @@ public class TestArrowReader {
     assertThat(totalRows).isEqualTo(1);
   }
 
+  @Test
+  public void testUnsignedInt32ColumnPromotedToLong() throws Exception {
+    Schema schema = new Schema(Types.NestedField.optional(1, "col", Types.LongType.get()));
+    int value = 100;
+    Table table =
+        createSingleRowUnsignedIntTable(schema, PrimitiveType.PrimitiveTypeName.INT32, 32, value);
+
+    int totalRows = 0;
+    try (VectorizedTableScanIterable vectorizedReader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : vectorizedReader) {
+        FieldVector vector = batch.column(0).getArrowVector();
+        assertThat(vector)
+            .as("UINT32 should be stored in an IntVector matching the physical Parquet type")
+            .isInstanceOf(IntVector.class);
+        assertThat(batch.column(0).getLong(0))
+            .as("UINT32 value should widen to long through the accessor")
+            .isEqualTo((long) value);
+        totalRows += batch.numRows();
+      }
+    }
+
+    assertThat(totalRows).isEqualTo(1);
+  }
+
   /**
    * Tests that the vectorized reader correctly handles int-to-long type promotion when the Parquet
    * file has an INT(32, true) logical type annotation. This reproduces a bug where reading a file


### PR DESCRIPTION
Follow-up to [#16006](https://github.com/apache/iceberg/pull/16006): the vectorized path now accepts Parquet `UINT32` for an Iceberg `LongType` field, matching the non-vectorized path.

It turns out the existing vectorized read path already handles this correctly -- Parquet UINT32 is physically INT32 (so the vector stays IntVector), and IntAccessor.getLong widens int to long with sign extension, which is correct for unsigned 32-bit values since they all fit in a Java long. So no new reader, accessor, or vector type is needed; the only change is relaxing the precondition in VectorizedArrowReader to allow UINT32 when the Iceberg field is LongType. 
