### PR TITLE
Arrow: bulk-copy fixed-size-binary vectorized reads

### DIFF
--- a/arrow/src/jmh/java/org/apache/iceberg/arrow/VectorizedReadFixedWidthBinaryBenchmark.java
+++ b/arrow/src/jmh/java/org/apache/iceberg/arrow/VectorizedReadFixedWidthBinaryBenchmark.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.arrow.vectorized.ColumnarBatch;
+import org.apache.iceberg.arrow.vectorized.VectorizedTableScanIterable;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.parquet.Parquet;
+import org.apache.iceberg.types.Types;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Benchmarks the vectorized Arrow read path for fixed-width binary columns (Iceberg {@code UUID},
+ * {@code fixed[N]} and high-precision {@code decimal(p>18)}, all stored as Parquet {@code
+ * FIXED_LEN_BYTE_ARRAY} and materialized into Arrow {@code FixedSizeBinaryVector}s).
+ *
+ * <p>The columns are required and high-cardinality (unique random values), so Parquet encodes them
+ * as plain {@code FIXED_LEN_BYTE_ARRAY}. That is the path exercised by {@code
+ * FixedSizeBinaryReader} in {@code VectorizedParquetDefinitionLevelReader}.
+ *
+ * <p>The benchmark consumes minimally (the column vectors are fully materialized during batch
+ * production, before any accessor call), so {@code -prof gc} reports the allocation cost of
+ * materialization itself rather than accessor-side copies.
+ *
+ * <p>Run with:
+ *
+ * <pre>
+ *   ./gradlew :iceberg-arrow:jmh \
+ *     -PjmhIncludeRegex=VectorizedReadFixedWidthBinaryBenchmark \
+ *     -PjmhOutputPath=benchmark/arrow-fixedbinary.txt
+ * </pre>
+ */
+@Fork(
+    value = 1,
+    jvmArgsAppend = {
+      // Arrow accesses JDK internals (java.nio.Buffer.address) reflectively; the read path fails
+      // without these in the forked JVM. Mirrors the module-open flags the Gradle test tasks use.
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "-Dio.netty.tryReflectionSetAccessible=true"
+    })
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+public class VectorizedReadFixedWidthBinaryBenchmark {
+
+  private static final int NUM_ROWS = 1_500_000;
+  private static final int BATCH_SIZE = 10_000;
+  private static final long SEED = 1729L;
+
+  // "uncompressed" isolates the read/materialization path; "gzip" reflects a realistic on-disk file
+  // where Parquet page decompression dominates heap allocation.
+  @Param({"uncompressed", "gzip"})
+  private String compression;
+
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "uuid", Types.UUIDType.get()),
+          required(2, "decimal38", Types.DecimalType.of(38, 0)),
+          required(3, "fixed16", Types.FixedType.ofLength(16)));
+
+  private File tableDir;
+  private Table table;
+  private byte[] firstFixed16;
+
+  @Setup
+  public void setupBenchmark() throws IOException {
+    this.tableDir = java.nio.file.Files.createTempDirectory("arrow-fixedbinary-bench").toFile();
+    File tableLocation = new File(tableDir, "table");
+    HadoopTables tables = new HadoopTables();
+    this.table = tables.create(SCHEMA, tableLocation.toString());
+
+    File dataFile = new File(tableDir, "data.parquet");
+    writeData(dataFile);
+
+    DataFile appended =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withInputFile(Files.localInput(dataFile))
+            .withFormat(FileFormat.PARQUET)
+            .withRecordCount(NUM_ROWS)
+            .withFileSizeInBytes(dataFile.length())
+            .build();
+    table.newAppend().appendFile(appended).commit();
+
+    sanityCheck();
+  }
+
+  @TearDown
+  public void tearDownBenchmark() throws IOException {
+    try (Stream<java.nio.file.Path> paths = java.nio.file.Files.walk(tableDir.toPath())) {
+      paths
+          .sorted(Comparator.reverseOrder())
+          .forEach(
+              path -> {
+                try {
+                  java.nio.file.Files.deleteIfExists(path);
+                } catch (IOException e) {
+                  throw new UncheckedIOException(e);
+                }
+              });
+    }
+  }
+
+  private void writeData(File dataFile) throws IOException {
+    Random random = new Random(SEED);
+    try (FileAppender<GenericRecord> appender =
+        Parquet.write(Files.localOutput(dataFile))
+            .schema(SCHEMA)
+            .set("write.parquet.compression-codec", compression)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      for (int i = 0; i < NUM_ROWS; i++) {
+        GenericRecord record = GenericRecord.create(SCHEMA);
+        record.setField("uuid", new UUID(random.nextLong(), random.nextLong()));
+
+        // 15 random bytes -> unscaled magnitude < 10^38, so it fits decimal(38, 0) (16-byte fixed)
+        byte[] unscaled = new byte[15];
+        random.nextBytes(unscaled);
+        record.setField("decimal38", new BigDecimal(new BigInteger(1, unscaled)));
+
+        byte[] fixed = new byte[16];
+        random.nextBytes(fixed);
+        record.setField("fixed16", fixed);
+
+        if (i == 0) {
+          this.firstFixed16 = fixed.clone();
+        }
+        appender.add(record);
+      }
+    }
+  }
+
+  /**
+   * Fail fast in @Setup if materialization is wrong, so a regression never measures as "faster".
+   */
+  private void sanityCheck() throws IOException {
+    try (VectorizedTableScanIterable scan =
+        new VectorizedTableScanIterable(table.newScan(), BATCH_SIZE, false)) {
+      ColumnarBatch first = scan.iterator().next();
+      byte[] read = first.column(2).getBinary(0);
+      if (!Arrays.equals(read, firstFixed16)) {
+        throw new IllegalStateException(
+            "fixed16 row 0 mismatch: expected "
+                + Arrays.toString(firstFixed16)
+                + " but was "
+                + Arrays.toString(read));
+      }
+    }
+  }
+
+  @Benchmark
+  public void scanFixedWidthBinary(Blackhole blackhole) throws IOException {
+    try (VectorizedTableScanIterable scan =
+        new VectorizedTableScanIterable(table.newScan(), BATCH_SIZE, false)) {
+      for (ColumnarBatch batch : scan) {
+        // Vectors are already materialized here; reading one value keeps the batch live and proves
+        // the data was decoded, while adding only negligible (per-batch, not per-row) allocation.
+        blackhole.consume(batch.column(2).getBinary(0));
+        blackhole.consume(batch.numRows());
+      }
+    }
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -550,6 +550,33 @@ public final class VectorizedParquetDefinitionLevelReader
 
   class FixedSizeBinaryReader extends BaseReader {
     @Override
+    protected void nextRleBatch(
+        FieldVector vector,
+        int typeWidth,
+        NullabilityHolder nullabilityHolder,
+        VectorizedValuesReader valuesReader,
+        int idx,
+        int numValues,
+        byte[] byteArray) {
+      if (currentValue == maxDefLevel && valuesReader.supportsBulkFixedLengthRead()) {
+        // The whole run is non-null and the values are stored contiguously in the page, so copy
+        // them into the vector's data buffer in a single memcpy instead of one value at a time,
+        // mirroring how the numeric readers handle a non-null run.
+        valuesReader.readFixedLengthBytes(numValues, vector, idx, typeWidth);
+        nullabilityHolder.setNotNulls(idx, numValues);
+        if (setArrowValidityVector) {
+          ArrowBuf validityBuffer = vector.getValidityBuffer();
+          for (int i = 0; i < numValues; i++) {
+            BitVectorHelper.setBit(validityBuffer, idx + i);
+          }
+        }
+      } else {
+        super.nextRleBatch(
+            vector, typeWidth, nullabilityHolder, valuesReader, idx, numValues, byteArray);
+      }
+    }
+
+    @Override
     protected void nextVal(
         FieldVector vector,
         int idx,

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPlainValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedPlainValuesReader.java
@@ -74,4 +74,16 @@ class VectorizedPlainValuesReader extends ValuesAsBytesReader implements Vectori
   public void readDoubles(int total, FieldVector vec, int rowId) {
     readValues(total, vec, rowId, DOUBLE_SIZE);
   }
+
+  @Override
+  public boolean supportsBulkFixedLengthRead() {
+    return true;
+  }
+
+  @Override
+  public void readFixedLengthBytes(int total, FieldVector vec, int rowId, int typeWidth) {
+    // Plain FIXED_LEN_BYTE_ARRAY values are stored contiguously with no length prefix, matching the
+    // layout of a FixedSizeBinaryVector data buffer, so the whole run copies in a single memcpy.
+    readValues(total, vec, rowId, typeWidth);
+  }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedValuesReader.java
@@ -101,6 +101,23 @@ interface VectorizedValuesReader {
   }
 
   /**
+   * Whether this reader can bulk-copy a run of contiguous fixed-length values via {@link
+   * #readFixedLengthBytes(int, FieldVector, int, int)}. Readers that decode each value individually
+   * (for example byte-stream-split) return false so callers keep the per-value path.
+   */
+  default boolean supportsBulkFixedLengthRead() {
+    return false;
+  }
+
+  /**
+   * Read `total` fixed-length (`typeWidth`-byte) values into `vec` starting at `vec[rowId]`. Only
+   * valid when {@link #supportsBulkFixedLengthRead()} returns true.
+   */
+  default void readFixedLengthBytes(int total, FieldVector vec, int rowId, int typeWidth) {
+    throw new UnsupportedOperationException("readFixedLengthBytes is not supported");
+  }
+
+  /**
    * Initialize the reader from a page. See {@link ValuesReader#initFromPage(int,
    * ByteBufferInputStream)}.
    */

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -24,7 +24,7 @@ if (jdkVersion != '17' && jdkVersion != '21') {
 def flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")).split(",")
 def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
 def scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
-def jmhProjects = [project(":iceberg-core"), project(":iceberg-data")]
+def jmhProjects = [project(":iceberg-core"), project(":iceberg-data"), project(":iceberg-arrow")]
 
 if (flinkVersions.contains("1.20")) {
   jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.20"))


### PR DESCRIPTION
## What

`FixedSizeBinaryReader` in the vectorized Parquet reader (the path for Iceberg `UUID`, `fixed[N]` and high-precision `decimal(p>18)`, all stored as Parquet `FIXED_LEN_BYTE_ARRAY`) materialized values one at a time: `readBinary()`, wrap in a `ByteBuffer`, copy into a scratch array, then `FixedSizeBinaryVector.set()`. The numeric readers beside it already blit an entire non-null run into the Arrow data buffer with a single `ArrowBuf.setBytes` memcpy (via `readLongs`/`readValues`). Plain `FIXED_LEN_BYTE_ARRAY` is stored contiguously with no length prefix, byte-identical to a `FixedSizeBinaryVector` data buffer, so the per-value loop was pure overhead.

This adds the missing fixed-width sibling of those bulk reads: `readFixedLengthBytes` on `VectorizedValuesReader`, plus a `nextRleBatch` fast path in `FixedSizeBinaryReader` that copies a non-null run in one memcpy. A `supportsBulkFixedLengthRead()` capability flag (default false, true only for the plain reader) keeps non-contiguous encoders such as byte-stream-split on their existing per-value path.

## Benchmark

`VectorizedReadFixedWidthBinaryBenchmark` (new): 1.5M required rows of `uuid` + `decimal(38,0)` + `fixed[16]`, read via `VectorizedTableScanIterable`. JMH AverageTime, `-prof gc`.

| compression | baseline | this PR | speedup |
| --- | --- | --- | --- |
| gzip | 275.98 ms/op | 170.96 ms/op | 1.6x |
| uncompressed | 171.30 ms/op | 65.91 ms/op | 2.6x |

Heap allocation per op is unchanged: the per-value `Binary`/`ByteBuffer` wrappers were already being scalar-replaced by the JIT, so the win is CPU (the bulk memcpy replaces millions of per-value calls, bounds checks and copies), not allocation.

## Testing

Output is byte-identical. Covered by the existing `TestArrowReader` (required and nullable `uuid`/`fixed`/`decimal` columns exercise both the bulk run and the per-value null fallback).

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Bulk-copy fixed-size-binary values in the vectorized Parquet reader instead of materializing one value at a time.
