### PR TITLE
Spark: Add selective shredded variant extraction Parquet readers

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
@@ -27,12 +27,26 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 
 public class PathUtil {
   private PathUtil() {}
+
+  /**
+   * One step in a variant JSONPath: an object member name or a zero-based array index (RFC 9535
+   * {@code [n]} selector).
+   *
+   * <p>This is a copy of the canonical implementation from <a
+   * href="https://github.com/apache/iceberg/pull/15384">PR #15384</a>. Once that PR merges, this
+   * class will be the single definition and this note can be removed.
+   */
+  public sealed interface PathSegment permits PathSegment.Name, PathSegment.Index {
+    record Name(String name) implements PathSegment {}
+
+    record Index(int index) implements PathSegment {}
+  }
 
   private static final String RFC9535_NAME_FIRST =
       "[A-Za-z_\\x{0080}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]";
@@ -41,46 +55,304 @@ public class PathUtil {
   private static final Predicate<String> RFC9535_MEMBER_NAME_SHORTHAND =
       Pattern.compile(RFC9535_NAME_FIRST + RFC9535_NAME_CHARS).asMatchPredicate();
 
+  /** Letters that follow {@code \} for control-character escapes in RFC 9535 quoted segments. */
+  private static final String RFC9535_SIMPLE_ESCAPE_LETTERS = "btnfr";
+
+  private static final String RFC9535_SIMPLE_ESCAPE_CHARS = "\b\t\n\f\r";
+
   private static final Pattern RFC9535_REQUIRES_ESCAPE =
       Pattern.compile(
           "[^\\x{0020}-\\x{0026}\\x{0028}-\\x{005B}\\x{005D}-\\x{D7FF}\\x{E000}-\\x{10FFFF}]");
 
+  /**
+   * Matches one bracket segment {@code ['...']} where inner text may contain RFC 9535 escapes
+   * (quote, backslash, control characters, and four-digit hex escapes).
+   */
+  private static final Pattern BRACKET_SEGMENT = Pattern.compile("\\['((?:[^'\\\\]|\\\\.)*)'\\]");
+
   private static final Map<Character, String> RFC9535_ESCAPE_REPLACEMENTS = buildReplacementMap();
 
-  private static final Splitter DOT = Splitter.on(".");
   private static final String ROOT = "$";
 
-  static List<String> parse(String path) {
+  /**
+   * Parses a path into segments. After the root {@code $}, each segment is either dot shorthand
+   * ({@code .name} per RFC 9535), a single-quoted bracket name ({@code ['...']}) with RFC 9535
+   * escapes, or a numeric array index ({@code [n]}). Forms may be mixed (e.g. {@code $.a['b.c']},
+   * {@code $.items[0].tags}, {@code $.matrix[0][1]}). Wildcards and recursive descent are not
+   * supported.
+   *
+   * <p>The root path {@code $} yields an empty segment list.
+   */
+  public static List<PathSegment> parse(String path) {
     Preconditions.checkArgument(path != null, "Invalid path: null");
+    Preconditions.checkArgument(!path.isEmpty(), "Invalid path: empty");
     Preconditions.checkArgument(
-        !path.contains("[") && !path.contains("]"), "Unsupported path, contains bracket: %s", path);
-    Preconditions.checkArgument(
-        !path.contains("*"), "Unsupported path, contains wildcard: %s", path);
-    Preconditions.checkArgument(
-        !path.contains(".."), "Unsupported path, contains recursive descent: %s", path);
+        path.startsWith(ROOT), "Invalid path, does not start with %s: %s", ROOT, path);
 
-    List<String> parts = DOT.splitToList(path);
-    Preconditions.checkArgument(
-        ROOT.equals(parts.get(0)), "Invalid path, does not start with %s: %s", ROOT, path);
-
-    List<String> names = parts.subList(1, parts.size());
-    for (String name : names) {
-      Preconditions.checkArgument(
-          RFC9535_MEMBER_NAME_SHORTHAND.test(name),
-          "Invalid path: %s (%s has invalid characters)",
-          path,
-          name);
+    if (path.equals(ROOT)) {
+      return Lists.newArrayList();
     }
 
-    return names;
+    return parseAfterRoot(path);
   }
 
+  /**
+   * Parses a JSON path into navigation steps for shredded variant extraction. Object field steps
+   * are plain strings; array index steps use {@code "[n]"} encoding (see {@link
+   * #isArrayIndexPart}).
+   */
+  public static List<String> parseObjectPath(String path) {
+    List<String> parts = Lists.newArrayList();
+    for (PathSegment segment : parse(path)) {
+      if (segment instanceof PathSegment.Name) {
+        parts.add(((PathSegment.Name) segment).name());
+      } else if (segment instanceof PathSegment.Index) {
+        parts.add("[" + ((PathSegment.Index) segment).index() + "]");
+      } else {
+        throw new IllegalStateException("Unknown segment: " + segment);
+      }
+    }
+    return parts;
+  }
+
+  /**
+   * Returns true when {@code part} is an array index step encoded as {@code "[n]"} by {@link
+   * #parseObjectPath}.
+   */
+  public static boolean isArrayIndexPart(String part) {
+    if (part.length() < 3 || part.charAt(0) != '[' || part.charAt(part.length() - 1) != ']') {
+      return false;
+    }
+    for (int i = 1; i < part.length() - 1; i++) {
+      if (!Character.isDigit(part.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /** Returns the array index from a {@code "[n]"} part produced by {@link #parseObjectPath}. */
+  public static int parseArrayIndexPart(String part) {
+    Preconditions.checkArgument(isArrayIndexPart(part), "Invalid array index part: %s", part);
+    return Integer.parseInt(part.substring(1, part.length() - 1));
+  }
+
+  /** Normalizes object field names only (no array indices). */
   public static String toNormalizedPath(Iterable<String> fields) {
-    return ROOT
-        + Streams.stream(fields)
-            .map(PathUtil::rfc9535escape)
-            .map(name -> "['" + name + "']")
-            .collect(Collectors.joining(""));
+    return toNormalizedPath(
+        Streams.stream(fields).map(PathSegment.Name::new).collect(Collectors.toList()));
+  }
+
+  static String toNormalizedPath(List<PathSegment> segments) {
+    StringBuilder builder = new StringBuilder(ROOT);
+    for (PathSegment segment : segments) {
+      if (segment instanceof PathSegment.Name) {
+        String name = ((PathSegment.Name) segment).name();
+        builder.append("['").append(rfc9535escape(name)).append("']");
+      } else if (segment instanceof PathSegment.Index) {
+        int index = ((PathSegment.Index) segment).index();
+        Preconditions.checkArgument(index >= 0, "Invalid path, negative array index: %s", index);
+        builder.append('[').append(index).append(']');
+      } else {
+        throw new IllegalStateException("Unknown segment: " + segment);
+      }
+    }
+    return builder.toString();
+  }
+
+  private static List<PathSegment> parseAfterRoot(String path) {
+    List<PathSegment> segments = Lists.newArrayList();
+    Matcher bracketMatcher = BRACKET_SEGMENT.matcher(path);
+    int len = path.length();
+    int pos = ROOT.length();
+
+    while (pos < len) {
+      char ch = path.charAt(pos);
+      pos =
+          switch (ch) {
+            case '.' -> appendDotSegment(segments, path, pos);
+            case '[' -> appendBracketOrIndexSegment(segments, path, pos, bracketMatcher);
+            default ->
+                throw new IllegalArgumentException(
+                    String.format(
+                        "Invalid path, expected '.' or '[' at position %s: %s", pos, path));
+          };
+    }
+
+    return segments;
+  }
+
+  /**
+   * Appends a dot-style segment to {@code segments} by reading from {@code path[dotPos]}: a single
+   * leading {@code .} then an RFC 9535 shorthand name until the next {@code .} or {@code [}.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param dotPos index of the {@code .} starting the segment
+   */
+  private static int appendDotSegment(List<PathSegment> segments, String path, int dotPos) {
+    int pos = dotPos + 1;
+    int pathLen = path.length();
+    Preconditions.checkArgument(pos < pathLen, "Invalid path, trailing dot: %s", path);
+    int start = pos;
+    while (pos < pathLen) {
+      char ch = path.charAt(pos);
+      if (ch == '.' || ch == '[') {
+        break;
+      }
+      pos++;
+    }
+
+    Preconditions.checkArgument(pos > start, "Invalid path, empty segment after '.': %s", path);
+    String name = path.substring(start, pos);
+    Preconditions.checkArgument(
+        RFC9535_MEMBER_NAME_SHORTHAND.test(name),
+        "Invalid path: %s (%s has invalid characters)",
+        path,
+        name);
+    segments.add(new PathSegment.Name(name));
+    return pos;
+  }
+
+  /**
+   * Appends a bracket segment to {@code segments} starting at {@code path[bracketPos]}. If the next
+   * character is a digit, consumes a numeric array index {@code [n]}; otherwise consumes a quoted
+   * name {@code ['...']}. A lone {@code [} with no following quoted form (e.g. the path ends at
+   * {@code $[}) is rejected in {@link #appendQuotedBracketSegment} when the pattern does not match.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [}
+   */
+  private static int appendBracketOrIndexSegment(
+      List<PathSegment> segments, String path, int bracketPos, Matcher bracketMatcher) {
+    Preconditions.checkArgument(
+        bracketPos < path.length() && path.charAt(bracketPos) == '[', "Invalid path: %s", path);
+    if (bracketPos + 1 < path.length() && isAsciiDigit(path.charAt(bracketPos + 1))) {
+      return appendArrayIndexSegment(segments, path, bracketPos);
+    }
+    return appendQuotedBracketSegment(segments, path, bracketPos, bracketMatcher);
+  }
+
+  private static boolean isAsciiDigit(char ch) {
+    return ch >= '0' && ch <= '9';
+  }
+
+  /**
+   * Appends a non-negative array index from {@code [n]} to {@code segments}, starting with {@code
+   * [} at {@code path[bracketPos]}.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [} before the digits
+   */
+  private static int appendArrayIndexSegment(
+      List<PathSegment> segments, String path, int bracketPos) {
+    int pos = bracketPos + 1;
+    int len = path.length();
+    int start = pos;
+    while (pos < len && isAsciiDigit(path.charAt(pos))) {
+      pos++;
+    }
+    Preconditions.checkArgument(pos > start, "Invalid path, empty array index in: %s", path);
+    Preconditions.checkArgument(
+        pos < len && path.charAt(pos) == ']', "Invalid path, unclosed array index in: %s", path);
+    int index;
+    String digits = path.substring(start, pos);
+    try {
+      index = Integer.parseInt(digits);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid path, array index out of int range: %s", path), e);
+    }
+    Preconditions.checkArgument(index >= 0, "Invalid path, negative array index in: %s", path);
+    segments.add(new PathSegment.Index(index));
+    return pos + 1;
+  }
+
+  /**
+   * Appends a name from a {@code ['...']} segment to {@code segments} using the bracket matcher
+   * (inner text may use RFC 9535 escapes). Expects a full quoted bracket token at {@code
+   * path[bracketPos]}; otherwise the matcher or alignment checks throw.
+   *
+   * @param segments output; segments parsed so far, updated in place
+   * @param path full path
+   * @param bracketPos index of the opening {@code [} that must begin {@code ['}
+   */
+  private static int appendQuotedBracketSegment(
+      List<PathSegment> segments, String path, int bracketPos, Matcher bracketMatcher) {
+    Preconditions.checkArgument(
+        bracketMatcher.find(bracketPos), "Invalid path, malformed bracket segment: %s", path);
+    Preconditions.checkArgument(
+        bracketMatcher.start() == bracketPos,
+        "Invalid path, unexpected characters at position %s: %s",
+        bracketPos,
+        path);
+    segments.add(new PathSegment.Name(rfc9535unescape(bracketMatcher.group(1))));
+    return bracketMatcher.end();
+  }
+
+  /** Unescapes the inner text of a {@code ['...']} segment (inverse of {@link #rfc9535escape}). */
+  @VisibleForTesting
+  @SuppressWarnings("StatementSwitchToExpressionSwitch")
+  static String rfc9535unescape(String escaped) {
+    if (!escaped.contains("\\")) {
+      return escaped;
+    }
+
+    StringBuilder builder = new StringBuilder(escaped.length());
+    int cursor = 0;
+    while (cursor < escaped.length()) {
+      char ch = escaped.charAt(cursor);
+      if (ch != '\\') {
+        builder.append(ch);
+        cursor += 1;
+      } else {
+        Preconditions.checkArgument(
+            cursor + 1 < escaped.length(), "Invalid escape sequence at end of: %s", escaped);
+        char next = escaped.charAt(cursor + 1);
+        switch (next) {
+          case 'u':
+            Preconditions.checkArgument(
+                cursor + 5 < escaped.length(),
+                "Invalid \\uXXXX escape at position %s in: %s",
+                cursor,
+                escaped);
+            builder.append((char) Integer.parseInt(escaped.substring(cursor + 2, cursor + 6), 16));
+            cursor += 6;
+            break;
+          case 'b':
+          case 't':
+          case 'f':
+          case 'n':
+          case 'r':
+          case '\'':
+          case '\\':
+            builder.append(rfc9535SimpleEscapedChar(next));
+            cursor += 2;
+            break;
+          default:
+            throw new IllegalArgumentException(
+                "Invalid escape sequence \\" + next + " in: " + escaped);
+        }
+      }
+    }
+
+    return builder.toString();
+  }
+
+  private static char rfc9535SimpleEscapedChar(char next) {
+    int idx = RFC9535_SIMPLE_ESCAPE_LETTERS.indexOf(next);
+    if (idx >= 0) {
+      return RFC9535_SIMPLE_ESCAPE_CHARS.charAt(idx);
+    }
+    if (next == '\'') {
+      return '\'';
+    }
+    if (next == '\\') {
+      return '\\';
+    }
+    throw new IllegalArgumentException("Invalid simple escape: \\" + next);
   }
 
   @VisibleForTesting

--- a/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/PathUtil.java
@@ -96,47 +96,6 @@ public class PathUtil {
     return parseAfterRoot(path);
   }
 
-  /**
-   * Parses a JSON path into navigation steps for shredded variant extraction. Object field steps
-   * are plain strings; array index steps use {@code "[n]"} encoding (see {@link
-   * #isArrayIndexPart}).
-   */
-  public static List<String> parseObjectPath(String path) {
-    List<String> parts = Lists.newArrayList();
-    for (PathSegment segment : parse(path)) {
-      if (segment instanceof PathSegment.Name) {
-        parts.add(((PathSegment.Name) segment).name());
-      } else if (segment instanceof PathSegment.Index) {
-        parts.add("[" + ((PathSegment.Index) segment).index() + "]");
-      } else {
-        throw new IllegalStateException("Unknown segment: " + segment);
-      }
-    }
-    return parts;
-  }
-
-  /**
-   * Returns true when {@code part} is an array index step encoded as {@code "[n]"} by {@link
-   * #parseObjectPath}.
-   */
-  public static boolean isArrayIndexPart(String part) {
-    if (part.length() < 3 || part.charAt(0) != '[' || part.charAt(part.length() - 1) != ']') {
-      return false;
-    }
-    for (int i = 1; i < part.length() - 1; i++) {
-      if (!Character.isDigit(part.charAt(i))) {
-        return false;
-      }
-    }
-    return true;
-  }
-
-  /** Returns the array index from a {@code "[n]"} part produced by {@link #parseObjectPath}. */
-  public static int parseArrayIndexPart(String part) {
-    Preconditions.checkArgument(isArrayIndexPart(part), "Invalid array index part: %s", part);
-    return Integer.parseInt(part.substring(1, part.length() - 1));
-  }
-
   /** Normalizes object field names only (no array indices). */
   public static String toNormalizedPath(Iterable<String> fields) {
     return toNormalizedPath(

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionBinding.java
@@ -361,7 +361,9 @@ public class TestExpressionBinding {
       new String[] {
         "$", // root path
         "$.event_id",
-        "$.event.id"
+        "$.event.id",
+        "$['event_id']", // bracket notation
+        "$.events[0].event_id" // array index accessor
       };
 
   @ParameterizedTest
@@ -378,9 +380,7 @@ public class TestExpressionBinding {
         null,
         "",
         "event_id", // missing root
-        "$['event_id']", // uses bracket notation
         "$..event_id", // uses recursive descent
-        "$.events[0].event_id", // uses position accessor
         "$.events.*" // uses wildcard
       };
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -18,11 +18,14 @@
  */
 package org.apache.iceberg.expressions;
 
+import static org.apache.iceberg.expressions.PathUtil.PathSegment.Index;
+import static org.apache.iceberg.expressions.PathUtil.PathSegment.Name;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -30,9 +33,13 @@ import org.junit.jupiter.params.provider.FieldSource;
 @SuppressWarnings({"AvoidEscapedUnicodeCharacters", "IllegalTokenText"})
 public class TestPathUtil {
 
+  private static List<PathUtil.PathSegment> names(String... names) {
+    return java.util.Arrays.stream(names).map(Name::new).collect(Collectors.toList());
+  }
+
   @Test
   public void testSimplePath() {
-    assertThat(PathUtil.parse("$.event.id")).isEqualTo(List.of("event", "id"));
+    assertThat(PathUtil.parse("$.event.id")).isEqualTo(names("event", "id"));
   }
 
   private static final String[] VALID_PATHS =
@@ -40,8 +47,18 @@ public class TestPathUtil {
         "$", // root path
         "$.event_id",
         "$.event.id",
+        "$['event_id']", // bracket form
+        "$.event['x.y']", // mixed: dot then bracket
+        "$['event']['id']", // bracket then bracket
+        "$['a'].b", // bracket then dot
         "$.\u2603", // snowman
         "$.\uD834\uDD1E", // surrogate pair, U+1D11E
+        "$.matrix[0][1]",
+        "$.basket[0][2].a",
+        "$.items[0].tags[1]",
+        "$['matrix'][0][1]",
+        "$['items'][0]['tags'][1]",
+        "$['basket'][0][2]['a']",
       };
 
   @ParameterizedTest
@@ -55,9 +72,7 @@ public class TestPathUtil {
         null,
         "",
         "event_id", // missing root
-        "$['event_id']", // uses bracket notation
         "$..event_id", // uses recursive descent
-        "$.events[0].event_id", // uses position accessor
         "$.events.*", // uses wildcard
         "$.0invalid", // starts with a digit
         "$._\uD834", // dangling high surrogate
@@ -79,6 +94,10 @@ public class TestPathUtil {
         new String[] {"$.a.b.c", "$['a']['b']['c']"},
         new String[] {"$.\u2603", "$['☃']"},
         new String[] {"$.a\uD834\uDD1Eb.x", "$['a\uD834\uDD1Eb']['x']"},
+        // Dot shorthand vs bracket form for names; array steps use unquoted [n] in both.
+        new String[] {"$.matrix[0][1]", "$['matrix'][0][1]"},
+        new String[] {"$.items[0].tags[1]", "$['items'][0]['tags'][1]"},
+        new String[] {"$.basket[0][2].a", "$['basket'][0][2]['a']"},
       };
 
   @ParameterizedTest
@@ -122,5 +141,61 @@ public class TestPathUtil {
   @FieldSource("ESCAPE_CASES")
   public void testPathEscaping(String name, String escaped) {
     assertThat(PathUtil.rfc9535escape(name)).isEqualTo(escaped);
+  }
+
+  @Test
+  void testParseArrayPath() {
+    assertThat(PathUtil.parse("$.commits[0].author.name"))
+        .isEqualTo(
+            List.of(new Name("commits"), new Index(0), new Name("author"), new Name("name")));
+  }
+
+  @Test
+  void testParseArrayIndexOnly() {
+    assertThat(PathUtil.parse("$.a[1][2].b"))
+        .isEqualTo(List.of(new Name("a"), new Index(1), new Index(2), new Name("b")));
+  }
+
+  @Test
+  void testParseBracketMixed() {
+    assertThat(PathUtil.parse("$['issue']['labels'][0]['name']"))
+        .isEqualTo(List.of(new Name("issue"), new Name("labels"), new Index(0), new Name("name")));
+  }
+
+  @Test
+  void testParseObjectPathSupportsDotAndBracketKeys() {
+    assertThat(PathUtil.parseObjectPath("$.size")).containsExactly("size");
+    assertThat(PathUtil.parseObjectPath("$.pull_request.user.login"))
+        .containsExactly("pull_request", "user", "login");
+    assertThat(PathUtil.parseObjectPath("$['city']")).containsExactly("city");
+    assertThat(PathUtil.parseObjectPath("$['pull_request']['user']['login']"))
+        .containsExactly("pull_request", "user", "login");
+  }
+
+  @Test
+  void testParseObjectPathSupportsArrayIndexes() {
+    assertThat(PathUtil.parseObjectPath("$.commits[0].author.name"))
+        .containsExactly("commits", "[0]", "author", "name");
+    assertThat(PathUtil.parseObjectPath("$.a[1][2].b")).containsExactly("a", "[1]", "[2]", "b");
+    assertThat(PathUtil.parseObjectPath("$['issue']['labels'][0]['name']"))
+        .containsExactly("issue", "labels", "[0]", "name");
+  }
+
+  @Test
+  void testIsArrayIndexPartDetectsNumericBrackets() {
+    assertThat(PathUtil.isArrayIndexPart("[0]")).isTrue();
+    assertThat(PathUtil.isArrayIndexPart("[12]")).isTrue();
+    assertThat(PathUtil.isArrayIndexPart("commits")).isFalse();
+    assertThat(PathUtil.isArrayIndexPart("['field']")).isFalse();
+    assertThat(PathUtil.isArrayIndexPart("[x]")).isFalse();
+  }
+
+  @Test
+  void testParseArrayIndexPart() {
+    assertThat(PathUtil.parseArrayIndexPart("[0]")).isEqualTo(0);
+    assertThat(PathUtil.parseArrayIndexPart("[12]")).isEqualTo(12);
+    assertThatThrownBy(() -> PathUtil.parseArrayIndexPart("commits"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid array index part");
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPathUtil.java
@@ -163,39 +163,9 @@ public class TestPathUtil {
   }
 
   @Test
-  void testParseObjectPathSupportsDotAndBracketKeys() {
-    assertThat(PathUtil.parseObjectPath("$.size")).containsExactly("size");
-    assertThat(PathUtil.parseObjectPath("$.pull_request.user.login"))
-        .containsExactly("pull_request", "user", "login");
-    assertThat(PathUtil.parseObjectPath("$['city']")).containsExactly("city");
-    assertThat(PathUtil.parseObjectPath("$['pull_request']['user']['login']"))
-        .containsExactly("pull_request", "user", "login");
-  }
-
-  @Test
-  void testParseObjectPathSupportsArrayIndexes() {
-    assertThat(PathUtil.parseObjectPath("$.commits[0].author.name"))
-        .containsExactly("commits", "[0]", "author", "name");
-    assertThat(PathUtil.parseObjectPath("$.a[1][2].b")).containsExactly("a", "[1]", "[2]", "b");
-    assertThat(PathUtil.parseObjectPath("$['issue']['labels'][0]['name']"))
-        .containsExactly("issue", "labels", "[0]", "name");
-  }
-
-  @Test
-  void testIsArrayIndexPartDetectsNumericBrackets() {
-    assertThat(PathUtil.isArrayIndexPart("[0]")).isTrue();
-    assertThat(PathUtil.isArrayIndexPart("[12]")).isTrue();
-    assertThat(PathUtil.isArrayIndexPart("commits")).isFalse();
-    assertThat(PathUtil.isArrayIndexPart("['field']")).isFalse();
-    assertThat(PathUtil.isArrayIndexPart("[x]")).isFalse();
-  }
-
-  @Test
-  void testParseArrayIndexPart() {
-    assertThat(PathUtil.parseArrayIndexPart("[0]")).isEqualTo(0);
-    assertThat(PathUtil.parseArrayIndexPart("[12]")).isEqualTo(12);
-    assertThatThrownBy(() -> PathUtil.parseArrayIndexPart("commits"))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid array index part");
+  void testNameAndIndexSegmentsAreDistinct() {
+    // $[0] is an array index; $['[0]'] is a field whose name is literally "[0]" — must not conflate
+    assertThat(PathUtil.parse("$[0]")).containsExactly(new Index(0));
+    assertThat(PathUtil.parse("$['[0]']")).containsExactly(new Name("[0]"));
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
@@ -324,6 +324,17 @@ public class ParquetVariantExtractionReaders {
         GroupType variantGroup,
         List<String> variantColumnPath,
         FieldSpec field) {
+      if (field.pathParts().isEmpty()) {
+        // Root extraction ($): reconstruct the full shredded variant via buildRowCachedReader,
+        // which keys on the empty path. All root-reconstructing readers (this $ path and every
+        // array-index path $[n] from buildArrayPathReader) share that one cached reader, so the
+        // full root value is read and rebuilt only once per row regardless of how many such
+        // fields reference the same column.
+        RowCachedReader cachedReader =
+            buildRowCachedReader(fileSchema, variantGroup, variantColumnPath);
+        return new PathNavigatingFieldReader(cachedReader, ImmutableList.of());
+      }
+
       GroupType fieldGroup =
           VariantExtractionPathResolver.resolveShreddedFieldGroup(variantGroup, field.pathParts());
       if (fieldGroup == null
@@ -375,6 +386,9 @@ public class ParquetVariantExtractionReaders {
       return new PathNavigatingFieldReader(cachedReader, field.pathParts());
     }
 
+    // Reconstructs the full root variant value, cached per row. Keyed on the empty path so that all
+    // callers needing the whole root value ($ root extraction and every $[n] array-index path)
+    // share one reader and read/rebuild the root value only once per row.
     private RowCachedReader buildRowCachedReader(
         MessageType fileSchema, GroupType variantGroup, List<String> readerPath) {
       return rowCachedReaders.computeIfAbsent(

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
@@ -1,0 +1,797 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.iceberg.expressions.PathUtil;
+import org.apache.iceberg.parquet.ParquetVariantReaders.VariantValueReader;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.VariantArray;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantObject;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+
+/**
+ * Selective Parquet readers for shredded variant extraction paths.
+ *
+ * <p>A shredded variant stores known fields in separate typed Parquet columns alongside a {@code
+ * value} binary blob that holds anything not shredded. This class reads one or more specific paths
+ * (e.g. {@code $.user.name}, {@code $[0]}) from a shredded variant column while touching only the
+ * Parquet columns relevant to those paths.
+ *
+ * <h2>Reader selection strategy (per field path)</h2>
+ *
+ * <ol>
+ *   <li><b>Selective spine</b> — for 2+ part object paths whose top key is shredded, a chain of
+ *       {@code SelectiveObjectReader} instances walk only the {@code value} blob and the single
+ *       child column subtree at each level, skipping all siblings.
+ *   <li><b>Shredded leaf</b> — for paths that resolve directly to a shredded typed or serialized
+ *       column, a {@code RowCachedReader} reads that column once per row and caches the result so
+ *       multiple fields sharing the same path (e.g. {@code $.size} as {@code double} AND as {@code
+ *       long}) do not re-read the physical column.
+ *   <li><b>Array path</b> — for paths starting with an array index (e.g. {@code $[0]}), the full
+ *       shredded root value is reconstructed once and the index is applied in memory.
+ *   <li><b>Root fallback</b> — for unshredded paths, the root serialized {@code value} blob is read
+ *       once per row (shared across all fallback fields) and the path is applied in memory.
+ *   <li><b>Null</b> — paths that cannot be resolved in the file schema return {@code null}.
+ * </ol>
+ *
+ * <h2>Column deduplication</h2>
+ *
+ * {@link VariantExtractionRowReader} collects all {@link TripleIterator} column cursors via
+ * identity-based deduplication ({@link java.util.IdentityHashMap}). This is necessary because
+ * multiple field readers may reference the exact same underlying physical column object; advancing
+ * it twice per row would corrupt the read stream.
+ */
+public class ParquetVariantExtractionReaders {
+  private ParquetVariantExtractionReaders() {}
+
+  public static int leafColumnCount(ParquetValueReader<?> reader) {
+    return reader.columns().size();
+  }
+
+  public static ParquetValueReader<VariantExtractionRow> buildRowReader(
+      MessageType fileSchema,
+      GroupType variantGroup,
+      List<String> variantColumnPath,
+      List<VariantExtractionField> fields) {
+    return new VariantExtractionRowReader(fileSchema, variantGroup, variantColumnPath, fields);
+  }
+
+  /**
+   * The result of reading one Parquet row through a {@link ParquetVariantExtractionReaders} reader.
+   * Holds the row's variant metadata, one {@link VariantValue} per requested field (indexed by
+   * {@link VariantExtractionField#ordinal()}), and a placeholder flag for fields that were declared
+   * as placeholders rather than real extraction targets. All value slots are {@code null} when the
+   * variant column itself is SQL NULL.
+   */
+  public static final class VariantExtractionRow {
+    private VariantMetadata metadata;
+    private final VariantValue[] values;
+    private final boolean[] placeholders;
+
+    private VariantExtractionRow(
+        VariantMetadata metadata, VariantValue[] values, boolean[] placeholders) {
+      this.metadata = metadata;
+      this.values = values;
+      this.placeholders = placeholders;
+    }
+
+    /**
+     * Returns the variant metadata for this row, or {@code null} when the Parquet variant column is
+     * SQL NULL (the shredded {@code metadata} column is absent at the current definition level).
+     */
+    public VariantMetadata metadata() {
+      return metadata;
+    }
+
+    public VariantValue value(int ordinal) {
+      return values[ordinal];
+    }
+
+    public boolean placeholder(int ordinal) {
+      return placeholders[ordinal];
+    }
+
+    public int numFields() {
+      return values.length;
+    }
+  }
+
+  /**
+   * Describes one field to extract from a shredded variant column. Each field has a unique {@code
+   * ordinal} (its slot index in the output row), a parsed {@code pathParts} list (from a JSON path
+   * like {@code $.user.name} or {@code $[0]}), and an optional {@code placeholder} flag for
+   * ordinals that should be filled with a sentinel rather than a real value.
+   */
+  public static final class VariantExtractionField {
+    private final int ordinal;
+    private final boolean placeholder;
+    private final List<String> pathParts;
+
+    public VariantExtractionField(int ordinal, boolean placeholder, List<String> pathParts) {
+      this.ordinal = ordinal;
+      this.placeholder = placeholder;
+      this.pathParts = pathParts;
+    }
+
+    public int ordinal() {
+      return ordinal;
+    }
+
+    public boolean placeholder() {
+      return placeholder;
+    }
+
+    public List<String> pathParts() {
+      return pathParts;
+    }
+  }
+
+  /**
+   * Orchestrates reading one Parquet row into a {@link VariantExtractionRow}. Builds one {@link
+   * FieldValueReader} per requested field during construction using the reader selection strategy
+   * described in {@link ParquetVariantExtractionReaders}. The {@code rowPosition} counter
+   * invalidates per-row caches in {@link RowCachedReader} instances; {@code rootValuePosition}
+   * tracks lazy advancement of the root fallback column so it is consumed exactly once per row even
+   * when multiple fields need it.
+   */
+  private static class VariantExtractionRowReader
+      implements ParquetValueReader<VariantExtractionRow> {
+    private final int numFields;
+    private final FieldSpec[] fields;
+    private final ParquetValueReader<VariantMetadata> metadataReader;
+    private final VariantValueReader rootFallbackReader;
+    private final int rootValueDefinitionLevel;
+    private final TripleIterator<?> column;
+    private final List<TripleIterator<?>> columnCursors;
+    private final Map<List<String>, RowCachedReader> rowCachedReaders = Maps.newHashMap();
+    private long rowPosition = 0L;
+    private long rootValuePosition = 0L;
+
+    private VariantExtractionRowReader(
+        MessageType fileSchema,
+        GroupType variantGroup,
+        List<String> variantColumnPath,
+        List<VariantExtractionField> extractionFields) {
+      this.numFields =
+          extractionFields.stream().mapToInt(VariantExtractionField::ordinal).max().orElse(-1) + 1;
+      this.fields = new FieldSpec[numFields];
+      for (VariantExtractionField field : extractionFields) {
+        fields[field.ordinal()] = new FieldSpec(field);
+      }
+
+      ColumnDescriptor metadataDesc =
+          fileSchema.getColumnDescription(
+              VariantExtractionPathResolver.pathArray(variantColumnPath, "metadata"));
+      this.metadataReader = ParquetVariantReaders.metadata(fileSchema, metadataDesc);
+
+      for (FieldSpec field : fields) {
+        if (field != null && !field.placeholder()) {
+          field.reader = buildFieldReader(fileSchema, variantGroup, variantColumnPath, field);
+        }
+      }
+
+      boolean needsRootFallback =
+          Arrays.stream(fields).filter(Objects::nonNull).anyMatch(field -> field.needsRootFallback);
+
+      if (needsRootFallback && VariantExtractionPathResolver.hasRootSerializedValue(variantGroup)) {
+        ColumnDescriptor valueDesc =
+            fileSchema.getColumnDescription(
+                VariantExtractionPathResolver.pathArray(variantColumnPath, "value"));
+        this.rootValueDefinitionLevel = fileSchema.getMaxDefinitionLevel(valueDesc.getPath()) - 1;
+        this.rootFallbackReader = ParquetVariantReaders.serialized(valueDesc);
+      } else {
+        this.rootValueDefinitionLevel = Integer.MAX_VALUE;
+        this.rootFallbackReader = null;
+      }
+
+      this.column = metadataReader.column();
+      this.columnCursors = collectColumnCursors();
+    }
+
+    private List<TripleIterator<?>> collectColumnCursors() {
+      ImmutableList.Builder<TripleIterator<?>> columns = ImmutableList.builder();
+      Set<TripleIterator<?>> seenColumns = Collections.newSetFromMap(new IdentityHashMap<>());
+      addColumnCursors(columns, seenColumns, metadataReader.columns());
+      if (rootFallbackReader != null) {
+        addColumnCursors(columns, seenColumns, rootFallbackReader.columns());
+      }
+
+      for (FieldSpec field : fields) {
+        if (field != null && field.reader != null) {
+          addColumnCursors(columns, seenColumns, field.reader.columns());
+        }
+      }
+
+      return columns.build();
+    }
+
+    private void addColumnCursors(
+        ImmutableList.Builder<TripleIterator<?>> columns,
+        Set<TripleIterator<?>> seenColumns,
+        Iterable<TripleIterator<?>> columnsToAdd) {
+      for (TripleIterator<?> columnToAdd : columnsToAdd) {
+        if (seenColumns.add(columnToAdd)) {
+          columns.add(columnToAdd);
+        }
+      }
+    }
+
+    private FieldValueReader buildFieldReader(
+        MessageType fileSchema,
+        GroupType variantGroup,
+        List<String> variantColumnPath,
+        FieldSpec field) {
+      FieldValueReader reader =
+          buildSelectiveNestedReader(fileSchema, variantGroup, variantColumnPath, field);
+      if (reader != null) {
+        return reader;
+      }
+      reader = buildShreddedLeafReader(fileSchema, variantGroup, variantColumnPath, field);
+      if (reader != null) {
+        return reader;
+      }
+      reader = buildArrayPathReader(fileSchema, variantGroup, variantColumnPath, field);
+      if (reader != null) {
+        return reader;
+      }
+      if (VariantExtractionPathResolver.hasRootSerializedValue(variantGroup)) {
+        field.needsRootFallback = true;
+      }
+      return null;
+    }
+
+    /**
+     * Builds a {@link SelectiveObjectReader} chain for a 2+ part object path whose top key is
+     * shredded. Each level reads only the {@code value} blob plus the single child subtree toward
+     * the target leaf, avoiding reconstruction of all siblings.
+     */
+    private FieldValueReader buildSelectiveNestedReader(
+        MessageType fileSchema,
+        GroupType variantGroup,
+        List<String> variantColumnPath,
+        FieldSpec field) {
+      if (field.pathParts().size() <= 1 || PathUtil.isArrayIndexPart(field.pathParts().get(0))) {
+        return null;
+      }
+      String topKey = field.pathParts().get(0);
+      GroupType topGroup =
+          VariantExtractionPathResolver.resolveShreddedFieldGroup(
+              variantGroup, ImmutableList.of(topKey));
+      if (topGroup == null) {
+        return null;
+      }
+      List<String> topPath =
+          VariantExtractionPathResolver.readerPath(variantColumnPath, ImmutableList.of(topKey));
+      List<String> remainingPath = field.pathParts().subList(1, field.pathParts().size());
+      ParquetVariantReaders.VariantValueReader selective =
+          buildSelectivePathReader(fileSchema, topGroup, topPath, remainingPath);
+      if (selective == null) {
+        return null;
+      }
+      // selective reads from topGroup and returns the topKey-level VariantValue — a partial
+      // object including only the remainingPath child (e.g. $.a.b.c returns {b:{c:leaf}}).
+      // PathNavigatingFieldReader then applies remainingPath in-memory to extract the leaf.
+      RowCachedReader sharedReader =
+          rowCachedReaders.computeIfAbsent(field.pathParts(), k -> new RowCachedReader(selective));
+      return new PathNavigatingFieldReader(sharedReader, remainingPath);
+    }
+
+    /**
+     * Builds a reader for a path whose final hop is a directly shredded typed or serialized leaf.
+     * The underlying column reader is shared across all fields with the same path (e.g. {@code
+     * $.size} as {@code double} AND as {@code long}); the Spark-level cast handles per-ordinal type
+     * conversion.
+     */
+    private FieldValueReader buildShreddedLeafReader(
+        MessageType fileSchema,
+        GroupType variantGroup,
+        List<String> variantColumnPath,
+        FieldSpec field) {
+      GroupType fieldGroup =
+          VariantExtractionPathResolver.resolveShreddedFieldGroup(variantGroup, field.pathParts());
+      if (fieldGroup == null
+          || (!VariantExtractionPathResolver.hasTypedValue(fieldGroup)
+              && !VariantExtractionPathResolver.hasSerializedValue(fieldGroup))) {
+        return null;
+      }
+      RowCachedReader shared =
+          rowCachedReaders.computeIfAbsent(
+              field.pathParts(),
+              k -> {
+                VariantValueReader reader;
+                if (VariantExtractionPathResolver.hasTypedValue(fieldGroup)) {
+                  List<String> readerPath =
+                      VariantExtractionPathResolver.readerPath(
+                          variantColumnPath, field.pathParts());
+                  reader =
+                      (VariantValueReader)
+                          ParquetVariantVisitor.visitShreddedValueGroup(
+                              fieldGroup, new VariantReaderBuilder(fileSchema, readerPath));
+                } else {
+                  ColumnDescriptor valueDesc =
+                      fileSchema.getColumnDescription(
+                          VariantExtractionPathResolver.pathToSerializedField(
+                              variantColumnPath, field.pathParts()));
+                  reader = ParquetVariantReaders.serialized(valueDesc);
+                }
+                return new RowCachedReader(reader);
+              });
+      return new PathNavigatingFieldReader(shared, ImmutableList.of());
+    }
+
+    /**
+     * Builds a reader for paths starting with an array index (e.g. {@code $[0]}). Root arrays
+     * cannot use an object-field prefix, so the full shredded root value is reconstructed and the
+     * array index path is applied in memory.
+     */
+    private FieldValueReader buildArrayPathReader(
+        MessageType fileSchema,
+        GroupType variantGroup,
+        List<String> variantColumnPath,
+        FieldSpec field) {
+      if (field.pathParts().isEmpty() || !PathUtil.isArrayIndexPart(field.pathParts().get(0))) {
+        return null;
+      }
+      RowCachedReader cachedReader =
+          buildRowCachedReader(fileSchema, variantGroup, variantColumnPath);
+      return new PathNavigatingFieldReader(cachedReader, field.pathParts());
+    }
+
+    private RowCachedReader buildRowCachedReader(
+        MessageType fileSchema, GroupType variantGroup, List<String> readerPath) {
+      return rowCachedReaders.computeIfAbsent(
+          Collections.emptyList(),
+          ignored -> {
+            VariantValueReader reader =
+                (VariantValueReader)
+                    ParquetVariantVisitor.visitShreddedValueGroup(
+                        variantGroup, new VariantReaderBuilder(fileSchema, readerPath));
+            return new RowCachedReader(reader);
+          });
+    }
+
+    /**
+     * Recursively builds a selective {@link ParquetVariantReaders.VariantValueReader} for {@code
+     * pathParts} starting at {@code currentGroup}.
+     *
+     * <p>Object hops compose a chain of {@link SelectiveObjectReader} instances (one child field
+     * per level, plus that level's {@code value} blob). The leaf is a full shredded-value reader
+     * from {@link ParquetVariantVisitor#visitShreddedValueGroup}. Unresolvable steps fall back to a
+     * value-blob reader or full group reconstruction; array-index steps use full reconstruction.
+     * Returns {@code null} when the path cannot be resolved.
+     *
+     * @param currentGroup shredded value group at this level ({@code value} / {@code typed_value})
+     * @param currentPath Parquet column path to {@code currentGroup}
+     * @param pathParts object-field segments to follow from {@code currentGroup}
+     */
+    private ParquetVariantReaders.VariantValueReader buildSelectivePathReader(
+        MessageType fileSchema,
+        GroupType currentGroup,
+        List<String> currentPath,
+        List<String> pathParts) {
+      // Base case: leaf reached or array index step — build a full reader for this group.
+      if (pathParts.isEmpty() || PathUtil.isArrayIndexPart(pathParts.get(0))) {
+        return (ParquetVariantReaders.VariantValueReader)
+            ParquetVariantVisitor.visitShreddedValueGroup(
+                currentGroup, new VariantReaderBuilder(fileSchema, currentPath));
+      }
+
+      String fieldKey = pathParts.get(0);
+      List<String> remainingPath = pathParts.subList(1, pathParts.size());
+
+      // Build a reader for the serialized value blob at this level — used when typed_value absent.
+      ParquetVariantReaders.VariantValueReader valueReader = null;
+      int valueDL = Integer.MAX_VALUE;
+      if (ParquetSchemaUtil.hasField(currentGroup, "value")) {
+        ColumnDescriptor valueDesc =
+            fileSchema.getColumnDescription(
+                concat(currentPath, ImmutableList.of("value")).toArray(String[]::new));
+        valueReader = ParquetVariantReaders.serialized(valueDesc);
+        valueDL = valueDesc.getMaxDefinitionLevel() - 1;
+      }
+
+      // If typed_value is absent or a primitive, there are no shredded children to recurse into.
+      if (!ParquetSchemaUtil.hasField(currentGroup, "typed_value")
+          || currentGroup.getType("typed_value").isPrimitive()) {
+        return valueBlobOnlyReader(valueReader, valueDL);
+      }
+
+      // If the next path key is not shredded in typed_value, fall back to the value blob.
+      GroupType typedGroup = currentGroup.getType("typed_value").asGroupType();
+      if (!ParquetSchemaUtil.hasField(typedGroup, fieldKey)) {
+        return valueBlobOnlyReader(valueReader, valueDL);
+      }
+
+      // Recurse into the shredded child group for fieldKey.
+      int fieldsDL =
+          fileSchema.getMaxDefinitionLevel(
+                  concat(currentPath, ImmutableList.of("typed_value")).toArray(String[]::new))
+              - 1;
+      GroupType fieldGroup = typedGroup.getType(fieldKey).asGroupType();
+      List<String> fieldPath =
+          concat(concat(currentPath, ImmutableList.of("typed_value")), ImmutableList.of(fieldKey));
+      ParquetVariantReaders.VariantValueReader childReader =
+          buildSelectivePathReader(fileSchema, fieldGroup, fieldPath, remainingPath);
+
+      if (childReader == null) {
+        // Child path unresolvable — fall back to full reconstruction at this level.
+        return (ParquetVariantReaders.VariantValueReader)
+            ParquetVariantVisitor.visitShreddedValueGroup(
+                currentGroup, new VariantReaderBuilder(fileSchema, currentPath));
+      }
+
+      return new SelectiveObjectReader(valueReader, valueDL, fieldsDL, fieldKey, childReader);
+    }
+
+    private static ParquetVariantReaders.VariantValueReader valueBlobOnlyReader(
+        ParquetVariantReaders.VariantValueReader valueReader, int valueDL) {
+      return valueReader != null
+          ? ParquetVariantReaders.shredded(valueDL, valueReader, Integer.MAX_VALUE, null)
+          : null;
+    }
+
+    private static List<String> concat(List<String> base, List<String> suffix) {
+      ImmutableList.Builder<String> builder = ImmutableList.builder();
+      builder.addAll(base);
+      builder.addAll(suffix);
+      return builder.build();
+    }
+
+    @Override
+    public VariantExtractionRow read(VariantExtractionRow reuse) {
+      VariantMetadata metadata = metadataReader.read(null);
+
+      VariantExtractionRow result;
+      if (reuse != null && reuse.numFields() == numFields) {
+        result = reuse;
+        Arrays.fill(result.values, null);
+        Arrays.fill(result.placeholders, false);
+        result.metadata = metadata;
+      } else {
+        result =
+            new VariantExtractionRow(metadata, new VariantValue[numFields], new boolean[numFields]);
+      }
+
+      if (metadata == null) {
+        // SQL NULL variant column: shredded metadata is absent. Skip field readers and leave
+        // values/placeholders unset so callers materialize an all-null extraction row.
+        return result;
+      }
+
+      VariantValue[] values = result.values;
+      boolean[] placeholders = result.placeholders;
+      VariantValue rootValue = null;
+      boolean rootValueRead = false;
+      long currentRowPosition = rowPosition;
+      rowPosition += 1;
+
+      for (FieldSpec field : fields) {
+        if (field == null) {
+          continue;
+        }
+
+        if (field.placeholder()) {
+          placeholders[field.ordinal()] = true;
+        } else if (field.needsRootFallback) {
+          if (!rootValueRead) {
+            rootValue = readRootValue(metadata, currentRowPosition);
+            rootValueRead = true;
+          }
+
+          values[field.ordinal()] = extractPath(rootValue, field.pathParts());
+        } else if (field.reader != null) {
+          values[field.ordinal()] = field.reader.read(metadata, currentRowPosition);
+        }
+      }
+
+      return result;
+    }
+
+    // Reads the root-level fallback value for the current row, advancing the root fallback
+    // column cursors exactly once. Rows where no fallback field was requested do not call this
+    // method, so the cursors may have fallen behind; skipRootValue() catches them up.
+    private VariantValue readRootValue(VariantMetadata metadata, long currentRowPosition) {
+      if (rootFallbackReader == null) {
+        return null;
+      }
+
+      // Catch up: advance past rows where no fallback field was requested (so those rows' cursors
+      // were never consumed).
+      while (rootValuePosition < currentRowPosition) {
+        skipRootValue();
+        rootValuePosition += 1;
+      }
+
+      rootValuePosition += 1;
+      if (rootFallbackReader.column().currentDefinitionLevel() > rootValueDefinitionLevel) {
+        return rootFallbackReader.read(metadata);
+      }
+
+      for (TripleIterator<?> child : rootFallbackReader.columns()) {
+        child.nextNull();
+      }
+
+      return null;
+    }
+
+    // Advances root fallback column cursors for one row without consuming the value.
+    private void skipRootValue() {
+      if (rootFallbackReader.column().currentDefinitionLevel() > rootValueDefinitionLevel) {
+        rootFallbackReader.column().nextBinary();
+      } else {
+        for (TripleIterator<?> child : rootFallbackReader.columns()) {
+          child.nextNull();
+        }
+      }
+    }
+
+    @Override
+    public TripleIterator<?> column() {
+      return column;
+    }
+
+    @Override
+    public List<TripleIterator<?>> columns() {
+      return columnCursors;
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore) {
+      metadataReader.setPageSource(pageStore);
+      if (rootFallbackReader != null) {
+        rootFallbackReader.setPageSource(pageStore);
+      }
+      this.rowPosition = 0L;
+      this.rootValuePosition = 0L;
+
+      // Call setPageSource on each RowCachedReader exactly once.
+      // All PathNavigatingFieldReaders reference readers from this map, so iterating
+      // the map avoids double-initialization when multiple fields share the same reader.
+      rowCachedReaders.values().forEach(r -> r.setPageSource(pageStore));
+    }
+  }
+
+  private static class FieldSpec {
+    private final VariantExtractionField field;
+    private FieldValueReader reader;
+    private boolean needsRootFallback;
+
+    private FieldSpec(VariantExtractionField field) {
+      this.field = field;
+    }
+
+    private int ordinal() {
+      return field.ordinal();
+    }
+
+    private boolean placeholder() {
+      return field.placeholder();
+    }
+
+    private List<String> pathParts() {
+      return field.pathParts();
+    }
+  }
+
+  private interface FieldValueReader {
+    VariantValue read(VariantMetadata metadata, long rowPosition);
+
+    List<TripleIterator<?>> columns();
+  }
+
+  private static class RowCachedReader {
+    private final VariantValueReader delegate;
+    private long cachedRowPosition = -1L;
+    private VariantValue cachedValue = null;
+
+    private RowCachedReader(VariantValueReader delegate) {
+      this.delegate = delegate;
+    }
+
+    private VariantValue read(VariantMetadata metadata, long rowPosition) {
+      if (cachedRowPosition != rowPosition) {
+        cachedValue = delegate.read(metadata);
+        cachedRowPosition = rowPosition;
+      }
+
+      return cachedValue;
+    }
+
+    private List<TripleIterator<?>> columns() {
+      return delegate.columns();
+    }
+
+    private void setPageSource(PageReadStore pageStore) {
+      delegate.setPageSource(pageStore);
+      cachedRowPosition = -1L;
+      cachedValue = null;
+    }
+  }
+
+  private static class PathNavigatingFieldReader implements FieldValueReader {
+    private final RowCachedReader cachedReader;
+    private final List<String> remainingPath;
+
+    private PathNavigatingFieldReader(RowCachedReader cachedReader, List<String> remainingPath) {
+      this.cachedReader = cachedReader;
+      this.remainingPath = remainingPath;
+    }
+
+    @Override
+    public VariantValue read(VariantMetadata metadata, long rowPosition) {
+      VariantValue value = cachedReader.read(metadata, rowPosition);
+      return value != null ? extractPath(value, remainingPath) : null;
+    }
+
+    @Override
+    public List<TripleIterator<?>> columns() {
+      return cachedReader.columns();
+    }
+  }
+
+  /**
+   * Reads exactly one child field from a shredded object variant, touching only path-relevant
+   * columns. Unlike {@link RowCachedReader} wrapping a full {@link
+   * ParquetVariantReaders.ShreddedObjectReader} (which reconstructs every sibling field), this
+   * reader includes only:
+   *
+   * <ol>
+   *   <li>the {@code value} blob at this level (for leftover/fallback data), and
+   *   <li>the columns of the single requested child subtree.
+   * </ol>
+   *
+   * <p>Per-row: if the probe column's definition level indicates the typed object is present, the
+   * child field is read and merged with any leftover {@code value} data into a partial {@link
+   * ShreddedObject}. Otherwise the {@code value} blob is returned directly.
+   */
+  private static class SelectiveObjectReader implements ParquetVariantReaders.VariantValueReader {
+    private final ParquetVariantReaders.VariantValueReader valueReader;
+    private final int valueDefinitionLevel;
+    private final int fieldsDefinitionLevel;
+    private final String childFieldName;
+    private final ParquetVariantReaders.VariantValueReader childReader;
+    private final TripleIterator<?> probeColumn;
+    private final List<TripleIterator<?>> allColumns;
+
+    private SelectiveObjectReader(
+        ParquetVariantReaders.VariantValueReader valueReader,
+        int valueDefinitionLevel,
+        int fieldsDefinitionLevel,
+        String childFieldName,
+        ParquetVariantReaders.VariantValueReader childReader) {
+      this.valueReader = valueReader;
+      this.valueDefinitionLevel = valueDefinitionLevel;
+      this.fieldsDefinitionLevel = fieldsDefinitionLevel;
+      this.childFieldName = childFieldName;
+      this.childReader = childReader;
+      // Deepest leaf column propagated up from child: present whenever parent typed_value present.
+      this.probeColumn = childReader.column();
+      ImmutableList.Builder<TripleIterator<?>> cols = ImmutableList.builder();
+      if (valueReader != null) {
+        cols.addAll(valueReader.columns());
+      }
+      cols.addAll(childReader.columns());
+      this.allColumns = cols.build();
+    }
+
+    // Returns true when this level's {@code typed_value} group is present for the current row.
+    // This is key to determine if we should read the child value or not.
+    private boolean isTypedValuePresent() {
+      return probeColumn.currentDefinitionLevel() > fieldsDefinitionLevel;
+    }
+
+    @Override
+    public VariantValue read(VariantMetadata metadata) {
+      // Advance value column: read if present, else skip.
+      VariantValue value = null;
+      if (valueReader != null) {
+        if (valueReader.column().currentDefinitionLevel() > valueDefinitionLevel) {
+          value = valueReader.read(metadata);
+        } else {
+          for (TripleIterator<?> c : valueReader.columns()) {
+            c.nextNull();
+          }
+        }
+      }
+
+      if (isTypedValuePresent()) {
+        // recursively read the child value and overlay it on the value blob
+        VariantValue childValue = childReader.read(metadata);
+        ShreddedObject object =
+            (value != null && value.type() == PhysicalType.OBJECT)
+                ? Variants.object(metadata, (VariantObject) value)
+                : Variants.object(metadata);
+        if (childValue != null) {
+          // Include variant NULL values — JSON null is a valid field value, not "missing".
+          object.put(childFieldName, childValue);
+        }
+        return object;
+      } else {
+        // typed_value null: advance child columns and return serialized value blob.
+        for (TripleIterator<?> c : childReader.columns()) {
+          c.nextNull();
+        }
+        return value;
+      }
+    }
+
+    @Override
+    public TripleIterator<?> column() {
+      // Return the deepest probe column so parent readers can check our presence correctly.
+      return probeColumn;
+    }
+
+    @Override
+    public List<TripleIterator<?>> columns() {
+      return allColumns;
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore) {
+      if (valueReader != null) {
+        valueReader.setPageSource(pageStore);
+      }
+      childReader.setPageSource(pageStore);
+    }
+  }
+
+  private static VariantValue extractPath(VariantValue value, List<String> pathParts) {
+    VariantValue current = value;
+    for (String part : pathParts) {
+      if (current == null || current.type() == PhysicalType.NULL) {
+        return null;
+      }
+
+      if (PathUtil.isArrayIndexPart(part)) {
+        if (current.type() != PhysicalType.ARRAY) {
+          return null;
+        }
+        int index = PathUtil.parseArrayIndexPart(part);
+        VariantArray array = current.asArray();
+        if (index >= array.numElements()) {
+          return null;
+        }
+        current = array.get(index);
+      } else {
+        if (current.type() != PhysicalType.OBJECT) {
+          return null;
+        }
+        current = current.asObject().get(part);
+      }
+    }
+
+    return current;
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantExtractionReaders.java
@@ -137,9 +137,10 @@ public class ParquetVariantExtractionReaders {
   public static final class VariantExtractionField {
     private final int ordinal;
     private final boolean placeholder;
-    private final List<String> pathParts;
+    private final List<PathUtil.PathSegment> pathParts;
 
-    public VariantExtractionField(int ordinal, boolean placeholder, List<String> pathParts) {
+    public VariantExtractionField(
+        int ordinal, boolean placeholder, List<PathUtil.PathSegment> pathParts) {
       this.ordinal = ordinal;
       this.placeholder = placeholder;
       this.pathParts = pathParts;
@@ -153,7 +154,7 @@ public class ParquetVariantExtractionReaders {
       return placeholder;
     }
 
-    public List<String> pathParts() {
+    public List<PathUtil.PathSegment> pathParts() {
       return pathParts;
     }
   }
@@ -175,7 +176,8 @@ public class ParquetVariantExtractionReaders {
     private final int rootValueDefinitionLevel;
     private final TripleIterator<?> column;
     private final List<TripleIterator<?>> columnCursors;
-    private final Map<List<String>, RowCachedReader> rowCachedReaders = Maps.newHashMap();
+    private final Map<List<PathUtil.PathSegment>, RowCachedReader> rowCachedReaders =
+        Maps.newHashMap();
     private long rowPosition = 0L;
     private long rootValuePosition = 0L;
 
@@ -282,19 +284,22 @@ public class ParquetVariantExtractionReaders {
         GroupType variantGroup,
         List<String> variantColumnPath,
         FieldSpec field) {
-      if (field.pathParts().size() <= 1 || PathUtil.isArrayIndexPart(field.pathParts().get(0))) {
+      if (field.pathParts().size() <= 1
+          || field.pathParts().get(0) instanceof PathUtil.PathSegment.Index) {
         return null;
       }
-      String topKey = field.pathParts().get(0);
+      String topKey = ((PathUtil.PathSegment.Name) field.pathParts().get(0)).name();
       GroupType topGroup =
           VariantExtractionPathResolver.resolveShreddedFieldGroup(
-              variantGroup, ImmutableList.of(topKey));
+              variantGroup, ImmutableList.of(new PathUtil.PathSegment.Name(topKey)));
       if (topGroup == null) {
         return null;
       }
       List<String> topPath =
-          VariantExtractionPathResolver.readerPath(variantColumnPath, ImmutableList.of(topKey));
-      List<String> remainingPath = field.pathParts().subList(1, field.pathParts().size());
+          VariantExtractionPathResolver.readerPath(
+              variantColumnPath, ImmutableList.of(new PathUtil.PathSegment.Name(topKey)));
+      List<PathUtil.PathSegment> remainingPath =
+          field.pathParts().subList(1, field.pathParts().size());
       ParquetVariantReaders.VariantValueReader selective =
           buildSelectivePathReader(fileSchema, topGroup, topPath, remainingPath);
       if (selective == null) {
@@ -361,7 +366,8 @@ public class ParquetVariantExtractionReaders {
         GroupType variantGroup,
         List<String> variantColumnPath,
         FieldSpec field) {
-      if (field.pathParts().isEmpty() || !PathUtil.isArrayIndexPart(field.pathParts().get(0))) {
+      if (field.pathParts().isEmpty()
+          || !(field.pathParts().get(0) instanceof PathUtil.PathSegment.Index)) {
         return null;
       }
       RowCachedReader cachedReader =
@@ -400,16 +406,16 @@ public class ParquetVariantExtractionReaders {
         MessageType fileSchema,
         GroupType currentGroup,
         List<String> currentPath,
-        List<String> pathParts) {
+        List<PathUtil.PathSegment> pathParts) {
       // Base case: leaf reached or array index step — build a full reader for this group.
-      if (pathParts.isEmpty() || PathUtil.isArrayIndexPart(pathParts.get(0))) {
+      if (pathParts.isEmpty() || pathParts.get(0) instanceof PathUtil.PathSegment.Index) {
         return (ParquetVariantReaders.VariantValueReader)
             ParquetVariantVisitor.visitShreddedValueGroup(
                 currentGroup, new VariantReaderBuilder(fileSchema, currentPath));
       }
 
-      String fieldKey = pathParts.get(0);
-      List<String> remainingPath = pathParts.subList(1, pathParts.size());
+      String fieldKey = ((PathUtil.PathSegment.Name) pathParts.get(0)).name();
+      List<PathUtil.PathSegment> remainingPath = pathParts.subList(1, pathParts.size());
 
       // Build a reader for the serialized value blob at this level — used when typed_value absent.
       ParquetVariantReaders.VariantValueReader valueReader = null;
@@ -600,7 +606,7 @@ public class ParquetVariantExtractionReaders {
       return field.placeholder();
     }
 
-    private List<String> pathParts() {
+    private List<PathUtil.PathSegment> pathParts() {
       return field.pathParts();
     }
   }
@@ -642,9 +648,10 @@ public class ParquetVariantExtractionReaders {
 
   private static class PathNavigatingFieldReader implements FieldValueReader {
     private final RowCachedReader cachedReader;
-    private final List<String> remainingPath;
+    private final List<PathUtil.PathSegment> remainingPath;
 
-    private PathNavigatingFieldReader(RowCachedReader cachedReader, List<String> remainingPath) {
+    private PathNavigatingFieldReader(
+        RowCachedReader cachedReader, List<PathUtil.PathSegment> remainingPath) {
       this.cachedReader = cachedReader;
       this.remainingPath = remainingPath;
     }
@@ -767,18 +774,19 @@ public class ParquetVariantExtractionReaders {
     }
   }
 
-  private static VariantValue extractPath(VariantValue value, List<String> pathParts) {
+  private static VariantValue extractPath(
+      VariantValue value, List<PathUtil.PathSegment> pathParts) {
     VariantValue current = value;
-    for (String part : pathParts) {
+    for (PathUtil.PathSegment segment : pathParts) {
       if (current == null || current.type() == PhysicalType.NULL) {
         return null;
       }
 
-      if (PathUtil.isArrayIndexPart(part)) {
+      if (segment instanceof PathUtil.PathSegment.Index) {
         if (current.type() != PhysicalType.ARRAY) {
           return null;
         }
-        int index = PathUtil.parseArrayIndexPart(part);
+        int index = ((PathUtil.PathSegment.Index) segment).index();
         VariantArray array = current.asArray();
         if (index >= array.numElements()) {
           return null;
@@ -788,7 +796,7 @@ public class ParquetVariantExtractionReaders {
         if (current.type() != PhysicalType.OBJECT) {
           return null;
         }
-        current = current.asObject().get(part);
+        current = current.asObject().get(((PathUtil.PathSegment.Name) segment).name());
       }
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantReaders.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.schema.MessageType;
 
 public class ParquetVariantReaders {
   private ParquetVariantReaders() {}
@@ -62,8 +63,15 @@ public class ParquetVariantReaders {
         (ParquetValueReader<VariantMetadata>) metadata, (VariantValueReader) value);
   }
 
+  @Deprecated
   public static ParquetValueReader<VariantMetadata> metadata(ColumnDescriptor desc) {
     return new VariantMetadataReader(desc);
+  }
+
+  public static ParquetValueReader<VariantMetadata> metadata(
+      MessageType schema, ColumnDescriptor desc) {
+    int definitionLevel = schema.getMaxDefinitionLevel(desc.getPath()) - 1;
+    return new VariantMetadataReader(desc, definitionLevel);
   }
 
   public static VariantValueReader serialized(ColumnDescriptor desc) {
@@ -146,13 +154,25 @@ public class ParquetVariantReaders {
     // Caches the last parsed metadata for adjacent rows with identical bytes.
     private byte[] lastMetadataBytes;
     private VariantMetadata cachedMetadata;
+    private final int definitionLevel;
 
     private VariantMetadataReader(ColumnDescriptor desc) {
       super(desc);
+      this.definitionLevel = Integer.MIN_VALUE;
+    }
+
+    private VariantMetadataReader(ColumnDescriptor desc, int definitionLevel) {
+      super(desc);
+      this.definitionLevel = definitionLevel;
     }
 
     @Override
     public VariantMetadata read(VariantMetadata reuse) {
+      if (definitionLevel != Integer.MIN_VALUE
+          && column.currentDefinitionLevel() <= definitionLevel) {
+        return null;
+      }
+
       ByteBuffer data = column.nextBinary().toByteBuffer();
       int length = data.remaining();
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantVisitor.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantVisitor.java
@@ -163,6 +163,17 @@ public abstract class ParquetVariantVisitor<R> {
   /** Handler called after visiting any primitive or group type. */
   public void afterField(Type type) {}
 
+  /**
+   * Visits a shredded variant value group (a {@code variant_value_pair} or root value group)
+   * without requiring a {@code metadata} field.
+   *
+   * <p>Use this to build readers for a single shredded path under a variant column.
+   */
+  public static <R> R visitShreddedValueGroup(
+      GroupType valueGroup, ParquetVariantVisitor<R> visitor) {
+    return visitValue(valueGroup, visitor);
+  }
+
   public static <R> R visit(GroupType type, ParquetVariantVisitor<R> visitor) {
     Preconditions.checkArgument(
         ParquetSchemaUtil.hasField(type, METADATA), "Invalid variant, missing metadata: %s", type);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantExtractionPathResolver.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantExtractionPathResolver.java
@@ -31,10 +31,13 @@ class VariantExtractionPathResolver {
 
   private VariantExtractionPathResolver() {}
 
-  static List<String> readerPath(Iterable<String> variantColumnPath, List<String> objectPathParts) {
+  static List<String> readerPath(
+      Iterable<String> variantColumnPath, List<PathUtil.PathSegment> objectPathParts) {
     List<String> path = Lists.newArrayList(variantColumnPath);
     path.add(TYPED_VALUE);
-    path.addAll(objectPathParts);
+    for (PathUtil.PathSegment seg : objectPathParts) {
+      path.add(((PathUtil.PathSegment.Name) seg).name());
+    }
     return path;
   }
 
@@ -46,7 +49,8 @@ class VariantExtractionPathResolver {
     return path.toArray(new String[0]);
   }
 
-  static GroupType resolveShreddedFieldGroup(GroupType variantGroup, List<String> objectPathParts) {
+  static GroupType resolveShreddedFieldGroup(
+      GroupType variantGroup, List<PathUtil.PathSegment> objectPathParts) {
     if (!ParquetSchemaUtil.hasField(variantGroup, TYPED_VALUE)) {
       return null;
     }
@@ -57,7 +61,12 @@ class VariantExtractionPathResolver {
     }
 
     GroupType current = typedValue.asGroupType();
-    for (String part : objectPathParts) {
+    for (PathUtil.PathSegment seg : objectPathParts) {
+      if (seg instanceof PathUtil.PathSegment.Index) {
+        // Array indexes are not shredded as Parquet fields.
+        return null;
+      }
+      String part = ((PathUtil.PathSegment.Name) seg).name();
       if (!ParquetSchemaUtil.hasField(current, part)) {
         return null;
       }
@@ -92,24 +101,27 @@ class VariantExtractionPathResolver {
   }
 
   static String[] pathToSerializedField(
-      List<String> variantColumnPath, List<String> objectPathParts) {
+      List<String> variantColumnPath, List<PathUtil.PathSegment> objectPathParts) {
     List<String> path = Lists.newArrayList(variantColumnPath);
     path.add(TYPED_VALUE);
-    path.addAll(objectPathParts);
+    for (PathUtil.PathSegment seg : objectPathParts) {
+      path.add(((PathUtil.PathSegment.Name) seg).name());
+    }
     path.add(VALUE);
     return path.toArray(new String[0]);
   }
 
   /**
-   * Returns the leading object-field path parts up to (but not including) the first array index
-   * part. For a purely object path such as {@code ["actor", "login"]} this is the full list.
+   * Returns the leading segments up to (but not including) the first {@link
+   * PathUtil.PathSegment.Index}. For a purely object path such as {@code [Name("actor"),
+   * Name("login")]} this is the full list.
    */
-  static List<String> objectPathBeforeFirstArray(List<String> pathParts) {
-    for (int i = 0; i < pathParts.size(); i++) {
-      if (PathUtil.isArrayIndexPart(pathParts.get(i))) {
-        return pathParts.subList(0, i);
+  static List<PathUtil.PathSegment> segmentsBeforeFirstIndex(List<PathUtil.PathSegment> segments) {
+    for (int i = 0; i < segments.size(); i++) {
+      if (segments.get(i) instanceof PathUtil.PathSegment.Index) {
+        return segments.subList(0, i);
       }
     }
-    return pathParts;
+    return segments;
   }
 }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantExtractionPathResolver.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantExtractionPathResolver.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import java.util.List;
+import org.apache.iceberg.expressions.PathUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.Type;
+
+/** Resolves shredded Parquet paths for variant extraction pushdown. */
+class VariantExtractionPathResolver {
+  private static final String VALUE = "value";
+  private static final String TYPED_VALUE = "typed_value";
+
+  private VariantExtractionPathResolver() {}
+
+  static List<String> readerPath(Iterable<String> variantColumnPath, List<String> objectPathParts) {
+    List<String> path = Lists.newArrayList(variantColumnPath);
+    path.add(TYPED_VALUE);
+    path.addAll(objectPathParts);
+    return path;
+  }
+
+  static String[] pathArray(Iterable<String> variantColumnPath, String... suffix) {
+    List<String> path = Lists.newArrayList(variantColumnPath);
+    for (String part : suffix) {
+      path.add(part);
+    }
+    return path.toArray(new String[0]);
+  }
+
+  static GroupType resolveShreddedFieldGroup(GroupType variantGroup, List<String> objectPathParts) {
+    if (!ParquetSchemaUtil.hasField(variantGroup, TYPED_VALUE)) {
+      return null;
+    }
+
+    Type typedValue = variantGroup.getType(TYPED_VALUE);
+    if (typedValue.isPrimitive()) {
+      return objectPathParts.isEmpty() ? variantGroup : null;
+    }
+
+    GroupType current = typedValue.asGroupType();
+    for (String part : objectPathParts) {
+      if (!ParquetSchemaUtil.hasField(current, part)) {
+        return null;
+      }
+
+      Type field = current.getType(part);
+      if (field.isPrimitive()) {
+        return null;
+      }
+
+      current = field.asGroupType();
+    }
+
+    return current;
+  }
+
+  static boolean hasTypedValue(GroupType valueGroup) {
+    return ParquetSchemaUtil.hasField(valueGroup, TYPED_VALUE);
+  }
+
+  /**
+   * Returns true when the given group (either a per-field shredded value group or the root variant
+   * group) has an inline serialized {@code value} column. Both call sites check the same predicate;
+   * the two names distinguish the caller context for clarity.
+   */
+  static boolean hasSerializedValue(GroupType valueGroup) {
+    return ParquetSchemaUtil.hasField(valueGroup, VALUE);
+  }
+
+  /** Returns true when the root variant group has an inline serialized {@code value} column. */
+  static boolean hasRootSerializedValue(GroupType variantGroup) {
+    return hasSerializedValue(variantGroup);
+  }
+
+  static String[] pathToSerializedField(
+      List<String> variantColumnPath, List<String> objectPathParts) {
+    List<String> path = Lists.newArrayList(variantColumnPath);
+    path.add(TYPED_VALUE);
+    path.addAll(objectPathParts);
+    path.add(VALUE);
+    return path.toArray(new String[0]);
+  }
+
+  /**
+   * Returns the leading object-field path parts up to (but not including) the first array index
+   * part. For a purely object path such as {@code ["actor", "login"]} this is the full list.
+   */
+  static List<String> objectPathBeforeFirstArray(List<String> pathParts) {
+    for (int i = 0; i < pathParts.size(); i++) {
+      if (PathUtil.isArrayIndexPart(pathParts.get(i))) {
+        return pathParts.subList(0, i);
+      }
+    }
+    return pathParts;
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantReaderBuilder.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantReaderBuilder.java
@@ -80,7 +80,7 @@ public class VariantReaderBuilder extends ParquetVariantVisitor<ParquetValueRead
   @Override
   public ParquetValueReader<?> metadata(PrimitiveType metadata) {
     ColumnDescriptor desc = schema.getColumnDescription(currentPath());
-    return ParquetVariantReaders.metadata(desc);
+    return ParquetVariantReaders.metadata(schema, desc);
   }
 
   @Override

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
@@ -1,0 +1,1402 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.InternalWriter;
+import org.apache.iceberg.expressions.PathUtil;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtractionField;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtractionRow;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.ShreddedObject;
+import org.apache.iceberg.variants.ValueArray;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.jupiter.api.Test;
+
+class TestParquetVariantExtractionReaders {
+
+  // Duplicates SparkVariantExtractionUtil.PLACEHOLDER_PATH; the parquet module cannot depend on
+  // spark so the constant is copied here. Keep the two values in sync.
+  private static final String PLACEHOLDER_PATH = "$.__placeholder_field__";
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "var", Types.VariantType.get()));
+
+  private static final Schema OPTIONAL_VARIANT_SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "var", Types.VariantType.get()));
+
+  @Test
+  void selectiveReaderReadsFewerColumnsThanFullVariantReader() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType zipField = shreddedStringField("zip");
+    GroupType sizeField = shreddedLongField("size");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField, zipField, sizeField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.size"));
+
+    ParquetValueReader<?> fullReader =
+        ParquetVariantVisitor.visit(
+            variantGroup, new VariantReaderBuilder(fileSchema, List.of("v")));
+    ParquetValueReader<?> selectiveReader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema, variantGroup, List.of("v"), fields);
+
+    int fullColumns = ParquetVariantExtractionReaders.leafColumnCount(fullReader);
+    int selectiveColumns = ParquetVariantExtractionReaders.leafColumnCount(selectiveReader);
+
+    assertThat(selectiveColumns)
+        .as("selective reader should read fewer Parquet columns than the full variant")
+        .isLessThan(fullColumns);
+    assertThat(selectiveColumns)
+        .as("selective reader should not include unrelated shredded fields (city, zip)")
+        .isLessThan(fullColumns - 2);
+  }
+
+  @Test
+  void multipleExtractionsUnionColumnPaths() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType zipField = shreddedStringField("zip");
+    GroupType sizeField = shreddedLongField("size");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField, zipField, sizeField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    List<VariantExtractionField> bothFields =
+        ImmutableList.of(extractionField(0, false, "$.city"), extractionField(1, false, "$.zip"));
+
+    ParquetValueReader<?> cityOnlyReader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema,
+            variantGroup,
+            List.of("v"),
+            ImmutableList.of(extractionField(0, false, "$.city")));
+    ParquetValueReader<?> bothReader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema, variantGroup, List.of("v"), bothFields);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(bothReader))
+        .as("two extractions should read more columns than one")
+        .isGreaterThan(ParquetVariantExtractionReaders.leafColumnCount(cityOnlyReader));
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(bothReader))
+        .as("two extractions should still read fewer columns than the full variant")
+        .isLessThan(
+            ParquetVariantExtractionReaders.leafColumnCount(
+                ParquetVariantVisitor.visit(
+                    variantGroup, new VariantReaderBuilder(fileSchema, List.of("v")))));
+  }
+
+  @Test
+  void unshreddedVariantUsesMetadataAndValueColumnsOnly() {
+    GroupType variantGroup = unshreddedVariant("v");
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.size"));
+
+    ParquetValueReader<?> selectiveReader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema, variantGroup, List.of("v"), fields);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(selectiveReader))
+        .as("unshredded fallback reads metadata and root value only")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void placeholderReadsMetadataOnly() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, true, PLACEHOLDER_PATH));
+
+    ParquetValueReader<?> reader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema, variantGroup, List.of("v"), fields);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(reader)).isEqualTo(1);
+  }
+
+  @Test
+  void shreddedExtractionReadsTypedValue() throws IOException {
+    VariantMetadata metadata = Variants.metadata("size");
+    ShreddedObject object = Variants.object(metadata);
+    object.put("size", Variants.of(42L));
+    Variant variant = Variant.of(metadata, object);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile outputFile = new InMemoryOutputFile();
+    try (FileAppender<Record> writer =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(object))
+            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .build()) {
+      writer.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(outputFile.toInputFile()))) {
+      fileSchema = reader.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.size"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                schema ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        schema, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.placeholder(0)).isFalse();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo(42L);
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // SelectiveObjectReader correctness tests (spec-driven)
+  // Invariants from the Parquet Variant Shredding spec:
+  //   value=null,  typed_value=null   → field is MISSING from the object
+  //   value=0x00,  typed_value=null   → field is PRESENT with JSON null
+  //   value=null,  typed_value=X      → field is PRESENT with typed value X
+  //   value=obj,   typed_value={...}  → PARTIALLY SHREDDED object; keys are disjoint
+  // -----------------------------------------------------------------------
+
+  /**
+   * Nested path where every step is shredded into typed_value.
+   *
+   * <p>Schema: var.typed_value.user.typed_value.login.typed_value = string
+   *
+   * <p>Row: user.login = "alice" (fully typed)
+   *
+   * <p>Expected: reads login.typed_value directly; login.value and user.value are null.
+   */
+  @Test
+  void nestedPathFullyTyped() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+    ShreddedObject loginObj = Variants.object(meta);
+    loginObj.put("login", Variants.of("alice"));
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", loginObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("alice");
+    }
+  }
+
+  /**
+   * Nested path where the child field exists in the schema but the row has JSON null for it.
+   *
+   * <p>The null value goes into login.value (as serialized variant null); login.typed_value is
+   * absent. The SelectiveObjectReader must return the variant null (not skip it and fall back to an
+   * ancestor blob).
+   */
+  @Test
+  void nestedPathJsonNullUsesValueColumn() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+    ShreddedObject loginObj = Variants.object(meta);
+    loginObj.put("login", Variants.ofNull());
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", loginObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      // login exists but is JSON null → the extraction returns a variant null, not Java null.
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).type()).isEqualTo(PhysicalType.NULL);
+    }
+  }
+
+  /**
+   * Nested path where the parent field is shredded but the leaf is not shredded.
+   *
+   * <p>Schema has user.typed_value, but login is NOT shredded. Login lives in user.value.
+   *
+   * <p>The SelectiveObjectReader must recover login from user.value.
+   */
+  @Test
+  void nestedPathLeafNotShredded() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+    // Build an object where 'user' is shredded but 'login' within user is NOT shredded.
+    // We achieve this by giving user a typed_value that has no login field.
+    ShreddedObject userWithLoginInValue = Variants.object(meta);
+    userWithLoginInValue.put("login", Variants.of("bob"));
+
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", userWithLoginInValue);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    // Shred: user is in typed_value, but login inside user is left in user.value (not typed).
+    // We use a shredding schema that only includes 'user' at the root level, with no typed
+    // children inside user — so user.value gets the serialized user blob including login.
+    ShreddedObject userShell = Variants.object(meta); // empty user — forces login into user.value
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc(
+                (id, name) -> {
+                  // Shred 'user' at root level but don't shred login within user.
+                  return ParquetVariantUtil.toParquetSchema(rootObj);
+                })
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("bob");
+    }
+  }
+
+  /**
+   * Multiple rows across two separate writes: simulates two different shredding schemas for the
+   * same column (like two row groups with different inference results).
+   *
+   * <p>Row 1: user.login typed (login.typed_value = "alice") Row 2: user.login not typed (login in
+   * user.value blob)
+   *
+   * <p>Both must read correctly from the same extraction reader.
+   */
+  @Test
+  void nestedPathMixedTypedAndUntypedAcrossRows() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+
+    ShreddedObject userAlice = Variants.object(meta);
+    userAlice.put("login", Variants.of("alice"));
+    ShreddedObject rootAlice = Variants.object(meta);
+    rootAlice.put("user", userAlice);
+
+    ShreddedObject userBob = Variants.object(meta);
+    userBob.put("login", Variants.of("bob"));
+    ShreddedObject rootBob = Variants.object(meta);
+    rootBob.put("user", userBob);
+
+    Record r1 = GenericRecord.create(SCHEMA).copy("id", 1, "var", Variant.of(meta, rootAlice));
+    Record r2 = GenericRecord.create(SCHEMA).copy("id", 2, "var", Variant.of(meta, rootBob));
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootAlice))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(r1);
+      w.add(r2);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      List<VariantExtractionRow> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0).value(0).asPrimitive().get()).isEqualTo("alice");
+      assertThat(rows.get(1).value(0).asPrimitive().get()).isEqualTo("bob");
+    }
+  }
+
+  /**
+   * Two extractions under the same top-level prefix share the same SelectiveObjectReader.
+   *
+   * <p>Schema: user.login (string) and user.role (string) both shredded.
+   *
+   * <p>Verifies both fields are extracted correctly from a single shared prefix reader.
+   */
+  @Test
+  void twoFieldsUnderSamePrefixAreShared() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login", "role");
+    ShreddedObject userObj = Variants.object(meta);
+    userObj.put("login", Variants.of("alice"));
+    userObj.put("role", Variants.of("admin"));
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", userObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(
+            extractionField(0, false, "$.user.login"), extractionField(1, false, "$.user.role"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("alice");
+      assertThat(row.value(1).asPrimitive().get()).isEqualTo("admin");
+    }
+  }
+
+  /**
+   * Same path extracted twice with different target types must share one physical column.
+   *
+   * <p>Both ordinals must produce the correct value; the column count must be the same as for a
+   * single extraction of that path (no double-read of the same Parquet column).
+   */
+  @Test
+  void samePathDifferentTargetTypesSharePhysicalColumn() throws IOException {
+    VariantMetadata metadata = Variants.metadata("size");
+    ShreddedObject object = Variants.object(metadata);
+    object.put("size", Variants.of(42L));
+    Variant variant = Variant.of(metadata, object);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile outputFile = new InMemoryOutputFile();
+    try (FileAppender<Record> writer =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(object))
+            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .build()) {
+      writer.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(outputFile.toInputFile()))) {
+      fileSchema = reader.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    // Ordinal 0: $.size as long.  Ordinal 1: same path $.size but treated as long again
+    // (different ordinal, same physical column).
+    List<VariantExtractionField> singleField =
+        ImmutableList.of(extractionField(0, false, "$.size"));
+    List<VariantExtractionField> twoFields =
+        ImmutableList.of(extractionField(0, false, "$.size"), extractionField(1, false, "$.size"));
+
+    int singleColumns =
+        ParquetVariantExtractionReaders.leafColumnCount(
+            ParquetVariantExtractionReaders.buildRowReader(
+                fileSchema, variantGroup, List.of("var"), singleField));
+    int twoColumns =
+        ParquetVariantExtractionReaders.leafColumnCount(
+            ParquetVariantExtractionReaders.buildRowReader(
+                fileSchema, variantGroup, List.of("var"), twoFields));
+
+    assertThat(twoColumns)
+        .as("two extractions for the same path must not add extra Parquet columns")
+        .isEqualTo(singleColumns);
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(outputFile.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                schema ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        schema, variantGroup, List.of("var"), twoFields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0).asPrimitive().get()).as("ordinal 0").isEqualTo(42L);
+      assertThat(row.value(1).asPrimitive().get()).as("ordinal 1").isEqualTo(42L);
+    }
+  }
+
+  /**
+   * Selective reader for a nested path reads fewer columns than the full variant reader even when
+   * many siblings exist at the parent level.
+   */
+  @Test
+  void selectiveNestedReaderReadsFarFewerColumnsThanFull() {
+    // Simulate a pull_request-like schema with many sibling fields under typed_value
+    GroupType loginField = shreddedStringField("login");
+    GroupType emailField = shreddedStringField("email");
+    GroupType userGroup =
+        org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .named("value")
+            .optionalGroup()
+            .addFields(loginField, emailField)
+            .named("typed_value")
+            .named("user");
+    GroupType draftField = shreddedStringField("draft");
+    GroupType titleField = shreddedStringField("title");
+    GroupType bodyField = shreddedStringField("body");
+    GroupType createdAtField = shreddedStringField("created_at");
+    GroupType prGroup =
+        org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+            .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+            .named("value")
+            .optionalGroup()
+            .addFields(userGroup, draftField, titleField, bodyField, createdAtField)
+            .named("typed_value")
+            .named("pull_request");
+    GroupType variantGroup = shreddedObjectVariant("v", prGroup);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    // Full variant reader
+    int fullColumns =
+        ParquetVariantExtractionReaders.leafColumnCount(
+            ParquetVariantVisitor.visit(
+                variantGroup, new VariantReaderBuilder(fileSchema, List.of("v"))));
+
+    // Selective reader for $.pull_request.user.login
+    int selectiveColumns =
+        ParquetVariantExtractionReaders.leafColumnCount(
+            ParquetVariantExtractionReaders.buildRowReader(
+                fileSchema,
+                variantGroup,
+                List.of("v"),
+                ImmutableList.of(extractionField(0, false, "$.pull_request.user.login"))));
+
+    assertThat(selectiveColumns)
+        .as(
+            "selective reader for pull_request.user.login should read far fewer columns"
+                + " than full variant (%d full vs %d selective)",
+            fullColumns, selectiveColumns)
+        .isLessThan(fullColumns / 2);
+  }
+
+  /**
+   * Partially shredded object (spec row 2): the top-level object has some fields in {@code
+   * typed_value} and other fields in {@code value}. Both must be accessible after merge.
+   *
+   * <p>Root object: {@code {"action":"opened", "user":{"login":"alice"}}}. Schema shreds {@code
+   * user.login} but leaves {@code action} unshredded (in {@code value}).
+   */
+  @Test
+  void partiallyShredded_bothValueAndTypedFieldsAccessible() throws IOException {
+    VariantMetadata meta = Variants.metadata("action", "login", "user");
+    ShreddedObject userObj = Variants.object(meta);
+    userObj.put("login", Variants.of("alice"));
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("action", Variants.of("opened"));
+    rootObj.put("user", userObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    // Extract both the typed field (user.login) and the unshredded field (action).
+    List<VariantExtractionField> fields =
+        ImmutableList.of(
+            extractionField(0, false, "$.user.login"), extractionField(1, false, "$.action"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0).asPrimitive().get())
+          .as("user.login from typed_value")
+          .isEqualTo("alice");
+      assertThat(row.value(1).asPrimitive().get())
+          .as("action from value blob (not shredded)")
+          .isEqualTo("opened");
+    }
+  }
+
+  /**
+   * Spec: {@code value=null, typed_value=null} → field is MISSING, extraction returns Java null.
+   * Distinct from JSON null (which encodes as {@code value=0x00}).
+   */
+  @Test
+  void missingFieldReturnsNull() throws IOException {
+    // Object has "other" field but not "login"
+    VariantMetadata meta = Variants.metadata("login", "other", "user");
+    ShreddedObject userObj = Variants.object(meta);
+    userObj.put("other", Variants.of("value"));
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", userObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    // Extract $.user.login which does not exist in this row
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0))
+          .as("login is absent (missing) — should return Java null, not a Variant null")
+          .isNull();
+    }
+  }
+
+  /**
+   * Spec row 7: field is present with a value of the wrong shredded type. The {@code typed_value}
+   * column is null; the actual value is in {@code value}. The reader must return the value, not
+   * null.
+   *
+   * <p>Example: schema shreds {@code size} as INT64, but the row has {@code size = "large"} (a
+   * string). → {@code typed_value.size.typed_value = null}, {@code typed_value.size.value = string
+   * blob}.
+   */
+  @Test
+  void fieldWithWrongTypeFallsBackToValueColumn() throws IOException {
+    VariantMetadata meta = Variants.metadata("size");
+    ShreddedObject root = Variants.object(meta);
+    root.put("size", Variants.of("large")); // string, but shredded schema expects long
+    Variant variant = Variant.of(meta, root);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    // Provide a shredding schema that expects size as long — the writer will fall back to
+    // size.value for the string.
+    ShreddedObject longRoot = Variants.object(meta);
+    longRoot.put("size", Variants.of(99L)); // long placeholder to generate the long schema
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(longRoot))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.size"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0))
+          .as("wrong-type field should be returned from size.value, not null")
+          .isNotNull();
+      // The value is a string variant (from size.value), not a long.
+      assertThat(row.value(0).type()).isEqualTo(PhysicalType.STRING);
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("large");
+    }
+  }
+
+  /**
+   * When the variant column itself is SQL NULL, shredded metadata is absent and every extraction
+   * slot must be null. This is distinct from a present variant where only individual paths are
+   * missing or JSON-null.
+   */
+  @Test
+  void nullVariantColumnReturnsNullMetadataAndExtractions() throws IOException {
+    Record record = GenericRecord.create(OPTIONAL_VARIANT_SCHEMA).copy("id", 1, "var", null);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(OPTIONAL_VARIANT_SCHEMA)
+            .createWriterFunc(fs -> InternalWriter.create(OPTIONAL_VARIANT_SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(
+            extractionField(0, false, "$.size"), extractionField(1, true, PLACEHOLDER_PATH));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(OPTIONAL_VARIANT_SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.metadata()).isNull();
+      assertThat(row.value(0)).isNull();
+      assertThat(row.placeholder(0)).isFalse();
+      assertThat(row.placeholder(1)).isFalse();
+    }
+  }
+
+  /**
+   * Spec: when the top-level variant is null, {@code value = 0x00, typed_value = null}. Any nested
+   * field extraction must return null.
+   */
+  @Test
+  void wholeVariantNullReturnsNullForNestedPath() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("user", Variants.ofNull()); // user is null; the variant stores it in value
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      // user is null (not an object) → login cannot be extracted → null
+      assertThat(row.value(0))
+          .as("user is null variant, not an object — login extraction must return null")
+          .isNull();
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Array path tests
+  // -----------------------------------------------------------------------
+
+  /** Root variant is an array; extract element by index via {@code $[n]}. */
+  @Test
+  void arrayPath_extractsElementFromRootArray() throws IOException {
+    ValueArray arr = Variants.array();
+    arr.add(Variants.of(10L));
+    arr.add(Variants.of(20L));
+    arr.add(Variants.of(30L));
+    Variant variant = Variant.of(Variants.emptyMetadata(), arr);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(arr))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$[1]"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo(20L);
+    }
+  }
+
+  /** Root variant is an array of objects; extract a field from one element via {@code $[n].key}. */
+  @Test
+  void arrayPath_extractsFieldFromObjectInRootArray() throws IOException {
+    VariantMetadata meta = Variants.metadata("name");
+    ShreddedObject alice = Variants.object(meta);
+    alice.put("name", Variants.of("alice"));
+    ShreddedObject bob = Variants.object(meta);
+    bob.put("name", Variants.of("bob"));
+    ValueArray arr = Variants.array();
+    arr.add(alice);
+    arr.add(bob);
+    Variant variant = Variant.of(meta, arr);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(arr))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$[0].name"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("alice");
+    }
+  }
+
+  /**
+   * Shredded object field containing an array; extract element via {@code $.items[n]}.
+   *
+   * <p>{@code buildSelectiveNestedReader} walks to the {@code items} group (array base case in
+   * {@code buildSelectivePathReader}), then applies the index in memory.
+   */
+  @Test
+  void nestedArrayField_shreddedObjectWithArrayChild() throws IOException {
+    VariantMetadata meta = Variants.metadata("items");
+    ValueArray arr = Variants.array();
+    arr.add(Variants.of(10L));
+    arr.add(Variants.of(20L));
+    arr.add(Variants.of(30L));
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("items", arr);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.items[0]"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo(10L);
+    }
+  }
+
+  /**
+   * Shredded object field containing an array of objects; extract field from one element via {@code
+   * $.users[n].key}.
+   */
+  @Test
+  void nestedArrayOfObjects_extractsFieldFromElement() throws IOException {
+    VariantMetadata meta = Variants.metadata("users", "name");
+    ShreddedObject alice = Variants.object(meta);
+    alice.put("name", Variants.of("alice"));
+    ShreddedObject bob = Variants.object(meta);
+    bob.put("name", Variants.of("bob"));
+    ValueArray users = Variants.array();
+    users.add(alice);
+    users.add(bob);
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("users", users);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.users[0].name"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("alice");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Deep nesting tests
+  // -----------------------------------------------------------------------
+
+  /**
+   * Three-level deep nested object with all levels shredded. Exercises a chain of three {@link
+   * SelectiveObjectReader} instances and in-memory navigation of the result.
+   *
+   * <p>Schema: {@code {a: {b: {c: "deep"}}}} — each level is a typed_value object group.
+   */
+  @Test
+  void threeLevel_deepNested_allShredded() throws IOException {
+    VariantMetadata meta = Variants.metadata("a", "b", "c");
+    ShreddedObject cObj = Variants.object(meta);
+    cObj.put("c", Variants.of("deep"));
+    ShreddedObject bObj = Variants.object(meta);
+    bObj.put("b", cObj);
+    ShreddedObject rootObj = Variants.object(meta);
+    rootObj.put("a", bObj);
+    Variant variant = Variant.of(meta, rootObj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(rootObj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.a.b.c"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get()).isEqualTo("deep");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Mixed-row DL variation tests
+  // -----------------------------------------------------------------------
+
+  /**
+   * Same shredded schema across three rows; the {@code typed_value} column is present for some rows
+   * and absent for others. Verifies that {@code isTypedValuePresent()} evaluates correctly per row
+   * (not just once) as definition levels change throughout the column.
+   *
+   * <p>Row 1: {@code size = 42L} — {@code typed_value} populated (DL high) Row 2: {@code size =
+   * "large"} — wrong type; {@code typed_value} null, {@code value} blob used Row 3: {@code size =
+   * 99L} — {@code typed_value} populated again (DL high)
+   */
+  @Test
+  void mixedRows_typedValueAndValueBlobAlternatePerRow() throws IOException {
+    VariantMetadata meta = Variants.metadata("size");
+    ShreddedObject longSchema = Variants.object(meta);
+    longSchema.put("size", Variants.of(42L)); // drives INT64 shredding schema
+
+    ShreddedObject root1 = Variants.object(meta);
+    root1.put("size", Variants.of(42L));
+    ShreddedObject root2 = Variants.object(meta);
+    root2.put("size", Variants.of("large")); // string falls into value blob
+    ShreddedObject root3 = Variants.object(meta);
+    root3.put("size", Variants.of(99L));
+
+    Record r1 = GenericRecord.create(SCHEMA).copy("id", 1, "var", Variant.of(meta, root1));
+    Record r2 = GenericRecord.create(SCHEMA).copy("id", 2, "var", Variant.of(meta, root2));
+    Record r3 = GenericRecord.create(SCHEMA).copy("id", 3, "var", Variant.of(meta, root3));
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(longSchema))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(r1);
+      w.add(r2);
+      w.add(r3);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.size"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      List<VariantExtractionRow> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(3);
+      assertThat(rows.get(0).value(0).asPrimitive().get()).as("row 1: typed long").isEqualTo(42L);
+      assertThat(rows.get(1).value(0).type())
+          .as("row 2: value blob holds string")
+          .isEqualTo(PhysicalType.STRING);
+      assertThat(rows.get(1).value(0).asPrimitive().get())
+          .as("row 2: string value")
+          .isEqualTo("large");
+      assertThat(rows.get(2).value(0).asPrimitive().get()).as("row 3: typed long").isEqualTo(99L);
+    }
+  }
+
+  /**
+   * Same shredded schema across three rows with a nested path; {@code typed_value} at the parent
+   * level is populated for rows 1 and 3 but absent for row 2 (wrong type). Verifies per-row DL
+   * evaluation through a {@link SelectiveObjectReader}.
+   *
+   * <p>Row 1: {@code user.login = "alice"} — shredded Row 2: {@code user = 42L} — typed_value null
+   * for login step; value blob used Row 3: {@code user.login = "carol"} — shredded
+   */
+  @Test
+  void mixedRows_nestedPath_typedValueAbsentForSomeRows() throws IOException {
+    VariantMetadata meta = Variants.metadata("user", "login");
+
+    ShreddedObject userAlice = Variants.object(meta);
+    userAlice.put("login", Variants.of("alice"));
+    ShreddedObject root1 = Variants.object(meta);
+    root1.put("user", userAlice);
+
+    // Row 2: user is a scalar (long), not an object — typed_value for user is absent
+    ShreddedObject root2 = Variants.object(meta);
+    root2.put("user", Variants.of(42L));
+
+    ShreddedObject userCarol = Variants.object(meta);
+    userCarol.put("login", Variants.of("carol"));
+    ShreddedObject root3 = Variants.object(meta);
+    root3.put("user", userCarol);
+
+    // Schema is driven by root1 (user is a shredded object with login)
+    Record r1 = GenericRecord.create(SCHEMA).copy("id", 1, "var", Variant.of(meta, root1));
+    Record r2 = GenericRecord.create(SCHEMA).copy("id", 2, "var", Variant.of(meta, root2));
+    Record r3 = GenericRecord.create(SCHEMA).copy("id", 3, "var", Variant.of(meta, root3));
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(root1))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(r1);
+      w.add(r2);
+      w.add(r3);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(extractionField(0, false, "$.user.login"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      List<VariantExtractionRow> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(3);
+      assertThat(rows.get(0).value(0).asPrimitive().get())
+          .as("row 1: login from typed_value")
+          .isEqualTo("alice");
+      assertThat(rows.get(1).value(0))
+          .as("row 2: user is scalar, login extraction returns null")
+          .isNull();
+      assertThat(rows.get(2).value(0).asPrimitive().get())
+          .as("row 3: login from typed_value")
+          .isEqualTo("carol");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Miscellaneous edge cases
+  // -----------------------------------------------------------------------
+
+  /**
+   * Root variant is a scalar (not an object). Extracting any object field path must return null
+   * without throwing.
+   */
+  @Test
+  void topLevelScalar_fieldExtractionReturnsNull() throws IOException {
+    // Root is a long scalar, not an object — $.field cannot be navigated.
+    Variant variant = Variant.of(Variants.emptyMetadata(), Variants.of(42L));
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$.field"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).as("scalar variant root — field extraction returns null").isNull();
+    }
+  }
+
+  private static VariantExtractionField extractionField(
+      int ordinal, boolean placeholder, String jsonPath) {
+    return new VariantExtractionField(ordinal, placeholder, pathParts(jsonPath));
+  }
+
+  private static List<String> pathParts(String jsonPath) {
+    if (PLACEHOLDER_PATH.equals(jsonPath)) {
+      return ImmutableList.of();
+    }
+    // Handles dot-separated object steps, bracket array indexes, and mixed paths
+    // (e.g. "$.user.login", "$[0]", "$.items[0].name") via PathUtil.parseObjectPath.
+    return PathUtil.parseObjectPath(jsonPath);
+  }
+
+  private static GroupType shreddedObjectVariant(String name, GroupType... objectFields) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optionalGroup()
+        .addFields(objectFields)
+        .named("typed_value")
+        .named(name);
+  }
+
+  private static GroupType unshreddedVariant(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .named(name);
+  }
+
+  private static GroupType shreddedStringField(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("typed_value")
+        .named(name);
+  }
+
+  private static GroupType shreddedLongField(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optional(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("typed_value")
+        .named(name);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.schema.GroupType;
@@ -946,6 +947,51 @@ class TestParquetVariantExtractionReaders {
     }
   }
 
+  /** Root variant is an array; {@code $[0]} returns the first element (zero-indexed). */
+  @Test
+  void arrayPath_extractsFirstElementFromRootArray() throws IOException {
+    ValueArray arr = Variants.array();
+    arr.add(Variants.of(10L));
+    arr.add(Variants.of(20L));
+    arr.add(Variants.of(30L));
+    Variant variant = Variant.of(Variants.emptyMetadata(), arr);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(arr))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$[0]"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).asPrimitive().get())
+          .as("$[0] is the first element (zero-indexed)")
+          .isEqualTo(10L);
+    }
+  }
+
   /** Root variant is an array of objects; extract a field from one element via {@code $[n].key}. */
   @Test
   void arrayPath_extractsFieldFromObjectInRootArray() throws IOException {
@@ -1299,6 +1345,238 @@ class TestParquetVariantExtractionReaders {
     }
   }
 
+  /**
+   * Root array of <em>heterogeneous</em> objects shredded via the production {@link
+   * VariantShreddingAnalyzer}. Element 0 is {@code {name}}, element 1 is {@code {name, email}} —
+   * the analyzer does not require uniform elements: it unions the fields ({@code email}, {@code
+   * name}) and shreds each by majority vote. Verifies that both a field present in all elements
+   * ({@code name}) and one present in only some ({@code email}) are extractable via {@code
+   * $[i].key}, and that the missing {@code email} on element 0 returns null.
+   */
+  @Test
+  void arrayPath_heterogeneousObjects_shreddedByAnalyzer() throws IOException {
+    VariantMetadata meta = Variants.metadata("email", "name");
+    ShreddedObject alice = Variants.object(meta);
+    alice.put("name", Variants.of("alice"));
+    ShreddedObject bob = Variants.object(meta);
+    bob.put("name", Variants.of("bob"));
+    bob.put("email", Variants.of("bob@example.com"));
+    ValueArray arr = Variants.array();
+    arr.add(alice);
+    arr.add(bob);
+    Variant variant = Variant.of(meta, arr);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    // Production analyzer over the heterogeneous array produces a shredded typed_value schema.
+    Type shreddedType = new DirectAnalyzer().analyzeAndCreateSchema(List.of(arr), 0);
+    assertThat(shreddedType)
+        .as("analyzer should shred a root array of heterogeneous objects")
+        .isNotNull();
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> shreddedType)
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields =
+        ImmutableList.of(
+            extractionField(0, false, "$[0].name"),
+            extractionField(1, false, "$[1].name"),
+            extractionField(2, false, "$[1].email"),
+            extractionField(3, false, "$[0].email"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0).asPrimitive().get()).as("$[0].name").isEqualTo("alice");
+      assertThat(row.value(1).asPrimitive().get()).as("$[1].name").isEqualTo("bob");
+      assertThat(row.value(2).asPrimitive().get())
+          .as("$[1].email present")
+          .isEqualTo("bob@example.com");
+      assertThat(row.value(3)).as("$[0].email absent — missing field returns null").isNull();
+    }
+  }
+
+  /**
+   * Root path ($) on a root array of heterogeneous objects shredded via the analyzer. Reconstructs
+   * the full array and asserts both elements and their (unioned) fields are recovered.
+   */
+  @Test
+  void rootPathExtraction_shreddedArrayOfObjects() throws IOException {
+    VariantMetadata meta = Variants.metadata("email", "name");
+    ShreddedObject alice = Variants.object(meta);
+    alice.put("name", Variants.of("alice"));
+    ShreddedObject bob = Variants.object(meta);
+    bob.put("name", Variants.of("bob"));
+    bob.put("email", Variants.of("bob@example.com"));
+    ValueArray arr = Variants.array();
+    arr.add(alice);
+    arr.add(bob);
+    Variant variant = Variant.of(meta, arr);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    Type shreddedType = new DirectAnalyzer().analyzeAndCreateSchema(List.of(arr), 0);
+    assertThat(shreddedType).isNotNull();
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> shreddedType)
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).type()).isEqualTo(PhysicalType.ARRAY);
+      assertThat(row.value(0).asArray().numElements()).isEqualTo(2);
+      assertThat(row.value(0).asArray().get(0).asObject().get("name").asPrimitive().get())
+          .isEqualTo("alice");
+      assertThat(row.value(0).asArray().get(1).asObject().get("name").asPrimitive().get())
+          .isEqualTo("bob");
+      assertThat(row.value(0).asArray().get(1).asObject().get("email").asPrimitive().get())
+          .isEqualTo("bob@example.com");
+    }
+  }
+
+  // -----------------------------------------------------------------------
+  // Root path ($) extraction
+  // -----------------------------------------------------------------------
+
+  /**
+   * Root extraction path ($) on a shredded object variant. Extracts the full reconstructed variant
+   * value, not a field. Previously mishandled: resolveShreddedFieldGroup returned the typed_value
+   * object-fields group (not the root variant group), so buildShreddedLeafReader found neither
+   * typed_value nor value on it and fell through to the root fallback. This test verifies the
+   * shredded reconstruction path is used when shredding is present.
+   */
+  @Test
+  void rootPathExtraction_shreddedObject() throws IOException {
+    VariantMetadata meta = Variants.metadata("city", "size");
+    ShreddedObject obj = Variants.object(meta);
+    obj.put("city", Variants.of("Chicago"));
+    obj.put("size", Variants.of(42L));
+    Variant variant = Variant.of(meta, obj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .variantShreddingFunc((id, name) -> ParquetVariantUtil.toParquetSchema(obj))
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).type()).isEqualTo(PhysicalType.OBJECT);
+      assertThat(row.value(0).asObject().get("city").asPrimitive().get()).isEqualTo("Chicago");
+      assertThat(row.value(0).asObject().get("size").asPrimitive().get()).isEqualTo(42L);
+    }
+  }
+
+  /**
+   * Root extraction path ($) on an unshredded variant (no typed_value, only value column).
+   * Extraction must fall through to root serialized value fallback and return the whole variant.
+   */
+  @Test
+  void rootPathExtraction_unshreddedFallback() throws IOException {
+    VariantMetadata meta = Variants.metadata("x");
+    ShreddedObject obj = Variants.object(meta);
+    obj.put("x", Variants.of("hello"));
+    Variant variant = Variant.of(meta, obj);
+    Record record = GenericRecord.create(SCHEMA).copy("id", 1, "var", variant);
+
+    OutputFile out = new InMemoryOutputFile();
+    // Write with no shredding schema so the file has only metadata + value columns.
+    try (FileAppender<Record> w =
+        Parquet.write(out)
+            .schema(SCHEMA)
+            .createWriterFunc(fs -> InternalWriter.create(SCHEMA.asStruct(), fs))
+            .build()) {
+      w.add(record);
+    }
+
+    MessageType fileSchema;
+    GroupType variantGroup;
+    try (ParquetFileReader r = ParquetFileReader.open(ParquetIO.file(out.toInputFile()))) {
+      fileSchema = r.getFileMetaData().getSchema();
+      variantGroup = fileSchema.getType("var").asGroupType();
+    }
+
+    List<VariantExtractionField> fields = ImmutableList.of(extractionField(0, false, "$"));
+
+    try (CloseableIterable<VariantExtractionRow> reader =
+        Parquet.read(out.toInputFile())
+            .project(SCHEMA)
+            .createReaderFunc(
+                s ->
+                    ParquetVariantExtractionReaders.buildRowReader(
+                        s, variantGroup, List.of("var"), fields))
+            .build()) {
+      VariantExtractionRow row = Lists.newArrayList(reader).get(0);
+      assertThat(row.value(0)).isNotNull();
+      assertThat(row.value(0).type()).isEqualTo(PhysicalType.OBJECT);
+      assertThat(row.value(0).asObject().get("x").asPrimitive().get()).isEqualTo("hello");
+    }
+  }
+
   // -----------------------------------------------------------------------
   // Miscellaneous edge cases
   // -----------------------------------------------------------------------
@@ -1341,6 +1619,26 @@ class TestParquetVariantExtractionReaders {
             .build()) {
       VariantExtractionRow row = Lists.newArrayList(reader).get(0);
       assertThat(row.value(0)).as("scalar variant root — field extraction returns null").isNull();
+    }
+  }
+
+  /**
+   * Runs the production {@link VariantShreddingAnalyzer} directly over a set of variant values to
+   * produce a shredded {@code typed_value} schema. Unlike {@link
+   * ParquetVariantUtil#toParquetSchema} (which derives a schema from a single representative value
+   * and requires array elements to be uniformly typed), the analyzer samples all values, unions
+   * object fields, and picks each field's type by majority vote — so heterogeneous arrays of
+   * objects still shred.
+   */
+  private static final class DirectAnalyzer extends VariantShreddingAnalyzer<VariantValue, Void> {
+    @Override
+    protected List<VariantValue> extractVariantValues(List<VariantValue> rows, int idx) {
+      return rows;
+    }
+
+    @Override
+    protected int resolveColumnIndex(Void engineSchema, String columnName) {
+      throw new UnsupportedOperationException("Not used in direct tests");
     }
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetVariantExtractionReaders.java
@@ -1349,13 +1349,11 @@ class TestParquetVariantExtractionReaders {
     return new VariantExtractionField(ordinal, placeholder, pathParts(jsonPath));
   }
 
-  private static List<String> pathParts(String jsonPath) {
+  private static List<PathUtil.PathSegment> pathParts(String jsonPath) {
     if (PLACEHOLDER_PATH.equals(jsonPath)) {
       return ImmutableList.of();
     }
-    // Handles dot-separated object steps, bracket array indexes, and mixed paths
-    // (e.g. "$.user.login", "$[0]", "$.items[0].name") via PathUtil.parseObjectPath.
-    return PathUtil.parseObjectPath(jsonPath);
+    return PathUtil.parse(jsonPath);
   }
 
   private static GroupType shreddedObjectVariant(String name, GroupType... objectFields) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantExtractionPathResolver.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantExtractionPathResolver.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
+import org.apache.iceberg.expressions.PathUtil;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.variants.Variant;
 import org.apache.parquet.schema.GroupType;
@@ -57,7 +58,10 @@ class TestVariantExtractionPathResolver {
   void readerPathInsertsTypedValueAfterVariantColumn() {
     assertThat(
             VariantExtractionPathResolver.readerPath(
-                VARIANT_PATH, ImmutableList.of("pull_request", "user")))
+                VARIANT_PATH,
+                ImmutableList.of(
+                    new PathUtil.PathSegment.Name("pull_request"),
+                    new PathUtil.PathSegment.Name("user"))))
         .containsExactly("v", "typed_value", "pull_request", "user");
   }
 
@@ -73,7 +77,11 @@ class TestVariantExtractionPathResolver {
   void pathToSerializedFieldAppendsValueAfterObjectPath() {
     assertThat(
             VariantExtractionPathResolver.pathToSerializedField(
-                VARIANT_PATH, ImmutableList.of("pull_request", "user", "login")))
+                VARIANT_PATH,
+                ImmutableList.of(
+                    new PathUtil.PathSegment.Name("pull_request"),
+                    new PathUtil.PathSegment.Name("user"),
+                    new PathUtil.PathSegment.Name("login"))))
         .containsExactly("v", "typed_value", "pull_request", "user", "login", "value");
   }
 
@@ -82,13 +90,13 @@ class TestVariantExtractionPathResolver {
     // Each segment must be a direct child of the current typed_value container.
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                shreddedVariant, ImmutableList.of("pull_request")))
+                shreddedVariant, ImmutableList.of(new PathUtil.PathSegment.Name("pull_request"))))
         .isEqualTo(prGroup);
 
     GroupType flatUserVariant = shreddedObjectVariant("v", userGroup);
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                flatUserVariant, ImmutableList.of("user")))
+                flatUserVariant, ImmutableList.of(new PathUtil.PathSegment.Name("user"))))
         .isEqualTo(userGroup);
   }
 
@@ -98,11 +106,18 @@ class TestVariantExtractionPathResolver {
     // field names that are direct children of each typed_value group.
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                shreddedVariant, ImmutableList.of("pull_request", "user")))
+                shreddedVariant,
+                ImmutableList.of(
+                    new PathUtil.PathSegment.Name("pull_request"),
+                    new PathUtil.PathSegment.Name("user"))))
         .isNull();
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                shreddedVariant, ImmutableList.of("pull_request", "user", "login")))
+                shreddedVariant,
+                ImmutableList.of(
+                    new PathUtil.PathSegment.Name("pull_request"),
+                    new PathUtil.PathSegment.Name("user"),
+                    new PathUtil.PathSegment.Name("login"))))
         .isNull();
   }
 
@@ -117,15 +132,18 @@ class TestVariantExtractionPathResolver {
   void resolveShreddedFieldGroupReturnsNullForMissingOrUnshreddedPaths() {
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                shreddedVariant, ImmutableList.of("missing")))
+                shreddedVariant, ImmutableList.of(new PathUtil.PathSegment.Name("missing"))))
         .isNull();
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                shreddedVariant, ImmutableList.of("pull_request", "missing")))
+                shreddedVariant,
+                ImmutableList.of(
+                    new PathUtil.PathSegment.Name("pull_request"),
+                    new PathUtil.PathSegment.Name("missing"))))
         .isNull();
     assertThat(
             VariantExtractionPathResolver.resolveShreddedFieldGroup(
-                unshreddedVariant, ImmutableList.of("pull_request")))
+                unshreddedVariant, ImmutableList.of(new PathUtil.PathSegment.Name("pull_request"))))
         .isNull();
   }
 
@@ -144,16 +162,16 @@ class TestVariantExtractionPathResolver {
   }
 
   @Test
-  void objectPathBeforeFirstArrayTruncatesAtIndexSegment() {
+  void segmentsBeforeFirstIndexTruncatesAtIndexSegment() {
     assertThat(
-            VariantExtractionPathResolver.objectPathBeforeFirstArray(
-                ImmutableList.of("items", "[0]", "name")))
-        .containsExactly("items");
+            VariantExtractionPathResolver.segmentsBeforeFirstIndex(
+                PathUtil.parse("$.items[0].name")))
+        .containsExactly(new PathUtil.PathSegment.Name("items"));
     assertThat(
-            VariantExtractionPathResolver.objectPathBeforeFirstArray(
-                ImmutableList.of("actor", "login")))
-        .containsExactly("actor", "login");
-    assertThat(VariantExtractionPathResolver.objectPathBeforeFirstArray(ImmutableList.of("[0]")))
+            VariantExtractionPathResolver.segmentsBeforeFirstIndex(PathUtil.parse("$.actor.login")))
+        .containsExactly(
+            new PathUtil.PathSegment.Name("actor"), new PathUtil.PathSegment.Name("login"));
+    assertThat(VariantExtractionPathResolver.segmentsBeforeFirstIndex(PathUtil.parse("$[0]")))
         .isEmpty();
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantExtractionPathResolver.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantExtractionPathResolver.java
@@ -1,0 +1,192 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.junit.jupiter.api.Test;
+
+class TestVariantExtractionPathResolver {
+
+  private static final List<String> VARIANT_PATH = ImmutableList.of("v");
+
+  private final GroupType loginField = shreddedStringField("login");
+  private final GroupType userGroup =
+      org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+          .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+          .named("value")
+          .optionalGroup()
+          .addFields(loginField)
+          .named("typed_value")
+          .named("user");
+  private final GroupType prGroup =
+      org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+          .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+          .named("value")
+          .optionalGroup()
+          .addFields(userGroup, shreddedStringField("created_at"))
+          .named("typed_value")
+          .named("pull_request");
+  private final GroupType shreddedVariant = shreddedObjectVariant("v", prGroup);
+  private final GroupType unshreddedVariant = unshreddedVariant("v");
+
+  @Test
+  void readerPathInsertsTypedValueAfterVariantColumn() {
+    assertThat(
+            VariantExtractionPathResolver.readerPath(
+                VARIANT_PATH, ImmutableList.of("pull_request", "user")))
+        .containsExactly("v", "typed_value", "pull_request", "user");
+  }
+
+  @Test
+  void pathArrayAppendsSuffixParts() {
+    assertThat(VariantExtractionPathResolver.pathArray(VARIANT_PATH, "metadata"))
+        .containsExactly("v", "metadata");
+    assertThat(VariantExtractionPathResolver.pathArray(VARIANT_PATH, "value"))
+        .containsExactly("v", "value");
+  }
+
+  @Test
+  void pathToSerializedFieldAppendsValueAfterObjectPath() {
+    assertThat(
+            VariantExtractionPathResolver.pathToSerializedField(
+                VARIANT_PATH, ImmutableList.of("pull_request", "user", "login")))
+        .containsExactly("v", "typed_value", "pull_request", "user", "login", "value");
+  }
+
+  @Test
+  void resolveShreddedFieldGroupWalksDirectTypedValueChildren() {
+    // Each segment must be a direct child of the current typed_value container.
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                shreddedVariant, ImmutableList.of("pull_request")))
+        .isEqualTo(prGroup);
+
+    GroupType flatUserVariant = shreddedObjectVariant("v", userGroup);
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                flatUserVariant, ImmutableList.of("user")))
+        .isEqualTo(userGroup);
+  }
+
+  @Test
+  void resolveShreddedFieldGroupDoesNotCrossTypedValueBoundaries() {
+    // Deeper JSON paths are handled by SelectiveObjectReader; this resolver only walks
+    // field names that are direct children of each typed_value group.
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                shreddedVariant, ImmutableList.of("pull_request", "user")))
+        .isNull();
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                shreddedVariant, ImmutableList.of("pull_request", "user", "login")))
+        .isNull();
+  }
+
+  @Test
+  void resolveShreddedFieldGroupReturnsTypedValueContainerForEmptyPath() {
+    GroupType typedValueGroup = shreddedVariant.getType("typed_value").asGroupType();
+    assertThat(VariantExtractionPathResolver.resolveShreddedFieldGroup(shreddedVariant, List.of()))
+        .isEqualTo(typedValueGroup);
+  }
+
+  @Test
+  void resolveShreddedFieldGroupReturnsNullForMissingOrUnshreddedPaths() {
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                shreddedVariant, ImmutableList.of("missing")))
+        .isNull();
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                shreddedVariant, ImmutableList.of("pull_request", "missing")))
+        .isNull();
+    assertThat(
+            VariantExtractionPathResolver.resolveShreddedFieldGroup(
+                unshreddedVariant, ImmutableList.of("pull_request")))
+        .isNull();
+  }
+
+  @Test
+  void hasTypedValueAndHasSerializedValueDetectShreddedLayout() {
+    assertThat(VariantExtractionPathResolver.hasTypedValue(prGroup)).isTrue();
+    assertThat(VariantExtractionPathResolver.hasSerializedValue(prGroup)).isTrue();
+    assertThat(VariantExtractionPathResolver.hasTypedValue(loginField)).isTrue();
+    assertThat(VariantExtractionPathResolver.hasSerializedValue(loginField)).isTrue();
+  }
+
+  @Test
+  void hasRootSerializedValueMatchesRootVariantValueColumn() {
+    assertThat(VariantExtractionPathResolver.hasRootSerializedValue(shreddedVariant)).isTrue();
+    assertThat(VariantExtractionPathResolver.hasRootSerializedValue(unshreddedVariant)).isTrue();
+  }
+
+  @Test
+  void objectPathBeforeFirstArrayTruncatesAtIndexSegment() {
+    assertThat(
+            VariantExtractionPathResolver.objectPathBeforeFirstArray(
+                ImmutableList.of("items", "[0]", "name")))
+        .containsExactly("items");
+    assertThat(
+            VariantExtractionPathResolver.objectPathBeforeFirstArray(
+                ImmutableList.of("actor", "login")))
+        .containsExactly("actor", "login");
+    assertThat(VariantExtractionPathResolver.objectPathBeforeFirstArray(ImmutableList.of("[0]")))
+        .isEmpty();
+  }
+
+  private static GroupType shreddedObjectVariant(String name, GroupType... objectFields) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optionalGroup()
+        .addFields(objectFields)
+        .named("typed_value")
+        .named(name);
+  }
+
+  private static GroupType unshreddedVariant(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .named(name);
+  }
+
+  private static GroupType shreddedStringField(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("typed_value")
+        .named(name);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.data.SparkVariantExtractionUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
@@ -130,6 +131,16 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
         requestedField.nullable() || field.isRequired(),
         "Cannot project an optional field as non-null: %s",
         field.name());
+
+    // When the Iceberg field is VARIANT and Spark has rewritten it to an annotated struct
+    // (all sub-fields carry __VARIANT_METADATA_KEY via SupportsPushDownVariantExtractions),
+    // treat the field as a full variant projection. The struct is an optimizer artifact that
+    // maps ordinal slot i to a specific shredded path; Iceberg's projection must keep the full
+    // VariantType column so the reader can access both metadata/value and typed_value columns.
+    if (field.type().typeId() == TypeID.VARIANT
+        && SparkVariantExtractionUtil.isVariantExtractionStruct(requestedField.dataType())) {
+      return Types.VariantType.get();
+    }
 
     this.current = requestedField.dataType();
     try {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -68,6 +68,8 @@ import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.GeometryType$;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.GeographyVal;
 import org.apache.spark.unsafe.types.GeometryVal;
@@ -79,28 +81,38 @@ public class SparkParquetReaders {
 
   public static ParquetValueReader<InternalRow> buildReader(
       Schema expectedSchema, MessageType fileSchema) {
-    return buildReader(expectedSchema, fileSchema, ImmutableMap.of());
+    return buildReader(expectedSchema, fileSchema, null, ImmutableMap.of());
+  }
+
+  public static ParquetValueReader<InternalRow> buildReader(
+      Schema expectedSchema, MessageType fileSchema, Map<Integer, ?> idToConstant) {
+    return buildReader(expectedSchema, fileSchema, null, idToConstant);
   }
 
   @SuppressWarnings("unchecked")
   public static ParquetValueReader<InternalRow> buildReader(
-      Schema expectedSchema, MessageType fileSchema, Map<Integer, ?> idToConstant) {
+      Schema expectedSchema,
+      MessageType fileSchema,
+      StructType engineSchema,
+      Map<Integer, ?> idToConstant) {
     if (ParquetSchemaUtil.hasIds(fileSchema)) {
       return (ParquetValueReader<InternalRow>)
           TypeWithSchemaVisitor.visit(
-              expectedSchema.asStruct(), fileSchema, new ReadBuilder(fileSchema, idToConstant));
+              expectedSchema.asStruct(),
+              fileSchema,
+              new ReadBuilder(fileSchema, engineSchema, idToConstant));
     } else {
       return (ParquetValueReader<InternalRow>)
           TypeWithSchemaVisitor.visit(
               expectedSchema.asStruct(),
               fileSchema,
-              new FallbackReadBuilder(fileSchema, idToConstant));
+              new FallbackReadBuilder(fileSchema, engineSchema, idToConstant));
     }
   }
 
   private static class FallbackReadBuilder extends ReadBuilder {
-    FallbackReadBuilder(MessageType type, Map<Integer, ?> idToConstant) {
-      super(type, idToConstant);
+    FallbackReadBuilder(MessageType type, StructType engineSchema, Map<Integer, ?> idToConstant) {
+      super(type, engineSchema, idToConstant);
     }
 
     @Override
@@ -129,11 +141,21 @@ public class SparkParquetReaders {
 
   private static class ReadBuilder extends TypeWithSchemaVisitor<ParquetValueReader<?>> {
     private final MessageType type;
+    private final Map<String, StructField> engineFieldsByName;
     private final Map<Integer, ?> idToConstant;
 
-    ReadBuilder(MessageType type, Map<Integer, ?> idToConstant) {
+    ReadBuilder(MessageType type, StructType engineSchema, Map<Integer, ?> idToConstant) {
       this.type = type;
       this.idToConstant = idToConstant;
+      if (engineSchema != null) {
+        ImmutableMap.Builder<String, StructField> builder = ImmutableMap.builder();
+        for (StructField field : engineSchema.fields()) {
+          builder.put(field.name(), field);
+        }
+        this.engineFieldsByName = builder.buildOrThrow();
+      } else {
+        this.engineFieldsByName = ImmutableMap.of();
+      }
     }
 
     @Override
@@ -232,13 +254,39 @@ public class SparkParquetReaders {
 
     @Override
     public ParquetVariantVisitor<ParquetValueReader<?>> variantVisitor() {
+      StructField engineField = engineFieldForCurrentVariantColumn();
+      if (engineField != null
+          && SparkVariantExtractionUtil.isVariantExtractionStruct(engineField.dataType())) {
+        // Selective extraction reader is built in variant(); skip full variant tree.
+        return null;
+      }
+
       return new VariantReaderBuilder(type, Arrays.asList(currentPath()));
     }
 
     @Override
     public ParquetValueReader<?> variant(
         Types.VariantType iVariant, GroupType variant, ParquetValueReader<?> variantReader) {
+      StructField engineField = engineFieldForCurrentVariantColumn();
+      if (engineField != null
+          && SparkVariantExtractionUtil.isVariantExtractionStruct(engineField.dataType())) {
+        return SparkVariantExtractionReaders.buildStructReader(
+            type,
+            variant,
+            Lists.newArrayList(fieldNames.descendingIterator()),
+            (StructType) engineField.dataType());
+      }
+
       return new VariantReader(variantReader);
+    }
+
+    private StructField engineFieldForCurrentVariantColumn() {
+      String fieldName = fieldNames.peek();
+      if (fieldName == null) {
+        return null;
+      }
+
+      return engineFieldsByName.get(fieldName);
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
@@ -18,8 +18,9 @@
  */
 package org.apache.iceberg.spark.data;
 
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.ZoneId;
 import java.util.List;
 import org.apache.iceberg.expressions.PathUtil;
 import org.apache.iceberg.parquet.ParquetValueReader;
@@ -29,23 +30,29 @@ import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtract
 import org.apache.iceberg.parquet.ParquetVariantReaders.DelegatingValueReader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantValue;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.catalyst.expressions.variant.VariantCastArgs;
+import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
-import org.apache.spark.sql.types.Decimal;
-import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.TimestampNTZType;
 import org.apache.spark.sql.types.TimestampType;
 import org.apache.spark.unsafe.types.UTF8String;
+import org.apache.spark.unsafe.types.VariantVal;
 
 /** Parquet readers that materialize Spark variant extraction struct rows from shredded variants. */
 public class SparkVariantExtractionReaders {
+  // Empty variant metadata dictionary, reused for delegating primitive-leaf casts (primitives do
+  // not reference the dictionary, so the per-row dictionary need not be serialized).
+  private static final byte[] EMPTY_VARIANT_METADATA = serializeMetadata(VariantMetadata.empty());
+
   private SparkVariantExtractionReaders() {}
 
   public static ParquetValueReader<InternalRow> buildStructReader(
@@ -60,9 +67,13 @@ public class SparkVariantExtractionReaders {
     }
 
     DataType[] targetTypes = new DataType[numFields];
+    boolean[] failOnError = new boolean[numFields];
+    String[] timeZoneIds = new String[numFields];
     for (StructField field : extractionStruct.fields()) {
       int ordinal = Integer.parseInt(field.name());
       targetTypes[ordinal] = field.dataType();
+      failOnError[ordinal] = SparkVariantExtractionUtil.failOnError(field);
+      timeZoneIds[ordinal] = SparkVariantExtractionUtil.timeZoneId(field);
       fields.add(
           new VariantExtractionField(
               ordinal,
@@ -74,7 +85,8 @@ public class SparkVariantExtractionReaders {
         ParquetVariantExtractionReaders.buildRowReader(
             fileSchema, variantGroup, variantColumnPath, fields);
 
-    return new SparkVariantExtractionStructReader(parquetReader, targetTypes);
+    return new SparkVariantExtractionStructReader(
+        parquetReader, targetTypes, failOnError, timeZoneIds);
   }
 
   /** Counts leaf Parquet columns referenced by a reader tree. */
@@ -84,17 +96,30 @@ public class SparkVariantExtractionReaders {
 
   /** Visible for unit tests in {@code org.apache.iceberg.spark.data}. */
   static Object toSparkValueForTests(VariantValue value, DataType targetType) {
-    return toSparkValue(value, targetType);
+    return toSparkValueForTests(value, targetType, false);
+  }
+
+  /** Visible for unit tests in {@code org.apache.iceberg.spark.data}. */
+  static Object toSparkValueForTests(VariantValue value, DataType targetType, boolean failOnError) {
+    // Tests pass standalone primitive values, so an empty metadata dictionary and UTC suffice.
+    return toSparkValue(value, targetType, failOnError, VariantMetadata.empty(), "UTC");
   }
 
   private static class SparkVariantExtractionStructReader
       extends DelegatingValueReader<VariantExtractionRow, InternalRow> {
     private final DataType[] targetTypes;
+    private final boolean[] failOnError;
+    private final String[] timeZoneIds;
 
     private SparkVariantExtractionStructReader(
-        ParquetValueReader<VariantExtractionRow> reader, DataType[] targetTypes) {
+        ParquetValueReader<VariantExtractionRow> reader,
+        DataType[] targetTypes,
+        boolean[] failOnError,
+        String[] timeZoneIds) {
       super(reader);
       this.targetTypes = targetTypes;
+      this.failOnError = failOnError;
+      this.timeZoneIds = timeZoneIds;
     }
 
     @Override
@@ -120,7 +145,9 @@ public class SparkVariantExtractionReaders {
         if (row.placeholder(i)) {
           result.setBoolean(i, true);
         } else {
-          Object sparkValue = toSparkValue(row.value(i), targetTypes[i]);
+          Object sparkValue =
+              toSparkValue(
+                  row.value(i), targetTypes[i], failOnError[i], row.metadata(), timeZoneIds[i]);
           if (sparkValue == null) {
             result.setNullAt(i);
           } else {
@@ -133,38 +160,151 @@ public class SparkVariantExtractionReaders {
     }
   }
 
-  @SuppressWarnings("checkstyle:CyclomaticComplexity")
-  private static Object toSparkValue(VariantValue value, DataType targetType) {
+  /**
+   * Materializes a single extracted shredded value as the Spark {@code targetType}.
+   *
+   * <p>Uses a narrow inline conversion for the common, stable pairs ({@link #inlineOwned}) and
+   * delegates everything else to Spark's {@code VariantGet.cast}. The inline path exists purely for
+   * performance: it reads the shredded primitive directly, whereas delegating must serialize the
+   * value back into a Spark {@code VariantVal} and run a {@code Cast} — on the order of ~1 KB of
+   * transient allocation per value (vs. tens of bytes inline), which is significant on wide scans.
+   * It is intentionally kept to pairs that are either trivially Spark-identical (identity unwraps,
+   * integer range-checks) or that Spark's variant cannot represent at all and so <em>must</em> be
+   * handled here ({@code TIME}, nanos timestamps). Every cross-type, lossy, or zone-sensitive cast
+   * delegates, so its semantics — including {@code failOnError} throwing and {@code timeZoneId}
+   * handling — match the non-pushdown {@code variant_get} path exactly. A cross-check test asserts
+   * the inline pairs equal {@code VariantGet.cast} so the two paths cannot silently diverge.
+   */
+  private static Object toSparkValue(
+      VariantValue value,
+      DataType targetType,
+      boolean failOnError,
+      VariantMetadata metadata,
+      String timeZoneId) {
     if (value == null || value.type() == PhysicalType.NULL) {
+      // Missing path or variant null: always SQL NULL, regardless of failOnError. This mirrors
+      // Spark's VariantGet, which returns null for a missing path / variant null before any cast.
       return null;
     }
 
+    if (inlineOwned(value.type(), targetType)) {
+      return inlineConvert(value, targetType, failOnError);
+    }
+
+    // Any other (sourceType, targetType): delegate to Spark's VariantGet.cast so cross-type and
+    // lossy casts (e.g. string->long, double->float, decimal rescale, TZ<->NTZ) match the
+    // non-pushdown variant_get path exactly, including throwing on failOnError.
+    return delegate(value, metadata, targetType, failOnError, timeZoneId);
+  }
+
+  /**
+   * Returns true when the selective reader converts this {@code (sourceType, targetType)} pair
+   * directly, without delegating to Spark. The inline set is deliberately small and stable: pairs
+   * that are the identity (nothing to get wrong), integer-family range-checks (stable ANSI
+   * semantics), or physical types Spark's variant cannot represent ({@code TIME}, nanos timestamps)
+   * and therefore must be handled here. Everything else delegates.
+   */
+  private static boolean inlineOwned(PhysicalType sourceType, DataType targetType) {
+    if (isIntegerTarget(targetType)) {
+      // Integer/TIME source -> integer target (identity, widening, or range-checked narrowing).
+      // TIME has no Spark variant counterpart, so it must be inline.
+      return isInlineIntegerSource(sourceType);
+    } else if (DataTypes.StringType.sameType(targetType)) {
+      return sourceType == PhysicalType.STRING || sourceType == PhysicalType.UUID;
+    } else if (DataTypes.BinaryType.sameType(targetType)) {
+      return sourceType == PhysicalType.BINARY;
+    } else if (DataTypes.BooleanType.sameType(targetType)) {
+      return sourceType == PhysicalType.BOOLEAN_TRUE || sourceType == PhysicalType.BOOLEAN_FALSE;
+    } else if (DataTypes.DateType.sameType(targetType)) {
+      return sourceType == PhysicalType.DATE;
+    } else if (DataTypes.DoubleType.sameType(targetType)) {
+      return sourceType == PhysicalType.DOUBLE;
+    } else if (DataTypes.FloatType.sameType(targetType)) {
+      return sourceType == PhysicalType.FLOAT;
+    } else if (targetType instanceof TimestampType || targetType instanceof TimestampNTZType) {
+      // Nanos timestamps must be inline: Spark's variant cannot represent them.
+      return isInlineTimestampSource(sourceType, targetType instanceof TimestampNTZType);
+    }
+
+    // DecimalType and any other target: delegate to Spark.
+    return false;
+  }
+
+  private static boolean isInlineTimestampSource(PhysicalType sourceType, boolean ntz) {
+    if (ntz) {
+      return sourceType == PhysicalType.TIMESTAMPNTZ
+          || sourceType == PhysicalType.TIMESTAMPNTZ_NANOS;
+    } else {
+      return sourceType == PhysicalType.TIMESTAMPTZ || sourceType == PhysicalType.TIMESTAMPTZ_NANOS;
+    }
+  }
+
+  private static boolean isIntegerTarget(DataType targetType) {
+    return DataTypes.LongType.sameType(targetType)
+        || DataTypes.IntegerType.sameType(targetType)
+        || DataTypes.ShortType.sameType(targetType)
+        || DataTypes.ByteType.sameType(targetType);
+  }
+
+  private static boolean isInlineIntegerSource(PhysicalType sourceType) {
+    switch (sourceType) {
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+      case TIME:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  /**
+   * Delegates the cast to Spark's own {@code VariantGet.cast} by serializing the extracted leaf
+   * value into a Spark {@link VariantVal}. Used for every pair outside {@link #inlineOwned} so that
+   * cross-type and lossy casts match the non-pushdown {@code variant_get} path exactly (returning
+   * Spark's value, or throwing {@code INVALID_VARIANT_CAST} when {@code failOnError = true}).
+   */
+  private static Object delegate(
+      VariantValue value,
+      VariantMetadata metadata,
+      DataType targetType,
+      boolean failOnError,
+      String timeZoneId) {
+    byte[] metadataBytes;
+    if (value.type() == PhysicalType.OBJECT || value.type() == PhysicalType.ARRAY) {
+      // Object/array values reference the dictionary (e.g. for cast-to-string JSON rendering).
+      metadataBytes = serializeMetadata(metadata != null ? metadata : VariantMetadata.empty());
+    } else {
+      metadataBytes = EMPTY_VARIANT_METADATA;
+    }
+
+    byte[] valueBytes = new byte[value.sizeInBytes()];
+    value.writeTo(ByteBuffer.wrap(valueBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+
+    // Fall back to the session time zone (matching the non-pushdown variant_get path) when the
+    // extraction metadata did not carry one.
+    String zone = timeZoneId != null ? timeZoneId : SQLConf.get().sessionLocalTimeZone();
+    VariantCastArgs castArgs =
+        new VariantCastArgs(failOnError, scala.Option.apply(zone), ZoneId.of(zone));
+    return org.apache.spark.sql.catalyst.expressions.variant.VariantGet$.MODULE$.cast(
+        new VariantVal(valueBytes, metadataBytes), targetType, castArgs);
+  }
+
+  private static byte[] serializeMetadata(VariantMetadata metadata) {
+    byte[] bytes = new byte[metadata.sizeInBytes()];
+    metadata.writeTo(ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+    return bytes;
+  }
+
+  private static Object inlineConvert(
+      VariantValue value, DataType targetType, boolean failOnError) {
     if (DataTypes.StringType.sameType(targetType)) {
-      String stringValue = asString(value);
-      return stringValue != null ? UTF8String.fromString(stringValue) : null;
+      return asUTF8String(value);
     } else if (DataTypes.LongType.sameType(targetType)) {
       return asLong(value);
-    } else if (DataTypes.IntegerType.sameType(targetType)) {
-      Long longValue = asLong(value);
-      if (longValue == null) {
-        return null;
-      }
-      int intValue = (int) (long) longValue;
-      return (long) intValue == longValue ? intValue : null;
-    } else if (DataTypes.ByteType.sameType(targetType)) {
-      Long longValue = asLong(value);
-      if (longValue == null) {
-        return null;
-      }
-      byte byteValue = (byte) (long) longValue;
-      return (long) byteValue == longValue ? byteValue : null;
-    } else if (DataTypes.ShortType.sameType(targetType)) {
-      Long longValue = asLong(value);
-      if (longValue == null) {
-        return null;
-      }
-      short shortValue = (short) (long) longValue;
-      return (long) shortValue == longValue ? shortValue : null;
+    } else if (isIntegerTarget(targetType)) {
+      return inlineConvertNarrowInt(value, targetType, failOnError);
     } else if (DataTypes.DateType.sameType(targetType)) {
       return asDateDays(value);
     } else if (targetType instanceof TimestampType) {
@@ -178,31 +318,70 @@ public class SparkVariantExtractionReaders {
     } else if (DataTypes.DoubleType.sameType(targetType)) {
       return asDouble(value);
     } else if (DataTypes.FloatType.sameType(targetType)) {
-      Double doubleValue = asDouble(value);
-      if (doubleValue == null) {
-        return null;
-      }
-      float floatValue = (float) (double) doubleValue;
-      return Float.isInfinite(floatValue) && !Double.isInfinite(doubleValue) ? null : floatValue;
-    } else if (targetType instanceof DecimalType) {
-      DecimalType decimalType = (DecimalType) targetType;
-      BigDecimal decimal = asDecimal(value);
-      return decimal != null
-          ? Decimal.apply(decimal, decimalType.precision(), decimalType.scale())
-          : null;
+      return asFloat(value);
     }
 
-    // Unknown target type: return null (consistent with Spark variant_get type-mismatch behavior).
+    // Unreachable for inline-owned pairs; defensive null.
     return null;
   }
 
-  private static String asString(VariantValue value) {
+  /**
+   * Handles integer narrowing (int/short/byte targets): reads the shredded value as a long,
+   * truncates to the narrower width, then detects overflow by round-tripping back to long. A
+   * mismatch means the value did not fit; throws INVALID_VARIANT_CAST when failOnError, else null.
+   * Done inline because narrowing is a common, hot path with provably Spark-identical semantics.
+   */
+  private static Object inlineConvertNarrowInt(
+      VariantValue value, DataType targetType, boolean failOnError) {
+    Long longValue = asLong(value);
+    if (longValue == null) {
+      return null;
+    }
+    if (DataTypes.IntegerType.sameType(targetType)) {
+      int intValue = (int) (long) longValue;
+      return (long) intValue == longValue ? intValue : overflow(value, targetType, failOnError);
+    } else if (DataTypes.ShortType.sameType(targetType)) {
+      short shortValue = (short) (long) longValue;
+      return (long) shortValue == longValue ? shortValue : overflow(value, targetType, failOnError);
+    } else {
+      byte byteValue = (byte) (long) longValue;
+      return (long) byteValue == longValue ? byteValue : overflow(value, targetType, failOnError);
+    }
+  }
+
+  /**
+   * Handles an integer narrowing overflow: the shredded value is a valid integer for the wider type
+   * but does not fit the requested narrower integer type. Spark's {@code variant_get} ({@code
+   * failOnError = true}) throws {@code INVALID_VARIANT_CAST}; {@code try_variant_get} ({@code
+   * failOnError = false}) returns SQL NULL. This mirrors that. Only integer narrowing reaches here;
+   * all non-integer-family casts delegate to Spark.
+   */
+  private static Object overflow(VariantValue value, DataType targetType, boolean failOnError) {
+    if (failOnError) {
+      throw invalidVariantCast(value, targetType);
+    }
+
+    return null;
+  }
+
+  private static RuntimeException invalidVariantCast(VariantValue value, DataType targetType) {
+    String display =
+        value.type() == PhysicalType.OBJECT || value.type() == PhysicalType.ARRAY
+            ? value.toString()
+            : String.valueOf(value.asPrimitive().get());
+    // Reuse Spark's own error factory so the pushed-down path raises the exact same
+    // INVALID_VARIANT_CAST error the engine would raise on the whole-variant variant_get path.
+    return (RuntimeException)
+        org.apache.spark.sql.errors.QueryExecutionErrors$.MODULE$.invalidVariantCast(
+            display, targetType);
+  }
+
+  private static UTF8String asUTF8String(VariantValue value) {
     switch (value.type()) {
       case STRING:
       case UUID:
-        return (String) value.asPrimitive().get();
+        return UTF8String.fromString((String) value.asPrimitive().get());
       default:
-        // Variant physical type is not string-compatible; return null like variant_get does.
         return null;
     }
   }
@@ -286,23 +465,17 @@ public class SparkVariantExtractionReaders {
     }
   }
 
+  private static Float asFloat(VariantValue value) {
+    Double doubleValue = asDouble(value);
+    return doubleValue != null ? (float) (double) doubleValue : null;
+  }
+
   private static Boolean asBoolean(VariantValue value) {
     switch (value.type()) {
       case BOOLEAN_TRUE:
         return true;
       case BOOLEAN_FALSE:
         return false;
-      default:
-        return null;
-    }
-  }
-
-  private static BigDecimal asDecimal(VariantValue value) {
-    switch (value.type()) {
-      case DECIMAL4:
-      case DECIMAL8:
-      case DECIMAL16:
-        return (BigDecimal) value.asPrimitive().get();
       default:
         return null;
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
@@ -1,0 +1,294 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.parquet.ParquetValueReader;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtractionField;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtractionRow;
+import org.apache.iceberg.parquet.ParquetVariantReaders.DelegatingValueReader;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.variants.PhysicalType;
+import org.apache.iceberg.variants.VariantValue;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.MessageType;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType;
+import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.unsafe.types.UTF8String;
+
+/** Parquet readers that materialize Spark variant extraction struct rows from shredded variants. */
+public class SparkVariantExtractionReaders {
+  private SparkVariantExtractionReaders() {}
+
+  public static ParquetValueReader<InternalRow> buildStructReader(
+      MessageType fileSchema,
+      GroupType variantGroup,
+      List<String> variantColumnPath,
+      StructType extractionStruct) {
+    List<VariantExtractionField> fields = Lists.newArrayList();
+    int numFields = 0;
+    for (StructField field : extractionStruct.fields()) {
+      numFields = Math.max(numFields, Integer.parseInt(field.name()) + 1);
+    }
+
+    DataType[] targetTypes = new DataType[numFields];
+    for (StructField field : extractionStruct.fields()) {
+      int ordinal = Integer.parseInt(field.name());
+      targetTypes[ordinal] = field.dataType();
+      fields.add(
+          new VariantExtractionField(
+              ordinal,
+              SparkVariantExtractionUtil.isPlaceholderExtraction(field),
+              SparkVariantExtractionUtil.parseObjectPath(
+                  SparkVariantExtractionUtil.extractionPath(field))));
+    }
+
+    ParquetValueReader<VariantExtractionRow> parquetReader =
+        ParquetVariantExtractionReaders.buildRowReader(
+            fileSchema, variantGroup, variantColumnPath, fields);
+
+    return new SparkVariantExtractionStructReader(parquetReader, targetTypes);
+  }
+
+  /** Counts leaf Parquet columns referenced by a reader tree. */
+  public static int leafColumnCount(ParquetValueReader<?> reader) {
+    return ParquetVariantExtractionReaders.leafColumnCount(reader);
+  }
+
+  /** Visible for unit tests in {@code org.apache.iceberg.spark.data}. */
+  static Object toSparkValueForTests(VariantValue value, DataType targetType) {
+    return toSparkValue(value, targetType);
+  }
+
+  private static class SparkVariantExtractionStructReader
+      extends DelegatingValueReader<VariantExtractionRow, InternalRow> {
+    private final DataType[] targetTypes;
+
+    private SparkVariantExtractionStructReader(
+        ParquetValueReader<VariantExtractionRow> reader, DataType[] targetTypes) {
+      super(reader);
+      this.targetTypes = targetTypes;
+    }
+
+    @Override
+    public InternalRow read(InternalRow reuse) {
+      VariantExtractionRow row = readFromDelegate(null);
+      int numFields = row.numFields();
+      GenericInternalRow result =
+          reuse instanceof GenericInternalRow
+              ? (GenericInternalRow) reuse
+              : new GenericInternalRow(numFields);
+
+      if (row.metadata() == null) {
+        // SQL NULL variant: match Spark variant_get semantics by nulling every extraction slot,
+        // including full-variant placeholder slots. Distinct from a non-null variant where only
+        // missing or JSON-null paths produce per-field SQL NULLs.
+        for (int i = 0; i < numFields; i += 1) {
+          result.setNullAt(i);
+        }
+        return result;
+      }
+
+      for (int i = 0; i < numFields; i += 1) {
+        if (row.placeholder(i)) {
+          result.setBoolean(i, true);
+        } else {
+          Object sparkValue = toSparkValue(row.value(i), targetTypes[i]);
+          if (sparkValue == null) {
+            result.setNullAt(i);
+          } else {
+            result.update(i, sparkValue);
+          }
+        }
+      }
+
+      return result;
+    }
+  }
+
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
+  private static Object toSparkValue(VariantValue value, DataType targetType) {
+    if (value == null || value.type() == PhysicalType.NULL) {
+      return null;
+    }
+
+    if (DataTypes.StringType.sameType(targetType)) {
+      String stringValue = asString(value);
+      return stringValue != null ? UTF8String.fromString(stringValue) : null;
+    } else if (DataTypes.LongType.sameType(targetType)) {
+      return asLong(value);
+    } else if (DataTypes.IntegerType.sameType(targetType)) {
+      Long longValue = asLong(value);
+      return longValue != null ? (int) (long) longValue : null;
+    } else if (DataTypes.ByteType.sameType(targetType)) {
+      Long longValue = asLong(value);
+      return longValue != null ? (byte) (long) longValue : null;
+    } else if (DataTypes.ShortType.sameType(targetType)) {
+      Long longValue = asLong(value);
+      return longValue != null ? (short) (long) longValue : null;
+    } else if (DataTypes.DateType.sameType(targetType)) {
+      return asDateDays(value);
+    } else if (targetType instanceof TimestampType) {
+      return asTimestampMicros(value, false);
+    } else if (targetType instanceof TimestampNTZType) {
+      return asTimestampMicros(value, true);
+    } else if (DataTypes.BinaryType.sameType(targetType)) {
+      return asBinary(value);
+    } else if (DataTypes.BooleanType.sameType(targetType)) {
+      return asBoolean(value);
+    } else if (DataTypes.DoubleType.sameType(targetType)) {
+      return asDouble(value);
+    } else if (DataTypes.FloatType.sameType(targetType)) {
+      Double doubleValue = asDouble(value);
+      return doubleValue != null ? (float) (double) doubleValue : null;
+    } else if (targetType instanceof DecimalType) {
+      DecimalType decimalType = (DecimalType) targetType;
+      BigDecimal decimal = asDecimal(value);
+      return decimal != null
+          ? Decimal.apply(decimal, decimalType.precision(), decimalType.scale())
+          : null;
+    }
+
+    // Unknown target type: return null (consistent with Spark variant_get type-mismatch behavior).
+    return null;
+  }
+
+  private static String asString(VariantValue value) {
+    switch (value.type()) {
+      case STRING:
+      case UUID:
+        return (String) value.asPrimitive().get();
+      default:
+        // Variant physical type is not string-compatible; return null like variant_get does.
+        return null;
+    }
+  }
+
+  private static Long asLong(VariantValue value) {
+    switch (value.type()) {
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+      case TIME:
+        return ((Number) value.asPrimitive().get()).longValue();
+      default:
+        return null;
+    }
+  }
+
+  private static Integer asDateDays(VariantValue value) {
+    if (value.type() == PhysicalType.DATE) {
+      return (Integer) value.asPrimitive().get();
+    }
+
+    return null;
+  }
+
+  private static Long asTimestampMicros(VariantValue value, boolean timestampNtz) {
+    switch (value.type()) {
+      case TIMESTAMPTZ:
+      case TIMESTAMPTZ_NANOS:
+        if (timestampNtz) {
+          return null;
+        }
+        return toMicros(value);
+      case TIMESTAMPNTZ:
+      case TIMESTAMPNTZ_NANOS:
+        if (!timestampNtz) {
+          return null;
+        }
+        return toMicros(value);
+      default:
+        return null;
+    }
+  }
+
+  private static Long toMicros(VariantValue value) {
+    long raw = ((Number) value.asPrimitive().get()).longValue();
+    switch (value.type()) {
+      case TIMESTAMPTZ_NANOS:
+      case TIMESTAMPNTZ_NANOS:
+        return raw / 1000L;
+      case TIMESTAMPTZ:
+      case TIMESTAMPNTZ:
+        return raw;
+      default:
+        return null;
+    }
+  }
+
+  private static byte[] asBinary(VariantValue value) {
+    if (value.type() != PhysicalType.BINARY) {
+      return null;
+    }
+
+    ByteBuffer buffer = (ByteBuffer) value.asPrimitive().get();
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.duplicate().get(bytes);
+    return bytes;
+  }
+
+  private static Double asDouble(VariantValue value) {
+    switch (value.type()) {
+      case FLOAT:
+      case DOUBLE:
+      case INT8:
+      case INT16:
+      case INT32:
+      case INT64:
+        return ((Number) value.asPrimitive().get()).doubleValue();
+      default:
+        return null;
+    }
+  }
+
+  private static Boolean asBoolean(VariantValue value) {
+    switch (value.type()) {
+      case BOOLEAN_TRUE:
+        return true;
+      case BOOLEAN_FALSE:
+        return false;
+      default:
+        return null;
+    }
+  }
+
+  private static BigDecimal asDecimal(VariantValue value) {
+    switch (value.type()) {
+      case DECIMAL4:
+      case DECIMAL8:
+      case DECIMAL16:
+        return (BigDecimal) value.asPrimitive().get();
+      default:
+        return null;
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
@@ -39,12 +39,8 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.expressions.variant.VariantCastArgs;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataType;
-import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
-import org.apache.spark.sql.types.TimestampNTZType;
-import org.apache.spark.sql.types.TimestampType;
-import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
 /** Parquet readers that materialize Spark variant extraction struct rows from shredded variants. */
@@ -161,19 +157,16 @@ public class SparkVariantExtractionReaders {
   }
 
   /**
-   * Materializes a single extracted shredded value as the Spark {@code targetType}.
+   * Materializes a single extracted shredded value as the Spark {@code targetType} by delegating to
+   * Spark's own {@code VariantGet.cast}.
    *
-   * <p>Uses a narrow inline conversion for the common, stable pairs ({@link #inlineOwned}) and
-   * delegates everything else to Spark's {@code VariantGet.cast}. The inline path exists purely for
-   * performance: it reads the shredded primitive directly, whereas delegating must serialize the
-   * value back into a Spark {@code VariantVal} and run a {@code Cast} — on the order of ~1 KB of
-   * transient allocation per value (vs. tens of bytes inline), which is significant on wide scans.
-   * It is intentionally kept to pairs that are either trivially Spark-identical (identity unwraps,
-   * integer range-checks) or that Spark's variant cannot represent at all and so <em>must</em> be
-   * handled here ({@code TIME}, nanos timestamps). Every cross-type, lossy, or zone-sensitive cast
-   * delegates, so its semantics — including {@code failOnError} throwing and {@code timeZoneId}
-   * handling — match the non-pushdown {@code variant_get} path exactly. A cross-check test asserts
-   * the inline pairs equal {@code VariantGet.cast} so the two paths cannot silently diverge.
+   * <p>Delegation serializes the extracted leaf back into a Spark {@link VariantVal} and runs the
+   * same cast the whole-variant {@code variant_get} path runs, so every conversion — including
+   * cross-type and lossy casts, {@code failOnError} throwing, {@code timeZoneId} handling, and
+   * physical types Spark's variant cannot represent ({@code TIME}, nanos timestamps) — matches the
+   * non-pushdown path exactly. The selective reader's benefit is reading fewer Parquet columns; it
+   * intentionally does not reimplement Spark's cast semantics. A faster inline conversion for the
+   * hot primitive pairs can be layered on as a follow-up.
    */
   private static Object toSparkValue(
       VariantValue value,
@@ -187,83 +180,14 @@ public class SparkVariantExtractionReaders {
       return null;
     }
 
-    if (inlineOwned(value.type(), targetType)) {
-      return inlineConvert(value, targetType, failOnError);
-    }
-
-    // Any other (sourceType, targetType): delegate to Spark's VariantGet.cast so cross-type and
-    // lossy casts (e.g. string->long, double->float, decimal rescale, TZ<->NTZ) match the
-    // non-pushdown variant_get path exactly, including throwing on failOnError.
     return delegate(value, metadata, targetType, failOnError, timeZoneId);
   }
 
   /**
-   * Returns true when the selective reader converts this {@code (sourceType, targetType)} pair
-   * directly, without delegating to Spark. The inline set is deliberately small and stable: pairs
-   * that are the identity (nothing to get wrong), integer-family range-checks (stable ANSI
-   * semantics), or physical types Spark's variant cannot represent ({@code TIME}, nanos timestamps)
-   * and therefore must be handled here. Everything else delegates.
-   */
-  private static boolean inlineOwned(PhysicalType sourceType, DataType targetType) {
-    if (isIntegerTarget(targetType)) {
-      // Integer/TIME source -> integer target (identity, widening, or range-checked narrowing).
-      // TIME has no Spark variant counterpart, so it must be inline.
-      return isInlineIntegerSource(sourceType);
-    } else if (DataTypes.StringType.sameType(targetType)) {
-      return sourceType == PhysicalType.STRING || sourceType == PhysicalType.UUID;
-    } else if (DataTypes.BinaryType.sameType(targetType)) {
-      return sourceType == PhysicalType.BINARY;
-    } else if (DataTypes.BooleanType.sameType(targetType)) {
-      return sourceType == PhysicalType.BOOLEAN_TRUE || sourceType == PhysicalType.BOOLEAN_FALSE;
-    } else if (DataTypes.DateType.sameType(targetType)) {
-      return sourceType == PhysicalType.DATE;
-    } else if (DataTypes.DoubleType.sameType(targetType)) {
-      return sourceType == PhysicalType.DOUBLE;
-    } else if (DataTypes.FloatType.sameType(targetType)) {
-      return sourceType == PhysicalType.FLOAT;
-    } else if (targetType instanceof TimestampType || targetType instanceof TimestampNTZType) {
-      // Nanos timestamps must be inline: Spark's variant cannot represent them.
-      return isInlineTimestampSource(sourceType, targetType instanceof TimestampNTZType);
-    }
-
-    // DecimalType and any other target: delegate to Spark.
-    return false;
-  }
-
-  private static boolean isInlineTimestampSource(PhysicalType sourceType, boolean ntz) {
-    if (ntz) {
-      return sourceType == PhysicalType.TIMESTAMPNTZ
-          || sourceType == PhysicalType.TIMESTAMPNTZ_NANOS;
-    } else {
-      return sourceType == PhysicalType.TIMESTAMPTZ || sourceType == PhysicalType.TIMESTAMPTZ_NANOS;
-    }
-  }
-
-  private static boolean isIntegerTarget(DataType targetType) {
-    return DataTypes.LongType.sameType(targetType)
-        || DataTypes.IntegerType.sameType(targetType)
-        || DataTypes.ShortType.sameType(targetType)
-        || DataTypes.ByteType.sameType(targetType);
-  }
-
-  private static boolean isInlineIntegerSource(PhysicalType sourceType) {
-    switch (sourceType) {
-      case INT8:
-      case INT16:
-      case INT32:
-      case INT64:
-      case TIME:
-        return true;
-      default:
-        return false;
-    }
-  }
-
-  /**
    * Delegates the cast to Spark's own {@code VariantGet.cast} by serializing the extracted leaf
-   * value into a Spark {@link VariantVal}. Used for every pair outside {@link #inlineOwned} so that
-   * cross-type and lossy casts match the non-pushdown {@code variant_get} path exactly (returning
-   * Spark's value, or throwing {@code INVALID_VARIANT_CAST} when {@code failOnError = true}).
+   * value into a Spark {@link VariantVal}, so cross-type and lossy casts match the non-pushdown
+   * {@code variant_get} path exactly (returning Spark's value, or throwing {@code
+   * INVALID_VARIANT_CAST} when {@code failOnError = true}).
    */
   private static Object delegate(
       VariantValue value,
@@ -295,189 +219,5 @@ public class SparkVariantExtractionReaders {
     byte[] bytes = new byte[metadata.sizeInBytes()];
     metadata.writeTo(ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN), 0);
     return bytes;
-  }
-
-  private static Object inlineConvert(
-      VariantValue value, DataType targetType, boolean failOnError) {
-    if (DataTypes.StringType.sameType(targetType)) {
-      return asUTF8String(value);
-    } else if (DataTypes.LongType.sameType(targetType)) {
-      return asLong(value);
-    } else if (isIntegerTarget(targetType)) {
-      return inlineConvertNarrowInt(value, targetType, failOnError);
-    } else if (DataTypes.DateType.sameType(targetType)) {
-      return asDateDays(value);
-    } else if (targetType instanceof TimestampType) {
-      return asTimestampMicros(value, false);
-    } else if (targetType instanceof TimestampNTZType) {
-      return asTimestampMicros(value, true);
-    } else if (DataTypes.BinaryType.sameType(targetType)) {
-      return asBinary(value);
-    } else if (DataTypes.BooleanType.sameType(targetType)) {
-      return asBoolean(value);
-    } else if (DataTypes.DoubleType.sameType(targetType)) {
-      return asDouble(value);
-    } else if (DataTypes.FloatType.sameType(targetType)) {
-      return asFloat(value);
-    }
-
-    // Unreachable for inline-owned pairs; defensive null.
-    return null;
-  }
-
-  /**
-   * Handles integer narrowing (int/short/byte targets): reads the shredded value as a long,
-   * truncates to the narrower width, then detects overflow by round-tripping back to long. A
-   * mismatch means the value did not fit; throws INVALID_VARIANT_CAST when failOnError, else null.
-   * Done inline because narrowing is a common, hot path with provably Spark-identical semantics.
-   */
-  private static Object inlineConvertNarrowInt(
-      VariantValue value, DataType targetType, boolean failOnError) {
-    Long longValue = asLong(value);
-    if (longValue == null) {
-      return null;
-    }
-    if (DataTypes.IntegerType.sameType(targetType)) {
-      int intValue = (int) (long) longValue;
-      return (long) intValue == longValue ? intValue : overflow(value, targetType, failOnError);
-    } else if (DataTypes.ShortType.sameType(targetType)) {
-      short shortValue = (short) (long) longValue;
-      return (long) shortValue == longValue ? shortValue : overflow(value, targetType, failOnError);
-    } else {
-      byte byteValue = (byte) (long) longValue;
-      return (long) byteValue == longValue ? byteValue : overflow(value, targetType, failOnError);
-    }
-  }
-
-  /**
-   * Handles an integer narrowing overflow: the shredded value is a valid integer for the wider type
-   * but does not fit the requested narrower integer type. Spark's {@code variant_get} ({@code
-   * failOnError = true}) throws {@code INVALID_VARIANT_CAST}; {@code try_variant_get} ({@code
-   * failOnError = false}) returns SQL NULL. This mirrors that. Only integer narrowing reaches here;
-   * all non-integer-family casts delegate to Spark.
-   */
-  private static Object overflow(VariantValue value, DataType targetType, boolean failOnError) {
-    if (failOnError) {
-      throw invalidVariantCast(value, targetType);
-    }
-
-    return null;
-  }
-
-  private static RuntimeException invalidVariantCast(VariantValue value, DataType targetType) {
-    String display =
-        value.type() == PhysicalType.OBJECT || value.type() == PhysicalType.ARRAY
-            ? value.toString()
-            : String.valueOf(value.asPrimitive().get());
-    // Reuse Spark's own error factory so the pushed-down path raises the exact same
-    // INVALID_VARIANT_CAST error the engine would raise on the whole-variant variant_get path.
-    return (RuntimeException)
-        org.apache.spark.sql.errors.QueryExecutionErrors$.MODULE$.invalidVariantCast(
-            display, targetType);
-  }
-
-  private static UTF8String asUTF8String(VariantValue value) {
-    switch (value.type()) {
-      case STRING:
-      case UUID:
-        return UTF8String.fromString((String) value.asPrimitive().get());
-      default:
-        return null;
-    }
-  }
-
-  private static Long asLong(VariantValue value) {
-    switch (value.type()) {
-      case INT8:
-      case INT16:
-      case INT32:
-      case INT64:
-      case TIME:
-        return ((Number) value.asPrimitive().get()).longValue();
-      default:
-        return null;
-    }
-  }
-
-  private static Integer asDateDays(VariantValue value) {
-    if (value.type() == PhysicalType.DATE) {
-      return (Integer) value.asPrimitive().get();
-    }
-
-    return null;
-  }
-
-  private static Long asTimestampMicros(VariantValue value, boolean timestampNtz) {
-    switch (value.type()) {
-      case TIMESTAMPTZ:
-      case TIMESTAMPTZ_NANOS:
-        if (timestampNtz) {
-          return null;
-        }
-        return toMicros(value);
-      case TIMESTAMPNTZ:
-      case TIMESTAMPNTZ_NANOS:
-        if (!timestampNtz) {
-          return null;
-        }
-        return toMicros(value);
-      default:
-        return null;
-    }
-  }
-
-  private static Long toMicros(VariantValue value) {
-    long raw = ((Number) value.asPrimitive().get()).longValue();
-    switch (value.type()) {
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-        return raw / 1000L;
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-        return raw;
-      default:
-        return null;
-    }
-  }
-
-  private static byte[] asBinary(VariantValue value) {
-    if (value.type() != PhysicalType.BINARY) {
-      return null;
-    }
-
-    ByteBuffer buffer = (ByteBuffer) value.asPrimitive().get();
-    byte[] bytes = new byte[buffer.remaining()];
-    buffer.duplicate().get(bytes);
-    return bytes;
-  }
-
-  private static Double asDouble(VariantValue value) {
-    switch (value.type()) {
-      case FLOAT:
-      case DOUBLE:
-      case INT8:
-      case INT16:
-      case INT32:
-      case INT64:
-        return ((Number) value.asPrimitive().get()).doubleValue();
-      default:
-        return null;
-    }
-  }
-
-  private static Float asFloat(VariantValue value) {
-    Double doubleValue = asDouble(value);
-    return doubleValue != null ? (float) (double) doubleValue : null;
-  }
-
-  private static Boolean asBoolean(VariantValue value) {
-    switch (value.type()) {
-      case BOOLEAN_TRUE:
-        return true;
-      case BOOLEAN_FALSE:
-        return false;
-      default:
-        return null;
-    }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionReaders.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.spark.data;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
+import org.apache.iceberg.expressions.PathUtil;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetVariantExtractionReaders;
 import org.apache.iceberg.parquet.ParquetVariantExtractionReaders.VariantExtractionField;
@@ -66,8 +67,7 @@ public class SparkVariantExtractionReaders {
           new VariantExtractionField(
               ordinal,
               SparkVariantExtractionUtil.isPlaceholderExtraction(field),
-              SparkVariantExtractionUtil.parseObjectPath(
-                  SparkVariantExtractionUtil.extractionPath(field))));
+              PathUtil.parse(SparkVariantExtractionUtil.extractionPath(field))));
     }
 
     ParquetValueReader<VariantExtractionRow> parquetReader =
@@ -146,13 +146,25 @@ public class SparkVariantExtractionReaders {
       return asLong(value);
     } else if (DataTypes.IntegerType.sameType(targetType)) {
       Long longValue = asLong(value);
-      return longValue != null ? (int) (long) longValue : null;
+      if (longValue == null) {
+        return null;
+      }
+      int intValue = (int) (long) longValue;
+      return (long) intValue == longValue ? intValue : null;
     } else if (DataTypes.ByteType.sameType(targetType)) {
       Long longValue = asLong(value);
-      return longValue != null ? (byte) (long) longValue : null;
+      if (longValue == null) {
+        return null;
+      }
+      byte byteValue = (byte) (long) longValue;
+      return (long) byteValue == longValue ? byteValue : null;
     } else if (DataTypes.ShortType.sameType(targetType)) {
       Long longValue = asLong(value);
-      return longValue != null ? (short) (long) longValue : null;
+      if (longValue == null) {
+        return null;
+      }
+      short shortValue = (short) (long) longValue;
+      return (long) shortValue == longValue ? shortValue : null;
     } else if (DataTypes.DateType.sameType(targetType)) {
       return asDateDays(value);
     } else if (targetType instanceof TimestampType) {
@@ -167,7 +179,11 @@ public class SparkVariantExtractionReaders {
       return asDouble(value);
     } else if (DataTypes.FloatType.sameType(targetType)) {
       Double doubleValue = asDouble(value);
-      return doubleValue != null ? (float) (double) doubleValue : null;
+      if (doubleValue == null) {
+        return null;
+      }
+      float floatValue = (float) (double) doubleValue;
+      return Float.isInfinite(floatValue) && !Double.isInfinite(doubleValue) ? null : floatValue;
     } else if (targetType instanceof DecimalType) {
       DecimalType decimalType = (DecimalType) targetType;
       BigDecimal decimal = asDecimal(value);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.spark.data;
 
-import java.util.List;
 import org.apache.iceberg.expressions.PathUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.spark.sql.types.ArrayType;
@@ -38,8 +37,7 @@ import org.apache.spark.sql.types.VariantType;
 /**
  * Utilities for Spark variant extraction pushdown ({@code __VARIANT_METADATA_KEY}).
  *
- * <p>Path parsing ({@link #parseObjectPath}, {@link #isArrayIndexPart}, {@link
- * #isSupportedExtractionPath}) delegates to {@link PathUtil}.
+ * <p>Path parsing ({@link #isSupportedExtractionPath}) delegates to {@link PathUtil}.
  */
 public class SparkVariantExtractionUtil {
   public static final String VARIANT_METADATA_KEY = "__VARIANT_METADATA_KEY";
@@ -151,28 +149,5 @@ public class SparkVariantExtractionUtil {
     }
 
     return metadata.getString("path");
-  }
-
-  /**
-   * Returns true when the given path part represents a numeric array index, e.g. {@code "[0]"}.
-   * Array index parts are encoded as {@code "[N]"} strings in the list returned by {@link
-   * #parseObjectPath}.
-   */
-  public static boolean isArrayIndexPart(String part) {
-    return PathUtil.isArrayIndexPart(part);
-  }
-
-  /**
-   * Parses a JSON path like {@code $.size}, {@code $.actor.login}, {@code $['city']}, or {@code
-   * $.commits[0].author.name} into a list of path steps.
-   *
-   * <p>Object field steps are returned as plain strings. Array index steps are returned as {@code
-   * "[N]"} strings (e.g. {@code "[0]"}). These can be distinguished using {@link
-   * #isArrayIndexPart}.
-   *
-   * <p>Delegates to {@link PathUtil#parseObjectPath}.
-   */
-  public static List<String> parseObjectPath(String jsonPath) {
-    return PathUtil.parseObjectPath(jsonPath);
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
@@ -79,6 +79,36 @@ public class SparkVariantExtractionUtil {
   }
 
   /**
+   * Returns the {@code failOnError} flag for the extraction (false when absent). Spark sets this to
+   * true for {@code variant_get} and false for {@code try_variant_get}; the selective readers honor
+   * it on numeric narrowing overflow.
+   */
+  public static boolean failOnError(StructField field) {
+    Preconditions.checkArgument(
+        field.metadata().contains(VARIANT_METADATA_KEY),
+        "Missing %s on field %s",
+        VARIANT_METADATA_KEY,
+        field.name());
+    Metadata variantMetadata = field.metadata().getMetadata(VARIANT_METADATA_KEY);
+    return variantMetadata.contains("failOnError") && variantMetadata.getBoolean("failOnError");
+  }
+
+  /**
+   * Returns the {@code timeZoneId} for the extraction, or {@code null} when absent. Spark sets this
+   * from the session time zone; the selective readers pass it to Spark's {@code VariantGet.cast}
+   * when delegating zone-sensitive casts (e.g. timestamp {@code TZ <-> NTZ}).
+   */
+  public static String timeZoneId(StructField field) {
+    Preconditions.checkArgument(
+        field.metadata().contains(VARIANT_METADATA_KEY),
+        "Missing %s on field %s",
+        VARIANT_METADATA_KEY,
+        field.name());
+    Metadata variantMetadata = field.metadata().getMetadata(VARIANT_METADATA_KEY);
+    return variantMetadata.contains("timeZoneId") ? variantMetadata.getString("timeZoneId") : null;
+  }
+
+  /**
    * Returns true when the selective Parquet reader can handle the extraction path. Delegates to
    * {@link PathUtil#parse} for RFC 9535-compliant validation; any path that fails to parse is
    * declined.

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkVariantExtractionUtil.java
@@ -1,0 +1,178 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import java.util.List;
+import org.apache.iceberg.expressions.PathUtil;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.CharType;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.DecimalType;
+import org.apache.spark.sql.types.MapType;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.TimestampNTZType;
+import org.apache.spark.sql.types.TimestampType;
+import org.apache.spark.sql.types.VarcharType;
+import org.apache.spark.sql.types.VariantType;
+
+/**
+ * Utilities for Spark variant extraction pushdown ({@code __VARIANT_METADATA_KEY}).
+ *
+ * <p>Path parsing ({@link #parseObjectPath}, {@link #isArrayIndexPart}, {@link
+ * #isSupportedExtractionPath}) delegates to {@link PathUtil}.
+ */
+public class SparkVariantExtractionUtil {
+  public static final String VARIANT_METADATA_KEY = "__VARIANT_METADATA_KEY";
+  public static final String PLACEHOLDER_PATH = "$.__placeholder_field__";
+
+  private SparkVariantExtractionUtil() {}
+
+  public static boolean isVariantExtractionStruct(DataType dataType) {
+    if (!(dataType instanceof StructType)) {
+      return false;
+    }
+
+    StructType structType = (StructType) dataType;
+    if (structType.fields().length == 0) {
+      return false;
+    }
+
+    for (StructField field : structType.fields()) {
+      if (!field.metadata().contains(VARIANT_METADATA_KEY)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static String extractionPath(StructField field) {
+    Preconditions.checkArgument(
+        field.metadata().contains(VARIANT_METADATA_KEY),
+        "Missing %s on field %s",
+        VARIANT_METADATA_KEY,
+        field.name());
+    Metadata variantMetadata = field.metadata().getMetadata(VARIANT_METADATA_KEY);
+    return variantMetadata.getString("path");
+  }
+
+  public static boolean isPlaceholderExtraction(StructField field) {
+    return PLACEHOLDER_PATH.equals(extractionPath(field));
+  }
+
+  /**
+   * Returns true when the selective Parquet reader can handle the extraction path. Delegates to
+   * {@link PathUtil#parse} for RFC 9535-compliant validation; any path that fails to parse is
+   * declined.
+   */
+  public static boolean isSupportedExtractionPath(String jsonPath) {
+    try {
+      PathUtil.parse(jsonPath);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  /**
+   * Returns true when Spark pushdown can materialize the extraction target type from shredded
+   * variant columns. Must stay in sync with {@link SparkVariantExtractionReaders} cast support.
+   */
+  public static boolean isSupportedPushdownTargetType(DataType targetType) {
+    if (targetType == null || targetType instanceof VariantType) {
+      return false;
+    }
+
+    // @todo: add support for container types
+    // Spark treats char/varchar as string
+    if (isUnsupportedContainerType(targetType)) {
+      return false;
+    }
+
+    return isSupportedPrimitiveType(targetType);
+  }
+
+  private static boolean isUnsupportedContainerType(DataType targetType) {
+    return targetType instanceof StructType
+        || targetType instanceof ArrayType
+        || targetType instanceof MapType
+        || targetType instanceof CharType
+        || targetType instanceof VarcharType;
+  }
+
+  private static boolean isSupportedPrimitiveType(DataType targetType) {
+    return isSupportedBasicType(targetType) || isSupportedTemporalOrDecimalType(targetType);
+  }
+
+  private static boolean isSupportedBasicType(DataType targetType) {
+    return DataTypes.StringType.sameType(targetType)
+        || DataTypes.IntegerType.sameType(targetType)
+        || DataTypes.LongType.sameType(targetType)
+        || DataTypes.ByteType.sameType(targetType)
+        || DataTypes.ShortType.sameType(targetType)
+        || DataTypes.BooleanType.sameType(targetType)
+        || DataTypes.FloatType.sameType(targetType)
+        || DataTypes.DoubleType.sameType(targetType)
+        || DataTypes.DateType.sameType(targetType)
+        || DataTypes.BinaryType.sameType(targetType);
+  }
+
+  private static boolean isSupportedTemporalOrDecimalType(DataType targetType) {
+    return targetType instanceof DecimalType
+        || targetType instanceof TimestampType
+        || targetType instanceof TimestampNTZType;
+  }
+
+  public static String extractionPath(
+      org.apache.spark.sql.connector.read.VariantExtraction extraction) {
+    org.apache.spark.sql.types.Metadata metadata = extraction.metadata();
+    if (metadata.contains(VARIANT_METADATA_KEY)) {
+      return metadata.getMetadata(VARIANT_METADATA_KEY).getString("path");
+    }
+
+    return metadata.getString("path");
+  }
+
+  /**
+   * Returns true when the given path part represents a numeric array index, e.g. {@code "[0]"}.
+   * Array index parts are encoded as {@code "[N]"} strings in the list returned by {@link
+   * #parseObjectPath}.
+   */
+  public static boolean isArrayIndexPart(String part) {
+    return PathUtil.isArrayIndexPart(part);
+  }
+
+  /**
+   * Parses a JSON path like {@code $.size}, {@code $.actor.login}, {@code $['city']}, or {@code
+   * $.commits[0].author.name} into a list of path steps.
+   *
+   * <p>Object field steps are returned as plain strings. Array index steps are returned as {@code
+   * "[N]"} strings (e.g. {@code "[0]"}). These can be distinguished using {@link
+   * #isArrayIndexPart}.
+   *
+   * <p>Delegates to {@link PathUtil#parseObjectPath}.
+   */
+  public static List<String> parseObjectPath(String jsonPath) {
+    return PathUtil.parseObjectPath(jsonPath);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseRowReader.java
@@ -31,8 +31,23 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.types.StructType;
 
 abstract class BaseRowReader<T extends ScanTask> extends BaseReader<InternalRow, T> {
+  private final StructType engineReadSchema;
+
+  BaseRowReader(
+      Table table,
+      FileIO fileIO,
+      ScanTaskGroup<T> taskGroup,
+      Schema expectedSchema,
+      StructType engineReadSchema,
+      boolean caseSensitive,
+      boolean cacheDeleteFilesOnExecutors) {
+    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    this.engineReadSchema = engineReadSchema;
+  }
+
   BaseRowReader(
       Table table,
       FileIO fileIO,
@@ -40,7 +55,12 @@ abstract class BaseRowReader<T extends ScanTask> extends BaseReader<InternalRow,
       Schema expectedSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
-    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    this(
+        table, fileIO, taskGroup, expectedSchema, null, caseSensitive, cacheDeleteFilesOnExecutors);
+  }
+
+  protected StructType engineReadSchema() {
+    return engineReadSchema;
   }
 
   protected CloseableIterable<InternalRow> newIterable(
@@ -51,11 +71,18 @@ abstract class BaseRowReader<T extends ScanTask> extends BaseReader<InternalRow,
       Expression residual,
       Schema projection,
       Map<Integer, ?> idToConstant) {
-    ReadBuilder<InternalRow, ?> reader =
-        FormatModelRegistry.readBuilder(format, InternalRow.class, file);
+    // FormatModelRegistry always returns a ReadBuilder parameterised for InternalRow; the
+    // wildcard on the engine-schema type is erased at runtime so this cast is safe.
+    @SuppressWarnings("unchecked")
+    ReadBuilder<InternalRow, Object> reader =
+        (ReadBuilder<InternalRow, Object>)
+            FormatModelRegistry.readBuilder(format, InternalRow.class, file);
+    reader = reader.project(projection).idToConstant(idToConstant);
+    if (engineReadSchema != null) {
+      reader = reader.engineProjection(engineReadSchema);
+    }
+
     return reader
-        .project(projection)
-        .idToConstant(idToConstant)
         .reuseContainers()
         .split(start, length)
         .caseSensitive(caseSensitive())

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -51,6 +51,7 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
         partition.io(),
         partition.taskGroup(),
         partition.projection(),
+        partition.readSchema(),
         partition.isCaseSensitive(),
         partition.cacheDeleteFilesOnExecutors());
   }
@@ -60,13 +61,32 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
       FileIO fileIO,
       ScanTaskGroup<FileScanTask> taskGroup,
       Schema expectedSchema,
+      org.apache.spark.sql.types.StructType engineReadSchema,
       boolean caseSensitive,
       boolean cacheDeleteFilesOnExecutors) {
 
-    super(table, fileIO, taskGroup, expectedSchema, caseSensitive, cacheDeleteFilesOnExecutors);
+    super(
+        table,
+        fileIO,
+        taskGroup,
+        expectedSchema,
+        engineReadSchema,
+        caseSensitive,
+        cacheDeleteFilesOnExecutors);
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+  }
+
+  RowDataReader(
+      Table table,
+      FileIO fileIO,
+      ScanTaskGroup<FileScanTask> taskGroup,
+      Schema expectedSchema,
+      boolean caseSensitive,
+      boolean cacheDeleteFilesOnExecutors) {
+    this(
+        table, fileIO, taskGroup, expectedSchema, null, caseSensitive, cacheDeleteFilesOnExecutors);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -43,6 +43,7 @@ import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.connector.read.Batch;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.PartitionReaderFactory;
+import org.apache.spark.sql.types.StructType;
 
 class SparkBatch implements Batch {
 
@@ -53,6 +54,7 @@ class SparkBatch implements Batch {
   private final Types.StructType groupingKeyType;
   private final List<? extends ScanTaskGroup<?>> taskGroups;
   private final Schema projection;
+  private final StructType readSchema;
   private final boolean caseSensitive;
   private final boolean localityEnabled;
   private final boolean executorCacheLocalityEnabled;
@@ -67,6 +69,7 @@ class SparkBatch implements Batch {
       Types.StructType groupingKeyType,
       List<? extends ScanTaskGroup<?>> taskGroups,
       Schema projection,
+      StructType readSchema,
       int scanHashCode) {
     this.sparkContext = sparkContext;
     this.table = table;
@@ -75,6 +78,7 @@ class SparkBatch implements Batch {
     this.groupingKeyType = groupingKeyType;
     this.taskGroups = taskGroups;
     this.projection = projection;
+    this.readSchema = readSchema;
     this.caseSensitive = readConf.caseSensitive();
     this.localityEnabled = readConf.localityEnabled();
     this.executorCacheLocalityEnabled = readConf.executorCacheLocalityEnabled();
@@ -90,6 +94,7 @@ class SparkBatch implements Batch {
     Broadcast<FileIO> fileIOBroadcast =
         sparkContext.broadcast(SerializableFileIOWithSize.wrap(fileIO.get()));
     String projectionString = SchemaParser.toJson(projection);
+    String readSchemaJson = readSchema != null ? readSchema.json() : null;
     String[][] locations = computePreferredLocations();
 
     InputPartition[] partitions = new InputPartition[taskGroups.size()];
@@ -102,6 +107,7 @@ class SparkBatch implements Batch {
               tableBroadcast,
               fileIOBroadcast,
               projectionString,
+              readSchemaJson,
               caseSensitive,
               locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE,
               cacheDeleteFilesOnExecutors);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkChangelogScan.java
@@ -110,6 +110,7 @@ class SparkChangelogScan implements Scan, SupportsReportStatistics {
         EMPTY_GROUPING_KEY_TYPE,
         taskGroups(),
         projection,
+        null,
         hashCode());
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkFormatModels.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkFormatModels.java
@@ -53,7 +53,8 @@ public class SparkFormatModels {
             StructType.class,
             SparkParquetWriters::buildWriter,
             (icebergSchema, fileSchema, engineSchema, idToConstant) ->
-                SparkParquetReaders.buildReader(icebergSchema, fileSchema, idToConstant),
+                SparkParquetReaders.buildReader(
+                    icebergSchema, fileSchema, engineSchema, idToConstant),
             new SparkVariantShreddingAnalyzer(),
             (Function<StructType, UnaryOperator<InternalRow>>) unused -> InternalRow::copy));
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkInputPartition.java
@@ -25,11 +25,14 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.read.HasPartitionKey;
 import org.apache.spark.sql.connector.read.InputPartition;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.StructType;
 
 class SparkInputPartition implements InputPartition, HasPartitionKey, Serializable {
   private final Types.StructType groupingKeyType;
@@ -37,11 +40,13 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
   private final Broadcast<Table> tableBroadcast;
   private final Broadcast<FileIO> fileIOBroadcast;
   private final String projectionString;
+  private final String readSchemaJson;
   private final boolean caseSensitive;
   private final transient String[] preferredLocations;
   private final boolean cacheDeleteFilesOnExecutors;
 
   private transient Schema projection = null;
+  private transient StructType readSchema = null;
 
   SparkInputPartition(
       Types.StructType groupingKeyType,
@@ -49,6 +54,7 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
       Broadcast<Table> tableBroadcast,
       Broadcast<FileIO> fileIOBroadcast,
       String projectionString,
+      String readSchemaJson,
       boolean caseSensitive,
       String[] preferredLocations,
       boolean cacheDeleteFilesOnExecutors) {
@@ -57,6 +63,7 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
     this.tableBroadcast = tableBroadcast;
     this.fileIOBroadcast = fileIOBroadcast;
     this.projectionString = projectionString;
+    this.readSchemaJson = readSchemaJson;
     this.caseSensitive = caseSensitive;
     this.preferredLocations = preferredLocations;
     this.cacheDeleteFilesOnExecutors = cacheDeleteFilesOnExecutors;
@@ -103,5 +110,22 @@ class SparkInputPartition implements InputPartition, HasPartitionKey, Serializab
     }
 
     return projection;
+  }
+
+  public StructType readSchema() {
+    if (readSchemaJson == null) {
+      return null;
+    }
+
+    if (readSchema == null) {
+      DataType parsed = DataType.fromJson(readSchemaJson);
+      Preconditions.checkState(
+          parsed instanceof StructType,
+          "Expected StructType for read schema JSON, got: %s",
+          parsed.getClass().getSimpleName());
+      this.readSchema = (StructType) parsed;
+    }
+
+    return readSchema;
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkMicroBatchStream.java
@@ -166,6 +166,7 @@ public class SparkMicroBatchStream implements MicroBatchStream, SupportsTriggerA
               tableBroadcast,
               fileIOBroadcast,
               projection,
+              null,
               caseSensitive,
               locations != null ? locations[index] : SparkPlanningUtil.NO_LOCATION_PREFERENCE,
               cacheDeleteFilesOnExecutors);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -180,6 +180,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
         groupingKeyType(),
         taskGroups(),
         projection,
+        readSchema(),
         hashCode());
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
@@ -230,6 +230,65 @@ class TestSparkVariantExtractionReaders {
         .isEqualTo((short) 42);
   }
 
+  @Test
+  void int64OverflowToIntReturnsNull() {
+    long overflowValue = (long) Integer.MAX_VALUE + 1;
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(overflowValue), DataTypes.IntegerType))
+        .isNull();
+  }
+
+  @Test
+  void int64OverflowToShortReturnsNull() {
+    long overflowValue = (long) Short.MAX_VALUE + 1;
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(overflowValue), DataTypes.ShortType))
+        .isNull();
+  }
+
+  @Test
+  void int64OverflowToByteReturnsNull() {
+    long overflowValue = (long) Byte.MAX_VALUE + 1;
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(overflowValue), DataTypes.ByteType))
+        .isNull();
+  }
+
+  @Test
+  void int32OverflowToShortReturnsNull() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of((int) Short.MAX_VALUE + 1), DataTypes.ShortType))
+        .isNull();
+  }
+
+  @Test
+  void int32OverflowToByteReturnsNull() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of((int) Byte.MAX_VALUE + 1), DataTypes.ByteType))
+        .isNull();
+  }
+
+  @Test
+  void doubleOutOfFloatRangeReturnsNull() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(Double.MAX_VALUE), DataTypes.FloatType))
+        .isNull();
+  }
+
+  @Test
+  void doubleInFloatRangeCastsToFloat() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(1.5d), DataTypes.FloatType))
+        .isEqualTo(1.5f);
+  }
+
   private static StructField extractionField(
       int ordinal, String path, org.apache.spark.sql.types.DataType type) {
     Metadata variantMetadata =

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
@@ -1,0 +1,289 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.parquet.ParquetValueReader;
+import org.apache.iceberg.parquet.ParquetVariantExtractionReaders;
+import org.apache.iceberg.parquet.ParquetVariantVisitor;
+import org.apache.iceberg.parquet.VariantReaderBuilder;
+import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.Variants;
+import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.Type;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.junit.jupiter.api.Test;
+
+class TestSparkVariantExtractionReaders {
+
+  @Test
+  void selectiveReaderReadsFewerColumnsThanFullVariantReader() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType zipField = shreddedStringField("zip");
+    GroupType sizeField = shreddedLongField("size");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField, zipField, sizeField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    StructType extractionStruct =
+        new StructType(new StructField[] {extractionField(0, "$.size", DataTypes.LongType)});
+
+    ParquetValueReader<?> fullReader =
+        ParquetVariantVisitor.visit(
+            variantGroup, new VariantReaderBuilder(fileSchema, List.of("v")));
+    ParquetValueReader<?> selectiveReader =
+        SparkVariantExtractionReaders.buildStructReader(
+            fileSchema, variantGroup, List.of("v"), extractionStruct);
+
+    int fullColumns = ParquetVariantExtractionReaders.leafColumnCount(fullReader);
+    int selectiveColumns = ParquetVariantExtractionReaders.leafColumnCount(selectiveReader);
+
+    assertThat(selectiveColumns)
+        .as("selective reader should read fewer Parquet columns than the full variant")
+        .isLessThan(fullColumns);
+    assertThat(selectiveColumns)
+        .as("selective reader should not include unrelated shredded fields (city, zip)")
+        .isLessThan(fullColumns - 2);
+  }
+
+  @Test
+  void multipleExtractionsUnionColumnPaths() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType zipField = shreddedStringField("zip");
+    GroupType sizeField = shreddedLongField("size");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField, zipField, sizeField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    StructType extractionStruct =
+        new StructType(
+            new StructField[] {
+              extractionField(0, "$.city", DataTypes.StringType),
+              extractionField(1, "$.zip", DataTypes.StringType)
+            });
+
+    ParquetValueReader<?> cityOnlyReader =
+        SparkVariantExtractionReaders.buildStructReader(
+            fileSchema,
+            variantGroup,
+            List.of("v"),
+            new StructType(new StructField[] {extractionField(0, "$.city", DataTypes.StringType)}));
+    ParquetValueReader<?> bothReader =
+        SparkVariantExtractionReaders.buildStructReader(
+            fileSchema, variantGroup, List.of("v"), extractionStruct);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(bothReader))
+        .as("two extractions should read more columns than one")
+        .isGreaterThan(ParquetVariantExtractionReaders.leafColumnCount(cityOnlyReader));
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(bothReader))
+        .as("two extractions should still read fewer columns than the full variant")
+        .isLessThan(
+            ParquetVariantExtractionReaders.leafColumnCount(
+                ParquetVariantVisitor.visit(
+                    variantGroup, new VariantReaderBuilder(fileSchema, List.of("v")))));
+  }
+
+  @Test
+  void unshreddedVariantUsesMetadataAndValueColumnsOnly() {
+    GroupType variantGroup = unshreddedVariant("v");
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    StructType extractionStruct =
+        new StructType(new StructField[] {extractionField(0, "$.size", DataTypes.LongType)});
+
+    ParquetValueReader<?> selectiveReader =
+        SparkVariantExtractionReaders.buildStructReader(
+            fileSchema, variantGroup, List.of("v"), extractionStruct);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(selectiveReader))
+        .as("unshredded fallback reads metadata and root value only")
+        .isEqualTo(2);
+  }
+
+  @Test
+  void placeholderReadsMetadataOnly() {
+    GroupType cityField = shreddedStringField("city");
+    GroupType variantGroup = shreddedObjectVariant("v", cityField);
+    MessageType fileSchema =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveType.PrimitiveTypeName.INT32)
+            .named("id")
+            .addField(variantGroup)
+            .named("table");
+
+    StructType extractionStruct =
+        new StructType(
+            new StructField[] {
+              DataTypes.createStructField(
+                  "0",
+                  DataTypes.BooleanType,
+                  true,
+                  new MetadataBuilder()
+                      .putMetadata(
+                          SparkVariantExtractionUtil.VARIANT_METADATA_KEY,
+                          new MetadataBuilder()
+                              .putString("path", SparkVariantExtractionUtil.PLACEHOLDER_PATH)
+                              .build())
+                      .build())
+            });
+
+    ParquetValueReader<?> reader =
+        SparkVariantExtractionReaders.buildStructReader(
+            fileSchema, variantGroup, List.of("v"), extractionStruct);
+
+    assertThat(ParquetVariantExtractionReaders.leafColumnCount(reader)).isEqualTo(1);
+  }
+
+  @Test
+  void dateValueCastsToSparkDate() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.ofDate(12_345), DataTypes.DateType))
+        .isEqualTo(12_345);
+  }
+
+  @Test
+  void timestamptzValueCastsToSparkTimestamp() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.ofTimestamptz(1_000_000L), DataTypes.TimestampType))
+        .isEqualTo(1_000_000L);
+  }
+
+  @Test
+  void timestampntzValueCastsToSparkTimestampNtz() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.ofTimestampntz(2_000_000L), DataTypes.TimestampNTZType))
+        .isEqualTo(2_000_000L);
+  }
+
+  @Test
+  void timestamptzNanosValueCastsToSparkTimestampMicros() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.ofTimestamptzNanos(5_000_000L), DataTypes.TimestampType))
+        .isEqualTo(5_000L);
+  }
+
+  @Test
+  void binaryValueCastsToSparkBinary() {
+    byte[] payload = new byte[] {1, 2, 3};
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(ByteBuffer.wrap(payload)), DataTypes.BinaryType))
+        .isEqualTo(payload);
+  }
+
+  @Test
+  void byteValueCastsToSparkByte() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of((byte) 127), DataTypes.ByteType))
+        .isEqualTo((byte) 127);
+  }
+
+  @Test
+  void shortValueCastsToSparkShort() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of((short) 42), DataTypes.ShortType))
+        .isEqualTo((short) 42);
+  }
+
+  private static StructField extractionField(
+      int ordinal, String path, org.apache.spark.sql.types.DataType type) {
+    Metadata variantMetadata =
+        new MetadataBuilder()
+            .putString("path", path)
+            .putBoolean("failOnError", false)
+            .putString("timeZoneId", "UTC")
+            .build();
+    Metadata metadata =
+        new MetadataBuilder()
+            .putMetadata(SparkVariantExtractionUtil.VARIANT_METADATA_KEY, variantMetadata)
+            .build();
+    return DataTypes.createStructField(String.valueOf(ordinal), type, true, metadata);
+  }
+
+  private static GroupType shreddedObjectVariant(String name, GroupType... objectFields) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optionalGroup()
+        .addFields(objectFields)
+        .named("typed_value")
+        .named(name);
+  }
+
+  private static GroupType unshreddedVariant(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .as(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION))
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("metadata")
+        .required(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .named(name);
+  }
+
+  private static GroupType shreddedStringField(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .as(LogicalTypeAnnotation.stringType())
+        .named("typed_value")
+        .named(name);
+  }
+
+  private static GroupType shreddedLongField(String name) {
+    return org.apache.parquet.schema.Types.buildGroup(Type.Repetition.REQUIRED)
+        .optional(PrimitiveType.PrimitiveTypeName.BINARY)
+        .named("value")
+        .optional(PrimitiveType.PrimitiveTypeName.INT64)
+        .named("typed_value")
+        .named(name);
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
@@ -207,11 +207,27 @@ class TestSparkVariantExtractionReaders {
   }
 
   @Test
-  void timestamptzNanosValueCastsToSparkTimestampMicros() {
-    assertThat(
-            SparkVariantExtractionReaders.toSparkValueForTests(
-                Variants.ofTimestamptzNanos(5_000_000L), DataTypes.TimestampType))
-        .isEqualTo(5_000L);
+  void timestamptzNanosDelegatesAndMatchesSparkFailure() {
+    // Spark's variant binary format has no nanos type code, so the delegated cast reproduces the
+    // same failure the non-pushdown variant_get path hits when Spark decodes a nanos-typed
+    // VariantVal. The pushed-down reader must not silently truncate nanos to micros and succeed
+    // where the whole-variant path would throw.
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.ofTimestamptzNanos(5_000_000L), DataTypes.TimestampType))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("UNKNOWN_PRIMITIVE_TYPE_IN_VARIANT");
+  }
+
+  @Test
+  void timestampntzNanosDelegatesAndMatchesSparkFailure() {
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.ofTimestampntzNanos(5_000_000L), DataTypes.TimestampNTZType))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("UNKNOWN_PRIMITIVE_TYPE_IN_VARIANT");
   }
 
   @Test
@@ -342,7 +358,7 @@ class TestSparkVariantExtractionReaders {
 
   @Test
   void stringToLongDelegatesToSpark() {
-    // STRING -> Long is not inline-owned; Spark parses the numeric string.
+    // STRING -> Long: Spark parses the numeric string.
     assertThat(
             SparkVariantExtractionReaders.toSparkValueForTests(
                 Variants.of("4021"), DataTypes.LongType))
@@ -392,42 +408,41 @@ class TestSparkVariantExtractionReaders {
   }
 
   /**
-   * Cross-check: every inline-owned pair that Spark's {@code VariantGet.cast} also supports must
-   * produce the identical value. This makes the inline set's equivalence to Spark executable, so a
-   * divergence (or a future Spark behavior change) fails loudly instead of silently returning wrong
-   * data. Deliberately excluded: nanos timestamps, {@code TIME}, and {@code UUID} sources — Spark's
-   * variant cannot represent those (its {@code getType} throws {@code UNKNOWN_PRIMITIVE_TYPE}), so
-   * they are inline-owned precisely because there is no Spark reference to compare against.
-   * Overflow behavior is covered by the dedicated overflow tests; this matrix uses in-range values.
+   * Regression matrix: the pushed-down reader materializes each common {@code (source, target)}
+   * pair to the same value Spark's {@code VariantGet.cast} produces on the whole-variant path. The
+   * reader delegates to {@code VariantGet.cast}, so this guards the surrounding
+   * serialize-and-delegate plumbing (metadata handling, byte layout, time zone args) against
+   * regressions rather than an independent cast implementation. Overflow behavior is covered by the
+   * dedicated overflow tests; this matrix uses in-range values.
    */
   @Test
-  void inlineOwnedConversionsMatchSparkVariantGet() {
-    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.ByteType);
-    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.ShortType);
-    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.IntegerType);
-    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.LongType);
-    assertInlineMatchesSpark(Variants.of((short) 300), DataTypes.ShortType);
-    assertInlineMatchesSpark(Variants.of((short) 300), DataTypes.IntegerType);
-    assertInlineMatchesSpark(Variants.of(70_000), DataTypes.IntegerType);
-    assertInlineMatchesSpark(Variants.of(70_000), DataTypes.LongType);
-    assertInlineMatchesSpark(Variants.of(5_000_000_000L), DataTypes.LongType);
-    assertInlineMatchesSpark(Variants.of("hello"), DataTypes.StringType);
-    assertInlineMatchesSpark(Variants.of(true), DataTypes.BooleanType);
-    assertInlineMatchesSpark(Variants.of(false), DataTypes.BooleanType);
-    assertInlineMatchesSpark(Variants.ofDate(12_345), DataTypes.DateType);
-    assertInlineMatchesSpark(Variants.of(3.5d), DataTypes.DoubleType);
-    assertInlineMatchesSpark(Variants.of(1.5f), DataTypes.FloatType);
-    assertInlineMatchesSpark(Variants.ofTimestamptz(1_000_000L), DataTypes.TimestampType);
-    assertInlineMatchesSpark(Variants.ofTimestampntz(2_000_000L), DataTypes.TimestampNTZType);
+  void delegatedConversionsMatchSparkVariantGet() {
+    assertMatchesSpark(Variants.of((byte) 5), DataTypes.ByteType);
+    assertMatchesSpark(Variants.of((byte) 5), DataTypes.ShortType);
+    assertMatchesSpark(Variants.of((byte) 5), DataTypes.IntegerType);
+    assertMatchesSpark(Variants.of((byte) 5), DataTypes.LongType);
+    assertMatchesSpark(Variants.of((short) 300), DataTypes.ShortType);
+    assertMatchesSpark(Variants.of((short) 300), DataTypes.IntegerType);
+    assertMatchesSpark(Variants.of(70_000), DataTypes.IntegerType);
+    assertMatchesSpark(Variants.of(70_000), DataTypes.LongType);
+    assertMatchesSpark(Variants.of(5_000_000_000L), DataTypes.LongType);
+    assertMatchesSpark(Variants.of("hello"), DataTypes.StringType);
+    assertMatchesSpark(Variants.of(true), DataTypes.BooleanType);
+    assertMatchesSpark(Variants.of(false), DataTypes.BooleanType);
+    assertMatchesSpark(Variants.ofDate(12_345), DataTypes.DateType);
+    assertMatchesSpark(Variants.of(3.5d), DataTypes.DoubleType);
+    assertMatchesSpark(Variants.of(1.5f), DataTypes.FloatType);
+    assertMatchesSpark(Variants.ofTimestamptz(1_000_000L), DataTypes.TimestampType);
+    assertMatchesSpark(Variants.ofTimestampntz(2_000_000L), DataTypes.TimestampNTZType);
     // Overflow with failOnError=false: both yield SQL NULL.
-    assertInlineMatchesSpark(Variants.of((long) Integer.MAX_VALUE + 1), DataTypes.IntegerType);
-    assertInlineMatchesSpark(Variants.of((int) Short.MAX_VALUE + 1), DataTypes.ShortType);
+    assertMatchesSpark(Variants.of((long) Integer.MAX_VALUE + 1), DataTypes.IntegerType);
+    assertMatchesSpark(Variants.of((int) Short.MAX_VALUE + 1), DataTypes.ShortType);
   }
 
-  private static void assertInlineMatchesSpark(VariantValue value, DataType targetType) {
-    Object inline = SparkVariantExtractionReaders.toSparkValueForTests(value, targetType);
-    assertThat(inline)
-        .as("inline cast %s -> %s must equal Spark VariantGet.cast", value.type(), targetType)
+  private static void assertMatchesSpark(VariantValue value, DataType targetType) {
+    Object actual = SparkVariantExtractionReaders.toSparkValueForTests(value, targetType);
+    assertThat(actual)
+        .as("reader cast %s -> %s must equal Spark VariantGet.cast", value.type(), targetType)
         .isEqualTo(sparkVariantGetCast(value, targetType));
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionReaders.java
@@ -19,25 +19,34 @@
 package org.apache.iceberg.spark.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.ZoneId;
 import java.util.List;
 import org.apache.iceberg.parquet.ParquetValueReader;
 import org.apache.iceberg.parquet.ParquetVariantExtractionReaders;
 import org.apache.iceberg.parquet.ParquetVariantVisitor;
 import org.apache.iceberg.parquet.VariantReaderBuilder;
 import org.apache.iceberg.variants.Variant;
+import org.apache.iceberg.variants.VariantMetadata;
+import org.apache.iceberg.variants.VariantValue;
 import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
+import org.apache.spark.SparkRuntimeException;
+import org.apache.spark.sql.catalyst.expressions.variant.VariantCastArgs;
+import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.VariantVal;
 import org.junit.jupiter.api.Test;
 
 class TestSparkVariantExtractionReaders {
@@ -274,11 +283,53 @@ class TestSparkVariantExtractionReaders {
   }
 
   @Test
-  void doubleOutOfFloatRangeReturnsNull() {
+  void int64OverflowToIntFailOnErrorThrows() {
+    long overflowValue = (long) Integer.MAX_VALUE + 1;
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.of(overflowValue), DataTypes.IntegerType, true))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("INVALID_VARIANT_CAST");
+  }
+
+  @Test
+  void int64OverflowToShortFailOnErrorThrows() {
+    long overflowValue = (long) Short.MAX_VALUE + 1;
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.of(overflowValue), DataTypes.ShortType, true))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("INVALID_VARIANT_CAST");
+  }
+
+  @Test
+  void int64OverflowToByteFailOnErrorThrows() {
+    long overflowValue = (long) Byte.MAX_VALUE + 1;
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.of(overflowValue), DataTypes.ByteType, true))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("INVALID_VARIANT_CAST");
+  }
+
+  @Test
+  void int64InRangeToIntFailOnErrorReturnsValue() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(42L), DataTypes.IntegerType, true))
+        .isEqualTo(42);
+  }
+
+  @Test
+  void doubleOutOfFloatRangeReturnsInfinity() {
+    // double -> float is delegated to Spark, which yields Infinity (not null) on overflow.
     assertThat(
             SparkVariantExtractionReaders.toSparkValueForTests(
                 Variants.of(Double.MAX_VALUE), DataTypes.FloatType))
-        .isNull();
+        .isEqualTo(Float.POSITIVE_INFINITY);
   }
 
   @Test
@@ -287,6 +338,109 @@ class TestSparkVariantExtractionReaders {
             SparkVariantExtractionReaders.toSparkValueForTests(
                 Variants.of(1.5d), DataTypes.FloatType))
         .isEqualTo(1.5f);
+  }
+
+  @Test
+  void stringToLongDelegatesToSpark() {
+    // STRING -> Long is not inline-owned; Spark parses the numeric string.
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of("4021"), DataTypes.LongType))
+        .isEqualTo(4021L);
+  }
+
+  @Test
+  void stringToLongUnparseableTryReturnsNull() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of("guest"), DataTypes.LongType))
+        .isNull();
+  }
+
+  @Test
+  void stringToLongUnparseableFailOnErrorThrows() {
+    assertThatThrownBy(
+            () ->
+                SparkVariantExtractionReaders.toSparkValueForTests(
+                    Variants.of("guest"), DataTypes.LongType, true))
+        .isInstanceOf(SparkRuntimeException.class)
+        .hasMessageContaining("INVALID_VARIANT_CAST");
+  }
+
+  @Test
+  void doubleToLongDelegatesAndTruncates() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(3.9d), DataTypes.LongType))
+        .isEqualTo(3L);
+  }
+
+  @Test
+  void intToDoubleDelegatesToSpark() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(7), DataTypes.DoubleType))
+        .isEqualTo(7.0d);
+  }
+
+  @Test
+  void decimalDelegatesToSpark() {
+    assertThat(
+            SparkVariantExtractionReaders.toSparkValueForTests(
+                Variants.of(new java.math.BigDecimal("123.45")), DataTypes.createDecimalType(6, 2)))
+        .isEqualTo(org.apache.spark.sql.types.Decimal.apply(new java.math.BigDecimal("123.45")));
+  }
+
+  /**
+   * Cross-check: every inline-owned pair that Spark's {@code VariantGet.cast} also supports must
+   * produce the identical value. This makes the inline set's equivalence to Spark executable, so a
+   * divergence (or a future Spark behavior change) fails loudly instead of silently returning wrong
+   * data. Deliberately excluded: nanos timestamps, {@code TIME}, and {@code UUID} sources — Spark's
+   * variant cannot represent those (its {@code getType} throws {@code UNKNOWN_PRIMITIVE_TYPE}), so
+   * they are inline-owned precisely because there is no Spark reference to compare against.
+   * Overflow behavior is covered by the dedicated overflow tests; this matrix uses in-range values.
+   */
+  @Test
+  void inlineOwnedConversionsMatchSparkVariantGet() {
+    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.ByteType);
+    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.ShortType);
+    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.IntegerType);
+    assertInlineMatchesSpark(Variants.of((byte) 5), DataTypes.LongType);
+    assertInlineMatchesSpark(Variants.of((short) 300), DataTypes.ShortType);
+    assertInlineMatchesSpark(Variants.of((short) 300), DataTypes.IntegerType);
+    assertInlineMatchesSpark(Variants.of(70_000), DataTypes.IntegerType);
+    assertInlineMatchesSpark(Variants.of(70_000), DataTypes.LongType);
+    assertInlineMatchesSpark(Variants.of(5_000_000_000L), DataTypes.LongType);
+    assertInlineMatchesSpark(Variants.of("hello"), DataTypes.StringType);
+    assertInlineMatchesSpark(Variants.of(true), DataTypes.BooleanType);
+    assertInlineMatchesSpark(Variants.of(false), DataTypes.BooleanType);
+    assertInlineMatchesSpark(Variants.ofDate(12_345), DataTypes.DateType);
+    assertInlineMatchesSpark(Variants.of(3.5d), DataTypes.DoubleType);
+    assertInlineMatchesSpark(Variants.of(1.5f), DataTypes.FloatType);
+    assertInlineMatchesSpark(Variants.ofTimestamptz(1_000_000L), DataTypes.TimestampType);
+    assertInlineMatchesSpark(Variants.ofTimestampntz(2_000_000L), DataTypes.TimestampNTZType);
+    // Overflow with failOnError=false: both yield SQL NULL.
+    assertInlineMatchesSpark(Variants.of((long) Integer.MAX_VALUE + 1), DataTypes.IntegerType);
+    assertInlineMatchesSpark(Variants.of((int) Short.MAX_VALUE + 1), DataTypes.ShortType);
+  }
+
+  private static void assertInlineMatchesSpark(VariantValue value, DataType targetType) {
+    Object inline = SparkVariantExtractionReaders.toSparkValueForTests(value, targetType);
+    assertThat(inline)
+        .as("inline cast %s -> %s must equal Spark VariantGet.cast", value.type(), targetType)
+        .isEqualTo(sparkVariantGetCast(value, targetType));
+  }
+
+  private static Object sparkVariantGetCast(VariantValue value, DataType targetType) {
+    VariantMetadata metadata = VariantMetadata.empty();
+    byte[] metadataBytes = new byte[metadata.sizeInBytes()];
+    metadata.writeTo(ByteBuffer.wrap(metadataBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+    byte[] valueBytes = new byte[value.sizeInBytes()];
+    value.writeTo(ByteBuffer.wrap(valueBytes).order(ByteOrder.LITTLE_ENDIAN), 0);
+    VariantCastArgs castArgs =
+        new VariantCastArgs(false, scala.Option.apply("UTC"), ZoneId.of("UTC"));
+    return org.apache.spark.sql.catalyst.expressions.variant.VariantGet$.MODULE$.cast(
+        new VariantVal(valueBytes, metadataBytes), targetType, castArgs);
   }
 
   private static StructField extractionField(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.StructField;
+import org.apache.spark.sql.types.StructType;
+import org.apache.spark.sql.types.VariantType$;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.FieldSource;
+
+class TestSparkVariantExtractionUtil {
+
+  private static final DataType[] SUPPORTED_TARGET_TYPES =
+      new DataType[] {
+        DataTypes.StringType,
+        DataTypes.IntegerType,
+        DataTypes.LongType,
+        DataTypes.ByteType,
+        DataTypes.ShortType,
+        DataTypes.BooleanType,
+        DataTypes.FloatType,
+        DataTypes.DoubleType,
+        DataTypes.createDecimalType(9, 2),
+        DataTypes.DateType,
+        DataTypes.TimestampType,
+        DataTypes.TimestampNTZType,
+        DataTypes.BinaryType
+      };
+
+  private static final DataType[] UNSUPPORTED_TARGET_TYPES =
+      new DataType[] {
+        VariantType$.MODULE$,
+        new StructType(
+            new StructField[] {DataTypes.createStructField("a", DataTypes.IntegerType, true)}),
+        DataTypes.createArrayType(DataTypes.IntegerType),
+        DataTypes.createMapType(DataTypes.StringType, DataTypes.IntegerType),
+        DataTypes.createCharType(4),
+        DataTypes.createVarcharType(4)
+      };
+
+  @ParameterizedTest
+  @FieldSource("SUPPORTED_TARGET_TYPES")
+  void isSupportedPushdownTargetTypeAcceptsSupportedTypes(DataType targetType) {
+    assertThat(SparkVariantExtractionUtil.isSupportedPushdownTargetType(targetType)).isTrue();
+  }
+
+  @ParameterizedTest
+  @FieldSource("UNSUPPORTED_TARGET_TYPES")
+  void isSupportedPushdownTargetTypeRejectsUnsupportedTypes(DataType targetType) {
+    assertThat(SparkVariantExtractionUtil.isSupportedPushdownTargetType(targetType)).isFalse();
+  }
+
+  @Test
+  void parseObjectPathSupportsDotAndBracketKeys() {
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.size")).containsExactly("size");
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.pull_request.user.login"))
+        .containsExactly("pull_request", "user", "login");
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['city']")).containsExactly("city");
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['pull_request']['user']['login']"))
+        .containsExactly("pull_request", "user", "login");
+  }
+
+  @Test
+  void parseObjectPathSupportsArrayIndexes() {
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.commits[0].author.name"))
+        .containsExactly("commits", "[0]", "author", "name");
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.a[1][2].b"))
+        .containsExactly("a", "[1]", "[2]", "b");
+    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['issue']['labels'][0]['name']"))
+        .containsExactly("issue", "labels", "[0]", "name");
+  }
+
+  @Test
+  void isSupportedExtractionPathAcceptsAllValidPaths() {
+    assertThat(SparkVariantExtractionUtil.isSupportedExtractionPath("$.size")).isTrue();
+    assertThat(SparkVariantExtractionUtil.isSupportedExtractionPath("$.pull_request.user.login"))
+        .isTrue();
+    assertThat(SparkVariantExtractionUtil.isSupportedExtractionPath("$.commits[0].author.name"))
+        .isTrue();
+    assertThat(
+            SparkVariantExtractionUtil.isSupportedExtractionPath("$['issue']['labels'][0]['name']"))
+        .isTrue();
+  }
+
+  @Test
+  void isArrayIndexPartDetectsNumericBrackets() {
+    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[0]")).isTrue();
+    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[12]")).isTrue();
+    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("commits")).isFalse();
+    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("['field']")).isFalse();
+    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[x]")).isFalse();
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.Metadata;
+import org.apache.spark.sql.types.MetadataBuilder;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType$;
@@ -81,5 +83,35 @@ class TestSparkVariantExtractionUtil {
     assertThat(
             SparkVariantExtractionUtil.isSupportedExtractionPath("$['issue']['labels'][0]['name']"))
         .isTrue();
+  }
+
+  @Test
+  void failOnErrorReadsMetadataFlag() {
+    assertThat(SparkVariantExtractionUtil.failOnError(extractionField(true))).isTrue();
+    assertThat(SparkVariantExtractionUtil.failOnError(extractionField(false))).isFalse();
+  }
+
+  @Test
+  void failOnErrorDefaultsFalseWhenAbsent() {
+    Metadata variantMetadata = new MetadataBuilder().putString("path", "$.size").build();
+    Metadata metadata =
+        new MetadataBuilder()
+            .putMetadata(SparkVariantExtractionUtil.VARIANT_METADATA_KEY, variantMetadata)
+            .build();
+    StructField field = DataTypes.createStructField("0", DataTypes.LongType, true, metadata);
+    assertThat(SparkVariantExtractionUtil.failOnError(field)).isFalse();
+  }
+
+  private static StructField extractionField(boolean failOnError) {
+    Metadata variantMetadata =
+        new MetadataBuilder()
+            .putString("path", "$.size")
+            .putBoolean("failOnError", failOnError)
+            .build();
+    Metadata metadata =
+        new MetadataBuilder()
+            .putMetadata(SparkVariantExtractionUtil.VARIANT_METADATA_KEY, variantMetadata)
+            .build();
+    return DataTypes.createStructField("0", DataTypes.LongType, true, metadata);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVariantExtractionUtil.java
@@ -72,26 +72,6 @@ class TestSparkVariantExtractionUtil {
   }
 
   @Test
-  void parseObjectPathSupportsDotAndBracketKeys() {
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.size")).containsExactly("size");
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.pull_request.user.login"))
-        .containsExactly("pull_request", "user", "login");
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['city']")).containsExactly("city");
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['pull_request']['user']['login']"))
-        .containsExactly("pull_request", "user", "login");
-  }
-
-  @Test
-  void parseObjectPathSupportsArrayIndexes() {
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.commits[0].author.name"))
-        .containsExactly("commits", "[0]", "author", "name");
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$.a[1][2].b"))
-        .containsExactly("a", "[1]", "[2]", "b");
-    assertThat(SparkVariantExtractionUtil.parseObjectPath("$['issue']['labels'][0]['name']"))
-        .containsExactly("issue", "labels", "[0]", "name");
-  }
-
-  @Test
   void isSupportedExtractionPathAcceptsAllValidPaths() {
     assertThat(SparkVariantExtractionUtil.isSupportedExtractionPath("$.size")).isTrue();
     assertThat(SparkVariantExtractionUtil.isSupportedExtractionPath("$.pull_request.user.login"))
@@ -101,14 +81,5 @@ class TestSparkVariantExtractionUtil {
     assertThat(
             SparkVariantExtractionUtil.isSupportedExtractionPath("$['issue']['labels'][0]['name']"))
         .isTrue();
-  }
-
-  @Test
-  void isArrayIndexPartDetectsNumericBrackets() {
-    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[0]")).isTrue();
-    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[12]")).isTrue();
-    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("commits")).isFalse();
-    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("['field']")).isFalse();
-    assertThat(SparkVariantExtractionUtil.isArrayIndexPart("[x]")).isFalse();
   }
 }


### PR DESCRIPTION
**Changes**

This PR is part of the work to support variant extraction pushdown, the core change is to introduce new parquet readers to read selected variant paths instead of the whole variant:

- Add selective Parquet readers (ParquetVariantExtractionReaders, VariantExtractionPathResolver) to read only shredded typed_value columns for requested extraction paths.
- Add Spark row reader adapter (SparkVariantExtractionReaders, SparkParquetReaders) to materialize extraction slots from the engine read schema instead of full variant blobs.
- Wire engine read schema from SparkBatch through SparkInputPartition to RowDataReader only (row Parquet path).
- Update PruneColumnsWithoutReordering so annotated extraction structs map back to Iceberg VARIANT columns in the scan projection.

Issue: #16726 

**Note for reviewers**
- PathUtil.java is mostly copied from the existing PR #15384, will rebase once that PR is merged. 
- To reduce the scope, the new selective readers are only wired in for batch row scan. We can wire to other readers as a follow up. 
- To reduce the scope, only supports extracting mostly used data types. Do not support extracting arrays, struct / nested struct.Request shredded columns for unsupported types will lead to read the whole variant (extraction pushdown rejected). 
- Merge order: 
   1. #16714
   2. #16715

**End to end testing**

Requires #16715 for end-to-end testing. To try the full pushdown + selective read path without merging locally, use this branch: 

https://github.com/qlong/iceberg/tree/variant-extraction-integration-test

**Test results**

Test framework: [variant-conformance-benchmark](variant-conformance-benchmark)
Use 1-day Github activities data, ingested as json and shredded variants with 299 shreddred columns.  

Baseline: `gha-payload-iceberg-20260605` · variant + **extraction pushdown ON**  + **selective shredded variant extraction Parquet readers**
Compare A: same run  with payload stored as  `string_json`
Compare B: `gha-payload-iceberg-nopushed-20260605` · variant + pushdown OFF, read whole variant
Median of 3 timed runs per query (Spark `Time taken:`).
| Query | Variant + pushdown (s) | string_json (s) | Δ vs baseline | Variant no-pushdown (s) | Δ vs baseline |
|-------|------------------------:|----------------:|--------------:|------------------------:|--------------:|
| c-q01 | 2.605 | 2.373 | −8.9% | 2.945 | +13.0% |
| c-q04 | 3.875 | 6.412 | +65.5% | 72.082 | +1760% |
| c-q05b | 3.506 | 5.683 | +62.1% | 39.154 | +1017% |
| c-q06 | 4.668 | 6.583 | +41.0% | 76.935 | +1548% |
| c-q07 | 4.714 | 4.490 | −4.8% | 75.033 | +1492% |
| c-q08 | 3.701 | 4.707 | +27.2% | 87.059 | +2252% |
| c-q09 | 5.102 | 6.668 | +30.7% | 72.560 | +1322% |
| c-q10 | 4.395 | 6.568 | +49.4% | 68.179 | +1451% |
| c-q11 | 4.495 | 6.384 | +42.0% | 67.985 | +1413% |
| c-q12 | 3.995 | 4.284 | +7.2% | 70.509 | +1665% |
| c-q13 | 3.911 | 4.060 | +3.8% | 39.614 | +913% |
| c-q14 | 4.769 | 5.450 | +14.3% | 63.331 | +1228% |
| **Total (Σ)** | **49.74** | **63.66** | **+28.0%** | **735.39** | **+1379%** |


Co-authored with Claude Sonnet 4.6