### PR TITLE
Spark 4.1: Support SQL DDL for column default values

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -201,6 +201,16 @@ public class Spark3Util {
       } else if (change instanceof TableChange.UpdateColumnPosition) {
         apply(pendingUpdate, (TableChange.UpdateColumnPosition) change);
 
+      } else if (change instanceof TableChange.UpdateColumnDefaultValue) {
+        TableChange.UpdateColumnDefaultValue update = (TableChange.UpdateColumnDefaultValue) change;
+        String columnName = DOT.join(update.fieldNames());
+        Types.NestedField field = pendingUpdate.apply().findField(columnName);
+        Preconditions.checkArgument(field != null, "Cannot update missing column: %s", columnName);
+        org.apache.iceberg.expressions.Literal<?> defaultValue =
+            SparkDefaultValues.toIcebergLiteral(
+                columnName, field.type(), update.newCurrentDefault());
+        pendingUpdate.updateColumnDefault(columnName, defaultValue);
+
       } else {
         throw new UnsupportedOperationException("Cannot apply unknown table change: " + change);
       }
@@ -230,16 +240,16 @@ public class Spark3Util {
         add.isNullable(),
         "Incompatible change: cannot add required column: %s",
         leafName(add.fieldNames()));
-    if (add.defaultValue() != null) {
-      throw new UnsupportedOperationException(
-          String.format(
-              "Cannot add column %s since setting default values in Spark is currently unsupported",
-              leafName(add.fieldNames())));
-    }
 
     Type type = SparkSchemaUtil.convert(add.dataType());
+    org.apache.iceberg.expressions.Literal<?> defaultValue =
+        SparkDefaultValues.toIcebergLiteral(DOT.join(add.fieldNames()), type, add.defaultValue());
     pendingUpdate.addColumn(
-        parentName(add.fieldNames()), leafName(add.fieldNames()), type, add.comment());
+        parentName(add.fieldNames()),
+        leafName(add.fieldNames()),
+        type,
+        add.comment(),
+        defaultValue);
 
     if (add.position() instanceof TableChange.After) {
       TableChange.After after = (TableChange.After) add.position();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -70,11 +70,13 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
 import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableCatalogCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnChange;
 import org.apache.spark.sql.connector.catalog.TableChange.RemoveProperty;
@@ -117,6 +119,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  */
 public class SparkCatalog extends BaseCatalog {
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
+  private static final Set<TableCatalogCapability> CAPABILITIES =
+      ImmutableSet.of(TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
   private static final Pattern AT_TIMESTAMP = Pattern.compile("at_timestamp_(\\d+)");
@@ -186,6 +190,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws TableAlreadyExistsException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return createTable(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public Table createTable(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws TableAlreadyExistsException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return createTable(ident, icebergSchema, transforms, properties);
+  }
+
+  private Table createTable(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws TableAlreadyExistsException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       org.apache.iceberg.Table icebergTable =
@@ -205,6 +226,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws TableAlreadyExistsException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageCreate(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageCreate(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws TableAlreadyExistsException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageCreate(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageCreate(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws TableAlreadyExistsException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction =
@@ -224,6 +262,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws NoSuchTableException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageReplace(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws NoSuchTableException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageReplace(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws NoSuchTableException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction =
@@ -242,6 +297,21 @@ public class SparkCatalog extends BaseCatalog {
   public StagedTable stageCreateOrReplace(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties) {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageCreateOrReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageCreateOrReplace(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties) {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageCreateOrReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageCreateOrReplace(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties) {
     Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
     Transaction transaction =
         builder
@@ -741,6 +811,11 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public String name() {
     return catalogName;
+  }
+
+  @Override
+  public Set<TableCatalogCapability> capabilities() {
+    return CAPABILITIES;
   }
 
   private static void commitChanges(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -71,11 +71,13 @@ import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchViewException;
 import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
 import org.apache.spark.sql.connector.catalog.StagedTable;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableCatalogCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnChange;
 import org.apache.spark.sql.connector.catalog.TableChange.RemoveProperty;
@@ -123,6 +125,8 @@ public class SparkCatalog extends BaseCatalog {
 
   private static final Logger LOG = LoggerFactory.getLogger(SparkCatalog.class);
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
+  private static final Set<TableCatalogCapability> CAPABILITIES =
+      ImmutableSet.of(TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
   private static final Pattern AT_TIMESTAMP = Pattern.compile("at_timestamp_(\\d+)");
@@ -194,6 +198,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws TableAlreadyExistsException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return createTable(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public Table createTable(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws TableAlreadyExistsException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return createTable(ident, icebergSchema, transforms, properties);
+  }
+
+  private Table createTable(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws TableAlreadyExistsException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       org.apache.iceberg.Table icebergTable =
@@ -213,6 +234,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws TableAlreadyExistsException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageCreate(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageCreate(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws TableAlreadyExistsException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageCreate(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageCreate(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws TableAlreadyExistsException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction =
@@ -232,6 +270,23 @@ public class SparkCatalog extends BaseCatalog {
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties)
       throws NoSuchTableException {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageReplace(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties)
+      throws NoSuchTableException {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageReplace(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties)
+      throws NoSuchTableException {
     try {
       Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
       Transaction transaction =
@@ -250,6 +305,21 @@ public class SparkCatalog extends BaseCatalog {
   public StagedTable stageCreateOrReplace(
       Identifier ident, StructType schema, Transform[] transforms, Map<String, String> properties) {
     Schema icebergSchema = SparkSchemaUtil.convert(schema);
+    return stageCreateOrReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  @Override
+  public StagedTable stageCreateOrReplace(
+      Identifier ident, Column[] columns, Transform[] transforms, Map<String, String> properties) {
+    Schema icebergSchema = SparkSchemaUtil.convert(columns);
+    return stageCreateOrReplace(ident, icebergSchema, transforms, properties);
+  }
+
+  private StagedTable stageCreateOrReplace(
+      Identifier ident,
+      Schema icebergSchema,
+      Transform[] transforms,
+      Map<String, String> properties) {
     Catalog.TableBuilder builder = newBuilder(ident, icebergSchema);
     Transaction transaction =
         builder
@@ -797,6 +867,11 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public String name() {
     return catalogName;
+  }
+
+  @Override
+  public Set<TableCatalogCapability> capabilities() {
+    return CAPABILITIES;
   }
 
   private static void commitChanges(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkDefaultValues.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkDefaultValues.java
@@ -69,6 +69,12 @@ class SparkDefaultValues {
         columnName,
         type,
         defaultSql);
+    Preconditions.checkArgument(
+        type.typeId() != Type.TypeID.TIME,
+        "Column default for %s with type %s is not supported by Iceberg Spark DDL: %s",
+        columnName,
+        type,
+        defaultSql);
 
     Literal<?> literal = createLiteral(type, sparkValue).to(type);
     Preconditions.checkArgument(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkDefaultValues.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkDefaultValues.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.spark.sql.connector.catalog.ColumnDefaultValue;
+import org.apache.spark.sql.connector.catalog.DefaultValue;
+import org.apache.spark.sql.connector.expressions.Expression;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.types.UTF8String;
+
+class SparkDefaultValues {
+
+  private SparkDefaultValues() {}
+
+  static Literal<?> toIcebergLiteral(String columnName, Type type, DefaultValue defaultValue) {
+    if (defaultValue == null) {
+      return null;
+    }
+
+    Expression expression = defaultValue.getExpression();
+    if (expression instanceof org.apache.spark.sql.connector.expressions.Literal) {
+      org.apache.spark.sql.connector.expressions.Literal<?> literal =
+          (org.apache.spark.sql.connector.expressions.Literal<?>) expression;
+      return toIcebergLiteral(columnName, type, literal.value(), defaultValue.getSql());
+    } else if (defaultValue instanceof ColumnDefaultValue) {
+      ColumnDefaultValue columnDefault = (ColumnDefaultValue) defaultValue;
+      org.apache.spark.sql.connector.expressions.Literal<?> literal = columnDefault.getValue();
+      if (literal != null) {
+        return toIcebergLiteral(columnName, type, literal.value(), defaultValue.getSql());
+      }
+    }
+
+    throw new UnsupportedOperationException(
+        String.format(
+            "Column default for %s must be a literal value: %s",
+            columnName, defaultValue.getSql()));
+  }
+
+  private static Literal<?> toIcebergLiteral(
+      String columnName, Type type, Object sparkValue, String defaultSql) {
+    if (sparkValue == null) {
+      return null;
+    }
+
+    Preconditions.checkArgument(
+        type.isPrimitiveType() && type.typeId() != Type.TypeID.UNKNOWN,
+        "Column default for %s with type %s is not supported by Iceberg Spark DDL: %s",
+        columnName,
+        type,
+        defaultSql);
+
+    Literal<?> literal = createLiteral(type, sparkValue).to(type);
+    Preconditions.checkArgument(
+        literal != null,
+        "Column default for %s cannot be converted to Iceberg type %s: %s",
+        columnName,
+        type,
+        defaultSql);
+    return literal;
+  }
+
+  private static Literal<?> createLiteral(Type type, Object sparkValue) {
+    if (sparkValue instanceof UTF8String) {
+      return Literal.of(sparkValue.toString());
+    }
+    if (sparkValue instanceof Decimal) {
+      return Literal.of(((Decimal) sparkValue).toJavaBigDecimal());
+    }
+    if (sparkValue instanceof byte[]) {
+      return Literal.of(ByteBuffer.wrap((byte[]) sparkValue));
+    }
+
+    switch (type.typeId()) {
+      case DATE:
+        if (sparkValue instanceof Number) {
+          return Literal.of(((Number) sparkValue).intValue());
+        }
+        break;
+      case TIME:
+      case TIMESTAMP:
+        if (sparkValue instanceof Number) {
+          return Literal.of(((Number) sparkValue).longValue());
+        }
+        break;
+      default:
+    }
+
+    Object value = SparkValueConverter.convert(type, sparkValue);
+
+    switch (type.typeId()) {
+      case BOOLEAN:
+        return Literal.of((Boolean) value);
+      case INTEGER:
+      case DATE:
+        return Literal.of(((Number) value).intValue());
+      case LONG:
+      case TIME:
+      case TIMESTAMP:
+        return Literal.of(((Number) value).longValue());
+      case FLOAT:
+        return Literal.of(((Number) value).floatValue());
+      case DOUBLE:
+        return Literal.of(((Number) value).doubleValue());
+      case DECIMAL:
+        return Literal.of((BigDecimal) value);
+      case STRING:
+        return Literal.of((CharSequence) value);
+      case BINARY:
+      case FIXED:
+        if (value instanceof byte[]) {
+          return Literal.of(ByteBuffer.wrap((byte[]) value));
+        }
+        return Literal.of((ByteBuffer) value);
+      default:
+        throw new UnsupportedOperationException(
+            "Unsupported type for column default literal: " + type);
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -42,6 +43,7 @@ import org.apache.spark.sql.AnalysisException;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalog.Column;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 
@@ -126,6 +128,40 @@ public class SparkSchemaUtil {
   public static Schema convert(StructType sparkType) {
     Type converted = SparkTypeVisitor.visit(sparkType, new SparkTypeToType(sparkType));
     return new Schema(converted.asNestedType().asStructType().fields());
+  }
+
+  public static Schema convert(org.apache.spark.sql.connector.catalog.Column[] columns) {
+    StructField[] fields = new StructField[columns.length];
+    for (int index = 0; index < columns.length; index += 1) {
+      org.apache.spark.sql.connector.catalog.Column column = columns[index];
+      StructField field =
+          StructField.apply(column.name(), column.dataType(), column.nullable(), Metadata.empty());
+      if (column.comment() != null) {
+        field = field.withComment(column.comment());
+      }
+
+      fields[index] = field;
+    }
+
+    Schema schema = convert(new StructType(fields));
+    List<Types.NestedField> newFields = Lists.newArrayListWithExpectedSize(columns.length);
+    for (int index = 0; index < columns.length; index += 1) {
+      org.apache.spark.sql.connector.catalog.Column column = columns[index];
+      Types.NestedField field = schema.columns().get(index);
+      Literal<?> defaultValue =
+          SparkDefaultValues.toIcebergLiteral(column.name(), field.type(), column.defaultValue());
+      if (defaultValue != null) {
+        field =
+            Types.NestedField.from(field)
+                .withInitialDefault(defaultValue)
+                .withWriteDefault(defaultValue)
+                .build();
+      }
+
+      newFields.add(field);
+    }
+
+    return new Schema(newFields);
   }
 
   /**

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -19,12 +19,14 @@
 package org.apache.iceberg.spark;
 
 import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.analysis.NamespaceAlreadyExistsException;
@@ -37,6 +39,7 @@ import org.apache.spark.sql.catalyst.analysis.TableAlreadyExistsException;
 import org.apache.spark.sql.catalyst.analysis.ViewAlreadyExistsException;
 import org.apache.spark.sql.connector.catalog.CatalogExtension;
 import org.apache.spark.sql.connector.catalog.CatalogPlugin;
+import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.FunctionCatalog;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.NamespaceChange;
@@ -45,6 +48,7 @@ import org.apache.spark.sql.connector.catalog.StagingTableCatalog;
 import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
 import org.apache.spark.sql.connector.catalog.Table;
 import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableCatalogCapability;
 import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.View;
 import org.apache.spark.sql.connector.catalog.ViewCatalog;
@@ -65,6 +69,8 @@ public class SparkSessionCatalog<
         T extends TableCatalog & FunctionCatalog & SupportsNamespaces & ViewCatalog>
     extends BaseCatalog implements CatalogExtension {
   private static final String[] DEFAULT_NAMESPACE = new String[] {"default"};
+  private static final Set<TableCatalogCapability> CAPABILITIES =
+      ImmutableSet.of(TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE);
 
   private String catalogName = null;
   private TableCatalog icebergCatalog = null;
@@ -94,6 +100,18 @@ public class SparkSessionCatalog<
   @Override
   public String[] defaultNamespace() {
     return DEFAULT_NAMESPACE;
+  }
+
+  @Override
+  public Set<TableCatalogCapability> capabilities() {
+    if (sessionCatalog == null) {
+      return CAPABILITIES;
+    }
+
+    return ImmutableSet.<TableCatalogCapability>builder()
+        .addAll(sessionCatalog.capabilities())
+        .add(TableCatalogCapability.SUPPORT_COLUMN_DEFAULT_VALUE)
+        .build();
   }
 
   @Override
@@ -195,6 +213,19 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public Table createTable(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    String provider = properties.get("provider");
+    if (useIceberg(provider)) {
+      return icebergCatalog.createTable(ident, columns, partitions, properties);
+    } else {
+      // delegate to the session catalog
+      return getSessionCatalog().createTable(ident, columns, partitions, properties);
+    }
+  }
+
+  @Override
   public StagedTable stageCreate(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws TableAlreadyExistsException, NoSuchNamespaceException {
@@ -212,6 +243,27 @@ public class SparkSessionCatalog<
     // create the table with the session catalog, then wrap it in a staged table that will delete to
     // roll back
     Table table = catalog.createTable(ident, schema, partitions, properties);
+    return new RollbackStagedTable(catalog, ident, table);
+  }
+
+  @Override
+  public StagedTable stageCreate(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws TableAlreadyExistsException, NoSuchNamespaceException {
+    String provider = properties.get("provider");
+    TableCatalog catalog;
+    if (useIceberg(provider)) {
+      if (asStagingCatalog != null) {
+        return asStagingCatalog.stageCreate(ident, columns, partitions, properties);
+      }
+      catalog = icebergCatalog;
+    } else {
+      catalog = getSessionCatalog();
+    }
+
+    // create the table with the session catalog, then wrap it in a staged table that will delete to
+    // roll back
+    Table table = catalog.createTable(ident, columns, partitions, properties);
     return new RollbackStagedTable(catalog, ident, table);
   }
 
@@ -248,6 +300,38 @@ public class SparkSessionCatalog<
   }
 
   @Override
+  public StagedTable stageReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException, NoSuchTableException {
+    String provider = properties.get("provider");
+    TableCatalog catalog;
+    if (useIceberg(provider)) {
+      if (asStagingCatalog != null) {
+        return asStagingCatalog.stageReplace(ident, columns, partitions, properties);
+      }
+      catalog = icebergCatalog;
+    } else {
+      catalog = getSessionCatalog();
+    }
+
+    // attempt to drop the table and fail if it doesn't exist
+    if (!catalog.dropTable(ident)) {
+      throw new NoSuchTableException(ident);
+    }
+
+    try {
+      // create the table with the session catalog, then wrap it in a staged table that will delete
+      // to roll back
+      Table table = catalog.createTable(ident, columns, partitions, properties);
+      return new RollbackStagedTable(catalog, ident, table);
+
+    } catch (TableAlreadyExistsException e) {
+      // the table was deleted, but now already exists again. retry the replace.
+      return stageReplace(ident, columns, partitions, properties);
+    }
+  }
+
+  @Override
   public StagedTable stageCreateOrReplace(
       Identifier ident, StructType schema, Transform[] partitions, Map<String, String> properties)
       throws NoSuchNamespaceException {
@@ -274,6 +358,36 @@ public class SparkSessionCatalog<
     } catch (TableAlreadyExistsException e) {
       // the table was deleted, but now already exists again. retry the replace.
       return stageCreateOrReplace(ident, schema, partitions, properties);
+    }
+  }
+
+  @Override
+  public StagedTable stageCreateOrReplace(
+      Identifier ident, Column[] columns, Transform[] partitions, Map<String, String> properties)
+      throws NoSuchNamespaceException {
+    String provider = properties.get("provider");
+    TableCatalog catalog;
+    if (useIceberg(provider)) {
+      if (asStagingCatalog != null) {
+        return asStagingCatalog.stageCreateOrReplace(ident, columns, partitions, properties);
+      }
+      catalog = icebergCatalog;
+    } else {
+      catalog = getSessionCatalog();
+    }
+
+    // drop the table if it exists
+    catalog.dropTable(ident);
+
+    try {
+      // create the table with the session catalog, then wrap it in a staged table that will delete
+      // to roll back
+      Table sessionCatalogTable = catalog.createTable(ident, columns, partitions, properties);
+      return new RollbackStagedTable(catalog, ident, sessionCatalogTable);
+
+    } catch (TableAlreadyExistsException e) {
+      // the table was deleted, but now already exists again. retry the replace.
+      return stageCreateOrReplace(ident, columns, partitions, properties);
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestAlterTable.java
@@ -155,12 +155,18 @@ public class TestAlterTable extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testAddColumnWithDefaultValuesUnsupported() {
-    assertThatThrownBy(
-            () -> sql("ALTER TABLE %s ADD COLUMN col_with_default int DEFAULT 123", tableName))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageStartingWith(
-            "Cannot add column col_with_default since setting default values in Spark is currently unsupported");
+  public void testAddColumnWithDefaultValue() {
+    sql("DROP TABLE %s", tableName);
+    sql(
+        "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        tableName);
+    sql("ALTER TABLE %s ADD COLUMN col_with_default int DEFAULT 123", tableName);
+
+    NestedField field =
+        validationCatalog.loadTable(tableIdent).schema().findField("col_with_default");
+    assertThat(field.initialDefault()).as("Should have initial default").isEqualTo(123);
+    assertThat(field.writeDefault()).as("Should have write default").isEqualTo(123);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDefaultValues.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDefaultValues.java
@@ -168,6 +168,55 @@ public class TestSparkDefaultValues extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testReplaceTableWithDefaults() {
+    sql(
+        "CREATE TABLE %s (id INT, data STRING) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        tableName);
+
+    sql(
+        "REPLACE TABLE %s (id INT, data STRING DEFAULT 'replace-default') USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault()).isEqualTo("replace-default");
+    assertThat(table.schema().findField("data").writeDefault()).isEqualTo("replace-default");
+
+    sql("INSERT INTO %s VALUES (1, DEFAULT)", commitTarget());
+
+    assertEquals(
+        "Should use default value from REPLACE TABLE DDL",
+        ImmutableList.of(row(1, "replace-default")),
+        sql("SELECT * FROM %s", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testCreateOrReplaceTableWithDefaults() {
+    assertThat(validationCatalog.tableExists(tableIdent))
+        .as("Table should not already exist")
+        .isFalse();
+
+    sql(
+        "CREATE OR REPLACE TABLE %s (id INT, data STRING DEFAULT 'create-or-replace-default') "
+            + "USING iceberg TBLPROPERTIES ('format-version'='3')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault())
+        .isEqualTo("create-or-replace-default");
+    assertThat(table.schema().findField("data").writeDefault())
+        .isEqualTo("create-or-replace-default");
+
+    sql("INSERT INTO %s VALUES (1, DEFAULT)", commitTarget());
+
+    assertEquals(
+        "Should use default value from CREATE OR REPLACE TABLE DDL",
+        ImmutableList.of(row(1, "create-or-replace-default")),
+        sql("SELECT * FROM %s", selectTarget()));
+  }
+
+  @TestTemplate
   public void testAlterTableAddColumnWithDefault() {
     assertThat(validationCatalog.tableExists(tableIdent))
         .as("Table should not already exist")

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDefaultValues.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkDefaultValues.java
@@ -21,23 +21,27 @@ package org.apache.iceberg.spark.sql;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.types.Types;
-import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.SparkException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.TestTemplate;
 
 /**
  * Tests for Spark SQL Default values integration with Iceberg default values.
  *
- * <p>Note: These tests use {@code validationCatalog.createTable()} to create tables with default
- * values because the Iceberg Spark integration does not yet support default value clauses in Spark
- * DDL.
+ * <p>These tests cover Spark SQL DEFAULT writes against Iceberg defaults and Spark SQL DDL default
+ * clauses that create or update Iceberg defaults.
  */
 public class TestSparkDefaultValues extends CatalogTestBase {
 
@@ -141,22 +145,30 @@ public class TestSparkDefaultValues extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testCreateTableWithDefaultsUnsupported() {
+  public void testCreateTableWithDefaults() {
     assertThat(validationCatalog.tableExists(tableIdent))
         .as("Table should not already exist")
         .isFalse();
 
-    assertThatThrownBy(
-            () ->
-                sql(
-                    "CREATE TABLE %s (id INT, data STRING DEFAULT 'default-value') USING iceberg",
-                    tableName))
-        .isInstanceOf(AnalysisException.class)
-        .hasMessageContaining("does not support column default value");
+    sql(
+        "CREATE TABLE %s (id INT, data STRING DEFAULT 'default-value') USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault()).isEqualTo("default-value");
+    assertThat(table.schema().findField("data").writeDefault()).isEqualTo("default-value");
+
+    sql("INSERT INTO %s VALUES (1, DEFAULT)", commitTarget());
+
+    assertEquals(
+        "Should use default value from CREATE TABLE DDL",
+        ImmutableList.of(row(1, "default-value")),
+        sql("SELECT * FROM %s", selectTarget()));
   }
 
   @TestTemplate
-  public void testAlterTableAddColumnWithDefaultUnsupported() {
+  public void testAlterTableAddColumnWithDefault() {
     assertThat(validationCatalog.tableExists(tableIdent))
         .as("Table should not already exist")
         .isFalse();
@@ -166,10 +178,175 @@ public class TestSparkDefaultValues extends CatalogTestBase {
     validationCatalog.createTable(
         tableIdent, schema, PartitionSpec.unpartitioned(), ImmutableMap.of("format-version", "3"));
 
-    assertThatThrownBy(
-            () -> sql("ALTER TABLE %s ADD COLUMN data STRING DEFAULT 'default-value'", tableName))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessageContaining("default values in Spark is currently unsupported");
+    sql("INSERT INTO %s VALUES (1), (2)", commitTarget());
+
+    sql("ALTER TABLE %s ADD COLUMN data STRING DEFAULT 'default-value'", tableName);
+    sql("REFRESH TABLE %s", commitTarget());
+    sql("INSERT INTO %s VALUES (3, DEFAULT)", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault()).isEqualTo("default-value");
+    assertThat(table.schema().findField("data").writeDefault()).isEqualTo("default-value");
+
+    assertEquals(
+        "Should use default value for existing and new rows",
+        ImmutableList.of(row(1, "default-value"), row(2, "default-value"), row(3, "default-value")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testAlterTableSetAndDropColumnDefault() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional("data")
+                .withId(2)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("initial-default"))
+                .withWriteDefault(Literal.of("old-default"))
+                .build());
+
+    validationCatalog.createTable(
+        tableIdent, schema, PartitionSpec.unpartitioned(), ImmutableMap.of("format-version", "3"));
+
+    sql("ALTER TABLE %s ALTER COLUMN data SET DEFAULT 'new-default'", tableName);
+    sql("REFRESH TABLE %s", commitTarget());
+    sql("INSERT INTO %s VALUES (1, DEFAULT)", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault()).isEqualTo("initial-default");
+    assertThat(table.schema().findField("data").writeDefault()).isEqualTo("new-default");
+
+    assertEquals(
+        "Should use updated write default",
+        ImmutableList.of(row(1, "new-default")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+
+    sql("ALTER TABLE %s ALTER COLUMN data DROP DEFAULT", tableName);
+    sql("REFRESH TABLE %s", commitTarget());
+
+    Table updatedTable = validationCatalog.loadTable(tableIdent);
+    assertThat(updatedTable.schema().findField("data").initialDefault())
+        .isEqualTo("initial-default");
+    assertThat(updatedTable.schema().findField("data").writeDefault()).isNull();
+  }
+
+  @TestTemplate
+  public void testCreateTableDefaultValuesForPrimitiveTypes() {
+    List<DefaultColumn> columns = Lists.newArrayList();
+    columns.add(new DefaultColumn("bool_col", "BOOLEAN", "true", true));
+    columns.add(new DefaultColumn("int_col", "INT", "42", 42));
+    columns.add(new DefaultColumn("long_col", "BIGINT", "100L", 100L));
+    columns.add(new DefaultColumn("float_col", "FLOAT", "CAST('3.14' AS FLOAT)", 3.14F));
+    columns.add(new DefaultColumn("double_col", "DOUBLE", "2.718D", 2.718D));
+    columns.add(
+        new DefaultColumn("decimal_col", "DECIMAL(10, 2)", "99.99BD", new BigDecimal("99.99")));
+    columns.add(new DefaultColumn("string_col", "STRING", "'default-value'", "default-value"));
+    columns.add(
+        new DefaultColumn(
+            "date_col",
+            "DATE",
+            "DATE '2024-01-01'",
+            Literal.of("2024-01-01").to(Types.DateType.get()).value()));
+    columns.add(
+        new DefaultColumn(
+            "timestamp_col",
+            "TIMESTAMP",
+            "TIMESTAMP '2026-06-07 06:30:46.619896 UTC+00:00'",
+            Literal.of("2026-06-07T06:30:46.619896+00:00")
+                .to(Types.TimestampType.withZone())
+                .value()));
+    columns.add(
+        new DefaultColumn(
+            "timestamp_ntz_col",
+            "TIMESTAMP_NTZ",
+            "TIMESTAMP_NTZ '2026-06-07 06:30:46.619896'",
+            Literal.of("2026-06-07T06:30:46.619896")
+                .to(Types.TimestampType.withoutZone())
+                .value()));
+    columns.add(
+        new DefaultColumn(
+            "binary_col", "BINARY", "X'0A0B'", ByteBuffer.wrap(new byte[] {0x0a, 0x0b})));
+
+    StringBuilder createTable = new StringBuilder("CREATE TABLE ");
+    createTable.append(tableName).append(" (id INT");
+    for (DefaultColumn column : columns) {
+      createTable
+          .append(", ")
+          .append(column.name)
+          .append(" ")
+          .append(column.sqlType)
+          .append(" DEFAULT ")
+          .append(column.defaultSql);
+    }
+
+    createTable.append(") USING iceberg TBLPROPERTIES ('format-version'='3')");
+
+    sql(createTable.toString());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    for (DefaultColumn column : columns) {
+      assertThat(table.schema().findField(column.name).initialDefault())
+          .as("Initial default for %s", column.name)
+          .isEqualTo(column.expectedValue);
+      assertThat(table.schema().findField(column.name).writeDefault())
+          .as("Write default for %s", column.name)
+          .isEqualTo(column.expectedValue);
+    }
+  }
+
+  @TestTemplate
+  public void testCreateTableUnsupportedDefaultTypesFailClearly() {
+    for (DefaultColumn column : unsupportedDefaultColumns()) {
+      assertThatThrownBy(
+              () ->
+                  sql(
+                      "CREATE TABLE %s (id INT, %s %s DEFAULT %s) USING iceberg "
+                          + "TBLPROPERTIES ('format-version'='3')",
+                      tableName, column.name, column.sqlType, column.defaultSql))
+          .as("Should reject default for unsupported type %s", column.sqlType)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("Column default")
+          .hasMessageContaining("not supported by Iceberg Spark DDL");
+    }
+  }
+
+  @TestTemplate
+  public void testAlterTableAddColumnUnsupportedDefaultTypesFailClearly() {
+    sql("CREATE TABLE %s (id INT) USING iceberg TBLPROPERTIES ('format-version'='3')", tableName);
+
+    for (DefaultColumn column : unsupportedDefaultColumns()) {
+      assertThatThrownBy(
+              () ->
+                  sql(
+                      "ALTER TABLE %s ADD COLUMN %s %s DEFAULT %s",
+                      tableName, column.name, column.sqlType, column.defaultSql))
+          .as("Should reject default for unsupported type %s", column.sqlType)
+          .isInstanceOf(SparkException.class)
+          .hasMessageContaining("Column default")
+          .hasMessageContaining("not supported by Iceberg Spark DDL");
+    }
+  }
+
+  @TestTemplate
+  public void testCreateTableWithNullDefault() {
+    sql(
+        "CREATE TABLE %s (id INT, data STRING DEFAULT NULL) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        tableName);
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    assertThat(table.schema().findField("data").initialDefault()).isNull();
+    assertThat(table.schema().findField("data").writeDefault()).isNull();
+  }
+
+  private static List<DefaultColumn> unsupportedDefaultColumns() {
+    List<DefaultColumn> unsupportedColumns = Lists.newArrayList();
+    unsupportedColumns.add(new DefaultColumn("array_col", "ARRAY<INT>", "array(1, 2)", null));
+    unsupportedColumns.add(new DefaultColumn("map_col", "MAP<INT, INT>", "map(1, 2)", null));
+    unsupportedColumns.add(
+        new DefaultColumn("struct_col", "STRUCT<a: INT>", "named_struct('a', 1)", null));
+    return unsupportedColumns;
   }
 
   @TestTemplate
@@ -204,5 +381,19 @@ public class TestSparkDefaultValues extends CatalogTestBase {
         "Should have correct default values for existing and new rows",
         ImmutableList.of(row(1, "default_data"), row(2, "default_data"), row(3, "default_data")),
         sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  private static class DefaultColumn {
+    private final String name;
+    private final String sqlType;
+    private final String defaultSql;
+    private final Object expectedValue;
+
+    DefaultColumn(String name, String sqlType, String defaultSql, Object expectedValue) {
+      this.name = name;
+      this.sqlType = sqlType;
+      this.defaultSql = defaultSql;
+      this.expectedValue = expectedValue;
+    }
   }
 }


### PR DESCRIPTION
## Summary

Adds Spark 4.1 SQL DDL support for Iceberg column default values.

Supported syntax:

- `CREATE TABLE ... DEFAULT ...`
- `ALTER TABLE ... ADD COLUMN ... DEFAULT ...`
- `ALTER TABLE ... ALTER COLUMN ... SET DEFAULT ...`
- `ALTER TABLE ... ALTER COLUMN ... DROP DEFAULT`

The implementation uses Spark's typed default value APIs and converts Spark literal defaults to Iceberg literals.

## Scope

This PR is limited to Spark 4.1.

Complex type default value creation is not supported for now. Defaults for `ARRAY`, `MAP`, and `STRUCT` are rejected with a clear error message in both `CREATE TABLE` and `ALTER TABLE ADD COLUMN` paths.

Supported primitive Spark SQL types are covered by tests, including boolean, numeric, decimal, string, date, timestamp, timestamp_ntz, and binary.

Closes #16698 

## Validation

```bash
./gradlew --no-daemon --max-workers=2 \
  :iceberg-spark:iceberg-spark-4.1_2.13:test \
  --tests org.apache.iceberg.spark.sql.TestSparkDefaultValues \
  --tests org.apache.iceberg.spark.sql.TestAlterTable.testAddColumnWithDefaultValue \
  -x spotlessCheck
```

```bash
./gradlew --no-daemon --max-workers=2 \
  :iceberg-spark:iceberg-spark-4.1_2.13:spotlessCheck
```

## Notes

AI assistance was used to draft and iterate on the implementation and tests. The implementation, scope, and validation were manually reviewed.
