### PR TITLE
Core: Fix for global equality deletes applied to partitioned tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -561,7 +561,7 @@ class DeleteFileIndex {
       PartitionSpec spec = specsById.get(file.specId());
 
       EqualityDeletes deletes;
-      if (spec.isUnpartitioned()) {
+      if (spec.isUnpartitioned() || file.partition().equals(BaseFile.EMPTY_PARTITION_DATA)) {
         deletes = globalDeletes;
       } else {
         int specId = spec.specId();

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -481,6 +481,33 @@ public abstract class DeleteFileIndexTestBase<
   }
 
   @TestTemplate
+  public void testGlobalEqDeleteWithSpecIdCollision() {
+    // PartitionSpec.unpartitioned() has specId 0, but does not reserve it so we must handle
+    // a collision where SpecId 0 is a partitioned spec.
+    assertThat(SPEC.specId()).isEqualTo(PartitionSpec.unpartitioned().specId());
+
+    // Global equality delete written with PartitionSpec.unpartitioned() (specId = 0)
+    DeleteFile globalEqDelete =
+        withDataSequenceNumber(4, unpartitionedEqDeletes(PartitionSpec.unpartitioned()));
+
+    // specsById contains only the partitioned SPEC at ID 0, simulating a table that was created
+    // with a partitioned spec as its first (and only) spec. PartitionSpec.unpartitioned() is not
+    // in the table's spec history, but shares specId = 0 with the table's partitioned spec.
+    DeleteFileIndex index =
+        DeleteFileIndex.builderFor(Arrays.asList(globalEqDelete))
+            .specsById(ImmutableMap.of(SPEC.specId(), SPEC))
+            .build();
+
+    assertThat(index.hasEqualityDeletes()).isTrue();
+
+    // Global equality delete must apply to FILE_A (a partitioned data file)
+    assertThat(index.forDataFile(0, FILE_A))
+        .as(
+            "Global equality delete should apply to partitioned data file regardless of spec ID collision")
+        .hasSize(1);
+  }
+
+  @TestTemplate
   public void testPartitionedTableSequenceNumbers() {
     table.newRowDelta().addRows(FILE_A).addDeletes(FILE_A_EQ_1).addDeletes(fileADeletes()).commit();
 


### PR DESCRIPTION
Today you are unable to apply a global equality delete to a table without having an unpartitioned partition spec (as spec 0 in some cases) in specsById. This is super misleading because you are able to create the equality delete by passing PartitionSpec.unpartitioned(), but due to a collision with the specId, it is not properly registered as a global equality delete

```
PartitionSpec.unpartitioned() is a singleton constant with specId = 0. A table's first partition spec is also assigned specId = 0. When a global equality delete is written using PartitionSpec.unpartitioned() against a table whose first(and only) spec is partitioned, the delete file stores specId = 0. At read time, specsById.get(0) resolves to the table's partitioned spec rather than the unpartitioned constant, causing the delete to be misclassified as partition-scoped. It is indexed under an empty partition key in eqDeletesByPartition rather than globalDeletes. Since no data file's partition matches an empty key, the delete never applies and deleted rows are incorrectly returned to the reader.
```

Note, I'm compelled to think there is a better fix...but I don't think we can reserve the 0 specId for unpartitioned since tables already exist that break that convention. We could maybe use -1 but it would not fix the issue for existing tables. This fix just treats empty partition data as global.

Note the only other reference I could find to this issue is here https://github.com/apache/iceberg/issues/14678#issuecomment-3573864332 and the user found the workaround creating the table unpartitioned first and then altering it, and then closed the issue