### PR TITLE
API: Decouple default test version range from MAX_FORMAT_VERSION

### DIFF
--- a/api/src/test/java/org/apache/iceberg/TestHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/TestHelpers.java
@@ -74,12 +74,26 @@ public class TestHelpers {
   private TestHelpers() {}
 
   public static final int MAX_FORMAT_VERSION = 4;
+
+  // The highest format version covered by the default version-parameterized test ranges below.
+  // While a new format version is being incubated, this lags MAX_FORMAT_VERSION so that the
+  // existing parameterized test suite is not pinned to an incomplete code path. Bump this to
+  // MAX_FORMAT_VERSION when the incubating version's read/write code paths cover every feature
+  // exercised by the parameterized suite.
+  public static final int DEFAULT_MAX_TEST_FORMAT_VERSION = 3;
+
   public static final List<Integer> ALL_VERSIONS =
-      IntStream.rangeClosed(1, MAX_FORMAT_VERSION).boxed().collect(Collectors.toUnmodifiableList());
+      IntStream.rangeClosed(1, DEFAULT_MAX_TEST_FORMAT_VERSION)
+          .boxed()
+          .collect(Collectors.toUnmodifiableList());
   public static final List<Integer> V2_AND_ABOVE =
-      IntStream.rangeClosed(2, MAX_FORMAT_VERSION).boxed().collect(Collectors.toUnmodifiableList());
+      IntStream.rangeClosed(2, DEFAULT_MAX_TEST_FORMAT_VERSION)
+          .boxed()
+          .collect(Collectors.toUnmodifiableList());
   public static final List<Integer> V3_AND_ABOVE =
-      IntStream.rangeClosed(3, MAX_FORMAT_VERSION).boxed().collect(Collectors.toUnmodifiableList());
+      IntStream.rangeClosed(3, DEFAULT_MAX_TEST_FORMAT_VERSION)
+          .boxed()
+          .collect(Collectors.toUnmodifiableList());
 
   /** Wait in a tight check loop until system clock is past {@code timestampMillis} */
   public static long waitUntilAfter(long timestampMillis) {


### PR DESCRIPTION
## Summary
- During v4 incubation, narrow the default version-parameterized test ranges (`ALL_VERSIONS`, `V2_AND_ABOVE`, `V3_AND_ABOVE`) so they no longer cover v4 by default. Those ranges drive ~25 core tests plus several Flink tests, and exposing them to incomplete v4 read/write paths during incubation produces spurious failures.
- Add `DEFAULT_MAX_TEST_FORMAT_VERSION = 3` and rebase the three derived ranges on it. `MAX_FORMAT_VERSION` stays at 4 so bound tests in `TestTableMetadata`, `TestSchema`, and `TestFormatVersions` upgrade tests continue to validate against v4.
- Bump `DEFAULT_MAX_TEST_FORMAT_VERSION` to 4 once v4 read/write covers all features the parameterized suite exercises (equality deletes, etc.).

## Test plan
- [x] `:iceberg-api:spotlessCheck` passes
- [x] `:iceberg-api:compileTestJava` and `:iceberg-core:compileTestJava` pass
- [x] `TestFormatVersions`, `TestRowLineageMetadata`, `TestManifestWriterVersions` pass
  - `TestRowLineageMetadata` correctly drops from 22 to 11 cases (v4 no longer parameterized)
  - `TestFormatVersions` unchanged (upgrade-target tests still run against v4)
  - `TestManifestWriterVersions` explicit V4 cases still run

🤖 Generated with [Claude Code](https://claude.com/claude-code)