### PR TITLE
Spark: Cap RandomData collection size to speed up nested tests

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -52,6 +52,12 @@ public class RandomData {
   // Default percentage of number of values that are null for optional fields
   public static final float DEFAULT_NULL_PERCENTAGE = 0.05f;
 
+  // Exclusive upper bound on the number of elements generated for each list/map.
+  // Zero-length collections are in range, so this is a cap and not a minimum.
+  // Applied per nesting level, so deeply-nested schemas multiply quickly; keep
+  // this small enough to avoid combinatorial blow-up in heavily-nested tests.
+  private static final int COLLECTION_SIZE_BOUND = 10;
+
   private RandomData() {}
 
   public static List<Record> generateList(Schema schema, int numRecords, long seed) {
@@ -178,7 +184,7 @@ public class RandomData {
 
     @Override
     public Object list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
 
       List<Object> result = Lists.newArrayListWithExpectedSize(numElements);
       for (int i = 0; i < numElements; i += 1) {
@@ -194,7 +200,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Map<Object, Object> result = Maps.newLinkedHashMap();
       Set<Object> keySet = Sets.newHashSet();
@@ -286,7 +292,7 @@ public class RandomData {
 
     @Override
     public GenericArrayData list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
       Object[] arr = new Object[numElements];
       GenericArrayData result = new GenericArrayData(arr);
 
@@ -303,7 +309,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Object[] keysArr = new Object[numEntries];
       Object[] valuesArr = new Object[numEntries];

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -56,6 +56,12 @@ public class RandomData {
   // Default percentage of number of values that are null for optional fields
   public static final float DEFAULT_NULL_PERCENTAGE = 0.05f;
 
+  // Exclusive upper bound on the number of elements generated for each list/map.
+  // Zero-length collections are in range, so this is a cap and not a minimum.
+  // Applied per nesting level, so deeply-nested schemas multiply quickly; keep
+  // this small enough to avoid combinatorial blow-up in heavily-nested tests.
+  private static final int COLLECTION_SIZE_BOUND = 10;
+
   private RandomData() {}
 
   public static List<Record> generateList(Schema schema, int numRecords, long seed) {
@@ -182,7 +188,7 @@ public class RandomData {
 
     @Override
     public Object list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
 
       List<Object> result = Lists.newArrayListWithExpectedSize(numElements);
       for (int i = 0; i < numElements; i += 1) {
@@ -198,7 +204,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Map<Object, Object> result = Maps.newLinkedHashMap();
       Set<Object> keySet = Sets.newHashSet();
@@ -294,7 +300,7 @@ public class RandomData {
 
     @Override
     public GenericArrayData list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
       Object[] arr = new Object[numElements];
       GenericArrayData result = new GenericArrayData(arr);
 
@@ -311,7 +317,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Object[] keysArr = new Object[numEntries];
       Object[] valuesArr = new Object[numEntries];

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -56,6 +56,12 @@ public class RandomData {
   // Default percentage of number of values that are null for optional fields
   public static final float DEFAULT_NULL_PERCENTAGE = 0.05f;
 
+  // Exclusive upper bound on the number of elements generated for each list/map.
+  // Zero-length collections are in range, so this is a cap and not a minimum.
+  // Applied per nesting level, so deeply-nested schemas multiply quickly; keep
+  // this small enough to avoid combinatorial blow-up in heavily-nested tests.
+  private static final int COLLECTION_SIZE_BOUND = 10;
+
   private RandomData() {}
 
   public static List<Record> generateList(Schema schema, int numRecords, long seed) {
@@ -182,7 +188,7 @@ public class RandomData {
 
     @Override
     public Object list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
 
       List<Object> result = Lists.newArrayListWithExpectedSize(numElements);
       for (int i = 0; i < numElements; i += 1) {
@@ -198,7 +204,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Map<Object, Object> result = Maps.newLinkedHashMap();
       Set<Object> keySet = Sets.newHashSet();
@@ -294,7 +300,7 @@ public class RandomData {
 
     @Override
     public GenericArrayData list(Types.ListType list, Supplier<Object> elementResult) {
-      int numElements = random.nextInt(20);
+      int numElements = random.nextInt(COLLECTION_SIZE_BOUND);
       Object[] arr = new Object[numElements];
       GenericArrayData result = new GenericArrayData(arr);
 
@@ -311,7 +317,7 @@ public class RandomData {
 
     @Override
     public Object map(Types.MapType map, Supplier<Object> keyResult, Supplier<Object> valueResult) {
-      int numEntries = random.nextInt(20);
+      int numEntries = random.nextInt(COLLECTION_SIZE_BOUND);
 
       Object[] keysArr = new Object[numEntries];
       Object[] valuesArr = new Object[numEntries];


### PR DESCRIPTION
## What

`RandomData` (Spark test helper) sized every generated list and map with
`random.nextInt(20)`. Because the bound is applied at *every* nesting level, it
multiplies for deeply-nested schemas. The worst case is
`AvroDataTestBase.testMixedTypes`, which embeds the full ~19-field primitive
struct two-to-three levels deep across five fields — each run generates well
over a million leaf values, so the test cost is dominated by random-data volume
rather than the read/write code paths being exercised.

This replaces the hard-coded `20` with a named constant
`MAX_COLLECTION_SIZE = 10` in the Spark 3.5 / 4.0 / 4.1 test copies.

## Why

`testMixedTypes` is the single most expensive test method in the
`iceberg-spark` core suite, appearing at the top of every format read/write
test class. The collection size has no bearing on coverage — the schemas,
types, and nesting structures under test are identical regardless of how many
elements each collection holds — so this is pure scaffolding overhead.

## Impact

Measured locally (JDK 17, Spark 3.5 core), `testMixedTypes` per class,
single-threaded:

| Class | before | after |
|---|---:|---:|
| TestAvroDataFrameWrite | 24.1s | 7.8s |
| TestParquetDataFrameWrite | 20.0s | 3.6s |
| TestORCDataFrameWrite | 19.9s | 3.4s |
| TestParquetScan | 17.7s | 2.6s |
| TestParquetVectorizedScan | 17.5s | 2.3s |
| TestAvroScan | 17.5s | 2.4s |

Collections still hold up to nine elements, preserving data variety.

## Testing

`./gradlew :iceberg-spark:iceberg-spark-3.5_2.13:test` — **5,084 tests, 0
failures** (identical pass/skip counts to before the change).