### PR TITLE
CI: Scope CVE scan PR triggers

### DIFF
--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -28,6 +28,17 @@ on:
     tags:
     - 'apache-iceberg-**'
   pull_request:
+    paths:
+    - '.github/workflows/cve-scan.yml'
+    - 'build.gradle'
+    - 'settings.gradle'
+    - 'gradle.properties'
+    - 'gradle/**'
+    - 'gradlew'
+    - 'gradlew.bat'
+    - '**/build.gradle'
+    - '**/gradle.lockfile'
+    - '**/.trivyignore'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- Add PR path filters to the CVE Scan workflow
- Trigger CVE Scan for build, dependency, Gradle, scan, and workflow configuration changes
- Avoid running the bundled artifact CVE scan for ordinary source-only PRs

## Why

The CVE Scan workflow builds bundled runtime artifacts and scans those artifacts for dependency vulnerabilities. Source-only changes typically do not affect the dependency set being scanned, so running the full matrix on every PR adds CI cost without improving CVE coverage.

---

Co-authored-by: @codex
