### PR TITLE
Data: Handle null values properly in `IN` predicate filtering

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -138,7 +138,8 @@ public class Evaluator implements Serializable {
 
     @Override
     public <T> Boolean in(Bound<T> valueExpr, Set<T> literalSet) {
-      return literalSet.contains(valueExpr.eval(struct));
+      T value = valueExpr.eval(struct);
+      return value != null && literalSet.contains(value);
     }
 
     @Override

--- a/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestLocalScan.java
@@ -276,6 +276,48 @@ public class TestLocalScan {
   }
 
   @TestTemplate
+  public void testFilterByInPredicate() throws IOException {
+    File location = new File(tempDir, "junit" + System.nanoTime());
+
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.DEFAULT_FILE_FORMAT, format.name()),
+            location.toString());
+
+    AppendFiles append = table.newAppend();
+    Path path = new Path(location.toString(), format.addExtension("file-1"));
+    List<Record> records = Lists.newArrayList();
+    records.add(genericRecord.copy(ImmutableMap.of("id", 1L, "data", "v1")));
+    records.add(genericRecord.copy(ImmutableMap.of("id", 2L, "data", "v3")));
+    Record record = genericRecord.copy();
+    record.setField("id", 3L);
+    record.setField("data", null);
+    records.add(record);
+
+    writeFile(location.toString(), format.addExtension("file-1"), records);
+    DataFile file =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withRecordCount(records.size())
+            .withInputFile(HadoopInputFile.fromPath(path, CONF))
+            .build();
+    append.appendFile(file);
+    append.commit();
+
+    List<Record> filterResults =
+        Lists.newArrayList(
+            IcebergGenerics.read(table).where(Expressions.in("data", "v3", "v5")).build());
+
+    List<Record> expected =
+        ImmutableList.of(genericRecord.copy(ImmutableMap.of("id", 2L, "data", "v3")));
+    assertThat(filterResults)
+        .as("Should produce correct number of records")
+        .hasSameSizeAs(expected);
+    assertThat(filterResults).as("Filtered record set should match").isEqualTo(expected);
+  }
+
+  @TestTemplate
   public void testFullScan() {
     Iterable<Record> results = IcebergGenerics.read(sharedTable).build();
 


### PR DESCRIPTION
When scanning table records via `IcebergGenerics.read(table)` and specifying filter conditions with `where(filter)`, if the filter contains an `IN` predicate and the corresponding target column contains null values, the query may fail directly with the following error:

```
java.lang.NullPointerException: Invalid object: null
```

The root cause is: when `FilterIterator.advance()` is called, it invokes the `shouldKeep(item)` closure method of `CloseableIterable` to determine whether to keep the read item, during which the `in(...)` method of `EvalVisitor` is executed for evaluation. In the original logic, it directly checks that the corresponding target column value is not null, and throws immediately if it is null.

However, in many scenarios (such as the one constructed in the newly added test case), when a data file contains both possible valid values and null values in the target column, the records that contain null values will be read and passed to this method for evaluation, at which point an error will be thrown directly.

This PR fixes the issue by properly handling null values.