### PR TITLE
Data: Add metrics reporter to generic scan builder

### DIFF
--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -24,6 +24,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.metrics.MetricsReporter;
 
 public class IcebergGenerics {
   private IcebergGenerics() {}
@@ -93,6 +94,11 @@ public class IcebergGenerics {
 
     public ScanBuilder appendsAfter(long fromSnapshotId) {
       this.tableScan = tableScan.appendsAfter(fromSnapshotId);
+      return this;
+    }
+
+    public ScanBuilder metricsReporter(MetricsReporter reporter) {
+      this.tableScan = tableScan.metricsReporter(reporter);
       return this;
     }
 

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -58,7 +58,10 @@ import org.apache.iceberg.Tables;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.hadoop.HadoopInputFile;
 import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.metrics.InMemoryMetricsReporter;
+import org.apache.iceberg.metrics.ScanReport;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -287,6 +290,22 @@ public class TestLocalScan {
     Set<Record> records = Sets.newHashSet(results);
     assertThat(records).as("Should produce correct number of records").hasSameSizeAs(expected);
     assertThat(records).as("Random record set should match").isEqualTo(expected);
+  }
+
+  @TestTemplate
+  public void testScanMetricsReporter() throws IOException {
+    InMemoryMetricsReporter reporter = new InMemoryMetricsReporter();
+
+    try (CloseableIterable<Record> results =
+        IcebergGenerics.read(sharedTable).metricsReporter(reporter).build()) {
+      assertThat(Sets.newHashSet(results)).hasSize(9);
+    }
+
+    ScanReport scanReport = reporter.scanReport();
+    assertThat(scanReport).isNotNull();
+    assertThat(scanReport.tableName()).isEqualTo(sharedTable.name());
+    assertThat(scanReport.snapshotId()).isEqualTo(sharedTable.currentSnapshot().snapshotId());
+    assertThat(scanReport.scanMetrics().resultDataFiles().value()).isEqualTo(3);
   }
 
   @TestTemplate


### PR DESCRIPTION
This adds a delegating metricsReporter method to IcebergGenerics.ScanBuilder so callers can configure scan metrics reporting without accessing the underlying TableScan directly.

This follows the API shape proposed in #14654, which was closed as stale, and adds focused test coverage for the generic read path.

Closes #14875.

Tests (JDK 21):
- ./gradlew :iceberg-data:test --tests org.apache.iceberg.data.TestLocalScan.testScanMetricsReporter
- ./gradlew :iceberg-data:test --tests org.apache.iceberg.data.TestLocalScan
- ./gradlew :iceberg-data:spotlessCheck
- ./gradlew :iceberg-data:revapi
- ./gradlew :iceberg-data:javadoc