### PR TITLE
Core: Relative paths for manifest list

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.LocationUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,6 +123,17 @@ public class SnapshotParser {
   }
 
   static Snapshot fromJson(JsonNode node) {
+    return fromJson(node, null);
+  }
+
+  /**
+   * Parses a snapshot, resolving a relative {@code manifest-list} against {@code tableLocation}.
+   *
+   * <p>Relative locations are only valid in v4+ metadata, so callers pass {@code null} for older
+   * versions or when no table location is available (e.g. {@link #fromJson(String)}). Absolute
+   * paths are returned unchanged.
+   */
+  static Snapshot fromJson(JsonNode node, String tableLocation) {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse table version from a non-object: %s", node);
 
@@ -187,7 +199,7 @@ public class SnapshotParser {
           operation,
           summary,
           schemaId,
-          manifestList,
+          resolveManifestList(manifestList, tableLocation),
           firstRowId,
           addedRows,
           keyId);
@@ -209,6 +221,16 @@ public class SnapshotParser {
 
   public static Snapshot fromJson(String json) {
     return JsonUtil.parse(json, SnapshotParser::fromJson);
+  }
+
+  private static String resolveManifestList(String manifestList, String tableLocation) {
+    if (tableLocation == null) {
+      return manifestList;
+    }
+
+    // strip the trailing separator so the base matches TableMetadata.location()
+    return LocationUtil.resolveLocation(
+        LocationUtil.stripTrailingSlash(tableLocation), manifestList);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -59,6 +59,7 @@ public class TableMetadata implements Serializable {
   static final int MIN_FORMAT_VERSION_ROW_LINEAGE = 3;
   static final int MIN_FORMAT_VERSION_PARQUET_MANIFESTS = 4;
   static final int MIN_FORMAT_VERSION_OPTIONAL_LOCATION = 4;
+  static final int MIN_FORMAT_VERSION_RELATIVE_PATHS = 4;
   static final int INITIAL_SPEC_ID = 0;
   static final int INITIAL_SORT_ORDER_ID = 1;
   static final int INITIAL_SCHEMA_ID = 0;

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -515,8 +515,11 @@ public class TableMetadataParser {
 
       snapshots = Lists.newArrayListWithExpectedSize(snapshotArray.size());
       Iterator<JsonNode> iterator = snapshotArray.elements();
+      // relative paths are a v4+ feature; pre-v4 paths are absolute and must not be resolved
+      String snapshotBaseLocation =
+          formatVersion >= TableMetadata.MIN_FORMAT_VERSION_RELATIVE_PATHS ? location : null;
       while (iterator.hasNext()) {
-        snapshots.add(SnapshotParser.fromJson(iterator.next()));
+        snapshots.add(SnapshotParser.fromJson(iterator.next(), snapshotBaseLocation));
       }
     } else {
       snapshots = ImmutableList.of();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotJson.java
@@ -28,6 +28,7 @@ import java.util.List;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.JsonUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -222,6 +223,56 @@ public class TestSnapshotJson {
     assertThat(snapshot.summary()).isEqualTo(expected.summary());
     assertThat(snapshot.schemaId()).isEqualTo(expected.schemaId());
     assertThat(snapshot.firstRowId()).isNull();
+  }
+
+  @Test
+  public void testRelativeManifestListResolvedAgainstTableLocation() {
+    String json = snapshotJsonWithManifestList("metadata/snap-1.avro");
+    Snapshot snapshot =
+        JsonUtil.parse(json, node -> SnapshotParser.fromJson(node, "s3://bucket/db/table"));
+
+    assertThat(snapshot.manifestListLocation())
+        .isEqualTo("s3://bucket/db/table/metadata/snap-1.avro");
+  }
+
+  @Test
+  public void testAbsoluteManifestListNotResolved() {
+    String absolute = "gs://other-bucket/metadata/snap-1.avro";
+    String json = snapshotJsonWithManifestList(absolute);
+    Snapshot snapshot =
+        JsonUtil.parse(json, node -> SnapshotParser.fromJson(node, "s3://bucket/db/table"));
+
+    assertThat(snapshot.manifestListLocation()).isEqualTo(absolute);
+  }
+
+  @Test
+  public void testRelativeManifestListResolutionNormalizesTrailingSlash() {
+    String json = snapshotJsonWithManifestList("metadata/snap-1.avro");
+    Snapshot snapshot =
+        JsonUtil.parse(json, node -> SnapshotParser.fromJson(node, "s3://bucket/db/table/"));
+
+    assertThat(snapshot.manifestListLocation())
+        .isEqualTo("s3://bucket/db/table/metadata/snap-1.avro");
+  }
+
+  @Test
+  public void testManifestListNotResolvedWithoutTableLocation() {
+    String json = snapshotJsonWithManifestList("metadata/snap-1.avro");
+    Snapshot snapshot = SnapshotParser.fromJson(json);
+
+    assertThat(snapshot.manifestListLocation()).isEqualTo("metadata/snap-1.avro");
+  }
+
+  private static String snapshotJsonWithManifestList(String manifestList) {
+    return String.format(
+        "{\n"
+            + "  \"snapshot-id\" : 2,\n"
+            + "  \"timestamp-ms\" : 1234567890,\n"
+            + "  \"summary\" : { \"operation\" : \"append\" },\n"
+            + "  \"manifest-list\" : \"%s\",\n"
+            + "  \"schema-id\" : 0\n"
+            + "}",
+        manifestList);
   }
 
   private String createManifestListWithManifestFiles(long snapshotId, Long parentSnapshotId)

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -1193,6 +1193,15 @@ public class TestTableMetadata {
   }
 
   @Test
+  public void testV4RelativeManifestListResolvedAgainstTableLocation() throws Exception {
+    String json = readTableMetadataInputFile("TableMetadataV4RelativeManifestList.json");
+    TableMetadata metadata = TableMetadataParser.fromJson(json);
+
+    assertThat(metadata.currentSnapshot().manifestListLocation())
+        .isEqualTo("s3://bucket/test/location/metadata/snap-3055729675574597004.avro");
+  }
+
+  @Test
   public void testV4LocationMustBeAbsolute() {
     assertThatThrownBy(
             () ->
@@ -1944,7 +1953,8 @@ public class TestTableMetadata {
               new GenericManifestFile(localInput(manifestFile), SPEC_5.specId(), snapshotId)));
     }
 
-    return localInput(manifestList).location();
+    // qualify with a scheme so v4 treats it as absolute rather than relative to the table location
+    return "file:" + localInput(manifestList).location();
   }
 
   @Test

--- a/core/src/test/resources/TableMetadataV4RelativeManifestList.json
+++ b/core/src/test/resources/TableMetadataV4RelativeManifestList.json
@@ -1,0 +1,72 @@
+{
+  "format-version": 4,
+  "table-uuid": "9c12d441-03fe-4693-9a96-a0705ddf69c1",
+  "location": "s3://bucket/test/location",
+  "last-sequence-number": 34,
+  "last-updated-ms": 1602638573590,
+  "last-column-id": 3,
+  "next-row-id": 0,
+  "current-schema-id": 0,
+  "schemas": [
+    {
+      "type": "struct",
+      "schema-id": 0,
+      "fields": [
+        {
+          "id": 1,
+          "name": "x",
+          "required": true,
+          "type": "long"
+        },
+        {
+          "id": 2,
+          "name": "y",
+          "required": true,
+          "type": "long",
+          "doc": "comment"
+        },
+        {
+          "id": 3,
+          "name": "z",
+          "required": true,
+          "type": "long"
+        }
+      ]
+    }
+  ],
+  "default-spec-id": 0,
+  "partition-specs": [
+    {
+      "spec-id": 0,
+      "fields": [
+        {
+          "name": "x",
+          "transform": "identity",
+          "source-id": 1,
+          "field-id": 1000
+        }
+      ]
+    }
+  ],
+  "last-partition-id": 1000,
+  "default-sort-order-id": 0,
+  "sort-orders": [
+    {
+      "order-id": 0,
+      "fields": []
+    }
+  ],
+  "current-snapshot-id": 3055729675574597004,
+  "snapshots": [
+    {
+      "sequence-number": 34,
+      "snapshot-id": 3055729675574597004,
+      "timestamp-ms": 1602638573590,
+      "summary": {
+        "operation": "append"
+      },
+      "manifest-list": "metadata/snap-3055729675574597004.avro",
+      "schema-id": 0
+    }
+  ]
+}


### PR DESCRIPTION
I'm starting out small, but this adds support for relative paths for a manifest-list. If this looks good, I can make some larger changes in future PRs. 