### PR TITLE
Core: extract parallel manifest write logic out of SnapshotProducer

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -629,7 +629,7 @@ public class ManifestFiles {
       int parallelism,
       ExecutorService writePool,
       Function<List<F>, List<ManifestFile>> writeFunc) {
-    List<List<F>> groups = partition(files, parallelism);
+    List<List<F>> groups = divide(files, parallelism);
 
     // Pair each group with its index so results can be reassembled in input order.
     List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayList();
@@ -657,7 +657,7 @@ public class ManifestFiles {
     return builder.build();
   }
 
-  private static <T> List<List<T>> partition(Collection<T> collection, int groupCount) {
+  private static <T> List<List<T>> divide(Collection<T> collection, int groupCount) {
     List<T> list = Lists.newArrayList(collection);
     int groupSize = IntMath.divide(list.size(), groupCount, RoundingMode.CEILING);
     return Lists.partition(list, groupSize);

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -21,8 +21,14 @@ package org.apache.iceberg;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.IOException;
+import java.math.RoundingMode;
+import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.atomic.AtomicReferenceArray;
+import java.util.function.Function;
 import org.apache.iceberg.ManifestReader.FileType;
 import org.apache.iceberg.avro.AvroEncoderUtil;
 import org.apache.iceberg.avro.AvroSchemaUtil;
@@ -39,7 +45,11 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.math.IntMath;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
+import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -601,5 +611,55 @@ public class ManifestFiles {
         io.properties(),
         CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH,
         CatalogProperties.IO_MANIFEST_CACHE_MAX_CONTENT_LENGTH_DEFAULT);
+  }
+
+  /**
+   * Writes the given files into manifests in parallel, splitting them into the given number of
+   * groups and submitting each group to the provided executor.
+   *
+   * @param files content files to write
+   * @param parallelism number of parallel groups; the caller decides this based on its own
+   *     parallelism and minimum-group-size policy
+   * @param writePool executor used to run group writes concurrently
+   * @param writeFunc function that writes a single group and returns the resulting manifests
+   * @return manifests in input-group order
+   */
+  static <F> List<ManifestFile> writeParallel(
+      Collection<F> files,
+      int parallelism,
+      ExecutorService writePool,
+      Function<List<F>, List<ManifestFile>> writeFunc) {
+    List<List<F>> groups = partition(files, parallelism);
+
+    // Pair each group with its index so results can be reassembled in input order.
+    List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayList();
+    for (int i = 0; i < groups.size(); i++) {
+      groupsWithIndex.add(Pair.of(i, groups.get(i)));
+    }
+
+    AtomicReferenceArray<List<ManifestFile>> results = new AtomicReferenceArray<>(groups.size());
+
+    Tasks.foreach(groupsWithIndex)
+        .stopOnFailure()
+        .throwFailureWhenFinished()
+        .executeWith(writePool)
+        .run(
+            indexedGroup -> {
+              int index = indexedGroup.first();
+              List<F> group = indexedGroup.second();
+              results.set(index, writeFunc.apply(group));
+            });
+
+    ImmutableList.Builder<ManifestFile> builder = ImmutableList.builder();
+    for (int i = 0; i < results.length(); i++) {
+      builder.addAll(results.get(i));
+    }
+    return builder.build();
+  }
+
+  private static <T> List<List<T>> partition(Collection<T> collection, int groupCount) {
+    List<T> list = Lists.newArrayList(collection);
+    int groupSize = IntMath.divide(list.size(), groupCount, RoundingMode.CEILING);
+    return Lists.partition(list, groupSize);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -614,12 +614,12 @@ public class ManifestFiles {
   }
 
   /**
-   * Writes the given files into manifests in parallel, splitting them into the given number of
-   * groups and submitting each group to the provided executor.
+   * Writes the given files into manifests in parallel, splitting them into up to {@code
+   * parallelism} groups and submitting each group to the provided executor. The actual number of
+   * groups may be smaller because the group size is rounded up.
    *
    * @param files content files to write
-   * @param parallelism number of parallel groups; the caller decides this based on its own
-   *     parallelism and minimum-group-size policy
+   * @param parallelism upper bound on the number of parallel groups
    * @param writePool executor used to run group writes concurrently
    * @param writeFunc function that writes a single group and returns the resulting manifests
    * @return manifests in input-group order

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -45,9 +45,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.atomic.AtomicReferenceArray;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.events.CreateSnapshotEvent;
@@ -67,13 +65,11 @@ import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.Timer.Timed;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
 import org.apache.iceberg.util.Exceptions;
-import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
@@ -740,7 +736,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   protected List<ManifestFile> writeDataManifests(
       Collection<DataFile> files, Long dataSeq, PartitionSpec spec) {
-    return writeManifests(files, group -> writeDataFileGroup(group, dataSeq, spec));
+    int groupCount = manifestWriterCount(writePoolParallelism, files.size());
+    return ManifestFiles.writeParallel(
+        files, groupCount, writePool(), group -> writeDataFileGroup(group, dataSeq, spec));
   }
 
   // Deletes uncommitted manifests; clears list if clearManifests and any deleted.
@@ -778,7 +776,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
   protected List<ManifestFile> writeDeleteManifests(
       Collection<DeleteFile> files, PartitionSpec spec) {
-    return writeManifests(files, group -> writeDeleteFileGroup(group, spec));
+    int groupCount = manifestWriterCount(writePoolParallelism, files.size());
+    return ManifestFiles.writeParallel(
+        files, groupCount, writePool(), group -> writeDeleteFileGroup(group, spec));
   }
 
   private List<ManifestFile> writeDeleteFileGroup(
@@ -800,47 +800,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     return writer.toManifestFiles();
   }
 
-  private <F> List<ManifestFile> writeManifests(
-      Collection<F> files, Function<List<F>, List<ManifestFile>> writeFunc) {
-    int parallelism = manifestWriterCount(writePoolParallelism, files.size());
-    List<List<F>> groups = divide(files, parallelism);
-
-    // Create a new list pairing each group with its index
-    List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayList();
-    for (int i = 0; i < groups.size(); i++) {
-      groupsWithIndex.add(Pair.of(i, groups.get(i)));
-    }
-
-    AtomicReferenceArray<List<ManifestFile>> results = new AtomicReferenceArray<>(groups.size());
-
-    Tasks.foreach(groupsWithIndex)
-        .stopOnFailure()
-        .throwFailureWhenFinished()
-        .executeWith(writePool())
-        .run(
-            indexedGroup -> {
-              int index = indexedGroup.first();
-              List<F> group = indexedGroup.second();
-              List<ManifestFile> groupResults = writeFunc.apply(group);
-              results.set(index, groupResults);
-            });
-
-    // Collect results in order
-    ImmutableList.Builder<ManifestFile> builder = ImmutableList.builder();
-    for (int i = 0; i < results.length(); i++) {
-      builder.addAll(results.get(i));
-    }
-    return builder.build();
-  }
-
-  private static <T> List<List<T>> divide(Collection<T> collection, int groupCount) {
-    List<T> list = Lists.newArrayList(collection);
-    int groupSize = IntMath.divide(list.size(), groupCount, RoundingMode.CEILING);
-    return Lists.partition(list, groupSize);
-  }
-
   /**
-   * Calculates how many manifest writers can be used to concurrently to handle the given number of
+   * Calculates how many manifest writers can be used concurrently to handle the given number of
    * files without creating too small manifests.
    *
    * @param workerPoolSize the size of the available worker pool


### PR DESCRIPTION
From https://github.com/apache/iceberg/pull/16108#discussion_r3260581466, I changed `writeManifests` method in SnapshotProducer from static to non-static as now it need to accommodate the  manifest writer parallelism from passed-in executor service. 

However I believe we can separate the logic on how manifests are written entirely from producing a snapshot. How to write the manifests for a given set of files can be stateless and used outside the commit cycle, such as prewrite the manifest ahead of time when the number of changed files are too large and leads to OOM. 