### PR TITLE
Parquet: Fix decimal and UUID filter pushdown conversion

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -258,6 +258,11 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     }
 
     @Override
+    public Optional<Type> visit(LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidType) {
+      return Optional.of(Types.UUIDType.get());
+    }
+
+    @Override
     public Optional<Type> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
       // a null crs resolves to the Iceberg default in GeometryType.of
       return Optional.of(Types.GeometryType.of(geometryType.getCrs()));

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1626,13 +1626,12 @@ public class Parquet {
         } catch (IOException e) {
           throw new RuntimeIOException(e);
         }
-        Schema fileSchema = ParquetSchemaUtil.convert(type);
         builder
             .useStatsFilter()
             .useDictionaryFilter()
             .useRecordFilter(filterRecords)
             .useBloomFilter()
-            .withFilter(ParquetFilters.convert(fileSchema, filter, caseSensitive));
+            .withFilter(ParquetFilters.convert(type, filter, caseSensitive));
       } else {
         // turn off filtering
         builder

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -188,7 +188,7 @@ class ParquetFilters {
         case BINARY:
           return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
         case UUID:
-          return pred(op, FilterApi.binaryColumn(path), getParquetUUID(lit));
+          return uuidPred(op, path, lit);
         case DECIMAL:
           return decimalPred(
               op,
@@ -212,6 +212,19 @@ class ParquetFilters {
         return AlwaysFalse.INSTANCE;
       }
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
+    }
+  }
+
+  private static FilterPredicate uuidPred(Operation op, String path, Literal<?> lit) {
+    switch (op) {
+      case IS_NULL:
+      case NOT_NULL:
+      case EQ:
+      case NOT_EQ:
+        return pred(op, FilterApi.binaryColumn(path), getParquetUUID(lit));
+      default:
+        // Parquet UUID ordering is unsigned lexicographic, which does not match UUID.compareTo.
+        return AlwaysTrue.INSTANCE;
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -18,7 +18,11 @@
  */
 package org.apache.iceberg.parquet;
 
+import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.UUID;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.BoundPredicate;
 import org.apache.iceberg.expressions.BoundReference;
@@ -29,19 +33,31 @@ import org.apache.iceberg.expressions.ExpressionVisitors.ExpressionVisitor;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DecimalUtil;
+import org.apache.iceberg.util.UUIDUtil;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.filter2.predicate.FilterApi;
 import org.apache.parquet.filter2.predicate.FilterPredicate;
 import org.apache.parquet.filter2.predicate.Operators;
 import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
 
 class ParquetFilters {
 
   private ParquetFilters() {}
 
-  static FilterCompat.Filter convert(Schema schema, Expression expr, boolean caseSensitive) {
+  static FilterCompat.Filter convert(
+      MessageType parquetSchema, Expression expr, boolean caseSensitive) {
+    Schema schema = ParquetSchemaUtil.convert(parquetSchema);
     FilterPredicate pred =
-        ExpressionVisitors.visit(expr, new ConvertFilterToParquet(schema, caseSensitive));
+        ExpressionVisitors.visit(
+            expr,
+            new ConvertFilterToParquet(
+                schema, primitiveTypesById(parquetSchema, schema), caseSensitive));
     // TODO: handle AlwaysFalse.INSTANCE
     if (pred != null && pred != AlwaysTrue.INSTANCE) {
       // FilterCompat will apply LogicalInverseRewriter
@@ -51,12 +67,30 @@ class ParquetFilters {
     }
   }
 
+  private static Map<Integer, PrimitiveType> primitiveTypesById(
+      MessageType parquetSchema, Schema schema) {
+    Map<Integer, PrimitiveType> primitiveTypesById = Maps.newHashMap();
+
+    for (ColumnDescriptor desc : parquetSchema.getColumns()) {
+      PrimitiveType primitiveType = parquetSchema.getType(desc.getPath()).asPrimitiveType();
+      Integer fieldId = schema.aliasToId(String.join(".", desc.getPath()));
+      if (fieldId != null) {
+        primitiveTypesById.put(fieldId, primitiveType);
+      }
+    }
+
+    return primitiveTypesById;
+  }
+
   private static class ConvertFilterToParquet extends ExpressionVisitor<FilterPredicate> {
     private final Schema schema;
+    private final Map<Integer, PrimitiveType> primitiveTypesById;
     private final boolean caseSensitive;
 
-    private ConvertFilterToParquet(Schema schema, boolean caseSensitive) {
+    private ConvertFilterToParquet(
+        Schema schema, Map<Integer, PrimitiveType> primitiveTypesById, boolean caseSensitive) {
       this.schema = schema;
+      this.primitiveTypesById = primitiveTypesById;
       this.caseSensitive = caseSensitive;
     }
 
@@ -150,11 +184,18 @@ class ParquetFilters {
         case DOUBLE:
           return pred(op, FilterApi.doubleColumn(path), getParquetPrimitive(lit));
         case STRING:
-        case UUID:
         case FIXED:
         case BINARY:
-        case DECIMAL:
           return pred(op, FilterApi.binaryColumn(path), getParquetPrimitive(lit));
+        case UUID:
+          return pred(op, FilterApi.binaryColumn(path), getParquetUUID(lit));
+        case DECIMAL:
+          return decimalPred(
+              op,
+              path,
+              primitiveTypesById.get(ref.fieldId()),
+              (Types.DecimalType) ref.type().asPrimitiveType(),
+              lit);
       }
 
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
@@ -171,6 +212,42 @@ class ParquetFilters {
         return AlwaysFalse.INSTANCE;
       }
       throw new UnsupportedOperationException("Cannot convert to Parquet filter: " + pred);
+    }
+  }
+
+  private static FilterPredicate decimalPred(
+      Operation op,
+      String path,
+      PrimitiveType primitiveType,
+      Types.DecimalType decimalType,
+      Literal<?> lit) {
+    if (primitiveType == null) {
+      return AlwaysTrue.INSTANCE;
+    }
+
+    BigDecimal decimal = decimalValue(decimalType, lit);
+    if (lit != null && decimal == null) {
+      return AlwaysTrue.INSTANCE;
+    }
+
+    try {
+      switch (primitiveType.getPrimitiveTypeName()) {
+        case INT32:
+          return pred(op, FilterApi.intColumn(path), getDecimalAsInt(decimal));
+        case INT64:
+          return pred(op, FilterApi.longColumn(path), getDecimalAsLong(decimal));
+        case FIXED_LEN_BYTE_ARRAY:
+          return pred(
+              op,
+              FilterApi.binaryColumn(path),
+              getDecimalAsFixed(decimalType, primitiveType.getTypeLength(), decimal));
+        case BINARY:
+          return pred(op, FilterApi.binaryColumn(path), getDecimalAsBinary(decimal));
+        default:
+          return AlwaysTrue.INSTANCE;
+      }
+    } catch (ArithmeticException e) {
+      return AlwaysTrue.INSTANCE;
     }
   }
 
@@ -215,13 +292,69 @@ class ParquetFilters {
     }
   }
 
+  private static Integer getDecimalAsInt(BigDecimal decimal) {
+    if (decimal == null) {
+      return null;
+    }
+
+    return decimal.unscaledValue().intValueExact();
+  }
+
+  private static Long getDecimalAsLong(BigDecimal decimal) {
+    if (decimal == null) {
+      return null;
+    }
+
+    return decimal.unscaledValue().longValueExact();
+  }
+
+  private static Binary getDecimalAsFixed(Types.DecimalType type, int length, BigDecimal decimal) {
+    if (decimal == null) {
+      return null;
+    }
+
+    byte[] bytes =
+        DecimalUtil.toReusedFixLengthBytes(
+            type.precision(), type.scale(), decimal, new byte[length]);
+    return Binary.fromConstantByteArray(bytes);
+  }
+
+  private static Binary getDecimalAsBinary(BigDecimal decimal) {
+    if (decimal == null) {
+      return null;
+    }
+
+    return Binary.fromConstantByteArray(decimal.unscaledValue().toByteArray());
+  }
+
+  private static BigDecimal decimalValue(Types.DecimalType type, Literal<?> lit) {
+    if (lit == null) {
+      return null;
+    }
+
+    BigDecimal decimal = (BigDecimal) lit.value();
+    try {
+      BigDecimal scaled = decimal.setScale(type.scale(), RoundingMode.UNNECESSARY);
+      return scaled.precision() <= type.precision() ? scaled : null;
+    } catch (ArithmeticException e) {
+      return null;
+    }
+  }
+
+  private static Binary getParquetUUID(Literal<?> lit) {
+    if (lit == null) {
+      return null;
+    }
+
+    return Binary.fromConstantByteArray(UUIDUtil.convert((UUID) lit.value()));
+  }
+
   @SuppressWarnings("unchecked")
   private static <C extends Comparable<C>> C getParquetPrimitive(Literal<?> lit) {
     if (lit == null) {
       return null;
     }
 
-    // TODO: this needs to convert to handle BigDecimal and UUID
     Object value = lit.value();
     if (value instanceof Number) {
       return (C) lit.value();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -55,7 +55,7 @@ class ParquetFilters {
     Schema schema = ParquetSchemaUtil.convert(parquetSchema);
     FilterPredicate pred =
         ExpressionVisitors.visit(
-            expr,
+            Expressions.rewriteNot(expr),
             new ConvertFilterToParquet(
                 schema, primitiveTypesById(parquetSchema, schema), caseSensitive));
     // TODO: handle AlwaysFalse.INSTANCE

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -25,24 +25,29 @@ import static org.apache.iceberg.TableProperties.PARQUET_DICT_ENCODING_ENABLED_C
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.write;
 import static org.apache.iceberg.relocated.com.google.common.collect.Iterables.getOnlyElement;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.apache.parquet.schema.Types.buildMessage;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import org.apache.avro.generic.GenericData;
@@ -72,11 +77,16 @@ import org.apache.iceberg.variants.Variant;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.column.statistics.Statistics;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.example.GroupReadSupport;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
 import org.apache.parquet.io.LocalOutputFile;
+import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -632,7 +642,7 @@ public class TestParquet {
                 ImmutableMap.of(
                     "id", 5L, "ts", LocalDateTime.parse("2024-01-01T00:00:00.000003000"))));
 
-    File file = writeNanoRecords(schema, records);
+    File file = writeRecords(schema, records);
 
     // Boundary at 500 ns: only ids 3 (750 ns), 4 (1500 ns), 5 (3000 ns) qualify.
     List<Long> ids =
@@ -670,7 +680,7 @@ public class TestParquet {
                 ImmutableMap.of(
                     "id", 5L, "ts", OffsetDateTime.parse("2024-01-01T00:00:00.000003000+00:00"))));
 
-    File file = writeNanoRecords(schema, records);
+    File file = writeRecords(schema, records);
 
     // Boundary == 2024-01-01T00:00:00.000000500Z, expressed in +04:00. id2 is that same instant
     // (written in +05:00); a strict greaterThan excludes it, leaving ids 3/4/5.
@@ -679,7 +689,111 @@ public class TestParquet {
     assertThat(ids).containsExactlyInAnyOrder(3L, 4L, 5L);
   }
 
-  private File writeNanoRecords(Schema schema, List<Record> records) throws IOException {
+  @Test
+  public void decimalAndUuidFiltersUsePhysicalParquetValues() throws IOException {
+    UUID firstUuid = UUID.fromString("00000000-0000-0000-0000-000000000001");
+    UUID secondUuid = UUID.fromString("80000000-0000-0000-0000-000000000000");
+    UUID thirdUuid = UUID.fromString("00000000-0000-0000-0000-000000000003");
+
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "decimal_int", Types.DecimalType.of(9, 2)),
+            required(3, "decimal_fixed", Types.DecimalType.of(20, 10)),
+            required(4, "uuid_col", Types.UUIDType.get()));
+
+    Record template = org.apache.iceberg.data.GenericRecord.create(schema);
+    List<Record> records =
+        Lists.newArrayList(
+            template.copy(
+                ImmutableMap.of(
+                    "id",
+                    1L,
+                    "decimal_int",
+                    new BigDecimal("-12.34"),
+                    "decimal_fixed",
+                    new BigDecimal("-1234567890.1234567890"),
+                    "uuid_col",
+                    firstUuid)),
+            template.copy(
+                ImmutableMap.of(
+                    "id",
+                    2L,
+                    "decimal_int",
+                    new BigDecimal("0.00"),
+                    "decimal_fixed",
+                    new BigDecimal("0.0000000000"),
+                    "uuid_col",
+                    secondUuid)),
+            template.copy(
+                ImmutableMap.of(
+                    "id",
+                    3L,
+                    "decimal_int",
+                    new BigDecimal("56.78"),
+                    "decimal_fixed",
+                    new BigDecimal("1234567890.1234567890"),
+                    "uuid_col",
+                    thirdUuid)));
+
+    File file = writeRecords(schema, records);
+
+    assertThat(filterGroupIds(schema, file, equal("decimal_int", new BigDecimal("-12.34"))))
+        .containsExactlyInAnyOrder(1L);
+    assertThat(
+            filterGroupIds(schema, file, lessThan("decimal_fixed", new BigDecimal("0.0000000000"))))
+        .containsExactlyInAnyOrder(1L);
+    assertThat(
+            filterGroupIds(
+                schema, file, greaterThan("decimal_fixed", new BigDecimal("0.0000000000"))))
+        .containsExactlyInAnyOrder(3L);
+    assertThat(filterGroupIds(schema, file, equal("uuid_col", secondUuid)))
+        .containsExactlyInAnyOrder(2L);
+  }
+
+  @Test
+  public void binaryDecimalFilterUsesPhysicalParquetValues() throws IOException {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "decimal_binary", Types.DecimalType.of(9, 2)));
+    MessageType parquetSchema =
+        buildMessage()
+            .required(PrimitiveTypeName.INT64)
+            .id(1)
+            .named("id")
+            .required(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.decimalType(2, 9))
+            .id(2)
+            .named("decimal_binary")
+            .named("table");
+
+    File file = createTempFile(temp);
+    SimpleGroupFactory factory = new SimpleGroupFactory(parquetSchema);
+    try (ParquetWriter<Group> writer =
+        ExampleParquetWriter.builder(ParquetIO.file(Files.localOutput(file)))
+            .withType(parquetSchema)
+            .build()) {
+      writer.write(binaryDecimalRecord(factory, 1L, new BigDecimal("-12.34")));
+      writer.write(binaryDecimalRecord(factory, 2L, new BigDecimal("0.00")));
+      writer.write(binaryDecimalRecord(factory, 3L, new BigDecimal("56.78")));
+    }
+
+    assertThat(filterGroupIds(schema, file, lessThan("decimal_binary", new BigDecimal("0.00"))))
+        .containsExactlyInAnyOrder(1L);
+    assertThat(filterGroupIds(schema, file, greaterThan("decimal_binary", new BigDecimal("0.00"))))
+        .containsExactlyInAnyOrder(3L);
+  }
+
+  private Group binaryDecimalRecord(SimpleGroupFactory factory, long id, BigDecimal decimal) {
+    return factory
+        .newGroup()
+        .append("id", id)
+        .append(
+            "decimal_binary", Binary.fromConstantByteArray(decimal.unscaledValue().toByteArray()));
+  }
+
+  private File writeRecords(Schema schema, List<Record> records) throws IOException {
     File file = createTempFile(temp);
     try (FileAppender<Record> appender =
         Parquet.write(Files.localOutput(file))
@@ -702,6 +816,25 @@ public class TestParquet {
         Parquet.read(localInput(file)).project(schema).callInit().filter(filter).build()) {
       for (GenericData.Record record : reader) {
         ids.add((Long) record.get("id"));
+      }
+    }
+
+    return ids;
+  }
+
+  private List<Long> filterGroupIds(Schema schema, File file, Expression filter)
+      throws IOException {
+    List<Long> ids = Lists.newArrayList();
+    // GroupReadSupport keeps the same callInit path but avoids Avro decimal materialization.
+    try (CloseableIterable<Group> reader =
+        Parquet.read(localInput(file))
+            .project(schema)
+            .readSupport(new GroupReadSupport())
+            .callInit()
+            .filter(filter)
+            .build()) {
+      for (Group record : reader) {
+        ids.add(record.getLong("id", 0));
       }
     }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.not;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -140,6 +141,15 @@ class TestParquetFilters {
     FilterCompat.Filter filter =
         ParquetFilters.convert(
             PARQUET_SCHEMA, equal("decimal_int", new BigDecimal("12.345")), true);
+
+    assertThat(filter).isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void skipsNegatedDecimalLiteralWithIncompatibleScale() {
+    FilterCompat.Filter filter =
+        ParquetFilters.convert(
+            PARQUET_SCHEMA, not(equal("decimal_int", new BigDecimal("12.345"))), true);
 
     assertThat(filter).isSameAs(FilterCompat.NOOP);
   }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.DecimalUtil;
+import org.apache.iceberg.util.UUIDUtil;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.compat.FilterCompat.FilterPredicateCompat;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.filter2.predicate.Operators;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.junit.jupiter.api.Test;
+
+class TestParquetFilters {
+  private static final Schema TABLE_SCHEMA =
+      new Schema(
+          optional(1, "decimal_int", Types.DecimalType.of(9, 2)),
+          optional(2, "decimal_long", Types.DecimalType.of(18, 2)),
+          optional(3, "decimal_fixed", Types.DecimalType.of(19, 2)),
+          optional(4, "uuid_col", Types.UUIDType.get()));
+
+  private static final MessageType PARQUET_SCHEMA =
+      ParquetSchemaUtil.convert(TABLE_SCHEMA, "table");
+
+  private static final MessageType BINARY_DECIMAL_PARQUET_SCHEMA =
+      org.apache.parquet.schema.Types.buildMessage()
+          .optional(PrimitiveTypeName.BINARY)
+          .as(LogicalTypeAnnotation.decimalType(2, 9))
+          .named("decimal_int")
+          .named("table");
+
+  private static final MessageType EXTENDED_FIXED_DECIMAL_PARQUET_SCHEMA =
+      org.apache.parquet.schema.Types.buildMessage()
+          .optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+          .length(16)
+          .as(LogicalTypeAnnotation.decimalType(2, 19))
+          .named("decimal_fixed")
+          .named("table");
+
+  @Test
+  void convertsIntDecimalLiteral() {
+    BigDecimal decimal = new BigDecimal("12.34");
+
+    Operators.Eq<?> predicate = predicate(equal("decimal_int", decimal), Operators.Eq.class);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Integer.class);
+    assertThat(predicate.getValue()).isEqualTo(1234);
+  }
+
+  @Test
+  void convertsLongDecimalLiteral() {
+    BigDecimal decimal = new BigDecimal("1234567890123456.78");
+
+    Operators.Eq<?> predicate = predicate(equal("decimal_long", decimal), Operators.Eq.class);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Long.class);
+    assertThat(predicate.getValue()).isEqualTo(123456789012345678L);
+  }
+
+  @Test
+  void convertsFixedDecimalLiteral() {
+    Types.DecimalType decimalType = Types.DecimalType.of(19, 2);
+    BigDecimal decimal = new BigDecimal("12345678901234567.89");
+
+    Operators.Eq<?> predicate = predicate(equal("decimal_fixed", decimal), Operators.Eq.class);
+
+    byte[] expected =
+        DecimalUtil.toReusedFixLengthBytes(
+            decimalType.precision(),
+            decimalType.scale(),
+            decimal,
+            new byte[TypeUtil.decimalRequiredBytes(decimalType.precision())]);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Binary.class);
+    assertThat(((Binary) predicate.getValue()).getBytes()).isEqualTo(expected);
+  }
+
+  @Test
+  void usesParquetPhysicalTypeForBinaryDecimal() {
+    BigDecimal decimal = new BigDecimal("12.34");
+
+    Operators.Eq<?> predicate =
+        predicate(BINARY_DECIMAL_PARQUET_SCHEMA, equal("decimal_int", decimal), Operators.Eq.class);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Binary.class);
+    assertThat(((Binary) predicate.getValue()).getBytes())
+        .isEqualTo(decimal.unscaledValue().toByteArray());
+  }
+
+  @Test
+  void usesParquetTypeLengthForFixedDecimal() {
+    Types.DecimalType decimalType = Types.DecimalType.of(19, 2);
+    BigDecimal decimal = new BigDecimal("-12345678901234567.89");
+
+    Operators.Eq<?> predicate =
+        predicate(
+            EXTENDED_FIXED_DECIMAL_PARQUET_SCHEMA,
+            equal("decimal_fixed", decimal),
+            Operators.Eq.class);
+
+    byte[] expected =
+        DecimalUtil.toReusedFixLengthBytes(
+            decimalType.precision(), decimalType.scale(), decimal, new byte[16]);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Binary.class);
+    assertThat(((Binary) predicate.getValue()).getBytes()).isEqualTo(expected);
+  }
+
+  @Test
+  void skipsDecimalLiteralWithIncompatibleScale() {
+    FilterCompat.Filter filter =
+        ParquetFilters.convert(
+            PARQUET_SCHEMA, equal("decimal_int", new BigDecimal("12.345")), true);
+
+    assertThat(filter).isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void skipsDecimalLiteralThatExceedsPrecision() {
+    FilterCompat.Filter filter =
+        ParquetFilters.convert(
+            PARQUET_SCHEMA, equal("decimal_int", new BigDecimal("123456789.12")), true);
+
+    assertThat(filter).isSameAs(FilterCompat.NOOP);
+  }
+
+  @Test
+  void convertsDecimalLiteralWithTrailingZeros() {
+    Operators.Eq<?> predicate =
+        predicate(equal("decimal_int", new BigDecimal("12.340")), Operators.Eq.class);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Integer.class);
+    assertThat(predicate.getValue()).isEqualTo(1234);
+  }
+
+  @Test
+  void convertsUuidLiteral() {
+    UUID uuid = UUID.fromString("f24f9b64-81fa-49d1-b74e-8c09a6e31c56");
+
+    Operators.Eq<?> predicate = predicate(equal("uuid_col", uuid), Operators.Eq.class);
+
+    assertThat(predicate.getColumn().getColumnType()).isEqualTo(Binary.class);
+    assertThat(((Binary) predicate.getValue()).getBytes()).isEqualTo(UUIDUtil.convert(uuid));
+  }
+
+  private static <P extends FilterPredicate> P predicate(Expression expression, Class<P> type) {
+    return predicate(PARQUET_SCHEMA, expression, type);
+  }
+
+  private static <P extends FilterPredicate> P predicate(
+      MessageType parquetSchema, Expression expression, Class<P> type) {
+    FilterCompat.Filter filter = ParquetFilters.convert(parquetSchema, expression, true);
+    assertThat(filter).isInstanceOf(FilterPredicateCompat.class);
+
+    FilterPredicate predicate = ((FilterPredicateCompat) filter).getFilterPredicate();
+    assertThat(predicate).isInstanceOf(type);
+    return type.cast(predicate);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetFilters.java
@@ -19,8 +19,10 @@
 package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
 import static org.apache.iceberg.expressions.Expressions.not;
 import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.parquet.schema.Types.buildMessage;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
@@ -53,14 +55,14 @@ class TestParquetFilters {
       ParquetSchemaUtil.convert(TABLE_SCHEMA, "table");
 
   private static final MessageType BINARY_DECIMAL_PARQUET_SCHEMA =
-      org.apache.parquet.schema.Types.buildMessage()
+      buildMessage()
           .optional(PrimitiveTypeName.BINARY)
           .as(LogicalTypeAnnotation.decimalType(2, 9))
           .named("decimal_int")
           .named("table");
 
   private static final MessageType EXTENDED_FIXED_DECIMAL_PARQUET_SCHEMA =
-      org.apache.parquet.schema.Types.buildMessage()
+      buildMessage()
           .optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
           .length(16)
           .as(LogicalTypeAnnotation.decimalType(2, 19))
@@ -180,6 +182,17 @@ class TestParquetFilters {
 
     assertThat(predicate.getColumn().getColumnType()).isEqualTo(Binary.class);
     assertThat(((Binary) predicate.getValue()).getBytes()).isEqualTo(UUIDUtil.convert(uuid));
+  }
+
+  @Test
+  void skipsUuidOrderingPredicate() {
+    FilterCompat.Filter filter =
+        ParquetFilters.convert(
+            PARQUET_SCHEMA,
+            lessThan("uuid_col", UUID.fromString("00000000-0000-0000-0000-000000000001")),
+            true);
+
+    assertThat(filter).isSameAs(FilterCompat.NOOP);
   }
 
   private static <P extends FilterPredicate> P predicate(Expression expression, Class<P> type) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -165,6 +165,22 @@ public class TestParquetSchemaUtil {
   }
 
   @Test
+  public void testConvertUuidLogicalType() {
+    MessageType messageType =
+        org.apache.parquet.schema.Types.buildMessage()
+            .optional(PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
+            .length(16)
+            .as(LogicalTypeAnnotation.uuidType())
+            .id(1)
+            .named("uuid_col")
+            .named("test");
+
+    Schema actualSchema = ParquetSchemaUtil.convert(messageType);
+
+    assertThat(actualSchema.findType(1)).isEqualTo(Types.UUIDType.get());
+  }
+
+  @Test
   public void testSchemaConversionWithoutAssigningIds() {
     MessageType messageType =
         new MessageType(


### PR DESCRIPTION
This fixes Parquet filter pushdown conversion for decimal and UUID predicates.

Changes:
- Use the Parquet `MessageType` when building the pushed Parquet filter so decimal predicates use the actual physical primitive type.
- Convert decimal literals for `INT32`, `INT64`, `BINARY`, and `FIXED_LEN_BYTE_ARRAY` encodings.
- Use the actual fixed-length byte array length for fixed decimal predicates.
- Fall back to `NOOP` when decimal literals cannot be represented safely at the file schema scale/precision.
- Convert Parquet UUID logical type back to Iceberg `UUIDType` so UUID predicates bind correctly.

Tests:
- `./gradlew :iceberg-parquet:spotlessCheck :iceberg-parquet:test`

Closes #16035
