### PR TITLE
Core: Skip unnecessary manifest scans during expire snapshots metadata cleanup

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -242,7 +242,7 @@ class RemoveSnapshots implements ExpireSnapshots {
       Set<Integer> reachableSchemas = Sets.newConcurrentHashSet();
       reachableSchemas.add(base.currentSchemaId());
 
-      boolean mayHasExpiredSpecs =
+      boolean mayHaveExpiredSpecs =
           base.specs().size() > 1
               || base.specs().stream().anyMatch(s -> s.specId() != base.defaultSpecId());
 
@@ -251,7 +251,7 @@ class RemoveSnapshots implements ExpireSnapshots {
           .run(
               snapshotId -> {
                 Snapshot snapshot = base.snapshot(snapshotId);
-                if (mayHasExpiredSpecs) {
+                if (mayHaveExpiredSpecs && reachableSpecs.size() < base.specs().size()) {
                   snapshot.allManifests(ops.io()).stream()
                       .map(ManifestFile::partitionSpecId)
                       .forEach(reachableSpecs::add);

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -242,14 +242,20 @@ class RemoveSnapshots implements ExpireSnapshots {
       Set<Integer> reachableSchemas = Sets.newConcurrentHashSet();
       reachableSchemas.add(base.currentSchemaId());
 
+      boolean mayHasExpiredSpecs =
+          base.specs().size() > 1
+              || base.specs().stream().anyMatch(s -> s.specId() != base.defaultSpecId());
+
       Tasks.foreach(idsToRetain)
           .executeWith(planExecutorService())
           .run(
               snapshotId -> {
                 Snapshot snapshot = base.snapshot(snapshotId);
-                snapshot.allManifests(ops.io()).stream()
-                    .map(ManifestFile::partitionSpecId)
-                    .forEach(reachableSpecs::add);
+                if (mayHasExpiredSpecs) {
+                  snapshot.allManifests(ops.io()).stream()
+                      .map(ManifestFile::partitionSpecId)
+                      .forEach(reachableSpecs::add);
+                }
                 reachableSchemas.add(snapshot.schemaId());
               });
 

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -242,9 +242,7 @@ class RemoveSnapshots implements ExpireSnapshots {
       Set<Integer> reachableSchemas = Sets.newConcurrentHashSet();
       reachableSchemas.add(base.currentSchemaId());
 
-      boolean mayHaveExpiredSpecs =
-          base.specs().size() > 1
-              || base.specs().stream().anyMatch(s -> s.specId() != base.defaultSpecId());
+      boolean mayHaveExpiredSpecs = base.specs().size() > 1;
 
       Tasks.foreach(idsToRetain)
           .executeWith(planExecutorService())


### PR DESCRIPTION
## Summary

When `cleanExpiredMetadata` is enabled, the expire snapshots operation scans all manifest lists of retained snapshots to determine reachable partition specs. For tables that retain many snapshots, this scan is expensive as it requires reading every manifest list file.

This PR adds two optimizations to skip unnecessary manifest I/O:
- Skip scanning entirely if the table has only a single spec that is the current default spec (the common case for most tables).
- Once all known specs have been confirmed reachable during the scan, skip manifest I/O for the remaining snapshots.

## Test plan
- [x] Existing `TestRemoveSnapshots` tests pass (covers `testRemoveSpecDuringExpiration`, `testRemoveSpecsDoesntRemoveDefaultSpec`, `testNoSchemasOrSpecsToRemove`)
- [x] `./gradlew :iceberg-core:spotlessCheck` passes
- [ ] CI validates no regressions across all test suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)