### PR TITLE
Docs: Add no-emdash / ASCII-only rule to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -172,5 +172,6 @@ The `api/` module has the strongest stability guarantees — breaking changes ar
 - **Never** break public API without an approved `revapi.yml` exception.
 - **Never** add Hadoop dependencies where `FileIO` abstractions exist.
 - **Never** commit secrets, credentials, or cloud-specific tokens.
+- **Never** use em-dashes (U+2014) or other non-ASCII Unicode characters in source code. The only exception is tests or sample data that specifically exercise Unicode or UTF handling.
 - **Ask first** before adding new third-party dependencies (license compatibility matters).
 - **Ask first** before promoting package-private classes/methods to public.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,5 +204,6 @@ Add the following block at the bottom of PR descriptions:
 - **Never** break public API without an approved `revapi.yml` exception.
 - **Never** add Hadoop dependencies where `FileIO` abstractions exist.
 - **Never** commit secrets, credentials, or cloud-specific tokens.
+- **Never** use em-dashes (U+2014) or other non-ASCII Unicode characters in source code. The only exception is tests or sample data that specifically exercise Unicode or UTF handling.
 - **Ask first** before adding new third-party dependencies (license compatibility matters).
 - **Ask first** before promoting package-private classes/methods to public.


### PR DESCRIPTION
## What

Adds a Boundaries rule to AGENTS.md: never use em-dashes (U+2014) or other non-ASCII Unicode characters in source code, except in tests or sample data that specifically exercise Unicode or UTF handling.

## Why

This came up in review of #16500, where em-dashes introduced as AI artifacts had to be removed from the diff by hand. Capturing the convention in AGENTS.md gives agents and contributors one place to learn it, so the cleanup does not recur per PR. See the review thread: https://github.com/apache/iceberg/pull/16500#discussion_r3336611200

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Add a Boundaries rule to AGENTS.md forbidding em-dashes and other non-ASCII characters in source code.
