### PR TITLE
Spark 4.1: [WIP] Geometry / Geography end-to-end support

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
@@ -131,6 +132,12 @@ public class Conversions {
         variantMetadata.writeTo(variantBuffer, 0);
         variantValue.writeTo(variantBuffer, variantMetadata.sizeInBytes());
         return variantBuffer;
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // Geometry and geography lower/upper bounds are single points encoded as an
+        // x:y:z:m concatenation of 8-byte little-endian IEEE 754 doubles. See the
+        // Bound Serialization section of the Iceberg spec.
+        return ((GeospatialBound) value).toByteBuffer();
       case UNKNOWN:
         // underlying type not known
         return null;
@@ -196,6 +203,9 @@ public class Conversions {
         return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
       case VARIANT:
         return Variant.from(tmp);
+      case GEOMETRY:
+      case GEOGRAPHY:
+        return GeospatialBound.fromByteBuffer(tmp);
       case UNKNOWN:
         // underlying type not known
         return null;

--- a/api/src/test/java/org/apache/iceberg/types/TestConversions.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestConversions.java
@@ -26,6 +26,7 @@ import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.types.Types.BinaryType;
 import org.apache.iceberg.types.Types.BooleanType;
 import org.apache.iceberg.types.Types.DateType;
@@ -33,6 +34,8 @@ import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.DoubleType;
 import org.apache.iceberg.types.Types.FixedType;
 import org.apache.iceberg.types.Types.FloatType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.LongType;
 import org.apache.iceberg.types.Types.StringType;
@@ -189,6 +192,70 @@ public class TestConversions {
     assertConversion(new BigDecimal("0.011"), DecimalType.of(10, 3), new byte[] {11});
     assertThat(Literal.of(new BigDecimal("0.011")).toByteBuffer().array())
         .isEqualTo(new byte[] {11});
+  }
+
+  @Test
+  public void testByteBufferConversionsForGeometry() {
+    // geometry and geography lower/upper bounds are points encoded as an x:y:z:m concatenation
+    // of 8-byte little-endian IEEE 754 doubles. x and y are mandatory; the encoding is x:y when
+    // both z and m are unset, x:y:z when only m is unset, and x:y:NaN:m when only z is unset.
+
+    // x=10.0 -> 0, 0, 0, 0, 0, 0, 36, 64 (little-endian IEEE 754)
+    // y=13.0 -> 0, 0, 0, 0, 0, 0, 42, 64
+    // z=15.0 -> 0, 0, 0, 0, 0, 0, 46, 64
+    // m=20.0 -> 0, 0, 0, 0, 0, 0, 52, 64
+    // NaN    -> 0, 0, 0, 0, 0, 0, -8, 127
+
+    byte[] xyBytes = new byte[] {0, 0, 0, 0, 0, 0, 36, 64, 0, 0, 0, 0, 0, 0, 42, 64};
+    byte[] xyzBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, 46, 64
+        };
+    byte[] xymBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, -8, 127,
+          0, 0, 0, 0, 0, 0, 52, 64
+        };
+    byte[] xyzmBytes =
+        new byte[] {
+          0, 0, 0, 0, 0, 0, 36, 64,
+          0, 0, 0, 0, 0, 0, 42, 64,
+          0, 0, 0, 0, 0, 0, 46, 64,
+          0, 0, 0, 0, 0, 0, 52, 64
+        };
+
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.crs84(), xyBytes);
+    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeometryType.crs84(), xyzBytes);
+    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeometryType.crs84(), xymBytes);
+    assertConversion(
+        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeometryType.crs84(), xyzmBytes);
+
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeographyType.crs84(), xyBytes);
+    assertConversion(GeospatialBound.createXYZ(10.0, 13.0, 15.0), GeographyType.crs84(), xyzBytes);
+    assertConversion(GeospatialBound.createXYM(10.0, 13.0, 20.0), GeographyType.crs84(), xymBytes);
+    assertConversion(
+        GeospatialBound.createXYZM(10.0, 13.0, 15.0, 20.0), GeographyType.crs84(), xyzmBytes);
+
+    // a non-default CRS must not change the binary encoding
+    assertConversion(GeospatialBound.createXY(10.0, 13.0), GeometryType.of("EPSG:3857"), xyBytes);
+  }
+
+  @Test
+  public void testNullByteBufferConversionsForGeometry() {
+    // Null is handled by the shared guards in toByteBuffer / fromByteBuffer before the type
+    // switch, so this does not exercise the GEOMETRY / GEOGRAPHY arms (those are covered by
+    // testByteBufferConversionsForGeometry). It pins the null contract for geo types so a future
+    // change to the guards cannot silently alter null handling.
+    assertThat(Conversions.toByteBuffer(GeometryType.crs84(), null)).isNull();
+    assertThat(Conversions.toByteBuffer(GeographyType.crs84(), null)).isNull();
+    GeospatialBound geometryBound = Conversions.fromByteBuffer(GeometryType.crs84(), null);
+    GeospatialBound geographyBound = Conversions.fromByteBuffer(GeographyType.crs84(), null);
+    assertThat(geometryBound).isNull();
+    assertThat(geographyBound).isNull();
   }
 
   private <T> void assertConversion(T value, Type type, byte[] expectedBinary) {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -229,6 +229,18 @@ abstract class BaseParquetReaders<T> {
         LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
       return Optional.of(ParquetValueReaders.uuids(desc));
     }
+
+    @Override
+    public Optional<ParquetValueReader<?>> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      return Optional.of(ParquetValueReaders.byteBuffers(desc));
+    }
+
+    @Override
+    public Optional<ParquetValueReader<?>> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      return Optional.of(ParquetValueReaders.byteBuffers(desc));
+    }
   }
 
   private class ReadBuilder extends TypeWithSchemaVisitor<ParquetValueReader<?>> {

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -270,5 +270,17 @@ abstract class BaseParquetWriter<T> {
         LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
       return Optional.of(ParquetValueWriters.uuids(desc));
     }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      return Optional.of(ParquetValueWriters.byteBuffers(desc));
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      return Optional.of(ParquetValueWriters.byteBuffers(desc));
+    }
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -29,9 +30,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -246,6 +249,28 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     @Override
     public Optional<Type> visit(LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonType) {
       return Optional.of(Types.BinaryType.get());
+    }
+
+    @Override
+    public Optional<Type> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      String crs = geometryType.getCrs();
+      return Optional.of(crs == null ? Types.GeometryType.crs84() : Types.GeometryType.of(crs));
+    }
+
+    @Override
+    public Optional<Type> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      String crs = geographyType.getCrs();
+      EdgeInterpolationAlgorithm algorithm = geographyType.getAlgorithm();
+      EdgeAlgorithm icebergAlgorithm =
+          algorithm == null
+              ? null
+              : EdgeAlgorithm.valueOf(algorithm.name().toUpperCase(Locale.ROOT));
+      if (crs == null && icebergAlgorithm == null) {
+        return Optional.of(Types.GeographyType.crs84());
+      }
+
+      return Optional.of(Types.GeographyType.of(crs, icebergAlgorithm));
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -264,11 +264,23 @@ class ParquetMetrics {
         int truncateLength) {
       if (primitive.getPrimitiveTypeName() == PrimitiveType.PrimitiveTypeName.INT96) {
         return null;
-      } else if (truncateLength <= 0) {
+      } else if (truncateLength <= 0 || isGeospatial(icebergType)) {
+        // Parquet's lex min/max statistics are not meaningful for geometry/geography. Spatial
+        // bounding boxes are tracked separately via GeospatialBound and are not yet plumbed
+        // through the standard FieldMetrics path, so fall back to counts only.
         return counts(fieldId);
       } else {
         return bounds(fieldId, icebergType, primitive, truncateLength);
       }
+    }
+
+    private static boolean isGeospatial(org.apache.iceberg.types.Type.PrimitiveType icebergType) {
+      if (icebergType == null) {
+        return false;
+      }
+      org.apache.iceberg.types.Type.TypeID id = icebergType.typeId();
+      return id == org.apache.iceberg.types.Type.TypeID.GEOMETRY
+          || id == org.apache.iceberg.types.Type.TypeID.GEOGRAPHY;
     }
 
     private FieldMetrics<ByteBuffer> counts(int fieldId) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -30,12 +30,15 @@ import java.util.function.BiFunction;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type.NestedType;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.FixedType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
@@ -43,6 +46,7 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
@@ -280,9 +284,35 @@ public class TypeToMessageType {
             .id(id)
             .named(name);
 
+      case GEOMETRY:
+        GeometryType geometry = (GeometryType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(LogicalTypeAnnotation.geometryType(geometry.crs()))
+            .id(id)
+            .named(name);
+
+      case GEOGRAPHY:
+        GeographyType geography = (GeographyType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(
+                LogicalTypeAnnotation.geographyType(
+                    geography.crs(), toParquet(geography.algorithm())))
+            .id(id)
+            .named(name);
+
       default:
         throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);
     }
+  }
+
+  private static EdgeInterpolationAlgorithm toParquet(EdgeAlgorithm algorithm) {
+    if (algorithm == null) {
+      return null;
+    }
+
+    // Iceberg and Parquet share the same algorithm names (SPHERICAL, VINCENTY, THOMAS, ANDOYER,
+    // KARNEY) so we can map by name.
+    return EdgeInterpolationAlgorithm.valueOf(algorithm.name());
   }
 
   private static LogicalTypeAnnotation decimalAnnotation(int precision, int scale) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -38,6 +38,8 @@ import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType$;
 import org.apache.spark.sql.types.FloatType$;
+import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType;
@@ -244,6 +246,8 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, ImmutableSet.of(StringType$.class))
           .put(TypeID.FIXED, ImmutableSet.of(BinaryType$.class))
           .put(TypeID.BINARY, ImmutableSet.of(BinaryType$.class))
+          .put(TypeID.GEOMETRY, ImmutableSet.of(GeometryType.class))
+          .put(TypeID.GEOGRAPHY, ImmutableSet.of(GeographyType.class))
           .put(TypeID.UNKNOWN, ImmutableSet.of(NullType$.class))
           .buildOrThrow();
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -32,6 +32,8 @@ import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
@@ -162,6 +164,12 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
           ((DecimalType) atomic).precision(), ((DecimalType) atomic).scale());
     } else if (atomic instanceof BinaryType) {
       return Types.BinaryType.get();
+    } else if (atomic instanceof GeometryType) {
+      return Types.GeometryType.of(((GeometryType) atomic).crs());
+    } else if (atomic instanceof GeographyType) {
+      // The edge interpolation algorithm is not part of the Spark type. Default to SPHERICAL,
+      // which matches the Iceberg default and Spark's current runtime behavior.
+      return Types.GeographyType.of(((GeographyType) atomic).crs());
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -34,6 +34,8 @@ import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType$;
 import org.apache.spark.sql.types.DoubleType$;
 import org.apache.spark.sql.types.FloatType$;
+import org.apache.spark.sql.types.GeographyType$;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType$;
@@ -145,6 +147,15 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
         return BinaryType$.MODULE$;
       case BINARY:
         return BinaryType$.MODULE$;
+      case GEOMETRY:
+        Types.GeometryType geometry = (Types.GeometryType) primitive;
+        return GeometryType$.MODULE$.apply(geometry.crs());
+      case GEOGRAPHY:
+        // Spark currently only supports the SPHERICAL edge interpolation algorithm. The Iceberg
+        // edge algorithm is preserved on the Iceberg type and applied during predicate evaluation;
+        // it is not propagated to Spark to avoid runtime mismatches.
+        Types.GeographyType geography = (Types.GeographyType) primitive;
+        return GeographyType$.MODULE$.apply(geography.crs());
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.parquet.ParquetVariantReaders.DelegatingValueReader;
 import org.apache.iceberg.parquet.ParquetVariantVisitor;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VariantReaderBuilder;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -63,6 +64,8 @@ import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.internal.types.CartesianSpatialReferenceSystemMapper;
+import org.apache.spark.sql.internal.types.GeographicSpatialReferenceSystemMapper;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.unsafe.types.CalendarInterval;
@@ -292,6 +295,10 @@ public class SparkParquetReaders {
         case BINARY:
           if (expected != null && expected.typeId() == TypeID.UUID) {
             return new UUIDReader(desc);
+          } else if (expected != null && expected.typeId() == TypeID.GEOMETRY) {
+            return new GeometryReader(desc, ((Types.GeometryType) expected).crs());
+          } else if (expected != null && expected.typeId() == TypeID.GEOGRAPHY) {
+            return new GeographyReader(desc, ((Types.GeographyType) expected).crs());
           }
           return new ParquetValueReaders.ByteArrayReader(desc);
         case INT32:
@@ -399,6 +406,50 @@ public class SparkParquetReaders {
     public UTF8String read(UTF8String ignored) {
       return UTF8String.fromString(UUIDUtil.convert(column.nextBinary().toByteBuffer()).toString());
     }
+  }
+
+  private static class GeometryReader extends PrimitiveReader<GeometryVal> {
+    private final int srid;
+
+    GeometryReader(ColumnDescriptor desc, String crs) {
+      super(desc);
+      Integer mapped = CartesianSpatialReferenceSystemMapper.getSrid(crs);
+      Preconditions.checkArgument(
+          mapped != null, "Cannot map CRS to a Spark cartesian SRID: %s", crs);
+      this.srid = mapped;
+    }
+
+    @Override
+    public GeometryVal read(GeometryVal ignored) {
+      // The Parquet column stores pure WKB. Spark's internal GEOMETRY value is a 4-byte
+      // little-endian SRID header followed by the WKB body, so prepend the SRID derived from the
+      // column's CRS before wrapping as a GeometryVal.
+      return GeometryVal.fromBytes(prependSrid(srid, column.nextBinary().getBytes()));
+    }
+  }
+
+  private static class GeographyReader extends PrimitiveReader<GeographyVal> {
+    private final int srid;
+
+    GeographyReader(ColumnDescriptor desc, String crs) {
+      super(desc);
+      Integer mapped = GeographicSpatialReferenceSystemMapper.getSrid(crs);
+      Preconditions.checkArgument(
+          mapped != null, "Cannot map CRS to a Spark geographic SRID: %s", crs);
+      this.srid = mapped;
+    }
+
+    @Override
+    public GeographyVal read(GeographyVal ignored) {
+      return GeographyVal.fromBytes(prependSrid(srid, column.nextBinary().getBytes()));
+    }
+  }
+
+  private static byte[] prependSrid(int srid, byte[] wkb) {
+    byte[] bytes = new byte[Integer.BYTES + wkb.length];
+    ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).putInt(srid);
+    System.arraycopy(wkb, 0, bytes, Integer.BYTES, wkb.length);
+    return bytes;
   }
 
   private static class ArrayReader<E> extends RepeatedReader<ArrayData, ReusableArrayData, E> {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -71,6 +71,8 @@ import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
@@ -206,6 +208,18 @@ public class SparkParquetWriters {
       public Optional<ParquetValueWriter<?>> visit(
           LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
         return Optional.of(uuids(desc));
+      }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+        return Optional.of(new GeometryWriter(desc));
+      }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+        return Optional.of(new GeographyWriter(desc));
       }
 
       @Override
@@ -470,6 +484,37 @@ public class SparkParquetWriters {
     @Override
     public void write(int repetitionLevel, byte[] bytes) {
       column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(bytes));
+    }
+  }
+
+  private static class GeometryWriter extends PrimitiveWriter<GeometryVal> {
+    GeometryWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeometryVal value) {
+      // Spark stores GEOMETRY internally as a 4-byte little-endian SRID header followed by the
+      // WKB body. The Parquet/Iceberg representation is pure WKB, so skip the SRID header. The
+      // CRS is preserved on the column's GeometryLogicalTypeAnnotation, not per-row.
+      byte[] bytes = value.getBytes();
+      column.writeBinary(
+          repetitionLevel,
+          Binary.fromConstantByteArray(bytes, Integer.BYTES, bytes.length - Integer.BYTES));
+    }
+  }
+
+  private static class GeographyWriter extends PrimitiveWriter<GeographyVal> {
+    GeographyWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeographyVal value) {
+      byte[] bytes = value.getBytes();
+      column.writeBinary(
+          repetitionLevel,
+          Binary.fromConstantByteArray(bytes, Integer.BYTES, bytes.length - Integer.BYTES));
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeoTypes.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeoTypes.java
@@ -1,0 +1,554 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.types.Geography;
+import org.apache.spark.sql.types.Geometry;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * End-to-end Spark SQL tests for the geometry and geography types: schema, Parquet round-trip, and
+ * deletion vectors.
+ *
+ * <p>Exercises the geometry/geography path through CREATE / INSERT (built from WKB literals via
+ * Spark's stock {@code ST_GeomFromWKB} / {@code ST_GeogFromWKB}), SELECT (verifies WKB and SRID
+ * round-trip through the Iceberg Parquet readers/writers) and DELETE on a v3 + merge-on-read table
+ * (verifies that deletion vectors are produced for tables containing geo columns).
+ *
+ * <p>Topological predicates such as {@code ST_Intersects} are not part of stock Spark 4.1; the
+ * predicate coverage here is intentionally limited to {@code ST_Srid(...) = ...}, which exercises
+ * that the Iceberg reader re-attached the per-row SRID header from the column's CRS.
+ */
+public class TestSparkGeoTypes extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String GEOMETRY_TABLE = "default.geo_geom";
+  private static final String GEOGRAPHY_TABLE = "default.geo_geog";
+
+  private static final int DEFAULT_SRID = 4326;
+
+  // WKB byte-order octet for little-endian (NDR).
+  private static final byte WKB_LE = 0x01;
+  // WKB type code for a 2D Point.
+  private static final int WKB_POINT = 1;
+
+  @BeforeAll
+  public static void setupCatalog() {
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    String warehouse = System.getProperty("java.io.tmpdir") + "/iceberg_spark_geo_warehouse";
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", warehouse);
+
+    // Spark 4.1 gates the GEOMETRY/GEOGRAPHY parser and built-in ST_ functions behind this flag.
+    spark.conf().set("spark.sql.geospatial.enabled", "true");
+  }
+
+  @BeforeEach
+  public void cleanupTables() {
+    sql("DROP TABLE IF EXISTS %s", qualified(GEOMETRY_TABLE));
+    sql("DROP TABLE IF EXISTS %s", qualified(GEOGRAPHY_TABLE));
+  }
+
+  @AfterEach
+  public void dropTables() {
+    sql("DROP TABLE IF EXISTS %s", qualified(GEOMETRY_TABLE));
+    sql("DROP TABLE IF EXISTS %s", qualified(GEOGRAPHY_TABLE));
+  }
+
+  @Test
+  public void testGeometryRoundTrip() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(%d)) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    insertGeometry(GEOMETRY_TABLE, 1L, point2D(1.0, 2.0));
+    insertGeometry(GEOMETRY_TABLE, 2L, point2D(3.0, 4.0));
+    insertGeometry(GEOMETRY_TABLE, 3L, point2D(10.0, 20.0));
+
+    List<Row> rows =
+        spark.table(qualified(GEOMETRY_TABLE)).select("id", "geom").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(3);
+
+    assertGeometryRow(rows.get(0), 1L, point2D(1.0, 2.0), DEFAULT_SRID);
+    assertGeometryRow(rows.get(1), 2L, point2D(3.0, 4.0), DEFAULT_SRID);
+    assertGeometryRow(rows.get(2), 3L, point2D(10.0, 20.0), DEFAULT_SRID);
+  }
+
+  @Test
+  public void testGeographyRoundTrip() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, geog GEOGRAPHY(%d)) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOGRAPHY_TABLE), DEFAULT_SRID);
+
+    insertGeography(GEOGRAPHY_TABLE, 1L, point2D(-122.4194, 37.7749)); // San Francisco
+    insertGeography(GEOGRAPHY_TABLE, 2L, point2D(-73.9857, 40.7484)); // New York
+
+    List<Row> rows =
+        spark.table(qualified(GEOGRAPHY_TABLE)).select("id", "geog").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+
+    assertGeographyRow(rows.get(0), 1L, point2D(-122.4194, 37.7749), DEFAULT_SRID);
+    assertGeographyRow(rows.get(1), 2L, point2D(-73.9857, 40.7484), DEFAULT_SRID);
+  }
+
+  @Test
+  public void testSridFilterRoundtrip() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(%d)) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    insertGeometry(GEOMETRY_TABLE, 1L, point2D(1.0, 2.0));
+    insertGeometry(GEOMETRY_TABLE, 2L, point2D(3.0, 4.0));
+
+    // ST_Srid validates that the Iceberg reader re-attached the SRID header that we encode in
+    // GeometryVal from the column's CRS. If the header were missing, ST_Srid would return 0.
+    Dataset<Row> matched =
+        spark
+            .table(qualified(GEOMETRY_TABLE))
+            .where("ST_Srid(geom) = " + DEFAULT_SRID)
+            .select("id");
+    assertThat(matched.collectAsList())
+        .extracting(row -> row.getLong(0))
+        .containsExactlyInAnyOrder(1L, 2L);
+
+    Dataset<Row> mismatched =
+        spark
+            .table(qualified(GEOMETRY_TABLE))
+            .where("ST_Srid(geom) <> " + DEFAULT_SRID)
+            .select("id");
+    assertThat(mismatched.collectAsList()).isEmpty();
+  }
+
+  @Test
+  public void testDeleteWithDeletionVector() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(%d)) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'write.delete.mode'='merge-on-read', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    // Coalesce all rows into a single data file so the DELETE has to record a DV
+    // instead of dropping the file outright.
+    sql(
+        "INSERT INTO %s "
+            + "SELECT /*+ COALESCE(1) */ * FROM ("
+            + "  SELECT 1L AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d) AS geom UNION ALL "
+            + "  SELECT 2L AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d) AS geom UNION ALL "
+            + "  SELECT 3L AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d) AS geom"
+            + ")",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(point2D(1.0, 2.0)),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(point2D(3.0, 4.0)),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(point2D(5.0, 6.0)),
+        DEFAULT_SRID);
+
+    long beforeDelete = spark.table(qualified(GEOMETRY_TABLE)).count();
+    assertThat(beforeDelete).isEqualTo(3L);
+
+    sql("DELETE FROM %s WHERE id = 2", qualified(GEOMETRY_TABLE));
+
+    // A v3 merge-on-read DELETE must record a Puffin deletion vector. The summary entries below
+    // are the public contract for "this DELETE produced a DV".
+    Table table = icebergCatalog().loadTable(TableIdentifier.parse(GEOMETRY_TABLE));
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(SnapshotSummary.ADDED_DVS_PROP, "1")
+        .containsEntry(SnapshotSummary.ADDED_POS_DELETES_PROP, "1");
+
+    List<Row> survivors =
+        spark.table(qualified(GEOMETRY_TABLE)).select("id", "geom").orderBy("id").collectAsList();
+    assertThat(survivors).hasSize(2);
+    assertGeometryRow(survivors.get(0), 1L, point2D(1.0, 2.0), DEFAULT_SRID);
+    assertGeometryRow(survivors.get(1), 3L, point2D(5.0, 6.0), DEFAULT_SRID);
+  }
+
+  @Test
+  public void testNullGeometryValue() {
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(%d)) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    // Force everything into a single Parquet file so null/non-null values are
+    // co-located in the same column chunk; this exercises definition-level encoding
+    // and ParquetMetrics.counts() for the geometry column.
+    sql(
+        "INSERT INTO %s "
+            + "SELECT /*+ COALESCE(1) */ * FROM ("
+            + "  SELECT 1L AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d) AS geom UNION ALL "
+            + "  SELECT 2L AS id, CAST(NULL AS GEOMETRY(%d)) AS geom UNION ALL "
+            + "  SELECT 3L AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d) AS geom"
+            + ")",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(point2D(1.0, 2.0)),
+        DEFAULT_SRID,
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(point2D(3.0, 4.0)),
+        DEFAULT_SRID);
+
+    List<Row> rows =
+        spark.table(qualified(GEOMETRY_TABLE)).select("id", "geom").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(3);
+
+    assertGeometryRow(rows.get(0), 1L, point2D(1.0, 2.0), DEFAULT_SRID);
+    assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
+    assertThat(rows.get(1).get(1)).isNull();
+    assertGeometryRow(rows.get(2), 3L, point2D(3.0, 4.0), DEFAULT_SRID);
+  }
+
+  @Test
+  public void testMultipleGeoColumnsInOneTable() {
+    // A single table that mixes geometry and geography columns. This validates that the
+    // per-column CRS metadata stored on the Parquet logical type annotations is honored
+    // independently for each column when reading.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  geom GEOMETRY(%d),"
+            + "  geog GEOGRAPHY(%d)"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID, DEFAULT_SRID);
+
+    byte[] geomWkb = point2D(1.0, 2.0);
+    byte[] geogWkb = point2D(-122.4194, 37.7749);
+    sql(
+        "INSERT INTO %s SELECT 1L, "
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d), "
+            + "ST_SetSrid(ST_GeogFromWKB(X'%s'), %d)",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(geomWkb),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(geogWkb),
+        DEFAULT_SRID);
+
+    Row row = spark.table(qualified(GEOMETRY_TABLE)).collectAsList().get(0);
+    assertThat(row.getLong(0)).isEqualTo(1L);
+
+    Object geomCell = row.get(1);
+    assertThat(geomCell).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) geomCell).getBytes()).containsExactly(geomWkb);
+    assertThat(((Geometry) geomCell).getSrid()).isEqualTo(DEFAULT_SRID);
+
+    Object geogCell = row.get(2);
+    assertThat(geogCell).isInstanceOf(Geography.class);
+    assertThat(((Geography) geogCell).getBytes()).containsExactly(geogWkb);
+    assertThat(((Geography) geogCell).getSrid()).isEqualTo(DEFAULT_SRID);
+  }
+
+  @Test
+  public void testStructWithGeometry() {
+    // Geometry as a leaf inside a STRUCT. Exercises the StructReader/StructWriter
+    // delegation path, where the inner element is our GeometryReader/Writer.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  event STRUCT<eid: BIGINT, loc: GEOMETRY(%d)>"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    byte[] wkb = point2D(7.0, 8.0);
+    sql(
+        "INSERT INTO %s SELECT 1L, "
+            + "named_struct('eid', 42L, 'loc', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d))",
+        qualified(GEOMETRY_TABLE), HexFormat.of().formatHex(wkb), DEFAULT_SRID);
+
+    Row row = spark.table(qualified(GEOMETRY_TABLE)).collectAsList().get(0);
+    assertThat(row.getLong(0)).isEqualTo(1L);
+
+    Row event = row.getStruct(1);
+    assertThat(event.getLong(0)).isEqualTo(42L);
+
+    Object loc = event.get(1);
+    assertThat(loc).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) loc).getBytes()).containsExactly(wkb);
+    assertThat(((Geometry) loc).getSrid()).isEqualTo(DEFAULT_SRID);
+  }
+
+  @Test
+  public void testArrayOfGeometry() {
+    // ARRAY<GEOMETRY> exercises the RepeatedReader / ArrayDataWriter path that
+    // delegates per element to our GeometryReader/Writer. Spark surfaces the column
+    // as a java.util.List of Geometry instances at the Row API.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  points ARRAY<GEOMETRY(%d)>"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    byte[] wkb1 = point2D(1.0, 2.0);
+    byte[] wkb2 = point2D(3.0, 4.0);
+    sql(
+        "INSERT INTO %s SELECT 1L, array("
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d), "
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d))",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(wkb1),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(wkb2),
+        DEFAULT_SRID);
+
+    Row row = spark.table(qualified(GEOMETRY_TABLE)).collectAsList().get(0);
+    assertThat(row.getLong(0)).isEqualTo(1L);
+
+    List<Object> elements = row.getList(1);
+    assertThat(elements).hasSize(2);
+    assertThat(elements.get(0)).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) elements.get(0)).getBytes()).containsExactly(wkb1);
+    assertThat(((Geometry) elements.get(0)).getSrid()).isEqualTo(DEFAULT_SRID);
+    assertThat(elements.get(1)).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) elements.get(1)).getBytes()).containsExactly(wkb2);
+    assertThat(((Geometry) elements.get(1)).getSrid()).isEqualTo(DEFAULT_SRID);
+  }
+
+  @Test
+  public void testMapOfGeometry() {
+    // MAP<STRING, GEOMETRY> exercises the RepeatedKeyValueReader / MapDataWriter path.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  places MAP<STRING, GEOMETRY(%d)>"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    byte[] homeWkb = point2D(1.0, 2.0);
+    byte[] workWkb = point2D(5.0, 6.0);
+    sql(
+        "INSERT INTO %s SELECT 1L, map("
+            + "'home', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d), "
+            + "'work', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d))",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(homeWkb),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(workWkb),
+        DEFAULT_SRID);
+
+    Row row = spark.table(qualified(GEOMETRY_TABLE)).collectAsList().get(0);
+    assertThat(row.getLong(0)).isEqualTo(1L);
+
+    Map<Object, Object> places = row.getJavaMap(1);
+    assertThat(places).hasSize(2);
+
+    Object home = places.get("home");
+    assertThat(home).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) home).getBytes()).containsExactly(homeWkb);
+    assertThat(((Geometry) home).getSrid()).isEqualTo(DEFAULT_SRID);
+
+    Object work = places.get("work");
+    assertThat(work).isInstanceOf(Geometry.class);
+    assertThat(((Geometry) work).getBytes()).containsExactly(workWkb);
+    assertThat(((Geometry) work).getSrid()).isEqualTo(DEFAULT_SRID);
+  }
+
+  @Test
+  public void testStructOfArrayOfGeometry() {
+    // Two levels of nesting: STRUCT<id, points ARRAY<GEOMETRY>>. Validates that the
+    // visitor framework resolves the geometry leaf correctly under nested wrappers.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  trip STRUCT<tid: BIGINT, points: ARRAY<GEOMETRY(%d)>>"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    byte[] startWkb = point2D(0.0, 0.0);
+    byte[] midWkb = point2D(1.0, 1.0);
+    byte[] endWkb = point2D(2.0, 2.0);
+    sql(
+        "INSERT INTO %s SELECT 1L, named_struct("
+            + "'tid', 99L, "
+            + "'points', array("
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d), "
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d), "
+            + "ST_SetSrid(ST_GeomFromWKB(X'%s'), %d)))",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(startWkb),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(midWkb),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(endWkb),
+        DEFAULT_SRID);
+
+    Row row = spark.table(qualified(GEOMETRY_TABLE)).collectAsList().get(0);
+    assertThat(row.getLong(0)).isEqualTo(1L);
+
+    Row trip = row.getStruct(1);
+    assertThat(trip.getLong(0)).isEqualTo(99L);
+
+    List<Object> points = trip.getList(1);
+    assertThat(points).hasSize(3);
+    assertThat(((Geometry) points.get(0)).getBytes()).containsExactly(startWkb);
+    assertThat(((Geometry) points.get(0)).getSrid()).isEqualTo(DEFAULT_SRID);
+    assertThat(((Geometry) points.get(1)).getBytes()).containsExactly(midWkb);
+    assertThat(((Geometry) points.get(2)).getBytes()).containsExactly(endWkb);
+  }
+
+  @Test
+  public void testDeleteWithDeletionVectorOnNestedGeometry() {
+    // Verify that wrapping the geometry inside a STRUCT does not break the row-level
+    // DELETE / DV path: writes still succeed, the file is reused, and a Puffin DV is
+    // produced instead of a copy-on-write rewrite.
+    sql(
+        "CREATE TABLE %s ("
+            + "  id BIGINT,"
+            + "  event STRUCT<eid: BIGINT, loc: GEOMETRY(%d)>"
+            + ") USING iceberg "
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'write.delete.mode'='merge-on-read', "
+            + "'read.parquet.vectorization.enabled'='false')",
+        qualified(GEOMETRY_TABLE), DEFAULT_SRID);
+
+    sql(
+        "INSERT INTO %s "
+            + "SELECT /*+ COALESCE(1) */ * FROM ("
+            + "  SELECT 1L AS id, named_struct("
+            + "    'eid', 10L,"
+            + "    'loc', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d)) AS event UNION ALL "
+            + "  SELECT 2L AS id, named_struct("
+            + "    'eid', 20L,"
+            + "    'loc', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d)) AS event UNION ALL "
+            + "  SELECT 3L AS id, named_struct("
+            + "    'eid', 30L,"
+            + "    'loc', ST_SetSrid(ST_GeomFromWKB(X'%s'), %d)) AS event"
+            + ")",
+        qualified(GEOMETRY_TABLE),
+        HexFormat.of().formatHex(point2D(1.0, 2.0)),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(point2D(3.0, 4.0)),
+        DEFAULT_SRID,
+        HexFormat.of().formatHex(point2D(5.0, 6.0)),
+        DEFAULT_SRID);
+
+    sql("DELETE FROM %s WHERE id = 2", qualified(GEOMETRY_TABLE));
+
+    Table table = icebergCatalog().loadTable(TableIdentifier.parse(GEOMETRY_TABLE));
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(SnapshotSummary.ADDED_DVS_PROP, "1")
+        .containsEntry(SnapshotSummary.ADDED_POS_DELETES_PROP, "1");
+
+    List<Row> survivors = spark.table(qualified(GEOMETRY_TABLE)).orderBy("id").collectAsList();
+    assertThat(survivors).hasSize(2);
+    assertThat(survivors.get(0).getLong(0)).isEqualTo(1L);
+    assertThat(((Geometry) survivors.get(0).getStruct(1).get(1)).getBytes())
+        .containsExactly(point2D(1.0, 2.0));
+    assertThat(survivors.get(1).getLong(0)).isEqualTo(3L);
+    assertThat(((Geometry) survivors.get(1).getStruct(1).get(1)).getBytes())
+        .containsExactly(point2D(5.0, 6.0));
+  }
+
+  // ---- helpers ----
+
+  private static String qualified(String name) {
+    return CATALOG + "." + name;
+  }
+
+  private void insertGeometry(String name, long id, byte[] wkb) {
+    sql(
+        "INSERT INTO %s SELECT %d AS id, ST_SetSrid(ST_GeomFromWKB(X'%s'), %d)",
+        qualified(name), id, HexFormat.of().formatHex(wkb), DEFAULT_SRID);
+  }
+
+  private void insertGeography(String name, long id, byte[] wkb) {
+    sql(
+        "INSERT INTO %s SELECT %d AS id, ST_SetSrid(ST_GeogFromWKB(X'%s'), %d)",
+        qualified(name), id, HexFormat.of().formatHex(wkb), DEFAULT_SRID);
+  }
+
+  private static void assertGeometryRow(Row row, long expectedId, byte[] expectedWkb, int srid) {
+    assertThat(row.getLong(0)).isEqualTo(expectedId);
+    Object cell = row.get(1);
+    assertThat(cell).isInstanceOf(Geometry.class);
+    Geometry value = (Geometry) cell;
+    assertThat(value.getBytes()).containsExactly(expectedWkb);
+    assertThat(value.getSrid()).isEqualTo(srid);
+  }
+
+  private static void assertGeographyRow(Row row, long expectedId, byte[] expectedWkb, int srid) {
+    assertThat(row.getLong(0)).isEqualTo(expectedId);
+    Object cell = row.get(1);
+    assertThat(cell).isInstanceOf(Geography.class);
+    Geography value = (Geography) cell;
+    assertThat(value.getBytes()).containsExactly(expectedWkb);
+    assertThat(value.getSrid()).isEqualTo(srid);
+  }
+
+  private static byte[] point2D(double x, double y) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(1 + Integer.BYTES + 2 * Double.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.put(WKB_LE);
+    buffer.putInt(WKB_POINT);
+    buffer.putDouble(x);
+    buffer.putDouble(y);
+    return buffer.array();
+  }
+
+  private static Catalog icebergCatalog() {
+    return ((SparkCatalog) spark.sessionState().catalogManager().catalog(CATALOG)).icebergCatalog();
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> **Closing as done.** This was a WIP / tracking PR that wired Iceberg's geometry and
> geography types end-to-end on Spark 4.1 to prove the full `CREATE / INSERT / SELECT /
> DELETE` path over Parquet. That goal is complete: every piece has since landed on `main`
> through focused, individually reviewed sub-PRs. Nothing here remains to merge.

## What landed, and where

The end-to-end change was split into these merged PRs:

| Layer | Merged PR |
| :---- | :---- |
| API — single-value binary serialization (`Conversions`) | #16607 |
| Parquet — map geometry/geography to Parquet logical types (`TypeToMessageType`, `MessageTypeToType`) | #16765 |
| Parquet — skip lexicographic footer bounds for geo (`ParquetMetrics`) | #16850 |
| Parquet — read/write WKB values (`BaseParquetReaders` / `BaseParquetWriter`) | #16982 |
| Core — reland the geo metrics counts-without-bounds test | #17147 |
| Spark 4.1 — map geo Spark types (`TypeToSparkType`, `SparkTypeToType`, `PruneColumnsWithoutReordering`) | #16851 |
| Spark 4.1 — read/write geo values in Parquet (`SparkParquetReaders` / `SparkParquetWriters`) | #17073 |
| Spark 4.1 — DML with deletion vectors, nested geo, nulls; vectorized-read fallback | #17149 |

The large in-progress `TestSparkGeoTypes` here was not merged as-is; its coverage was
reworked into `TestSparkGeospatial` plus the DML/vectorization-fallback tests in #17149.

## Follow-ups (tracked separately)

- Core — read/write geo in Avro: #17119
- Parquet — compute geometry bounding-box metrics (bounds / data skipping): #17161
- Spatial predicate pushdown and geography spherical bounds are subsequent work.

Thanks to everyone who reviewed the split-out PRs.
