### PR TITLE
Parquet: Pre-size row-group filter maps to the column count

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -97,11 +97,12 @@ public class ParquetBloomRowGroupFilter {
     private boolean eval(
         MessageType fileSchema, BlockMetaData rowGroup, BloomFilterReader bloomFilterReader) {
       this.bloomReader = bloomFilterReader;
+      int columnCount = rowGroup.getColumns().size();
       this.fieldsWithBloomFilter = Sets.newHashSet();
-      this.columnMetaMap = Maps.newHashMap();
+      this.columnMetaMap = Maps.newHashMapWithExpectedSize(columnCount);
       this.bloomCache = Maps.newHashMap();
-      this.parquetPrimitiveTypes = Maps.newHashMap();
-      this.types = Maps.newHashMap();
+      this.parquetPrimitiveTypes = Maps.newHashMapWithExpectedSize(columnCount);
+      this.types = Maps.newHashMapWithExpectedSize(columnCount);
 
       for (ColumnChunkMetaData meta : rowGroup.getColumns()) {
         PrimitiveType colType = fileSchema.getType(meta.getPath().toArray()).asPrimitiveType();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -91,11 +91,13 @@ public class ParquetDictionaryRowGroupFilter {
         BlockMetaData rowGroup,
         DictionaryPageReadStore dictionaryReadStore) {
       this.dictionaries = dictionaryReadStore;
+      int fileColumnCount = fileSchema.getColumns().size();
+      int rowGroupColumnCount = rowGroup.getColumns().size();
       this.dictCache = Maps.newHashMap();
-      this.isFallback = Maps.newHashMap();
-      this.mayContainNulls = Maps.newHashMap();
-      this.cols = Maps.newHashMap();
-      this.conversions = Maps.newHashMap();
+      this.isFallback = Maps.newHashMapWithExpectedSize(rowGroupColumnCount);
+      this.mayContainNulls = Maps.newHashMapWithExpectedSize(rowGroupColumnCount);
+      this.cols = Maps.newHashMapWithExpectedSize(fileColumnCount);
+      this.conversions = Maps.newHashMapWithExpectedSize(fileColumnCount);
 
       for (ColumnDescriptor desc : fileSchema.getColumns()) {
         PrimitiveType colType = fileSchema.getType(desc.getPath()).asPrimitiveType();

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -86,9 +86,10 @@ public class ParquetMetricsRowGroupFilter {
         return ROWS_CANNOT_MATCH;
       }
 
-      this.stats = Maps.newHashMap();
-      this.valueCounts = Maps.newHashMap();
-      this.conversions = Maps.newHashMap();
+      int columnCount = rowGroup.getColumns().size();
+      this.stats = Maps.newHashMapWithExpectedSize(columnCount);
+      this.valueCounts = Maps.newHashMapWithExpectedSize(columnCount);
+      this.conversions = Maps.newHashMapWithExpectedSize(columnCount);
       for (ColumnChunkMetaData col : rowGroup.getColumns()) {
         PrimitiveType colType = fileSchema.getType(col.getPath().toArray()).asPrimitiveType();
         if (colType.getId() != null) {


### PR DESCRIPTION
The row-group filters (`ParquetMetricsRowGroupFilter`, `ParquetDictionaryRowGroupFilter`, `ParquetBloomRowGroupFilter`) rebuild their per-column maps (`stats` / `valueCounts` / `conversions`, etc.) for every row group, filling them with one entry per column from `Maps.newHashMap()`. On wide schemas the map's backing table (its `Node[]` bucket array) is reallocated several times per row group as it grows past the load-factor threshold. Sizing the maps to the row group's column count up front goes straight to the right capacity and avoids those intermediate table reallocations. The lazy caches (`dictCache`, `bloomCache`) and the conditional `fieldsWithBloomFilter` set are left at the default size since they are not filled to the column count.

This runs on the scan-planning path for every Parquet file in every engine (one `shouldRead` per row group) and is behavior-preserving.

Benchmarked the always-on `ParquetMetricsRowGroupFilter.shouldRead` with JMH and the gc profiler on a 64-column schema (one op = one row-group filter call):

| Metric | Before | After | Delta |
|---|---|---|---|
| Allocation | 17,280 B/op | 14,448 B/op | -2,832 B (-16%) |
| Time | 8.1 us/op | 6.3 us/op | faster (overlapping CIs) |

`shouldRead` is a thin wrapper that does `new MetricsEvalVisitor().eval(...)`, so the maps are allocated inside `eval`; the benchmark drives the public `shouldRead` entry point, which fully contains `eval` (and `eval` is private, so it is the only entry point). The visitor allocation is identical on both runs and the only change between them is the map sizing, so the measured delta is attributable entirely to the pre-sizing.

The dictionary and bloom filters get the identical pre-sizing for the same structural reason (their `shouldRead` is likewise a thin wrapper over an `eval` that fills maps to the column count per row group). Correctness is covered by the existing `TestMetricsRowGroupFilter`, `TestMetricsRowGroupFilterTypes`, `TestDictionaryRowGroupFilter`, and `TestBloomRowGroupFilter` suites.
