### PR TITLE
Core: Avoid implementing HadoopConfigurable in ResolvingFileIO

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -519,6 +519,10 @@ acceptedBreaks:
       justification: "Removing deprecated code for 1.11.0"
   "1.11.0":
     org.apache.iceberg:iceberg-core:
+    - code: "java.class.noLongerImplementsInterface"
+      old: "class org.apache.iceberg.io.ResolvingFileIO"
+      new: "class org.apache.iceberg.io.ResolvingFileIO"
+      justification: "Hadoop dependency should be optional"
     - code: "java.class.removed"
       old: "class org.apache.iceberg.PartitionStats"
       justification: "Removed deprecated functionality for partition stats"

--- a/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/io/ResolvingFileIO.java
@@ -49,8 +49,7 @@ import org.slf4j.LoggerFactory;
  * Delegate FileIO implementations must implement the {@link DelegateFileIO} mixin interface,
  * otherwise initialization will fail.
  */
-public class ResolvingFileIO
-    implements HadoopConfigurable, DelegateFileIO, SupportsStorageCredentials {
+public class ResolvingFileIO implements DelegateFileIO, SupportsStorageCredentials {
   private static final Logger LOG = LoggerFactory.getLogger(ResolvingFileIO.class);
   private static final int BATCH_SIZE = 100_000;
   private static final String FALLBACK_IMPL = "org.apache.iceberg.hadoop.HadoopFileIO";
@@ -72,7 +71,7 @@ public class ResolvingFileIO
   private final AtomicBoolean isClosed = new AtomicBoolean(false);
   private final transient StackTraceElement[] createStack;
   private SerializableMap<String, String> properties;
-  private SerializableSupplier<Configuration> hadoopConf;
+  private SerializableSupplier<Object> hadoopConf;
   // use modifiable collection for Kryo serde
   private List<StorageCredential> storageCredentials = Lists.newArrayList();
 
@@ -146,20 +145,19 @@ public class ResolvingFileIO
     }
   }
 
-  @Override
+  @SuppressWarnings("unchecked")
   public void serializeConfWith(
       Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
-    this.hadoopConf = confSerializer.apply(getConf());
+    this.hadoopConf = (SerializableSupplier<Object>) (Object) confSerializer.apply(getConf());
   }
 
-  @Override
+  @SuppressWarnings("unchecked")
   public void setConf(Configuration conf) {
-    this.hadoopConf = new SerializableConfiguration(conf);
+    this.hadoopConf = (SerializableSupplier<Object>) (Object) new SerializableConfiguration(conf);
   }
 
-  @Override
   public Configuration getConf() {
-    return Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
+    return (Configuration) Optional.ofNullable(hadoopConf).map(Supplier::get).orElse(null);
   }
 
   @VisibleForTesting
@@ -187,7 +185,7 @@ public class ResolvingFileIO
     return ioInstances.computeIfAbsent(
         impl,
         key -> {
-          Configuration conf = getConf();
+          Object conf = getConf();
           FileIO fileIO;
 
           try {

--- a/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/SerializationUtil.java
@@ -30,6 +30,7 @@ import java.util.function.Function;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
+import org.apache.iceberg.io.ResolvingFileIO;
 
 public class SerializationUtil {
 
@@ -58,6 +59,8 @@ public class SerializationUtil {
       Object obj, Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
     if (obj instanceof HadoopConfigurable) {
       ((HadoopConfigurable) obj).serializeConfWith(confSerializer);
+    } else if (obj instanceof ResolvingFileIO io) {
+      io.serializeConfWith(confSerializer);
     }
 
     try (ByteArrayOutputStream baos = new ByteArrayOutputStream();

--- a/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/mapreduce/IcebergInputFormat.java
@@ -59,6 +59,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.mapping.NameMappingParser;
 import org.apache.iceberg.mr.Catalogs;
 import org.apache.iceberg.mr.InputFormatConfig;
@@ -176,10 +177,12 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     if (table != null
         && config.getBoolean(
             InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
-            InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT)
-        && table.io() instanceof HadoopConfigurable) {
-      ((HadoopConfigurable) table.io())
-          .serializeConfWith(conf -> new NonSerializingConfig(config)::get);
+            InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT)) {
+      if (table.io() instanceof HadoopConfigurable io) {
+        io.serializeConfWith(conf -> new NonSerializingConfig(config)::get);
+      } else if (table.io() instanceof ResolvingFileIO io) {
+        io.serializeConfWith(conf -> new NonSerializingConfig(config)::get);
+      }
     }
   }
 
@@ -194,9 +197,12 @@ public class IcebergInputFormat<T> extends InputFormat<Void, T> {
     if (table != null
         && config.getBoolean(
             InputFormatConfig.CONFIG_SERIALIZATION_DISABLED,
-            InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT)
-        && table.io() instanceof HadoopConfigurable) {
-      ((HadoopConfigurable) table.io()).setConf(config);
+            InputFormatConfig.CONFIG_SERIALIZATION_DISABLED_DEFAULT)) {
+      if (table.io() instanceof HadoopConfigurable io) {
+        io.setConf(config);
+      } else if (table.io() instanceof ResolvingFileIO io) {
+        io.setConf(config);
+      }
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SerializableFileIOWithSize.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.ResolvingFileIO;
 import org.apache.iceberg.util.SerializableSupplier;
 import org.apache.spark.util.KnownSizeEstimation;
 import org.slf4j.Logger;
@@ -104,6 +105,8 @@ class SerializableFileIOWithSize
       Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {
     if (fileIO instanceof HadoopConfigurable configurable) {
       configurable.serializeConfWith(confSerializer);
+    } else if (fileIO instanceof ResolvingFileIO io) {
+      io.serializeConfWith(confSerializer);
     }
   }
 
@@ -111,6 +114,8 @@ class SerializableFileIOWithSize
   public void setConf(Configuration conf) {
     if (fileIO instanceof HadoopConfigurable configurable) {
       configurable.setConf(conf);
+    } else if (fileIO instanceof ResolvingFileIO io) {
+      io.setConf(conf);
     }
   }
 
@@ -118,6 +123,9 @@ class SerializableFileIOWithSize
   public Configuration getConf() {
     if (fileIO instanceof HadoopConfigurable hadoopConfigurable) {
       return hadoopConfigurable.getConf();
+    }
+    if (fileIO instanceof ResolvingFileIO io) {
+      return io.getConf();
     }
 
     return null;


### PR DESCRIPTION
`ResolvingFileIO` throws `NoClassDefFoundError` in Trino / Starburst because the project disallows Hadoop dependency as #14284 explains. This PR avoid implementing `HadoopConfigurable` to avoid the exception. 

```
java.util.concurrent.CompletionException: io.trino.spi.TrinoException: Error processing metadata for table jcf_scan_plan_test.test_table_1
	at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1015)
	at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:995)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:531)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2221)
	at io.airlift.concurrent.MoreFutures$2.onFailure(MoreFutures.java:495)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1111)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1021)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:784)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:533)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.afterRanInterruptiblyFailure(TrustedListenableFutureTask.java:138)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:89)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: io.trino.spi.TrinoException: Error processing metadata for table schema.table
	at io.trino.plugin.iceberg.IcebergExceptions.translateMetadataException(IcebergExceptions.java:54)
	at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$2(IcebergSplitSource.java:282)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1011)
	... 15 more
Caused by: java.lang.IllegalArgumentException: Cannot initialize FileIO implementation org.apache.iceberg.io.ResolvingFileIO: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.io.ResolvingFileIO [java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable]
	at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:407)
	at org.apache.iceberg.rest.RESTTableScan.scanFileIO(RESTTableScan.java:238)
	at org.apache.iceberg.rest.RESTTableScan.planTableScan(RESTTableScan.java:213)
	at org.apache.iceberg.rest.RESTTableScan.planFiles(RESTTableScan.java:196)
	at io.trino.plugin.iceberg.IcebergSplitSource.planFiles(IcebergSplitSource.java:371)
	at io.trino.plugin.iceberg.IcebergSplitSource.getNextBatchInternal(IcebergSplitSource.java:305)
	at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$1(IcebergSplitSource.java:277)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	... 4 more
Caused by: java.lang.NoSuchMethodException: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.io.ResolvingFileIO [java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable]
	at org.apache.iceberg.common.DynConstructors.buildCheckedException(DynConstructors.java:253)
	at org.apache.iceberg.common.DynConstructors$Builder.buildChecked(DynConstructors.java:211)
	at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:404)
	... 12 more
	Suppressed: java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable
		at java.base/java.lang.ClassLoader.defineClass1(Native Method)
		at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)
		at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)
		at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:454)
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:367)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		at java.base/java.lang.ClassLoader.defineClass1(Native Method)
		at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)
		at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)
		at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:454)
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:367)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		at java.base/java.lang.Class.forName0(Native Method)
		at java.base/java.lang.Class.forName(Class.java:547)
		at org.apache.iceberg.common.DynConstructors$Builder.classForName(DynConstructors.java:224)
		at org.apache.iceberg.common.DynConstructors$Builder.impl(DynConstructors.java:145)
		at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:403)
		... 12 more
	Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configurable
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:377)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		... 33 more
```