### PR TITLE
API, Spark 4.1: Add ignore_missing_files to snapshot procedure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/SnapshotTable.java
@@ -69,6 +69,18 @@ public interface SnapshotTable extends Action<SnapshotTable, SnapshotTable.Resul
     throw new UnsupportedOperationException("Setting executor service is not supported");
   }
 
+  /**
+   * Enables ignoring {@link java.io.FileNotFoundException} when listing source data files. When
+   * enabled, source data files that have disappeared (for example, because a partition directory
+   * was removed by concurrent cleanup) are skipped with a warning instead of failing the snapshot.
+   * The default is to fail.
+   *
+   * @return this for method chaining
+   */
+  default SnapshotTable ignoreMissingFiles() {
+    throw new UnsupportedOperationException("Ignoring missing files is not supported");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the number of imported data files. */

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -609,6 +609,7 @@ See [`migrate`](#migrate) to replace an existing table with an Iceberg table.
 | `location`    |    | string | Table location for the new table (delegated to the catalog by default) |
 | `properties`  | ️   | map<string, string> | Properties to add to the newly created table |
 | `parallelism` |    | int | Number of threads to use for file reading (defaults to 1) |
+| `ignore_missing_files` |  | boolean | When true, skip source data files that cannot be found instead of failing (defaults to false) |
 
 #### Output
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -23,11 +23,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.util.List;
 import java.util.Map;
 import org.apache.avro.generic.GenericData;
+import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
@@ -424,5 +427,43 @@ public class TestSnapshotTableProcedure extends ExtensionsTestBase {
         "Should have expected rows",
         ImmutableList.of(row(123, 1L), row(456, 2L)),
         sql("SELECT variant_get(data, '$.key', 'int'), id FROM %s ORDER BY id", tableName));
+  }
+
+  @TestTemplate
+  public void testSnapshotMissingFilesFailByDefault() throws IOException {
+    createPartitionedSourceWithMissingFiles();
+
+    assertThatThrownBy(
+            () -> sql("CALL %s.system.snapshot('%s', '%s')", catalogName, SOURCE_NAME, tableName))
+        .as("Snapshot should fail by default when source files are missing")
+        .hasRootCauseInstanceOf(FileNotFoundException.class);
+  }
+
+  @TestTemplate
+  public void testSnapshotIgnoreMissingFiles() throws IOException {
+    createPartitionedSourceWithMissingFiles();
+
+    Object result =
+        scalarSql(
+            "CALL %s.system.snapshot(source_table => '%s', table => '%s', ignore_missing_files => true)",
+            catalogName, SOURCE_NAME, tableName);
+    assertThat(result).as("Should have imported only the surviving partition").isEqualTo(1L);
+
+    assertEquals(
+        "Snapshot table should only contain rows from the surviving partition",
+        ImmutableList.of(row("b", 2L)),
+        sql("SELECT * FROM %s", tableName));
+  }
+
+  private void createPartitionedSourceWithMissingFiles() throws IOException {
+    String location = Files.createTempDirectory(temp, "junit").toFile().toString();
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING parquet PARTITIONED BY (id) LOCATION '%s'",
+        SOURCE_NAME, location);
+    sql("INSERT INTO TABLE %s (id, data) VALUES (1, 'a'), (2, 'b')", SOURCE_NAME);
+
+    // Remove one partition's directory while leaving the catalog entry intact to simulate a
+    // concurrent deletion racing with the snapshot.
+    FileUtils.deleteDirectory(new File(location, "id=1"));
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/SnapshotTableSparkAction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.actions;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import org.apache.iceberg.Snapshot;
@@ -56,6 +57,7 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
   private Identifier destTableIdent;
   private String destTableLocation = null;
   private ExecutorService executorService;
+  private boolean ignoreMissingFiles = false;
 
   SnapshotTableSparkAction(
       SparkSession spark, CatalogPlugin sourceCatalog, Identifier sourceTableIdent) {
@@ -107,6 +109,12 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
   }
 
   @Override
+  public SnapshotTableSparkAction ignoreMissingFiles() {
+    this.ignoreMissingFiles = true;
+    return this;
+  }
+
+  @Override
   public SnapshotTable.Result execute() {
     String desc = String.format("Snapshotting table %s as %s", sourceTableIdent(), destTableIdent);
     JobGroupInfo info = newJobGroupInfo("SNAPSHOT-TABLE", desc);
@@ -144,7 +152,14 @@ public class SnapshotTableSparkAction extends BaseTableCreationSparkAction<Snaps
       String stagingLocation = getMetadataLocation(icebergTable);
       LOG.info("Generating Iceberg metadata for {} in {}", destTableIdent(), stagingLocation);
       SparkTableUtil.importSparkTable(
-          spark(), v1TableIdent, icebergTable, stagingLocation, executorService);
+          spark(),
+          v1TableIdent,
+          icebergTable,
+          stagingLocation,
+          Collections.emptyMap(),
+          false,
+          ignoreMissingFiles,
+          executorService);
 
       LOG.info("Committing staged changes to {}", destTableIdent());
       stagedTable.commitStagedChanges();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/SnapshotTableProcedure.java
@@ -49,10 +49,17 @@ class SnapshotTableProcedure extends BaseProcedure {
       optionalInParameter("properties", STRING_MAP);
   private static final ProcedureParameter PARALLELISM_PARAM =
       optionalInParameter("parallelism", DataTypes.IntegerType);
+  private static final ProcedureParameter IGNORE_MISSING_FILES_PARAM =
+      optionalInParameter("ignore_missing_files", DataTypes.BooleanType);
 
   private static final ProcedureParameter[] PARAMETERS =
       new ProcedureParameter[] {
-        SOURCE_TABLE_PARAM, TABLE_PARAM, LOCATION_PARAM, PROPERTIES_PARAM, PARALLELISM_PARAM
+        SOURCE_TABLE_PARAM,
+        TABLE_PARAM,
+        LOCATION_PARAM,
+        PROPERTIES_PARAM,
+        PARALLELISM_PARAM,
+        IGNORE_MISSING_FILES_PARAM
       };
 
   private static final StructType OUTPUT_TYPE =
@@ -114,6 +121,11 @@ class SnapshotTableProcedure extends BaseProcedure {
       int parallelism = input.asInt(PARALLELISM_PARAM);
       Preconditions.checkArgument(parallelism > 0, "Parallelism should be larger than 0");
       action = action.executeWith(SparkTableUtil.migrationService(parallelism));
+    }
+
+    boolean ignoreMissingFiles = input.asBoolean(IGNORE_MISSING_FILES_PARAM, false);
+    if (ignoreMissingFiles) {
+      action = action.ignoreMissingFiles();
     }
 
     SnapshotTable.Result result = action.tableProperties(properties).execute();


### PR DESCRIPTION
Adds an `ignore_missing_files` option to the `snapshot` procedure, mirroring
  the same option on `migrate` (#16643). When enabled, source data files that
  have disappeared (for example, removed by concurrent cleanup) are skipped with
  a warning instead of failing the snapshot. The default behavior is unchanged.