### PR TITLE
Spark: Spark tests cache rewrite input

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -41,18 +41,24 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -142,6 +148,14 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+
+  // Cache of pre-written input data files keyed by table shape (schema/spec/props are
+  // fixed per key), so identical large inputs are materialized via Spark only once per JVM
+  // fork and reused by every test that asks for the same shape. The Spark write of SCALE
+  // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
+  @TempDir private static Path inputCacheDir;
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -2305,8 +2319,18 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
+    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = createTable();
+              writeRecords(files, SCALE);
+              golden.refresh();
+              return golden;
+            });
     Table table = createTable();
-    writeRecords(files, SCALE);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
   }
@@ -2314,12 +2338,68 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTablePartitioned(
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    String key =
+        "partitioned|opts="
+            + new TreeMap<>(options)
+            + "|files="
+            + files
+            + "|rows="
+            + numRecords
+            + "|partitions="
+            + partitions;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = TABLES.create(SCHEMA, spec, options, tableLocation);
+              assertThat(golden.currentSnapshot()).as("Table must be empty").isNull();
+              writeRecords(files, numRecords, partitions);
+              golden.refresh();
+              return golden;
+            });
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
-
-    writeRecords(files, numRecords, partitions);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
+  }
+
+  /**
+   * Returns the input data files for a given table shape, materializing them with Spark exactly
+   * once per JVM fork and reusing them afterwards. On a cache miss the {@code goldenBuilder} writes
+   * the data into a stable cache location (kept alive for the whole class via a static {@link
+   * TempDir}); on a hit the cached {@link DataFile}s are returned and re-appended to a fresh table
+   * by {@link #appendInputFiles}. The data is deterministic (fixed RNG seed) so reuse is
+   * byte-identical to regenerating it.
+   */
+  private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
+    return INPUT_FILE_CACHE.computeIfAbsent(
+        key,
+        ignored -> {
+          String savedLocation = this.tableLocation;
+          try {
+            this.tableLocation =
+                inputCacheDir
+                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
+                    .toUri()
+                    .toString();
+            Table golden = goldenBuilder.get();
+            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+            // value counts, and re-appending stat-less files breaks tests that read bounds.
+            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+                .map(FileScanTask::file)
+                .map(DataFile::copy)
+                .collect(Collectors.toList());
+          } finally {
+            this.tableLocation = savedLocation;
+          }
+        });
+  }
+
+  private static void appendInputFiles(Table table, List<DataFile> inputFiles) {
+    AppendFiles append = table.newAppend();
+    inputFiles.forEach(append::appendFile);
+    append.commit();
   }
 
   protected Table createTablePartitioned(int partitions, int files) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2319,7 +2319,7 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2339,14 +2339,9 @@ public class TestRewriteDataFilesAction extends TestBase {
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
-        "partitioned|opts="
-            + new TreeMap<>(options)
-            + "|files="
-            + files
-            + "|rows="
-            + numRecords
-            + "|partitions="
-            + partitions;
+        String.format(
+            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
+            new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -50,7 +50,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -112,6 +111,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -154,7 +154,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // fork and reused by every test that asks for the same shape. The Spark write of SCALE
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
-  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -107,6 +107,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -2341,8 +2342,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
         String.format(
-            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
-            new TreeMap<>(options), files, numRecords, partitions);
+            "partitioned|fv=%d|spec=%s|opts=%s|files=%d|rows=%d|partitions=%d",
+            formatVersion, spec, new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2394,7 +2395,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -155,6 +155,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
   private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
+  private static final Map<String, Object> INPUT_CACHE_LOCKS = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
@@ -2368,27 +2369,38 @@ public class TestRewriteDataFilesAction extends TestBase {
    * byte-identical to regenerating it.
    */
   private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
-    return INPUT_FILE_CACHE.computeIfAbsent(
-        key,
-        ignored -> {
-          String savedLocation = this.tableLocation;
-          try {
-            this.tableLocation =
-                inputCacheDir
-                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
-                    .toUri()
-                    .toString();
-            Table golden = goldenBuilder.get();
-            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
-            // value counts, and re-appending stat-less files breaks tests that read bounds.
-            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+    List<DataFile> cached = INPUT_FILE_CACHE.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    // Serialize builds per key: concurrent callers requesting the same table shape block on the
+    // first build and then reuse its result, instead of materializing identical input twice. The
+    // heavy Spark write happens outside any map lock, so distinct shapes can still build in
+    // parallel.
+    Object lock = INPUT_CACHE_LOCKS.computeIfAbsent(key, ignored -> new Object());
+    synchronized (lock) {
+      List<DataFile> existing = INPUT_FILE_CACHE.get(key);
+      if (existing != null) {
+        return existing;
+      }
+      String savedLocation = this.tableLocation;
+      try {
+        this.tableLocation =
+            inputCacheDir.resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet()).toUri().toString();
+        Table golden = goldenBuilder.get();
+        // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+        // value counts, and re-appending stat-less files breaks tests that read bounds.
+        List<DataFile> built =
+            Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
                 .collect(Collectors.toList());
-          } finally {
-            this.tableLocation = savedLocation;
-          }
-        });
+        INPUT_FILE_CACHE.put(key, built);
+        return built;
+      } finally {
+        this.tableLocation = savedLocation;
+      }
+    }
   }
 
   private static void appendInputFiles(Table table, List<DataFile> inputFiles) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -136,6 +136,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -149,6 +150,9 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+  // Row group size used by createTable(); part of the unpartitioned cache key so a future
+  // override of this property can't silently hand back cached files of a different shape.
+  private static final int INPUT_PARQUET_ROW_GROUP_SIZE_BYTES = 20 * 1024;
 
   // Cache of pre-written input data files keyed by table shape (schema/spec/props are
   // fixed per key), so identical large inputs are materialized via Spark only once per JVM
@@ -183,6 +187,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
     spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false");
+  }
+
+  @AfterAll
+  public static void clearInputFileCache() {
+    // inputCacheDir is a static @TempDir that JUnit recreates if the class runs twice in one JVM
+    // (IDE re-run, forkCount=0). Clear the cache so a second run can't return DataFiles pointing
+    // into the deleted first-run directory.
+    INPUT_FILE_CACHE.clear();
+    INPUT_CACHE_LOCKS.clear();
+    INPUT_CACHE_SEQ.set(0);
   }
 
   @BeforeEach
@@ -2196,6 +2210,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveNoOrphans(Table table) {
+    // Cached input files live under the static inputCacheDir, outside table.location(), so
+    // deleteOrphanFiles (which only scans the table prefix) never sees them by design. Orphan
+    // coverage therefore does not extend to the shared cached inputs.
     assertThat(
             actions()
                 .deleteOrphanFiles(table)
@@ -2308,7 +2325,9 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     table
         .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(20 * 1024))
+        .set(
+            TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES,
+            Integer.toString(INPUT_PARQUET_ROW_GROUP_SIZE_BYTES))
         .commit();
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
     return table;
@@ -2321,7 +2340,10 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
+    String key =
+        String.format(
+            "unpartitioned|fv=%d|rowGroup=%d|files=%d|rows=%d",
+            formatVersion, INPUT_PARQUET_ROW_GROUP_SIZE_BYTES, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2391,11 +2413,20 @@ public class TestRewriteDataFilesAction extends TestBase {
         Table golden = goldenBuilder.get();
         // includeColumnStats() is required: a plain scan drops lower/upper bounds and
         // value counts, and re-appending stat-less files breaks tests that read bounds.
-        List<DataFile> built =
-            Streams.stream(golden.newScan().includeColumnStats().planFiles())
-                .map(FileScanTask::file)
-                .map(DataFile::copy)
-                .collect(ImmutableList.toImmutableList());
+        // planFiles() returns a CloseableIterable holding manifest readers open, so close it via
+        // try-with-resources; otherwise every cache miss leaks file descriptors and can leave
+        // manifest files locked on Windows.
+        List<DataFile> built;
+        try (CloseableIterable<FileScanTask> tasks =
+            golden.newScan().includeColumnStats().planFiles()) {
+          built =
+              Streams.stream(tasks)
+                  .map(FileScanTask::file)
+                  .map(DataFile::copy)
+                  .collect(ImmutableList.toImmutableList());
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to plan cached input files", e);
+        }
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -50,7 +50,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -113,6 +112,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -155,7 +155,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // fork and reused by every test that asks for the same shape. The Spark write of SCALE
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
-  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -41,19 +41,25 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -143,6 +149,14 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+
+  // Cache of pre-written input data files keyed by table shape (schema/spec/props are
+  // fixed per key), so identical large inputs are materialized via Spark only once per JVM
+  // fork and reused by every test that asks for the same shape. The Spark write of SCALE
+  // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
+  @TempDir private static Path inputCacheDir;
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -2355,8 +2369,18 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
+    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = createTable();
+              writeRecords(files, SCALE);
+              golden.refresh();
+              return golden;
+            });
     Table table = createTable();
-    writeRecords(files, SCALE);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
   }
@@ -2364,12 +2388,68 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTablePartitioned(
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    String key =
+        "partitioned|opts="
+            + new TreeMap<>(options)
+            + "|files="
+            + files
+            + "|rows="
+            + numRecords
+            + "|partitions="
+            + partitions;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = TABLES.create(SCHEMA, spec, options, tableLocation);
+              assertThat(golden.currentSnapshot()).as("Table must be empty").isNull();
+              writeRecords(files, numRecords, partitions);
+              golden.refresh();
+              return golden;
+            });
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
-
-    writeRecords(files, numRecords, partitions);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
+  }
+
+  /**
+   * Returns the input data files for a given table shape, materializing them with Spark exactly
+   * once per JVM fork and reusing them afterwards. On a cache miss the {@code goldenBuilder} writes
+   * the data into a stable cache location (kept alive for the whole class via a static {@link
+   * TempDir}); on a hit the cached {@link DataFile}s are returned and re-appended to a fresh table
+   * by {@link #appendInputFiles}. The data is deterministic (fixed RNG seed) so reuse is
+   * byte-identical to regenerating it.
+   */
+  private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
+    return INPUT_FILE_CACHE.computeIfAbsent(
+        key,
+        ignored -> {
+          String savedLocation = this.tableLocation;
+          try {
+            this.tableLocation =
+                inputCacheDir
+                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
+                    .toUri()
+                    .toString();
+            Table golden = goldenBuilder.get();
+            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+            // value counts, and re-appending stat-less files breaks tests that read bounds.
+            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+                .map(FileScanTask::file)
+                .map(DataFile::copy)
+                .collect(Collectors.toList());
+          } finally {
+            this.tableLocation = savedLocation;
+          }
+        });
+  }
+
+  private static void appendInputFiles(Table table, List<DataFile> inputFiles) {
+    AppendFiles append = table.newAppend();
+    inputFiles.forEach(append::appendFile);
+    append.commit();
   }
 
   protected Table createTablePartitioned(int partitions, int files) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -156,6 +156,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
   private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
+  private static final Map<String, Object> INPUT_CACHE_LOCKS = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
@@ -2418,27 +2419,38 @@ public class TestRewriteDataFilesAction extends TestBase {
    * byte-identical to regenerating it.
    */
   private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
-    return INPUT_FILE_CACHE.computeIfAbsent(
-        key,
-        ignored -> {
-          String savedLocation = this.tableLocation;
-          try {
-            this.tableLocation =
-                inputCacheDir
-                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
-                    .toUri()
-                    .toString();
-            Table golden = goldenBuilder.get();
-            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
-            // value counts, and re-appending stat-less files breaks tests that read bounds.
-            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+    List<DataFile> cached = INPUT_FILE_CACHE.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    // Serialize builds per key: concurrent callers requesting the same table shape block on the
+    // first build and then reuse its result, instead of materializing identical input twice. The
+    // heavy Spark write happens outside any map lock, so distinct shapes can still build in
+    // parallel.
+    Object lock = INPUT_CACHE_LOCKS.computeIfAbsent(key, ignored -> new Object());
+    synchronized (lock) {
+      List<DataFile> existing = INPUT_FILE_CACHE.get(key);
+      if (existing != null) {
+        return existing;
+      }
+      String savedLocation = this.tableLocation;
+      try {
+        this.tableLocation =
+            inputCacheDir.resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet()).toUri().toString();
+        Table golden = goldenBuilder.get();
+        // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+        // value counts, and re-appending stat-less files breaks tests that read bounds.
+        List<DataFile> built =
+            Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
                 .collect(Collectors.toList());
-          } finally {
-            this.tableLocation = savedLocation;
-          }
-        });
+        INPUT_FILE_CACHE.put(key, built);
+        return built;
+      } finally {
+        this.tableLocation = savedLocation;
+      }
+    }
   }
 
   private static void appendInputFiles(Table table, List<DataFile> inputFiles) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -108,6 +108,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -2391,8 +2392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
         String.format(
-            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
-            new TreeMap<>(options), files, numRecords, partitions);
+            "partitioned|fv=%d|spec=%s|opts=%s|files=%d|rows=%d|partitions=%d",
+            formatVersion, spec, new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2444,7 +2445,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -137,6 +137,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -150,6 +151,9 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+  // Row group size used by createTable(); part of the unpartitioned cache key so a future
+  // override of this property can't silently hand back cached files of a different shape.
+  private static final int INPUT_PARQUET_ROW_GROUP_SIZE_BYTES = 20 * 1024;
 
   // Cache of pre-written input data files keyed by table shape (schema/spec/props are
   // fixed per key), so identical large inputs are materialized via Spark only once per JVM
@@ -184,6 +188,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
     spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false");
+  }
+
+  @AfterAll
+  public static void clearInputFileCache() {
+    // inputCacheDir is a static @TempDir that JUnit recreates if the class runs twice in one JVM
+    // (IDE re-run, forkCount=0). Clear the cache so a second run can't return DataFiles pointing
+    // into the deleted first-run directory.
+    INPUT_FILE_CACHE.clear();
+    INPUT_CACHE_LOCKS.clear();
+    INPUT_CACHE_SEQ.set(0);
   }
 
   @BeforeEach
@@ -2246,6 +2260,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveNoOrphans(Table table) {
+    // Cached input files live under the static inputCacheDir, outside table.location(), so
+    // deleteOrphanFiles (which only scans the table prefix) never sees them by design. Orphan
+    // coverage therefore does not extend to the shared cached inputs.
     assertThat(
             actions()
                 .deleteOrphanFiles(table)
@@ -2358,7 +2375,9 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     table
         .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(20 * 1024))
+        .set(
+            TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES,
+            Integer.toString(INPUT_PARQUET_ROW_GROUP_SIZE_BYTES))
         .commit();
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
     return table;
@@ -2371,7 +2390,10 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
+    String key =
+        String.format(
+            "unpartitioned|fv=%d|rowGroup=%d|files=%d|rows=%d",
+            formatVersion, INPUT_PARQUET_ROW_GROUP_SIZE_BYTES, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2441,11 +2463,20 @@ public class TestRewriteDataFilesAction extends TestBase {
         Table golden = goldenBuilder.get();
         // includeColumnStats() is required: a plain scan drops lower/upper bounds and
         // value counts, and re-appending stat-less files breaks tests that read bounds.
-        List<DataFile> built =
-            Streams.stream(golden.newScan().includeColumnStats().planFiles())
-                .map(FileScanTask::file)
-                .map(DataFile::copy)
-                .collect(ImmutableList.toImmutableList());
+        // planFiles() returns a CloseableIterable holding manifest readers open, so close it via
+        // try-with-resources; otherwise every cache miss leaks file descriptors and can leave
+        // manifest files locked on Windows.
+        List<DataFile> built;
+        try (CloseableIterable<FileScanTask> tasks =
+            golden.newScan().includeColumnStats().planFiles()) {
+          built =
+              Streams.stream(tasks)
+                  .map(FileScanTask::file)
+                  .map(DataFile::copy)
+                  .collect(ImmutableList.toImmutableList());
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to plan cached input files", e);
+        }
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2369,7 +2369,7 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2389,14 +2389,9 @@ public class TestRewriteDataFilesAction extends TestBase {
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
-        "partitioned|opts="
-            + new TreeMap<>(options)
-            + "|files="
-            + files
-            + "|rows="
-            + numRecords
-            + "|partitions="
-            + partitions;
+        String.format(
+            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
+            new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -50,7 +50,6 @@ import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -113,6 +112,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -155,7 +155,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // fork and reused by every test that asks for the same shape. The Spark write of SCALE
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
-  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -41,19 +41,25 @@ import static org.mockito.Mockito.spy;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.TreeMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -143,6 +149,14 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+
+  // Cache of pre-written input data files keyed by table shape (schema/spec/props are
+  // fixed per key), so identical large inputs are materialized via Spark only once per JVM
+  // fork and reused by every test that asks for the same shape. The Spark write of SCALE
+  // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
+  @TempDir private static Path inputCacheDir;
+  private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = new ConcurrentHashMap<>();
+  private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
   private static final Schema SCHEMA =
@@ -2355,8 +2369,18 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
+    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = createTable();
+              writeRecords(files, SCALE);
+              golden.refresh();
+              return golden;
+            });
     Table table = createTable();
-    writeRecords(files, SCALE);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
   }
@@ -2364,12 +2388,68 @@ public class TestRewriteDataFilesAction extends TestBase {
   protected Table createTablePartitioned(
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
+    String key =
+        "partitioned|opts="
+            + new TreeMap<>(options)
+            + "|files="
+            + files
+            + "|rows="
+            + numRecords
+            + "|partitions="
+            + partitions;
+    List<DataFile> inputFiles =
+        cachedInputFiles(
+            key,
+            () -> {
+              Table golden = TABLES.create(SCHEMA, spec, options, tableLocation);
+              assertThat(golden.currentSnapshot()).as("Table must be empty").isNull();
+              writeRecords(files, numRecords, partitions);
+              golden.refresh();
+              return golden;
+            });
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
-
-    writeRecords(files, numRecords, partitions);
+    appendInputFiles(table, inputFiles);
     table.refresh();
     return table;
+  }
+
+  /**
+   * Returns the input data files for a given table shape, materializing them with Spark exactly
+   * once per JVM fork and reusing them afterwards. On a cache miss the {@code goldenBuilder} writes
+   * the data into a stable cache location (kept alive for the whole class via a static {@link
+   * TempDir}); on a hit the cached {@link DataFile}s are returned and re-appended to a fresh table
+   * by {@link #appendInputFiles}. The data is deterministic (fixed RNG seed) so reuse is
+   * byte-identical to regenerating it.
+   */
+  private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
+    return INPUT_FILE_CACHE.computeIfAbsent(
+        key,
+        ignored -> {
+          String savedLocation = this.tableLocation;
+          try {
+            this.tableLocation =
+                inputCacheDir
+                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
+                    .toUri()
+                    .toString();
+            Table golden = goldenBuilder.get();
+            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+            // value counts, and re-appending stat-less files breaks tests that read bounds.
+            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+                .map(FileScanTask::file)
+                .map(DataFile::copy)
+                .collect(Collectors.toList());
+          } finally {
+            this.tableLocation = savedLocation;
+          }
+        });
+  }
+
+  private static void appendInputFiles(Table table, List<DataFile> inputFiles) {
+    AppendFiles append = table.newAppend();
+    inputFiles.forEach(append::appendFile);
+    append.commit();
   }
 
   protected Table createTablePartitioned(int partitions, int files) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -156,6 +156,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   // rows dominates these tests; the rewrite under test still runs per test on a fresh table.
   @TempDir private static Path inputCacheDir;
   private static final Map<String, List<DataFile>> INPUT_FILE_CACHE = Maps.newConcurrentMap();
+  private static final Map<String, Object> INPUT_CACHE_LOCKS = Maps.newConcurrentMap();
   private static final AtomicInteger INPUT_CACHE_SEQ = new AtomicInteger();
 
   private static final HadoopTables TABLES = new HadoopTables(new Configuration());
@@ -2418,27 +2419,38 @@ public class TestRewriteDataFilesAction extends TestBase {
    * byte-identical to regenerating it.
    */
   private List<DataFile> cachedInputFiles(String key, Supplier<Table> goldenBuilder) {
-    return INPUT_FILE_CACHE.computeIfAbsent(
-        key,
-        ignored -> {
-          String savedLocation = this.tableLocation;
-          try {
-            this.tableLocation =
-                inputCacheDir
-                    .resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet())
-                    .toUri()
-                    .toString();
-            Table golden = goldenBuilder.get();
-            // includeColumnStats() is required: a plain scan drops lower/upper bounds and
-            // value counts, and re-appending stat-less files breaks tests that read bounds.
-            return Streams.stream(golden.newScan().includeColumnStats().planFiles())
+    List<DataFile> cached = INPUT_FILE_CACHE.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    // Serialize builds per key: concurrent callers requesting the same table shape block on the
+    // first build and then reuse its result, instead of materializing identical input twice. The
+    // heavy Spark write happens outside any map lock, so distinct shapes can still build in
+    // parallel.
+    Object lock = INPUT_CACHE_LOCKS.computeIfAbsent(key, ignored -> new Object());
+    synchronized (lock) {
+      List<DataFile> existing = INPUT_FILE_CACHE.get(key);
+      if (existing != null) {
+        return existing;
+      }
+      String savedLocation = this.tableLocation;
+      try {
+        this.tableLocation =
+            inputCacheDir.resolve("input-" + INPUT_CACHE_SEQ.incrementAndGet()).toUri().toString();
+        Table golden = goldenBuilder.get();
+        // includeColumnStats() is required: a plain scan drops lower/upper bounds and
+        // value counts, and re-appending stat-less files breaks tests that read bounds.
+        List<DataFile> built =
+            Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
                 .collect(Collectors.toList());
-          } finally {
-            this.tableLocation = savedLocation;
-          }
-        });
+        INPUT_FILE_CACHE.put(key, built);
+        return built;
+      } finally {
+        this.tableLocation = savedLocation;
+      }
+    }
   }
 
   private static void appendInputFiles(Table table, List<DataFile> inputFiles) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -108,6 +108,7 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.OutputFileFactory;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -2391,8 +2392,8 @@ public class TestRewriteDataFilesAction extends TestBase {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
         String.format(
-            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
-            new TreeMap<>(options), files, numRecords, partitions);
+            "partitioned|fv=%d|spec=%s|opts=%s|files=%d|rows=%d|partitions=%d",
+            formatVersion, spec, new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2444,7 +2445,7 @@ public class TestRewriteDataFilesAction extends TestBase {
             Streams.stream(golden.newScan().includeColumnStats().planFiles())
                 .map(FileScanTask::file)
                 .map(DataFile::copy)
-                .collect(Collectors.toList());
+                .collect(ImmutableList.toImmutableList());
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -137,6 +137,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
@@ -150,6 +151,9 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TempDir private File tableDir;
   private static final int SCALE = 400000;
+  // Row group size used by createTable(); part of the unpartitioned cache key so a future
+  // override of this property can't silently hand back cached files of a different shape.
+  private static final int INPUT_PARQUET_ROW_GROUP_SIZE_BYTES = 20 * 1024;
 
   // Cache of pre-written input data files keyed by table shape (schema/spec/props are
   // fixed per key), so identical large inputs are materialized via Spark only once per JVM
@@ -184,6 +188,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
     spark.conf().set(SQLConf.ADAPTIVE_EXECUTION_ENABLED().key(), "false");
+  }
+
+  @AfterAll
+  public static void clearInputFileCache() {
+    // inputCacheDir is a static @TempDir that JUnit recreates if the class runs twice in one JVM
+    // (IDE re-run, forkCount=0). Clear the cache so a second run can't return DataFiles pointing
+    // into the deleted first-run directory.
+    INPUT_FILE_CACHE.clear();
+    INPUT_CACHE_LOCKS.clear();
+    INPUT_CACHE_SEQ.set(0);
   }
 
   @BeforeEach
@@ -2246,6 +2260,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   protected void shouldHaveNoOrphans(Table table) {
+    // Cached input files live under the static inputCacheDir, outside table.location(), so
+    // deleteOrphanFiles (which only scans the table prefix) never sees them by design. Orphan
+    // coverage therefore does not extend to the shared cached inputs.
     assertThat(
             actions()
                 .deleteOrphanFiles(table)
@@ -2358,7 +2375,9 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = TABLES.create(SCHEMA, spec, options, tableLocation);
     table
         .updateProperties()
-        .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(20 * 1024))
+        .set(
+            TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES,
+            Integer.toString(INPUT_PARQUET_ROW_GROUP_SIZE_BYTES))
         .commit();
     assertThat(table.currentSnapshot()).as("Table must be empty").isNull();
     return table;
@@ -2371,7 +2390,10 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
+    String key =
+        String.format(
+            "unpartitioned|fv=%d|rowGroup=%d|files=%d|rows=%d",
+            formatVersion, INPUT_PARQUET_ROW_GROUP_SIZE_BYTES, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2441,11 +2463,20 @@ public class TestRewriteDataFilesAction extends TestBase {
         Table golden = goldenBuilder.get();
         // includeColumnStats() is required: a plain scan drops lower/upper bounds and
         // value counts, and re-appending stat-less files breaks tests that read bounds.
-        List<DataFile> built =
-            Streams.stream(golden.newScan().includeColumnStats().planFiles())
-                .map(FileScanTask::file)
-                .map(DataFile::copy)
-                .collect(ImmutableList.toImmutableList());
+        // planFiles() returns a CloseableIterable holding manifest readers open, so close it via
+        // try-with-resources; otherwise every cache miss leaks file descriptors and can leave
+        // manifest files locked on Windows.
+        List<DataFile> built;
+        try (CloseableIterable<FileScanTask> tasks =
+            golden.newScan().includeColumnStats().planFiles()) {
+          built =
+              Streams.stream(tasks)
+                  .map(FileScanTask::file)
+                  .map(DataFile::copy)
+                  .collect(ImmutableList.toImmutableList());
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to plan cached input files", e);
+        }
         INPUT_FILE_CACHE.put(key, built);
         return built;
       } finally {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2369,7 +2369,7 @@ public class TestRewriteDataFilesAction extends TestBase {
    * @return the created table
    */
   protected Table createTable(int files) {
-    String key = "unpartitioned|fv=" + formatVersion + "|files=" + files + "|rows=" + SCALE;
+    String key = String.format("unpartitioned|fv=%d|files=%d|rows=%d", formatVersion, files, SCALE);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,
@@ -2389,14 +2389,9 @@ public class TestRewriteDataFilesAction extends TestBase {
       int partitions, int files, int numRecords, Map<String, String> options) {
     PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("c1").truncate("c2", 2).build();
     String key =
-        "partitioned|opts="
-            + new TreeMap<>(options)
-            + "|files="
-            + files
-            + "|rows="
-            + numRecords
-            + "|partitions="
-            + partitions;
+        String.format(
+            "partitioned|opts=%s|files=%d|rows=%d|partitions=%d",
+            new TreeMap<>(options), files, numRecords, partitions);
     List<DataFile> inputFiles =
         cachedInputFiles(
             key,


### PR DESCRIPTION
## What

`TestRewriteDataFilesAction` is the slowest single class in the Spark core test module. Each test materializes a large (`SCALE = 400000`-row) input table via a Spark write before exercising the rewrite under test, and many tests reuse the same input shape across the `formatVersion` matrix.

This caches the written input data files keyed by table shape (`formatVersion`, spec, `files`, `rows`, `partitions`, properties) and reuses them by re-appending the cached `DataFile`s to a fresh table. The expensive Spark write of the input now runs once per JVM fork instead of once per test; the rewrite under test still runs per test on its own fresh table. 

Applied identically to Spark 3.5, 4.0 and 4.1.


## Why it is safe

- The generated data is deterministic (fixed `Random(42)` seed), so reuse is
  byte-identical to regenerating it.
- Cached files live in a static `@TempDir`, so they survive across tests (not wiped
  by the per-test temp dir) and are cleaned up after the class.
- `includeColumnStats()` is used when collecting the cached files so lower/upper
  bounds and value counts are preserved on re-append.
- The rewrite under test is unchanged and still runs per test, so no assertion is weakened.
  
## Results 

**CI core job durations** (baseline main run vs. this PR's latest green run; core jobs averaged per Spark version across the JVM/Scala matrix):

| Spark core jobs | Before | After | Δ |
|---|---:|---:|---:|
| 3.5 | 40.6 min | 36.5 min | −10.0% |
| 4.0 | 47.3 min | 43.8 min | −7.5% |
| 4.1 | 42.9 min | 40.9 min | −4.6% |
| **Average** | **42.8 min** | **39.4 min** | **−7.9%** |

Test-only change, applied identically across v3.5, v4.0, and v4.1.

## Notes
- Scoped to the `createTable(int)` / `createTablePartitioned(...)` helpers; the few
  in-test `writeRecords(..., SCALE, ...)` call sites are not yet cached, so there is more potential for this change.