### PR TITLE
Core: Fix RESTMetricsReporter.report() blocking the calling thread

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -61,14 +61,6 @@ public class SystemConfigs {
           1,
           Integer::parseUnsignedInt);
 
-  /** Sets the thread pool size for asynchronous REST metrics reporting. */
-  public static final ConfigEntry<Integer> METRICS_REPORTER_THREAD_POOL_SIZE =
-      new ConfigEntry<>(
-          "iceberg.rest.metrics.reporter.num-threads",
-          "ICEBERG_REST_METRICS_REPORTER_NUM_THREADS",
-          1,
-          Integer::parseUnsignedInt);
-
   /** Whether to use the shared worker pool when planning table scans. */
   public static final ConfigEntry<Boolean> SCAN_THREAD_POOL_ENABLED =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -61,6 +61,14 @@ public class SystemConfigs {
           1,
           Integer::parseUnsignedInt);
 
+  /** Sets the thread pool size for asynchronous REST metrics reporting. */
+  public static final ConfigEntry<Integer> METRICS_REPORTER_THREAD_POOL_SIZE =
+      new ConfigEntry<>(
+          "iceberg.rest.metrics.reporter.num-threads",
+          "ICEBERG_REST_METRICS_REPORTER_NUM_THREADS",
+          1,
+          Integer::parseUnsignedInt);
+
   /** Whether to use the shared worker pool when planning table scans. */
   public static final ConfigEntry<Boolean> SCAN_THREAD_POOL_ENABLED =
       new ConfigEntry<>(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest;
 
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.RejectedExecutionException;
 import java.util.function.Supplier;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
@@ -57,18 +58,25 @@ class RESTMetricsReporter implements MetricsReporter {
       return;
     }
 
-    executor.execute(
-        () -> {
-          try {
-            client.post(
-                metricsEndpoint,
-                ReportMetricsRequest.of(report),
-                null,
-                headers,
-                ErrorHandlers.defaultErrorHandler());
-          } catch (Exception e) {
-            LOG.warn("Failed to report metrics to REST endpoint {}", metricsEndpoint, e);
-          }
-        });
+    try {
+      executor.execute(
+          () -> {
+            try {
+              client.post(
+                  metricsEndpoint,
+                  ReportMetricsRequest.of(report),
+                  null,
+                  headers,
+                  ErrorHandlers.defaultErrorHandler());
+            } catch (Exception e) {
+              LOG.warn("Failed to report metrics to REST endpoint {}", metricsEndpoint, e);
+            }
+          });
+    } catch (RejectedExecutionException e) {
+      LOG.warn(
+          "Failed to report metrics to REST endpoint {}: metrics executor has been shut down",
+          metricsEndpoint,
+          e);
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
@@ -21,10 +21,10 @@ package org.apache.iceberg.rest;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
+import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
-import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,8 +36,11 @@ import org.slf4j.LoggerFactory;
 class RESTMetricsReporter implements MetricsReporter {
   private static final Logger LOG = LoggerFactory.getLogger(RESTMetricsReporter.class);
 
+  // Best-effort async reporting: callers enqueue and return immediately. Defaults to a single
+  // thread; high-throughput servers can tune via SystemConfigs.METRICS_REPORTER_THREAD_POOL_SIZE.
   private static final ExecutorService METRICS_EXECUTOR =
-      ThreadPools.newExitingWorkerPool("rest-metrics-reporter", 1);
+      ThreadPools.newExitingWorkerPool(
+          "rest-metrics-reporter", SystemConfigs.METRICS_REPORTER_THREAD_POOL_SIZE.value());
 
   private final RESTClient client;
   private final String metricsEndpoint;
@@ -57,21 +60,18 @@ class RESTMetricsReporter implements MetricsReporter {
       return;
     }
 
-    Tasks.range(1)
-        .executeWith(METRICS_EXECUTOR)
-        .suppressFailureWhenFinished()
-        .onFailure(
-            (item, exception) ->
-                LOG.warn(
-                    "Failed to report metrics to REST endpoint {}", metricsEndpoint, exception))
-        .run(
-            item -> {
-              client.post(
-                  metricsEndpoint,
-                  ReportMetricsRequest.of(report),
-                  null,
-                  headers,
-                  ErrorHandlers.defaultErrorHandler());
-            });
+    METRICS_EXECUTOR.execute(
+        () -> {
+          try {
+            client.post(
+                metricsEndpoint,
+                ReportMetricsRequest.of(report),
+                null,
+                headers,
+                ErrorHandlers.defaultErrorHandler());
+          } catch (Exception e) {
+            LOG.warn("Failed to report metrics to REST endpoint {}", metricsEndpoint, e);
+          }
+        });
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTMetricsReporter.java
@@ -21,11 +21,9 @@ package org.apache.iceberg.rest;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Supplier;
-import org.apache.iceberg.SystemConfigs;
 import org.apache.iceberg.metrics.MetricsReport;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.rest.requests.ReportMetricsRequest;
-import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,21 +34,20 @@ import org.slf4j.LoggerFactory;
 class RESTMetricsReporter implements MetricsReporter {
   private static final Logger LOG = LoggerFactory.getLogger(RESTMetricsReporter.class);
 
-  // Best-effort async reporting: callers enqueue and return immediately. Defaults to a single
-  // thread; high-throughput servers can tune via SystemConfigs.METRICS_REPORTER_THREAD_POOL_SIZE.
-  private static final ExecutorService METRICS_EXECUTOR =
-      ThreadPools.newExitingWorkerPool(
-          "rest-metrics-reporter", SystemConfigs.METRICS_REPORTER_THREAD_POOL_SIZE.value());
-
   private final RESTClient client;
   private final String metricsEndpoint;
   private final Supplier<Map<String, String>> headers;
+  private final ExecutorService executor;
 
   RESTMetricsReporter(
-      RESTClient client, String metricsEndpoint, Supplier<Map<String, String>> headers) {
+      RESTClient client,
+      String metricsEndpoint,
+      Supplier<Map<String, String>> headers,
+      ExecutorService executor) {
     this.client = client;
     this.metricsEndpoint = metricsEndpoint;
     this.headers = headers;
+    this.executor = executor;
   }
 
   @Override
@@ -60,7 +57,7 @@ class RESTMetricsReporter implements MetricsReporter {
       return;
     }
 
-    METRICS_EXECUTOR.execute(
+    executor.execute(
         () -> {
           try {
             client.post(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.ExecutorService;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -99,6 +100,7 @@ import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.EnvironmentUtil;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.ThreadPools;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
 import org.apache.iceberg.view.ImmutableViewVersion;
@@ -165,6 +167,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private Object conf = null;
   private FileIO io = null;
   private MetricsReporter reporter = null;
+  private ExecutorService metricsExecutor = null;
   private boolean reportingViaRestEnabled;
   private Integer pageSize = null;
   private CloseableGroup closeables = null;
@@ -235,6 +238,9 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     } else {
       this.endpoints = ImmutableSet.copyOf(config.endpoints());
     }
+
+    this.metricsExecutor = ThreadPools.newFixedThreadPool("rest-metrics-reporter", 1);
+    this.closeables.addCloseable(metricsExecutor::shutdown);
 
     this.client = clientBuilder.apply(mergedProps);
     this.closeables.addCloseable(this.client);
@@ -651,7 +657,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private MetricsReporter metricsReporter(String metricsEndpoint, RESTClient restClient) {
     if (reportingViaRestEnabled && endpoints.contains(Endpoint.V1_REPORT_METRICS)) {
       RESTMetricsReporter restMetricsReporter =
-          new RESTMetricsReporter(restClient, metricsEndpoint, Map::of);
+          new RESTMetricsReporter(restClient, metricsEndpoint, Map::of, metricsExecutor);
       return MetricsReporters.combine(reporter, restMetricsReporter);
     } else {
       return this.reporter;

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -239,9 +239,6 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       this.endpoints = ImmutableSet.copyOf(config.endpoints());
     }
 
-    this.metricsExecutor = ThreadPools.newFixedThreadPool("rest-metrics-reporter", 1);
-    this.closeables.addCloseable(metricsExecutor::shutdown);
-
     this.client = clientBuilder.apply(mergedProps);
     this.closeables.addCloseable(this.client);
 
@@ -282,6 +279,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
             mergedProps,
             RESTCatalogProperties.METRICS_REPORTING_ENABLED,
             RESTCatalogProperties.METRICS_REPORTING_ENABLED_DEFAULT);
+
+    if (reportingViaRestEnabled) {
+      this.metricsExecutor = ThreadPools.newFixedThreadPool("rest-metrics-reporter", 1);
+      this.closeables.addCloseable(metricsExecutor::shutdown);
+    }
+
     this.namespaceSeparator =
         PropertyUtil.propertyAsString(
             mergedProps,

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -30,6 +30,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -3709,8 +3710,8 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Mockito.verify(adapter, times(2))
         .execute(matches(HTTPMethod.GET, RESOURCE_PATHS.table(TABLE)), any(), any(), any());
 
-    // CommitReport reflects the table state after the commit
-    Mockito.verify(adapter)
+    // CommitReport reflects the table state after the commit (reported asynchronously)
+    Mockito.verify(adapter, timeout(5000))
         .execute(
             matches(
                 HTTPMethod.POST,

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -3749,6 +3749,13 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
     catalog.loadTable(TABLE).newFastAppend().appendFile(fileOnMain).commit();
 
+    // Wait for the async metrics report from the first commit to reach the adapter before
+    // setting up the next stub. Without this, the background metrics thread can call
+    // adapter.execute() while Mockito is in the middle of stubbing, causing
+    // UnfinishedStubbingException.
+    Mockito.verify(adapter, timeout(5000))
+        .execute(matches(HTTPMethod.POST, RESOURCE_PATHS.metrics(TABLE)), any(), any(), any());
+
     DataFile fileOnAnotherBranch =
         DataFiles.builder(SPEC)
             .withPath("/path/commit-test-conflicting.parquet")


### PR DESCRIPTION
Followup of #13507.

## Problem

`RESTMetricsReporter.report()` uses `Tasks.range(1).executeWith(METRICS_EXECUTOR).run()` introduced in #13507. Despite submitting work to a background executor, the **calling thread blocks** inside `Tasks.waitFor()` — a `sleep(10ms)` poll loop — until the HTTP POST completes, making `report()` synchronous from the caller's perspective.

```java
// Tasks.waitFor() — called on the calling thread after submitting to METRICS_EXECUTOR
while (true) {
    if (allDone(futures)) { return; }
    Thread.sleep(10);   // ← calling thread is stuck here until HTTP completes
}
```

Any caller that wraps `report()` in its own thread pool to achieve non-blocking behavior finds all its threads stuck in `waitFor()`. In production we observed **9,351 threads** accumulating at ~2.7 threads/second over several hours.

## Fix

Replace `Tasks.range(1).executeWith(METRICS_EXECUTOR).run()` with a direct `executor.execute(lambda)` so `report()` enqueues the HTTP call and **returns immediately**.

The executor is moved from a static field in `RESTMetricsReporter` into `RESTSessionCatalog` as an instance field, giving each catalog its own single-threaded pool. This is the right granularity: in Spark, each `SparkSession` has its own `CatalogManager` and therefore its own `RESTSessionCatalog` instance, so concurrency is naturally distributed — one background thread per session — with no global state and no tuning config needed.

The executor uses `ThreadPools.newFixedThreadPool` (no JVM shutdown hook) and is registered with `CloseableGroup` before the HTTP client, so it shuts down cleanly before the client closes when the catalog is closed.