### PR TITLE
Arrow: Fix truncation of decimals with precision larger than 18

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowVectorAccessors.java
@@ -99,7 +99,9 @@ final class ArrowVectorAccessors {
 
     @Override
     public BigDecimal ofBigDecimal(BigDecimal value, int precision, int scale) {
-      return BigDecimal.valueOf(value.unscaledValue().longValue(), scale);
+      // Return the value unchanged: it already has the correct unscaled value and scale. The
+      // unscaled value can exceed the range of a long, so it must not be narrowed to one.
+      return value;
     }
   }
 }

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
@@ -386,6 +387,72 @@ public class TestArrowReader {
     }
 
     assertThat(totalRowsRead).as("Should read all rows").isEqualTo(millisValues.size());
+  }
+
+  /**
+   * Reads a decimal(38, 0) column whose values exceed Long.MAX_VALUE. Decimals with precision &gt;=
+   * 19 are stored as a FIXED_LEN_BYTE_ARRAY, and reading them must not narrow the unscaled value
+   * through {@code BigInteger.longValue()}. This reproduces a bug where the binary-backed decimal
+   * accessor silently truncated such values.
+   */
+  @Test
+  public void testHighPrecisionDecimalIsReadCorrectly() throws Exception {
+    tables = new HadoopTables();
+    int precision = 38;
+    int scale = 0;
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "decimal", Types.DecimalType.of(precision, scale)));
+    Table table = tables.create(schema, tableLocation);
+
+    // Both values have an unscaled magnitude well beyond Long.MAX_VALUE (~9.2e18).
+    List<BigDecimal> values =
+        Lists.newArrayList(
+            new BigDecimal(new BigInteger("12345678901234567890"), scale),
+            new BigDecimal(new BigInteger("99999999999999999999999999999999999999"), scale));
+
+    List<GenericRecord> records = Lists.newArrayListWithCapacity(values.size());
+    for (BigDecimal value : values) {
+      GenericRecord record = GenericRecord.create(schema);
+      record.setField("decimal", value);
+      records.add(record);
+    }
+
+    File parquetFile = File.createTempFile("decimal", ".parquet", tempDir);
+    assertThat(parquetFile.delete()).isTrue();
+    FileAppender<GenericRecord> appender =
+        Parquet.write(Files.localOutput(parquetFile))
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build();
+    try {
+      appender.addAll(records);
+    } finally {
+      appender.close();
+    }
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withInputFile(localInput(parquetFile))
+            .withMetrics(appender.metrics())
+            .withFormat(FileFormat.PARQUET)
+            .build();
+    table.newAppend().appendFile(dataFile).commit();
+
+    int rowIndex = 0;
+    try (VectorizedTableScanIterable vectorizedReader =
+        new VectorizedTableScanIterable(table.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : vectorizedReader) {
+        for (int i = 0; i < batch.numRows(); i++) {
+          assertThat(batch.column(0).getDecimal(i, precision, scale))
+              .as("decimal(%d, %d) value at row %d must not be truncated", precision, scale, i)
+              .isEqualTo(values.get(rowIndex));
+          rowIndex++;
+        }
+      }
+    }
+
+    assertThat(rowIndex).isEqualTo(values.size());
   }
 
   @ParameterizedTest


### PR DESCRIPTION
## Problem

Reading a decimal column through the vectorized Arrow reader silently corrupts values whose unscaled magnitude exceeds `Long.MAX_VALUE`. This affects any decimal with precision larger than 18 (for example `decimal(38, 0)`) holding a sufficiently large value. No error is raised; the returned `BigDecimal` is simply wrong, and often negative.

## Root cause

Decimals with precision larger than 18 are stored as a binary / `FIXED_LEN_BYTE_ARRAY` and read into a `FixedSizeBinaryVector`. The binary-backed decimal accessors decode the bytes into the correct `BigDecimal` and then hand it to `JavaDecimalFactory.ofBigDecimal`, which rebuilds it as `BigDecimal.valueOf(value.unscaledValue().longValue(), scale)`. `BigInteger.longValue()` keeps only the low 64 bits, so any unscaled value beyond `Long` range is truncated. The incoming `value` is already the correct `BigDecimal` (it carries the right unscaled value and scale), so this round-trip is both unnecessary and lossy.

The `ofLong` path used for INT32/INT64-backed decimals (precision up to 18) is unaffected, which is why only high-precision decimals are corrupted and the existing tests, which use `decimal(9, 2)`, never caught it.

## Fix

Return `value` unchanged. It already represents the decimal with the correct unscaled value and scale, matching how the Spark accessor factory preserves the full value.

## Tests

Added `TestArrowReader.testHighPrecisionDecimalIsReadCorrectly`, which writes a `decimal(38, 0)` Parquet file with values larger than `Long.MAX_VALUE` and asserts they round-trip through the vectorized reader. It fails before the fix (`expected 12345678901234567890 but was -6101065172474983726`) and passes after.