### PR TITLE
Core: Fix thread conflict when deleting duplicate files in manifest

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -228,7 +228,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
               filtered[index] = manifest;
             });
 
-    collectDeletedFiles(deleteFiles, filtered);
+    deleteFiles.addAll(collectDeletedFiles(filtered));
 
     validateRequiredDeletes(filtered);
 
@@ -278,8 +278,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   @SuppressWarnings("CollectionUndefinedEquality")
   private void validateRequiredDeletes(ManifestFile... manifests) {
     if (failMissingDeletePaths) {
-      Set<F> deletedFiles = newFileSet();
-      collectDeletedFiles(deletedFiles, manifests);
+      Set<F> deletedFiles = collectDeletedFiles(manifests);
       ValidationException.check(
           deletedFiles.containsAll(deleteFiles),
           "Missing required files to delete: %s",
@@ -301,7 +300,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     }
   }
 
-  private void collectDeletedFiles(Set<F> deletedFiles, ManifestFile[] manifests) {
+  private Set<F> collectDeletedFiles(ManifestFile[] manifests) {
+    Set<F> deletedFiles = newFileSet();
+
     if (manifests != null) {
       for (ManifestFile manifest : manifests) {
         Pair<Set<F>, Integer> result = filteredManifestResults.get(manifest);
@@ -310,6 +311,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
         }
       }
     }
+
+    return deletedFiles;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -228,7 +228,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
               filtered[index] = manifest;
             });
 
-    deleteFiles.addAll(collectDeletedFiles(filtered));
+    deleteFiles.addAll(deletedFiles(filtered));
 
     validateRequiredDeletes(filtered);
 
@@ -278,7 +278,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   @SuppressWarnings("CollectionUndefinedEquality")
   private void validateRequiredDeletes(ManifestFile... manifests) {
     if (failMissingDeletePaths) {
-      Set<F> deletedFiles = collectDeletedFiles(manifests);
+      Set<F> deletedFiles = deletedFiles(manifests);
       ValidationException.check(
           deletedFiles.containsAll(deleteFiles),
           "Missing required files to delete: %s",
@@ -300,7 +300,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     }
   }
 
-  private Set<F> collectDeletedFiles(ManifestFile[] manifests) {
+  private Set<F> deletedFiles(ManifestFile[] manifests) {
     Set<F> deletedFiles = newFileSet();
 
     if (manifests != null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -72,7 +71,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   private final Map<Integer, PartitionSpec> specsById;
   private final PartitionSet deleteFilePartitions;
-  private final Set<F> deleteFiles = Collections.synchronizedSet(newFileSet());
+  private final Set<F> deleteFiles = newFileSet();
   private final Set<String> manifestsWithDeletes = Sets.newHashSet();
   private final PartitionSet dropPartitions;
   private final CharSequenceSet deletePaths = CharSequenceSet.empty();
@@ -93,9 +92,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private final Map<ManifestFile, ManifestFile> filteredManifests = Maps.newConcurrentMap();
 
   // tracking where files were deleted to validate retries quickly
-  private final Map<ManifestFile, Iterable<F>> filteredManifestToDeletedFiles =
-      Maps.newConcurrentMap();
-  private final Map<ManifestFile, Integer> filteredManifestToDuplicateDeleteCounts =
+  private final Map<ManifestFile, FilterResult<F>> filteredManifestResults =
       Maps.newConcurrentMap();
 
   private final Supplier<ExecutorService> workerPoolSupplier;
@@ -231,6 +228,15 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
               filtered[index] = manifest;
             });
 
+    for (ManifestFile manifest : filtered) {
+      FilterResult<F> result = filteredManifestResults.get(manifest);
+      if (result != null) {
+        for (F file : result.deletedFiles()) {
+          deleteFiles.add(file);
+        }
+      }
+    }
+
     validateRequiredDeletes(filtered);
 
     return Arrays.asList(filtered);
@@ -258,13 +264,12 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     for (ManifestFile manifest : manifests) {
       PartitionSpec manifestSpec = specsById.get(manifest.partitionSpecId());
-      Iterable<F> manifestDeletes = filteredManifestToDeletedFiles.get(manifest);
-      if (manifestDeletes != null) {
-        for (F file : manifestDeletes) {
+      FilterResult<F> result = filteredManifestResults.get(manifest);
+      if (result != null) {
+        for (F file : result.deletedFiles()) {
           summaryBuilder.deletedFile(manifestSpec, file);
         }
-        summaryBuilder.incrementDuplicateDeletes(
-            filteredManifestToDuplicateDeleteCounts.getOrDefault(manifest, 0));
+        summaryBuilder.incrementDuplicateDeletes(result.duplicateDeleteCount());
       }
     }
 
@@ -281,16 +286,14 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private void validateRequiredDeletes(ManifestFile... manifests) {
     if (failMissingDeletePaths) {
       Set<F> deletedFiles = deletedFiles(manifests);
-      synchronized (deleteFiles) {
-        ValidationException.check(
-            deletedFiles.containsAll(deleteFiles),
-            "Missing required files to delete: %s",
-            COMMA.join(
-                deleteFiles.stream()
-                    .filter(f -> !deletedFiles.contains(f))
-                    .map(ContentFile::location)
-                    .collect(Collectors.toList())));
-      }
+      ValidationException.check(
+          deletedFiles.containsAll(deleteFiles),
+          "Missing required files to delete: %s",
+          COMMA.join(
+              deleteFiles.stream()
+                  .filter(f -> !deletedFiles.contains(f))
+                  .map(ContentFile::location)
+                  .collect(Collectors.toList())));
 
       CharSequenceSet deletedFilePaths =
           deletedFiles.stream()
@@ -309,9 +312,9 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     if (manifests != null) {
       for (ManifestFile manifest : manifests) {
-        Iterable<F> manifestDeletes = filteredManifestToDeletedFiles.get(manifest);
-        if (manifestDeletes != null) {
-          for (F file : manifestDeletes) {
+        FilterResult<F> result = filteredManifestResults.get(manifest);
+        if (result != null) {
+          for (F file : result.deletedFiles()) {
             deletedFiles.add(file);
           }
         }
@@ -357,7 +360,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
         // remove the entry from the cache
         filteredManifests.remove(manifest);
-        filteredManifestToDuplicateDeleteCounts.remove(filtered);
+        filteredManifestResults.remove(filtered);
       }
     }
   }
@@ -539,9 +542,6 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                     if (allRowsMatch) {
                       writer.delete(entry);
                       F fileCopy = file.copyWithoutStats();
-                      // add the file here in case it was deleted using an expression. The
-                      // DeleteManifestFilterManager will then remove its matching DV
-                      deleteFiles.add(fileCopy);
 
                       if (deletedFiles.contains(file)) {
                         LOG.warn(
@@ -571,13 +571,31 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
       // update caches
       filteredManifests.put(manifest, filtered);
-      filteredManifestToDeletedFiles.put(filtered, deletedFiles);
-      filteredManifestToDuplicateDeleteCounts.put(filtered, duplicateDeleteCount.get());
+      filteredManifestResults.put(
+          filtered, new FilterResult<>(deletedFiles, duplicateDeleteCount.get()));
 
       return filtered;
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest writer");
+    }
+  }
+
+  private static class FilterResult<T> {
+    private final Iterable<T> deletedFiles;
+    private final int duplicateDeleteCount;
+
+    private FilterResult(Iterable<T> deletedFiles, int duplicateDeleteCount) {
+      this.deletedFiles = deletedFiles;
+      this.duplicateDeleteCount = duplicateDeleteCount;
+    }
+
+    private Iterable<T> deletedFiles() {
+      return deletedFiles;
+    }
+
+    private int duplicateDeleteCount() {
+      return duplicateDeleteCount;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -92,7 +92,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private final Map<ManifestFile, ManifestFile> filteredManifests = Maps.newConcurrentMap();
 
   // tracking where files were deleted to validate retries quickly
-  private final Map<ManifestFile, FilterResult<F>> filteredManifestResults =
+  private final Map<ManifestFile, Pair<Set<F>, Integer>> filteredManifestResults =
       Maps.newConcurrentMap();
 
   private final Supplier<ExecutorService> workerPoolSupplier;
@@ -228,14 +228,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
               filtered[index] = manifest;
             });
 
-    for (ManifestFile manifest : filtered) {
-      FilterResult<F> result = filteredManifestResults.get(manifest);
-      if (result != null) {
-        for (F file : result.deletedFiles()) {
-          deleteFiles.add(file);
-        }
-      }
-    }
+    collectDeletedFiles(deleteFiles, filtered);
 
     validateRequiredDeletes(filtered);
 
@@ -264,12 +257,12 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     for (ManifestFile manifest : manifests) {
       PartitionSpec manifestSpec = specsById.get(manifest.partitionSpecId());
-      FilterResult<F> result = filteredManifestResults.get(manifest);
+      Pair<Set<F>, Integer> result = filteredManifestResults.get(manifest);
       if (result != null) {
-        for (F file : result.deletedFiles()) {
+        for (F file : result.first()) {
           summaryBuilder.deletedFile(manifestSpec, file);
         }
-        summaryBuilder.incrementDuplicateDeletes(result.duplicateDeleteCount());
+        summaryBuilder.incrementDuplicateDeletes(result.second());
       }
     }
 
@@ -285,7 +278,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   @SuppressWarnings("CollectionUndefinedEquality")
   private void validateRequiredDeletes(ManifestFile... manifests) {
     if (failMissingDeletePaths) {
-      Set<F> deletedFiles = deletedFiles(manifests);
+      Set<F> deletedFiles = newFileSet();
+      collectDeletedFiles(deletedFiles, manifests);
       ValidationException.check(
           deletedFiles.containsAll(deleteFiles),
           "Missing required files to delete: %s",
@@ -307,21 +301,15 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     }
   }
 
-  private Set<F> deletedFiles(ManifestFile[] manifests) {
-    Set<F> deletedFiles = newFileSet();
-
+  private void collectDeletedFiles(Set<F> deletedFiles, ManifestFile[] manifests) {
     if (manifests != null) {
       for (ManifestFile manifest : manifests) {
-        FilterResult<F> result = filteredManifestResults.get(manifest);
+        Pair<Set<F>, Integer> result = filteredManifestResults.get(manifest);
         if (result != null) {
-          for (F file : result.deletedFiles()) {
-            deletedFiles.add(file);
-          }
+          deletedFiles.addAll(result.first());
         }
       }
     }
-
-    return deletedFiles;
   }
 
   /**
@@ -571,31 +559,12 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
       // update caches
       filteredManifests.put(manifest, filtered);
-      filteredManifestResults.put(
-          filtered, new FilterResult<>(deletedFiles, duplicateDeleteCount.get()));
+      filteredManifestResults.put(filtered, Pair.of(deletedFiles, duplicateDeleteCount.get()));
 
       return filtered;
 
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to close manifest writer");
-    }
-  }
-
-  private static class FilterResult<T> {
-    private final Iterable<T> deletedFiles;
-    private final int duplicateDeleteCount;
-
-    private FilterResult(Iterable<T> deletedFiles, int duplicateDeleteCount) {
-      this.deletedFiles = deletedFiles;
-      this.duplicateDeleteCount = duplicateDeleteCount;
-    }
-
-    private Iterable<T> deletedFiles() {
-      return deletedFiles;
-    }
-
-    private int duplicateDeleteCount() {
-      return duplicateDeleteCount;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +72,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   private final Map<Integer, PartitionSpec> specsById;
   private final PartitionSet deleteFilePartitions;
-  private final Set<F> deleteFiles = newFileSet();
+  private final Set<F> deleteFiles = Collections.synchronizedSet(newFileSet());
   private final Set<String> manifestsWithDeletes = Sets.newHashSet();
   private final PartitionSet dropPartitions;
   private final CharSequenceSet deletePaths = CharSequenceSet.empty();
@@ -82,7 +83,6 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private long minSequenceNumber = 0;
   private boolean failAnyDelete = false;
   private boolean failMissingDeletePaths = false;
-  private int duplicateDeleteCount = 0;
   private boolean caseSensitive = true;
   private boolean allDeletesReferenceManifests = true;
   // this is only being used for the DeleteManifestFilterManager to detect orphaned DVs for removed
@@ -94,6 +94,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   // tracking where files were deleted to validate retries quickly
   private final Map<ManifestFile, Iterable<F>> filteredManifestToDeletedFiles =
+      Maps.newConcurrentMap();
+  private final Map<ManifestFile, Integer> filteredManifestToDuplicateDeleteCounts =
       Maps.newConcurrentMap();
 
   private final Supplier<ExecutorService> workerPoolSupplier;
@@ -261,10 +263,10 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
         for (F file : manifestDeletes) {
           summaryBuilder.deletedFile(manifestSpec, file);
         }
+        summaryBuilder.incrementDuplicateDeletes(
+            filteredManifestToDuplicateDeleteCounts.getOrDefault(manifest, 0));
       }
     }
-
-    summaryBuilder.incrementDuplicateDeletes(duplicateDeleteCount);
 
     return summaryBuilder;
   }
@@ -279,14 +281,16 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private void validateRequiredDeletes(ManifestFile... manifests) {
     if (failMissingDeletePaths) {
       Set<F> deletedFiles = deletedFiles(manifests);
-      ValidationException.check(
-          deletedFiles.containsAll(deleteFiles),
-          "Missing required files to delete: %s",
-          COMMA.join(
-              deleteFiles.stream()
-                  .filter(f -> !deletedFiles.contains(f))
-                  .map(ContentFile::location)
-                  .collect(Collectors.toList())));
+      synchronized (deleteFiles) {
+        ValidationException.check(
+            deletedFiles.containsAll(deleteFiles),
+            "Missing required files to delete: %s",
+            COMMA.join(
+                deleteFiles.stream()
+                    .filter(f -> !deletedFiles.contains(f))
+                    .map(ContentFile::location)
+                    .collect(Collectors.toList())));
+      }
 
       CharSequenceSet deletedFilePaths =
           deletedFiles.stream()
@@ -353,6 +357,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
         // remove the entry from the cache
         filteredManifests.remove(manifest);
+        filteredManifestToDuplicateDeleteCounts.remove(filtered);
       }
     }
   }
@@ -501,6 +506,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
     // when this point is reached, there is at least one file that will be deleted in the
     // manifest. produce a copy of the manifest with all deleted files removed.
     Set<F> deletedFiles = newFileSet();
+    AtomicInteger duplicateDeleteCount = new AtomicInteger(0);
 
     try {
       ManifestWriter<F> writer = newManifestWriter(reader.spec());
@@ -542,7 +548,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                             "Deleting a duplicate path from manifest {}: {}",
                             manifest.path(),
                             file.location());
-                        duplicateDeleteCount += 1;
+                        duplicateDeleteCount.incrementAndGet();
                       } else {
                         // only add the file to deletes if it is a new delete
                         // this keeps the snapshot summary accurate for non-duplicate data
@@ -566,6 +572,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       // update caches
       filteredManifests.put(manifest, filtered);
       filteredManifestToDeletedFiles.put(filtered, deletedFiles);
+      filteredManifestToDuplicateDeleteCounts.put(filtered, duplicateDeleteCount.get());
 
       return filtered;
 

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
@@ -334,5 +335,56 @@ public class TestOverwrite extends TestBase {
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
+  }
+
+  @TestTemplate
+  public void testFullOverwriteAcrossManyManifests() {
+    // A full overwrite filters existing manifests in parallel and records every removed file in
+    // ManifestFilterManager's shared deleteFiles set. The colliding file locations below
+    // concentrate many concurrent adds in the same hash bucket, guarding against regressions that
+    // mutate the
+    // set without synchronization.
+    table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
+
+    int manifestCount = 16;
+    int filesPerManifest = 64;
+
+    // FILE_0_TO_4 and FILE_5_TO_9 were appended together in createTestTable.
+    int liveFiles = 2;
+    int globalIndex = 0;
+    for (int i = 0; i < manifestCount; i++) {
+      AppendFiles append = table.newAppend();
+      for (int j = 0; j < filesPerManifest; j++) {
+        append.appendFile(
+            DataFiles.builder(PARTITION_BY_DATE)
+                .withPath(collidingLocation(globalIndex))
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .withPartitionPath("date=2018-06-08")
+                .build());
+        liveFiles += 1;
+        globalIndex += 1;
+      }
+      commit(table, append, branch);
+    }
+
+    Snapshot overwriteSnapshot =
+        commit(table, table.newOverwrite().overwriteByRowFilter(alwaysTrue()), branch);
+
+    assertThat(overwriteSnapshot.operation()).isEqualTo(DataOperations.DELETE);
+    assertThat(overwriteSnapshot.summary())
+        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(liveFiles))
+        .doesNotContainKey(SnapshotSummary.DELETED_DUPLICATE_FILES);
+  }
+
+  // Builds unique file locations with identical String.hashCode() values. DataFileSet hashes by
+  // location, so these paths exercise contention in ManifestFilterManager's shared deleteFiles set.
+  private static String collidingLocation(int index) {
+    StringBuilder location = new StringBuilder("/path/to/collide-");
+    for (int bit = 0; bit < 12; bit++) {
+      location.append(((index >> bit) & 1) == 0 ? "Aa" : "BB");
+    }
+    return location.toString();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg;
 
-import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
@@ -335,56 +334,5 @@ public class TestOverwrite extends TestBase {
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
-  }
-
-  @TestTemplate
-  public void testFullOverwriteAcrossManyManifests() {
-    // A full overwrite filters existing manifests in parallel and records every removed file in
-    // ManifestFilterManager's shared deleteFiles set. The colliding file locations below
-    // concentrate many concurrent adds in the same hash bucket, guarding against regressions that
-    // mutate the
-    // set without synchronization.
-    table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
-
-    int manifestCount = 16;
-    int filesPerManifest = 64;
-
-    // FILE_0_TO_4 and FILE_5_TO_9 were appended together in createTestTable.
-    int liveFiles = 2;
-    int globalIndex = 0;
-    for (int i = 0; i < manifestCount; i++) {
-      AppendFiles append = table.newAppend();
-      for (int j = 0; j < filesPerManifest; j++) {
-        append.appendFile(
-            DataFiles.builder(PARTITION_BY_DATE)
-                .withPath(collidingLocation(globalIndex))
-                .withFormat(FileFormat.PARQUET)
-                .withFileSizeInBytes(10)
-                .withRecordCount(1)
-                .withPartitionPath("date=2018-06-08")
-                .build());
-        liveFiles += 1;
-        globalIndex += 1;
-      }
-      commit(table, append, branch);
-    }
-
-    Snapshot overwriteSnapshot =
-        commit(table, table.newOverwrite().overwriteByRowFilter(alwaysTrue()), branch);
-
-    assertThat(overwriteSnapshot.operation()).isEqualTo(DataOperations.DELETE);
-    assertThat(overwriteSnapshot.summary())
-        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(liveFiles))
-        .doesNotContainKey(SnapshotSummary.DELETED_DUPLICATE_FILES);
-  }
-
-  // Builds unique file locations with identical String.hashCode() values. DataFileSet hashes by
-  // location, so these paths exercise contention in ManifestFilterManager's shared deleteFiles set.
-  private static String collidingLocation(int index) {
-    StringBuilder location = new StringBuilder("/path/to/collide-");
-    for (int bit = 0; bit < 12; bit++) {
-      location.append(((index >> bit) & 1) == 0 ? "Aa" : "BB");
-    }
-    return location.toString();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -21,7 +21,15 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -210,6 +218,86 @@ public class TestSnapshotSummary extends TestBase {
         .containsEntry(SnapshotSummary.CREATED_MANIFESTS_COUNT, "1")
         .containsEntry(SnapshotSummary.KEPT_MANIFESTS_COUNT, "0")
         .containsEntry(SnapshotSummary.REPLACED_MANIFESTS_COUNT, "1");
+  }
+
+  @TestTemplate
+  public void deleteDuplicateFilesWithinMultipleManifests() throws Exception {
+    int manifestCount = 40;
+    List<ManifestFile> manifests = Lists.newArrayList();
+    for (int index = 0; index < manifestCount; index += 1) {
+      DataFile file =
+          DataFiles.builder(SPEC)
+              .withPath("/path/to/duplicate-" + index + ".parquet")
+              .withFileSizeInBytes(10)
+              .withPartitionPath("data_bucket=" + (index % BUCKETS_NUMBER))
+              .withRecordCount(1)
+              .build();
+      manifests.add(writeManifestWithName("duplicate-" + index, file, file));
+    }
+
+    AppendFiles appendFiles = table.newFastAppend();
+    for (ManifestFile manifest : manifests) {
+      appendFiles.appendManifest(manifest);
+    }
+    appendFiles.commit();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(manifestCount);
+    try {
+      table
+          .newDelete()
+          .deleteFromRowFilter(Expressions.alwaysTrue())
+          .scanManifestsWith(executorService)
+          .commit();
+
+      assertThat(table.currentSnapshot().summary())
+          .containsEntry(SnapshotSummary.DELETED_DUPLICATE_FILES, String.valueOf(manifestCount))
+          .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(manifestCount));
+    } finally {
+      executorService.shutdownNow();
+    }
+  }
+
+  @TestTemplate
+  public void deleteDuplicateFilesWithConcurrentDeleteRetry() throws Exception {
+    String tableName = "retry-duplicate-delete";
+    File retryTableDir = temp.resolve(tableName).toFile();
+    AtomicBoolean failCommitAfterConcurrentDelete = new AtomicBoolean(false);
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations(tableName, retryTableDir) {
+          @Override
+          public void commit(TableMetadata base, TableMetadata updatedMetadata) {
+            if (base != null && failCommitAfterConcurrentDelete.compareAndSet(true, false)) {
+              TestTables.load(retryTableDir, tableName)
+                  .newDelete()
+                  .deleteFromRowFilter(Expressions.alwaysTrue())
+                  .commit();
+              throw new CommitFailedException("Injected concurrent delete");
+            }
+
+            super.commit(base, updatedMetadata);
+          }
+        };
+    this.table =
+        TestTables.create(
+            retryTableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, ops);
+    table.updateProperties().set("random-snapshot-ids", "true").commit();
+
+    DataFile file =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/concurrent-delete-duplicate.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+    ManifestFile manifest = writeManifestWithName("concurrent-delete-duplicate", file, file);
+    table.newFastAppend().appendManifest(manifest).commit();
+
+    failCommitAfterConcurrentDelete.set(true);
+    table.newDelete().deleteFromRowFilter(Expressions.alwaysTrue()).commit();
+
+    assertThat(table.currentSnapshot().summary())
+        .doesNotContainKey(SnapshotSummary.DELETED_DUPLICATE_FILES)
+        .doesNotContainKey(SnapshotSummary.DELETED_FILES_PROP);
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -22,14 +22,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Expressions;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -218,43 +214,6 @@ public class TestSnapshotSummary extends TestBase {
         .containsEntry(SnapshotSummary.CREATED_MANIFESTS_COUNT, "1")
         .containsEntry(SnapshotSummary.KEPT_MANIFESTS_COUNT, "0")
         .containsEntry(SnapshotSummary.REPLACED_MANIFESTS_COUNT, "1");
-  }
-
-  @TestTemplate
-  public void deleteDuplicateFilesWithinMultipleManifests() throws Exception {
-    int manifestCount = 40;
-    List<ManifestFile> manifests = Lists.newArrayList();
-    for (int index = 0; index < manifestCount; index += 1) {
-      DataFile file =
-          DataFiles.builder(SPEC)
-              .withPath("/path/to/duplicate-" + index + ".parquet")
-              .withFileSizeInBytes(10)
-              .withPartitionPath("data_bucket=" + (index % BUCKETS_NUMBER))
-              .withRecordCount(1)
-              .build();
-      manifests.add(writeManifestWithName("duplicate-" + index, file, file));
-    }
-
-    AppendFiles appendFiles = table.newFastAppend();
-    for (ManifestFile manifest : manifests) {
-      appendFiles.appendManifest(manifest);
-    }
-    appendFiles.commit();
-
-    ExecutorService executorService = Executors.newFixedThreadPool(manifestCount);
-    try {
-      table
-          .newDelete()
-          .deleteFromRowFilter(Expressions.alwaysTrue())
-          .scanManifestsWith(executorService)
-          .commit();
-
-      assertThat(table.currentSnapshot().summary())
-          .containsEntry(SnapshotSummary.DELETED_DUPLICATE_FILES, String.valueOf(manifestCount))
-          .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(manifestCount));
-    } finally {
-      executorService.shutdownNow();
-    }
   }
 
   @TestTemplate


### PR DESCRIPTION
`deleteFiles` and `duplicateDeleteCount` are not thread-safe and they are modified concurrently in `filterManifests`. In addition, `duplicateDeleteCount` will be counted repeatedly during the retry process after a commit failure.

Add two tests:
`deleteDuplicateFilesWithinMultipleManifests` ensures that the count of duplicate files is accurate under concurrent conditions.
`deleteDuplicateFilesWithConcurrentDeleteRetry` ensures that retrying is not affected by previous unsuccessful commits.