### PR TITLE
Site: Add Iceberg-Go 0.6.0 release blog post

### DIFF
--- a/site/docs/blog/posts/2026-06-01-iceberg-go-0.6.0-release.md
+++ b/site/docs/blog/posts/2026-06-01-iceberg-go-0.6.0-release.md
@@ -1,0 +1,157 @@
+---
+date: 2026-06-01
+title: Apache Iceberg Go 0.6.0 Release
+slug: apache-iceberg-go-0.6.0-release
+authors:
+  - iceberg-pmc
+categories:
+  - release
+---
+
+<!--
+ - Licensed to the Apache Software Foundation (ASF) under one or more
+ - contributor license agreements.  See the NOTICE file distributed with
+ - this work for additional information regarding copyright ownership.
+ - The ASF licenses this file to You under the Apache License, Version 2.0
+ - (the "License"); you may not use this file except in compliance with
+ - the License.  You may obtain a copy of the License at
+ -
+ -   http://www.apache.org/licenses/LICENSE-2.0
+ -
+ - Unless required by applicable law or agreed to in writing, software
+ - distributed under the License is distributed on an "AS IS" BASIS,
+ - WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ - See the License for the specific language governing permissions and
+ - limitations under the License.
+ -->
+
+The Apache Iceberg community is pleased to announce version 0.6.0 of [iceberg-go](https://github.com/apache/iceberg-go).
+
+This release covers approximately three months of development since the 0.5.0 release in March 2026 and is the result of merging nearly **200 PRs** from **40 contributors**, including **26 first-time contributors**. See the [full changelog](https://github.com/apache/iceberg-go/compare/v0.5.0...v0.6.0) for the complete list of changes.
+
+`iceberg-go` is a native Go implementation of the Apache Iceberg table format, providing libraries for reading, writing, and managing Iceberg tables in Go applications.
+
+<!-- more -->
+
+## Release Highlights
+
+### Iceberg V3 Table Spec Support
+
+This release continues to advance `iceberg-go`'s implementation of the Iceberg V3 table specification:
+
+- **Variant type**: [Support for the V3 `variant` type](https://github.com/apache/iceberg-go/pull/932) (non-shredding) was added
+- **Deletion vectors**: A [deletion vector reader](https://github.com/apache/iceberg-go/pull/866) and [`SerializeDV`/`DVWriter` authoring APIs](https://github.com/apache/iceberg-go/pull/1100), with [blob header validation on read](https://github.com/apache/iceberg-go/pull/1055), [cardinality validation through `ReadDV`](https://github.com/apache/iceberg-go/pull/1056), and [required blob properties enforced on write](https://github.com/apache/iceberg-go/pull/1060)
+- **Row lineage**: [Row lineage support in V3](https://github.com/apache/iceberg-go/pull/735), with [reserved row-lineage fields projected as null](https://github.com/apache/iceberg-go/pull/1045) when a file lacks them
+- **Nanosecond timestamps**: [Parquet support for the nanosecond timestamp types](https://github.com/apache/iceberg-go/pull/819) and [mapping of nanosecond Arrow timestamps to the V3 `TimestampNs`/`TimestampTzNs` types](https://github.com/apache/iceberg-go/pull/1081)
+- **Defaults**: [`write-default` and `initial-default` implemented for V3](https://github.com/apache/iceberg-go/pull/779) and [enforced for required fields](https://github.com/apache/iceberg-go/pull/820)
+- **Format-version gating**: [V3-only metadata fields are gated on sub-V3 reads](https://github.com/apache/iceberg-go/pull/1069), [V2-only fields are gated on V1 reads](https://github.com/apache/iceberg-go/pull/1088), and the [remaining V3 metadata-upgrade validation rules](https://github.com/apache/iceberg-go/pull/1070) were ported
+- **Format-version upgrade**: A [`Transaction.UpgradeFormatVersion`](https://github.com/apache/iceberg-go/pull/827) API was added
+
+### Row-Level Deletes
+
+`iceberg-go` gained a full equality-delete path and an atomic row-level mutation API:
+
+- **Equality deletes**: [Write path](https://github.com/apache/iceberg-go/pull/809), [read path in the scanner](https://github.com/apache/iceberg-go/pull/818), and [support for partitioned tables](https://github.com/apache/iceberg-go/pull/823)
+- **RowDelta API**: An [atomic row-level mutation API](https://github.com/apache/iceberg-go/pull/789) was added
+- **Overwrite with deletes**: [Delete file removal in overwrite commits](https://github.com/apache/iceberg-go/pull/851) and [deletion vectors classified in scan planning](https://github.com/apache/iceberg-go/pull/855)
+
+### Table Maintenance and Compaction
+
+A new compaction and maintenance suite landed in this release:
+
+- **Compaction execution**: [`RewriteDataFiles` for compaction](https://github.com/apache/iceberg-go/pull/892) with a [bin-pack strategy](https://github.com/apache/iceberg-go/pull/850) and [`Analyze` for dry-run planning](https://github.com/apache/iceberg-go/pull/893)
+- **Dangling deletes**: [Dangling equality deletes are dropped during `RewriteDataFiles`](https://github.com/apache/iceberg-go/pull/947)
+- **RewriteFiles op**: A [`RewriteFiles` snapshot-op builder](https://github.com/apache/iceberg-go/pull/1033) was added
+
+### Concurrency and Conflict Resolution
+
+Optimistic concurrency control was substantially hardened:
+
+- **Conflict validation framework**: A [conflict validation framework](https://github.com/apache/iceberg-go/pull/928) was added and [wired into producers](https://github.com/apache/iceberg-go/pull/934)
+- **Commit retries**: [`doCommit` retries on commit-conflict errors](https://github.com/apache/iceberg-go/pull/912), with [refresh-and-replay between retries](https://github.com/apache/iceberg-go/pull/945) and [concurrent-write conflicts wrapped with `ErrCommitFailed`](https://github.com/apache/iceberg-go/pull/944)
+- **RowDelta conflicts**: [`RowDelta` uses a partition-scoped conflict check](https://github.com/apache/iceberg-go/pull/983) instead of always-true
+
+### Hadoop Catalog
+
+A Hadoop catalog implementation was added over the course of the release:
+
+- **Scaffold and path helpers**: [Initial Hadoop catalog scaffold](https://github.com/apache/iceberg-go/pull/953)
+- **Namespace and table operations**: [Namespace operations](https://github.com/apache/iceberg-go/pull/963), [list/drop/rename](https://github.com/apache/iceberg-go/pull/970), and [table and namespace CRUD](https://github.com/apache/iceberg-go/pull/969)
+- **CLI integration**: [Hadoop catalog CLI integration](https://github.com/apache/iceberg-go/pull/1034)
+
+### Catalog Improvements
+
+- **Multi-table commits**: A [`TransactionalCatalog` interface and REST multi-table commit](https://github.com/apache/iceberg-go/pull/787), plus [`CommitAndReload`](https://github.com/apache/iceberg-go/pull/817)
+- **OAuth and credentials**: [OAuth token refresh](https://github.com/apache/iceberg-go/pull/793), [vended credential refresh](https://github.com/apache/iceberg-go/pull/795), [audience and resource OAuth params](https://github.com/apache/iceberg-go/pull/815), and a [`WithOAuthTLSConfig` option](https://github.com/apache/iceberg-go/pull/895) for separate OAuth-server TLS
+- **Hive catalog**: [Register table](https://github.com/apache/iceberg-go/pull/816) and [create view](https://github.com/apache/iceberg-go/pull/788) support
+- **REST views**: [`RegisterView` was added to the REST catalog](https://github.com/apache/iceberg-go/pull/753)
+
+### Expanded CLI
+
+The command-line tool gained a large set of new commands:
+
+- **Maintenance commands**: [`expire-snapshots`](https://github.com/apache/iceberg-go/pull/1063), [`clean-orphan-files`](https://github.com/apache/iceberg-go/pull/1066), [`partition-stats`](https://github.com/apache/iceberg-go/pull/1065), and [`compact analyze`/`compact run`](https://github.com/apache/iceberg-go/pull/903)
+- **Table operations**: [`branch create`/`tag create`](https://github.com/apache/iceberg-go/pull/1068), [`upgrade`/`rollback`](https://github.com/apache/iceberg-go/pull/1071), [`snapshots`/`refs`](https://github.com/apache/iceberg-go/pull/1072), and an [`info` summary command](https://github.com/apache/iceberg-go/pull/1064)
+- **Schema flags**: [`--schema-from-file`](https://github.com/apache/iceberg-go/pull/927) to infer a schema from Parquet files and a [`--show-defaults` flag](https://github.com/apache/iceberg-go/pull/1067)
+- **Argument parsing**: The CLI [migrated from docopt-go to go-arg](https://github.com/apache/iceberg-go/pull/980)
+
+### Write Performance and Bloom Filters
+
+- **File sizing**: [Parquet files are rolled based on actual compressed size](https://github.com/apache/iceberg-go/pull/759)
+- **Partitioned writes**: A [clustered partitioned write path](https://github.com/apache/iceberg-go/pull/948) was added
+- **Memory pressure**: [Reduced memory pressure by releasing records](https://github.com/apache/iceberg-go/pull/886) and an [optional skip of the duplicate check on `AddDataFiles`](https://github.com/apache/iceberg-go/pull/901)
+- **Bloom filters**: [Bloom filter scan pruning for Parquet row groups](https://github.com/apache/iceberg-go/pull/891) and [bloom filter properties wired into the Parquet writer](https://github.com/apache/iceberg-go/pull/878)
+- **Metadata compression**: [Support for the zstd metadata compression codec](https://github.com/apache/iceberg-go/pull/1020)
+
+### IO Improvements
+
+- **In-memory FS**: A [native in-memory filesystem](https://github.com/apache/iceberg-go/pull/1025) was added
+- **Aliyun OSS**: The [`oss` scheme is registered for Aliyun OSS](https://github.com/apache/iceberg-go/pull/1074) S3-compatible storage
+- **New interfaces**: A [`ListableIO` interface](https://github.com/apache/iceberg-go/pull/917) replaces reflect-based directory walking, and a [`BulkRemovableIO` interface](https://github.com/apache/iceberg-go/pull/916) was added
+- **S3 Table Buckets**: [`PermanentRedirect` is resolved for S3 Table Buckets](https://github.com/apache/iceberg-go/pull/975)
+
+### Statistics
+
+- **Statistics updates**: [`SetStatistics`, `RemoveStatistics`, `AddEncryptionKey`, and `RemoveEncryptionKey` updates](https://github.com/apache/iceberg-go/pull/902) were implemented
+- **Partition statistics**: [`SetPartitionStatisticsUpdate` and `RemovePartitionStatisticsUpdate`](https://github.com/apache/iceberg-go/pull/1018) were added
+
+### Bug Fixes
+
+Notable bug fixes in this release include:
+
+- [Fix a nil field `Type` panic in `MarshalJSON`](https://github.com/apache/iceberg-go/pull/765)
+- [Use floored division in `HourTransform` for pre-epoch timestamps](https://github.com/apache/iceberg-go/pull/926)
+- [Handle `LargeString` columns in partition transforms](https://github.com/apache/iceberg-go/pull/780)
+- [Fast-append must inherit all parent manifests unconditionally](https://github.com/apache/iceberg-go/pull/869)
+- [Fix a goroutine leak in `positionDeleteRecordsToDataFiles`](https://github.com/apache/iceberg-go/pull/825)
+- [Fix a deadlock in `MapExec` when workers error](https://github.com/apache/iceberg-go/pull/810)
+- [Fix a refcount leak in `enrichRecordsWithPosDeleteFields`](https://github.com/apache/iceberg-go/pull/762)
+- [Reject duplicate field IDs at schema construction](https://github.com/apache/iceberg-go/pull/879)
+- [Change equality_ids Avro element type from Long to Integer to match the spec](https://github.com/apache/iceberg-go/pull/880)
+- [Decode pre-1.4 Java Iceberg legacy manifest list field names](https://github.com/apache/iceberg-go/pull/890)
+- [Resolve a data race in `MarshalJSON` on a shared `*Schema`](https://github.com/apache/iceberg-go/pull/967)
+- [Emit a proper Avro fixed schema for `FixedType` partition columns](https://github.com/apache/iceberg-go/pull/881)
+
+### Breaking Changes
+
+Some of these changes are breaking changes that need to be called out:
+
+- **Manifest entries iterator** ([#985](https://github.com/apache/iceberg-go/pull/985)): `FetchEntries` was replaced with an iterator-based approach.
+- **Multi-arg transforms** ([#824](https://github.com/apache/iceberg-go/pull/824)): partition and sort fields now support multi-argument transforms, changing the relevant field signatures.
+
+## New Contributors
+
+Welcome to all 26 first-time contributors:
+@starpact, @PranjalChaitanya, @rockwotj, @RSP22, @Hashcode-Ankit, @hcrosse, @Herrtian, @gabrnavarro, @Narwhal-fish, @alliasgher, @abhirathod95, @rohilsurana, @twmb, @cassio-paesleme, @Jeffail, @benbellick, @varun0630, @hectar-glitches, @swjtu-zhanglei, @jacobmarble, @C-Loftus, @nssalian, @tanmayrauth, @fallintoplace, @happydave1, @mzzz-zzm
+
+## Getting Involved
+
+The `iceberg-go` project welcomes contributions. We use GitHub [issues](https://github.com/apache/iceberg-go/issues) for tracking work and the [Apache Iceberg Community Slack](https://iceberg.apache.org/community/#slack) for discussions.
+
+The easiest way to get started is to:
+
+1. Try `iceberg-go` with your workloads and report any issues you encounter
+2. Review the [contributor guide](https://github.com/apache/iceberg-go/blob/main/CONTRIBUTING.md)
+3. Look for [good first issues](https://github.com/apache/iceberg-go/contribute)
+
+For more information, visit the [iceberg-go repository](https://github.com/apache/iceberg-go).


### PR DESCRIPTION
Adds the release blog post for [iceberg-go 0.6.0](https://github.com/apache/iceberg-go/releases/tag/v0.6.0).
Full changelog: https://github.com/apache/iceberg-go/compare/v0.5.0...v0.6.0