### PR TITLE
Spark: Fix first row ID carry over for manifest rewrite

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -52,6 +52,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   private final int sortOrderIdPosition;
   private final int fileSpecIdPosition;
   private final int equalityIdsPosition;
+  private final int firstRowIdPosition;
   private final int referencedDataFilePosition;
   private final int contentOffsetPosition;
   private final int contentSizePosition;
@@ -104,6 +105,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     this.sortOrderIdPosition = positions.get(DataFile.SORT_ORDER_ID.name());
     this.fileSpecIdPosition = positions.get(DataFile.SPEC_ID.name());
     this.equalityIdsPosition = positions.get(DataFile.EQUALITY_IDS.name());
+    this.firstRowIdPosition = positions.get(DataFile.FIRST_ROW_ID.name());
     this.referencedDataFilePosition = positions.get(DataFile.REFERENCED_DATA_FILE.name());
     this.contentOffsetPosition = positions.get(DataFile.CONTENT_OFFSET.name());
     this.contentSizePosition = positions.get(DataFile.CONTENT_SIZE.name());
@@ -254,6 +256,15 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
       return null;
     }
     return wrapped.getLong(contentSizePosition);
+  }
+
+  @Override
+  public Long firstRowId() {
+    if (wrapped.isNullAt(firstRowIdPosition)) {
+      return null;
+    }
+
+    return wrapped.getLong(firstRowIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -201,9 +202,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
@@ -211,15 +215,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -229,14 +228,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -246,9 +238,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
@@ -256,15 +251,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -274,14 +264,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -291,9 +274,9 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, "2");
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA, spec, ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"), tableLocation);
 
     ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
     ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
@@ -316,17 +299,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter)
-        .extracting(r -> r.<Long>getAs("_row_id"))
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
         .doesNotContainNull()
         .doesNotHaveDuplicates();
     assertThat(rowsAfter)
@@ -1274,6 +1250,17 @@ public class TestRewriteManifestsAction extends TestBase {
         .load(tableLocation)
         .as(Encoders.bean(ThreeColumnRecord.class))
         .sort("c1", "c2", "c3")
+        .collectAsList();
+  }
+
+  private List<Row> recordsWithLineage() {
+    return spark
+        .read()
+        .format("iceberg")
+        .load(tableLocation)
+        .selectExpr(
+            MetadataColumns.ROW_ID.name(), MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(), "*")
+        .orderBy(MetadataColumns.ROW_ID.name())
         .collectAsList();
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -197,6 +197,144 @@ public class TestRewriteManifestsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testRewriteV3ManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteV3PartitionedManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsAfterV2ToV3Upgrade() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
+    ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
+    writeRecords(Lists.newArrayList(record1));
+    writeRecords(Lists.newArrayList(record2));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    table
+        .updateProperties()
+        .set(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion))
+        .commit();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter)
+        .extracting(r -> r.<Long>getAs("_row_id"))
+        .doesNotContainNull()
+        .doesNotHaveDuplicates();
+    assertThat(rowsAfter)
+        .extracting(r -> new ThreeColumnRecord(r.getAs("c1"), r.getAs("c2"), r.getAs("c3")))
+        .containsExactlyInAnyOrder(record1, record2);
+  }
+
+  @TestTemplate
   public void testRewriteManifestsEmptyTable() throws IOException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -52,6 +52,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   private final int sortOrderIdPosition;
   private final int fileSpecIdPosition;
   private final int equalityIdsPosition;
+  private final int firstRowIdPosition;
   private final int referencedDataFilePosition;
   private final int contentOffsetPosition;
   private final int contentSizePosition;
@@ -104,6 +105,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     this.sortOrderIdPosition = positions.get(DataFile.SORT_ORDER_ID.name());
     this.fileSpecIdPosition = positions.get(DataFile.SPEC_ID.name());
     this.equalityIdsPosition = positions.get(DataFile.EQUALITY_IDS.name());
+    this.firstRowIdPosition = positions.get(DataFile.FIRST_ROW_ID.name());
     this.referencedDataFilePosition = positions.get(DataFile.REFERENCED_DATA_FILE.name());
     this.contentOffsetPosition = positions.get(DataFile.CONTENT_OFFSET.name());
     this.contentSizePosition = positions.get(DataFile.CONTENT_SIZE.name());
@@ -254,6 +256,15 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
       return null;
     }
     return wrapped.getLong(contentSizePosition);
+  }
+
+  @Override
+  public Long firstRowId() {
+    if (wrapped.isNullAt(firstRowIdPosition)) {
+      return null;
+    }
+
+    return wrapped.getLong(firstRowIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -201,9 +202,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
@@ -211,15 +215,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -229,14 +228,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -246,9 +238,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
@@ -256,15 +251,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -274,14 +264,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -291,9 +274,9 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, "2");
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA, spec, ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"), tableLocation);
 
     ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
     ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
@@ -316,17 +299,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter)
-        .extracting(r -> r.<Long>getAs("_row_id"))
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
         .doesNotContainNull()
         .doesNotHaveDuplicates();
     assertThat(rowsAfter)
@@ -1274,6 +1250,17 @@ public class TestRewriteManifestsAction extends TestBase {
         .load(tableLocation)
         .as(Encoders.bean(ThreeColumnRecord.class))
         .sort("c1", "c2", "c3")
+        .collectAsList();
+  }
+
+  private List<Row> recordsWithLineage() {
+    return spark
+        .read()
+        .format("iceberg")
+        .load(tableLocation)
+        .selectExpr(
+            MetadataColumns.ROW_ID.name(), MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(), "*")
+        .orderBy(MetadataColumns.ROW_ID.name())
         .collectAsList();
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -197,6 +197,144 @@ public class TestRewriteManifestsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testRewriteV3ManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteV3PartitionedManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsAfterV2ToV3Upgrade() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
+    ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
+    writeRecords(Lists.newArrayList(record1));
+    writeRecords(Lists.newArrayList(record2));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    table
+        .updateProperties()
+        .set(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion))
+        .commit();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter)
+        .extracting(r -> r.<Long>getAs("_row_id"))
+        .doesNotContainNull()
+        .doesNotHaveDuplicates();
+    assertThat(rowsAfter)
+        .extracting(r -> new ThreeColumnRecord(r.getAs("c1"), r.getAs("c2"), r.getAs("c3")))
+        .containsExactlyInAnyOrder(record1, record2);
+  }
+
+  @TestTemplate
   public void testRewriteManifestsEmptyTable() throws IOException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -52,10 +52,10 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   private final int sortOrderIdPosition;
   private final int fileSpecIdPosition;
   private final int equalityIdsPosition;
+  private final int firstRowIdPosition;
   private final int referencedDataFilePosition;
   private final int contentOffsetPosition;
   private final int contentSizePosition;
-  private final int firstRowIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -105,10 +105,10 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     this.sortOrderIdPosition = positions.get(DataFile.SORT_ORDER_ID.name());
     this.fileSpecIdPosition = positions.get(DataFile.SPEC_ID.name());
     this.equalityIdsPosition = positions.get(DataFile.EQUALITY_IDS.name());
+    this.firstRowIdPosition = positions.get(DataFile.FIRST_ROW_ID.name());
     this.referencedDataFilePosition = positions.get(DataFile.REFERENCED_DATA_FILE.name());
     this.contentOffsetPosition = positions.get(DataFile.CONTENT_OFFSET.name());
     this.contentSizePosition = positions.get(DataFile.CONTENT_SIZE.name());
-    this.firstRowIdPosition = positions.get(DataFile.FIRST_ROW_ID.name());
   }
 
   public F wrap(Row row) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkContentFile.java
@@ -55,6 +55,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
   private final int referencedDataFilePosition;
   private final int contentOffsetPosition;
   private final int contentSizePosition;
+  private final int firstRowIdPosition;
   private final Type lowerBoundsType;
   private final Type upperBoundsType;
   private final Type keyMetadataType;
@@ -107,6 +108,7 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
     this.referencedDataFilePosition = positions.get(DataFile.REFERENCED_DATA_FILE.name());
     this.contentOffsetPosition = positions.get(DataFile.CONTENT_OFFSET.name());
     this.contentSizePosition = positions.get(DataFile.CONTENT_SIZE.name());
+    this.firstRowIdPosition = positions.get(DataFile.FIRST_ROW_ID.name());
   }
 
   public F wrap(Row row) {
@@ -254,6 +256,15 @@ public abstract class SparkContentFile<F> implements ContentFile<F> {
       return null;
     }
     return wrapped.getLong(contentSizePosition);
+  }
+
+  @Override
+  public Long firstRowId() {
+    if (wrapped.isNullAt(firstRowIdPosition)) {
+      return null;
+    }
+
+    return wrapped.getLong(firstRowIdPosition);
   }
 
   private int fieldPosition(String name, StructType sparkType) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.ManifestContent;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -201,9 +202,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
@@ -211,15 +215,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -229,14 +228,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -246,9 +238,12 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
@@ -256,15 +251,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
 
-    List<Row> rowsBefore =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
-    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
+    List<Row> rowsBefore = recordsWithLineage();
+    assertThat(rowsBefore)
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
+        .doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -274,14 +264,7 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
   }
@@ -291,9 +274,9 @@ public class TestRewriteManifestsAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
     PartitionSpec spec = PartitionSpec.unpartitioned();
-    Map<String, String> options = Maps.newHashMap();
-    options.put(TableProperties.FORMAT_VERSION, "2");
-    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+    Table table =
+        TABLES.create(
+            SCHEMA, spec, ImmutableMap.of(TableProperties.FORMAT_VERSION, "2"), tableLocation);
 
     ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
     ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
@@ -316,17 +299,10 @@ public class TestRewriteManifestsAction extends TestBase {
 
     assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
 
-    List<Row> rowsAfter =
-        spark
-            .read()
-            .format("iceberg")
-            .load(tableLocation)
-            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
-            .orderBy("_row_id")
-            .collectAsList();
+    List<Row> rowsAfter = recordsWithLineage();
 
     assertThat(rowsAfter)
-        .extracting(r -> r.<Long>getAs("_row_id"))
+        .extracting(r -> r.<Long>getAs(MetadataColumns.ROW_ID.name()))
         .doesNotContainNull()
         .doesNotHaveDuplicates();
     assertThat(rowsAfter)
@@ -1274,6 +1250,17 @@ public class TestRewriteManifestsAction extends TestBase {
         .load(tableLocation)
         .as(Encoders.bean(ThreeColumnRecord.class))
         .sort("c1", "c2", "c3")
+        .collectAsList();
+  }
+
+  private List<Row> recordsWithLineage() {
+    return spark
+        .read()
+        .format("iceberg")
+        .load(tableLocation)
+        .selectExpr(
+            MetadataColumns.ROW_ID.name(), MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(), "*")
+        .orderBy(MetadataColumns.ROW_ID.name())
         .collectAsList();
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -197,6 +197,145 @@ public class TestRewriteManifestsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testRewriteV3ManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "CCCC", "CCCC")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteV3PartitionedManifestsPreservesFirstRowId() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
+    writeRecords(Lists.newArrayList(new ThreeColumnRecord(2, "BBBB", "BBBB")));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    List<Row> rowsBefore =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter).containsExactlyElementsOf(rowsBefore);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsAfterV2ToV3Upgrade() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    Map<String, String> options = Maps.newHashMap();
+    options.put(TableProperties.FORMAT_VERSION, "2");
+    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
+    Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
+
+    ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");
+    ThreeColumnRecord record2 = new ThreeColumnRecord(2, "CCCC", "CCCC");
+    writeRecords(Lists.newArrayList(record1));
+    writeRecords(Lists.newArrayList(record2));
+    table.refresh();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    table
+        .updateProperties()
+        .set(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion))
+        .commit();
+
+    SparkActions.get()
+        .rewriteManifests(table)
+        .rewriteIf(manifest -> true)
+        .option(RewriteManifestsSparkAction.USE_CACHING, useCaching)
+        .execute();
+
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(1);
+
+    List<Row> rowsAfter =
+        spark
+            .read()
+            .format("iceberg")
+            .load(tableLocation)
+            .selectExpr("_row_id", "_last_updated_sequence_number", "*")
+            .orderBy("_row_id")
+            .collectAsList();
+
+    assertThat(rowsAfter)
+        .extracting(r -> r.<Long>getAs("_row_id"))
+        .doesNotContainNull()
+        .doesNotHaveDuplicates();
+    assertThat(rowsAfter)
+        .extracting(r -> new ThreeColumnRecord(r.getAs("c1"), r.getAs("c2"), r.getAs("c3")))
+        .containsExactlyInAnyOrder(record1, record2);
+  }
+
+  @TestTemplate
   public void testRewriteManifestsEmptyTable() throws IOException {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteManifestsAction.java
@@ -203,7 +203,6 @@ public class TestRewriteManifestsAction extends TestBase {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, null, "AAAA")));
@@ -220,6 +219,7 @@ public class TestRewriteManifestsAction extends TestBase {
             .selectExpr("_row_id", "_last_updated_sequence_number", "*")
             .orderBy("_row_id")
             .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -248,7 +248,6 @@ public class TestRewriteManifestsAction extends TestBase {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").build();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion));
-    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
     writeRecords(Lists.newArrayList(new ThreeColumnRecord(1, "AAAA", "AAAA")));
@@ -265,6 +264,7 @@ public class TestRewriteManifestsAction extends TestBase {
             .selectExpr("_row_id", "_last_updated_sequence_number", "*")
             .orderBy("_row_id")
             .collectAsList();
+    assertThat(rowsBefore).extracting(r -> r.<Long>getAs("_row_id")).doesNotContainNull();
 
     SparkActions.get()
         .rewriteManifests(table)
@@ -293,7 +293,6 @@ public class TestRewriteManifestsAction extends TestBase {
     PartitionSpec spec = PartitionSpec.unpartitioned();
     Map<String, String> options = Maps.newHashMap();
     options.put(TableProperties.FORMAT_VERSION, "2");
-    options.put(TableProperties.SNAPSHOT_ID_INHERITANCE_ENABLED, snapshotIdInheritanceEnabled);
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
 
     ThreeColumnRecord record1 = new ThreeColumnRecord(1, null, "AAAA");


### PR DESCRIPTION
During a manifest rewrite via Spark actions, we do not correctly carry over the first row ID for the entries being moved. This is because the records from the `entries` metadata table that Spark reads are adapted into a SparkContentFile structure. This SparkContentFile structure did not override firstRowId and as a result the adaptation would null out the carried over first row ID. This can lead to new row IDs being assigned via inheritance.