### PR TITLE
Flink: SQL: Pass only white-listed Catalog properties for Table LIKE 

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -106,7 +106,6 @@ public class FlinkCatalog extends AbstractCatalog {
       String defaultDatabase,
       Namespace baseNamespace,
       CatalogLoader catalogLoader,
-      Map<String, String> catalogProps,
       boolean cacheEnabled,
       long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
@@ -337,10 +336,9 @@ public class FlinkCatalog extends AbstractCatalog {
     Table table = loadIcebergTable(tablePath);
 
     // Flink's CREATE TABLE LIKE clause relies on properties sent back here to create new table.
-    // Inorder to create such table in non iceberg catalog, we need to send across catalog
-    // properties also.
     // As Flink API accepts only Map<String, String> for props, here we are serializing catalog
-    // props as json string to distinguish between catalog and table properties in createTable.
+    // name, database, table as json string to distinguish between catalog info
+    // and table properties in createTable.
     String srcCatalogProps =
         FlinkCreateTableOptions.toJson(
             getName(), tablePath.getDatabaseName(), tablePath.getObjectName());

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -94,13 +94,11 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  */
 @Internal
 public class FlinkCatalog extends AbstractCatalog {
-
   private final CatalogLoader catalogLoader;
   private final Catalog icebergCatalog;
   private final Namespace baseNamespace;
   private final SupportsNamespaces asNamespaceCatalog;
   private final Closeable closeable;
-  private final Map<String, String> catalogProps;
   private final boolean cacheEnabled;
 
   public FlinkCatalog(
@@ -113,7 +111,6 @@ public class FlinkCatalog extends AbstractCatalog {
       long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
-    this.catalogProps = catalogProps;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 
@@ -346,7 +343,7 @@ public class FlinkCatalog extends AbstractCatalog {
     // props as json string to distinguish between catalog and table properties in createTable.
     String srcCatalogProps =
         FlinkCreateTableOptions.toJson(
-            getName(), tablePath.getDatabaseName(), tablePath.getObjectName(), catalogProps);
+            getName(), tablePath.getDatabaseName(), tablePath.getObjectName());
 
     Map<String, String> tableProps = table.properties();
     if (tableProps.containsKey(FlinkCreateTableOptions.CONNECTOR_PROPS_KEY)

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -54,6 +54,7 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
@@ -77,6 +78,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -94,6 +96,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  */
 @Internal
 public class FlinkCatalog extends AbstractCatalog {
+
+  /**
+   * Catalog property keys propagated to a CREATE TABLE LIKE target so it can reconstruct the
+   * Iceberg catalog. Anything outside this set must be supplied explicitly via the WITH clause on
+   * the LIKE target.
+   */
+  private static final Set<String> INHERITABLE_CATALOG_PROPS =
+      ImmutableSet.of(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, CatalogProperties.CATALOG_IMPL);
+
   private final CatalogLoader catalogLoader;
   private final Catalog icebergCatalog;
   private final Namespace baseNamespace;
@@ -112,7 +123,10 @@ public class FlinkCatalog extends AbstractCatalog {
       long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
-    this.catalogProps = catalogProps;
+    this.catalogProps =
+        catalogProps.entrySet().stream()
+            .filter(entry -> INHERITABLE_CATALOG_PROPS.contains(entry.getKey()))
+            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -54,7 +54,6 @@ import org.apache.flink.table.expressions.Expression;
 import org.apache.flink.table.factories.Factory;
 import org.apache.flink.util.StringUtils;
 import org.apache.iceberg.CachingCatalog;
-import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataTableType;
@@ -78,7 +77,6 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -96,14 +94,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
  */
 @Internal
 public class FlinkCatalog extends AbstractCatalog {
-
-  /**
-   * Catalog property keys propagated to a CREATE TABLE LIKE target so it can reconstruct the
-   * Iceberg catalog. Anything outside this set must be supplied explicitly via the WITH clause on
-   * the LIKE target.
-   */
-  private static final Set<String> INHERITABLE_CATALOG_PROPS =
-      ImmutableSet.of(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE, CatalogProperties.CATALOG_IMPL);
 
   private final CatalogLoader catalogLoader;
   private final Catalog icebergCatalog;
@@ -123,10 +113,7 @@ public class FlinkCatalog extends AbstractCatalog {
       long cacheExpirationIntervalMs) {
     super(catalogName, defaultDatabase);
     this.catalogLoader = catalogLoader;
-    this.catalogProps =
-        catalogProps.entrySet().stream()
-            .filter(entry -> INHERITABLE_CATALOG_PROPS.contains(entry.getKey()))
-            .collect(ImmutableMap.toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    this.catalogProps = catalogProps;
     this.baseNamespace = baseNamespace;
     this.cacheEnabled = cacheEnabled;
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -170,7 +170,6 @@ public class FlinkCatalogFactory implements CatalogFactory {
         defaultDatabase,
         baseNamespace,
         catalogLoader,
-        properties,
         cacheEnabled,
         cacheExpirationIntervalMs);
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -18,16 +18,20 @@
  */
 package org.apache.iceberg.flink;
 
-import java.util.Map;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
-import org.apache.iceberg.CatalogProperties;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.JsonUtil;
 
 class FlinkCreateTableOptions {
+  private final String catalogName;
+  private final String catalogDb;
+  private final String catalogTable;
 
-  private FlinkCreateTableOptions() {}
+  private FlinkCreateTableOptions(String catalogName, String catalogDb, String catalogTable) {
+    this.catalogName = catalogName;
+    this.catalogDb = catalogDb;
+    this.catalogTable = catalogTable;
+  }
 
   public static final ConfigOption<String> CATALOG_NAME =
       ConfigOptions.key("catalog-name")
@@ -75,38 +79,39 @@ class FlinkCreateTableOptions {
   public static final String CONNECTOR_PROPS_KEY = "connector";
   public static final String LOCATION_KEY = "location";
 
-  static String toJson(
-      String catalogName, String catalogDb, String catalogTable, Map<String, String> catalogProps) {
+  static String toJson(String catalogName, String catalogDb, String catalogTable) {
     return JsonUtil.generate(
         gen -> {
           gen.writeStartObject();
           gen.writeStringField(CATALOG_NAME.key(), catalogName);
           gen.writeStringField(CATALOG_DATABASE.key(), catalogDb);
           gen.writeStringField(CATALOG_TABLE.key(), catalogTable);
-
-          String catalogType = catalogProps.get(CATALOG_TYPE.key());
-          if (catalogType != null) {
-            gen.writeStringField(CATALOG_TYPE.key(), catalogType);
-          }
-
-          String catalogImpl = catalogProps.get(CatalogProperties.CATALOG_IMPL);
-          if (catalogImpl != null) {
-            gen.writeStringField(CatalogProperties.CATALOG_IMPL, catalogImpl);
-          }
-
           gen.writeEndObject();
         },
         false);
   }
 
-  static Map<String, String> fromJson(String createTableOptions) {
+  static FlinkCreateTableOptions fromJson(String createTableOptions) {
     return JsonUtil.parse(
         createTableOptions,
         node -> {
-          ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
-          node.fieldNames()
-              .forEachRemaining(field -> properties.put(field, JsonUtil.getString(field, node)));
-          return properties.build();
+          String catalogName = JsonUtil.getString(CATALOG_NAME.key(), node);
+          String catalogDb = JsonUtil.getString(CATALOG_DATABASE.key(), node);
+          String catalogTable = JsonUtil.getString(CATALOG_TABLE.key(), node);
+
+          return new FlinkCreateTableOptions(catalogName, catalogDb, catalogTable);
         });
+  }
+
+  String catalogName() {
+    return catalogName;
+  }
+
+  String catalogDb() {
+    return catalogDb;
+  }
+
+  String catalogTable() {
+    return catalogTable;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCreateTableOptions.java
@@ -21,21 +21,13 @@ package org.apache.iceberg.flink;
 import java.util.Map;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.JsonUtil;
 
 class FlinkCreateTableOptions {
-  private final String catalogName;
-  private final String catalogDb;
-  private final String catalogTable;
-  private final Map<String, String> catalogProps;
 
-  private FlinkCreateTableOptions(
-      String catalogName, String catalogDb, String catalogTable, Map<String, String> props) {
-    this.catalogName = catalogName;
-    this.catalogDb = catalogDb;
-    this.catalogTable = catalogTable;
-    this.catalogProps = props;
-  }
+  private FlinkCreateTableOptions() {}
 
   public static final ConfigOption<String> CATALOG_NAME =
       ConfigOptions.key("catalog-name")
@@ -60,12 +52,6 @@ class FlinkCreateTableOptions {
           .stringType()
           .noDefaultValue()
           .withDescription("Table name managed in the underlying iceberg catalog and database.");
-
-  public static final ConfigOption<Map<String, String>> CATALOG_PROPS =
-      ConfigOptions.key("catalog-props")
-          .mapType()
-          .noDefaultValue()
-          .withDescription("Properties for the underlying catalog for iceberg table.");
 
   public static final ConfigOption<Boolean> USE_DYNAMIC_ICEBERG_SINK =
       ConfigOptions.key("use-dynamic-iceberg-sink")
@@ -97,38 +83,30 @@ class FlinkCreateTableOptions {
           gen.writeStringField(CATALOG_NAME.key(), catalogName);
           gen.writeStringField(CATALOG_DATABASE.key(), catalogDb);
           gen.writeStringField(CATALOG_TABLE.key(), catalogTable);
-          JsonUtil.writeStringMap(CATALOG_PROPS.key(), catalogProps, gen);
+
+          String catalogType = catalogProps.get(CATALOG_TYPE.key());
+          if (catalogType != null) {
+            gen.writeStringField(CATALOG_TYPE.key(), catalogType);
+          }
+
+          String catalogImpl = catalogProps.get(CatalogProperties.CATALOG_IMPL);
+          if (catalogImpl != null) {
+            gen.writeStringField(CatalogProperties.CATALOG_IMPL, catalogImpl);
+          }
+
           gen.writeEndObject();
         },
         false);
   }
 
-  static FlinkCreateTableOptions fromJson(String createTableOptions) {
+  static Map<String, String> fromJson(String createTableOptions) {
     return JsonUtil.parse(
         createTableOptions,
         node -> {
-          String catalogName = JsonUtil.getString(CATALOG_NAME.key(), node);
-          String catalogDb = JsonUtil.getString(CATALOG_DATABASE.key(), node);
-          String catalogTable = JsonUtil.getString(CATALOG_TABLE.key(), node);
-          Map<String, String> catalogProps = JsonUtil.getStringMap(CATALOG_PROPS.key(), node);
-
-          return new FlinkCreateTableOptions(catalogName, catalogDb, catalogTable, catalogProps);
+          ImmutableMap.Builder<String, String> properties = ImmutableMap.builder();
+          node.fieldNames()
+              .forEachRemaining(field -> properties.put(field, JsonUtil.getString(field, node)));
+          return properties.build();
         });
-  }
-
-  String catalogName() {
-    return catalogName;
-  }
-
-  String catalogDb() {
-    return catalogDb;
-  }
-
-  String catalogTable() {
-    return catalogTable;
-  }
-
-  Map<String, String> catalogProps() {
-    return catalogProps;
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -249,9 +249,15 @@ public class FlinkDynamicTableFactory
     String srcCatalogProps = tableProps.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY);
     if (srcCatalogProps != null) {
       Map<String, String> mergedProps = Maps.newHashMap();
-      Map<String, String> inheritedCatalogProps = FlinkCreateTableOptions.fromJson(srcCatalogProps);
+      FlinkCreateTableOptions createTableOptions =
+          FlinkCreateTableOptions.fromJson(srcCatalogProps);
 
-      mergedProps.putAll(inheritedCatalogProps);
+      mergedProps.put(FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.catalogName());
+      mergedProps.put(
+          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.catalogDb());
+      mergedProps.put(
+          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.catalogTable());
+
       tableProps.forEach(
           (k, v) -> {
             if (!FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY.equals(k)) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -249,16 +249,9 @@ public class FlinkDynamicTableFactory
     String srcCatalogProps = tableProps.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY);
     if (srcCatalogProps != null) {
       Map<String, String> mergedProps = Maps.newHashMap();
-      FlinkCreateTableOptions createTableOptions =
-          FlinkCreateTableOptions.fromJson(srcCatalogProps);
+      Map<String, String> inheritedCatalogProps = FlinkCreateTableOptions.fromJson(srcCatalogProps);
 
-      mergedProps.put(FlinkCreateTableOptions.CATALOG_NAME.key(), createTableOptions.catalogName());
-      mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_DATABASE.key(), createTableOptions.catalogDb());
-      mergedProps.put(
-          FlinkCreateTableOptions.CATALOG_TABLE.key(), createTableOptions.catalogTable());
-      mergedProps.putAll(createTableOptions.catalogProps());
-
+      mergedProps.putAll(inheritedCatalogProps);
       tableProps.forEach(
           (k, v) -> {
             if (!FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY.equals(k)) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkDynamicTableFactory.java
@@ -237,13 +237,13 @@ public class FlinkDynamicTableFactory
   }
 
   /**
-   * Merges source catalog properties with connector properties. Iceberg Catalog properties are
-   * serialized as json in FlinkCatalog#getTable to be able to isolate catalog props from iceberg
-   * table props, Here, we flatten and merge them back to use to create catalog.
+   * Merges source catalog properties (catalog name, database, table) with connector properties.
+   * Source catalog name, database, table are serialized as json in FlinkCatalog#getTable to be able
+   * to isolate them from iceberg table props, Here, we flatten and merge them back.
    *
    * @param tableProps the existing table properties
-   * @return a map of merged properties, with source catalog properties taking precedence when keys
-   *     conflict
+   * @return a map of merged properties, defaulting to source catalog name, database and table
+   *     unless overridden.
    */
   private static Map<String, String> mergeSrcCatalogProps(Map<String, String> tableProps) {
     String srcCatalogProps = tableProps.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/CatalogTestBase.java
@@ -89,6 +89,7 @@ public abstract class CatalogTestBase extends TestBase {
       config.put(CatalogProperties.URI, getURI(hiveConf));
     }
     config.put(CatalogProperties.WAREHOUSE_LOCATION, String.format("file://%s", warehouseRoot()));
+    config.put("extra-catalog-prop", "extra-value");
 
     this.flinkDatabase = catalogName + "." + DATABASE;
     this.icebergNamespace =

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -34,10 +34,10 @@ import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
-import org.apache.flink.table.catalog.CommonCatalogOptions;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.BaseTable;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -231,8 +231,18 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
 
     // `type` option is filtered out by Flink
     // https://github.com/apache/flink/blob/edc3d68736de73665440f4313ddcfd9142d8d42b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java#L378
-    Map<String, String> filteredOptions = Maps.newHashMap(config);
-    filteredOptions.remove(CommonCatalogOptions.CATALOG_TYPE.key());
+    // Only catalog-type / catalog-impl are retained for the LIKE target to reconstruct the
+    // catalog; everything else (e.g. warehouse) must be supplied explicitly via WITH.
+    Map<String, String> filteredOptions = Maps.newHashMap();
+    if (config.containsKey(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)) {
+      filteredOptions.put(
+          FlinkCatalogFactory.ICEBERG_CATALOG_TYPE,
+          config.get(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE));
+    }
+    if (config.containsKey(CatalogProperties.CATALOG_IMPL)) {
+      filteredOptions.put(
+          CatalogProperties.CATALOG_IMPL, config.get(CatalogProperties.CATALOG_IMPL));
+    }
 
     String srcCatalogProps =
         FlinkCreateTableOptions.toJson(catalogName, DATABASE, "tl", filteredOptions);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -37,7 +37,6 @@ import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.BaseTable;
-import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -218,21 +217,9 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
 
   @TestTemplate
   public void testCreateTableLikeInFlinkCatalog() throws TableNotExistException {
-    // Create a separate source catalog  with an arbitrary extra property
-    // (catalog-cred), alongside the warehouse and uri set by the fixture, so we can assert
-    // the LIKE allowlist drops every catalog property outside catalog-type, catalog-impl.
-    String credentialKey = "catalog-cred";
-    String credentialValue = "secret-value";
-    String sourceCatalog = catalogName + "_with_cred";
-    String sourceDatabase = "db_with_cred";
-    String sourceFlinkDatabase = sourceCatalog + "." + sourceDatabase;
-    Map<String, String> sourceConfig = Maps.newHashMap(config);
-    sourceConfig.put(credentialKey, credentialValue);
-    sql("CREATE CATALOG %s WITH %s", sourceCatalog, toWithClause(sourceConfig));
-    sql("CREATE DATABASE %s", sourceFlinkDatabase);
-    sql("CREATE TABLE %s.tl(id BIGINT)", sourceFlinkDatabase);
+    sql("CREATE TABLE tl(id BIGINT)");
 
-    sql("CREATE TABLE `default_catalog`.`default_database`.tl2 LIKE %s.tl", sourceFlinkDatabase);
+    sql("CREATE TABLE `default_catalog`.`default_database`.tl2 LIKE tl");
 
     CatalogTable catalogTable = catalogTable("default_catalog", "default_database", "tl2");
     assertThat(catalogTable.getUnresolvedSchema())
@@ -241,41 +228,15 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
                 .column("id", DataTypes.BIGINT())
                 .build());
 
-    // `type` option is filtered out by Flink
-    // https://github.com/apache/flink/blob/edc3d68736de73665440f4313ddcfd9142d8d42b/flink-table/flink-table-common/src/main/java/org/apache/flink/table/factories/FactoryUtil.java#L378
-    // Only catalog-type / catalog-impl are retained for the LIKE target to reconstruct the
-    // catalog; everything else (e.g. warehouse) must be supplied explicitly via WITH.
-    Map<String, String> filteredOptions = Maps.newHashMap();
-    if (sourceConfig.containsKey(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)) {
-      filteredOptions.put(
-          FlinkCatalogFactory.ICEBERG_CATALOG_TYPE,
-          sourceConfig.get(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE));
-    }
-    if (sourceConfig.containsKey(CatalogProperties.CATALOG_IMPL)) {
-      filteredOptions.put(
-          CatalogProperties.CATALOG_IMPL, sourceConfig.get(CatalogProperties.CATALOG_IMPL));
-    }
-
-    String expectedSourceCatalogProps =
-        FlinkCreateTableOptions.toJson(sourceCatalog, sourceDatabase, "tl", filteredOptions);
+    String srcCatalogProps = FlinkCreateTableOptions.toJson(catalogName, DATABASE, "tl");
     Map<String, String> options = catalogTable.getOptions();
     assertThat(options)
         .containsEntry(
             FlinkCreateTableOptions.CONNECTOR_PROPS_KEY,
             FlinkDynamicTableFactory.FACTORY_IDENTIFIER)
-        .containsEntry(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY, expectedSourceCatalogProps);
-
-    Map<String, String> srcCatalogProps =
-        FlinkCreateTableOptions.fromJson(
-            options.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY));
-    assertThat(srcCatalogProps)
-        .doesNotContainKey(credentialKey)
-        .doesNotContainKey(CatalogProperties.URI)
-        .doesNotContainKey(CatalogProperties.WAREHOUSE_LOCATION);
-
-    sql("DROP TABLE IF EXISTS %s.tl", sourceFlinkDatabase);
-    dropDatabase(sourceFlinkDatabase, true);
-    dropCatalog(sourceCatalog, true);
+        .containsEntry(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY, srcCatalogProps);
+    assertThat(options.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY))
+        .doesNotContain("extra-catalog-prop", "extra-value");
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -218,9 +218,21 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
 
   @TestTemplate
   public void testCreateTableLikeInFlinkCatalog() throws TableNotExistException {
-    sql("CREATE TABLE tl(id BIGINT)");
+    // Create a separate source catalog  with an arbitrary extra property
+    // (catalog-cred), alongside the warehouse and uri set by the fixture, so we can assert
+    // the LIKE allowlist drops every catalog property outside catalog-type, catalog-impl.
+    String credentialKey = "catalog-cred";
+    String credentialValue = "secret-value";
+    String sourceCatalog = catalogName + "_with_cred";
+    String sourceDatabase = "db_with_cred";
+    String sourceFlinkDatabase = sourceCatalog + "." + sourceDatabase;
+    Map<String, String> sourceConfig = Maps.newHashMap(config);
+    sourceConfig.put(credentialKey, credentialValue);
+    sql("CREATE CATALOG %s WITH %s", sourceCatalog, toWithClause(sourceConfig));
+    sql("CREATE DATABASE %s", sourceFlinkDatabase);
+    sql("CREATE TABLE %s.tl(id BIGINT)", sourceFlinkDatabase);
 
-    sql("CREATE TABLE `default_catalog`.`default_database`.tl2 LIKE tl");
+    sql("CREATE TABLE `default_catalog`.`default_database`.tl2 LIKE %s.tl", sourceFlinkDatabase);
 
     CatalogTable catalogTable = catalogTable("default_catalog", "default_database", "tl2");
     assertThat(catalogTable.getUnresolvedSchema())
@@ -234,24 +246,36 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
     // Only catalog-type / catalog-impl are retained for the LIKE target to reconstruct the
     // catalog; everything else (e.g. warehouse) must be supplied explicitly via WITH.
     Map<String, String> filteredOptions = Maps.newHashMap();
-    if (config.containsKey(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)) {
+    if (sourceConfig.containsKey(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE)) {
       filteredOptions.put(
           FlinkCatalogFactory.ICEBERG_CATALOG_TYPE,
-          config.get(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE));
+          sourceConfig.get(FlinkCatalogFactory.ICEBERG_CATALOG_TYPE));
     }
-    if (config.containsKey(CatalogProperties.CATALOG_IMPL)) {
+    if (sourceConfig.containsKey(CatalogProperties.CATALOG_IMPL)) {
       filteredOptions.put(
-          CatalogProperties.CATALOG_IMPL, config.get(CatalogProperties.CATALOG_IMPL));
+          CatalogProperties.CATALOG_IMPL, sourceConfig.get(CatalogProperties.CATALOG_IMPL));
     }
 
-    String srcCatalogProps =
-        FlinkCreateTableOptions.toJson(catalogName, DATABASE, "tl", filteredOptions);
+    String expectedSourceCatalogProps =
+        FlinkCreateTableOptions.toJson(sourceCatalog, sourceDatabase, "tl", filteredOptions);
     Map<String, String> options = catalogTable.getOptions();
     assertThat(options)
         .containsEntry(
             FlinkCreateTableOptions.CONNECTOR_PROPS_KEY,
             FlinkDynamicTableFactory.FACTORY_IDENTIFIER)
-        .containsEntry(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY, srcCatalogProps);
+        .containsEntry(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY, expectedSourceCatalogProps);
+
+    Map<String, String> srcCatalogProps =
+        FlinkCreateTableOptions.fromJson(
+            options.get(FlinkCreateTableOptions.SRC_CATALOG_PROPS_KEY));
+    assertThat(srcCatalogProps)
+        .doesNotContainKey(credentialKey)
+        .doesNotContainKey(CatalogProperties.URI)
+        .doesNotContainKey(CatalogProperties.WAREHOUSE_LOCATION);
+
+    sql("DROP TABLE IF EXISTS %s.tl", sourceFlinkDatabase);
+    dropDatabase(sourceFlinkDatabase, true);
+    dropCatalog(sourceCatalog, true);
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -179,7 +179,10 @@ public class TestIcebergSourceSql extends TestSqlBase {
     List<Record> expected = generateExpectedRecords(false);
     SqlHelpers.sql(
         getTableEnv(),
-        "create table `default_catalog`.`default_database`.flink_table LIKE iceberg_catalog.`default`.%s",
+        "create table `default_catalog`.`default_database`.flink_table "
+            + "WITH ('warehouse'='%s') "
+            + "LIKE iceberg_catalog.`default`.%s",
+        CATALOG_EXTENSION.warehouse(),
         TestFixtures.TABLE);
 
     // Read from table in flink catalog
@@ -199,8 +202,11 @@ public class TestIcebergSourceSql extends TestSqlBase {
         getStreamingTableEnv(),
         "CREATE TABLE %s "
             + "(eventTS AS CAST(t1 AS TIMESTAMP(3)), "
-            + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) LIKE iceberg_catalog.`default`.%s",
+            + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) "
+            + "WITH ('warehouse'='%s') "
+            + "LIKE iceberg_catalog.`default`.%s",
         flinkTable,
+        CATALOG_EXTENSION.warehouse(),
         TestFixtures.TABLE);
 
     assertThatThrownBy(() -> SqlHelpers.sql(getStreamingTableEnv(), "SELECT * FROM %s", flinkTable))
@@ -218,8 +224,11 @@ public class TestIcebergSourceSql extends TestSqlBase {
         getStreamingTableEnv(),
         "CREATE TABLE %s "
             + "(eventTS AS CAST(t1 AS TIMESTAMP(3)), "
-            + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) WITH ('watermark-column'='t1') LIKE iceberg_catalog.`default`.%s",
+            + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) "
+            + "WITH ('watermark-column'='t1', 'warehouse'='%s') "
+            + "LIKE iceberg_catalog.`default`.%s",
         flinkTable,
+        CATALOG_EXTENSION.warehouse(),
         TestFixtures.TABLE);
 
     TestHelpers.assertRecordsWithOrder(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestIcebergSourceSql.java
@@ -180,7 +180,7 @@ public class TestIcebergSourceSql extends TestSqlBase {
     SqlHelpers.sql(
         getTableEnv(),
         "create table `default_catalog`.`default_database`.flink_table "
-            + "WITH ('warehouse'='%s') "
+            + "WITH ('catalog-type'='hadoop', 'warehouse'='%s') "
             + "LIKE iceberg_catalog.`default`.%s",
         CATALOG_EXTENSION.warehouse(),
         TestFixtures.TABLE);
@@ -203,7 +203,7 @@ public class TestIcebergSourceSql extends TestSqlBase {
         "CREATE TABLE %s "
             + "(eventTS AS CAST(t1 AS TIMESTAMP(3)), "
             + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) "
-            + "WITH ('warehouse'='%s') "
+            + "WITH ('catalog-type'='hadoop', 'warehouse'='%s') "
             + "LIKE iceberg_catalog.`default`.%s",
         flinkTable,
         CATALOG_EXTENSION.warehouse(),
@@ -225,7 +225,7 @@ public class TestIcebergSourceSql extends TestSqlBase {
         "CREATE TABLE %s "
             + "(eventTS AS CAST(t1 AS TIMESTAMP(3)), "
             + "WATERMARK FOR eventTS AS SOURCE_WATERMARK()) "
-            + "WITH ('watermark-column'='t1', 'warehouse'='%s') "
+            + "WITH ('catalog-type'='hadoop', 'warehouse'='%s', 'watermark-column'='t1') "
             + "LIKE iceberg_catalog.`default`.%s",
         flinkTable,
         CATALOG_EXTENSION.warehouse(),


### PR DESCRIPTION
Pass restricted set of source catalog properties for CREATE TABLE LIKE functionality.

With this change,  uri or any other source properties need to be still passed. 
```
CREATE TABLE table_wm (
    eventTS AS CAST(t1 AS TIMESTAMP(3)),
    WATERMARK FOR eventTS AS SOURCE_WATERMARK()
) WITH (
  'uri'='u',
 'catalog-creds-key'='val', // if required
) LIKE iceberg_catalog.db.t;
```

