### PR TITLE
Core: Extend org.apache.iceberg.hadoop.Configurable in HadoopConfigurable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopConfigurable.java
@@ -19,19 +19,18 @@
 package org.apache.iceberg.hadoop;
 
 import java.util.function.Function;
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.util.SerializableSupplier;
 
 /**
- * An interface that extends the Hadoop {@link Configurable} interface to offer better serialization
- * support for customizable Iceberg objects such as {@link org.apache.iceberg.io.FileIO}.
+ * An interface that extends {@link Configurable} to offer better serialization support for
+ * customizable Iceberg objects such as {@link org.apache.iceberg.io.FileIO}.
  *
  * <p>If an object is serialized and needs to use Hadoop configuration, it is recommended for the
  * object to implement this interface so that a serializable supplier of configuration can be
  * provided instead of an actual Hadoop configuration which is not serializable.
  */
-public interface HadoopConfigurable extends Configurable {
+public interface HadoopConfigurable extends Configurable<Configuration> {
 
   /**
    * Take a function that serializes Hadoop configuration into a supplier. An implementation is
@@ -43,4 +42,23 @@ public interface HadoopConfigurable extends Configurable {
    */
   void serializeConfWith(
       Function<Configuration, SerializableSupplier<Configuration>> confSerializer);
+
+  /**
+   * Set the configuration to be used by this object.
+   *
+   * @param conf configuration to be used
+   */
+  @Override
+  default void setConf(Configuration conf) {
+    throw new UnsupportedOperationException("setConf is not implemented");
+  }
+
+  /**
+   * Return the configuration used by this object.
+   *
+   * @return Configuration
+   */
+  default Configuration getConf() {
+    throw new UnsupportedOperationException("getConf is not implemented");
+  }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -20,13 +20,13 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalog;
@@ -93,7 +93,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void testTableFromCatalogHasOverrides() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration conf = ((Configurable) table.io()).getConf();
+    Configuration conf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = conf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -104,7 +104,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void ensureRoundTripSerializedTableRetainsHadoopConfig() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration originalConf = ((Configurable) table.io()).getConf();
+    Configuration originalConf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = originalConf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -115,7 +115,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
     Table serializableTable = SerializableTableWithSize.copyOf(table);
     Table kryoSerializedTable =
         KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
-    Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
+    Configuration configFromKryoSerde = ((HadoopConfigurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(kryoSerializedCatalogOverride)
         .as(
@@ -124,7 +124,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
 
     // Do the same for Java based serde
     Table javaSerializedTable = TestHelpers.roundTripSerialize(serializableTable);
-    Configuration configFromJavaSerde = ((Configurable) javaSerializedTable.io()).getConf();
+    Configuration configFromJavaSerde = ((HadoopConfigurable) javaSerializedTable.io()).getConf();
     String javaSerializedCatalogOverride = configFromJavaSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(javaSerializedCatalogOverride)
         .as(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -20,13 +20,13 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalog;
@@ -93,7 +93,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void testTableFromCatalogHasOverrides() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration conf = ((Configurable) table.io()).getConf();
+    Configuration conf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = conf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -104,7 +104,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void ensureRoundTripSerializedTableRetainsHadoopConfig() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration originalConf = ((Configurable) table.io()).getConf();
+    Configuration originalConf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = originalConf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -115,7 +115,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
     Table serializableTable = SerializableTableWithSize.copyOf(table);
     Table kryoSerializedTable =
         KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
-    Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
+    Configuration configFromKryoSerde = ((HadoopConfigurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(kryoSerializedCatalogOverride)
         .as(
@@ -124,7 +124,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
 
     // Do the same for Java based serde
     Table javaSerializedTable = TestHelpers.roundTripSerialize(serializableTable);
-    Configuration configFromJavaSerde = ((Configurable) javaSerializedTable.io()).getConf();
+    Configuration configFromJavaSerde = ((HadoopConfigurable) javaSerializedTable.io()).getConf();
     String javaSerializedCatalogOverride = configFromJavaSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(javaSerializedCatalogOverride)
         .as(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkCatalogHadoopOverrides.java
@@ -20,13 +20,13 @@ package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.KryoHelpers;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.hadoop.HadoopConfigurable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalog;
@@ -93,7 +93,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void testTableFromCatalogHasOverrides() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration conf = ((Configurable) table.io()).getConf();
+    Configuration conf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = conf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -104,7 +104,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
   @TestTemplate
   public void ensureRoundTripSerializedTableRetainsHadoopConfig() throws Exception {
     Table table = getIcebergTableFromSparkCatalog();
-    Configuration originalConf = ((Configurable) table.io()).getConf();
+    Configuration originalConf = ((HadoopConfigurable) table.io()).getConf();
     String actualCatalogOverride = originalConf.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(actualCatalogOverride)
         .as(
@@ -115,7 +115,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
     Table serializableTable = SerializableTableWithSize.copyOf(table);
     Table kryoSerializedTable =
         KryoHelpers.roundTripSerialize(SerializableTableWithSize.copyOf(table));
-    Configuration configFromKryoSerde = ((Configurable) kryoSerializedTable.io()).getConf();
+    Configuration configFromKryoSerde = ((HadoopConfigurable) kryoSerializedTable.io()).getConf();
     String kryoSerializedCatalogOverride = configFromKryoSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(kryoSerializedCatalogOverride)
         .as(
@@ -124,7 +124,7 @@ public class TestSparkCatalogHadoopOverrides extends CatalogTestBase {
 
     // Do the same for Java based serde
     Table javaSerializedTable = TestHelpers.roundTripSerialize(serializableTable);
-    Configuration configFromJavaSerde = ((Configurable) javaSerializedTable.io()).getConf();
+    Configuration configFromJavaSerde = ((HadoopConfigurable) javaSerializedTable.io()).getConf();
     String javaSerializedCatalogOverride = configFromJavaSerde.get(CONFIG_TO_OVERRIDE, "/whammies");
     assertThat(javaSerializedCatalogOverride)
         .as(


### PR DESCRIPTION
`ResolvingFileIO` throws `NoClassDefFoundError` in Trino / Starburst because the project disallows Hadoop dependency as #14284 explains. 

After this PR, HadoopConfigurable extends `org.apache.iceberg.hadoop.Configurable` instead of `org.apache.hadoop.conf.Configurable`.

```
java.util.concurrent.CompletionException: io.trino.spi.TrinoException: Error processing metadata for table jcf_scan_plan_test.test_table_1
	at java.base/java.util.concurrent.CompletableFuture.wrapInCompletionException(CompletableFuture.java:323)
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:359)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:364)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1015)
	at java.base/java.util.concurrent.CompletableFuture$UniExceptionally.tryFire(CompletableFuture.java:995)
	at java.base/java.util.concurrent.CompletableFuture.postComplete(CompletableFuture.java:531)
	at java.base/java.util.concurrent.CompletableFuture.completeExceptionally(CompletableFuture.java:2221)
	at io.airlift.concurrent.MoreFutures$2.onFailure(MoreFutures.java:495)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1111)
	at com.google.common.util.concurrent.DirectExecutor.execute(DirectExecutor.java:30)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1021)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:784)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:533)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.afterRanInterruptiblyFailure(TrustedListenableFutureTask.java:138)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:89)
	at com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:80)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1090)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:614)
	at java.base/java.lang.Thread.run(Thread.java:1474)
Caused by: io.trino.spi.TrinoException: Error processing metadata for table schema.table
	at io.trino.plugin.iceberg.IcebergExceptions.translateMetadataException(IcebergExceptions.java:54)
	at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$2(IcebergSplitSource.java:282)
	at java.base/java.util.concurrent.CompletableFuture.uniExceptionally(CompletableFuture.java:1011)
	... 15 more
Caused by: java.lang.IllegalArgumentException: Cannot initialize FileIO implementation org.apache.iceberg.io.ResolvingFileIO: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.io.ResolvingFileIO [java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable]
	at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:407)
	at org.apache.iceberg.rest.RESTTableScan.scanFileIO(RESTTableScan.java:238)
	at org.apache.iceberg.rest.RESTTableScan.planTableScan(RESTTableScan.java:213)
	at org.apache.iceberg.rest.RESTTableScan.planFiles(RESTTableScan.java:196)
	at io.trino.plugin.iceberg.IcebergSplitSource.planFiles(IcebergSplitSource.java:371)
	at io.trino.plugin.iceberg.IcebergSplitSource.getNextBatchInternal(IcebergSplitSource.java:305)
	at io.trino.plugin.iceberg.IcebergSplitSource.lambda$getNextBatch$1(IcebergSplitSource.java:277)
	at com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:128)
	at com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:74)
	... 4 more
Caused by: java.lang.NoSuchMethodException: Cannot find constructor for interface org.apache.iceberg.io.FileIO
	Missing org.apache.iceberg.io.ResolvingFileIO [java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable]
	at org.apache.iceberg.common.DynConstructors.buildCheckedException(DynConstructors.java:253)
	at org.apache.iceberg.common.DynConstructors$Builder.buildChecked(DynConstructors.java:211)
	at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:404)
	... 12 more
	Suppressed: java.lang.NoClassDefFoundError: org/apache/hadoop/conf/Configurable
		at java.base/java.lang.ClassLoader.defineClass1(Native Method)
		at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)
		at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)
		at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:454)
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:367)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		at java.base/java.lang.ClassLoader.defineClass1(Native Method)
		at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:962)
		at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:144)
		at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:454)
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:367)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		at java.base/java.lang.Class.forName0(Native Method)
		at java.base/java.lang.Class.forName(Class.java:547)
		at org.apache.iceberg.common.DynConstructors$Builder.classForName(DynConstructors.java:224)
		at org.apache.iceberg.common.DynConstructors$Builder.impl(DynConstructors.java:145)
		at org.apache.iceberg.CatalogUtil.loadFileIO(CatalogUtil.java:403)
		... 12 more
	Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.conf.Configurable
		at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:377)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:557)
		at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:124)
		at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:490)
		... 33 more
```