### PR TITLE
Infra: Update collaborators list

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -49,8 +49,6 @@ github:
     issues: true
     projects: true
   collaborators:  # Note: the number of collaborators is limited to 10
-    - chenjunjiedada
-    - jun-he
     - marton-bod
     - samarthjain
     - SreeramGarlapati
@@ -59,6 +57,8 @@ github:
     - ajantha-bhat
     - jbonofre
     - manuzhang
+    - anuragmantri
+    - nssalian
   ghp_branch: gh-pages
   ghp_path: /
 


### PR DESCRIPTION
## Summary

Update the GitHub collaborators list in `.asf.yaml`:

- Add `anuragmantri` and `nssalian` who volunteered to be the release managers for the next two releases 1.12.0 and 1.13.0
- Remove `chenjunjiedada` and `jun-he` (inactive) to stay within the 10-collaborator limit

## Test plan

- [ ] ASF infra picks up the change after merge and updates GitHub repo collaborators accordingly