### PR TITLE
Core: Backport DV encryption metadata preservation to 1.10.x

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DVUtil.java
+++ b/core/src/main/java/org/apache/iceberg/DVUtil.java
@@ -26,13 +26,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import org.apache.iceberg.deletes.BaseDVFileWriter;
 import org.apache.iceberg.deletes.DVFileWriter;
+import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.IOUtil;
 import org.apache.iceberg.io.InputFile;
-import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -188,8 +190,14 @@ class DVUtil {
       FileIO fileIO,
       String dvOutputLocation,
       Map<String, Pair<PartitionSpec, StructLike>> partitions) {
-    OutputFile dvOutputFile = fileIO.newOutputFile(dvOutputLocation);
-    try (DVFileWriter dvFileWriter = new BaseDVFileWriter(() -> dvOutputFile, path -> null)) {
+    EncryptedOutputFile dvOutputFile;
+    if (fileIO instanceof EncryptingFileIO) {
+      dvOutputFile = ((EncryptingFileIO) fileIO).newEncryptingOutputFile(dvOutputLocation);
+    } else {
+      dvOutputFile = EncryptedFiles.plainAsEncryptedOutput(fileIO.newOutputFile(dvOutputLocation));
+    }
+
+    try (DVFileWriter dvFileWriter = Deletes.writeDVs(dvOutputFile, path -> null)) {
       for (Map.Entry<String, PositionDeleteIndex> entry : mergedIndexByFile.entrySet()) {
         String referencedLocation = entry.getKey();
         PositionDeleteIndex mergedPositions = entry.getValue();

--- a/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BaseDVFileWriter.java
@@ -30,6 +30,9 @@ import org.apache.iceberg.IcebergBuild;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptedFiles;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.io.DeleteWriteResult;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.OutputFileFactory;
@@ -52,7 +55,7 @@ public class BaseDVFileWriter implements DVFileWriter {
   private static final String REFERENCED_DATA_FILE_KEY = "referenced-data-file";
   private static final String CARDINALITY_KEY = "cardinality";
 
-  private final Supplier<OutputFile> dvOutputFile;
+  private final Supplier<EncryptedOutputFile> dvOutputFile;
   private final Function<String, PositionDeleteIndex> loadPreviousDeletes;
   private final Map<String, Deletes> deletesByPath = Maps.newHashMap();
   private final Map<String, BlobMetadata> blobsByPath = Maps.newHashMap();
@@ -60,12 +63,18 @@ public class BaseDVFileWriter implements DVFileWriter {
 
   public BaseDVFileWriter(
       OutputFileFactory fileFactory, Function<String, PositionDeleteIndex> loadPreviousDeletes) {
-    this(() -> fileFactory.newOutputFile().encryptingOutputFile(), loadPreviousDeletes);
+    this(loadPreviousDeletes, fileFactory::newOutputFile);
   }
 
   public BaseDVFileWriter(
       Supplier<OutputFile> dvOutputFile,
       Function<String, PositionDeleteIndex> loadPreviousDeletes) {
+    this(loadPreviousDeletes, () -> EncryptedFiles.plainAsEncryptedOutput(dvOutputFile.get()));
+  }
+
+  BaseDVFileWriter(
+      Function<String, PositionDeleteIndex> loadPreviousDeletes,
+      Supplier<EncryptedOutputFile> dvOutputFile) {
     this.dvOutputFile = dvOutputFile;
     this.loadPreviousDeletes = loadPreviousDeletes;
   }
@@ -108,7 +117,12 @@ public class BaseDVFileWriter implements DVFileWriter {
         return;
       }
 
-      PuffinWriter writer = newWriter();
+      EncryptedOutputFile outputFile = dvOutputFile.get();
+      EncryptionKeyMetadata keyMetadata = outputFile.keyMetadata();
+      PuffinWriter writer =
+          Puffin.write(outputFile.encryptingOutputFile())
+              .createdBy(IcebergBuild.fullVersion())
+              .build();
 
       try (PuffinWriter closeableWriter = writer) {
         for (Deletes deletes : deletesByPath.values()) {
@@ -134,7 +148,7 @@ public class BaseDVFileWriter implements DVFileWriter {
       long puffinFileSize = writer.fileSize();
 
       for (String path : deletesByPath.keySet()) {
-        DeleteFile dv = createDV(puffinPath, puffinFileSize, path);
+        DeleteFile dv = createDV(puffinPath, puffinFileSize, path, keyMetadata);
         dvs.add(dv);
       }
 
@@ -142,7 +156,8 @@ public class BaseDVFileWriter implements DVFileWriter {
     }
   }
 
-  private DeleteFile createDV(String path, long size, String referencedDataFile) {
+  private DeleteFile createDV(
+      String path, long size, String referencedDataFile, EncryptionKeyMetadata keyMetadata) {
     Deletes deletes = deletesByPath.get(referencedDataFile);
     BlobMetadata blobMetadata = blobsByPath.get(referencedDataFile);
     return FileMetadata.deleteFileBuilder(deletes.spec())
@@ -151,6 +166,7 @@ public class BaseDVFileWriter implements DVFileWriter {
         .withPath(path)
         .withPartition(deletes.partition())
         .withFileSizeInBytes(size)
+        .withEncryptionKeyMetadata(keyMetadata)
         .withReferencedDataFile(referencedDataFile)
         .withContentOffset(blobMetadata.offset())
         .withContentSizeInBytes(blobMetadata.length())
@@ -163,11 +179,6 @@ public class BaseDVFileWriter implements DVFileWriter {
     PositionDeleteIndex positions = deletes.positions();
     BlobMetadata blobMetadata = writer.write(toBlob(positions, path));
     blobsByPath.put(path, blobMetadata);
-  }
-
-  private PuffinWriter newWriter() {
-    OutputFile outputFile = dvOutputFile.get();
-    return Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build();
   }
 
   private Blob toBlob(PositionDeleteIndex positions, String path) {

--- a/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/Deletes.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -51,6 +52,11 @@ public class Deletes {
       POSITION_DELETE_SCHEMA.accessorForField(MetadataColumns.DELETE_FILE_POS.fieldId());
 
   private Deletes() {}
+
+  public static DVFileWriter writeDVs(
+      EncryptedOutputFile outputFile, Function<String, PositionDeleteIndex> loadPreviousDeletes) {
+    return new BaseDVFileWriter(loadPreviousDeletes, () -> outputFile);
+  }
 
   public static <T> CloseableIterable<T> filter(
       CloseableIterable<T> rows, Function<T, StructLike> rowToDeleteKey, StructLikeSet deleteSet) {

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -45,6 +45,9 @@ import org.apache.iceberg.deletes.BaseDVFileWriter;
 import org.apache.iceberg.deletes.DVFileWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionTestHelpers;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -1867,6 +1870,32 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testDuplicateDVsAreMergedWithEncryption() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    TestTables.TestTable encryptedTable = createEncryptedTable();
+    DataFile dataFile = newDataFile("data_bucket=0");
+    commit(encryptedTable, encryptedTable.newRowDelta().addRows(dataFile), branch);
+
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(encryptedTable, 1, 1).format(FileFormat.PUFFIN).build();
+
+    DeleteFile deleteFile1 = dvWithPositions(encryptedTable, dataFile, fileFactory, 0, 2);
+    DeleteFile deleteFile2 = dvWithPositions(encryptedTable, dataFile, fileFactory, 2, 4);
+    commit(
+        encryptedTable,
+        encryptedTable.newRowDelta().addDeletes(deleteFile1).addDeletes(deleteFile2),
+        branch);
+
+    Iterable<DeleteFile> addedDeleteFiles =
+        latestSnapshot(encryptedTable, branch).addedDeleteFiles(encryptedTable.io());
+    DeleteFile mergedDV = Iterables.getOnlyElement(addedDeleteFiles);
+
+    assertThat(mergedDV.keyMetadata()).isNotNull();
+    assertDVHasDeletedPositions(encryptedTable, mergedDV, LongStream.range(0, 4).boxed()::iterator);
+  }
+
+  @TestTemplate
   public void testDuplicateDVsMergedMultipleSpecs() throws IOException {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
@@ -2314,18 +2343,33 @@ public class TestRowDelta extends TestBase {
   private DeleteFile dvWithPositions(
       DataFile dataFile, OutputFileFactory fileFactory, int fromInclusive, int toExclusive)
       throws IOException {
+    return dvWithPositions(table, dataFile, fileFactory, fromInclusive, toExclusive);
+  }
+
+  private DeleteFile dvWithPositions(
+      Table targetTable,
+      DataFile dataFile,
+      OutputFileFactory fileFactory,
+      int fromInclusive,
+      int toExclusive)
+      throws IOException {
 
     List<PositionDelete<?>> deletes = Lists.newArrayList();
     for (int i = fromInclusive; i < toExclusive; i++) {
       deletes.add(PositionDelete.create().set(dataFile.location(), i));
     }
 
-    return writeDV(deletes, dataFile.specId(), dataFile.partition(), fileFactory);
+    return writeDV(targetTable, deletes, dataFile.specId(), dataFile.partition(), fileFactory);
   }
 
   private void assertDVHasDeletedPositions(DeleteFile dv, Iterable<Long> positions) {
+    assertDVHasDeletedPositions(table, dv, positions);
+  }
+
+  private void assertDVHasDeletedPositions(
+      Table targetTable, DeleteFile dv, Iterable<Long> positions) {
     assertThat(dv).isNotNull();
-    PositionDeleteIndex index = DVUtil.readDV(dv, table.io());
+    PositionDeleteIndex index = DVUtil.readDV(dv, targetTable.io());
     assertThat(positions)
         .allSatisfy(
             pos ->
@@ -2335,6 +2379,7 @@ public class TestRowDelta extends TestBase {
   }
 
   private DeleteFile writeDV(
+      Table targetTable,
       List<PositionDelete<?>> deletes,
       int specId,
       StructLike partition,
@@ -2345,10 +2390,29 @@ public class TestRowDelta extends TestBase {
     try (DVFileWriter closeableWriter = writer) {
       for (PositionDelete<?> delete : deletes) {
         closeableWriter.delete(
-            delete.path().toString(), delete.pos(), table.specs().get(specId), partition);
+            delete.path().toString(), delete.pos(), targetTable.specs().get(specId), partition);
       }
     }
 
     return Iterables.getOnlyElement(writer.result().deleteFiles());
+  }
+
+  private TestTables.TestTable createEncryptedTable() {
+    EncryptionManager encryptionManager = EncryptionTestHelpers.createEncryptionManager();
+    String tableName = "encrypted-" + branch;
+    java.io.File encryptedTableDir = temp.resolve(tableName).toFile();
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations(
+            tableName,
+            encryptedTableDir,
+            EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryptionManager)) {
+          @Override
+          public EncryptionManager encryption() {
+            return encryptionManager;
+          }
+        };
+
+    return TestTables.create(
+        encryptedTableDir, tableName, SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, ops);
   }
 }

--- a/data/src/test/java/org/apache/iceberg/io/TestDVWriters.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestDVWriters.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -30,6 +32,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
@@ -42,9 +45,11 @@ import org.apache.iceberg.data.BaseDeleteLoader;
 import org.apache.iceberg.data.DeleteLoader;
 import org.apache.iceberg.deletes.BaseDVFileWriter;
 import org.apache.iceberg.deletes.DVFileWriter;
+import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
+import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -79,6 +84,24 @@ public abstract class TestDVWriters<T> extends WriterTestBase<T> {
     this.fileFactory = OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
     this.parquetFileFactory =
         OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PARQUET).build();
+  }
+
+  @TestTemplate
+  public void testDVWriterPreservesEncryptionKeyMetadata() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    OutputFile outputFile = Files.localOutput(temp.resolve("non-native-dv.puffin").toString());
+    ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putLong(456L);
+    buffer.flip();
+    EncryptedOutputFile encryptedOutputFile = EncryptedFiles.encryptedOutput(outputFile, buffer);
+
+    DVFileWriter writer = Deletes.writeDVs(encryptedOutputFile, path -> null);
+    writer.delete("/path/to/data.parquet", 1L, PartitionSpec.unpartitioned(), null);
+    writer.close();
+
+    DeleteFile deleteFile = Iterables.getOnlyElement(writer.result().deleteFiles());
+    assertThat(decode(deleteFile.keyMetadata())).isEqualTo(456L);
   }
 
   @TestTemplate
@@ -347,6 +370,10 @@ public abstract class TestDVWriters<T> extends WriterTestBase<T> {
     }
 
     return writer.toDeleteFile();
+  }
+
+  private static long decode(ByteBuffer buffer) {
+    return buffer.duplicate().order(ByteOrder.LITTLE_ENDIAN).getLong();
   }
 
   private static class PreviousDeleteLoader implements Function<String, PositionDeleteIndex> {


### PR DESCRIPTION
Backports #15911 to 1.10.x with incremental differences 

  - Uses Java 11-compatible syntax in DVUtil: explicit instanceof + cast instead of pattern matching.
  - Does not include the NativeEncryptionKeyMetadata.copyWithLength(fileSize) special handling because 1.10.x lacks the API.
  - Does not mark the legacy BaseDVFileWriter(Supplier<OutputFile>, ...) constructor deprecated.
  - Adapts tests for 1.10.x APIs:
      - TestRowDelta uses latestSnapshot(...).addedDeleteFiles(io) instead of SnapshotChanges.
      - TestDVWriters adds only one generic encryption metadata preservation test.
      - The original PR’s native-key-metadata-with-final-file-size test is omitted.

---

Co-authored-by: @codex