### PR TITLE
S3FileIO: Always normalize listPrefix key to end with trailing slash

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3FileIO.java
@@ -376,6 +376,61 @@ public class TestS3FileIO {
                     && fi.createdAtMillis() < Instant.now().minusSeconds(30).toEpochMilli());
   }
 
+  @Test
+  public void testListPrefixNormalizesTrailingSlashForGeneralPurposeBucket() {
+    S3Client localMockedClient = mock(S3Client.class);
+
+    List<S3Object> s3Objects =
+        Arrays.asList(
+            S3Object.builder()
+                .key("warehouse/ns/table/data/file1.parquet")
+                .size(1024L)
+                .lastModified(Instant.now())
+                .build());
+
+    ListObjectsV2Response response = ListObjectsV2Response.builder().contents(s3Objects).build();
+    ListObjectsV2Iterable mockedResponse = mock(ListObjectsV2Iterable.class);
+    Mockito.when(mockedResponse.stream()).thenReturn(Stream.of(response));
+
+    // Expect the request to have a trailing slash even though we pass a prefix without one
+    Mockito.when(
+            localMockedClient.listObjectsV2Paginator(
+                ListObjectsV2Request.builder()
+                    .prefix("warehouse/ns/table/")
+                    .bucket(S3_GENERAL_PURPOSE_BUCKET)
+                    .build()))
+        .thenReturn(mockedResponse);
+
+    S3FileIO localS3FileIo = new S3FileIO(() -> localMockedClient);
+    localS3FileIo.initialize(properties);
+
+    // Call listPrefix WITHOUT trailing slash
+    List<FileInfo> fileInfoList =
+        StreamSupport.stream(
+                Spliterators.spliteratorUnknownSize(
+                    localS3FileIo.listPrefix("s3://bucket/warehouse/ns/table").iterator(),
+                    Spliterator.ORDERED),
+                false)
+            .collect(Collectors.toList());
+
+    assertThat(fileInfoList).hasSize(1);
+    assertThat(fileInfoList.get(0).location()).endsWith("file1.parquet");
+  }
+
+  @Test
+  public void testListPrefixDoesNotMatchSiblingPaths() {
+    // Create objects under two tables with similar name prefixes
+    String tablePrefix = "s3://bucket/warehouse/ns/table/";
+    String siblingPrefix = "s3://bucket/warehouse/ns/table_sibling/";
+
+    createRandomObjects(tablePrefix, 3);
+    createRandomObjects(siblingPrefix, 2);
+
+    // listPrefix with "table" (no trailing slash) should only return the 3 objects under "table/"
+    assertThat(Streams.stream(s3FileIO.listPrefix("s3://bucket/warehouse/ns/table")).count())
+        .isEqualTo(3);
+  }
+
   /**
    * Ignoring because the test is flaky, failing with 500s from S3Mock. Coverage of prefix delete
    * exists through integration tests.

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIO.java
@@ -331,10 +331,10 @@ public class S3FileIO
     PrefixedS3Client client = clientForStoragePath(prefix);
 
     S3URI uri = new S3URI(prefix, client.s3FileIOProperties().bucketToAccessPointMapping());
-    if (uri.useS3DirectoryBucket()
-        && client.s3FileIOProperties().isS3DirectoryBucketListPrefixAsDirectory()) {
-      uri = uri.toDirectoryPath();
-    }
+    // Always normalize the prefix to end with "/" to prevent matching sibling prefixes.
+    // Without this, prefix "warehouse/ns/table" would also match "warehouse/ns/table_other/...".
+    // This is also required for STS session policies that scope ListBucket to "<key>/*".
+    uri = uri.toDirectoryPath();
 
     S3URI s3uri = uri;
     ListObjectsV2Request request =


### PR DESCRIPTION
## Description

`S3FileIO.listPrefix()` currently only normalizes the prefix with a trailing slash for S3 Directory Buckets (via `toDirectoryPath()`), but not for standard S3 buckets. This causes the prefix passed to `ListObjectsV2` to potentially match sibling keys.

## Problem

Given a table location `s3://bucket/warehouse/ns/table`, calling `listPrefix("s3://bucket/warehouse/ns/table")` sets `prefix=warehouse/ns/table` in the `ListObjectsV2Request`. S3 returns **all** keys starting with that string, including:

- `warehouse/ns/table/metadata/...` (correct — belongs to this table)
- `warehouse/ns/table_archive/data/...` (**wrong** — different table with similar name)

This also breaks STS credential vending from REST catalogs like [Lakekeeper](https://github.com/lakekeeper/lakekeeper), which scope the session policy to:

```json
{"Condition": {"StringLike": {"s3:prefix": "warehouse/ns/table/*"}}}
```

A prefix without trailing slash does not match `StringLike` pattern `.../*`, resulting in `403 AccessDenied`.

## Fix

Apply `toDirectoryPath()` unconditionally in `listPrefix()`, not just for Directory Buckets. This ensures the key always ends with `/` before being used as a ListObjects prefix, matching how [Trino normalizes keys](https://github.com/trinodb/trino/blob/master/lib/trino-filesystem-s3/src/main/java/io/trino/filesystem/s3/S3FileSystem.java#L404-L410) via `directoryKey()`.

## Testing

- Existing integration test (`TestS3FileIO.testListPrefix`) creates objects under `prefix/<scale>/` subdirectories, so the normalized prefix `path/to/list/` still matches all expected objects
- Verified manually with vended STS credentials: `ListObjectsV2(prefix="key/")` succeeds where `ListObjectsV2(prefix="key")` returns 403

## Related

- Lakekeeper discussion: https://github.com/lakekeeper/lakekeeper/issues/1795
- Airbyte companion fix: https://github.com/airbytehq/airbyte/pull/78624