### PR TITLE
Parquet: Fix timestamp_ns and timestamptz_ns predicate pushdown

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -220,8 +220,15 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     @Override
     public Optional<Type> visit(
         LogicalTypeAnnotation.TimestampLogicalTypeAnnotation timestampType) {
-      return Optional.of(
-          timestampType.isAdjustedToUTC() ? TimestampType.withZone() : TimestampType.withoutZone());
+      boolean adjustToUtc = timestampType.isAdjustedToUTC();
+      if (timestampType.getUnit() == LogicalTypeAnnotation.TimeUnit.NANOS) {
+        return Optional.of(
+            adjustToUtc
+                ? Types.TimestampNanoType.withZone()
+                : Types.TimestampNanoType.withoutZone());
+      }
+
+      return Optional.of(adjustToUtc ? TimestampType.withZone() : TimestampType.withoutZone());
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -143,6 +143,7 @@ class ParquetFilters {
         case LONG:
         case TIME:
         case TIMESTAMP:
+        case TIMESTAMP_NANO:
           return pred(op, FilterApi.longColumn(path), getParquetPrimitive(lit));
         case FLOAT:
           return pred(op, FilterApi.floatColumn(path), getParquetPrimitive(lit));

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -417,7 +417,7 @@ public class TestParquet {
                 ImmutableMap.of(
                     "id", 5L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000003000"))));
 
-    File file = writeNanoRecords(schema, records, "ts-nano");
+    File file = writeNanoRecords(schema, records);
 
     // Boundary at 500 ns: only ids 3 (750 ns), 4 (1500 ns), 5 (3000 ns) qualify.
     List<Long> ids =
@@ -455,7 +455,7 @@ public class TestParquet {
                 ImmutableMap.of(
                     "id", 5L, "ts", OffsetDateTime.parse("2024-01-01T00:00:00.000003000+00:00"))));
 
-    File file = writeNanoRecords(schema, records, "ts-tz-nano");
+    File file = writeNanoRecords(schema, records);
 
     // Boundary == 2024-01-01T00:00:00.000000500Z, expressed in +04:00. id2 is that same instant
     // (written in +05:00); a strict greaterThan excludes it, leaving ids 3/4/5.
@@ -464,10 +464,8 @@ public class TestParquet {
     assertThat(ids).containsExactlyInAnyOrder(3L, 4L, 5L);
   }
 
-  private File writeNanoRecords(Schema schema, List<Record> records, String prefix)
-      throws IOException {
-    File file = temp.resolve(prefix + ".parquet").toFile();
-    assertThat(file.delete() || !file.exists()).isTrue();
+  private File writeNanoRecords(Schema schema, List<Record> records) throws IOException {
+    File file = createTempFile(temp);
     try (FileAppender<Record> appender =
         Parquet.write(Files.localOutput(file))
             .schema(schema)
@@ -477,6 +475,7 @@ public class TestParquet {
         appender.add(record);
       }
     }
+
     return file;
   }
 
@@ -490,6 +489,7 @@ public class TestParquet {
         ids.add((Long) record.get("id"));
       }
     }
+
     return ids;
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -24,6 +24,8 @@ import static org.apache.iceberg.TableProperties.PARQUET_COLUMN_STATS_ENABLED_PR
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.expressions.Expressions.greaterThan;
+import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.write;
 import static org.apache.iceberg.relocated.com.google.common.collect.Iterables.getOnlyElement;
@@ -36,6 +38,8 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Function;
@@ -48,6 +52,11 @@ import org.apache.iceberg.Metrics;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
@@ -377,5 +386,110 @@ public class TestParquet {
             createWriterFunc,
             records.toArray(new GenericData.Record[] {}));
     return Pair.of(file, size);
+  }
+
+  @Test
+  public void timestampNanoFilterRespectsNanoseconds() throws IOException {
+    // Predicate pushdown on timestamp_ns must filter at full nanosecond resolution. The five rows
+    // differ only by sub-microsecond nanoseconds, so a micros-truncating push down could not
+    // separate id 2 (250 ns) from id 3 (750 ns) and would return the wrong rows.
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "ts", Types.TimestampNanoType.withoutZone()));
+
+    Record template = org.apache.iceberg.data.GenericRecord.create(schema);
+    List<Record> records =
+        Lists.newArrayList(
+            template.copy(
+                ImmutableMap.of(
+                    "id", 1L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000000"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 2L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000250"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 3L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000000750"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 4L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000001500"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 5L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000003000"))));
+
+    File file = writeNanoRecords(schema, records, "ts-nano");
+
+    // Boundary at 500 ns: only ids 3 (750 ns), 4 (1500 ns), 5 (3000 ns) qualify.
+    List<Long> ids =
+        filterIds(schema, file, greaterThanOrEqual("ts", "2024-01-01T00:00:00.000000500"));
+    assertThat(ids).containsExactlyInAnyOrder(3L, 4L, 5L);
+  }
+
+  @Test
+  public void timestamptzNanoFilterAcrossTimezones() throws IOException {
+    // Each row is written in a different zone offset; instants are 0/500/750/1500/3000 ns past the
+    // same UTC second. id2 lands exactly on the filter boundary but in +05:00, so a strict
+    // greaterThan must exclude it by instant, not by wall-clock (its 05:00 vs the boundary's
+    // 04:00).
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "ts", Types.TimestampNanoType.withZone()));
+
+    Record template = org.apache.iceberg.data.GenericRecord.create(schema);
+    List<Record> records =
+        Lists.newArrayList(
+            template.copy(
+                ImmutableMap.of(
+                    "id", 1L, "ts", OffsetDateTime.parse("2024-01-01T00:00:00.000000000+00:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 2L, "ts", OffsetDateTime.parse("2024-01-01T05:00:00.000000500+05:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 3L, "ts", OffsetDateTime.parse("2023-12-31T16:00:00.000000750-08:00"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 4L, "ts", OffsetDateTime.parse("2024-01-01T05:30:00.000001500+05:30"))),
+            template.copy(
+                ImmutableMap.of(
+                    "id", 5L, "ts", OffsetDateTime.parse("2024-01-01T00:00:00.000003000+00:00"))));
+
+    File file = writeNanoRecords(schema, records, "ts-tz-nano");
+
+    // Boundary == 2024-01-01T00:00:00.000000500Z, expressed in +04:00. id2 is that same instant
+    // (written in +05:00); a strict greaterThan excludes it, leaving ids 3/4/5.
+    List<Long> ids =
+        filterIds(schema, file, greaterThan("ts", "2024-01-01T04:00:00.000000500+04:00"));
+    assertThat(ids).containsExactlyInAnyOrder(3L, 4L, 5L);
+  }
+
+  private File writeNanoRecords(Schema schema, List<Record> records, String prefix)
+      throws IOException {
+    File file = temp.resolve(prefix + ".parquet").toFile();
+    assertThat(file.delete() || !file.exists()).isTrue();
+    try (FileAppender<Record> appender =
+        Parquet.write(Files.localOutput(file))
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      for (Record record : records) {
+        appender.add(record);
+      }
+    }
+    return file;
+  }
+
+  private List<Long> filterIds(Schema schema, File file, Expression filter) throws IOException {
+    List<Long> ids = Lists.newArrayList();
+    // callInit() drives the parquet-mr ReadSupport path, the only read path that runs
+    // ParquetFilters.
+    try (CloseableIterable<GenericData.Record> reader =
+        Parquet.read(localInput(file)).project(schema).callInit().filter(filter).build()) {
+      for (GenericData.Record record : reader) {
+        ids.add((Long) record.get("id"));
+      }
+    }
+    return ids;
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -504,8 +504,7 @@ public class TestParquetSchemaUtil {
   @Test
   public void testTimestampNanoConversionPreservesUnit() {
     // INT64 + TIMESTAMP(NANOS) must round-trip back to Iceberg as timestamp_ns, not micros. A
-    // micros
-    // field is included to confirm the unit branch leaves the existing mapping untouched.
+    // micros field is included to confirm the unit branch leaves the existing mapping untouched.
     MessageType messageType =
         org.apache.parquet.schema.Types.buildMessage()
             .required(PrimitiveTypeName.INT64)

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -501,6 +501,39 @@ public class TestParquetSchemaUtil {
         .isEqualTo(expectedSchema.asStruct());
   }
 
+  @Test
+  public void testTimestampNanoConversionPreservesUnit() {
+    // INT64 + TIMESTAMP(NANOS) must round-trip back to Iceberg as timestamp_ns, not micros. A
+    // micros
+    // field is included to confirm the unit branch leaves the existing mapping untouched.
+    MessageType messageType =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .id(1)
+            .named("ts_tz_ns")
+            .optional(PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(false, LogicalTypeAnnotation.TimeUnit.NANOS))
+            .id(2)
+            .named("ts_ns")
+            .required(PrimitiveTypeName.INT64)
+            .as(LogicalTypeAnnotation.timestampType(true, LogicalTypeAnnotation.TimeUnit.MICROS))
+            .id(3)
+            .named("ts_tz_micros")
+            .named("table");
+
+    Schema expectedSchema =
+        new Schema(
+            required(1, "ts_tz_ns", Types.TimestampNanoType.withZone()),
+            optional(2, "ts_ns", Types.TimestampNanoType.withoutZone()),
+            required(3, "ts_tz_micros", Types.TimestampType.withZone()));
+
+    Schema actualSchema = ParquetSchemaUtil.convert(messageType);
+    assertThat(actualSchema.asStruct())
+        .as("Schema must match")
+        .isEqualTo(expectedSchema.asStruct());
+  }
+
   private Type primitive(
       Integer id, String name, PrimitiveTypeName typeName, Repetition repetition) {
     PrimitiveBuilder<PrimitiveType> builder =


### PR DESCRIPTION
## Problem

Filtering a `timestamp_ns` or `timestamptz_ns` column through the parquet-mr `ReadSupport` read path (`Parquet.read(...).callInit().filter(...)`, the path used when no Iceberg-native `createReaderFunc` is set) silently returned the wrong rows. A nanosecond predicate matched every row regardless of the filter boundary, so sub-microsecond filtering was effectively ignored. No exception was thrown.

## Root cause

Two complementary gaps on the read path:

- `MessageTypeToType` ignored the timestamp unit and always mapped a Parquet `INT64 TIMESTAMP(NANOS)` column back to Iceberg micros `TimestampType`. The filter path in `Parquet` builds its file schema via `ParquetSchemaUtil.convert(messageType)` and binds the user filter against it, so a nanosecond literal bound as microseconds (~1.7e15) while the column data is raw nanoseconds (~1.7e18). Every row trivially satisfied the predicate.
- `ParquetFilters` had no `TIMESTAMP_NANO` case, so once the schema reported the correct nano type the conversion would instead throw `UnsupportedOperationException`.

Both fixes are required: the first restores the correct bound type, the second pushes it down as an `INT64` (long) column predicate compared directly against the raw nanoseconds, which is exact with no unit conversion. This is the Parquet analog of the ORC fix in #16609.

## Changes

- `MessageTypeToType`: honor `TimestampLogicalTypeAnnotation.getUnit()` - `NANOS` maps to `TimestampNanoType` (with/without zone), other units keep `TimestampType`.
- `ParquetFilters`: add `case TIMESTAMP_NANO` to the long-column predicate group.

## Tests

- `TestParquetSchemaUtil.testTimestampNanoConversionPreservesUnit` - a Parquet `TIMESTAMP(NANOS)` / `TIMESTAMPTZ(NANOS)` schema converts back to `timestamp_ns` / `timestamptz_ns`, with micros left unchanged.
- `TestParquet.timestampNanoFilterRespectsNanoseconds` and `timestamptzNanoFilterAcrossTimezones` - end-to-end through the `ReadSupport` read path: five rows differing only by sub-microsecond nanoseconds filter to exactly the expected ids, including a multi-timezone `timestamptz_ns` variant where a row sits exactly on the filter boundary in a different offset.
