### PR TITLE
Core: Add branch support for RewriteManifests operation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -84,6 +84,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   }
 
   @Override
+  public RewriteManifests toBranch(String branch) {
+    targetBranch(branch);
+    return this;
+  }
+
+  @Override
   protected String operation() {
     return DataOperations.REPLACE;
   }
@@ -168,10 +174,11 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
-    List<ManifestFile> currentManifests = base.currentSnapshot().allManifests(ops().io());
+    List<ManifestFile> currentManifests =
+        snapshot != null ? snapshot.allManifests(ops().io()) : Collections.emptyList();
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(currentManifestSet, base.currentSnapshot().snapshotId());
+    validateDeletedManifests(currentManifestSet, snapshot != null ? snapshot.snapshotId() : -1L);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -178,7 +178,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
         snapshot != null ? snapshot.allManifests(ops().io()) : Collections.emptyList();
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(currentManifestSet, snapshot != null ? snapshot.snapshotId() : -1L);
+    validateDeletedManifests(currentManifestSet, snapshot);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);
@@ -290,17 +290,22 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     return predicate == null || predicate.test(manifest);
   }
 
-  private void validateDeletedManifests(
-      Set<ManifestFile> currentManifests, long currentSnapshotID) {
+  private void validateDeletedManifests(Set<ManifestFile> currentManifests, Snapshot snapshot) {
     // directly deleted manifests must be still present in the current snapshot
     deletedManifests.stream()
         .filter(manifest -> !currentManifests.contains(manifest))
         .findAny()
         .ifPresent(
             manifest -> {
+              if (snapshot == null) {
+                throw new ValidationException(
+                    "Deleted manifest %s could not be found: branch %s has no snapshot",
+                    manifest.path(), targetBranch());
+              }
+
               throw new ValidationException(
                   "Deleted manifest %s could not be found in the latest snapshot %d",
-                  manifest.path(), currentSnapshotID);
+                  manifest.path(), snapshot.snapshotId());
             });
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -1078,16 +1078,106 @@ public class TestRewriteManifests extends TestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsOnBranchUnsupported() {
+  public void testRewriteManifestsOnBranch() throws IOException {
+    String branch = "branch";
 
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createBranch(branch, mainSnapshotId).commit();
 
+    // append a second file only on the branch so the branch diverges from main
+    table.newFastAppend().appendFile(FILE_B).toBranch(branch).commit();
+    long branchAppendId = table.snapshot(branch).snapshotId();
+
+    assertThat(table.snapshot(branch).allManifests(table.io())).hasSize(2);
+
+    // cluster by a constant combines the branch's manifests into one
+    table.rewriteManifests().clusterBy(file -> "").toBranch(branch).commit();
+
+    // main must be untouched: same snapshot, same single manifest with only FILE_A
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
+    List<ManifestFile> mainManifests = table.currentSnapshot().allManifests(table.io());
+    assertThat(mainManifests).hasSize(1);
+    validateManifestEntries(
+        mainManifests.get(0),
+        ids(mainSnapshotId),
+        files(FILE_A),
+        statuses(ManifestEntry.Status.ADDED));
+
+    // the branch reflects the rewrite over its own (diverged) manifests, including FILE_B
+    List<ManifestFile> branchManifests = table.snapshot(branch).allManifests(table.io());
+    assertThat(branchManifests).hasSize(1);
+
+    // get the file order correct
+    List<DataFile> files;
+    List<Long> ids;
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(branchManifests.get(0), table.io(), table.specs())) {
+      if (reader.iterator().next().location().equals(FILE_A.location())) {
+        files = Arrays.asList(FILE_A, FILE_B);
+        ids = Arrays.asList(mainSnapshotId, branchAppendId);
+      } else {
+        files = Arrays.asList(FILE_B, FILE_A);
+        ids = Arrays.asList(branchAppendId, mainSnapshotId);
+      }
+    }
+
+    validateManifestEntries(
+        branchManifests.get(0),
+        ids.iterator(),
+        files.iterator(),
+        statuses(ManifestEntry.Status.EXISTING, ManifestEntry.Status.EXISTING));
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsCreatesBranchIfNeeded() {
+    String branch = "newBranch";
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+
+    // the branch does not exist yet; rewriting to it forks the branch from main
+    table.rewriteManifests().clusterBy(file -> "").toBranch(branch).commit();
+
+    // main must be untouched
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(mainSnapshotId);
     assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
-    assertThatThrownBy(() -> table.rewriteManifests().toBranch("someBranch").commit())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage(
-            "Cannot commit to branch someBranch: org.apache.iceberg.BaseRewriteManifests does not support branch commits");
+    // the branch was created, forked from main, with main's manifests rewritten onto it
+    SnapshotRef branchRef = table.ops().current().ref(branch);
+    assertThat(branchRef).isNotNull();
+    assertThat(branchRef.isBranch()).isTrue();
+
+    Snapshot branchSnapshot = table.snapshot(branch);
+    assertThat(branchSnapshot.snapshotId()).isNotEqualTo(mainSnapshotId);
+    assertThat(branchSnapshot.parentId()).isEqualTo(mainSnapshotId);
+    assertThat(branchSnapshot.operation()).isEqualTo(DataOperations.REPLACE);
+
+    List<ManifestFile> branchManifests = branchSnapshot.allManifests(table.io());
+    assertThat(branchManifests).hasSize(1);
+    validateManifestEntries(
+        branchManifests.get(0),
+        ids(mainSnapshotId),
+        files(FILE_A),
+        statuses(ManifestEntry.Status.EXISTING));
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsToBranchRejectsNullBranch() {
+    assertThatThrownBy(() -> table.rewriteManifests().toBranch(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid branch name: null");
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsToBranchRejectsTag() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long snapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createTag("tag1", snapshotId).commit();
+
+    assertThatThrownBy(() -> table.rewriteManifests().toBranch("tag1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("tag1 is a tag, not a branch. Tags cannot be targets for producing snapshots");
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -1181,6 +1181,30 @@ public class TestRewriteManifests extends TestBase {
   }
 
   @TestTemplate
+  public void testRewriteManifestsOnEmptyTable() {
+    assertThat(table.currentSnapshot()).isNull();
+
+    table.rewriteManifests().clusterBy(file -> "").commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    assertThat(snapshot).isNotNull();
+    assertThat(snapshot.operation()).isEqualTo(DataOperations.REPLACE);
+    assertThat(snapshot.allManifests(table.io())).isEmpty();
+  }
+
+  @TestTemplate
+  public void testDeleteMissingManifestOnEmptyTable() throws IOException {
+    assertThat(table.currentSnapshot()).isNull();
+
+    ManifestFile manifest = writeManifest(FILE_A);
+
+    assertThatThrownBy(() -> table.rewriteManifests().deleteManifest(manifest).commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage(
+            "Deleted manifest %s could not be found: branch main has no snapshot", manifest.path());
+  }
+
+  @TestTemplate
   public void testRewriteDataManifestsPreservesDeletes() {
     assumeThat(formatVersion).isGreaterThan(1);
 


### PR DESCRIPTION
## What

Adds branch support to `RewriteManifests` via `toBranch(String)` so manifest compaction/clustering can target a named branch. Closes #15981.

`RewriteManifests` was the only `SnapshotUpdate` that could not commit to a branch: `BaseRewriteManifests` inherited the default `SnapshotUpdate.toBranch`, which throws `UnsupportedOperationException`. There was also a second, latent bug: even if `toBranch` were unblocked, `apply(base, snapshot)` read manifests from `base.currentSnapshot()` (always the `main` tip) rather than the `snapshot` argument that `SnapshotProducer` passes in (the tip of the target branch), so a branch commit would have rewritten the wrong manifests.

## Changes

- Override `toBranch` to delegate to the inherited `SnapshotProducer.targetBranch`, which already rejects `null` and tag refs with `IllegalArgumentException`.
- Read the current manifests from the `snapshot` parameter (`snapshot != null ? snapshot.allManifests(io) : Collections.emptyList()`), mirroring `FastAppend.apply` and `MergingSnapshotProducer.apply`.

Rewriting an existing branch now compacts that branch's manifests without affecting `main`. Targeting a branch that does not exist yet forks it from `main` (parent = the current `main` snapshot), consistent with other `SnapshotUpdate` operations.

## Tests

New tests in `TestRewriteManifests`, exercised across format versions v1-v4:

- `testRewriteManifestsOnBranch`: the branch diverges from `main` (an extra file appended only on the branch) before the rewrite, so it verifies the rewrite operates on the branch tip and leaves `main` untouched. This is the case that actually exercises the `apply()` fix.
- `testRewriteManifestsCreatesBranchIfNeeded`: rewriting to a non-existent branch forks it from `main`.
- `testRewriteManifestsToBranchRejectsNullBranch` and `testRewriteManifestsToBranchRejectsTag`: validation.

## Notes

This revives the approach from the stale PR #15982 by @jlkvanloon (added as a commit co-author), with broader test coverage. In particular, the original happy-path test appended both files to `main` before branching, so `main` and the branch were identical at rewrite time and the test did not exercise the `apply()` fix.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Add toBranch support to the RewriteManifests operation so manifest compaction can target a named branch.
