### PR TITLE
Spark: Support Initial Snapshot Load for Streaming Reads

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MicroBatches.java
+++ b/core/src/main/java/org/apache/iceberg/MicroBatches.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -30,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.Pair;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -46,7 +50,8 @@ public class MicroBatches {
                 .filter(m -> m.snapshotId().equals(snapshot.snapshotId()))
                 .collect(Collectors.toList());
 
-    List<Pair<ManifestFile, Integer>> manifestIndexes = indexManifests(manifests);
+    // no specsById available here; liveFileCount falls back to each manifest's own embedded spec
+    List<Pair<ManifestFile, Integer>> manifestIndexes = indexManifests(manifests, io, null);
 
     return skipManifests(manifestIndexes, startFileIndex);
   }
@@ -62,15 +67,14 @@ public class MicroBatches {
     ManifestGroup manifestGroup =
         new ManifestGroup(io, ImmutableList.of(manifestFile))
             .specsById(specsById)
-            .caseSensitive(caseSensitive);
+            .caseSensitive(caseSensitive)
+            .ignoreDeleted();
     if (!scanAllFiles) {
       manifestGroup =
-          manifestGroup
-              .filterManifestEntries(
-                  entry ->
-                      entry.snapshotId() == snapshot.snapshotId()
-                          && entry.status() == ManifestEntry.Status.ADDED)
-              .ignoreDeleted();
+          manifestGroup.filterManifestEntries(
+              entry ->
+                  entry.snapshotId() == snapshot.snapshotId()
+                      && entry.status() == ManifestEntry.Status.ADDED);
     }
 
     return manifestGroup.planFiles();
@@ -86,16 +90,36 @@ public class MicroBatches {
    *     manifest.
    */
   private static List<Pair<ManifestFile, Integer>> indexManifests(
-      List<ManifestFile> manifestFiles) {
+      List<ManifestFile> manifestFiles, FileIO io, Map<Integer, PartitionSpec> specsById) {
     int currentFileIndex = 0;
     List<Pair<ManifestFile, Integer>> manifestIndexes = Lists.newArrayList();
 
     for (ManifestFile manifest : manifestFiles) {
       manifestIndexes.add(Pair.of(manifest, currentFileIndex));
-      currentFileIndex += manifest.addedFilesCount() + manifest.existingFilesCount();
+      currentFileIndex += liveFileCount(manifest, io, specsById);
     }
 
     return manifestIndexes;
+  }
+
+  /**
+   * Number of live files in a manifest. Falls back to counting entries directly when the summary
+   * counts are unavailable.
+   */
+  private static int liveFileCount(
+      ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
+    Integer added = manifest.addedFilesCount();
+    Integer existing = manifest.existingFilesCount();
+    if (added != null && existing != null) {
+      return added + existing;
+    }
+
+    try (CloseableIterable<ManifestEntry<DataFile>> entries =
+        ManifestFiles.read(manifest, io, specsById).liveEntries()) {
+      return Iterables.size(entries);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to read manifest: " + manifest.path(), e);
+    }
   }
 
   /**
@@ -186,6 +210,7 @@ public class MicroBatches {
     private final FileIO io;
     private boolean caseSensitive;
     private Map<Integer, PartitionSpec> specsById;
+    private DeleteFileIndex deleteFileIndex;
 
     private MicroBatchBuilder(Snapshot snapshot, FileIO io) {
       this.snapshot = snapshot;
@@ -201,6 +226,10 @@ public class MicroBatches {
     public MicroBatchBuilder specsById(Map<Integer, PartitionSpec> specs) {
       this.specsById = specs;
       return this;
+    }
+
+    public long snapshotId() {
+      return snapshot.snapshotId();
     }
 
     public MicroBatch generate(long startFileIndex, long targetSizeInBytes, boolean scanAllFiles) {
@@ -318,6 +347,78 @@ public class MicroBatches {
           currentSizeInBytes,
           tasks,
           isLastIndex);
+    }
+
+    /** Total number of live files (added and existing) in the snapshot. */
+    public long fullScanFileCount() {
+      long count = 0;
+      for (ManifestFile manifest : snapshot.dataManifests(io)) {
+        count += liveFileCount(manifest, io, specsById);
+      }
+      return count;
+    }
+
+    /**
+     * Returns the live files in {@code [startFileIndex, endFileIndex)} with deletes attached,
+     * without materializing files outside that range.
+     */
+    public List<FileScanTask> planFullScan(long startFileIndex, long endFileIndex) {
+      Preconditions.checkArgument(startFileIndex >= 0, "startFileIndex must be >= 0");
+      if (startFileIndex >= endFileIndex) {
+        return Lists.newArrayList();
+      }
+
+      List<Pair<ManifestFile, Integer>> manifestIndex =
+          indexManifests(snapshot.dataManifests(io), io, specsById);
+      DeleteFileIndex deletes = deleteFileIndex();
+      List<FileScanTask> tasks = Lists.newArrayList();
+
+      for (Pair<ManifestFile, Integer> indexed : skipManifests(manifestIndex, startFileIndex)) {
+        long manifestStart = indexed.second();
+        if (manifestStart >= endFileIndex) {
+          break;
+        }
+
+        ManifestFile manifest = indexed.first();
+        PartitionSpec spec = specsById.get(manifest.partitionSpecId());
+        String schemaAsString = SchemaParser.toJson(spec.schema());
+        String specAsString = PartitionSpecParser.toJson(spec);
+        ResidualEvaluator residuals =
+            ResidualEvaluator.of(spec, Expressions.alwaysTrue(), caseSensitive);
+
+        try (CloseableIterable<ManifestEntry<DataFile>> entries =
+                ManifestFiles.read(manifest, io, specsById)
+                    .caseSensitive(caseSensitive)
+                    .liveEntries();
+            CloseableIterator<ManifestEntry<DataFile>> entryIter = entries.iterator()) {
+          long pos = manifestStart;
+          while (entryIter.hasNext() && pos < endFileIndex) {
+            ManifestEntry<DataFile> entry = entryIter.next();
+            if (pos >= startFileIndex) {
+              DataFile dataFile = ContentFileUtil.copy(entry.file(), true, null);
+              tasks.add(
+                  new BaseFileScanTask(
+                      dataFile, deletes.forEntry(entry), schemaAsString, specAsString, residuals));
+            }
+            pos++;
+          }
+        } catch (IOException e) {
+          LOG.warn("Failed to close manifest reader for {}", manifest.path(), e);
+        }
+      }
+
+      return tasks;
+    }
+
+    private DeleteFileIndex deleteFileIndex() {
+      if (deleteFileIndex == null) {
+        deleteFileIndex =
+            DeleteFileIndex.builderFor(io, snapshot.deleteManifests(io))
+                .specsById(specsById)
+                .caseSensitive(caseSensitive)
+                .build();
+      }
+      return deleteFileIndex;
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestMicroBatchBuilder.java
@@ -19,10 +19,15 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.iceberg.MicroBatches.MicroBatch;
+import org.apache.iceberg.MicroBatches.MicroBatchBuilder;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.BeforeEach;
@@ -139,6 +144,89 @@ public class TestMicroBatchBuilder extends TestBase {
     assertThat(batch5.sizeInBytes()).isEqualTo(0);
     assertThat(batch5.tasks()).isEmpty();
     assertThat(batch5.lastIndexOfSnapshot()).isTrue();
+  }
+
+  @TestTemplate
+  public void testFullScanFileCountMatchesManifestMetadata() {
+    add(table.newAppend(), files("A", "B", "C"));
+
+    MicroBatchBuilder builder = MicroBatches.from(table.snapshot(1L), table.io());
+
+    assertThat(builder.fullScanFileCount()).isEqualTo(3);
+  }
+
+  @TestTemplate
+  public void testPlanFullScanEmptyRangeReturnsNoTasks() {
+    add(table.newAppend(), files("A"));
+
+    MicroBatchBuilder builder = MicroBatches.from(table.snapshot(1L), table.io());
+
+    assertThat(builder.planFullScan(0, 0)).isEmpty();
+    assertThat(builder.planFullScan(1, 1)).isEmpty();
+  }
+
+  @TestTemplate
+  public void testPlanFullScanDeletesAttachAcrossASliceBoundaryThatSplitsAManifest()
+      throws IOException {
+    // positional deletes / DVs require format version 2+
+    assumeThat(formatVersion).isGreaterThan(1);
+
+    // FILE_A and FILE_B land in one manifest; their deletes land in a separate delete
+    // manifest from a later row-delta commit.
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    table.newRowDelta().addDeletes(fileADeletes()).addDeletes(fileBDeletes()).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    assertThat(snapshot.dataManifests(table.io())).hasSize(1);
+    assertThat(snapshot.deleteManifests(table.io())).hasSize(1);
+
+    List<FileScanTask> expected;
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(snapshot.snapshotId()).planFiles()) {
+      expected = Lists.newArrayList(tasks);
+    }
+    assertThat(expected).hasSize(2);
+
+    MicroBatchBuilder builder = MicroBatches.from(snapshot, table.io()).specsById(table.specs());
+    assertThat(builder.fullScanFileCount()).isEqualTo(2);
+
+    // Slice at the boundary between the two files in the single manifest: each half must still
+    // resolve to the correct file with the correct deletes attached
+    List<FileScanTask> firstHalf = builder.planFullScan(0, 1);
+    List<FileScanTask> secondHalf = builder.planFullScan(1, 2);
+    assertThat(firstHalf).hasSize(1);
+    assertThat(secondHalf).hasSize(1);
+
+    FileScanTask first = firstHalf.get(0);
+    FileScanTask second = secondHalf.get(0);
+    assertThat(first.file().location()).isNotEqualTo(second.file().location());
+
+    FileScanTask expectedFirst = expectedTaskFor(expected, first.file().location());
+    FileScanTask expectedSecond = expectedTaskFor(expected, second.file().location());
+
+    assertThat(deleteLocations(first)).isEqualTo(deleteLocations(expectedFirst));
+    assertThat(deleteLocations(second)).isEqualTo(deleteLocations(expectedSecond));
+    assertThat(deleteLocations(first)).isNotEmpty();
+    assertThat(deleteLocations(second)).isNotEmpty();
+
+    // a single full-range slice must agree with the two boundary-split half-slices
+    List<FileScanTask> full = builder.planFullScan(0, 2);
+    assertThat(full).hasSize(2);
+    assertThat(deleteLocations(expectedTaskFor(full, first.file().location())))
+        .isEqualTo(deleteLocations(first));
+    assertThat(deleteLocations(expectedTaskFor(full, second.file().location())))
+        .isEqualTo(deleteLocations(second));
+  }
+
+  private static FileScanTask expectedTaskFor(List<FileScanTask> tasks, String location) {
+    return tasks.stream()
+        .filter(t -> t.file().location().equals(location))
+        .findFirst()
+        .orElseThrow(() -> new IllegalStateException("No task found for location: " + location));
+  }
+
+  private static List<String> deleteLocations(FileScanTask task) {
+    return task.deletes().stream().map(ContentFile::location).sorted().collect(Collectors.toList());
   }
 
   private static DataFile file(String name) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -238,6 +238,10 @@ public class SparkReadConf {
         .parse();
   }
 
+  public String streamFromSnapshot() {
+    return confParser.stringConf().option(SparkReadOptions.STREAM_FROM_SNAPSHOT).parseOptional();
+  }
+
   public Long startTimestamp() {
     return confParser.longConf().option(SparkReadOptions.START_TIMESTAMP).parseOptional();
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkReadOptions.java
@@ -80,6 +80,15 @@ public class SparkReadOptions {
   // Timestamp in milliseconds; start a stream from the snapshot that occurs after this timestamp
   public static final String STREAM_FROM_TIMESTAMP = "stream-from-timestamp";
 
+  // Starting point for a streaming read. Accepts a snapshot id, "latest", or "earliest"
+  public static final String STREAM_FROM_SNAPSHOT = "stream-from-snapshot";
+
+  // Value indicating stream should only read snapshots that occur after startup
+  public static final String STREAM_FROM_SNAPSHOT_LATEST = "latest";
+
+  // Value indicating stream should read all snapshots starting from oldest ancestor
+  public static final String STREAM_FROM_SNAPSHOT_EARLIEST = "earliest";
+
   // maximum file per micro_batch
   public static final String STREAMING_MAX_FILES_PER_MICRO_BATCH =
       "streaming-max-files-per-micro-batch";

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -271,18 +271,29 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
       if (this.lastOffsetForTriggerAvailableNow != null) {
         return this.lastOffsetForTriggerAvailableNow;
       }
-      Snapshot lastValidSnapshot = table().snapshot(startOffset.snapshotId());
-      Snapshot nextValidSnapshot;
-      do {
-        nextValidSnapshot = nextValidSnapshot(lastValidSnapshot);
-        if (nextValidSnapshot != null) {
-          lastValidSnapshot = nextValidSnapshot;
+      // Bootstrap START_OFFSET into a real starting offset so we honor initial-snapshot mode
+      StreamingOffset effectiveStart = startOffset;
+      if (StreamingOffset.START_OFFSET.equals(startOffset)) {
+        effectiveStart =
+            MicroBatchUtils.determineStartingOffset(
+                table(), readConf().streamFromTimestamp(), readConf().streamFromSnapshot());
+        if (StreamingOffset.START_OFFSET.equals(effectiveStart)) {
+          return StreamingOffset.START_OFFSET;
         }
-      } while (nextValidSnapshot != null);
+      }
+      Snapshot lastValidSnapshot = table().snapshot(effectiveStart.snapshotId());
+      Snapshot next;
+      while ((next = nextValidSnapshot(lastValidSnapshot)) != null) {
+        lastValidSnapshot = next;
+      }
+      // no snapshot after effectiveStart: preserve its scanAllFiles flag
+      boolean scanAllFiles =
+          lastValidSnapshot.snapshotId() == effectiveStart.snapshotId()
+              && effectiveStart.shouldScanAllFiles();
       return new StreamingOffset(
           lastValidSnapshot.snapshotId(),
-          MicroBatchUtils.addedFilesCount(table(), lastValidSnapshot),
-          false);
+          MicroBatchUtils.endPositionFor(table(), lastValidSnapshot, scanAllFiles),
+          scanAllFiles);
     }
 
     return computeLimitedOffset(limit);
@@ -399,16 +410,24 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
   private void addMicroBatchToQueue(
       Snapshot snapshot, long startFileIndex, long endFileIndex, boolean shouldScanAllFile) {
     LOG.info("Adding MicroBatch for snapshot: {} to the queue", snapshot.snapshotId());
-    MicroBatches.MicroBatch microBatch =
-        MicroBatches.from(snapshot, table().io())
-            .caseSensitive(readConf().caseSensitive())
-            .specsById(table().specs())
-            .generate(startFileIndex, endFileIndex, Long.MAX_VALUE, shouldScanAllFile);
+
+    List<FileScanTask> tasks;
+    if (shouldScanAllFile) {
+      MicroBatches.MicroBatchBuilder plan = fullScanBuilder(snapshot);
+      tasks = plan.planFullScan(startFileIndex, endFileIndex);
+    } else {
+      MicroBatches.MicroBatch microBatch =
+          MicroBatches.from(snapshot, table().io())
+              .caseSensitive(readConf().caseSensitive())
+              .specsById(table().specs())
+              .generate(startFileIndex, endFileIndex, Long.MAX_VALUE, false);
+      tasks = microBatch.tasks();
+    }
 
     long position = startFileIndex;
-    for (FileScanTask task : microBatch.tasks()) {
+    for (FileScanTask task : tasks) {
       Pair<StreamingOffset, FileScanTask> elem =
-          Pair.of(new StreamingOffset(microBatch.snapshotId(), position, shouldScanAllFile), task);
+          Pair.of(new StreamingOffset(snapshot.snapshotId(), position, shouldScanAllFile), task);
       queuedFileCount.incrementAndGet();
       queuedRowCount.addAndGet(task.file().recordCount());
       queue.addLast(elem);
@@ -432,7 +451,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
       addMicroBatchToQueue(
           currentSnapshot,
           fromOffset.position(),
-          MicroBatchUtils.addedFilesCount(table(), currentSnapshot),
+          endFileIndexFor(currentSnapshot, fromOffset.shouldScanAllFiles()),
           fromOffset.shouldScanAllFiles());
     }
     if (toOffset != null) {
@@ -468,13 +487,9 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
       return; // Empty table
     }
 
-    // START_OFFSET case: initialize using nextValidSnapshot which respects timestamp filtering
     Snapshot current = startSnapshot;
     if (current == null) {
-      current = nextValidSnapshot(null);
-      if (current != null) {
-        addMicroBatchToQueue(current, 0, MicroBatchUtils.addedFilesCount(table(), current), false);
-      }
+      current = addInitialQueueEntry();
     }
 
     // Continue loading more snapshots within safety limits
@@ -526,18 +541,45 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
           minQueuedRows,
           queuedFileCount.get(),
           minQueuedFiles);
-    } else {
-      // add an entire snapshot to the queue
-      Snapshot nextValidSnapshot = nextValidSnapshot(readFrom);
-      if (nextValidSnapshot != null) {
-        addMicroBatchToQueue(
-            nextValidSnapshot,
-            0,
-            MicroBatchUtils.addedFilesCount(table(), nextValidSnapshot),
-            false);
-      } else {
+      return;
+    }
+
+    if (readFrom == null) {
+      // nothing queued yet, pick initial snapshot or incremental
+      if (addInitialQueueEntry() == null) {
         LOG.debug("No snapshots ready to be read");
       }
+      return;
     }
+
+    Snapshot next = nextValidSnapshot(readFrom);
+    if (next != null) {
+      addMicroBatchToQueue(next, 0, MicroBatchUtils.addedFilesCount(table(), next), false);
+    } else {
+      LOG.debug("No snapshots ready to be read");
+    }
+  }
+
+  private Snapshot addInitialQueueEntry() {
+    StreamingOffset startingOffset =
+        MicroBatchUtils.determineStartingOffset(
+            table(), readConf().streamFromTimestamp(), readConf().streamFromSnapshot());
+    if (StreamingOffset.START_OFFSET.equals(startingOffset)) {
+      return null;
+    }
+    Snapshot snap = table().snapshot(startingOffset.snapshotId());
+    if (snap == null) {
+      return null;
+    }
+    addMicroBatchToQueue(
+        snap,
+        startingOffset.position(),
+        endFileIndexFor(snap, startingOffset.shouldScanAllFiles()),
+        startingOffset.shouldScanAllFiles());
+    return snap;
+  }
+
+  private long endFileIndexFor(Snapshot snapshot, boolean scanAllFiles) {
+    return scanAllFiles ? Long.MAX_VALUE : MicroBatchUtils.addedFilesCount(table(), snapshot);
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkMicroBatchPlanner.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source;
 
 import java.util.Locale;
 import org.apache.iceberg.DataOperations;
+import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -37,6 +38,7 @@ abstract class BaseSparkMicroBatchPlanner implements SparkMicroBatchPlanner {
   private static final Logger LOG = LoggerFactory.getLogger(BaseSparkMicroBatchPlanner.class);
   private final Table table;
   private final SparkReadConf readConf;
+  private MicroBatches.MicroBatchBuilder fullScanBuilder;
 
   BaseSparkMicroBatchPlanner(Table table, SparkReadConf readConf) {
     this.table = table;
@@ -92,7 +94,8 @@ abstract class BaseSparkMicroBatchPlanner implements SparkMicroBatchPlanner {
     // if there were no valid snapshots, check for an initialOffset again
     if (curSnapshot == null) {
       StreamingOffset startingOffset =
-          MicroBatchUtils.determineStartingOffset(table, readConf.streamFromTimestamp());
+          MicroBatchUtils.determineStartingOffset(
+              table, readConf.streamFromTimestamp(), readConf.streamFromSnapshot());
       LOG.debug("determineStartingOffset picked startingOffset: {}", startingOffset);
       if (StreamingOffset.START_OFFSET.equals(startingOffset)) {
         return null;
@@ -115,6 +118,16 @@ abstract class BaseSparkMicroBatchPlanner implements SparkMicroBatchPlanner {
       nextSnapshot = SnapshotUtil.snapshotAfter(table, nextSnapshot.snapshotId());
     }
     return nextSnapshot;
+  }
+
+  protected MicroBatches.MicroBatchBuilder fullScanBuilder(Snapshot snapshot) {
+    if (fullScanBuilder == null || fullScanBuilder.snapshotId() != snapshot.snapshotId()) {
+      fullScanBuilder =
+          MicroBatches.from(snapshot, table.io())
+              .caseSensitive(readConf.caseSensitive())
+              .specsById(table.specs());
+    }
+    return fullScanBuilder;
   }
 
   static class UnpackedLimits {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/MicroBatchUtils.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/MicroBatchUtils.java
@@ -18,11 +18,15 @@
  */
 package org.apache.iceberg.spark.source;
 
+import java.util.Locale;
+import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.spark.SparkReadOptions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 
@@ -30,15 +34,25 @@ class MicroBatchUtils {
 
   private MicroBatchUtils() {}
 
-  static StreamingOffset determineStartingOffset(Table table, long fromTimestamp) {
+  static StreamingOffset determineStartingOffset(
+      Table table, long fromTimestamp, String fromSnapshot) {
+    ValidationException.check(
+        fromSnapshot == null || fromTimestamp == Long.MIN_VALUE,
+        "Cannot set both '%s' and '%s' options",
+        SparkReadOptions.STREAM_FROM_SNAPSHOT,
+        SparkReadOptions.STREAM_FROM_TIMESTAMP);
+
     if (table.currentSnapshot() == null) {
       return StreamingOffset.START_OFFSET;
     }
 
+    if (fromSnapshot != null) {
+      return startingOffsetFromSnapshotOption(table, fromSnapshot);
+    }
+
     if (fromTimestamp == Long.MIN_VALUE) {
-      // start from the oldest snapshot, since default value is MIN_VALUE
-      // avoids looping to find first snapshot
-      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0, false);
+      // initial-snapshot mode: planner routes this snapshot through BatchScan so deletes apply
+      return new StreamingOffset(table.currentSnapshot().snapshotId(), 0L, true);
     }
 
     if (table.currentSnapshot().timestampMillis() < fromTimestamp) {
@@ -58,6 +72,56 @@ class MicroBatchUtils {
     }
   }
 
+  private static StreamingOffset startingOffsetFromSnapshotOption(
+      Table table, String fromSnapshot) {
+    String normalized = fromSnapshot.toLowerCase(Locale.ROOT);
+    Snapshot currentSnapshot = table.currentSnapshot();
+
+    if (SparkReadOptions.STREAM_FROM_SNAPSHOT_LATEST.equals(normalized)) {
+      return new StreamingOffset(
+          currentSnapshot.snapshotId(), addedFilesCount(table, currentSnapshot), false);
+    }
+
+    if (SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST.equals(normalized)) {
+      return new StreamingOffset(SnapshotUtil.oldestAncestor(table).snapshotId(), 0L, false);
+    }
+
+    long fromSnapshotId;
+    try {
+      fromSnapshotId = Long.parseLong(fromSnapshot);
+    } catch (NumberFormatException e) {
+      throw new ValidationException(
+          "Invalid value for '%s': %s. Expected a snapshot id, '%s', or '%s'.",
+          SparkReadOptions.STREAM_FROM_SNAPSHOT,
+          fromSnapshot,
+          SparkReadOptions.STREAM_FROM_SNAPSHOT_LATEST,
+          SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST);
+    }
+
+    ValidationException.check(
+        table.snapshot(fromSnapshotId) != null,
+        "Cannot find snapshot for '%s': %s",
+        SparkReadOptions.STREAM_FROM_SNAPSHOT,
+        fromSnapshotId);
+    ValidationException.check(
+        SnapshotUtil.isAncestorOf(table, currentSnapshot.snapshotId(), fromSnapshotId),
+        "Snapshot %s is not an ancestor of the current snapshot",
+        fromSnapshotId);
+
+    if (fromSnapshotId == currentSnapshot.snapshotId()) {
+      // Requested snapshot is current — position past its end (same as `latest`)
+      return new StreamingOffset(
+          currentSnapshot.snapshotId(), addedFilesCount(table, currentSnapshot), false);
+    }
+
+    try {
+      Snapshot next = SnapshotUtil.snapshotAfter(table, fromSnapshotId);
+      return new StreamingOffset(next.snapshotId(), 0L, false);
+    } catch (IllegalStateException e) {
+      return StreamingOffset.START_OFFSET;
+    }
+  }
+
   static long addedFilesCount(Table table, Snapshot snapshot) {
     long addedFilesCount =
         PropertyUtil.propertyAsLong(snapshot.summary(), SnapshotSummary.ADDED_FILES_PROP, -1);
@@ -65,5 +129,11 @@ class MicroBatchUtils {
         ? Iterables.size(
             SnapshotChanges.builderFor(table).snapshot(snapshot).build().addedDataFiles())
         : addedFilesCount;
+  }
+
+  static long endPositionFor(Table table, Snapshot snapshot, boolean scanAllFiles) {
+    return scanAllFiles
+        ? MicroBatches.from(snapshot, table.io()).fullScanFileCount()
+        : addedFilesCount(table, snapshot);
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -107,7 +107,11 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
 
     InitialOffsetStore initialOffsetStore =
         new InitialOffsetStore(
-            table, checkpointLocation, fromTimestamp, sparkContext.hadoopConfiguration());
+            table,
+            checkpointLocation,
+            fromTimestamp,
+            readConf.streamFromSnapshot(),
+            sparkContext.hadoopConfiguration());
     this.initialOffset = initialOffsetStore.initialOffset();
   }
 
@@ -123,8 +127,13 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
     }
 
     Snapshot latestSnapshot = table.currentSnapshot();
+    boolean scanAllFiles =
+        initialOffset.shouldScanAllFiles()
+            && initialOffset.snapshotId() == latestSnapshot.snapshotId();
     return new StreamingOffset(
-        latestSnapshot.snapshotId(), MicroBatchUtils.addedFilesCount(table, latestSnapshot), false);
+        latestSnapshot.snapshotId(),
+        MicroBatchUtils.endPositionFor(table, latestSnapshot, scanAllFiles),
+        scanAllFiles);
   }
 
   @Override
@@ -267,13 +276,19 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
     private final FileIO io;
     private final String initialOffsetLocation;
     private final long fromTimestamp;
+    private final String fromSnapshot;
 
     InitialOffsetStore(
-        Table table, String checkpointLocation, long fromTimestamp, Configuration conf) {
+        Table table,
+        String checkpointLocation,
+        long fromTimestamp,
+        String fromSnapshot,
+        Configuration conf) {
       this.table = table;
       this.io = new HadoopFileIO(conf);
       this.initialOffsetLocation = SLASH.join(checkpointLocation, "offsets/0");
       this.fromTimestamp = fromTimestamp;
+      this.fromSnapshot = fromSnapshot;
     }
 
     public StreamingOffset initialOffset() {
@@ -283,7 +298,8 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
       }
 
       table.refresh();
-      StreamingOffset offset = MicroBatchUtils.determineStartingOffset(table, fromTimestamp);
+      StreamingOffset offset =
+          MicroBatchUtils.determineStartingOffset(table, fromTimestamp, fromSnapshot);
 
       OutputFile outputFile = io.newOutputFile(initialOffsetLocation);
       writeOffset(offset, outputFile);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
@@ -42,6 +42,7 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
 
   private final boolean caseSensitive;
   private final long fromTimestamp;
+  private final String fromSnapshot;
   private final StreamingOffset lastOffsetForTriggerAvailableNow;
 
   SyncSparkMicroBatchPlanner(
@@ -49,6 +50,7 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
     super(table, readConf);
     this.caseSensitive = readConf().caseSensitive();
     this.fromTimestamp = readConf().streamFromTimestamp();
+    this.fromSnapshot = readConf().streamFromSnapshot();
     this.lastOffsetForTriggerAvailableNow = lastOffsetForTriggerAvailableNow;
   }
 
@@ -57,14 +59,13 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
     List<FileScanTask> fileScanTasks = Lists.newArrayList();
     StreamingOffset batchStartOffset =
         StreamingOffset.START_OFFSET.equals(startOffset)
-            ? MicroBatchUtils.determineStartingOffset(table(), fromTimestamp)
+            ? MicroBatchUtils.determineStartingOffset(table(), fromTimestamp, fromSnapshot)
             : startOffset;
 
     StreamingOffset currentOffset = null;
 
     // [(startOffset : startFileIndex), (endOffset : endFileIndex) )
     do {
-      long endFileIndex;
       if (currentOffset == null) {
         currentOffset = batchStartOffset;
       } else {
@@ -82,29 +83,32 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
 
       validateCurrentSnapshotExists(snapshot, currentOffset);
 
-      if (!shouldProcess(snapshot)) {
+      // skip non-append snapshots unless scanning all files in initial snapshot
+      if (!currentOffset.shouldScanAllFiles() && !shouldProcess(snapshot)) {
         LOG.debug("Skipping snapshot: {} of table {}", currentOffset.snapshotId(), table().name());
         continue;
       }
 
       Snapshot currentSnapshot = table().snapshot(currentOffset.snapshotId());
-      if (currentOffset.snapshotId() == endOffset.snapshotId()) {
-        endFileIndex = endOffset.position();
+      boolean isTerminalSnapshot = currentOffset.snapshotId() == endOffset.snapshotId();
+
+      if (currentOffset.shouldScanAllFiles()) {
+        // BatchScan path so each FileScanTask carries DeleteFile[] / DV refs for the reader
+        MicroBatches.MicroBatchBuilder plan = fullScanBuilder(currentSnapshot);
+        long end = isTerminalSnapshot ? endOffset.position() : Long.MAX_VALUE;
+        fileScanTasks.addAll(plan.planFullScan(currentOffset.position(), end));
       } else {
-        endFileIndex = MicroBatchUtils.addedFilesCount(table(), currentSnapshot);
+        long endFileIndex =
+            isTerminalSnapshot
+                ? endOffset.position()
+                : MicroBatchUtils.addedFilesCount(table(), currentSnapshot);
+        MicroBatch latestMicroBatch =
+            MicroBatches.from(currentSnapshot, table().io())
+                .caseSensitive(caseSensitive)
+                .specsById(table().specs())
+                .generate(currentOffset.position(), endFileIndex, Long.MAX_VALUE, false);
+        fileScanTasks.addAll(latestMicroBatch.tasks());
       }
-
-      MicroBatch latestMicroBatch =
-          MicroBatches.from(currentSnapshot, table().io())
-              .caseSensitive(caseSensitive)
-              .specsById(table().specs())
-              .generate(
-                  currentOffset.position(),
-                  endFileIndex,
-                  Long.MAX_VALUE,
-                  currentOffset.shouldScanAllFiles());
-
-      fileScanTasks.addAll(latestMicroBatch.tasks());
     } while (currentOffset.snapshotId() != endOffset.snapshotId());
 
     return fileScanTasks;
@@ -126,7 +130,11 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
     StreamingOffset startingOffset = startOffset;
 
     if (startOffset.equals(StreamingOffset.START_OFFSET)) {
-      startingOffset = MicroBatchUtils.determineStartingOffset(table(), fromTimestamp);
+      startingOffset =
+          MicroBatchUtils.determineStartingOffset(table(), fromTimestamp, fromSnapshot);
+      if (StreamingOffset.START_OFFSET.equals(startingOffset)) {
+        return StreamingOffset.START_OFFSET;
+      }
     }
 
     Snapshot curSnapshot = table().snapshot(startingOffset.snapshotId());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMicroBatchPlanningUtils.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestMicroBatchPlanningUtils.java
@@ -20,9 +20,16 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MicroBatches;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotSummary;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.junit.jupiter.api.AfterEach;
@@ -78,7 +85,8 @@ public class TestMicroBatchPlanningUtils extends CatalogTestBase {
     table.refresh();
     long snapshot2Id = table.currentSnapshot().snapshotId();
 
-    StreamingOffset offset = MicroBatchUtils.determineStartingOffset(table, snapshot1Time + 1);
+    StreamingOffset offset =
+        MicroBatchUtils.determineStartingOffset(table, snapshot1Time + 1, null);
 
     assertThat(offset.snapshotId()).isEqualTo(snapshot2Id);
     assertThat(offset.position()).isEqualTo(0L);
@@ -96,5 +104,44 @@ public class TestMicroBatchPlanningUtils extends CatalogTestBase {
     long actual = MicroBatchUtils.addedFilesCount(table, table.currentSnapshot());
 
     assertThat(actual).isEqualTo(expectedAddedFiles);
+  }
+
+  @TestTemplate
+  public void testPlanFullScanOrderIsStableAcrossInstances() throws Exception {
+    // Multiple appends create multiple manifests. A checkpointed position must resolve to the
+    // same file across independent builder instances (e.g. after a restart).
+    sql("INSERT INTO %s VALUES (1, 'one'), (2, 'two')", tableName);
+    sql("INSERT INTO %s VALUES (3, 'three'), (4, 'four')", tableName);
+    sql("INSERT INTO %s VALUES (5, 'five'), (6, 'six')", tableName);
+    table.refresh();
+    Snapshot snapshot = table.currentSnapshot();
+
+    List<FileScanTask> expectedTasks;
+    try (CloseableIterable<FileScanTask> iterable =
+        table.newScan().useSnapshot(snapshot.snapshotId()).planFiles()) {
+      expectedTasks = Lists.newArrayList(iterable);
+    }
+    assertThat(expectedTasks).hasSizeGreaterThan(1);
+
+    MicroBatches.MicroBatchBuilder first = builderFor(snapshot);
+    MicroBatches.MicroBatchBuilder second = builderFor(snapshot);
+
+    assertThat(first.fullScanFileCount()).isEqualTo(expectedTasks.size());
+    assertThat(second.fullScanFileCount()).isEqualTo(first.fullScanFileCount());
+    assertThat(locationsOf(planFullScan(second)))
+        .as("checkpointed positions must resolve to the same files across independent builders")
+        .isEqualTo(locationsOf(planFullScan(first)));
+  }
+
+  private MicroBatches.MicroBatchBuilder builderFor(Snapshot snapshot) {
+    return MicroBatches.from(snapshot, table.io()).caseSensitive(true).specsById(table.specs());
+  }
+
+  private static List<FileScanTask> planFullScan(MicroBatches.MicroBatchBuilder builder) {
+    return builder.planFullScan(0, builder.fullScanFileCount());
+  }
+
+  private static List<String> locationsOf(List<FileScanTask> tasks) {
+    return tasks.stream().map(t -> t.file().location()).collect(Collectors.toList());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkReadOptions;
+import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.VoidFunction2;
 import org.apache.spark.sql.Dataset;
@@ -74,6 +75,7 @@ import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.streaming.StreamingQuery;
+import org.apache.spark.sql.streaming.StreamingQueryProgress;
 import org.apache.spark.sql.streaming.Trigger;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -148,6 +150,15 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
               Lists.newArrayList(
                   new SimpleRecord(15, "fifteen"), new SimpleRecord(16, "sixteen"))));
 
+  /** Five rows in one file, used by the initial-snapshot delete/DV tests. */
+  private static final List<SimpleRecord> FIVE_ROWS =
+      Lists.newArrayList(
+          new SimpleRecord(1, "one"),
+          new SimpleRecord(2, "two"),
+          new SimpleRecord(3, "three"),
+          new SimpleRecord(4, "four"),
+          new SimpleRecord(5, "five"));
+
   @BeforeAll
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
@@ -165,6 +176,31 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         tableName);
     this.table = validationCatalog.loadTable(tableIdent);
     microBatches.set(0);
+  }
+
+  /** Recreates {@code tableName} as a merge-on-read table at the given format version. */
+  private void createMergeOnReadTable(String formatVersion) {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ("
+            + "  'format-version' = '%s',"
+            + "  'write.delete.mode' = 'merge-on-read',"
+            + "  'write.update.mode' = 'merge-on-read',"
+            + "  'write.merge.mode' = 'merge-on-read'"
+            + ")",
+        tableName, formatVersion);
+    this.table = validationCatalog.loadTable(tableIdent);
+  }
+
+  private static List<SimpleRecord> excludingData(List<SimpleRecord> records, String data) {
+    List<SimpleRecord> result = Lists.newArrayList();
+    for (SimpleRecord r : records) {
+      if (!data.equals(r.getData())) {
+        result.add(r);
+      }
+    }
+    return result;
   }
 
   @AfterEach
@@ -819,6 +855,590 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testInitialSnapshotReadsCurrentDataThenIncremental() throws Exception {
+    List<List<SimpleRecord>> existing = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(existing);
+
+    StreamingQuery query = startStream();
+
+    List<SimpleRecord> afterInitial = rowsAvailable(query);
+    assertThat(afterInitial).containsExactlyInAnyOrderElementsOf(Iterables.concat(existing));
+
+    List<SimpleRecord> newRecords =
+        Lists.newArrayList(new SimpleRecord(100, "hundred"), new SimpleRecord(101, "hundred-one"));
+    appendData(newRecords);
+
+    List<SimpleRecord> total = Lists.newArrayList(Iterables.concat(existing));
+    total.addAll(newRecords);
+
+    List<SimpleRecord> afterIncremental = rowsAvailable(query);
+    assertThat(afterIncremental).containsExactlyInAnyOrderElementsOf(total);
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotFromOverwriteSnapshot() throws Exception {
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+
+    List<SimpleRecord> postOverwrite =
+        Lists.newArrayList(
+            new SimpleRecord(100, "hundred"),
+            new SimpleRecord(101, "hundred-one"),
+            new SimpleRecord(102, "hundred-two"));
+    spark
+        .createDataFrame(postOverwrite, SimpleRecord.class)
+        .select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("overwrite")
+        .save(tableName);
+
+    table.refresh();
+    assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.OVERWRITE);
+
+    // The initial read must reflect the post-overwrite state only
+    StreamingQuery query = startStream();
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(postOverwrite);
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotFromDeleteSnapshot() throws Exception {
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+
+    table.refresh();
+    table.updateSpec().removeField("id_bucket").addField(ref("id")).commit();
+    table.refresh();
+    table.newDelete().deleteFromRowFilter(Expressions.equal("id", 4)).commit();
+
+    table.refresh();
+    assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.DELETE);
+
+    // The initial read must reflect the post-delete state only
+    StreamingQuery query = startStream();
+    List<SimpleRecord> actual = rowsAvailable(query);
+    List<SimpleRecord> expected =
+        Lists.newArrayList(
+            new SimpleRecord(1, "one"),
+            new SimpleRecord(2, "two"),
+            new SimpleRecord(3, "three"),
+            new SimpleRecord(5, "five"),
+            new SimpleRecord(6, "six"),
+            new SimpleRecord(7, "seven"));
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotRecoversFromEmptyTableCheckpointWithNewCommits() throws Exception {
+    File writerCheckpointFolder = temp.resolve("empty-checkpoint-folder").toFile();
+    File writerCheckpoint = new File(writerCheckpointFolder, "writer-checkpoint");
+    File output = temp.resolve("empty-checkpoint-output").toFile();
+
+    Map<String, String> options = Maps.newHashMap();
+    options.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
+    if (async) {
+      options.put(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
+    }
+
+    DataStreamWriter<Row> querySource =
+        spark
+            .readStream()
+            .options(options)
+            .format("iceberg")
+            .load(tableName)
+            .writeStream()
+            .options(options)
+            .option("checkpointLocation", writerCheckpoint.toString())
+            .format("parquet")
+            .queryName("empty_checkpoint_test")
+            .option("path", output.getPath());
+
+    // Empty table at first stream start so persist START_OFFSET as the initial offset
+    StreamingQuery firstQuery = querySource.start();
+    firstQuery.processAllAvailable();
+    firstQuery.stop();
+
+    // Commits land while the stream is down, restart must not drop the backlog
+    List<SimpleRecord> firstBatch =
+        Lists.newArrayList(
+            new SimpleRecord(1, "one"), new SimpleRecord(2, "two"), new SimpleRecord(3, "three"));
+    List<SimpleRecord> secondBatch =
+        Lists.newArrayList(new SimpleRecord(4, "four"), new SimpleRecord(5, "five"));
+    appendData(firstBatch);
+    appendData(secondBatch);
+
+    StreamingQuery restarted = querySource.start();
+    restarted.processAllAvailable();
+    restarted.stop();
+
+    List<SimpleRecord> actual =
+        spark.read().load(output.getPath()).as(Encoders.bean(SimpleRecord.class)).collectAsList();
+    List<SimpleRecord> expected = Lists.newArrayList();
+    expected.addAll(firstBatch);
+    expected.addAll(secondBatch);
+    assertThat(actual).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotLatestSkipsBacklog() throws Exception {
+    List<List<SimpleRecord>> existing = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(existing);
+
+    StreamingQuery query =
+        startStream(
+            SparkReadOptions.STREAM_FROM_SNAPSHOT, SparkReadOptions.STREAM_FROM_SNAPSHOT_LATEST);
+
+    // With "latest", the backlog must not be visible
+    assertThat(rowsAvailable(query)).isEmpty();
+
+    List<SimpleRecord> newRecords =
+        Lists.newArrayList(new SimpleRecord(100, "hundred"), new SimpleRecord(101, "hundred-one"));
+    appendData(newRecords);
+
+    // New appends after the stream starts should be picked up
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(newRecords);
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotEarliestReplaysHistory() throws Exception {
+    // historical default, stream snapshots from the oldest ancestor
+    List<List<SimpleRecord>> existing = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(existing);
+
+    StreamingQuery query =
+        startStream(
+            SparkReadOptions.STREAM_FROM_SNAPSHOT, SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST);
+
+    assertThat(rowsAvailable(query))
+        .containsExactlyInAnyOrderElementsOf(Iterables.concat(existing));
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotSpecificIdReadsAfterSnapshot() throws Exception {
+    List<SimpleRecord> ignored =
+        Lists.newArrayList(new SimpleRecord(-1, "minus-one"), new SimpleRecord(0, "zero"));
+    appendData(ignored);
+    table.refresh();
+    long ignoredSnapshotId = table.currentSnapshot().snapshotId();
+
+    List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
+    appendDataAsMultipleSnapshots(expected);
+
+    StreamingQuery query =
+        startStream(SparkReadOptions.STREAM_FROM_SNAPSHOT, Long.toString(ignoredSnapshotId));
+
+    assertThat(rowsAvailable(query))
+        .containsExactlyInAnyOrderElementsOf(Iterables.concat(expected));
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotEqualToCurrentBehavesLikeLatest() throws Exception {
+    // stream-from-snapshot=<current_id> must position past the current snapshot's end
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+    table.refresh();
+    long currentSnapshotId = table.currentSnapshot().snapshotId();
+    long expectedPosition = MicroBatchUtils.addedFilesCount(table, table.currentSnapshot());
+
+    SparkMicroBatchStream stream =
+        newMicroBatchStream(
+            ImmutableMap.of(
+                SparkReadOptions.STREAM_FROM_SNAPSHOT, Long.toString(currentSnapshotId)),
+            "stream-from-current-snapshot-id-checkpoint");
+    try {
+      StreamingOffset initial = (StreamingOffset) stream.initialOffset();
+      assertThat(initial.snapshotId()).isEqualTo(currentSnapshotId);
+      assertThat(initial.position()).isEqualTo(expectedPosition);
+      assertThat(initial.shouldScanAllFiles()).isFalse();
+    } finally {
+      stream.stop();
+    }
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotAndStreamFromTimestampAreMutuallyExclusive() throws Exception {
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+
+    Map<String, String> options =
+        ImmutableMap.of(
+            SparkReadOptions.STREAM_FROM_SNAPSHOT,
+            SparkReadOptions.STREAM_FROM_SNAPSHOT_LATEST,
+            SparkReadOptions.STREAM_FROM_TIMESTAMP,
+            Long.toString(System.currentTimeMillis()));
+
+    assertThatThrownBy(() -> newMicroBatchStream(options, "mutex-checkpoint"))
+        .hasMessageContaining(SparkReadOptions.STREAM_FROM_SNAPSHOT)
+        .hasMessageContaining(SparkReadOptions.STREAM_FROM_TIMESTAMP);
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotInvalidValue() throws Exception {
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+
+    assertThatThrownBy(
+            () ->
+                newMicroBatchStream(
+                    ImmutableMap.of(SparkReadOptions.STREAM_FROM_SNAPSHOT, "not-a-snapshot"),
+                    "invalid-value-checkpoint"))
+        .hasMessageContaining(SparkReadOptions.STREAM_FROM_SNAPSHOT)
+        .hasMessageContaining("not-a-snapshot");
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotIdNotFound() throws Exception {
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+
+    assertThatThrownBy(
+            () ->
+                newMicroBatchStream(
+                    ImmutableMap.of(SparkReadOptions.STREAM_FROM_SNAPSHOT, "12345"),
+                    "not-found-checkpoint"))
+        .hasMessageContaining("Cannot find snapshot")
+        .hasMessageContaining("12345");
+  }
+
+  @TestTemplate
+  public void testStreamFromSnapshotNotAncestorOfCurrentErrorsOut() throws Exception {
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+    table.refresh();
+    long rollbackPoint = table.currentSnapshot().snapshotId();
+
+    // orphanedSnapshotId still exists in the log but is no longer an ancestor after the rollback
+    appendData(Lists.newArrayList(new SimpleRecord(2, "two")));
+    table.refresh();
+    long orphanedSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.manageSnapshots().rollbackTo(rollbackPoint).commit();
+    appendData(Lists.newArrayList(new SimpleRecord(3, "three")));
+    table.refresh();
+    assertThat(table.snapshot(orphanedSnapshotId)).isNotNull();
+    assertThat(
+            SnapshotUtil.isAncestorOf(
+                table, table.currentSnapshot().snapshotId(), orphanedSnapshotId))
+        .isFalse();
+
+    assertThatThrownBy(
+            () ->
+                newMicroBatchStream(
+                    ImmutableMap.of(
+                        SparkReadOptions.STREAM_FROM_SNAPSHOT, Long.toString(orphanedSnapshotId)),
+                    "not-ancestor-checkpoint"))
+        .hasMessageContaining("not an ancestor")
+        .hasMessageContaining(Long.toString(orphanedSnapshotId));
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotAppliesPositionalDeletes() throws Exception {
+    createMergeOnReadTable("2");
+
+    // five rows in one file so Spark's V2 DELETE produces a positional delete rather than rewriting
+    appendData(FIVE_ROWS);
+
+    sql("DELETE FROM %s WHERE data = 'one'", tableName);
+    table.refresh();
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).isNotEmpty();
+
+    StreamingQuery query = startStream();
+    assertThat(rowsAvailable(query))
+        .containsExactlyInAnyOrderElementsOf(excludingData(FIVE_ROWS, "one"));
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotAppliesEqualityDeletes() throws Exception {
+    createMergeOnReadTable("2");
+    appendData(FIVE_ROWS);
+    table.refresh();
+
+    // write an equality delete file
+    Schema deleteRowSchema = table.schema().select("data");
+    Record deleteRecord = GenericRecord.create(deleteRowSchema);
+    List<Record> deletes = Lists.newArrayList(deleteRecord.copy("data", "one"));
+    File deleteOut = File.createTempFile("eq-delete", ".parquet");
+    deleteOut.delete();
+    deleteOut.deleteOnExit();
+    DeleteFile equalityDelete =
+        FileHelpers.writeDeleteFile(
+            table, Files.localOutput(deleteOut), null, deletes, deleteRowSchema);
+    table.newRowDelta().addDeletes(equalityDelete).commit();
+    table.refresh();
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).isNotEmpty();
+
+    StreamingQuery query = startStream();
+    assertThat(rowsAvailable(query))
+        .containsExactlyInAnyOrderElementsOf(excludingData(FIVE_ROWS, "one"));
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotAppliesDeletionVectors() throws Exception {
+    createMergeOnReadTable("3");
+    appendData(FIVE_ROWS);
+
+    sql("DELETE FROM %s WHERE data = 'one'", tableName);
+    table.refresh();
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).isNotEmpty();
+
+    StreamingQuery query = startStream();
+    assertThat(rowsAvailable(query))
+        .containsExactlyInAnyOrderElementsOf(excludingData(FIVE_ROWS, "one"));
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotWithCarriedForwardDeletesOnAppend() throws Exception {
+    createMergeOnReadTable("2");
+    appendData(FIVE_ROWS);
+
+    sql("DELETE FROM %s WHERE data = 'one'", tableName);
+
+    appendData(Lists.newArrayList(new SimpleRecord(100, "hundred")));
+    table.refresh();
+    assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.APPEND);
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).isNotEmpty();
+
+    List<SimpleRecord> expected = excludingData(FIVE_ROWS, "one");
+    expected.add(new SimpleRecord(100, "hundred"));
+
+    StreamingQuery query = startStream();
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(expected);
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotAppliesDeletesAcrossRateLimitedBatches() throws Exception {
+    createMergeOnReadTable("2");
+
+    // Three data files, 5 rows each, so the DELETE produces a row-level delete
+    List<SimpleRecord> file1 =
+        Lists.newArrayList(
+            new SimpleRecord(1, "one"),
+            new SimpleRecord(2, "two"),
+            new SimpleRecord(3, "three"),
+            new SimpleRecord(4, "four"),
+            new SimpleRecord(5, "five"));
+    List<SimpleRecord> file2 =
+        Lists.newArrayList(
+            new SimpleRecord(6, "six"),
+            new SimpleRecord(7, "seven"),
+            new SimpleRecord(8, "eight"),
+            new SimpleRecord(9, "nine"),
+            new SimpleRecord(10, "ten"));
+    List<SimpleRecord> file3 =
+        Lists.newArrayList(
+            new SimpleRecord(11, "eleven"),
+            new SimpleRecord(12, "twelve"),
+            new SimpleRecord(13, "thirteen"),
+            new SimpleRecord(14, "fourteen"),
+            new SimpleRecord(15, "fifteen"));
+    appendData(file1);
+    appendData(file2);
+    appendData(file3);
+
+    sql("DELETE FROM %s WHERE data = 'seven'", tableName);
+    table.refresh();
+    assertThat(table.currentSnapshot().deleteManifests(table.io())).isNotEmpty();
+
+    List<SimpleRecord> expected = Lists.newArrayList();
+    expected.addAll(file1);
+    for (SimpleRecord r : file2) {
+      if (!"seven".equals(r.getData())) {
+        expected.add(r);
+      }
+    }
+    expected.addAll(file3);
+
+    List<SimpleRecord> captured = Collections.synchronizedList(Lists.newArrayList());
+    AtomicInteger batchCount = new AtomicInteger();
+
+    Map<String, String> options = Maps.newHashMap();
+    options.put(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1");
+    options.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
+    if (async) {
+      options.put(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
+    }
+
+    StreamingQuery query =
+        spark
+            .readStream()
+            .options(options)
+            .format("iceberg")
+            .load(tableName)
+            .writeStream()
+            .options(options)
+            .trigger(Trigger.AvailableNow())
+            .foreachBatch(
+                (VoidFunction2<Dataset<Row>, Long>)
+                    (dataset, batchId) -> {
+                      batchCount.incrementAndGet();
+                      captured.addAll(
+                          dataset.as(Encoders.bean(SimpleRecord.class)).collectAsList());
+                    })
+            .start();
+    query.processAllAvailable();
+    query.awaitTermination(60000);
+
+    assertThat(captured).containsExactlyInAnyOrderElementsOf(expected);
+    assertThat(batchCount.get()).isGreaterThan(1);
+    stopStreams();
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotRateLimitSplitsIntoMultipleBatches() throws Exception {
+    // initial data
+    appendData(
+        Lists.newArrayList(
+            new SimpleRecord(1, "one"), new SimpleRecord(2, "two"), new SimpleRecord(3, "three")));
+    appendData(Lists.newArrayList(new SimpleRecord(4, "four"), new SimpleRecord(5, "five")));
+
+    // overwrite initial data, rows 1-5 must not appear in the stream
+    List<SimpleRecord> postOverwrite =
+        Lists.newArrayList(
+            new SimpleRecord(100, "hundred"),
+            new SimpleRecord(101, "hundred-one"),
+            new SimpleRecord(102, "hundred-two"),
+            new SimpleRecord(103, "hundred-three"));
+    spark
+        .createDataFrame(postOverwrite, SimpleRecord.class)
+        .select("id", "data")
+        .write()
+        .format("iceberg")
+        .mode("overwrite")
+        .save(tableName);
+
+    // Append again so the current snapshot's manifest list still references the overwrite's files
+    List<SimpleRecord> postOverwriteAppend =
+        Lists.newArrayList(new SimpleRecord(200, "two-hundred"));
+    appendData(postOverwriteAppend);
+
+    table.refresh();
+    assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.APPEND);
+
+    List<SimpleRecord> expected = Lists.newArrayList();
+    expected.addAll(postOverwrite);
+    expected.addAll(postOverwriteAppend);
+
+    List<SimpleRecord> captured = Collections.synchronizedList(Lists.newArrayList());
+    AtomicInteger batchCount = new AtomicInteger();
+
+    Map<String, String> options = Maps.newHashMap();
+    options.put(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1");
+    options.put(SparkReadOptions.ASYNC_MICRO_BATCH_PLANNING_ENABLED, async.toString());
+    if (async) {
+      options.put(SparkReadOptions.STREAMING_SNAPSHOT_POLLING_INTERVAL_MS, "1");
+    }
+
+    StreamingQuery query =
+        spark
+            .readStream()
+            .options(options)
+            .format("iceberg")
+            .load(tableName)
+            .writeStream()
+            .options(options)
+            .trigger(Trigger.AvailableNow())
+            .foreachBatch(
+                (VoidFunction2<Dataset<Row>, Long>)
+                    (dataset, batchId) -> {
+                      batchCount.incrementAndGet();
+                      captured.addAll(
+                          dataset.as(Encoders.bean(SimpleRecord.class)).collectAsList());
+                    })
+            .start();
+    query.processAllAvailable();
+    query.awaitTermination(60000);
+
+    // only latest state of live rows arrive, nothing from before the overwrite
+    assertThat(captured).containsExactlyInAnyOrderElementsOf(expected);
+    // rate-limiting should split the initial snapshot read across multiple batches
+    assertThat(batchCount.get()).isGreaterThan(1);
+
+    long totalInputRows = 0L;
+    for (StreamingQueryProgress progress : query.recentProgress()) {
+      totalInputRows += progress.numInputRows();
+    }
+    assertThat(totalInputRows).isEqualTo((long) expected.size());
+    stopStreams();
+  }
+
+  @TestTemplate
+  public void testRestartMidInitialSnapshotResumesWithoutDuplicatesOrGaps() throws Exception {
+    // Three appends create three manifests, a restart must resolve the checkpoint identically
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+    appendData(Lists.newArrayList(new SimpleRecord(2, "two")));
+    appendData(Lists.newArrayList(new SimpleRecord(3, "three")));
+
+    table.refresh();
+    List<String> allFileLocations = Lists.newArrayList();
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(table.currentSnapshot().snapshotId()).planFiles()) {
+      for (FileScanTask task : tasks) {
+        allFileLocations.add(task.file().location());
+      }
+    }
+    assertThat(allFileLocations).hasSize(3);
+
+    Map<String, String> options =
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "1");
+
+    // Consume only the first micro-batch, then abandon the stream to simulate a mid-scan crash
+    SparkMicroBatchStream firstRunStream =
+        newMicroBatchStream(options, "restart-mid-initial-checkpoint");
+    Offset startOffset = firstRunStream.initialOffset();
+    Offset firstBatchEnd =
+        firstRunStream.latestOffset(startOffset, firstRunStream.getDefaultReadLimit());
+    assertThat(firstBatchEnd).isNotNull();
+
+    List<String> firstRunLocations =
+        fileLocationsOf(firstRunStream.planInputPartitions(startOffset, firstBatchEnd));
+    assertThat(firstRunLocations).hasSize(1);
+    firstRunStream.stop();
+
+    // "Restart": a new stream/planner instance replans the full scan from the same snapshot
+    SparkMicroBatchStream restartedStream =
+        newMicroBatchStream(options, "restart-mid-initial-checkpoint");
+    List<String> secondRunLocations = Lists.newArrayList();
+    Offset resumeOffset = firstBatchEnd;
+    Offset nextEnd =
+        restartedStream.latestOffset(resumeOffset, restartedStream.getDefaultReadLimit());
+    while (nextEnd != null) {
+      secondRunLocations.addAll(
+          fileLocationsOf(restartedStream.planInputPartitions(resumeOffset, nextEnd)));
+      resumeOffset = nextEnd;
+      nextEnd = restartedStream.latestOffset(resumeOffset, restartedStream.getDefaultReadLimit());
+    }
+    restartedStream.stop();
+
+    List<String> allConsumedLocations = Lists.newArrayList();
+    allConsumedLocations.addAll(firstRunLocations);
+    allConsumedLocations.addAll(secondRunLocations);
+
+    assertThat(allConsumedLocations).containsExactlyInAnyOrderElementsOf(allFileLocations);
+  }
+
+  @TestTemplate
+  public void testInitialSnapshotToIncrementalTransitionRespectsRateLimit() throws Exception {
+    // Two files exactly matching the file limit, so the initial snapshot uses the whole budget
+    appendData(Lists.newArrayList(new SimpleRecord(1, "one")));
+    appendData(Lists.newArrayList(new SimpleRecord(2, "two")));
+
+    Map<String, String> options =
+        ImmutableMap.of(SparkReadOptions.STREAMING_MAX_FILES_PER_MICRO_BATCH, "2");
+    SparkMicroBatchStream stream = newMicroBatchStream(options, "rate-limit-transition-checkpoint");
+    try {
+      Offset startOffset = stream.initialOffset();
+
+      // A next snapshot lands only after the initial offset is locked in, simulating a race
+      appendData(Lists.newArrayList(new SimpleRecord(3, "three")));
+
+      Offset endOffset = stream.latestOffset(startOffset, stream.getDefaultReadLimit());
+      assertThat(endOffset).isNotNull();
+
+      List<String> files = fileLocationsOf(stream.planInputPartitions(startOffset, endOffset));
+      assertThat(files)
+          .as(
+              "one microbatch must not exceed the configured file limit even across the"
+                  + " initial-snapshot-to-incremental transition")
+          .hasSizeLessThanOrEqualTo(2);
+    } finally {
+      stream.stop();
+    }
+  }
+
+  @TestTemplate
   public void testReadStreamWithSnapshotTypeOverwriteErrorsOut() throws Exception {
     // upgrade table to version 2 - to facilitate creation of Snapshot of type OVERWRITE.
     TableOperations ops = ((BaseTable) table).operations();
@@ -858,7 +1478,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     // type OVERWRITE
     assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.OVERWRITE);
 
-    StreamingQuery query = startStream();
+    StreamingQuery query =
+        startStream(
+            ImmutableMap.of(
+                SparkReadOptions.STREAM_FROM_SNAPSHOT,
+                SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST));
 
     assertThatThrownBy(query::processAllAvailable)
         .cause()
@@ -967,7 +1591,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     // DELETE.
     assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.DELETE);
 
-    StreamingQuery query = startStream();
+    StreamingQuery query =
+        startStream(
+            ImmutableMap.of(
+                SparkReadOptions.STREAM_FROM_SNAPSHOT,
+                SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST));
 
     assertThatThrownBy(query::processAllAvailable)
         .cause()
@@ -990,7 +1618,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     // DELETE.
     assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.DELETE);
 
-    StreamingQuery query = startStream(SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS, "true");
+    StreamingQuery query =
+        startStream(
+            ImmutableMap.of(
+                SparkReadOptions.STREAMING_SKIP_DELETE_SNAPSHOTS,
+                "true",
+                SparkReadOptions.STREAM_FROM_SNAPSHOT,
+                SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST));
     assertThat(rowsAvailable(query))
         .containsExactlyInAnyOrderElementsOf(Iterables.concat(dataAcrossSnapshots));
   }
@@ -1022,7 +1656,13 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     // OVERWRITE.
     assertThat(table.currentSnapshot().operation()).isEqualTo(DataOperations.OVERWRITE);
 
-    StreamingQuery query = startStream(SparkReadOptions.STREAMING_SKIP_OVERWRITE_SNAPSHOTS, "true");
+    StreamingQuery query =
+        startStream(
+            ImmutableMap.of(
+                SparkReadOptions.STREAMING_SKIP_OVERWRITE_SNAPSHOTS,
+                "true",
+                SparkReadOptions.STREAM_FROM_SNAPSHOT,
+                SparkReadOptions.STREAM_FROM_SNAPSHOT_EARLIEST));
     assertThat(rowsAvailable(query))
         .containsExactlyInAnyOrderElementsOf(Iterables.concat(dataAcrossSnapshots));
   }
@@ -1145,6 +1785,17 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         .sql("select * from " + MEMORY_TABLE)
         .as(Encoders.bean(SimpleRecord.class))
         .collectAsList();
+  }
+
+  private static List<String> fileLocationsOf(InputPartition[] partitions) {
+    List<String> locations = Lists.newArrayList();
+    for (InputPartition partition : partitions) {
+      SparkInputPartition sparkInputPartition = (SparkInputPartition) partition;
+      for (FileScanTask task : sparkInputPartition.<FileScanTask>taskGroup().tasks()) {
+        locations.add(task.file().location());
+      }
+    }
+    return locations;
   }
 
   private SparkMicroBatchStream newMicroBatchStream(


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/13188

Implements an initial-snapshot bootstrap for streaming reads of Iceberg tables in Spark. A streaming query started with a fresh checkpoint now reads the current snapshot in full before continuing incrementally - matching how Delta Lake's streaming source behaves by default.

Currently a fresh Iceberg streaming query without options replays the table's history from the oldest ancestor snapshot, which is slow for long-lived tables and any expired/deleted snapshots cannot be streamed. The only existing workarounds (bootstrap via batch read + cut over by timestamp) are fragile, so users can't easily express the common pattern of loading the entire table and then keeping up with new append data.

## About the Change

This PR adds a `stream-from-snapshot` option:
| `stream-from-snapshot` | Behavior |
|---|---|
| *(not set)* | **new default**: read the current snapshot in full, then continue with new snapshots |
| `latest` | read snapshots committed after latest on stream startup |
| `earliest` | read from the oldest ancestor (the existing default) |
| *`<snapshot-id>`* | read snapshots after the given snapshot id (exclusive) |

`stream-from-snapshot` and `stream-from-timestamp` are mutually exclusive. Previous default behavior to read from oldest ancestor can be opted-in via `stream-from-snapshot=earliest`

**Follow-ups**:
- Docs update with new default behavior & `stream-from-snapshot` option
- Ports to other supported spark versions