### PR TITLE
AWS: Support assumed role credentials for REST SigV4 signing

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
 import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
@@ -32,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
 import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
@@ -44,6 +46,10 @@ import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClientBuilder;
 import software.amazon.awssdk.services.kms.model.DataKeySpec;
 import software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 public class AwsProperties implements Serializable {
 
@@ -119,6 +125,10 @@ public class AwsProperties implements Serializable {
   /**
    * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients will assume a role of the
    * given ARN, instead of using the default credential chain.
+   *
+   * <p>Also used for REST catalog SigV4 signing: if set, REST requests will be signed with
+   * credentials of the assumed role instead of the base credentials, so that catalog requests and
+   * data access are performed with the same role.
    */
   public static final String CLIENT_ASSUME_ROLE_ARN = "client.assume-role.arn";
 
@@ -448,9 +458,35 @@ public class AwsProperties implements Serializable {
     return restSigningName;
   }
 
+  /**
+   * Returns the {@link AwsCredentialsProvider} used for SigV4 signing of REST catalog requests.
+   *
+   * <p>If {@link #CLIENT_ASSUME_ROLE_ARN} is set, the configured role is assumed through an
+   * auto-refreshing {@link StsAssumeRoleCredentialsProvider}, so that REST request signing uses the
+   * same assumed role as the AWS clients created by {@link AssumeRoleAwsClientFactory}.
+   */
   public AwsCredentialsProvider restCredentialsProvider() {
-    return credentialsProvider(
-        this.restAccessKeyId, this.restSecretAccessKey, this.restSessionToken);
+    AwsCredentialsProvider provider =
+        credentialsProvider(this.restAccessKeyId, this.restSecretAccessKey, this.restSessionToken);
+    if (Strings.isNullOrEmpty(clientAssumeRoleArn)) {
+      return provider;
+    }
+
+    StsClient stsClient =
+        StsClient.builder().credentialsProvider(provider).region(restSigningRegion()).build();
+    StsAssumeRoleCredentialsProvider assumeRoleProvider =
+        StsAssumeRoleCredentialsProvider.builder()
+            .stsClient(stsClient)
+            .refreshRequest(
+                AssumeRoleRequest.builder()
+                    .roleArn(clientAssumeRoleArn)
+                    .roleSessionName(restSessionName())
+                    .durationSeconds(clientAssumeRoleTimeoutSec)
+                    .externalId(clientAssumeRoleExternalId)
+                    .tags(stsClientAssumeRoleTags)
+                    .build())
+            .build();
+    return new AssumeRoleRestCredentialsProvider(assumeRoleProvider, stsClient, provider);
   }
 
   public String kmsEndpoint() {
@@ -463,6 +499,14 @@ public class AwsProperties implements Serializable {
 
   public DataKeySpec kmsDataKeySpec() {
     return this.kmsDataKeySpec;
+  }
+
+  private String restSessionName() {
+    if (clientAssumeRoleSessionName != null) {
+      return clientAssumeRoleSessionName;
+    }
+
+    return String.format("iceberg-aws-%s", UUID.randomUUID());
   }
 
   private Set<software.amazon.awssdk.services.sts.model.Tag> toStsTags(
@@ -540,6 +584,41 @@ public class AwsProperties implements Serializable {
   private <T extends SdkClientBuilder> void configureEndpoint(T builder, String endpoint) {
     if (endpoint != null) {
       builder.endpointOverride(URI.create(endpoint));
+    }
+  }
+
+  /**
+   * Wraps an {@link StsAssumeRoleCredentialsProvider} so that closing the provider also closes the
+   * underlying STS client and the base credentials provider, neither of which is closed by the
+   * assume-role provider itself.
+   */
+  private static class AssumeRoleRestCredentialsProvider
+      implements AwsCredentialsProvider, SdkAutoCloseable {
+    private final StsAssumeRoleCredentialsProvider delegate;
+    private final StsClient stsClient;
+    private final AwsCredentialsProvider baseCredentialsProvider;
+
+    AssumeRoleRestCredentialsProvider(
+        StsAssumeRoleCredentialsProvider delegate,
+        StsClient stsClient,
+        AwsCredentialsProvider baseCredentialsProvider) {
+      this.delegate = delegate;
+      this.stsClient = stsClient;
+      this.baseCredentialsProvider = baseCredentialsProvider;
+    }
+
+    @Override
+    public AwsCredentials resolveCredentials() {
+      return delegate.resolveCredentials();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+      stsClient.close();
+      if (baseCredentialsProvider instanceof SdkAutoCloseable closeableProvider) {
+        closeableProvider.close();
+      }
     }
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -25,8 +25,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.IOException;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.utils.SdkAutoCloseable;
 
 public class TestAwsProperties {
 
@@ -42,5 +46,32 @@ public class TestAwsProperties {
         .isEqualTo(awsPropertiesWithProps.glueCatalogId());
     assertThat(deSerializedAwsPropertiesWithProps.dynamoDbTableName())
         .isEqualTo(awsPropertiesWithProps.dynamoDbTableName());
+  }
+
+  @Test
+  public void testRestCredentialsProviderWithStaticCredentials() {
+    AwsProperties properties =
+        new AwsProperties(
+            ImmutableMap.of(
+                AwsProperties.REST_ACCESS_KEY_ID, "id",
+                AwsProperties.REST_SECRET_ACCESS_KEY, "secret"));
+    assertThat(properties.restCredentialsProvider()).isInstanceOf(StaticCredentialsProvider.class);
+  }
+
+  @Test
+  public void testRestCredentialsProviderWithAssumeRole() {
+    AwsProperties properties =
+        new AwsProperties(
+            ImmutableMap.of(
+                AwsProperties.REST_SIGNER_REGION, "us-west-2",
+                AwsProperties.REST_ACCESS_KEY_ID, "id",
+                AwsProperties.REST_SECRET_ACCESS_KEY, "secret",
+                AwsProperties.CLIENT_ASSUME_ROLE_ARN,
+                    "arn:aws:iam::123456789012:role/myRoleToAssume"));
+    AwsCredentialsProvider provider = properties.restCredentialsProvider();
+    assertThat(provider)
+        .isNotInstanceOf(StaticCredentialsProvider.class)
+        .isInstanceOf(SdkAutoCloseable.class);
+    ((SdkAutoCloseable) provider).close();
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4AuthSession.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestRESTSigV4AuthSession.java
@@ -311,6 +311,25 @@ class TestRESTSigV4AuthSession {
   }
 
   @Test
+  void closeWithAssumeRoleCredentialsProvider() {
+    AwsProperties properties =
+        new AwsProperties(
+            Map.of(
+                AwsProperties.REST_SIGNER_REGION,
+                "us-west-2",
+                AwsProperties.REST_ACCESS_KEY_ID,
+                "id",
+                AwsProperties.REST_SECRET_ACCESS_KEY,
+                "secret",
+                AwsProperties.CLIENT_ASSUME_ROLE_ARN,
+                "arn:aws:iam::123456789012:role/myRoleToAssume"));
+    AuthSession delegate = Mockito.mock(AuthSession.class);
+    RESTSigV4AuthSession session = new RESTSigV4AuthSession(signer, delegate, properties);
+    session.close();
+    Mockito.verify(delegate).close();
+  }
+
+  @Test
   void closeWithCloseableCredentialsProvider() {
     AuthSession delegate = Mockito.mock(AuthSession.class);
     CloseableAwsCredentialsProvider credentialsProvider =

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -682,6 +682,11 @@ This client factory has the following configurable catalog properties:
 
 By using this client factory, an STS client is initialized with the default credential and region to assume the specified role.
 The Glue, S3 and DynamoDB clients are then initialized with the assume-role credential and region to access resources.
+
+When `client.assume-role.arn` is set and the REST catalog is configured with SigV4 authentication (`rest.auth.type=sigv4`),
+REST catalog requests are also signed with credentials of the assumed role, so that catalog requests and data access
+are performed with the same role.
+
 Here is an example to start Spark shell with this client factory:
 
 ```shell


### PR DESCRIPTION
  ### Motivation
  When `client.assume-role.arn` is set, AWS clients created by `AssumeRoleAwsClientFactory` (S3, Glue, DynamoDB, KMS) assume the configured role, but the REST catalog SigV4 signer keeps signing requests with the base credentials. Catalog requests and data access are therefore performed as two different identities, which breaks credential-less setups (instance profile / IRSA base credentials + a cross-account role) against SigV4-signed REST catalogs.

  ### Changes
  - `AwsProperties.restCredentialsProvider()` wraps the base credentials in an auto-refreshing `StsAssumeRoleCredentialsProvider` when `client.assume-role.arn` is set, reusing the existing `client.assume-role.*` properties (session name, external-id, timeout, tags) consistently with `AssumeRoleAwsClientFactory`.
  - The returned provider is `SdkAutoCloseable` and closes the underlying STS client and therefore performed as two different identities, which breaks credential-less setups (instance profile / IRSA base credentials + a cross-account role) against SigV4-signed REST catalogs.

  ### Changes
  - `AwsProperties.restCredentialsProvider()` wraps the base credentials in an auto-refreshing `StsAssumeRoleCredentialsProvider` when `client.assume-role.arn` is set, auto-refreshing `StsAssumeRoleCredentialsProvider` when `client.assume-role.arn` is set, reusing the existing `client.assume-role.*` properties (session name, external-id, timeout, tags) consistently with `AssumeRoleAwsClientFactory`.
  - The returned provider is `SdkAutoCloseable` and closes the underlying STS client and base provider; `RESTSigV4AuthSession` already closes closeable providers since #<PR of f2ed6a9db>.

  ### Behavior change
  Users who set `client.assume-role.arn` for data access while SigV4-signing with base credentials will now sign catalog requests with the assumed role. This is the intended consistency fix, but it changes the signing identity for that configuration.

  ### Alternatives considered
 `client.credentials-provider` with a custom provider class: requires every user to ship a wrapper class, since the SDK's `StsAssumeRoleCredentialsProvider` has no static `create()`/`create(Map)` factory.

  ### Testing
  New unit tests in `TestAwsProperties` and `TestRESTSigV4AuthSession`; `./gradlew :iceberg-aws:check` passes.

 ### AI disclosure
Drafted with AI assistance (Claude Code) based on a patch we run in production against StarRocks-bundled Iceberg; design, tests and verification reviewed by the author. Reviewer attention welcome on the STS client lifecycle/closing in  `AssumeRoleRestCredentialsProvider`.