### PR TITLE
Arrow: avoid per-value byte[] in dictionary-encoded fixed-binary decode

### DIFF
--- a/arrow/src/jmh/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictFixedBinaryDecodeBenchmark.java
+++ b/arrow/src/jmh/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictFixedBinaryDecodeBenchmark.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized.parquet;
+
+import java.nio.ByteBuffer;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.parquet.column.Dictionary;
+import org.apache.parquet.column.Encoding;
+import org.apache.parquet.io.api.Binary;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * Microbenchmark isolating the eager dictionary-encoded fixed-width-binary decode (the {@code
+ * FixedSizeBinaryDictEncodedReader} per-value path). End-to-end this path only fires when a
+ * column's dictionary overflows to plain mid-chunk, so its cost is masked by page reading; this
+ * drives the decode directly to measure per-value time and allocation ({@code -prof gc}).
+ *
+ * <pre>
+ *   ./gradlew :iceberg-arrow:jmh \
+ *     -PjmhIncludeRegex=VectorizedDictFixedBinaryDecodeBenchmark \
+ *     -PjmhOutputPath=benchmark/arrow-dict-fixedbinary.txt
+ * </pre>
+ */
+@Fork(
+    value = 1,
+    jvmArgsAppend = {
+      "--add-opens=java.base/java.nio=ALL-UNNAMED",
+      "--add-opens=java.base/java.lang=ALL-UNNAMED",
+      "-Dio.netty.tryReflectionSetAccessible=true"
+    })
+@State(Scope.Benchmark)
+@Warmup(iterations = 3, time = 2)
+@Measurement(iterations = 5, time = 2)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class VectorizedDictFixedBinaryDecodeBenchmark {
+
+  private static final int TYPE_WIDTH = 16;
+  private static final int NUM_VALUES = 4096;
+  private static final int DICT_SIZE = 256;
+  private static final long SEED = 1729L;
+
+  private RootAllocator allocator;
+  private FixedSizeBinaryVector vector;
+  private Dictionary dictionary;
+  private VectorizedDictionaryEncodedParquetValuesReader.FixedSizeBinaryDictEncodedReader reader;
+  private int[] ids;
+
+  @Setup
+  public void setupBenchmark() {
+    this.allocator = new RootAllocator();
+    this.vector = new FixedSizeBinaryVector("fixed", allocator, TYPE_WIDTH);
+    vector.allocateNew(NUM_VALUES);
+
+    Random random = new Random(SEED);
+    Binary[] entries = new Binary[DICT_SIZE];
+    for (int i = 0; i < DICT_SIZE; i++) {
+      byte[] bytes = new byte[TYPE_WIDTH];
+      random.nextBytes(bytes);
+      // Match the Binary type a real Parquet dictionary produces for FIXED_LEN_BYTE_ARRAY.
+      entries[i] = Binary.fromConstantByteBuffer(ByteBuffer.wrap(bytes), 0, TYPE_WIDTH);
+    }
+    this.dictionary =
+        new Dictionary(Encoding.RLE_DICTIONARY) {
+          @Override
+          public int getMaxId() {
+            return DICT_SIZE - 1;
+          }
+
+          @Override
+          public Binary decodeToBinary(int id) {
+            return entries[id];
+          }
+        };
+
+    this.reader =
+        new VectorizedDictionaryEncodedParquetValuesReader(0, false)
+            .fixedSizeBinaryDictEncodedReader();
+
+    this.ids = new int[NUM_VALUES];
+    for (int i = 0; i < NUM_VALUES; i++) {
+      ids[i] = random.nextInt(DICT_SIZE);
+    }
+  }
+
+  @TearDown
+  public void tearDownBenchmark() {
+    vector.close();
+    allocator.close();
+  }
+
+  @Benchmark
+  public void decodeDictFixedBinary(Blackhole blackhole) {
+    for (int i = 0; i < NUM_VALUES; i++) {
+      reader.nextVal(vector, dictionary, i, ids[i], TYPE_WIDTH);
+    }
+    blackhole.consume(vector);
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -23,7 +23,6 @@ import java.nio.ByteOrder;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.iceberg.parquet.ParquetUtil;
@@ -151,10 +150,10 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     @Override
     protected void nextVal(
         FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
-      byte[] bytes = dict.decodeToBinary(currentVal).getBytesUnsafe();
-      byte[] vectorBytes = new byte[typeWidth];
-      System.arraycopy(bytes, 0, vectorBytes, 0, typeWidth);
-      ((FixedSizeBinaryVector) vector).set(idx, vectorBytes);
+      // Write the decoded bytes straight into the vector's data buffer (no per-value byte[]), like
+      // the numeric dict readers. toByteBuffer() respects the dictionary entry's backing offset.
+      ByteBuffer buffer = dict.decodeToBinary(currentVal).toByteBuffer();
+      vector.getDataBuffer().setBytes((long) idx * typeWidth, buffer);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDictionaryEncodedParquetValuesReader.java
@@ -23,7 +23,6 @@ import java.nio.ByteOrder;
 import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.FieldVector;
-import org.apache.arrow.vector.FixedSizeBinaryVector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.iceberg.parquet.ParquetUtil;
@@ -155,10 +154,10 @@ public class VectorizedDictionaryEncodedParquetValuesReader
     @Override
     protected void nextVal(
         FieldVector vector, Dictionary dict, int idx, int currentVal, int typeWidth) {
-      byte[] bytes = dict.decodeToBinary(currentVal).getBytesUnsafe();
-      byte[] vectorBytes = new byte[typeWidth];
-      System.arraycopy(bytes, 0, vectorBytes, 0, typeWidth);
-      ((FixedSizeBinaryVector) vector).set(idx, vectorBytes);
+      // Write the decoded bytes straight into the vector's data buffer (no per-value byte[]), like
+      // the numeric dict readers. toByteBuffer() respects the dictionary entry's backing offset.
+      ByteBuffer buffer = dict.decodeToBinary(currentVal).toByteBuffer();
+      vector.getDataBuffer().setBytes((long) idx * typeWidth, buffer);
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedParquetDefinitionLevelReader.java
@@ -575,10 +575,10 @@ public final class VectorizedParquetDefinitionLevelReader
             .fixedSizeBinaryDictEncodedReader()
             .nextBatch(vector, idx, numValues, dict, holder, typeWidth);
       } else if (Mode.PACKED.equals(mode)) {
-        byte[] bytes = dict.decodeToBinary(reader.readInteger()).getBytes();
-        byte[] vectorBytes = new byte[typeWidth];
-        System.arraycopy(bytes, 0, vectorBytes, 0, typeWidth);
-        ((FixedSizeBinaryVector) vector).set(idx, vectorBytes);
+        // Write the bytes straight into the data buffer (no per-value byte[]), like the numeric
+        // dict readers; toByteBuffer() respects the dictionary entry's backing offset.
+        ByteBuffer buffer = dict.decodeToBinary(reader.readInteger()).toByteBuffer();
+        vector.getDataBuffer().setBytes((long) idx * typeWidth, buffer);
       }
     }
   }

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedParquetDefinitionLevelReader.java
@@ -24,6 +24,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.parquet.column.Dictionary;
 import org.apache.parquet.column.Encoding;
 import org.apache.parquet.io.api.Binary;
@@ -100,6 +102,124 @@ public class TestVectorizedParquetDefinitionLevelReader {
           .as("row 1 should receive the second decoded timestamp")
           .isEqualTo(222_222L);
     }
+  }
+
+  @Test
+  public void fixedSizeBinaryReaderPackedDictionaryDecodeDecodesRowsCorrectly() {
+    int typeWidth = 4;
+    byte[] value0 = {10, 11, 12, 13};
+    byte[] value1 = {20, 21, 22, 23};
+    try (RootAllocator allocator = new RootAllocator();
+        FixedSizeBinaryVector vector = new FixedSizeBinaryVector("fixed", allocator, typeWidth)) {
+      vector.allocateNew(2);
+
+      VectorizedParquetDefinitionLevelReader definitionReader =
+          new VectorizedParquetDefinitionLevelReader(1, 1, false);
+      VectorizedDictionaryEncodedParquetValuesReader dictionaryReader =
+          new VectorizedDictionaryEncodedParquetValuesReader(1, false);
+
+      dictionaryReader.mode = BaseVectorizedParquetValuesReader.Mode.PACKED;
+      dictionaryReader.currentCount = 2;
+      dictionaryReader.packedValuesBuffer[0] = 0;
+      dictionaryReader.packedValuesBuffer[1] = 1;
+
+      VectorizedParquetDefinitionLevelReader.FixedSizeBinaryReader reader =
+          definitionReader.fixedSizeBinaryReader();
+      reader.nextDictEncodedVal(
+          vector,
+          0,
+          dictionaryReader,
+          fixedDictionary(value0, value1),
+          BaseVectorizedParquetValuesReader.Mode.PACKED,
+          1,
+          null,
+          typeWidth);
+      reader.nextDictEncodedVal(
+          vector,
+          1,
+          dictionaryReader,
+          fixedDictionary(value0, value1),
+          BaseVectorizedParquetValuesReader.Mode.PACKED,
+          1,
+          null,
+          typeWidth);
+
+      vector.setValueCount(2);
+
+      assertThat(readFixed(vector, 0, typeWidth))
+          .as("row 0 should receive the first decoded value")
+          .isEqualTo(value0);
+      assertThat(readFixed(vector, 1, typeWidth))
+          .as("row 1 should receive the second decoded value")
+          .isEqualTo(value1);
+    }
+  }
+
+  @Test
+  public void fixedSizeBinaryDictEncodedReaderDecodesContiguousRunCorrectly() {
+    int typeWidth = 4;
+    byte[] value0 = {10, 11, 12, 13};
+    byte[] value1 = {20, 21, 22, 23};
+    try (RootAllocator allocator = new RootAllocator();
+        FixedSizeBinaryVector vector = new FixedSizeBinaryVector("fixed", allocator, typeWidth)) {
+      vector.allocateNew(2);
+
+      VectorizedDictionaryEncodedParquetValuesReader dictionaryReader =
+          new VectorizedDictionaryEncodedParquetValuesReader(0, false);
+      dictionaryReader.mode = BaseVectorizedParquetValuesReader.Mode.PACKED;
+      dictionaryReader.currentCount = 2;
+      dictionaryReader.packedValuesBuffer[0] = 0;
+      dictionaryReader.packedValuesBuffer[1] = 1;
+
+      NullabilityHolder holder = new NullabilityHolder(2);
+      dictionaryReader
+          .fixedSizeBinaryDictEncodedReader()
+          .nextBatch(vector, 0, 2, fixedDictionary(value0, value1), holder, typeWidth);
+
+      vector.setValueCount(2);
+
+      assertThat(readFixed(vector, 0, typeWidth))
+          .as("row 0 should receive the first decoded value")
+          .isEqualTo(value0);
+      assertThat(readFixed(vector, 1, typeWidth))
+          .as("row 1 should receive the second decoded value")
+          .isEqualTo(value1);
+    }
+  }
+
+  private static Dictionary fixedDictionary(byte[] value0, byte[] value1) {
+    return new Dictionary(Encoding.PLAIN_DICTIONARY) {
+      @Override
+      public int getMaxId() {
+        return 1;
+      }
+
+      @Override
+      public Binary decodeToBinary(int id) {
+        if (id == 0) {
+          return fixedBinaryWithOffset(value0);
+        } else if (id == 1) {
+          return fixedBinaryWithOffset(value1);
+        }
+
+        throw new IllegalArgumentException("Unexpected dictionary id: " + id);
+      }
+    };
+  }
+
+  private static Binary fixedBinaryWithOffset(byte[] value) {
+    // Back the entry at a non-zero offset so the test fails if the reader ignores the backing
+    // offset (as a plain getBytesUnsafe()[0, len) copy would).
+    byte[] padded = new byte[value.length + 3];
+    System.arraycopy(value, 0, padded, 3, value.length);
+    return Binary.fromConstantByteArray(padded, 3, value.length);
+  }
+
+  /** Read the raw bytes written into the vector's data buffer, independent of the validity bits. */
+  private static byte[] readFixed(FixedSizeBinaryVector vector, int idx, int typeWidth) {
+    byte[] bytes = new byte[typeWidth];
+    vector.getDataBuffer().getBytes((long) idx * typeWidth, bytes);
+    return bytes;
   }
 
   private static Binary int96Binary(long micros) {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedParquetDefinitionLevelReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/parquet/TestVectorizedParquetDefinitionLevelReader.java
@@ -197,9 +197,11 @@ public class TestVectorizedParquetDefinitionLevelReader {
       @Override
       public Binary decodeToBinary(int id) {
         if (id == 0) {
-          return fixedBinaryWithOffset(value0);
+          // A real Parquet FIXED_LEN_BYTE_ARRAY dictionary backs entries with a sliced ByteBuffer.
+          return byteBufferBackedWithOffset(value0);
         } else if (id == 1) {
-          return fixedBinaryWithOffset(value1);
+          // Cover the byte[]-backed Binary variant in the same decode as well.
+          return byteArraySliceBackedWithOffset(value1);
         }
 
         throw new IllegalArgumentException("Unexpected dictionary id: " + id);
@@ -207,9 +209,14 @@ public class TestVectorizedParquetDefinitionLevelReader {
     };
   }
 
-  private static Binary fixedBinaryWithOffset(byte[] value) {
-    // Back the entry at a non-zero offset so the test fails if the reader ignores the backing
-    // offset (as a plain getBytesUnsafe()[0, len) copy would).
+  private static Binary byteBufferBackedWithOffset(byte[] value) {
+    // Non-zero offset so the test fails if the reader ignores the entry's backing offset.
+    byte[] padded = new byte[value.length + 3];
+    System.arraycopy(value, 0, padded, 3, value.length);
+    return Binary.fromConstantByteBuffer(ByteBuffer.wrap(padded), 3, value.length);
+  }
+
+  private static Binary byteArraySliceBackedWithOffset(byte[] value) {
     byte[] padded = new byte[value.length + 3];
     System.arraycopy(value, 0, padded, 3, value.length);
     return Binary.fromConstantByteArray(padded, 3, value.length);

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -24,7 +24,7 @@ if (jdkVersion != '17' && jdkVersion != '21') {
 def flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")).split(",")
 def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
 def scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
-def jmhProjects = [project(":iceberg-core"), project(":iceberg-data")]
+def jmhProjects = [project(":iceberg-core"), project(":iceberg-data"), project(":iceberg-arrow")]
 
 if (flinkVersions.contains("1.20")) {
   jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.20"))


### PR DESCRIPTION
## What

The dictionary-encoded fixed-binary readers (`FixedSizeBinaryDictEncodedReader` and the packed branch of `FixedSizeBinaryReader.nextDictEncodedVal`) allocated a `byte[typeWidth]` per value, copied the decoded bytes into it, then called `FixedSizeBinaryVector.set()`. The numeric dictionary readers in the same file write straight into the vector's data buffer. This switches the fixed-binary ones to the same pattern: `decodeToBinary(id).toByteBuffer()` plus `ArrowBuf.setBytes`, dropping the per-value array. `toByteBuffer()` also positions at the dictionary entry's backing offset (the same thing the var-width dictionary reader already does), so the decode is correct regardless of how the dictionary backs its `Binary` entries.

This is an allocation cleanup, not a bug fix: with the current Parquet (1.17.1) the previous `getBytesUnsafe()` returns an exact-size copy, so the result was already correct.

## Benchmark

`VectorizedDictFixedBinaryDecodeBenchmark` (new) drives the eager-dictionary fixed-binary decode directly, since end-to-end the path is masked by page reading. JMH AverageTime, `-prof gc`, 4096 16-byte values per op:

| per value | before | after |
| --- | --- | --- |
| allocation | 32 B | 0 B |
| time | 15.9 ns | 13.6 ns |

The old path allocated a runtime-sized `byte[]` per value (which the JIT cannot scalar-replace); the `toByteBuffer()` plus `setBytes` form lets the JIT scalar-replace the wrapper, so per-value heap allocation drops to zero (about 15% faster).

## Testing

Adds two unit tests to `TestVectorizedParquetDefinitionLevelReader` that drive the eager-dictionary fixed-binary decode (the batch reader and the packed-inline branch) with a dictionary entry backed at a non-zero offset. This path previously had no direct coverage; the end-to-end tests only hit the lazy dictionary path.

## Note

Companion to #16718 (the bulk-copy fixed-binary read optimization). Both touch `VectorizedParquetDefinitionLevelReader.java` in different methods and both add `iceberg-arrow` to the JMH `jmhProjects` list, so whichever merges second needs a trivial rebase.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Avoid the per-value byte[] allocation in the dictionary-encoded fixed-binary Arrow readers.
