### PR TITLE
CI: Retry Trivy scanner image pull to absorb transient Docker Hub timeouts

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -52,10 +52,10 @@ jobs:
   cve-scan:
     runs-on: ubuntu-24.04
     env:
-      # Trivy scanner image, pinned by digest (matches lhotari/sandboxed-trivy-action's
-      # default at the pinned ref). Pre-pulled with retry below to absorb transient Docker
-      # Hub (registry-1.docker.io) timeouts that otherwise fail the job with exit code 125.
-      TRIVY_IMAGE: aquasec/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c
+      # Trivy scanner image, pinned by digest. Pulled from GHCR (ghcr.io), which serves the
+      # identical manifest digest as Docker Hub but is more reliable on GitHub-hosted runners.
+      # Pre-pulled with retry below to absorb transient registry pull timeouts (exit code 125).
+      TRIVY_IMAGE: ghcr.io/aquasecurity/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c
     permissions:
       contents: read
       security-events: write
@@ -149,11 +149,14 @@ jobs:
         fi
     - name: Pull Trivy image (with retry)
       # Pre-pull the scanner image so the action's docker run finds it locally and never hits
-      # the registry. Retrying with backoff absorbs transient Docker Hub timeouts (exit 125).
+      # the registry. Retrying with backoff absorbs transient registry pull timeouts (exit 125).
       run: |
         for attempt in 1 2 3 4 5; do
           if docker pull "${TRIVY_IMAGE}"; then
             exit 0
+          fi
+          if [ "${attempt}" = "5" ]; then
+            break
           fi
           echo "docker pull failed (attempt ${attempt}/5); retrying in $((attempt * 10))s..." >&2
           sleep "$((attempt * 10))"

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -51,6 +51,11 @@ jobs:
   # ------------------------------------------------------------------
   cve-scan:
     runs-on: ubuntu-24.04
+    env:
+      # Trivy scanner image, pinned by digest (matches lhotari/sandboxed-trivy-action's
+      # default at the pinned ref). Pre-pulled with retry below to absorb transient Docker
+      # Hub (registry-1.docker.io) timeouts that otherwise fail the job with exit code 125.
+      TRIVY_IMAGE: aquasec/trivy:0.69.3@sha256:bcc376de8d77cfe086a917230e818dc9f8528e3c852f7b1aff648949b6258d1c
     permissions:
       contents: read
       security-events: write
@@ -142,6 +147,19 @@ jobs:
         else
           cp ${{ matrix.scan-path }}/iceberg-${{ matrix.distribution }}-*.jar /tmp/cve-scan/
         fi
+    - name: Pull Trivy image (with retry)
+      # Pre-pull the scanner image so the action's docker run finds it locally and never hits
+      # the registry. Retrying with backoff absorbs transient Docker Hub timeouts (exit 125).
+      run: |
+        for attempt in 1 2 3 4 5; do
+          if docker pull "${TRIVY_IMAGE}"; then
+            exit 0
+          fi
+          echo "docker pull failed (attempt ${attempt}/5); retrying in $((attempt * 10))s..." >&2
+          sleep "$((attempt * 10))"
+        done
+        echo "Failed to pull ${TRIVY_IMAGE} after 5 attempts" >&2
+        exit 1
     - name: Run Trivy vulnerability scan
       uses: lhotari/sandboxed-trivy-action@f01374b6cc3bf7264ab238293e94f6db7ada6dd0 # v1.0.2
       with:
@@ -155,6 +173,7 @@ jobs:
         exit-code: ${{ github.event_name == 'pull_request' && '1' || '0' }}
         format: 'sarif'
         output: 'trivy-results.sarif'
+        trivy-image: ${{ env.TRIVY_IMAGE }}
     - name: Print Trivy scan results
       if: always()
       run: |


### PR DESCRIPTION
## Problem

The CVE Scan workflow intermittently fails while pulling the Trivy scanner image. Recent examples are #16657 (job `flink-runtime-1.20`) and #16652, #16669 (job `open-api-test-fixtures-runtime`), all failed the same way within hours of each other:

```
Running Trivy in sandboxed container (aquasec/trivy:0.69.3@sha256:bcc376...)...
Unable to find image 'aquasec/trivy:...' locally
docker: Error response from daemon: Get "https://registry-1.docker.io/v2/": context deadline exceeded
##[error]Process completed with exit code 125
```

`lhotari/sandboxed-trivy-action` runs Trivy inside a Docker container. The scanner image is not cached on the runner, so Docker pulls it from Docker Hub, and that pull occasionally times out (`context deadline exceeded`, exit code 125), failing the job and blocking unrelated PRs. It hits different matrix entries on different PRs, which marks it as transient infrastructure flakiness rather than a code issue.

This is a transient Docker Hub availability blip, not a rate limit: the error is a network timeout rather than an HTTP 429, and GitHub-hosted runners are exempt from Docker Hub's anonymous pull limits for public images.

## Change

Pull the scanner image from GHCR (`ghcr.io/aquasecurity/trivy`) instead of Docker Hub, and pre-pull it before the scan with a bounded retry and backoff.

Aqua publishes Trivy to GHCR at the byte-identical manifest digest as Docker Hub (`sha256:bcc376...`), so the scanned image content is unchanged and the digest pin is preserved, but ghcr.io is not subject to the `registry-1.docker.io` timeouts that triggered the failures above. The bounded retry is kept as defense-in-depth in case GHCR has its own transient blip.

The action's `docker run` uses Docker's default `--pull=missing`, so once the image is present locally it is reused and the registry is not contacted again. The image is defined once as a job-level `TRIVY_IMAGE` env var and passed to the action via its `trivy-image` input, so the pre-pulled image and the scanned image are guaranteed identical. The retry is bounded to 5 attempts with linear backoff, and skips the sleep after the final attempt so it fails cleanly if the registry is genuinely down.
