### PR TITLE
Core: Add EntryStatus.MODIFIED and TrackingBuilder status derivation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -27,7 +27,7 @@ enum EntryStatus {
    * The old (replaced) state of an entry that has been modified. Paired with MODIFIED. Added in v4.
    */
   REPLACED(3),
-  /** The new (live) state of an entry that has been modified. Paired with REPLACED. Added in v4. */
+  /** The new (live) state of an entry that has been modified. Added in v4. */
   MODIFIED(4);
 
   private static final EntryStatus[] VALUES = EntryStatus.values();
@@ -40,6 +40,10 @@ enum EntryStatus {
 
   public int id() {
     return id;
+  }
+
+  boolean isLive() {
+    return this == EXISTING || this == ADDED || this == MODIFIED;
   }
 
   static EntryStatus fromId(int id) {

--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -24,13 +24,11 @@ enum EntryStatus {
   ADDED(1),
   DELETED(2),
   /**
-   * Non-live entry recording that a prior file version was superseded by a column update or DV
-   * change. Added in v4.
+   * Non-live entry recording that a prior file version was superseded by another live entry. Added
+   * in v4.
    */
   REPLACED(3),
-  /**
-   * Live entry recording that the file was modified by a column update or DV change. Added in v4.
-   */
+  /** Live entry recording that the file was modified in this snapshot. Added in v4. */
   MODIFIED(4);
 
   private static final EntryStatus[] VALUES = EntryStatus.values();

--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -28,7 +28,7 @@ enum EntryStatus {
    * in v4.
    */
   REPLACED(3),
-  /** Live entry recording that the file was modified in this snapshot. Added in v4. */
+  /** The new (live) state of an entry that has been modified. Paired with REPLACED. Added in v4. */
   MODIFIED(4);
 
   private static final EntryStatus[] VALUES = EntryStatus.values();

--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -23,8 +23,15 @@ enum EntryStatus {
   EXISTING(0),
   ADDED(1),
   DELETED(2),
-  /** Indicates an entry that has been replaced by a column update or DV change. Added in v4. */
-  REPLACED(3);
+  /**
+   * Non-live entry recording that a prior file version was superseded by a column update or DV
+   * change. Added in v4.
+   */
+  REPLACED(3),
+  /**
+   * Live entry recording that the file was modified by a column update or DV change. Added in v4.
+   */
+  MODIFIED(4);
 
   private static final EntryStatus[] VALUES = EntryStatus.values();
 

--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -24,8 +24,7 @@ enum EntryStatus {
   ADDED(1),
   DELETED(2),
   /**
-   * Non-live entry recording that a prior file version was superseded by another live entry. Added
-   * in v4.
+   * The old (replaced) state of an entry that has been modified. Paired with MODIFIED. Added in v4.
    */
   REPLACED(3),
   /** The new (live) state of an entry that has been modified. Paired with REPLACED. Added in v4. */

--- a/core/src/main/java/org/apache/iceberg/EntryStatus.java
+++ b/core/src/main/java/org/apache/iceberg/EntryStatus.java
@@ -20,22 +20,24 @@ package org.apache.iceberg;
 
 /** Status of an entry in a manifest file. */
 enum EntryStatus {
-  EXISTING(0),
-  ADDED(1),
-  DELETED(2),
+  EXISTING(0, true),
+  ADDED(1, true),
+  DELETED(2, false),
   /**
    * The old (replaced) state of an entry that has been modified. Paired with MODIFIED. Added in v4.
    */
-  REPLACED(3),
+  REPLACED(3, false),
   /** The new (live) state of an entry that has been modified. Added in v4. */
-  MODIFIED(4);
+  MODIFIED(4, true);
 
   private static final EntryStatus[] VALUES = EntryStatus.values();
 
   private final int id;
+  private final boolean live;
 
-  EntryStatus(int id) {
+  EntryStatus(int id, boolean live) {
     this.id = id;
+    this.live = live;
   }
 
   public int id() {
@@ -43,7 +45,7 @@ enum EntryStatus {
   }
 
   boolean isLive() {
-    return this == EXISTING || this == ADDED || this == MODIFIED;
+    return live;
   }
 
   static EntryStatus fromId(int id) {

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -81,13 +81,6 @@ interface Tracking {
   /** Returns the status of the entry. */
   EntryStatus status();
 
-  /** Returns whether this entry is live. */
-  default boolean isLive() {
-    return status() == EntryStatus.ADDED
-        || status() == EntryStatus.EXISTING
-        || status() == EntryStatus.MODIFIED;
-  }
-
   /** Returns the snapshot ID where the file was added, deleted, replaced, or modified. */
   Long snapshotId();
 

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -28,13 +28,13 @@ interface Tracking {
           0,
           "status",
           Types.IntegerType.get(),
-          "Entry status: 0=existing, 1=added, 2=deleted, 3=replaced");
+          "Entry status: 0=existing, 1=added, 2=deleted, 3=replaced, 4=modified");
   Types.NestedField SNAPSHOT_ID =
       Types.NestedField.optional(
           1,
           "snapshot_id",
           Types.LongType.get(),
-          "Snapshot ID where the file was added or deleted");
+          "Snapshot ID where the file was added, deleted, replaced, or modified");
   Types.NestedField SEQUENCE_NUMBER =
       Types.NestedField.optional(
           3, "sequence_number", Types.LongType.get(), "Data sequence number of the file");
@@ -83,10 +83,12 @@ interface Tracking {
 
   /** Returns whether this entry is live. */
   default boolean isLive() {
-    return status() == EntryStatus.ADDED || status() == EntryStatus.EXISTING;
+    return status() == EntryStatus.ADDED
+        || status() == EntryStatus.EXISTING
+        || status() == EntryStatus.MODIFIED;
   }
 
-  /** Returns the snapshot ID where the file was added or deleted. */
+  /** Returns the snapshot ID where the file was added, deleted, replaced, or modified. */
   Long snapshotId();
 
   /** Returns the data sequence number of the file. */

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -34,7 +34,7 @@ interface Tracking {
           1,
           "snapshot_id",
           Types.LongType.get(),
-          "Snapshot ID where the file was added, deleted, replaced, or modified");
+          "Snapshot ID where the file was added, deleted, or replaced");
   Types.NestedField SEQUENCE_NUMBER =
       Types.NestedField.optional(
           3, "sequence_number", Types.LongType.get(), "Data sequence number of the file");
@@ -81,7 +81,7 @@ interface Tracking {
   /** Returns the status of the entry. */
   EntryStatus status();
 
-  /** Returns the snapshot ID where the file was added, deleted, replaced, or modified. */
+  /** Returns the snapshot ID where the file was added, deleted, or replaced. */
   Long snapshotId();
 
   /** Returns the data sequence number of the file. */

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -81,6 +81,11 @@ interface Tracking {
   /** Returns the status of the entry. */
   EntryStatus status();
 
+  /** Returns whether the entry is live. */
+  default boolean isLive() {
+    return status().isLive();
+  }
+
   /** Returns the snapshot ID where the file was added, deleted, or replaced. */
   Long snapshotId();
 

--- a/core/src/main/java/org/apache/iceberg/Tracking.java
+++ b/core/src/main/java/org/apache/iceberg/Tracking.java
@@ -81,7 +81,7 @@ interface Tracking {
   /** Returns the status of the entry. */
   EntryStatus status();
 
-  /** Returns whether the entry is live. */
+  /** Returns whether this entry is live. */
   default boolean isLive() {
     return status().isLive();
   }

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -23,12 +23,12 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
 class TrackingBuilder {
-  private EntryStatus status;
-  private Long snapshotId;
   private final long newSnapshotId;
+  private final Long snapshotId;
   private final Long dataSequenceNumber;
   private final Long fileSequenceNumber;
   private final Long firstRowId;
+  private EntryStatus status;
   private Long dvSnapshotId;
   private byte[] deletedPositions;
   private byte[] replacedPositions;
@@ -100,36 +100,35 @@ class TrackingBuilder {
 
   /** Indicates that the DV has been updated for the new Tracking. */
   TrackingBuilder dvUpdated() {
-    // DV applies to data files; deleted/replaced positions apply to manifest files
-    Preconditions.checkState(
-        deletedPositions == null && replacedPositions == null,
-        "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
     this.dvSnapshotId = newSnapshotId;
-    promoteToModified();
+    if (status == EntryStatus.EXISTING) {
+      this.status = EntryStatus.MODIFIED;
+    }
+
     return this;
   }
 
   TrackingBuilder deletedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set deleted positions on ADDED entry");
-    // DV applies to data files; deleted positions apply to manifest files
-    Preconditions.checkState(
-        dvSnapshotId == null,
-        "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
     this.deletedPositions = ByteBuffers.toByteArray(positions);
-    promoteToModified();
+    this.dvSnapshotId = newSnapshotId;
+    if (status == EntryStatus.EXISTING) {
+      this.status = EntryStatus.MODIFIED;
+    }
+
     return this;
   }
 
   TrackingBuilder replacedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set replaced positions on ADDED entry");
-    // DV applies to data files; replaced positions apply to manifest files
-    Preconditions.checkState(
-        dvSnapshotId == null,
-        "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
     this.replacedPositions = ByteBuffers.toByteArray(positions);
-    promoteToModified();
+    this.dvSnapshotId = newSnapshotId;
+    if (status == EntryStatus.EXISTING) {
+      this.status = EntryStatus.MODIFIED;
+    }
+
     return this;
   }
 
@@ -143,13 +142,6 @@ class TrackingBuilder {
         firstRowId,
         deletedPositions,
         replacedPositions);
-  }
-
-  private void promoteToModified() {
-    if (status == EntryStatus.EXISTING) {
-      this.status = EntryStatus.MODIFIED;
-      this.snapshotId = newSnapshotId;
-    }
   }
 
   private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -23,16 +23,19 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
 class TrackingBuilder {
-  private final EntryStatus status;
-  private final Long snapshotId;
+  // null for the fresh-added path; non-null for the source-based path.
+  private final Tracking source;
+  // ID of the snapshot in which the new Tracking instance will be committed.
+  private final long newSnapshotId;
+  // Inherited from the source (or null for fresh-add).
   private final Long dataSequenceNumber;
   private final Long fileSequenceNumber;
   private final Long firstRowId;
-  // ID of the snapshot in which the new Tracking instance will be committed.
-  private final long newSnapshotId;
+  // Mutation state.
   private Long dvSnapshotId;
   private byte[] deletedPositions;
   private byte[] replacedPositions;
+  private boolean mutated;
 
   /**
    * Creates a builder for a newly added file.
@@ -74,8 +77,7 @@ class TrackingBuilder {
   }
 
   private TrackingBuilder(long newSnapshotId) {
-    this.status = EntryStatus.ADDED;
-    this.snapshotId = newSnapshotId;
+    this.source = null;
     this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = null;
     this.fileSequenceNumber = null;
@@ -83,13 +85,13 @@ class TrackingBuilder {
     this.dvSnapshotId = null;
     this.deletedPositions = null;
     this.replacedPositions = null;
+    this.mutated = false;
   }
 
   private TrackingBuilder(Tracking source, long newSnapshotId) {
     validateSource(source);
     validateStatusTransition(source.status(), EntryStatus.EXISTING);
-    this.status = EntryStatus.EXISTING;
-    this.snapshotId = source.snapshotId();
+    this.source = source;
     this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = source.dataSequenceNumber();
     this.fileSequenceNumber = source.fileSequenceNumber();
@@ -97,6 +99,7 @@ class TrackingBuilder {
     this.dvSnapshotId = source.dvSnapshotId();
     this.deletedPositions = null;
     this.replacedPositions = null;
+    this.mutated = false;
   }
 
   /** Indicates that the DV has been updated for the new Tracking. */
@@ -106,41 +109,67 @@ class TrackingBuilder {
         deletedPositions == null && replacedPositions == null,
         "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
     this.dvSnapshotId = newSnapshotId;
+    this.mutated = true;
     return this;
   }
 
   TrackingBuilder deletedPositions(ByteBuffer positions) {
-    Preconditions.checkState(
-        status == EntryStatus.EXISTING, "Cannot set deleted positions on %s entry", status);
+    Preconditions.checkState(source != null, "Cannot set deleted positions on ADDED entry");
     // DV applies to data files; deleted positions apply to manifest files
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
     this.deletedPositions = ByteBuffers.toByteArray(positions);
+    this.mutated = true;
     return this;
   }
 
   TrackingBuilder replacedPositions(ByteBuffer positions) {
-    Preconditions.checkState(
-        status == EntryStatus.EXISTING, "Cannot set replaced positions on %s entry", status);
+    Preconditions.checkState(source != null, "Cannot set replaced positions on ADDED entry");
     // DV applies to data files; replaced positions apply to manifest files
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
     this.replacedPositions = ByteBuffers.toByteArray(positions);
+    this.mutated = true;
     return this;
   }
 
   Tracking build() {
+    EntryStatus status = deriveStatus();
+    Long outputSnapshotId = (status == EntryStatus.EXISTING) ? source.snapshotId() : newSnapshotId;
     return new TrackingStruct(
         status,
-        snapshotId,
+        outputSnapshotId,
         dataSequenceNumber,
         fileSequenceNumber,
         dvSnapshotId,
         firstRowId,
         deletedPositions,
         replacedPositions);
+  }
+
+  /** Derives the output status from the source, the snapshot, and any mutations. */
+  private EntryStatus deriveStatus() {
+    if (source == null) {
+      return EntryStatus.ADDED;
+    }
+
+    boolean sameSnapshot = source.snapshotId() != null && source.snapshotId() == newSnapshotId;
+
+    if (mutated) {
+      if (source.status() == EntryStatus.ADDED && sameSnapshot) {
+        return EntryStatus.ADDED;
+      }
+
+      return EntryStatus.MODIFIED;
+    }
+
+    if (sameSnapshot) {
+      return source.status();
+    }
+
+    return EntryStatus.EXISTING;
   }
 
   private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -98,8 +98,15 @@ class TrackingBuilder {
     this.replacedPositions = null;
   }
 
-  /** Indicates that the DV has been updated for the new Tracking. */
+  /**
+   * Records that the file's DV was updated by this commit, advancing {@code dvSnapshotId} to the
+   * commit snapshot. An EXISTING entry transitions to MODIFIED; an ADDED entry stays ADDED (a file
+   * added and given a DV in the same commit).
+   */
   TrackingBuilder dvUpdated() {
+    Preconditions.checkState(
+        deletedPositions == null && replacedPositions == null,
+        "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
     this.dvSnapshotId = newSnapshotId;
     if (status == EntryStatus.EXISTING) {
       this.status = EntryStatus.MODIFIED;
@@ -108,6 +115,11 @@ class TrackingBuilder {
     return this;
   }
 
+  /**
+   * Records the manifest-leaf positions deleted by this commit, advancing {@code dvSnapshotId} to
+   * the commit snapshot and transitioning an EXISTING entry to MODIFIED. Cannot be called on an
+   * ADDED entry.
+   */
   TrackingBuilder deletedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set deleted positions on ADDED entry");
@@ -120,6 +132,11 @@ class TrackingBuilder {
     return this;
   }
 
+  /**
+   * Records the manifest-leaf positions replaced by this commit, advancing {@code dvSnapshotId} to
+   * the commit snapshot and transitioning an EXISTING entry to MODIFIED. Cannot be called on an
+   * ADDED entry.
+   */
   TrackingBuilder replacedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set replaced positions on ADDED entry");

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -98,11 +98,7 @@ class TrackingBuilder {
     this.replacedPositions = null;
   }
 
-  /**
-   * Records that the file's DV was updated by this commit, advancing {@code dvSnapshotId} to the
-   * commit snapshot. An EXISTING entry transitions to MODIFIED; an ADDED entry stays ADDED (a file
-   * added and given a DV in the same commit).
-   */
+  /** Indicates that the DV has been updated for the new Tracking. */
   TrackingBuilder dvUpdated() {
     Preconditions.checkState(
         deletedPositions == null && replacedPositions == null,
@@ -115,37 +111,23 @@ class TrackingBuilder {
     return this;
   }
 
-  /**
-   * Records the manifest-leaf positions deleted by this commit, advancing {@code dvSnapshotId} to
-   * the commit snapshot and transitioning an EXISTING entry to MODIFIED. Cannot be called on an
-   * ADDED entry.
-   */
+  /** Sets the positions deleted by this commit for a manifest entry. */
   TrackingBuilder deletedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set deleted positions on ADDED entry");
     this.deletedPositions = ByteBuffers.toByteArray(positions);
     this.dvSnapshotId = newSnapshotId;
-    if (status == EntryStatus.EXISTING) {
-      this.status = EntryStatus.MODIFIED;
-    }
-
+    this.status = EntryStatus.MODIFIED;
     return this;
   }
 
-  /**
-   * Records the manifest-leaf positions replaced by this commit, advancing {@code dvSnapshotId} to
-   * the commit snapshot and transitioning an EXISTING entry to MODIFIED. Cannot be called on an
-   * ADDED entry.
-   */
+  /** Sets the positions replaced by this commit for a manifest entry. */
   TrackingBuilder replacedPositions(ByteBuffer positions) {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set replaced positions on ADDED entry");
     this.replacedPositions = ByteBuffers.toByteArray(positions);
     this.dvSnapshotId = newSnapshotId;
-    if (status == EntryStatus.EXISTING) {
-      this.status = EntryStatus.MODIFIED;
-    }
-
+    this.status = EntryStatus.MODIFIED;
     return this;
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -23,19 +23,15 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
 class TrackingBuilder {
-  // null for the fresh-added path; non-null for the source-based path.
-  private final Tracking source;
-  // ID of the snapshot in which the new Tracking instance will be committed.
+  private EntryStatus status;
+  private Long snapshotId;
   private final long newSnapshotId;
-  // Inherited from the source (or null for fresh-add).
   private final Long dataSequenceNumber;
   private final Long fileSequenceNumber;
   private final Long firstRowId;
-  // Mutation state.
   private Long dvSnapshotId;
   private byte[] deletedPositions;
   private byte[] replacedPositions;
-  private boolean mutated;
 
   /**
    * Creates a builder for a newly added file.
@@ -77,7 +73,8 @@ class TrackingBuilder {
   }
 
   private TrackingBuilder(long newSnapshotId) {
-    this.source = null;
+    this.status = EntryStatus.ADDED;
+    this.snapshotId = newSnapshotId;
     this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = null;
     this.fileSequenceNumber = null;
@@ -85,13 +82,13 @@ class TrackingBuilder {
     this.dvSnapshotId = null;
     this.deletedPositions = null;
     this.replacedPositions = null;
-    this.mutated = false;
   }
 
   private TrackingBuilder(Tracking source, long newSnapshotId) {
     validateSource(source);
     validateStatusTransition(source.status(), EntryStatus.EXISTING);
-    this.source = source;
+    this.status = EntryStatus.EXISTING;
+    this.snapshotId = source.snapshotId();
     this.newSnapshotId = newSnapshotId;
     this.dataSequenceNumber = source.dataSequenceNumber();
     this.fileSequenceNumber = source.fileSequenceNumber();
@@ -99,7 +96,6 @@ class TrackingBuilder {
     this.dvSnapshotId = source.dvSnapshotId();
     this.deletedPositions = null;
     this.replacedPositions = null;
-    this.mutated = false;
   }
 
   /** Indicates that the DV has been updated for the new Tracking. */
@@ -109,38 +105,38 @@ class TrackingBuilder {
         deletedPositions == null && replacedPositions == null,
         "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
     this.dvSnapshotId = newSnapshotId;
-    this.mutated = true;
+    promoteToModified();
     return this;
   }
 
   TrackingBuilder deletedPositions(ByteBuffer positions) {
-    Preconditions.checkState(source != null, "Cannot set deleted positions on ADDED entry");
+    Preconditions.checkState(
+        status != EntryStatus.ADDED, "Cannot set deleted positions on ADDED entry");
     // DV applies to data files; deleted positions apply to manifest files
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
     this.deletedPositions = ByteBuffers.toByteArray(positions);
-    this.mutated = true;
+    promoteToModified();
     return this;
   }
 
   TrackingBuilder replacedPositions(ByteBuffer positions) {
-    Preconditions.checkState(source != null, "Cannot set replaced positions on ADDED entry");
+    Preconditions.checkState(
+        status != EntryStatus.ADDED, "Cannot set replaced positions on ADDED entry");
     // DV applies to data files; replaced positions apply to manifest files
     Preconditions.checkState(
         dvSnapshotId == null,
         "Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
     this.replacedPositions = ByteBuffers.toByteArray(positions);
-    this.mutated = true;
+    promoteToModified();
     return this;
   }
 
   Tracking build() {
-    EntryStatus status = deriveStatus();
-    Long outputSnapshotId = (status == EntryStatus.EXISTING) ? source.snapshotId() : newSnapshotId;
     return new TrackingStruct(
         status,
-        outputSnapshotId,
+        snapshotId,
         dataSequenceNumber,
         fileSequenceNumber,
         dvSnapshotId,
@@ -149,27 +145,11 @@ class TrackingBuilder {
         replacedPositions);
   }
 
-  /** Derives the output status from the source, the snapshot, and any mutations. */
-  private EntryStatus deriveStatus() {
-    if (source == null) {
-      return EntryStatus.ADDED;
+  private void promoteToModified() {
+    if (status == EntryStatus.EXISTING) {
+      this.status = EntryStatus.MODIFIED;
+      this.snapshotId = newSnapshotId;
     }
-
-    boolean sameSnapshot = source.snapshotId() != null && source.snapshotId() == newSnapshotId;
-
-    if (mutated) {
-      if (source.status() == EntryStatus.ADDED && sameSnapshot) {
-        return EntryStatus.ADDED;
-      }
-
-      return EntryStatus.MODIFIED;
-    }
-
-    if (sameSnapshot) {
-      return source.status();
-    }
-
-    return EntryStatus.EXISTING;
   }
 
   private static Tracking terminal(EntryStatus to, Tracking source, long newSnapshotId) {

--- a/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -46,19 +47,12 @@ class TestEntryStatus {
         .hasMessageContaining(String.valueOf(id));
   }
 
-  @ParameterizedTest
-  @EnumSource(
-      value = EntryStatus.class,
-      names = {"EXISTING", "ADDED", "MODIFIED"})
-  void isLive(EntryStatus status) {
-    assertThat(status.isLive()).isTrue();
-  }
-
-  @ParameterizedTest
-  @EnumSource(
-      value = EntryStatus.class,
-      names = {"DELETED", "REPLACED"})
-  void isNotLive(EntryStatus status) {
-    assertThat(status.isLive()).isFalse();
+  @Test
+  void isLive() {
+    assertThat(EntryStatus.EXISTING.isLive()).isTrue();
+    assertThat(EntryStatus.ADDED.isLive()).isTrue();
+    assertThat(EntryStatus.MODIFIED.isLive()).isTrue();
+    assertThat(EntryStatus.DELETED.isLive()).isFalse();
+    assertThat(EntryStatus.REPLACED.isLive()).isFalse();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
+++ b/core/src/test/java/org/apache/iceberg/TestEntryStatus.java
@@ -45,4 +45,20 @@ class TestEntryStatus {
         .isInstanceOf(ArrayIndexOutOfBoundsException.class)
         .hasMessageContaining(String.valueOf(id));
   }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = EntryStatus.class,
+      names = {"EXISTING", "ADDED", "MODIFIED"})
+  void isLive(EntryStatus status) {
+    assertThat(status.isLive()).isTrue();
+  }
+
+  @ParameterizedTest
+  @EnumSource(
+      value = EntryStatus.class,
+      names = {"DELETED", "REPLACED"})
+  void isNotLive(EntryStatus status) {
+    assertThat(status.isLive()).isFalse();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -82,7 +82,7 @@ class TestTrackingStruct {
 
     Tracking copy = tracking.copy();
 
-    assertThat(copy.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(copy.status()).isEqualTo(EntryStatus.MODIFIED);
     assertThat(copy.snapshotId()).isEqualTo(tracking.snapshotId());
     assertThat(copy.dataSequenceNumber()).isEqualTo(tracking.dataSequenceNumber());
     assertThat(copy.fileSequenceNumber()).isEqualTo(tracking.fileSequenceNumber());
@@ -112,6 +112,9 @@ class TestTrackingStruct {
     assertThat(tracking.isLive()).isTrue();
 
     tracking.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
+    assertThat(tracking.isLive()).isTrue();
+
+    tracking.set(STATUS_ORDINAL, EntryStatus.MODIFIED.id());
     assertThat(tracking.isLive()).isTrue();
 
     tracking.set(STATUS_ORDINAL, EntryStatus.DELETED.id());
@@ -154,6 +157,20 @@ class TestTrackingStruct {
     tracking.inheritFrom(createManifestTracking(100L, 60L));
 
     // sequence numbers are not inherited for EXISTING entries
+    assertThat(tracking.dataSequenceNumber()).isEqualTo(5L);
+    assertThat(tracking.fileSequenceNumber()).isEqualTo(6L);
+  }
+
+  @Test
+  void testDoNotInheritSequenceNumberForModifiedEntries() {
+    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    tracking.set(STATUS_ORDINAL, EntryStatus.MODIFIED.id());
+    tracking.set(DATA_SEQUENCE_NUMBER_ORDINAL, 5L);
+    tracking.set(FILE_SEQUENCE_NUMBER_ORDINAL, 6L);
+
+    tracking.inheritFrom(createManifestTracking(100L, 60L));
+
+    // sequence numbers are not inherited for MODIFIED entries
     assertThat(tracking.dataSequenceNumber()).isEqualTo(5L);
     assertThat(tracking.fileSequenceNumber()).isEqualTo(6L);
   }
@@ -300,9 +317,12 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExistingBuilderAllowsDvMutation() {
-    Tracking existing = TrackingBuilder.from(sourceTracking(), 999L).dvUpdated().build();
-    assertThat(existing.dvSnapshotId()).isEqualTo(999L);
+  void testDvUpdatedProducesModifiedAndStampsCurrentSnapshot() {
+    Tracking modified = TrackingBuilder.from(sourceTracking(), 999L).dvUpdated().build();
+
+    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(modified.snapshotId()).isEqualTo(999L);
+    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
   }
 
   @Test
@@ -433,6 +453,81 @@ class TestTrackingStruct {
     assertThat(replaced.snapshotId()).isEqualTo(999L);
   }
 
+  private static Stream<Arguments> deriveStatusCases() {
+    long sameSnap = 42L;
+    long laterSnap = 999L;
+    return Stream.of(
+        // ADDED source
+        Arguments.of(EntryStatus.ADDED, sameSnap, false, EntryStatus.ADDED),
+        Arguments.of(EntryStatus.ADDED, sameSnap, true, EntryStatus.ADDED),
+        Arguments.of(EntryStatus.ADDED, laterSnap, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.ADDED, laterSnap, true, EntryStatus.MODIFIED),
+        // EXISTING source
+        Arguments.of(EntryStatus.EXISTING, sameSnap, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.EXISTING, sameSnap, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.EXISTING, laterSnap, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.EXISTING, laterSnap, true, EntryStatus.MODIFIED),
+        // MODIFIED source
+        Arguments.of(EntryStatus.MODIFIED, sameSnap, false, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.MODIFIED, sameSnap, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.MODIFIED, laterSnap, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.MODIFIED, laterSnap, true, EntryStatus.MODIFIED));
+  }
+
+  @ParameterizedTest
+  @MethodSource("deriveStatusCases")
+  void testDeriveStatus(
+      EntryStatus sourceStatus, long newSnapshotId, boolean mutate, EntryStatus expected) {
+    Tracking source = sourceTrackingWithStatus(sourceStatus);
+    TrackingBuilder builder = TrackingBuilder.from(source, newSnapshotId);
+    if (mutate) {
+      builder.dvUpdated();
+    }
+
+    assertThat(builder.build().status()).isEqualTo(expected);
+  }
+
+  @Test
+  void testExistingPreservesSourceSnapshotId() {
+    Tracking source = sourceTracking();
+    Tracking existing = TrackingBuilder.from(source, 999L).build();
+    assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
+  }
+
+  @Test
+  void testModifiedUsesNewSnapshotId() {
+    Tracking source = sourceTracking();
+    Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
+    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(modified.snapshotId()).isEqualTo(999L);
+  }
+
+  @Test
+  void testManifestDVPositionsProduceModified() {
+    ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1, 2});
+    ByteBuffer replacedBytes = ByteBuffer.wrap(new byte[] {3, 4});
+
+    // cross-commit: ADDED source carried into a new snapshot with MDV positions
+    Tracking addedSource = manifestSourceTracking();
+    Tracking crossCommit =
+        TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
+    assertThat(crossCommit.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(crossCommit.snapshotId()).isEqualTo(999L);
+    assertThat(crossCommit.deletedPositions()).isEqualTo(deletedBytes);
+
+    // same-commit: EXISTING source mutated within its own snapshot
+    TrackingStruct existingSource = manifestSourceTracking();
+    existingSource.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
+    Tracking sameCommit =
+        TrackingBuilder.from(existingSource, existingSource.snapshotId())
+            .replacedPositions(replacedBytes)
+            .build();
+    assertThat(sameCommit.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(sameCommit.snapshotId()).isEqualTo(existingSource.snapshotId());
+    assertThat(sameCommit.replacedPositions()).isEqualTo(replacedBytes);
+  }
+
   @Test
   void testInternalSetIgnoresUnknownOrdinal() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
@@ -493,7 +588,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExistingWithManifestDVPositionsJavaSerializationRoundTrip()
+  void testModifiedWithManifestDVPositionsJavaSerializationRoundTrip()
       throws IOException, ClassNotFoundException {
     Tracking tracking =
         TrackingBuilder.from(manifestSourceTracking(), 1L)
@@ -503,7 +598,7 @@ class TestTrackingStruct {
 
     Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
-    assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
     assertThat(deserialized.dvSnapshotId()).isNull();
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
@@ -523,7 +618,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExistingWithManifestDVPositionsKryoSerializationRoundTrip() throws IOException {
+  void testModifiedWithManifestDVPositionsKryoSerializationRoundTrip() throws IOException {
     Tracking tracking =
         TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
@@ -532,7 +627,7 @@ class TestTrackingStruct {
 
     Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
-    assertThat(deserialized.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
     assertThat(deserialized.dvSnapshotId()).isNull();
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -106,22 +106,13 @@ class TestTrackingStruct {
 
   @Test
   void testIsLive() {
-    TrackingStruct tracking = new TrackingStruct(Tracking.schema());
+    Tracking source = sourceTracking();
 
-    tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());
-    assertThat(tracking.isLive()).isTrue();
-
-    tracking.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
-    assertThat(tracking.isLive()).isTrue();
-
-    tracking.set(STATUS_ORDINAL, EntryStatus.MODIFIED.id());
-    assertThat(tracking.isLive()).isTrue();
-
-    tracking.set(STATUS_ORDINAL, EntryStatus.DELETED.id());
-    assertThat(tracking.isLive()).isFalse();
-
-    tracking.set(STATUS_ORDINAL, EntryStatus.REPLACED.id());
-    assertThat(tracking.isLive()).isFalse();
+    assertThat(TrackingBuilder.added(42L).build().isLive()).isTrue();
+    assertThat(TrackingBuilder.from(source, 999L).build().isLive()).isTrue();
+    assertThat(TrackingBuilder.from(source, 999L).dvUpdated().build().isLive()).isTrue();
+    assertThat(TrackingBuilder.deleted(source, 999L).isLive()).isFalse();
+    assertThat(TrackingBuilder.replaced(source, 999L).isLive()).isFalse();
   }
 
   @Test
@@ -453,46 +444,12 @@ class TestTrackingStruct {
     assertThat(replaced.snapshotId()).isEqualTo(999L);
   }
 
-  private static Stream<Arguments> deriveStatusCases() {
-    long sameSnapshot = 42L;
-    long laterSnapshot = 999L;
-    return Stream.of(
-        // ADDED source
-        Arguments.of(EntryStatus.ADDED, sameSnapshot, false, EntryStatus.ADDED),
-        Arguments.of(EntryStatus.ADDED, sameSnapshot, true, EntryStatus.ADDED),
-        Arguments.of(EntryStatus.ADDED, laterSnapshot, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.ADDED, laterSnapshot, true, EntryStatus.MODIFIED),
-        // EXISTING source
-        Arguments.of(EntryStatus.EXISTING, sameSnapshot, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.EXISTING, sameSnapshot, true, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.EXISTING, laterSnapshot, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.EXISTING, laterSnapshot, true, EntryStatus.MODIFIED),
-        // MODIFIED source
-        Arguments.of(EntryStatus.MODIFIED, sameSnapshot, false, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.MODIFIED, sameSnapshot, true, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.MODIFIED, laterSnapshot, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.MODIFIED, laterSnapshot, true, EntryStatus.MODIFIED));
-  }
-
-  @ParameterizedTest
-  @MethodSource("deriveStatusCases")
-  void testDeriveStatus(
-      EntryStatus sourceStatus, long newSnapshotId, boolean mutate, EntryStatus expected) {
-    Tracking source = sourceTrackingWithStatus(sourceStatus);
-    TrackingBuilder builder = TrackingBuilder.from(source, newSnapshotId);
-    if (mutate) {
-      builder.dvUpdated();
-    }
-
-    assertThat(builder.build().status()).isEqualTo(expected);
-  }
-
   @Test
   void testExistingPreservesSourceSnapshotId() {
     Tracking source = sourceTracking();
     Tracking existing = TrackingBuilder.from(source, 999L).build();
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
-    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId());
+    assertThat(existing.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
   }
 
   @Test
@@ -500,32 +457,29 @@ class TestTrackingStruct {
     Tracking source = sourceTracking();
     Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
     assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(modified.snapshotId()).isEqualTo(999L);
+    assertThat(modified.snapshotId()).isEqualTo(999L).isNotEqualTo(source.snapshotId());
+  }
+
+  @Test
+  void testCarryForwardFromModifiedSourceChangesToExisting() {
+    // A MODIFIED entry from a prior commit carried forward without mutation becomes EXISTING,
+    // preserving the snapshot id from the modify commit.
+    Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
+    Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
+    assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
+    assertThat(carried.snapshotId()).isEqualTo(modifiedSource.snapshotId()).isNotEqualTo(999L);
   }
 
   @Test
   void testManifestDVPositionsProduceModified() {
     ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1, 2});
-    ByteBuffer replacedBytes = ByteBuffer.wrap(new byte[] {3, 4});
 
-    // cross-commit: ADDED source carried into a new snapshot with MDV positions
     Tracking addedSource = manifestSourceTracking();
-    Tracking crossCommit =
+    Tracking modified =
         TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
-    assertThat(crossCommit.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(crossCommit.snapshotId()).isEqualTo(999L);
-    assertThat(crossCommit.deletedPositions()).isEqualTo(deletedBytes);
-
-    // same-commit: EXISTING source mutated within its own snapshot
-    TrackingStruct existingSource = manifestSourceTracking();
-    existingSource.set(STATUS_ORDINAL, EntryStatus.EXISTING.id());
-    Tracking sameCommit =
-        TrackingBuilder.from(existingSource, existingSource.snapshotId())
-            .replacedPositions(replacedBytes)
-            .build();
-    assertThat(sameCommit.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(sameCommit.snapshotId()).isEqualTo(existingSource.snapshotId());
-    assertThat(sameCommit.replacedPositions()).isEqualTo(replacedBytes);
+    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
+    assertThat(modified.snapshotId()).isEqualTo(999L);
+    assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -466,6 +466,12 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testIsLiveDelegatesToStatus() {
+    assertThat(sourceTrackingWithStatus(EntryStatus.ADDED).isLive()).isTrue();
+    assertThat(sourceTrackingWithStatus(EntryStatus.DELETED).isLive()).isFalse();
+  }
+
+  @Test
   void testInternalSetIgnoresUnknownOrdinal() {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(STATUS_ORDINAL, EntryStatus.ADDED.id());

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -454,24 +454,24 @@ class TestTrackingStruct {
   }
 
   private static Stream<Arguments> deriveStatusCases() {
-    long sameSnap = 42L;
-    long laterSnap = 999L;
+    long sameSnapshot = 42L;
+    long laterSnapshot = 999L;
     return Stream.of(
         // ADDED source
-        Arguments.of(EntryStatus.ADDED, sameSnap, false, EntryStatus.ADDED),
-        Arguments.of(EntryStatus.ADDED, sameSnap, true, EntryStatus.ADDED),
-        Arguments.of(EntryStatus.ADDED, laterSnap, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.ADDED, laterSnap, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.ADDED, sameSnapshot, false, EntryStatus.ADDED),
+        Arguments.of(EntryStatus.ADDED, sameSnapshot, true, EntryStatus.ADDED),
+        Arguments.of(EntryStatus.ADDED, laterSnapshot, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.ADDED, laterSnapshot, true, EntryStatus.MODIFIED),
         // EXISTING source
-        Arguments.of(EntryStatus.EXISTING, sameSnap, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.EXISTING, sameSnap, true, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.EXISTING, laterSnap, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.EXISTING, laterSnap, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.EXISTING, sameSnapshot, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.EXISTING, sameSnapshot, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.EXISTING, laterSnapshot, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.EXISTING, laterSnapshot, true, EntryStatus.MODIFIED),
         // MODIFIED source
-        Arguments.of(EntryStatus.MODIFIED, sameSnap, false, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.MODIFIED, sameSnap, true, EntryStatus.MODIFIED),
-        Arguments.of(EntryStatus.MODIFIED, laterSnap, false, EntryStatus.EXISTING),
-        Arguments.of(EntryStatus.MODIFIED, laterSnap, true, EntryStatus.MODIFIED));
+        Arguments.of(EntryStatus.MODIFIED, sameSnapshot, false, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.MODIFIED, sameSnapshot, true, EntryStatus.MODIFIED),
+        Arguments.of(EntryStatus.MODIFIED, laterSnapshot, false, EntryStatus.EXISTING),
+        Arguments.of(EntryStatus.MODIFIED, laterSnapshot, true, EntryStatus.MODIFIED));
   }
 
   @ParameterizedTest
@@ -574,8 +574,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testAddedWithDvSnapshotIdJavaSerializationRoundTrip()
-      throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTripForDataFile() throws IOException, ClassNotFoundException {
     Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
@@ -588,8 +587,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testModifiedWithManifestDVPositionsJavaSerializationRoundTrip()
-      throws IOException, ClassNotFoundException {
+  void testJavaSerializationRoundTripForManifest() throws IOException, ClassNotFoundException {
     Tracking tracking =
         TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))
@@ -605,7 +603,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testAddedWithDvSnapshotIdKryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTripForDataFile() throws IOException {
     Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
@@ -618,7 +616,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testModifiedWithManifestDVPositionsKryoSerializationRoundTrip() throws IOException {
+  void testKryoSerializationRoundTripForManifest() throws IOException {
     Tracking tracking =
         TrackingBuilder.from(manifestSourceTracking(), 1L)
             .deletedPositions(ByteBuffer.wrap(new byte[] {1, 2}))

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -439,13 +439,12 @@ class TestTrackingStruct {
 
   @Test
   void testCarryForwardFromModifiedSourceChangesToExisting() {
-    // A MODIFIED entry from a prior commit carried forward without mutation becomes EXISTING,
-    // preserving the snapshot id of the original add (the modify commit lives in dvSnapshotId).
+    // A MODIFIED entry from a prior commit carried forward without mutation; status becomes
+    // EXISTING.
     Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
     Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
     assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(carried.snapshotId()).isEqualTo(modifiedSource.snapshotId()).isNotEqualTo(999L);
-    // the modify-commit pointer and inherited fields are carried forward unchanged
     assertThat(carried.dvSnapshotId()).isEqualTo(modifiedSource.dvSnapshotId()).isNotEqualTo(999L);
     assertThat(carried.dataSequenceNumber()).isEqualTo(modifiedSource.dataSequenceNumber());
     assertThat(carried.fileSequenceNumber()).isEqualTo(modifiedSource.fileSequenceNumber());

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -221,7 +221,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testAddedBuilder() {
+  void testAddedWithSameCommitDvStaysAdded() {
     Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
@@ -322,6 +322,27 @@ class TestTrackingStruct {
   }
 
   @Test
+  void testDvUpdatedRejectedWhenManifestPositionsSet() {
+    assertThatThrownBy(
+            () ->
+                TrackingBuilder.from(manifestSourceTracking(), 999L)
+                    .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
+                    .dvUpdated())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
+
+    assertThatThrownBy(
+            () ->
+                TrackingBuilder.from(manifestSourceTracking(), 999L)
+                    .replacedPositions(ByteBuffer.wrap(new byte[] {1}))
+                    .dvUpdated())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage(
+            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
+  }
+
+  @Test
   void testBuilderRejectsNullSource() {
     assertThatThrownBy(() -> TrackingBuilder.from(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
@@ -419,11 +440,16 @@ class TestTrackingStruct {
   @Test
   void testCarryForwardFromModifiedSourceChangesToExisting() {
     // A MODIFIED entry from a prior commit carried forward without mutation becomes EXISTING,
-    // preserving the snapshot id from the modify commit.
+    // preserving the snapshot id of the original add (the modify commit lives in dvSnapshotId).
     Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
     Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
     assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
     assertThat(carried.snapshotId()).isEqualTo(modifiedSource.snapshotId()).isNotEqualTo(999L);
+    // the modify-commit pointer and inherited fields are carried forward unchanged
+    assertThat(carried.dvSnapshotId()).isEqualTo(modifiedSource.dvSnapshotId()).isNotEqualTo(999L);
+    assertThat(carried.dataSequenceNumber()).isEqualTo(modifiedSource.dataSequenceNumber());
+    assertThat(carried.fileSequenceNumber()).isEqualTo(modifiedSource.fileSequenceNumber());
+    assertThat(carried.firstRowId()).isEqualTo(modifiedSource.firstRowId());
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -86,7 +86,7 @@ class TestTrackingStruct {
     assertThat(copy.snapshotId()).isEqualTo(tracking.snapshotId());
     assertThat(copy.dataSequenceNumber()).isEqualTo(tracking.dataSequenceNumber());
     assertThat(copy.fileSequenceNumber()).isEqualTo(tracking.fileSequenceNumber());
-    assertThat(copy.dvSnapshotId()).isNull();
+    assertThat(copy.dvSnapshotId()).isEqualTo(tracking.dvSnapshotId());
     assertThat(copy.firstRowId()).isEqualTo(tracking.firstRowId());
     assertThat(copy.deletedPositions()).isEqualTo(tracking.deletedPositions());
     assertThat(copy.replacedPositions()).isEqualTo(tracking.replacedPositions());
@@ -102,17 +102,6 @@ class TestTrackingStruct {
     TrackingStruct tracking = new TrackingStruct(Tracking.schema());
     tracking.set(STATUS_ORDINAL, status.id());
     assertThat(tracking.status()).isEqualTo(status);
-  }
-
-  @Test
-  void testIsLive() {
-    Tracking source = sourceTracking();
-
-    assertThat(TrackingBuilder.added(42L).build().isLive()).isTrue();
-    assertThat(TrackingBuilder.from(source, 999L).build().isLive()).isTrue();
-    assertThat(TrackingBuilder.from(source, 999L).dvUpdated().build().isLive()).isTrue();
-    assertThat(TrackingBuilder.deleted(source, 999L).isLive()).isFalse();
-    assertThat(TrackingBuilder.replaced(source, 999L).isLive()).isFalse();
   }
 
   @Test
@@ -308,11 +297,14 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDvUpdatedProducesModifiedAndStampsCurrentSnapshot() {
-    Tracking modified = TrackingBuilder.from(sourceTracking(), 999L).dvUpdated().build();
+  void testDvUpdatedProducesModifiedAndAdvancesDvSnapshotId() {
+    Tracking source = sourceTracking();
+    Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
 
     assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(modified.snapshotId()).isEqualTo(999L);
+    // the entry snapshot id is preserved so we still know when the base file was added
+    assertThat(modified.snapshotId()).isEqualTo(source.snapshotId()).isNotEqualTo(999L);
+    // only the DV snapshot id advances to the commit snapshot
     assertThat(modified.dvSnapshotId()).isEqualTo(999L);
   }
 
@@ -327,34 +319,6 @@ class TestTrackingStruct {
             () -> TrackingBuilder.added(42L).replacedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("Cannot set replaced positions on ADDED entry");
-  }
-
-  @Test
-  void testDvSnapshotIdAndManifestDVPositionsAreMutuallyExclusive() {
-    // sourceTracking has dvSnapshotId=43, inherited by existing(source)
-    assertThatThrownBy(
-            () ->
-                TrackingBuilder.from(sourceTracking(), 1L)
-                    .deletedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set deleted positions on a data file entry (DV snapshot ID is set)");
-
-    assertThatThrownBy(
-            () ->
-                TrackingBuilder.from(sourceTracking(), 1L)
-                    .replacedPositions(ByteBuffer.wrap(new byte[] {1})))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage("Cannot set replaced positions on a data file entry (DV snapshot ID is set)");
-
-    // Setting MDV positions first then dvUpdated is also rejected
-    assertThatThrownBy(
-            () ->
-                TrackingBuilder.from(manifestSourceTracking(), 1L)
-                    .deletedPositions(ByteBuffer.wrap(new byte[] {1}))
-                    .dvUpdated())
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessage(
-            "Cannot mark DV updated on a manifest entry (deleted/replaced positions are set)");
   }
 
   @Test
@@ -453,14 +417,6 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testModifiedUsesNewSnapshotId() {
-    Tracking source = sourceTracking();
-    Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
-    assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(modified.snapshotId()).isEqualTo(999L).isNotEqualTo(source.snapshotId());
-  }
-
-  @Test
   void testCarryForwardFromModifiedSourceChangesToExisting() {
     // A MODIFIED entry from a prior commit carried forward without mutation becomes EXISTING,
     // preserving the snapshot id from the modify commit.
@@ -478,7 +434,9 @@ class TestTrackingStruct {
     Tracking modified =
         TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
     assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(modified.snapshotId()).isEqualTo(999L);
+    // the entry snapshot id is preserved; only the DV snapshot id advances to the commit snapshot
+    assertThat(modified.snapshotId()).isEqualTo(addedSource.snapshotId()).isNotEqualTo(999L);
+    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
     assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
   }
 
@@ -551,7 +509,7 @@ class TestTrackingStruct {
     Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isNull();
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
@@ -580,7 +538,7 @@ class TestTrackingStruct {
     Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isNull();
+    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -439,8 +439,6 @@ class TestTrackingStruct {
 
   @Test
   void testCarryForwardFromModifiedSourceChangesToExisting() {
-    // A MODIFIED entry from a prior commit carried forward without mutation; status becomes
-    // EXISTING.
     Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
     Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
     assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);


### PR DESCRIPTION

  - Add MODIFIED to EntryStatus for entries whose file was modified by
    a column update or DV change.
  - Update TrackingBuilder such that it derives the right status 
  - Added tests