### PR TITLE
Flink: Support ALTER TABLE ... DROP PARTITION syntax

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -45,6 +45,7 @@ import org.apache.flink.table.catalog.exceptions.DatabaseAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotEmptyException;
 import org.apache.flink.table.catalog.exceptions.DatabaseNotExistException;
 import org.apache.flink.table.catalog.exceptions.FunctionNotExistException;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableAlreadyExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
@@ -70,6 +71,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
+import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.flink.util.FlinkAlterTableUtil;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
 import org.apache.iceberg.io.CloseableIterable;
@@ -80,6 +82,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 
 /**
  * A Flink Catalog implementation that wraps an Iceberg {@link Catalog}.
@@ -724,8 +729,84 @@ public class FlinkCatalog extends AbstractCatalog {
   @Override
   public void dropPartition(
       ObjectPath tablePath, CatalogPartitionSpec partitionSpec, boolean ignoreIfNotExists)
-      throws CatalogException {
-    throw new UnsupportedOperationException();
+      throws PartitionNotExistException, CatalogException {
+    Table icebergTable;
+    try {
+      icebergTable = loadIcebergTable(tablePath);
+    } catch (TableNotExistException e) {
+      if (ignoreIfNotExists) {
+        return;
+      }
+      throw new PartitionNotExistException(getName(), tablePath, partitionSpec, e);
+    }
+
+    if (icebergTable.spec().isUnpartitioned()) {
+      if (ignoreIfNotExists) {
+        return;
+      }
+      throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+    }
+
+    org.apache.iceberg.expressions.Expression filter =
+        buildPartitionRowFilter(icebergTable, partitionSpec);
+
+    if (!ignoreIfNotExists && !partitionHasFiles(icebergTable, filter, tablePath)) {
+      throw new PartitionNotExistException(getName(), tablePath, partitionSpec);
+    }
+
+    icebergTable.newDelete().deleteFromRowFilter(filter).commit();
+  }
+
+  /**
+   * Build a row filter from a Flink partition spec. The filter is the conjunction of {@code col =
+   * value} predicates over the table's partition source columns. {@link
+   * org.apache.iceberg.DeleteFiles#deleteFromRowFilter(org.apache.iceberg.expressions.Expression)}
+   * applies a strict-projection check so that only files whose every row matches are dropped, which
+   * makes this safe across non-identity transforms and partition-spec evolution.
+   */
+  private static org.apache.iceberg.expressions.Expression buildPartitionRowFilter(
+      Table table, CatalogPartitionSpec partitionSpec) {
+    Schema schema = table.schema();
+    Set<String> expectedColumns = expectedPartitionColumns(table.spec(), schema);
+    Map<String, String> values = partitionSpec.getPartitionSpec();
+
+    Preconditions.checkArgument(
+        values.keySet().equals(expectedColumns),
+        "DROP PARTITION requires values for partition columns %s but got %s",
+        expectedColumns,
+        values.keySet());
+
+    org.apache.iceberg.expressions.Expression filter = Expressions.alwaysTrue();
+    for (Map.Entry<String, String> entry : values.entrySet()) {
+      Types.NestedField field = schema.findField(entry.getKey());
+      Object icebergValue = Conversions.fromPartitionString(field.type(), entry.getValue());
+      org.apache.iceberg.expressions.Expression predicate =
+          (icebergValue == null)
+              ? Expressions.isNull(entry.getKey())
+              : Expressions.equal(entry.getKey(), icebergValue);
+      filter = Expressions.and(filter, predicate);
+    }
+    return filter;
+  }
+
+  private static Set<String> expectedPartitionColumns(PartitionSpec spec, Schema schema) {
+    Set<String> columns = Sets.newLinkedHashSet();
+    for (PartitionField field : spec.fields()) {
+      if (!field.transform().equals(Transforms.alwaysNull())) {
+        columns.add(schema.findColumnName(field.sourceId()));
+      }
+    }
+    return columns;
+  }
+
+  private static boolean partitionHasFiles(
+      Table table, org.apache.iceberg.expressions.Expression filter, ObjectPath tablePath) {
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().filter(filter).planFiles()) {
+      return tasks.iterator().hasNext();
+    } catch (IOException e) {
+      throw new CatalogException(
+          String.format("Failed to check partition existence for table %s", tablePath), e);
+    }
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTablePartitions.java
@@ -24,8 +24,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.flink.table.catalog.CatalogPartitionSpec;
 import org.apache.flink.table.catalog.ObjectPath;
+import org.apache.flink.table.catalog.exceptions.PartitionNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.flink.table.catalog.exceptions.TableNotPartitionedException;
+import org.apache.flink.types.Row;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Parameter;
@@ -115,5 +117,114 @@ public class TestFlinkCatalogTablePartitions extends CatalogTestBase {
     expected.add(partitionSpec1);
     expected.add(partitionSpec2);
     assertThat(list).as("Should produce the expected catalog partition specs.").isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testDropPartitionIdentity() {
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s SELECT 1,'a'", tableName);
+    sql("INSERT INTO %s SELECT 2,'b'", tableName);
+    sql("INSERT INTO %s SELECT 3,'c'", tableName);
+
+    sql("ALTER TABLE %s DROP PARTITION (data='b')", tableName);
+
+    List<Row> remaining = sql("SELECT id, data FROM %s ORDER BY id", tableName);
+    assertThat(remaining).containsExactly(Row.of(1, "a"), Row.of(3, "c"));
+  }
+
+  @TestTemplate
+  public void testDropPartitionMultipleColumns() {
+    sql(
+        "CREATE TABLE %s (id INT, region VARCHAR, dt VARCHAR) PARTITIONED BY (region, dt) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql(
+        "INSERT INTO %s VALUES (1, 'us', '2024-01-01'), (2, 'us', '2024-01-02'), (3, 'eu', '2024-01-01')",
+        tableName);
+
+    sql("ALTER TABLE %s DROP PARTITION (region='us', dt='2024-01-01')", tableName);
+
+    List<Row> remaining = sql("SELECT id, region, dt FROM %s ORDER BY id", tableName);
+    assertThat(remaining)
+        .containsExactly(Row.of(2, "us", "2024-01-02"), Row.of(3, "eu", "2024-01-01"));
+  }
+
+  @TestTemplate
+  public void testDropPartitionIgnoreIfNotExistsOnMissingPartition() {
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s SELECT 1,'a'", tableName);
+
+    sql("ALTER TABLE %s DROP IF EXISTS PARTITION (data='z')", tableName);
+
+    List<Row> remaining = sql("SELECT id, data FROM %s", tableName);
+    assertThat(remaining).containsExactly(Row.of(1, "a"));
+  }
+
+  @TestTemplate
+  public void testDropPartitionMissingPartitionFails() {
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s SELECT 1,'a'", tableName);
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP PARTITION (data='z')", tableName))
+        .rootCause()
+        .isInstanceOf(PartitionNotExistException.class)
+        .hasMessageContaining(
+            "Partition CatalogPartitionSpec{{data=z}} of table db.test_table in catalog");
+
+    List<Row> remaining = sql("SELECT id, data FROM %s", tableName);
+    assertThat(remaining).containsExactly(Row.of(1, "a"));
+  }
+
+  @TestTemplate
+  public void testDropPartitionRejectsPartialKey() {
+    sql(
+        "CREATE TABLE %s (id INT, region VARCHAR, dt VARCHAR) PARTITIONED BY (region, dt) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s VALUES (1, 'us', '2024-01-01')", tableName);
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP PARTITION (region='us')", tableName))
+        .rootCause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "DROP PARTITION requires values for partition columns [region, dt] but got [region]");
+  }
+
+  @TestTemplate
+  public void testDropPartitionRejectsUnknownColumn() {
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) PARTITIONED BY (data) "
+            + "with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s SELECT 1,'a'", tableName);
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP PARTITION (id='1')", tableName))
+        .rootCause()
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "DROP PARTITION requires values for partition columns [data] but got [id]");
+  }
+
+  @TestTemplate
+  public void testDropPartitionUnpartitionedTable() {
+    sql(
+        "CREATE TABLE %s (id INT, data VARCHAR) with ('write.format.default'='%s')",
+        tableName, format.name());
+    sql("INSERT INTO %s SELECT 1,'a'", tableName);
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP PARTITION (data='a')", tableName))
+        .rootCause()
+        .isInstanceOf(PartitionNotExistException.class)
+        .hasMessageContaining(
+            "Partition CatalogPartitionSpec{{data=a}} of table db.test_table in catalog");
   }
 }


### PR DESCRIPTION
This closes #16646.

# Summary
This PR consists of ```dropPartition(...)``` implementation for Iceberg's ```FlinkCatalog``` and tests for ```ALTER TABLE ... DROP PARTITION``` functionality.