### PR TITLE
Hive: Fix conversion failure for nested VARIANT and reduce type-string allocations

### DIFF
--- a/hive-metastore/src/jmh/java/org/apache/iceberg/hive/HiveSchemaConversionBenchmark.java
+++ b/hive-metastore/src/jmh/java/org/apache/iceberg/hive/HiveSchemaConversionBenchmark.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hive;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+
+/**
+ * A benchmark that evaluates the performance of converting an Iceberg {@link Schema} to the Hive
+ * column list via {@link HiveSchemaUtil#convert(Schema)}. This conversion (and the recursive Hive
+ * type-string building it drives) runs on every Hive table/view commit through {@code
+ * HiveOperationsBase.storageDescriptor}, so its cost is paid by every engine committing to a Hive
+ * catalog.
+ *
+ * <p>To run this benchmark: <code>
+ * ./gradlew :iceberg-hive-metastore:jmh
+ * -PjmhIncludeRegex=HiveSchemaConversionBenchmark
+ * -PjmhOutputPath=benchmark/hive-schema-conversion-benchmark.txt
+ * </code>
+ */
+@Fork(1)
+@State(Scope.Benchmark)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+public class HiveSchemaConversionBenchmark {
+
+  @Param({"FLAT", "NESTED_WIDE", "NESTED_DEEP"})
+  private String shape;
+
+  private Schema schema;
+  private int nextId;
+
+  @Setup
+  public void setupBenchmark() {
+    this.nextId = 0;
+    switch (shape) {
+      case "FLAT":
+        this.schema = flatSchema();
+        break;
+      case "NESTED_WIDE":
+        this.schema = nestedWideSchema();
+        break;
+      case "NESTED_DEEP":
+        this.schema = nestedDeepSchema();
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown shape: " + shape);
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void convertSchema(Blackhole blackhole) {
+    blackhole.consume(HiveSchemaUtil.convert(schema));
+  }
+
+  private int id() {
+    return nextId++;
+  }
+
+  /** 30 primitive columns (incl. decimals); a control case with no nested types. */
+  private Schema flatSchema() {
+    List<NestedField> fields = Lists.newArrayList();
+    for (int i = 0; i < 6; i++) {
+      fields.add(optional(id(), "c_long_" + i, Types.LongType.get()));
+      fields.add(optional(id(), "c_int_" + i, Types.IntegerType.get()));
+      fields.add(optional(id(), "c_string_" + i, Types.StringType.get()));
+      fields.add(optional(id(), "c_double_" + i, Types.DoubleType.get()));
+      fields.add(optional(id(), "c_decimal_" + i, Types.DecimalType.of(20, 4)));
+    }
+    return new Schema(fields);
+  }
+
+  /** Several struct / list&lt;struct&gt; / map&lt;string,struct&gt; columns; a realistic shape. */
+  private Schema nestedWideSchema() {
+    List<NestedField> cols = Lists.newArrayList();
+    cols.add(optional(id(), "id", Types.LongType.get()));
+    cols.add(optional(id(), "name", Types.StringType.get()));
+    for (int i = 0; i < 6; i++) {
+      cols.add(optional(id(), "struct_" + i, recordStruct()));
+      cols.add(optional(id(), "list_" + i, Types.ListType.ofOptional(id(), recordStruct())));
+      cols.add(
+          optional(
+              id(),
+              "map_" + i,
+              Types.MapType.ofOptional(id(), id(), Types.StringType.get(), recordStruct())));
+    }
+    return new Schema(cols);
+  }
+
+  /** A single column nested 10 struct levels deep; exposes the depth-compounding cost. */
+  private Schema nestedDeepSchema() {
+    Type type = Types.IntegerType.get();
+    for (int i = 0; i < 10; i++) {
+      type =
+          Types.StructType.of(
+              optional(id(), "level_" + i, type),
+              optional(id(), "leaf_" + i, Types.StringType.get()));
+    }
+    return new Schema(optional(id(), "deep", type));
+  }
+
+  private Types.StructType recordStruct() {
+    return Types.StructType.of(
+        optional(id(), "f_a", Types.IntegerType.get()),
+        optional(id(), "f_b", Types.StringType.get()),
+        optional(id(), "f_c", Types.DoubleType.get()),
+        optional(id(), "f_d", Types.LongType.get()));
+  }
+}

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -141,51 +141,88 @@ public final class HiveSchemaUtil {
   }
 
   private static String convertToTypeString(Type type) {
+    StringBuilder sb = new StringBuilder();
+    appendTypeString(sb, type);
+    return sb.toString();
+  }
+
+  private static void appendTypeString(StringBuilder sb, Type type) {
     switch (type.typeId()) {
       case BOOLEAN:
-        return "boolean";
+        sb.append("boolean");
+        return;
       case INTEGER:
-        return "int";
+        sb.append("int");
+        return;
       case LONG:
-        return "bigint";
+        sb.append("bigint");
+        return;
       case FLOAT:
-        return "float";
+        sb.append("float");
+        return;
       case DOUBLE:
-        return "double";
+        sb.append("double");
+        return;
       case DATE:
-        return "date";
+        sb.append("date");
+        return;
       case TIME:
       case STRING:
       case UUID:
-        return "string";
+        sb.append("string");
+        return;
       case TIMESTAMP:
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (HiveVersion.min(HiveVersion.HIVE_3) && timestampType.shouldAdjustToUTC()) {
-          return "timestamp with local time zone";
+          sb.append("timestamp with local time zone");
+        } else {
+          sb.append("timestamp");
         }
-        return "timestamp";
+        return;
       case FIXED:
       case BINARY:
-        return "binary";
+        sb.append("binary");
+        return;
       case VARIANT:
-        return "unknown";
+        sb.append("unknown");
+        return;
       case DECIMAL:
-        final Types.DecimalType decimalType = (Types.DecimalType) type;
-        return String.format("decimal(%s,%s)", decimalType.precision(), decimalType.scale());
+        Types.DecimalType decimalType = (Types.DecimalType) type;
+        sb.append("decimal(")
+            .append(decimalType.precision())
+            .append(',')
+            .append(decimalType.scale())
+            .append(')');
+        return;
       case STRUCT:
-        final Types.StructType structType = type.asStructType();
-        final String nameToType =
-            structType.fields().stream()
-                .map(f -> String.format("%s:%s", f.name(), convert(f.type())))
-                .collect(Collectors.joining(","));
-        return String.format("struct<%s>", nameToType);
+        // Recurse via appendTypeString rather than convert(Type): the latter would parse each
+        // nested type string into a Hive TypeInfo only to stringify it straight back, allocating a
+        // throwaway TypeInfo tree at every nesting level.
+        List<Types.NestedField> fields = type.asStructType().fields();
+        sb.append("struct<");
+        for (int i = 0; i < fields.size(); i++) {
+          if (i > 0) {
+            sb.append(',');
+          }
+          Types.NestedField field = fields.get(i);
+          sb.append(field.name()).append(':');
+          appendTypeString(sb, field.type());
+        }
+        sb.append('>');
+        return;
       case LIST:
-        final Types.ListType listType = type.asListType();
-        return String.format("array<%s>", convert(listType.elementType()));
+        sb.append("array<");
+        appendTypeString(sb, type.asListType().elementType());
+        sb.append('>');
+        return;
       case MAP:
-        final Types.MapType mapType = type.asMapType();
-        return String.format(
-            "map<%s,%s>", convert(mapType.keyType()), convert(mapType.valueType()));
+        Types.MapType mapType = type.asMapType();
+        sb.append("map<");
+        appendTypeString(sb, mapType.keyType());
+        sb.append(',');
+        appendTypeString(sb, mapType.valueType());
+        sb.append('>');
+        return;
       default:
         throw new UnsupportedOperationException(type + " is not supported");
     }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -212,6 +212,15 @@ public class TestHiveSchemaUtil {
     assertThat(hiveSchema).containsExactly(new FieldSchema("variant_field", "unknown", null));
   }
 
+  @Test
+  public void testNestedVariantTypeConvertToHiveSchema() {
+    Schema schema =
+        new Schema(
+            optional(0, "nested", Types.StructType.of(optional(1, "v", Types.VariantType.get()))));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("nested", "struct<v:unknown>", null));
+  }
+
   protected List<FieldSchema> getSupportedFieldSchemas() {
     List<FieldSchema> fields = Lists.newArrayListWithCapacity(10);
     fields.add(new FieldSchema("c_float", serdeConstants.FLOAT_TYPE_NAME, "float comment"));

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -24,7 +24,7 @@ if (jdkVersion != '17' && jdkVersion != '21') {
 def flinkVersions = (System.getProperty("flinkVersions") != null ? System.getProperty("flinkVersions") : System.getProperty("defaultFlinkVersions")).split(",")
 def sparkVersions = (System.getProperty("sparkVersions") != null ? System.getProperty("sparkVersions") : System.getProperty("defaultSparkVersions")).split(",")
 def scalaVersion = System.getProperty("scalaVersion") != null ? System.getProperty("scalaVersion") : System.getProperty("defaultScalaVersion")
-def jmhProjects = [project(":iceberg-core"), project(":iceberg-data")]
+def jmhProjects = [project(":iceberg-core"), project(":iceberg-data"), project(":iceberg-hive-metastore")]
 
 if (flinkVersions.contains("1.20")) {
   jmhProjects.add(project(":iceberg-flink:iceberg-flink-1.20"))


### PR DESCRIPTION
## Problem

`HiveSchemaUtil.convert(Schema)` builds the Hive column list on every Hive table and view commit (via `HiveOperationsBase.storageDescriptor`). For nested types it recursed through `convert(Type)`, which is `TypeInfoUtils.getTypeInfoFromTypeString(convertToTypeString(type))`: it built the type substring, parsed it back into a Hive `TypeInfo` tree, then stringified that tree straight back to the same substring. That round trip produces no value, and because the recursion went through the parser at every nesting level the wasted work and the throwaway `TypeInfo` allocations compounded with schema depth.

It was also a latent crash. An Iceberg `VARIANT` maps to the placeholder string `"unknown"`, which is not a Hive type, so `TypeInfoUtils.getTypeInfoFromTypeString("unknown")` throws `RuntimeException: Internal error parsing position 0 of 'unknown'`. A `VARIANT` nested inside a `struct`/`list`/`map` therefore failed the commit outright. The top-level case never hit this because `convert(Schema)` calls `convertToTypeString` directly.

## Change

Rewrite the private `convertToTypeString` to recurse on itself via a `StringBuilder`-based `appendTypeString(StringBuilder, Type)`, building the Hive type string directly with no `TypeInfoUtils` parsing and no `String.format`. The public methods and their outputs are unchanged; only the internal string builder is restructured. Output strings are identical for every type the previous code handled, which is pinned byte for byte by the existing `testComplexSchemaConvertToHiveSchema`. Nested `VARIANT` now emits `"unknown"` directly, consistent with the already-tested top-level mapping.

## Tests

- Added `testNestedVariantTypeConvertToHiveSchema`: it throws on the previous code (reproducing the failure) and is green after the change.
- Existing `TestHiveSchemaUtil` coverage (nested struct/list/map strings, every primitive type, reverse conversion) still passes, confirming output is unchanged for all other types.

## Performance

Added `HiveSchemaConversionBenchmark` (JMH). The conversion runs once per commit; the benchmark isolates `HiveSchemaUtil.convert(Schema)`. JDK 17, average time, `-prof gc` (speedup is before/after):

| shape | time before | time after | time speedup | alloc before | alloc after | alloc reduction |
|---|---|---|---|---|---|---|
| flat (30 primitives) | 2.74 us/op | 2.12 us/op | 1.29x | 6,080 B/op | 5,872 B/op | 1.04x |
| nested (struct / list / map columns) | 45.66 us/op | 4.53 us/op | 10.1x | 118,632 B/op | 7,400 B/op | 16.0x |
| deeply nested (10 struct levels) | 40.87 us/op | 0.92 us/op | 44.3x | 122,576 B/op | 2,184 B/op | 56.1x |

Flat schemas are essentially unchanged (primitive cases never used the parsing path); the gain is concentrated on nested schemas, where the throwaway `TypeInfo` trees dominated, and grows with nesting depth (the old code re-parsed each subtree at every level).

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix the nested VARIANT conversion failure in HiveSchemaUtil and remove the quadratic type-string round-trip.
