### PR TITLE
Core: Relative paths for data files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -280,6 +280,10 @@ abstract class BaseFile<F> extends SupportsIndexProjection
     this.manifestLocation = manifestLocation;
   }
 
+  void setLocation(String location) {
+    this.filePath = location;
+  }
+
   @Override
   public Long fileSequenceNumber() {
     return fileSequenceNumber;

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.LocationUtil;
 
 class BaseSnapshot implements Snapshot {
   private final long snapshotId;
@@ -46,6 +47,8 @@ class BaseSnapshot implements Snapshot {
   private final Long firstRowId;
   private final Long addedRows;
   private final String keyId;
+  // base location for resolving relative data file paths; null when paths are absolute
+  private final String tableLocation;
 
   // lazily initialized
   private transient List<ManifestFile> allManifests = null;
@@ -68,6 +71,34 @@ class BaseSnapshot implements Snapshot {
       Long firstRowId,
       Long addedRows,
       String keyId) {
+    this(
+        sequenceNumber,
+        snapshotId,
+        parentId,
+        timestampMillis,
+        operation,
+        summary,
+        schemaId,
+        manifestList,
+        firstRowId,
+        addedRows,
+        keyId,
+        null);
+  }
+
+  BaseSnapshot(
+      long sequenceNumber,
+      long snapshotId,
+      Long parentId,
+      long timestampMillis,
+      String operation,
+      Map<String, String> summary,
+      Integer schemaId,
+      String manifestList,
+      Long firstRowId,
+      Long addedRows,
+      String keyId,
+      String tableLocation) {
     Preconditions.checkArgument(
         firstRowId == null || firstRowId >= 0,
         "Invalid first-row-id (cannot be negative): %s",
@@ -91,6 +122,7 @@ class BaseSnapshot implements Snapshot {
     this.firstRowId = firstRowId;
     this.addedRows = firstRowId != null ? addedRows : null;
     this.keyId = keyId;
+    this.tableLocation = tableLocation;
   }
 
   BaseSnapshot(
@@ -114,6 +146,7 @@ class BaseSnapshot implements Snapshot {
     this.firstRowId = null;
     this.addedRows = null;
     this.keyId = null;
+    this.tableLocation = null;
   }
 
   @Override
@@ -185,6 +218,7 @@ class BaseSnapshot implements Snapshot {
       this.allManifests =
           ManifestLists.read(
               fileIO.newInputFile(new BaseManifestListFile(manifestListLocation, keyId)));
+      tagDataManifestsForRelativePaths(allManifests);
     }
 
     if (dataManifests == null || deleteManifests == null) {
@@ -196,6 +230,20 @@ class BaseSnapshot implements Snapshot {
           ImmutableList.copyOf(
               Iterables.filter(
                   allManifests, manifest -> manifest.content() == ManifestContent.DELETES));
+    }
+  }
+
+  private void tagDataManifestsForRelativePaths(List<ManifestFile> manifests) {
+    if (tableLocation == null) {
+      return;
+    }
+
+    // strip the trailing separator so the base matches TableMetadata.location()
+    String baseLocation = LocationUtil.stripTrailingSlash(tableLocation);
+    for (ManifestFile manifest : manifests) {
+      if (manifest.content() == ManifestContent.DATA && manifest instanceof GenericManifestFile) {
+        ((GenericManifestFile) manifest).setBaseLocation(baseLocation);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -60,6 +60,8 @@ public class GenericManifestFile extends SupportsIndexProjection
   private PartitionFieldSummary[] partitions = null;
   private byte[] keyMetadata = null;
   private Long firstRowId = null;
+  // set when the manifest list is read; not part of the manifest schema
+  private String baseLocation = null;
 
   /** Used by Avro reflection to instantiate this class when reading manifest files. */
   public GenericManifestFile(Schema avroSchema) {
@@ -172,6 +174,7 @@ public class GenericManifestFile extends SupportsIndexProjection
             ? null
             : Arrays.copyOf(toCopy.keyMetadata, toCopy.keyMetadata.length);
     this.firstRowId = toCopy.firstRowId;
+    this.baseLocation = toCopy.baseLocation;
   }
 
   /** Constructor for Java serialization. */
@@ -270,6 +273,14 @@ public class GenericManifestFile extends SupportsIndexProjection
   @Override
   public Long firstRowId() {
     return firstRowId;
+  }
+
+  String baseLocation() {
+    return baseLocation;
+  }
+
+  void setBaseLocation(String baseLocation) {
+    this.baseLocation = baseLocation;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
+++ b/core/src/main/java/org/apache/iceberg/InheritableMetadataFactory.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.LocationUtil;
 
 class InheritableMetadataFactory {
 
@@ -34,11 +35,16 @@ class InheritableMetadataFactory {
     Preconditions.checkArgument(
         manifest.snapshotId() != null,
         "Cannot read from ManifestFile with null (unassigned) snapshot ID");
+    String baseLocation =
+        manifest instanceof GenericManifestFile
+            ? ((GenericManifestFile) manifest).baseLocation()
+            : null;
     return new BaseInheritableMetadata(
         manifest.partitionSpecId(),
         manifest.snapshotId(),
         manifest.sequenceNumber(),
-        manifest.path());
+        manifest.path(),
+        baseLocation);
   }
 
   /** Returns {@link InheritableMetadata} for rewriting a manifest before it is committed. */
@@ -51,13 +57,19 @@ class InheritableMetadataFactory {
     private final long snapshotId;
     private final long sequenceNumber;
     private final String manifestLocation;
+    private final String baseLocation;
 
     private BaseInheritableMetadata(
-        int specId, long snapshotId, long sequenceNumber, String manifestLocation) {
+        int specId,
+        long snapshotId,
+        long sequenceNumber,
+        String manifestLocation,
+        String baseLocation) {
       this.specId = specId;
       this.snapshotId = snapshotId;
       this.sequenceNumber = sequenceNumber;
       this.manifestLocation = manifestLocation;
+      this.baseLocation = baseLocation;
     }
 
     @Override
@@ -86,6 +98,9 @@ class InheritableMetadataFactory {
         file.setDataSequenceNumber(manifestEntry.dataSequenceNumber());
         file.setFileSequenceNumber(manifestEntry.fileSequenceNumber());
         file.setManifestLocation(manifestLocation);
+        if (baseLocation != null && file.path() != null) {
+          file.setLocation(LocationUtil.resolveLocation(baseLocation, file.location()));
+        }
       }
 
       return manifestEntry;

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -122,6 +122,10 @@ public class SnapshotParser {
   }
 
   static Snapshot fromJson(JsonNode node) {
+    return fromJson(node, null);
+  }
+
+  static Snapshot fromJson(JsonNode node, String tableLocation) {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse table version from a non-object: %s", node);
 
@@ -190,7 +194,8 @@ public class SnapshotParser {
           manifestList,
           firstRowId,
           addedRows,
-          keyId);
+          keyId,
+          tableLocation);
 
     } else {
       // fall back to an embedded manifest list. pass in the manifest's InputFile so length can be

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -59,6 +59,7 @@ public class TableMetadata implements Serializable {
   static final int MIN_FORMAT_VERSION_ROW_LINEAGE = 3;
   static final int MIN_FORMAT_VERSION_PARQUET_MANIFESTS = 4;
   static final int MIN_FORMAT_VERSION_OPTIONAL_LOCATION = 4;
+  static final int MIN_FORMAT_VERSION_RELATIVE_PATHS = 4;
   static final int INITIAL_SPEC_ID = 0;
   static final int INITIAL_SORT_ORDER_ID = 1;
   static final int INITIAL_SCHEMA_ID = 0;

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -515,8 +515,11 @@ public class TableMetadataParser {
 
       snapshots = Lists.newArrayListWithExpectedSize(snapshotArray.size());
       Iterator<JsonNode> iterator = snapshotArray.elements();
+      // only v4+ metadata may use relative paths
+      String snapshotBaseLocation =
+          formatVersion >= TableMetadata.MIN_FORMAT_VERSION_RELATIVE_PATHS ? location : null;
       while (iterator.hasNext()) {
-        snapshots.add(SnapshotParser.fromJson(iterator.next()));
+        snapshots.add(SnapshotParser.fromJson(iterator.next(), snapshotBaseLocation));
       }
     } else {
       snapshots = ImmutableList.of();

--- a/core/src/test/java/org/apache/iceberg/TestManifestReader.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestReader.java
@@ -22,10 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.iceberg.ManifestEntry.Status;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -283,5 +285,137 @@ public class TestManifestReader extends TestBase {
       assertThat(entry.status()).isEqualTo(Status.EXISTING);
       assertThat(entry.file().location()).isEqualTo(FILE_A.location());
     }
+  }
+
+  @TestTemplate
+  public void testRelativeDataFilePathIsResolvedWhenManifestTagged() throws IOException {
+    DataFile relativeFile = relativeDataFile("data/relative-file.parquet");
+    ManifestFile manifest = writeManifest(1000L, relativeFile);
+    ((GenericManifestFile) manifest).setBaseLocation("file:/table/location");
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, table.specs())) {
+      DataFile file = Iterables.getOnlyElement(reader.entries()).file();
+      assertThat(file.location()).isEqualTo("file:/table/location/data/relative-file.parquet");
+    }
+  }
+
+  @TestTemplate
+  public void testAbsoluteDataFilePathIsNotResolvedWhenManifestTagged() throws IOException {
+    // a path with a URI scheme is already absolute and left unchanged
+    DataFile absoluteFile = relativeDataFile("file:/somewhere/else/abs-file.parquet");
+    ManifestFile manifest = writeManifest(1000L, absoluteFile);
+    ((GenericManifestFile) manifest).setBaseLocation("file:/table/location");
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, table.specs())) {
+      DataFile file = Iterables.getOnlyElement(reader.entries()).file();
+      assertThat(file.location()).isEqualTo("file:/somewhere/else/abs-file.parquet");
+    }
+  }
+
+  @TestTemplate
+  public void testRelativeDataFilePathIsNotResolvedWithoutBaseLocation() throws IOException {
+    // without a base location, paths are left as stored
+    DataFile relativeFile = relativeDataFile("data/relative-file.parquet");
+    ManifestFile manifest = writeManifest(1000L, relativeFile);
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, FILE_IO, table.specs())) {
+      DataFile file = Iterables.getOnlyElement(reader.entries()).file();
+      assertThat(file.location()).isEqualTo("data/relative-file.parquet");
+    }
+  }
+
+  @TestTemplate
+  public void testSnapshotResolvesRelativeDataFilePaths() throws IOException {
+    String tableLocation = "file:/table/location";
+    DataFile relativeFile = relativeDataFile("data/relative-file.parquet");
+    ManifestFile dataManifest = writeManifest(1000L, relativeFile);
+    String manifestList = writeManifestList(1000L, dataManifest);
+
+    Snapshot snapshot =
+        new BaseSnapshot(
+            0L,
+            1000L,
+            null,
+            0L,
+            DataOperations.APPEND,
+            null,
+            0,
+            manifestList,
+            null,
+            null,
+            null,
+            tableLocation);
+
+    List<ManifestFile> dataManifests = snapshot.dataManifests(FILE_IO);
+    assertThat(dataManifests).hasSize(1);
+    assertThat(((GenericManifestFile) dataManifests.get(0)).baseLocation())
+        .isEqualTo(tableLocation);
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(dataManifests.get(0), FILE_IO, table.specs())) {
+      DataFile file = Iterables.getOnlyElement(reader.entries()).file();
+      assertThat(file.location()).isEqualTo("file:/table/location/data/relative-file.parquet");
+    }
+  }
+
+  @TestTemplate
+  public void testSnapshotDoesNotTagDeleteManifests() throws IOException {
+    assumeThat(formatVersion)
+        .as("Delete files only work for format version 2 or higher")
+        .isGreaterThanOrEqualTo(2);
+    DataFile relativeFile = relativeDataFile("data/relative-file.parquet");
+    ManifestFile dataManifest = writeManifest(1000L, relativeFile);
+    ManifestFile deleteManifest = writeDeleteManifest(formatVersion, 1000L, FILE_A_DELETES);
+    String manifestList = writeManifestList(1000L, dataManifest, deleteManifest);
+
+    Snapshot snapshot =
+        new BaseSnapshot(
+            0L,
+            1000L,
+            null,
+            0L,
+            DataOperations.OVERWRITE,
+            null,
+            0,
+            manifestList,
+            null,
+            null,
+            null,
+            "file:/table/location");
+
+    assertThat(((GenericManifestFile) snapshot.dataManifests(FILE_IO).get(0)).baseLocation())
+        .as("data manifests are tagged")
+        .isEqualTo("file:/table/location");
+    assertThat(((GenericManifestFile) snapshot.deleteManifests(FILE_IO).get(0)).baseLocation())
+        .as("delete manifests are not tagged")
+        .isNull();
+  }
+
+  private DataFile relativeDataFile(String path) {
+    return DataFiles.builder(SPEC)
+        .withPath(path)
+        .withFileSizeInBytes(10)
+        .withPartitionPath("data_bucket=0")
+        .withRecordCount(1)
+        .build();
+  }
+
+  private String writeManifestList(long snapshotId, ManifestFile... manifests) throws IOException {
+    File manifestList = temp.resolve("manifests" + System.nanoTime()).toFile();
+    try (ManifestListWriter writer =
+        ManifestLists.write(
+            formatVersion,
+            org.apache.iceberg.Files.localOutput(manifestList),
+            PlaintextEncryptionManager.instance(),
+            snapshotId,
+            null,
+            0L,
+            0L)) {
+      for (ManifestFile manifest : manifests) {
+        writer.add(manifest);
+      }
+    }
+
+    return org.apache.iceberg.Files.localInput(manifestList).location();
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/DeleteReadTests.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.file.Path;
@@ -39,6 +40,9 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -121,12 +125,7 @@ public abstract class DeleteReadTests {
     records.add(record.copy("id", 121, "data", "f"));
     records.add(record.copy("id", 122, "data", "g"));
 
-    this.dataFile =
-        FileHelpers.writeDataFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            records);
+    this.dataFile = FileHelpers.writeDataFile(table, localOutput(), Row.of(0), records);
 
     table.newAppend().appendFile(dataFile).commit();
   }
@@ -135,6 +134,34 @@ public abstract class DeleteReadTests {
   public void cleanup() throws IOException {
     dropTable("test");
     dropTable("test2");
+  }
+
+  // v4 resolves scheme-less paths against the table location, so files written outside the table
+  // must report absolute file: URIs to avoid being treated as relative on read
+  protected OutputFile localOutput() {
+    File file = temp.resolve("junit" + System.nanoTime()).toFile();
+    OutputFile delegate = Files.localOutput(file);
+    return new OutputFile() {
+      @Override
+      public PositionOutputStream create() {
+        return delegate.create();
+      }
+
+      @Override
+      public PositionOutputStream createOrOverwrite() {
+        return delegate.createOrOverwrite();
+      }
+
+      @Override
+      public String location() {
+        return file.toURI().toString();
+      }
+
+      @Override
+      public InputFile toInputFile() {
+        return delegate.toInputFile();
+      }
+    };
   }
 
   protected void initDateTable() throws IOException {
@@ -155,31 +182,31 @@ public abstract class DeleteReadTests {
     DataFile dataFile1 =
         FileHelpers.writeDataFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-01"))),
             dateRecords.subList(0, 1));
     DataFile dataFile2 =
         FileHelpers.writeDataFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-02"))),
             dateRecords.subList(1, 2));
     DataFile dataFile3 =
         FileHelpers.writeDataFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-03"))),
             dateRecords.subList(2, 3));
     DataFile dataFile4 =
         FileHelpers.writeDataFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-04"))),
             dateRecords.subList(3, 4));
     DataFile dataFile5 =
         FileHelpers.writeDataFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-05"))),
             dateRecords.subList(4, 5));
 
@@ -238,12 +265,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile eqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            deleteRowSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, deleteRowSchema);
 
     table.newRowDelta().addDeletes(eqDeletes).commit();
 
@@ -269,21 +291,21 @@ public abstract class DeleteReadTests {
     DeleteFile eqDeletes1 =
         FileHelpers.writeDeleteFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-01"))),
             dataDeletes.subList(0, 1),
             deleteRowSchema);
     DeleteFile eqDeletes2 =
         FileHelpers.writeDeleteFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-02"))),
             dataDeletes.subList(1, 2),
             deleteRowSchema);
     DeleteFile eqDeletes3 =
         FileHelpers.writeDeleteFile(
             dateTable,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(DateTimeUtil.daysFromDate(LocalDate.parse("2021-09-03"))),
             dataDeletes.subList(2, 3),
             deleteRowSchema);
@@ -315,12 +337,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile eqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            deleteRowSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, deleteRowSchema);
 
     table.newRowDelta().addDeletes(eqDeletes).commit();
 
@@ -346,12 +363,7 @@ public abstract class DeleteReadTests {
     GenericRecord record = GenericRecord.create(table.schema());
     records.add(record.copy("id", 144, "data", "a"));
 
-    this.dataFile =
-        FileHelpers.writeDataFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            records);
+    this.dataFile = FileHelpers.writeDataFile(table, localOutput(), Row.of(0), records);
 
     // At this point, the table has two data files, with 7 and 8 rows respectively, of which all but
     // one are in duplicate.
@@ -367,12 +379,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile eqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            deleteRowSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, deleteRowSchema);
 
     // At this point, 3 rows in the first data file and 4 rows in the second data file are deleted.
     table.newRowDelta().addDeletes(eqDeletes).commit();
@@ -394,12 +401,7 @@ public abstract class DeleteReadTests {
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            deletes,
-            formatVersion);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), deletes, formatVersion);
 
     table
         .newRowDelta()
@@ -427,12 +429,7 @@ public abstract class DeleteReadTests {
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            deletes,
-            formatVersion);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), deletes, formatVersion);
 
     table
         .newRowDelta()
@@ -443,12 +440,7 @@ public abstract class DeleteReadTests {
     deletes = Lists.newArrayList(Pair.of(dataFile.location(), 6L)); // id = 122
 
     posDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            deletes,
-            formatVersion);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), deletes, formatVersion);
 
     table
         .newRowDelta()
@@ -475,12 +467,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile eqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            dataSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, dataSchema);
 
     List<Pair<CharSequence, Long>> deletes =
         Lists.newArrayList(
@@ -489,12 +476,7 @@ public abstract class DeleteReadTests {
             );
 
     Pair<DeleteFile, CharSequenceSet> posDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            deletes,
-            formatVersion);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), deletes, formatVersion);
 
     table
         .newRowDelta()
@@ -522,12 +504,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile dataEqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            dataSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, dataSchema);
 
     Schema idSchema = table.schema().select("id");
     Record idDelete = GenericRecord.create(idSchema);
@@ -538,12 +515,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile idEqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            idDeletes,
-            idSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), idDeletes, idSchema);
 
     table.newRowDelta().addDeletes(dataEqDeletes).addDeletes(idEqDeletes).commit();
 
@@ -564,7 +536,7 @@ public abstract class DeleteReadTests {
     DataFile dataFileWithNull =
         FileHelpers.writeDataFile(
             table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(0),
             Lists.newArrayList(record.copy("id", 131, "data", null)));
 
@@ -579,12 +551,7 @@ public abstract class DeleteReadTests {
             );
 
     DeleteFile eqDeletes =
-        FileHelpers.writeDeleteFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            dataDeletes,
-            dataSchema);
+        FileHelpers.writeDeleteFile(table, localOutput(), Row.of(0), dataDeletes, dataSchema);
 
     table.newRowDelta().addDeletes(eqDeletes).commit();
 
@@ -639,7 +606,7 @@ public abstract class DeleteReadTests {
     DeleteFile eqDeletes =
         FileHelpers.writeDeleteFile(
             table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
+            localOutput(),
             Row.of(0),
             equalityDeletes,
             equalityDeletes.get(0).struct().asSchema());
@@ -670,11 +637,7 @@ public abstract class DeleteReadTests {
                   structRecord)));
     }
     DataFile binaryDataFile =
-        FileHelpers.writeDataFile(
-            table,
-            Files.localOutput(temp.resolve("junit" + System.nanoTime()).toFile()),
-            Row.of(0),
-            recordsWithOptionalColumns);
+        FileHelpers.writeDataFile(table, localOutput(), Row.of(0), recordsWithOptionalColumns);
 
     table.newAppend().appendFile(binaryDataFile).commit();
     records.addAll(recordsWithOptionalColumns);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -73,28 +73,28 @@ public class TestDeleteReachableFilesAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(1))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(2))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(3))
           .withRecordCount(1)
@@ -102,7 +102,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
@@ -110,7 +110,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -83,28 +83,28 @@ public class TestExpireSnapshotsAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=1") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=2") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=3") // easy way to set partition data for now
           .withRecordCount(1)
@@ -112,7 +112,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -120,7 +120,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -1270,7 +1270,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesExpired; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-expired-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-expired-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1290,7 +1290,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesRetained; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-retained-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-retained-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1389,7 +1389,7 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     DataFile fileInNewSpec =
         DataFiles.builder(table.spec())
-            .withPath("/path/to/data-in-new-spec.parquet")
+            .withPath("file:/path/to/data-in-new-spec.parquet")
             .withFileSizeInBytes(10)
             .withPartitionPath("c1=1/extra_col=11")
             .withRecordCount(1)

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -70,56 +70,56 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_A2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a2.parquet")
+          .withPath("file:/path/to/data-a2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b2.parquet")
+          .withPath("file:/path/to/data-b2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c2.parquet")
+          .withPath("file:/path/to/data-c2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d2.parquet")
+          .withPath("file:/path/to/data-d2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
@@ -127,7 +127,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -135,7 +135,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -143,7 +143,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -151,7 +151,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -159,7 +159,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -167,7 +167,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -175,7 +175,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -183,7 +183,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -191,21 +191,21 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_UNPARTITIONED =
       DataFiles.builder(PartitionSpec.unpartitioned())
-          .withPath("/path/to/data-unpartitioned.parquet")
+          .withPath("file:/path/to/data-unpartitioned.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_POS_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-pos-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_EQ_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-eq-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -580,7 +580,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     Configuration conf = new Configuration();
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
-    Path testFilePath = new Path(testFile.getAbsolutePath());
+    Path testFilePath = new Path(testFile.toURI());
 
     // Write a Parquet file with more than one row group
     ParquetFileWriter parquetFileWriter =

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -73,28 +73,28 @@ public class TestDeleteReachableFilesAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(1))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(2))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(3))
           .withRecordCount(1)
@@ -102,7 +102,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
@@ -110,7 +110,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -83,28 +83,28 @@ public class TestExpireSnapshotsAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=1") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=2") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=3") // easy way to set partition data for now
           .withRecordCount(1)
@@ -112,7 +112,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -120,7 +120,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -1270,7 +1270,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesExpired; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-expired-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-expired-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1290,7 +1290,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesRetained; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-retained-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-retained-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1389,7 +1389,7 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     DataFile fileInNewSpec =
         DataFiles.builder(table.spec())
-            .withPath("/path/to/data-in-new-spec.parquet")
+            .withPath("file:/path/to/data-in-new-spec.parquet")
             .withFileSizeInBytes(10)
             .withPartitionPath("c1=1/extra_col=11")
             .withRecordCount(1)

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -70,56 +70,56 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_A2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a2.parquet")
+          .withPath("file:/path/to/data-a2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b2.parquet")
+          .withPath("file:/path/to/data-b2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c2.parquet")
+          .withPath("file:/path/to/data-c2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
@@ -127,7 +127,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -135,7 +135,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -143,7 +143,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -151,7 +151,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -159,7 +159,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -167,7 +167,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -175,7 +175,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -183,7 +183,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -191,21 +191,21 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_UNPARTITIONED =
       DataFiles.builder(PartitionSpec.unpartitioned())
-          .withPath("/path/to/data-unpartitioned.parquet")
+          .withPath("file:/path/to/data-unpartitioned.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_POS_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-pos-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_EQ_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-eq-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -580,7 +580,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     Configuration conf = new Configuration();
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
-    Path testFilePath = new Path(testFile.getAbsolutePath());
+    Path testFilePath = new Path(testFile.toURI());
 
     // Write a Parquet file with more than one row group
     ParquetFileWriter parquetFileWriter =

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestDeleteReachableFilesAction.java
@@ -73,28 +73,28 @@ public class TestDeleteReachableFilesAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(1))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(2))
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(3))
           .withRecordCount(1)
@@ -102,7 +102,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)
@@ -110,7 +110,7 @@ public class TestDeleteReachableFilesAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartition(TestHelpers.Row.of(0))
           .withRecordCount(1)

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestExpireSnapshotsAction.java
@@ -83,28 +83,28 @@ public class TestExpireSnapshotsAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=1") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=2") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=3") // easy way to set partition data for now
           .withRecordCount(1)
@@ -112,7 +112,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -120,7 +120,7 @@ public class TestExpireSnapshotsAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=0") // easy way to set partition data for now
           .withRecordCount(1)
@@ -1270,7 +1270,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesExpired; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-expired-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-expired-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1290,7 +1290,7 @@ public class TestExpireSnapshotsAction extends TestBase {
     for (int i = 0; i < dataFilesRetained; i++) {
       DataFile df =
           DataFiles.builder(SPEC)
-              .withPath(String.format("/path/to/data-retained-%d.parquet", i))
+              .withPath(String.format("file:/path/to/data-retained-%d.parquet", i))
               .withFileSizeInBytes(10)
               .withPartitionPath("c1=1")
               .withRecordCount(1)
@@ -1389,7 +1389,7 @@ public class TestExpireSnapshotsAction extends TestBase {
 
     DataFile fileInNewSpec =
         DataFiles.builder(table.spec())
-            .withPath("/path/to/data-in-new-spec.parquet")
+            .withPath("file:/path/to/data-in-new-spec.parquet")
             .withFileSizeInBytes(10)
             .withPartitionPath("c1=1/extra_col=11")
             .withRecordCount(1)

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -70,56 +70,56 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_A =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a.parquet")
+          .withPath("file:/path/to/data-a.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_A2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-a2.parquet")
+          .withPath("file:/path/to/data-a2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b.parquet")
+          .withPath("file:/path/to/data-b.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_B2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-b2.parquet")
+          .withPath("file:/path/to/data-b2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c.parquet")
+          .withPath("file:/path/to/data-c.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_C2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-c2.parquet")
+          .withPath("file:/path/to/data-c2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=c") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d.parquet")
+          .withPath("file:/path/to/data-d.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
           .build();
   static final DataFile FILE_D2 =
       DataFiles.builder(SPEC)
-          .withPath("/path/to/data-d2.parquet")
+          .withPath("file:/path/to/data-d2.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=d") // easy way to set partition data for now
           .withRecordCount(1)
@@ -127,7 +127,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -135,7 +135,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-a2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-a2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -143,7 +143,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -151,7 +151,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_A2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-a2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-a2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=a") // easy way to set partition data for now
           .withRecordCount(1)
@@ -159,7 +159,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -167,7 +167,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_POS_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofPositionDeletes()
-          .withPath("/path/to/data-b2-pos-deletes.parquet")
+          .withPath("file:/path/to/data-b2-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -175,7 +175,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -183,7 +183,7 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
   static final DeleteFile FILE_B2_EQ_DELETES =
       FileMetadata.deleteFileBuilder(SPEC)
           .ofEqualityDeletes()
-          .withPath("/path/to/data-b2-eq-deletes.parquet")
+          .withPath("file:/path/to/data-b2-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withPartitionPath("c1=b") // easy way to set partition data for now
           .withRecordCount(1)
@@ -191,21 +191,21 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
 
   static final DataFile FILE_UNPARTITIONED =
       DataFiles.builder(PartitionSpec.unpartitioned())
-          .withPath("/path/to/data-unpartitioned.parquet")
+          .withPath("file:/path/to/data-unpartitioned.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_POS_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-pos-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-pos-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();
   static final DeleteFile FILE_UNPARTITIONED_EQ_DELETE =
       FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
           .ofEqualityDeletes()
-          .withPath("/path/to/data-unpartitioned-eq-deletes.parquet")
+          .withPath("file:/path/to/data-unpartitioned-eq-deletes.parquet")
           .withFileSizeInBytes(10)
           .withRecordCount(1)
           .build();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReaderDeletes.java
@@ -582,7 +582,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
     Configuration conf = new Configuration();
     File testFile = File.createTempFile("junit", null, temp.toFile());
     assertThat(testFile.delete()).as("Delete should succeed").isTrue();
-    Path testFilePath = new Path(testFile.getAbsolutePath());
+    Path testFilePath = new Path(testFile.toURI());
 
     // Write a Parquet file with more than one row group
     ParquetFileWriter parquetFileWriter =
@@ -714,11 +714,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
             recordWithStatus.copy("id", 201, "data", "i", "status", "INACTIVE"),
             recordWithStatus.copy("id", 202, "data", "j", "status", "ACTIVE"));
     DataFile dataFileWithStatus =
-        FileHelpers.writeDataFile(
-            table,
-            Files.localOutput(temp.resolve("junit-v2-" + System.nanoTime()).toFile()),
-            TestHelpers.Row.of(0),
-            recordsWithStatus);
+        FileHelpers.writeDataFile(table, localOutput(), TestHelpers.Row.of(0), recordsWithStatus);
     table.newAppend().appendFile(dataFileWithStatus).commit();
 
     // issue equality delete on `status` column
@@ -766,11 +762,7 @@ public class TestSparkReaderDeletes extends DeleteReadTests {
       data.add(record.copy("id", i, "a", i * 10, "b", i * 100));
     }
 
-    DataFile dataFile =
-        FileHelpers.writeDataFile(
-            eqTestTable,
-            Files.localOutput(File.createTempFile("junit", null, temp.toFile())),
-            data);
+    DataFile dataFile = FileHelpers.writeDataFile(eqTestTable, localOutput(), data);
     eqTestTable.newAppend().appendFile(dataFile).commit();
 
     Schema deleteSchema =


### PR DESCRIPTION
This adds support for reading data files using relative paths.

We've had some issues in the prior PR where a bunch of files have scheme-less "absolute" paths. By Iceberg's definition of absolute, those need schemes. I fixed the ones we ran into. 