### PR TITLE
Spark 4.1: Bind parameters in IcebergSparkSqlExtensionsParser

### DIFF
--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -134,6 +134,8 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
       parameterContext: ParameterContext): LogicalPlan = {
     val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
     if (isIcebergCommand(sqlTextAfterSubstitution)) {
+      // Iceberg DDL grammars do not accept parameter markers (`?` / `:name`), so the
+      // parameterContext is intentionally not propagated on this path.
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
         .asInstanceOf[LogicalPlan]
     } else {

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -33,6 +33,7 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.RewriteViewCommands
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.ParameterContext
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.NonReservedContext
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.QuotedIdentifierContext
@@ -122,6 +123,22 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
         .asInstanceOf[LogicalPlan]
     } else {
       RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
+    }
+  }
+
+  /**
+   * Parse a string to a LogicalPlan, binding the given parameters.
+   */
+  override def parsePlanWithParameters(
+      sqlText: String,
+      parameterContext: ParameterContext): LogicalPlan = {
+    val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
+    if (isIcebergCommand(sqlTextAfterSubstitution)) {
+      parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
+        .asInstanceOf[LogicalPlan]
+    } else {
+      RewriteViewCommands(SparkSession.active)
+        .apply(delegate.parsePlanWithParameters(sqlText, parameterContext))
     }
   }
 

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -116,31 +116,34 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
   /**
    * Parse a string to a LogicalPlan.
    */
-  override def parsePlan(sqlText: String): LogicalPlan = {
-    val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
-    if (isIcebergCommand(sqlTextAfterSubstitution)) {
-      parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
-        .asInstanceOf[LogicalPlan]
-    } else {
-      RewriteViewCommands(SparkSession.active).apply(delegate.parsePlan(sqlText))
-    }
-  }
+  override def parsePlan(sqlText: String): LogicalPlan =
+    parsePlanWithDelegate(sqlText)(delegate.parsePlan)
 
   /**
    * Parse a string to a LogicalPlan, binding the given parameters.
+   *
+   * Iceberg DDL grammars do not accept parameter markers (`?` / `:name`), so the
+   * parameterContext is only forwarded to the delegate on the non-Iceberg path.
    */
   override def parsePlanWithParameters(
       sqlText: String,
-      parameterContext: ParameterContext): LogicalPlan = {
+      parameterContext: ParameterContext): LogicalPlan =
+    parsePlanWithDelegate(sqlText) { sql =>
+      delegate.parsePlanWithParameters(sql, parameterContext)
+    }
+
+  /**
+   * Dispatch parsing: Iceberg commands are parsed by the extensions parser, everything else is
+   * handed to the wrapped Spark parser via `delegateParse`.
+   */
+  private def parsePlanWithDelegate(sqlText: String)(
+      delegateParse: String => LogicalPlan): LogicalPlan = {
     val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
     if (isIcebergCommand(sqlTextAfterSubstitution)) {
-      // Iceberg DDL grammars do not accept parameter markers (`?` / `:name`), so the
-      // parameterContext is intentionally not propagated on this path.
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
         .asInstanceOf[LogicalPlan]
     } else {
-      RewriteViewCommands(SparkSession.active)
-        .apply(delegate.parsePlanWithParameters(sqlText, parameterContext))
+      RewriteViewCommands(SparkSession.active).apply(delegateParse(sqlText))
     }
   }
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,14 +29,19 @@ import static org.mockito.Mockito.when;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.expressions.Term;
+import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.parser.AbstractSqlParser;
 import org.apache.spark.sql.catalyst.parser.AstBuilder;
+import org.apache.spark.sql.catalyst.parser.ParameterContext;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser;
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
+import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -182,6 +189,47 @@ public class TestExtendedParser {
         ExtendedParser.parseSortOrder(spark, "id ASC NULLS FIRST");
     assertThat(result).isSameAs(expected);
     verify(icebergParser).parseSortOrder("id ASC NULLS FIRST");
+  }
+
+  /** Tests that non-Iceberg SQL delegates with the parameter context intact. */
+  @Test
+  public void testParsePlanWithParametersDelegatesForNonIcebergSql() throws Exception {
+    ParserInterface delegate = mock(ParserInterface.class);
+    ParameterContext context = mock(ParameterContext.class);
+    LogicalPlan plan = new OneRowRelation();
+    when(delegate.parsePlanWithParameters(anyString(), any(ParameterContext.class)))
+        .thenReturn(plan);
+
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(delegate);
+
+    parser.parsePlanWithParameters("SELECT 1 WHERE 1 = ?", context);
+
+    verify(delegate).parsePlanWithParameters("SELECT 1 WHERE 1 = ?", context);
+  }
+
+  /** Tests that a positional parameter binds through a real Iceberg-extended parser. */
+  @Test
+  public void testParsePlanWithParametersBindsPositionalParameter() throws Exception {
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(originalParser);
+    setSessionStateParser(spark.sessionState(), parser);
+
+    List<Row> rows = spark.sql("SELECT ? AS id", new Object[] {42}).collectAsList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(0)).isEqualTo(42);
+  }
+
+  /** Tests that a named parameter binds through a real Iceberg-extended parser. */
+  @Test
+  public void testParsePlanWithParametersBindsNamedParameter() throws Exception {
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(originalParser);
+    setSessionStateParser(spark.sessionState(), parser);
+
+    Map<String, Object> args = Collections.singletonMap("id", 42);
+    List<Row> rows = spark.sql("SELECT :id AS id", args).collectAsList();
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(0)).isEqualTo(42);
   }
 
   private static void setSessionStateParser(Object sessionState, ParserInterface parser)


### PR DESCRIPTION
Closes #16625.

## Root cause

Spark 4.1 routes parameterized queries through `ParserInterface.parsePlanWithParameters(sqlText, parameterContext)` (SPARK-53573). The trait's default implementation ignores the `ParameterContext` and falls back to `parsePlan`. `IcebergSparkSqlExtensionsParser` overrides `parsePlan` but not `parsePlanWithParameters`, so with the extensions installed the context is dropped and parameter markers are never bound. Only 4.1 is affected — the method and `ParameterContext` are new in 4.1; 3.5 and 4.0 bind parameters post-parse.

## Fix

Override `parsePlanWithParameters` to mirror `parsePlan`: Iceberg commands keep the existing path, everything else delegates to the wrapped Spark parser with the `ParameterContext` intact.

## Testing

Added regression tests in `TestExtendedParser` (all fail without the fix, pass with it):
- `testParsePlanWithParametersDelegatesForNonIcebergSql` — non-Iceberg SQL delegates with the context preserved.
- `testParsePlanWithParametersBindsPositionalParameter` — `SELECT ? AS id` binds end-to-end.
- `testParsePlanWithParametersBindsNamedParameter` — `SELECT :id AS id` binds end-to-end.

`spotlessCheck`, `scalastyle*Check`, and `checkstyle*` all pass.
