### PR TITLE
Build: Bump datamodel-code-generator from 0.57.0 to 0.59.0

### DIFF
--- a/open-api/requirements.txt
+++ b/open-api/requirements.txt
@@ -16,5 +16,5 @@
 # under the License.
 
 openapi-spec-validator==0.9.0
-datamodel-code-generator==0.57.0
+datamodel-code-generator==0.59.0
 yamllint==1.38.0

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -256,12 +256,20 @@ class SortOrder(BaseModel):
 
 class EncryptedKey(BaseModel):
     key_id: str = Field(..., alias='key-id')
-    encrypted_key_metadata: Base64Str = Field(..., alias='encrypted-key-metadata')
+    encrypted_key_metadata: Base64Str = Field(
+        ...,
+        alias='encrypted-key-metadata',
+        json_schema_extra={'contentEncoding': 'base64'},
+    )
     encrypted_by_id: str | None = Field(None, alias='encrypted-by-id')
     properties: dict[str, str] | None = None
 
 
 class Summary(BaseModel):
+    model_config = ConfigDict(
+        extra='allow',
+    )
+    __pydantic_extra__: dict[str, str]
     operation: Literal['append', 'replace', 'overwrite', 'delete']
 
 


### PR DESCRIPTION
Bumps `datamodel-code-generator` from 0.57.0 to 0.59.0 and regenerates `open-api/rest-catalog-open-api.py` accordingly.

Supersedes #16701, which only bumped the pin without regenerating the Python models, causing the `openapi-spec-validator` job to fail on `git diff --exit-code`.

The regenerated diff reflects two intentional 0.59.0 generator changes:
- `EncryptedKey.encrypted_key_metadata` now emits `json_schema_extra={'contentEncoding': 'base64'}`.
- `Summary` now generates a typed `__pydantic_extra__: dict[str, str]` for its `additionalProperties` (Pydantic v2 now validates extra field values at runtime).

Generated via `make generate` in `open-api/` with the new version, so `git diff --exit-code` passes.

Made with [Cursor](https://cursor.com)