### PR TITLE
Kafka Connect: Split route field path once instead of per record

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
@@ -47,9 +47,12 @@ import org.apache.kafka.connect.data.Struct;
 
 class RecordUtils {
 
-  @SuppressWarnings("unchecked")
   static Object extractFromRecordValue(Object recordValue, String fieldName) {
-    List<String> fields = Splitter.on('.').splitToList(fieldName);
+    return extractFromRecordValue(recordValue, Splitter.on('.').splitToList(fieldName));
+  }
+
+  @SuppressWarnings("unchecked")
+  static Object extractFromRecordValue(Object recordValue, List<String> fields) {
     if (recordValue instanceof Struct) {
       return valueFromStruct((Struct) recordValue, fields);
     } else if (recordValue instanceof Map) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
@@ -30,6 +30,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -39,12 +40,16 @@ public class SinkWriter {
   private final IcebergWriterFactory writerFactory;
   private final Map<String, RecordWriter> writers;
   private final Map<TopicPartition, Offset> sourceOffsets;
+  // the route field is fixed per config, so split its dotted path once instead of per record
+  private final List<String> routeFieldPath;
 
   public SinkWriter(Catalog catalog, IcebergSinkConfig config) {
     this.config = config;
     this.writerFactory = new IcebergWriterFactory(catalog, config);
     this.writers = Maps.newHashMap();
     this.sourceOffsets = Maps.newHashMap();
+    String routeField = config.tablesRouteField();
+    this.routeFieldPath = routeField == null ? null : Splitter.on('.').splitToList(routeField);
   }
 
   public void close() {
@@ -90,9 +95,7 @@ public class SinkWriter {
   }
 
   private void routeRecordStatically(SinkRecord record) {
-    String routeField = config.tablesRouteField();
-
-    if (routeField == null) {
+    if (routeFieldPath == null) {
       // route to all tables
       config
           .tables()
@@ -102,7 +105,7 @@ public class SinkWriter {
               });
 
     } else {
-      String routeValue = extractRouteValue(record.value(), routeField);
+      String routeValue = extractRouteValue(record.value());
       if (routeValue != null) {
         config
             .tables()
@@ -118,21 +121,20 @@ public class SinkWriter {
   }
 
   private void routeRecordDynamically(SinkRecord record) {
-    String routeField = config.tablesRouteField();
-    Preconditions.checkNotNull(routeField, "Route field cannot be null with dynamic routing");
+    Preconditions.checkNotNull(routeFieldPath, "Route field cannot be null with dynamic routing");
 
-    String routeValue = extractRouteValue(record.value(), routeField);
+    String routeValue = extractRouteValue(record.value());
     if (routeValue != null) {
       String tableName = routeValue.toLowerCase(Locale.ROOT);
       writerForTable(tableName, record, true).write(record);
     }
   }
 
-  private String extractRouteValue(Object recordValue, String routeField) {
+  private String extractRouteValue(Object recordValue) {
     if (recordValue == null) {
       return null;
     }
-    Object routeValue = RecordUtils.extractFromRecordValue(recordValue, routeField);
+    Object routeValue = RecordUtils.extractFromRecordValue(recordValue, routeFieldPath);
     return routeValue == null ? null : routeValue.toString();
   }
 


### PR DESCRIPTION
When routing by a field (static routing with `iceberg.tables.route-field`, or dynamic routing), `SinkWriter` extracted the route value for every record via `RecordUtils.extractFromRecordValue(value, routeField)`, which re-parsed the dotted field path with `Splitter.on('.').splitToList(routeField)` on each call. The route field is fixed for the connector's lifetime, so this re-parse is pure per-record overhead.

This splits the path once in the `SinkWriter` constructor and adds a `RecordUtils.extractFromRecordValue(Object, List<String>)` overload that takes the already-split path; the existing `String` overload now delegates to it, so other callers are unchanged. Behavior is identical.

A throwaway A/B microbench over the whole `extractFromRecordValue` method (2M iterations x 9 trials, median; baseline = current `String` overload that splits per call, optimized = `List` overload with the path split once) showed:

| record value | route field | before | after | faster |
|---|---|---|---|---|
| struct | `key` | 52.8 ns | 5.7 ns | 89% |
| struct | `data.id.key` | 162.2 ns | 32.0 ns | 80% |
| map | `key` | 54.3 ns | 6.1 ns | 89% |
| map | `data.id.key` | 144.3 ns | 21.6 ns | 85% |

That is roughly 47 ns saved per record for a single-segment route field and ~120-130 ns for a three-segment path, paid once per record on the routing path. The numbers are indicative wall-clock from a microbench, not JMH.

Existing `TestSinkWriter` and `TestRecordUtils` cover both routing modes and the extraction overloads.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Split the Kafka Connect route field path once at construction instead of per record.
