### PR TITLE
parquet: Add tests for disabling statistics on multiple columns

### DIFF
--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -274,6 +274,97 @@ public class TestParquet {
   }
 
   @Test
+  public void testColumnStatisticsDisabledMultipleColumns() throws Exception {
+    Schema schema =
+        new Schema(
+            optional(1, "int_field", IntegerType.get()),
+            optional(2, "string_field", Types.StringType.get()),
+            optional(3, "double_field", Types.DoubleType.get()));
+
+    File file = createTempFile(temp);
+
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(5);
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    for (int i = 1; i <= 5; i++) {
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put("int_field", i);
+      record.put("string_field", "test");
+      record.put("double_field", i * 1.5);
+      records.add(record);
+    }
+
+    write(
+        file,
+        schema,
+        ImmutableMap.<String, String>builder()
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "int_field", "true")
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "string_field", "false")
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "double_field", "false")
+            .buildOrThrow(),
+        ParquetAvroWriter::buildWriter,
+        records.toArray(new GenericData.Record[] {}));
+
+    InputFile inputFile = Files.localInput(file);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile))) {
+      for (BlockMetaData block : reader.getFooter().getBlocks()) {
+        for (ColumnChunkMetaData column : block.getColumns()) {
+          boolean emptyStats = column.getStatistics().isEmpty();
+          if (column.getPath().toDotString().equals("int_field")) {
+            assertThat(emptyStats).as("int_field has statistics").isEqualTo(false);
+          } else if (column.getPath().toDotString().equals("string_field")) {
+            assertThat(emptyStats).as("string_field has statistics disabled").isEqualTo(true);
+          } else if (column.getPath().toDotString().equals("double_field")) {
+            assertThat(emptyStats).as("double_field has statistics disabled").isEqualTo(true);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testColumnStatisticsDisabledAllColumns() throws Exception {
+    Schema schema =
+        new Schema(
+            optional(1, "int_field", IntegerType.get()),
+            optional(2, "string_field", Types.StringType.get()));
+
+    File file = createTempFile(temp);
+
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(5);
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    for (int i = 1; i <= 5; i++) {
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put("int_field", i);
+      record.put("string_field", "test");
+      records.add(record);
+    }
+
+    write(
+        file,
+        schema,
+        ImmutableMap.<String, String>builder()
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "int_field", "false")
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "string_field", "false")
+            .buildOrThrow(),
+        ParquetAvroWriter::buildWriter,
+        records.toArray(new GenericData.Record[] {}));
+
+    InputFile inputFile = Files.localInput(file);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile))) {
+      for (BlockMetaData block : reader.getFooter().getBlocks()) {
+        for (ColumnChunkMetaData column : block.getColumns()) {
+          boolean emptyStats = column.getStatistics().isEmpty();
+          assertThat(emptyStats)
+              .as(column.getPath().toDotString() + " has statistics disabled")
+              .isEqualTo(true);
+        }
+      }
+    }
+  }
+
+  @Test
   public void testFooterMetricsWithNameMappingForFileWithoutIds() throws IOException {
     Schema schemaWithIds =
         new Schema(


### PR DESCRIPTION
This is an independent contribution and is not associated with any hackathon or competition.

## Summary

Adds two new test methods to `TestParquet.java` covering the edge case where per-column statistics are disabled on more than one column simultaneously.

## Root Cause

The existing test `testColumnStatisticsEnabled` only validates the single-column-disabled scenario. Issue #15347 reported that when statistics are disabled on multiple columns (e.g., `write.parquet.stats-enabled.column.foo=false` and `write.parquet.stats-enabled.column.bar=false`), the second column may still write statistics. These tests provide coverage for that scenario.

## Changes

- **`testColumnStatisticsDisabledMultipleColumns`**: Schema with 3 columns (int, string, double); stats enabled on col 1, disabled on cols 2 and 3. Verifies both disabled columns correctly omit statistics.
- **`testColumnStatisticsDisabledAllColumns`**: Schema with 2 columns; stats disabled on both. Verifies every column omits statistics.

## Testing

Both new tests follow the same pattern as the existing `testColumnStatisticsEnabled`: write Parquet data with the given properties, read back the footer, and assert that each ColumnChunkMetaData has the expected statistics state (empty or non-empty).
