### PR TITLE
Spark: Support ALTER TABLE ... DROP PARTITION syntax

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TransformUtil.java
@@ -21,9 +21,13 @@ package org.apache.iceberg.transforms;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.OffsetDateTime;
+import java.time.YearMonth;
 import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.Base64;
 import java.util.Locale;
@@ -40,12 +44,21 @@ class TransformUtil {
     return String.format(Locale.ROOT, "%04d", EPOCH_YEAR + yearOrdinal);
   }
 
+  static int parseHumanYear(String value) {
+    return Integer.parseInt(value) - EPOCH_YEAR;
+  }
+
   static String humanMonth(int monthOrdinal) {
     return String.format(
         Locale.ROOT,
         "%04d-%02d",
         EPOCH_YEAR + Math.floorDiv(monthOrdinal, 12),
         1 + Math.floorMod(monthOrdinal, 12));
+  }
+
+  static int parseHumanMonth(String value) {
+    YearMonth ym = YearMonth.parse(value);
+    return (ym.getYear() - EPOCH_YEAR) * 12 + (ym.getMonthValue() - 1);
   }
 
   static String humanDay(int dayOrdinal) {
@@ -56,6 +69,12 @@ class TransformUtil {
         day.getYear(),
         day.getMonth().getValue(),
         day.getDayOfMonth());
+  }
+
+  static int parseHumanDay(String value) {
+    return (int)
+        ChronoUnit.DAYS.between(
+            EPOCH, OffsetDateTime.of(LocalDate.parse(value), LocalTime.MIDNIGHT, ZoneOffset.UTC));
   }
 
   static String humanTime(Long microsFromMidnight) {
@@ -87,6 +106,15 @@ class TransformUtil {
         time.getMonth().getValue(),
         time.getDayOfMonth(),
         time.getHour());
+  }
+
+  private static final DateTimeFormatter HOUR_FORMATTER =
+      DateTimeFormatter.ofPattern("yyyy-MM-dd-HH", Locale.ROOT);
+
+  static int parseHumanHour(String value) {
+    return (int)
+        ChronoUnit.HOURS.between(
+            EPOCH, OffsetDateTime.of(LocalDateTime.parse(value, HOUR_FORMATTER), ZoneOffset.UTC));
   }
 
   static String base64encode(ByteBuffer buffer) {

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -280,4 +280,52 @@ public class Transforms {
   public static <T> Transform<T, Void> alwaysNull() {
     return VoidTransform.get();
   }
+
+  /**
+   * Parses the human-readable year partition value (e.g. "2024") to its int ordinal as stored by
+   * the year transform: years since 1970.
+   *
+   * @param value the human-readable year, formatted as "yyyy"
+   * @return the year ordinal (yyyy - 1970)
+   * @throws NumberFormatException if {@code value} is not a valid integer
+   */
+  public static int parseHumanYear(String value) {
+    return TransformUtil.parseHumanYear(value);
+  }
+
+  /**
+   * Parses the human-readable month partition value (e.g. "2024-01") to its int ordinal as stored
+   * by the month transform: months since 1970-01.
+   *
+   * @param value the human-readable month, formatted as "yyyy-MM"
+   * @return the month ordinal ((yyyy - 1970) * 12 + (MM - 1))
+   * @throws java.time.format.DateTimeParseException if {@code value} is malformed
+   */
+  public static int parseHumanMonth(String value) {
+    return TransformUtil.parseHumanMonth(value);
+  }
+
+  /**
+   * Parses the human-readable day partition value (e.g. "2024-02-15") to its int ordinal as stored
+   * by the day transform: days since 1970-01-01 (UTC).
+   *
+   * @param value the human-readable day, formatted as "yyyy-MM-dd"
+   * @return the day ordinal
+   * @throws java.time.format.DateTimeParseException if {@code value} is malformed
+   */
+  public static int parseHumanDay(String value) {
+    return TransformUtil.parseHumanDay(value);
+  }
+
+  /**
+   * Parses the human-readable hour partition value (e.g. "2024-02-15-11") to its int ordinal as
+   * stored by the hour transform: hours since 1970-01-01T00 (UTC).
+   *
+   * @param value the human-readable hour, formatted as "yyyy-MM-dd-HH"
+   * @return the hour ordinal
+   * @throws java.time.format.DateTimeParseException if {@code value} is malformed
+   */
+  public static int parseHumanHour(String value) {
+    return TransformUtil.parseHumanHour(value);
+  }
 }

--- a/api/src/test/java/org/apache/iceberg/transforms/TestTimeTransforms.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestTimeTransforms.java
@@ -121,4 +121,60 @@ public class TestTimeTransforms {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageMatching("Unsupported type: date");
   }
+
+  @Test
+  public void testParseHumanYearRoundTrip() {
+    for (int ordinal : new int[] {0, 54, -10, 130}) {
+      assertThat(Transforms.parseHumanYear(TransformUtil.humanYear(ordinal))).isEqualTo(ordinal);
+    }
+    assertThat(Transforms.parseHumanYear("2024")).isEqualTo(54);
+    assertThat(Transforms.parseHumanYear("1970")).isZero();
+    assertThat(Transforms.parseHumanYear("1960")).isEqualTo(-10);
+  }
+
+  @Test
+  public void testParseHumanMonthRoundTrip() {
+    for (int ordinal : new int[] {0, 648, -1, -13, 1500}) {
+      assertThat(Transforms.parseHumanMonth(TransformUtil.humanMonth(ordinal))).isEqualTo(ordinal);
+    }
+    assertThat(Transforms.parseHumanMonth("2024-01")).isEqualTo(648);
+    assertThat(Transforms.parseHumanMonth("1970-01")).isZero();
+    assertThat(Transforms.parseHumanMonth("1969-12")).isEqualTo(-1);
+  }
+
+  @Test
+  public void testParseHumanDayRoundTrip() {
+    for (int ordinal : new int[] {0, 19768, -1, -365, 30000}) {
+      assertThat(Transforms.parseHumanDay(TransformUtil.humanDay(ordinal))).isEqualTo(ordinal);
+    }
+    assertThat(Transforms.parseHumanDay("2024-02-15")).isEqualTo(19768);
+    assertThat(Transforms.parseHumanDay("1970-01-01")).isZero();
+    assertThat(Transforms.parseHumanDay("1969-12-31")).isEqualTo(-1);
+  }
+
+  @Test
+  public void testParseHumanHourRoundTrip() {
+    for (int ordinal : new int[] {0, 473699, -1, -24, 500_000}) {
+      assertThat(Transforms.parseHumanHour(TransformUtil.humanHour(ordinal))).isEqualTo(ordinal);
+    }
+    assertThat(Transforms.parseHumanHour("2024-01-15-11")).isEqualTo(473699);
+    assertThat(Transforms.parseHumanHour("1970-01-01-00")).isZero();
+    assertThat(Transforms.parseHumanHour("1969-12-31-23")).isEqualTo(-1);
+  }
+
+  @Test
+  public void testParseHumanRejectsMalformedInput() {
+    assertThatThrownBy(() -> Transforms.parseHumanYear("not-a-year"))
+        .isInstanceOf(NumberFormatException.class)
+        .hasMessage("For input string: \"not-a-year\"");
+    assertThatThrownBy(() -> Transforms.parseHumanMonth("2024/01"))
+        .isInstanceOf(java.time.format.DateTimeParseException.class)
+        .hasMessage("Text '2024/01' could not be parsed at index 4");
+    assertThatThrownBy(() -> Transforms.parseHumanDay("2024-02"))
+        .isInstanceOf(java.time.format.DateTimeParseException.class)
+        .hasMessage("Text '2024-02' could not be parsed at index 7");
+    assertThatThrownBy(() -> Transforms.parseHumanHour("2024-02-15"))
+        .isInstanceOf(java.time.format.DateTimeParseException.class)
+        .hasMessage("Text '2024-02-15' could not be parsed at index 10");
+  }
 }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDropPartition.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestDropPartition.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.iceberg.Parameter;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.CatalogTestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestDropPartition extends ExtensionsTestBase {
+
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}, formatVersion = {3}")
+  protected static Object[][] parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (Object[] catalogParams : CatalogTestBase.parameters()) {
+      for (int version : TestHelpers.ALL_VERSIONS) {
+        parameters.add(
+            new Object[] {catalogParams[0], catalogParams[1], catalogParams[2], version});
+      }
+    }
+
+    return parameters.toArray(new Object[0][]);
+  }
+
+  @Parameter(index = 3)
+  private int formatVersion;
+
+  @AfterEach
+  public void removeTable() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+  }
+
+  @TestTemplate
+  public void testDropPartitionIdentity() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (data) "
+            + "TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c')", tableName);
+
+    sql("ALTER TABLE %s DROP PARTITION (data = 'b')", tableName);
+
+    List<Object[]> remaining = sql("SELECT id, data FROM %s ORDER BY id", tableName);
+    assertThat(remaining).containsExactly(new Object[] {1L, "a"}, new Object[] {3L, "c"});
+  }
+
+  @TestTemplate
+  public void testDropPartitionMultipleColumns() {
+    sql(
+        "CREATE TABLE %s (id bigint, region string, dt string) USING iceberg "
+            + "PARTITIONED BY (region, dt) TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, 'us', '2024-01-01'), (2, 'us', '2024-01-02'), (3, 'eu', '2024-01-01')",
+        tableName);
+
+    sql("ALTER TABLE %s DROP PARTITION (region = 'us', dt = '2024-01-01')", tableName);
+
+    List<Object[]> remaining = sql("SELECT id, region, dt FROM %s ORDER BY id", tableName);
+    assertThat(remaining)
+        .containsExactly(
+            new Object[] {2L, "us", "2024-01-02"}, new Object[] {3L, "eu", "2024-01-01"});
+  }
+
+  @TestTemplate
+  public void testDropPartitionAtomicMultipleSpecs() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (data) "
+            + "TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')", tableName);
+
+    long snapshotsBefore = countSnapshots();
+    sql("ALTER TABLE %s DROP PARTITION (data = 'b'), PARTITION (data = 'd')", tableName);
+    long snapshotsAfter = countSnapshots();
+
+    List<Object[]> remaining = sql("SELECT id, data FROM %s ORDER BY id", tableName);
+    assertThat(remaining).containsExactly(new Object[] {1L, "a"}, new Object[] {3L, "c"});
+    assertThat(snapshotsAfter - snapshotsBefore)
+        .as("Dropping multiple partitions should commit one snapshot")
+        .isEqualTo(1L);
+  }
+
+  @TestTemplate
+  public void testDropPartitionBucketTransform() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (bucket(2, id)) "
+            + "TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql("INSERT INTO %s VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd')", tableName);
+
+    long before = (Long) sql("SELECT count(*) FROM %s", tableName).get(0)[0];
+    sql("ALTER TABLE %s DROP PARTITION (id_bucket = 0)", tableName);
+    long after = (Long) sql("SELECT count(*) FROM %s", tableName).get(0)[0];
+
+    // With 2 buckets and 4 distinct ids, both buckets are populated; dropping one removes
+    // strictly fewer than all rows
+    assertThat(after).as("Should remove at least one row from bucket 0").isLessThan(before);
+    assertThat(after).as("Should not remove every row (the other bucket survives)").isPositive();
+  }
+
+  @TestTemplate
+  public void testDropPartitionDoesNotExist() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (data) "
+            + "TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+    assertThatThrownBy(() -> sql("ALTER TABLE %s DROP PARTITION (data = 'missing')", tableName))
+        .hasMessageContaining("PARTITION (`data` = missing) cannot be found in table");
+
+    List<Object[]> remaining = sql("SELECT id, data FROM %s", tableName);
+    assertThat(remaining).containsExactly(new Object[] {1L, "a"});
+  }
+
+  @TestTemplate
+  public void testDropPartitionIfExists() {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg PARTITIONED BY (data) "
+            + "TBLPROPERTIES ('%s'='%d')",
+        tableName, TableProperties.FORMAT_VERSION, formatVersion);
+    sql("INSERT INTO %s VALUES (1, 'a')", tableName);
+
+    sql("ALTER TABLE %s DROP IF EXISTS PARTITION (data = 'missing')", tableName);
+
+    List<Object[]> remaining = sql("SELECT id, data FROM %s", tableName);
+    assertThat(remaining).containsExactly(new Object[] {1L, "a"});
+  }
+
+  @TestTemplate
+  public void testDropPartitionIdentityTimestamp() {
+    withUtcSession(
+        () -> {
+          sql(
+              "CREATE TABLE %s (id bigint, ts timestamp) USING iceberg PARTITIONED BY (ts) "
+                  + "TBLPROPERTIES ('%s'='%d')",
+              tableName, TableProperties.FORMAT_VERSION, formatVersion);
+          sql(
+              "INSERT INTO %s VALUES "
+                  + "(1, CAST('2024-01-15 10:00:00' AS TIMESTAMP)), "
+                  + "(2, CAST('2024-02-15 10:00:00' AS TIMESTAMP)), "
+                  + "(3, CAST('2024-03-15 10:00:00' AS TIMESTAMP))",
+              tableName);
+
+          sql("ALTER TABLE %s DROP PARTITION (ts = '2024-02-15 10:00:00')", tableName);
+
+          List<Object[]> remaining = sql("SELECT id FROM %s ORDER BY id", tableName);
+          assertThat(remaining).containsExactly(new Object[] {1L}, new Object[] {3L});
+        });
+  }
+
+  @TestTemplate
+  public void testDropPartitionDayTransform() {
+    withUtcSession(
+        () -> {
+          sql(
+              "CREATE TABLE %s (id bigint, ts timestamp) USING iceberg PARTITIONED BY (days(ts)) "
+                  + "TBLPROPERTIES ('%s'='%d')",
+              tableName, TableProperties.FORMAT_VERSION, formatVersion);
+          sql(
+              "INSERT INTO %s VALUES "
+                  + "(1, CAST('2024-01-15 10:00:00' AS TIMESTAMP)), "
+                  + "(2, CAST('2024-02-15 10:00:00' AS TIMESTAMP)), "
+                  + "(3, CAST('2024-02-15 22:00:00' AS TIMESTAMP)), "
+                  + "(4, CAST('2024-03-15 10:00:00' AS TIMESTAMP))",
+              tableName);
+
+          sql("ALTER TABLE %s DROP PARTITION (ts_day = '2024-02-15')", tableName);
+
+          List<Object[]> remaining = sql("SELECT id FROM %s ORDER BY id", tableName);
+          assertThat(remaining).containsExactly(new Object[] {1L}, new Object[] {4L});
+        });
+  }
+
+  @TestTemplate
+  public void testDropPartitionHourTransform() {
+    withUtcSession(
+        () -> {
+          sql(
+              "CREATE TABLE %s (id bigint, ts timestamp) USING iceberg PARTITIONED BY (hours(ts)) "
+                  + "TBLPROPERTIES ('%s'='%d')",
+              tableName, TableProperties.FORMAT_VERSION, formatVersion);
+          sql(
+              "INSERT INTO %s VALUES "
+                  + "(1, CAST('2024-01-15 10:00:00' AS TIMESTAMP)), "
+                  + "(2, CAST('2024-01-15 11:15:00' AS TIMESTAMP)), "
+                  + "(3, CAST('2024-01-15 11:45:00' AS TIMESTAMP)), "
+                  + "(4, CAST('2024-01-15 12:00:00' AS TIMESTAMP))",
+              tableName);
+
+          sql("ALTER TABLE %s DROP PARTITION (ts_hour = '2024-01-15-11')", tableName);
+
+          List<Object[]> remaining = sql("SELECT id FROM %s ORDER BY id", tableName);
+          assertThat(remaining).containsExactly(new Object[] {1L}, new Object[] {4L});
+        });
+  }
+
+  @TestTemplate
+  public void testDropPartitionMonthTransform() {
+    withUtcSession(
+        () -> {
+          sql(
+              "CREATE TABLE %s (id bigint, ts timestamp) USING iceberg PARTITIONED BY (months(ts)) "
+                  + "TBLPROPERTIES ('%s'='%d')",
+              tableName, TableProperties.FORMAT_VERSION, formatVersion);
+          sql(
+              "INSERT INTO %s VALUES "
+                  + "(1, CAST('2024-01-01 10:00:00' AS TIMESTAMP)), "
+                  + "(2, CAST('2024-01-15 10:00:00' AS TIMESTAMP)), "
+                  + "(3, CAST('2024-02-15 10:00:00' AS TIMESTAMP))",
+              tableName);
+
+          sql("ALTER TABLE %s DROP PARTITION (ts_month = '2024-01')", tableName);
+
+          List<Object[]> remaining = sql("SELECT id FROM %s ORDER BY id", tableName);
+          assertThat(remaining).containsExactly(new Object[] {3L});
+        });
+  }
+
+  @TestTemplate
+  public void testDropPartitionYearTransform() {
+    withUtcSession(
+        () -> {
+          sql(
+              "CREATE TABLE %s (id bigint, ts timestamp) USING iceberg PARTITIONED BY (years(ts)) "
+                  + "TBLPROPERTIES ('%s'='%d')",
+              tableName, TableProperties.FORMAT_VERSION, formatVersion);
+          sql(
+              "INSERT INTO %s VALUES "
+                  + "(1, CAST('2024-01-15 10:00:00' AS TIMESTAMP)), "
+                  + "(2, CAST('2024-07-15 10:00:00' AS TIMESTAMP)), "
+                  + "(3, CAST('2025-01-15 10:00:00' AS TIMESTAMP))",
+              tableName);
+
+          sql("ALTER TABLE %s DROP PARTITION (ts_year = '2024')", tableName);
+
+          List<Object[]> remaining = sql("SELECT id FROM %s ORDER BY id", tableName);
+          assertThat(remaining).containsExactly(new Object[] {3L});
+        });
+  }
+
+  private long countSnapshots() {
+    List<Object[]> snapshots = sql("SELECT count(*) FROM %s.snapshots", tableName);
+    return (Long) snapshots.get(0)[0];
+  }
+
+  private void withUtcSession(Runnable action) {
+    String key = "spark.sql.session.timeZone";
+    String prev = spark.conf().getOption(key).getOrElse(() -> null);
+    spark.conf().set(key, "UTC");
+    try {
+      action.run();
+    } finally {
+      if (prev != null) {
+        spark.conf().set(key, prev);
+      } else {
+        spark.conf().unset(key);
+      }
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -23,9 +23,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import javax.annotation.Nonnull;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFiles;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
@@ -40,6 +42,7 @@ import org.apache.iceberg.expressions.ExpressionUtil;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Projections;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
+import org.apache.iceberg.expressions.UnboundTerm;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -49,14 +52,21 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.CommitMetadata;
 import org.apache.iceberg.spark.Spark3Util;
 import org.apache.iceberg.spark.SparkReadConf;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
 import org.apache.iceberg.spark.TimeTravel;
 import org.apache.iceberg.spark.TimeTravel.AsOfTimestamp;
 import org.apache.iceberg.spark.TimeTravel.AsOfVersion;
+import org.apache.iceberg.transforms.Transform;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.SupportsAtomicPartitionManagement;
 import org.apache.spark.sql.connector.catalog.SupportsDeleteV2;
 import org.apache.spark.sql.connector.catalog.SupportsRead;
 import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations;
@@ -70,7 +80,14 @@ import org.apache.spark.sql.connector.write.LogicalWriteInfo;
 import org.apache.spark.sql.connector.write.RowLevelOperationBuilder;
 import org.apache.spark.sql.connector.write.RowLevelOperationInfo;
 import org.apache.spark.sql.connector.write.WriteBuilder;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.apache.spark.unsafe.types.UTF8String;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +97,11 @@ import org.slf4j.LoggerFactory;
  * <p>Note the table state (e.g. schema, snapshot) is pinned upon loading and must not change.
  */
 public class SparkTable extends BaseSparkTable
-    implements SupportsRead, SupportsWrite, SupportsDeleteV2, SupportsRowLevelOperations {
+    implements SupportsRead,
+        SupportsWrite,
+        SupportsDeleteV2,
+        SupportsRowLevelOperations,
+        SupportsAtomicPartitionManagement {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkTable.class);
 
@@ -288,6 +309,205 @@ public class SparkTable extends BaseSparkTable
     }
 
     deleteFiles.commit();
+  }
+
+  // Iceberg has no per-partition metastore state, partitions are derived from data file metadata
+  // in manifests. Only DROP PARTITION is supported here: partitionSchema exposes the partition
+  // fields from the current PartitionSpec (e.g. ts_day, id_bucket) and DROP PARTITION maps to a
+  // snapshot-level delete with a transform-aware row filter, so the user always names a whole
+  // physical partition.
+
+  @Override
+  public StructType partitionSchema() {
+    List<StructField> fields = Lists.newArrayList();
+    for (PartitionField field : table().spec().fields()) {
+      if (field.transform().equals(Transforms.alwaysNull())) {
+        continue;
+      }
+      Types.NestedField sourceField = table().schema().findField(field.sourceId());
+      DataType sparkType;
+      if (isTimeTransform(field.transform())) {
+        // Time transforms (year/month/day/hour) are surfaced as their human-readable string
+        // forms (e.g. "2024", "2024-02", "2024-02-15", "2024-02-15-11") so users can write a
+        // partition value that mirrors the on-disk partition path.
+        sparkType = DataTypes.StringType;
+      } else {
+        Type resultType = field.transform().getResultType(sourceField.type());
+        sparkType = SparkSchemaUtil.convert(resultType);
+      }
+      fields.add(
+          new StructField(field.name(), sparkType, sourceField.isOptional(), Metadata.empty()));
+    }
+    return new StructType(fields.toArray(new StructField[0]));
+  }
+
+  private static boolean isTimeTransform(Transform<?, ?> transform) {
+    String name = transform.toString();
+    return "year".equals(name) || "month".equals(name) || "day".equals(name) || "hour".equals(name);
+  }
+
+  @Override
+  public boolean partitionExists(InternalRow ident) {
+    return partitionHasFiles(partitionRowFilter(ident));
+  }
+
+  @Override
+  public boolean dropPartition(InternalRow ident) {
+    Expression filter = partitionRowFilter(ident);
+    if (!partitionHasFiles(filter)) {
+      return false;
+    }
+    table().newDelete().deleteFromRowFilter(filter).commit();
+    return true;
+  }
+
+  @Override
+  public boolean dropPartitions(InternalRow[] idents) {
+    if (idents.length == 0) {
+      return false;
+    }
+    Expression filter = Expressions.alwaysFalse();
+    for (InternalRow ident : idents) {
+      filter = Expressions.or(filter, partitionRowFilter(ident));
+    }
+    if (!partitionHasFiles(filter)) {
+      return false;
+    }
+    table().newDelete().deleteFromRowFilter(filter).commit();
+    return true;
+  }
+
+  @Override
+  public void createPartition(InternalRow ident, Map<String, String> properties) {
+    throw new UnsupportedOperationException(
+        "Iceberg does not support creating partitions explicitly; they are derived from data files");
+  }
+
+  @Override
+  public void createPartitions(InternalRow[] idents, Map<String, String>[] properties) {
+    throw new UnsupportedOperationException(
+        "Iceberg does not support creating partitions explicitly; they are derived from data files");
+  }
+
+  @Override
+  public void replacePartitionMetadata(InternalRow ident, Map<String, String> properties) {
+    throw new UnsupportedOperationException("Iceberg does not support per-partition metadata");
+  }
+
+  @Override
+  public Map<String, String> loadPartitionMetadata(InternalRow ident) {
+    throw new UnsupportedOperationException("Iceberg does not support per-partition metadata");
+  }
+
+  @Override
+  public InternalRow[] listPartitionIdentifiers(String[] names, InternalRow ident) {
+    throw new UnsupportedOperationException(
+        "Listing partition identifiers is not implemented for Iceberg tables");
+  }
+
+  private Expression partitionRowFilter(InternalRow ident) {
+    StructType partitionSchema = partitionSchema();
+    Preconditions.checkArgument(
+        ident.numFields() == partitionSchema.length(),
+        "Partition row width %s does not match partition schema width %s",
+        ident.numFields(),
+        partitionSchema.length());
+
+    Map<String, PartitionField> partFieldsByName = Maps.newLinkedHashMap();
+    for (PartitionField field : table().spec().fields()) {
+      if (!field.transform().equals(Transforms.alwaysNull())) {
+        partFieldsByName.put(field.name(), field);
+      }
+    }
+
+    Expression filter = Expressions.alwaysTrue();
+    StructField[] fields = partitionSchema.fields();
+    for (int i = 0; i < fields.length; i++) {
+      StructField field = fields[i];
+      PartitionField partField = partFieldsByName.get(field.name());
+      String sourceName = table().schema().findColumnName(partField.sourceId());
+      Object value = ident.isNullAt(i) ? null : ident.get(i, field.dataType());
+      Object javaValue = catalystToJava(value);
+      filter = Expressions.and(filter, partitionFieldPredicate(partField, sourceName, javaValue));
+    }
+    return filter;
+  }
+
+  private static Expression partitionFieldPredicate(
+      PartitionField partField, String sourceName, Object value) {
+    Transform<?, ?> transform = partField.transform();
+    String transformName = transform.toString();
+    if ("identity".equals(transformName)) {
+      return (value == null)
+          ? Expressions.isNull(sourceName)
+          : Expressions.equal(sourceName, value);
+    }
+    UnboundTerm<Object> term = constructTerm(sourceName, transformName);
+    Object termValue = (value == null) ? null : parseHumanDateIfNeeded(value, transformName);
+
+    return (termValue == null) ? Expressions.isNull(term) : Expressions.equal(term, termValue);
+  }
+
+  private static Object parseHumanDateIfNeeded(@Nonnull Object value, String transformName) {
+    Object termValue = value;
+    if ("year".equals(transformName)) {
+      termValue = Transforms.parseHumanYear(value.toString());
+    } else if ("month".equals(transformName)) {
+      termValue = Transforms.parseHumanMonth(value.toString());
+    } else if ("day".equals(transformName)) {
+      termValue = Transforms.parseHumanDay(value.toString());
+    } else if ("hour".equals(transformName)) {
+      termValue = Transforms.parseHumanHour(value.toString());
+    }
+
+    return termValue;
+  }
+
+  private static UnboundTerm<Object> constructTerm(String sourceName, String transformName) {
+    UnboundTerm<Object> term;
+    if ("year".equals(transformName)) {
+      term = Expressions.year(sourceName);
+    } else if ("month".equals(transformName)) {
+      term = Expressions.month(sourceName);
+    } else if ("day".equals(transformName)) {
+      term = Expressions.day(sourceName);
+    } else if ("hour".equals(transformName)) {
+      term = Expressions.hour(sourceName);
+    } else if (transformName.startsWith("bucket[") && transformName.endsWith("]")) {
+      int numBuckets = parseTransformArg(transformName, "bucket[");
+      term = Expressions.bucket(sourceName, numBuckets);
+    } else if (transformName.startsWith("truncate[") && transformName.endsWith("]")) {
+      int width = parseTransformArg(transformName, "truncate[");
+      term = Expressions.truncate(sourceName, width);
+    } else {
+      throw new UnsupportedOperationException(
+          "Unsupported partition transform for DROP PARTITION: " + transformName);
+    }
+
+    return term;
+  }
+
+  private static int parseTransformArg(String transformName, String prefix) {
+    return Integer.parseInt(transformName.substring(prefix.length(), transformName.length() - 1));
+  }
+
+  private static Object catalystToJava(Object value) {
+    if (value instanceof UTF8String) {
+      return value.toString();
+    } else if (value instanceof Decimal) {
+      return ((Decimal) value).toJavaBigDecimal();
+    }
+    return value;
+  }
+
+  private boolean partitionHasFiles(Expression filter) {
+    try (CloseableIterable<FileScanTask> tasks =
+        table().newScan().filter(filter).ignoreResiduals().planFiles()) {
+      return tasks.iterator().hasNext();
+    } catch (IOException e) {
+      LOG.warn("Failed to close file scan iterable while checking partition existence", e);
+      return true;
+    }
   }
 
   @Override


### PR DESCRIPTION
This closes #16670.

# Summary
This PR consists of `ALTER TABLE ... DROP PARTITION` functionality for Spark engine and tests for it.