### PR TITLE
Spark 4.1: Fail fast when a parameter context reaches an Iceberg DDL command

### DIFF
--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -128,7 +128,7 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
   override def parsePlanWithParameters(
       sqlText: String,
       parameterContext: ParameterContext): LogicalPlan =
-    parsePlanWithDelegate(sqlText, Some(parameterContext)) { sql =>
+    parsePlanWithDelegate(sqlText, Option(parameterContext)) { sql =>
       delegate.parsePlanWithParameters(sql, parameterContext)
     }
 

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -33,8 +33,11 @@ import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.RewriteViewCommands
 import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.parser.HybridParameterContext
+import org.apache.spark.sql.catalyst.parser.NamedParameterContext
 import org.apache.spark.sql.catalyst.parser.ParameterContext
 import org.apache.spark.sql.catalyst.parser.ParserInterface
+import org.apache.spark.sql.catalyst.parser.PositionalParameterContext
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.NonReservedContext
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.QuotedIdentifierContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
@@ -121,29 +124,43 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
 
   /**
    * Parse a string to a LogicalPlan, binding the given parameters.
-   *
-   * Iceberg DDL grammars do not accept parameter markers (`?` / `:name`), so the
-   * parameterContext is only forwarded to the delegate on the non-Iceberg path.
    */
   override def parsePlanWithParameters(
       sqlText: String,
       parameterContext: ParameterContext): LogicalPlan =
-    parsePlanWithDelegate(sqlText) { sql =>
+    parsePlanWithDelegate(sqlText, Some(parameterContext)) { sql =>
       delegate.parsePlanWithParameters(sql, parameterContext)
     }
 
-  /**
-   * Dispatch parsing: Iceberg commands are parsed by the extensions parser, everything else is
-   * handed to the wrapped Spark parser via `delegateParse`.
-   */
-  private def parsePlanWithDelegate(sqlText: String)(
+  private def parsePlanWithDelegate(
+      sqlText: String,
+      parameterContext: Option[ParameterContext] = None)(
       delegateParse: String => LogicalPlan): LogicalPlan = {
     val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
     if (isIcebergCommand(sqlTextAfterSubstitution)) {
+      parameterContext.foreach(checkNoParameterMarkers(sqlText, _))
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
         .asInstanceOf[LogicalPlan]
     } else {
       RewriteViewCommands(SparkSession.active).apply(delegateParse(sqlText))
+    }
+  }
+
+  private def checkNoParameterMarkers(sqlText: String, parameterContext: ParameterContext): Unit = {
+    val hasParameters = parameterContext match {
+      case NamedParameterContext(params) => params.nonEmpty
+      case PositionalParameterContext(params) => params.nonEmpty
+      case HybridParameterContext(args, _) => args.nonEmpty
+    }
+
+    // Iceberg grammars have no parameter markers (`?` / `:name`) to bind, so a non-empty context
+    // is a caller bug; fail fast rather than silently dropping it.
+    if (hasParameters) {
+      throw new IcebergParseException(
+        Some(sqlText),
+        "Iceberg SQL extensions do not support parameter markers (`?` / `:name`)",
+        Origin(),
+        Origin())
     }
   }
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
@@ -249,6 +249,16 @@ public class TestExtendedParser {
         .hasMessageContaining("parameter");
   }
 
+  /** Tests that a null parameter context is treated as having no parameters to bind. */
+  @Test
+  public void testParsePlanWithParametersAcceptsNullContextForIcebergCommand() throws Exception {
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(originalParser);
+
+    LogicalPlan plan = parser.parsePlanWithParameters("ALTER TABLE t DROP PARTITION FIELD x", null);
+
+    assertThat(plan).isNotNull();
+  }
+
   /** Tests that a rejected Iceberg-command parameter context is not forwarded to the delegate. */
   @Test
   public void testParsePlanWithParametersDoesNotForwardParametersToIcebergPath() throws Exception {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/TestExtendedParser.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -35,13 +36,18 @@ import org.apache.iceberg.SortDirection;
 import org.apache.iceberg.expressions.Term;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.catalyst.expressions.Expression;
+import org.apache.spark.sql.catalyst.expressions.Literal;
 import org.apache.spark.sql.catalyst.parser.AbstractSqlParser;
 import org.apache.spark.sql.catalyst.parser.AstBuilder;
 import org.apache.spark.sql.catalyst.parser.ParameterContext;
 import org.apache.spark.sql.catalyst.parser.ParserInterface;
+import org.apache.spark.sql.catalyst.parser.PositionalParameterContext;
+import org.apache.spark.sql.catalyst.parser.extensions.IcebergParseException;
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser;
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan;
 import org.apache.spark.sql.catalyst.plans.logical.OneRowRelation;
+import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -230,6 +236,36 @@ public class TestExtendedParser {
 
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).get(0)).isEqualTo(42);
+  }
+
+  /** Tests that a non-empty parameter context reaching an Iceberg command fails fast end-to-end. */
+  @Test
+  public void testParsePlanWithParametersRejectsParameterForIcebergCommand() throws Exception {
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(originalParser);
+    setSessionStateParser(spark.sessionState(), parser);
+
+    assertThatThrownBy(() -> spark.sql("ALTER TABLE t ADD PARTITION FIELD ?", new Object[] {1}))
+        .isInstanceOf(IcebergParseException.class)
+        .hasMessageContaining("parameter");
+  }
+
+  /** Tests that a rejected Iceberg-command parameter context is not forwarded to the delegate. */
+  @Test
+  public void testParsePlanWithParametersDoesNotForwardParametersToIcebergPath() throws Exception {
+    ParserInterface delegate = mock(ParserInterface.class);
+    ParameterContext context =
+        new PositionalParameterContext(
+            scala.jdk.javaapi.CollectionConverters.asScala(
+                    Collections.<Expression>singletonList(Literal.create(1, DataTypes.IntegerType)))
+                .toSeq());
+
+    IcebergSparkSqlExtensionsParser parser = new IcebergSparkSqlExtensionsParser(delegate);
+
+    assertThatThrownBy(
+            () -> parser.parsePlanWithParameters("ALTER TABLE t DROP PARTITION FIELD x", context))
+        .isInstanceOf(IcebergParseException.class)
+        .hasMessageContaining("parameter");
+    verify(delegate, never()).parsePlanWithParameters(anyString(), any(ParameterContext.class));
   }
 
   private static void setSessionStateParser(Object sessionState, ParserInterface parser)


### PR DESCRIPTION
Closes #16683. Follow-up to #16626.

Iceberg DDL is dispatched to a grammar with no parameter markers (`?` / `:name`), so `parsePlanWithParameters` does not forward the `ParameterContext` on that path. Previously a non-empty context reaching an Iceberg command was dropped silently; this rejects it with a clear `IcebergParseException` instead. The empty context Spark always supplies for arg-less queries still flows through unchanged.

Tested via two regression cases in `TestExtendedParser` (fail-fast end-to-end, and the rejected context is not forwarded to the delegate).