### PR TITLE
Flink: Backport source fetcher thread leak fix to v1.20 and v2.0 (#16545)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
@@ -168,4 +168,12 @@ class ArrayBatchRecords<T> implements RecordsWithSplitIds<RecordAndPosition<T>> 
   public static <T> ArrayBatchRecords<T> finishedSplit(String splitId) {
     return new ArrayBatchRecords<>(null, null, null, 0, 0, 0, Collections.singleton(splitId));
   }
+
+  /**
+   * Create an empty ArrayBatchRecords with no records and no finished splits. This is returned when
+   * the reader is woken up (e.g. during shutdown) while waiting for an array-pool entry.
+   */
+  public static <T> ArrayBatchRecords<T> emptyBatch() {
+    return new ArrayBatchRecords<>(null, null, null, 0, 0, 0, Collections.emptySet());
+  }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
@@ -23,10 +23,10 @@ import java.util.NoSuchElementException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
-import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /** This implementation stores record batch in array from recyclable pool */
@@ -35,12 +35,25 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
   private final int handoverQueueSize;
   private final RecordFactory<T> recordFactory;
 
-  private transient Pool<T[]> pool;
+  private transient PoolWithWakeup<T[]> pool;
 
   ArrayPoolDataIteratorBatcher(ReadableConfig config, RecordFactory<T> recordFactory) {
     this.batchSize = config.get(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT);
     this.handoverQueueSize = config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
     this.recordFactory = recordFactory;
+  }
+
+  /**
+   * Sets the pool for testing purposes.
+   *
+   * <p>This allows tests to inject a pool in a controlled state (e.g. empty) to verify the blocking
+   * and wakeup behavior without requiring real file I/O.
+   *
+   * @param testPool the pool to use for testing
+   */
+  @VisibleForTesting
+  void setPoolForTesting(PoolWithWakeup<T[]> testPool) {
+    this.pool = testPool;
   }
 
   @Override
@@ -54,8 +67,8 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
     return new ArrayPoolBatchIterator(splitId, inputIterator, pool);
   }
 
-  private Pool<T[]> createPoolOfBatches(int numBatches) {
-    Pool<T[]> poolOfBatches = new Pool<>(numBatches);
+  private PoolWithWakeup<T[]> createPoolOfBatches(int numBatches) {
+    PoolWithWakeup<T[]> poolOfBatches = new PoolWithWakeup<>(numBatches);
     for (int batchId = 0; batchId < numBatches; batchId++) {
       T[] batch = recordFactory.createBatch(batchSize);
       poolOfBatches.add(batch);
@@ -65,13 +78,14 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
   }
 
   private class ArrayPoolBatchIterator
-      implements CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> {
+      implements WakeableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> {
 
     private final String splitId;
     private final DataIterator<T> inputIterator;
-    private final Pool<T[]> pool;
+    private final PoolWithWakeup<T[]> pool;
 
-    ArrayPoolBatchIterator(String splitId, DataIterator<T> inputIterator, Pool<T[]> pool) {
+    ArrayPoolBatchIterator(
+        String splitId, DataIterator<T> inputIterator, PoolWithWakeup<T[]> pool) {
       this.splitId = splitId;
       this.inputIterator = inputIterator;
       this.pool = pool;
@@ -89,6 +103,12 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
       }
 
       T[] batch = getCachedEntry();
+      if (batch == null) {
+        // We were woken up (e.g. during shutdown) while waiting for a pool entry. Return an empty
+        // batch so that fetch() returns control and stays reentrant.
+        return ArrayBatchRecords.emptyBatch();
+      }
+
       int recordCount = 0;
       while (inputIterator.hasNext() && recordCount < batchSize) {
         // The record produced by inputIterator can be reused like for the RowData case.
@@ -118,6 +138,17 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
       inputIterator.close();
     }
 
+    @Override
+    public void wakeUp() {
+      pool.wakeUp();
+    }
+
+    /**
+     * Gets a cached entry from the pool, blocking until an entry is recycled or the reader is woken
+     * up.
+     *
+     * @return a cached array from the pool, or {@code null} if woken up
+     */
     private T[] getCachedEntry() {
       try {
         return pool.pollEntry();

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -48,7 +48,8 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   private final int indexOfSubtask;
   private final Queue<IcebergSourceSplit> splits;
 
-  private CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> currentReader;
+  // volatile because wakeUp() may read currentReader from a different thread than fetch()
+  private volatile CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> currentReader;
   private IcebergSourceSplit currentSplit;
   private String currentSplitId;
 
@@ -123,7 +124,15 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   }
 
   @Override
-  public void wakeUp() {}
+  public void wakeUp() {
+    // Flink calls wakeUp() to unblock a fetcher parked in fetch(). The only place fetch() can block
+    // is in ArrayPoolDataIteratorBatcher waiting for a pool entry (e.g. while the pool is exhausted
+    // during watermark alignment). Relay the signal so that thread can return control and exit
+    // cleanly on shutdown. fetch() stays reentrant: a woken read just returns an empty batch.
+    if (currentReader instanceof WakeableIterator wakeableIterator) {
+      wakeableIterator.wakeUp();
+    }
+  }
 
   @Override
   public void close() throws Exception {
@@ -136,11 +145,13 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   @Override
   public void pauseOrResumeSplits(
       Collection<IcebergSourceSplit> splitsToPause, Collection<IcebergSourceSplit> splitsToResume) {
-    // IcebergSourceSplitReader only reads splits sequentially. When waiting for watermark alignment
-    // the SourceOperator will stop processing and recycling the fetched batches. This exhausts the
-    // {@link ArrayPoolDataIteratorBatcher#pool} and the `currentReader.next()` call will be
-    // blocked even without split-level watermark alignment. Based on this the
-    // `pauseOrResumeSplits` and the `wakeUp` are left empty.
+    // Left empty intentionally. IcebergSourceSplitReader reads splits sequentially, so the pause
+    // needed for watermark alignment is achieved implicitly: when the SourceOperator stops
+    // processing and recycling the fetched batches, the {@link ArrayPoolDataIteratorBatcher#pool}
+    // exhausts and the `currentReader.next()` call blocks. We therefore do not need to pause/resume
+    // individual splits here. Note this method must not throw, because the SourceOperator can still
+    // invoke it (e.g. for a single split that drifted past the max allowed watermark), and Flink
+    // pairs such calls with wakeUp(); see wakeUp() for how that is handled reentrantly.
   }
 
   private long calculateBytes(IcebergSourceSplit split) {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/PoolWithWakeup.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/PoolWithWakeup.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.flink.connector.file.src.util.Pool;
+
+/**
+ * A recyclable object pool similar to Flink's {@link Pool}, but whose blocking {@link #pollEntry()}
+ * can be unblocked by {@link #wakeUp()} without interrupting the waiting thread.
+ */
+class PoolWithWakeup<T> {
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition notEmpty = lock.newCondition();
+  private final Deque<T> entries;
+  private final Pool.Recycler<T> recycler = this::addBack;
+
+  // Set by wakeUp() and consumed by pollEntry(). Guarded by lock.
+  private boolean wokenUp;
+
+  PoolWithWakeup(int poolCapacity) {
+    this.entries = new ArrayDeque<>(poolCapacity);
+  }
+
+  /** Adds an entry to the pool. Used to populate the pool initially. */
+  void add(T entry) {
+    addBack(entry);
+  }
+
+  /**
+   * Returns a recycler that adds entries back to the pool once they are no longer in use. A blocked
+   * {@link #pollEntry()} is woken up when an entry is recycled.
+   */
+  Pool.Recycler<T> recycler() {
+    return recycler;
+  }
+
+  /**
+   * Retrieves the next available entry, blocking until one is recycled or until {@link #wakeUp()}
+   * is called.
+   *
+   * @return the next entry, or {@code null} if the pool was woken up while waiting
+   */
+  T pollEntry() throws InterruptedException {
+    lock.lock();
+    try {
+      while (entries.isEmpty()) {
+        if (wokenUp) {
+          // Consume the wakeup signal and return without an entry.
+          wokenUp = false;
+          return null;
+        }
+
+        notEmpty.await();
+      }
+
+      return entries.pollFirst();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Unblocks a thread currently waiting in {@link #pollEntry()} without interrupting it. If no
+   * thread is currently blocked, the next {@link #pollEntry()} call that would otherwise block
+   * returns {@code null} once. Safe to call from a thread other than the one blocked in {@code
+   * pollEntry()}.
+   */
+  void wakeUp() {
+    lock.lock();
+    try {
+      wokenUp = true;
+      notEmpty.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void addBack(T entry) {
+    lock.lock();
+    try {
+      entries.addLast(entry);
+      notEmpty.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/WakeableIterator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/WakeableIterator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * A {@link CloseableIterator} that can be woken up while it is blocked producing the next element.
+ *
+ * <p>This lets {@link IcebergSourceSplitReader#wakeUp()} unblock a fetcher thread that is waiting
+ * for an array-pool entry in {@link ArrayPoolDataIteratorBatcher} so that the thread can return
+ * control and exit cleanly during shutdown.
+ */
+@Internal
+interface WakeableIterator<T> extends CloseableIterator<T> {
+  /** Wake up the iterator if it is currently blocked in {@link #next()}. */
+  void wakeUp();
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherWakeup.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherWakeup.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.io.CloseableIterator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests that {@link ArrayPoolDataIteratorBatcher}'s iterator reacts correctly to {@code wakeUp()},
+ * verifying the fix for issue #16426 (fetcher thread leak during cancellation). A real {@link
+ * PoolWithWakeup} is injected in a controlled state so no file I/O is needed.
+ */
+class TestArrayPoolDataIteratorBatcherWakeup {
+
+  private static Configuration config() {
+    Configuration config = new Configuration();
+    config.set(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 2);
+    config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
+    return config;
+  }
+
+  /**
+   * When the pool is exhausted, {@code next()} blocks. {@code wakeUp()} must unblock it and yield
+   * an empty batch so the fetcher thread can return control (and exit on shutdown) instead of
+   * leaking.
+   */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testWakeUpUnblocksExhaustedPoll() throws Exception {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    // Empty pool simulates exhaustion (watermark alignment / shutdown).
+    batcher.setPoolForTesting(new PoolWithWakeup<>(2));
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    when(mockIterator.hasNext()).thenReturn(true);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+    assertThat(iterator).isInstanceOf(WakeableIterator.class);
+
+    CountDownLatch threadStarted = new CountDownLatch(1);
+    AtomicReference<RecordsWithSplitIds<RecordAndPosition<RowData>>> result =
+        new AtomicReference<>();
+    Thread fetchThread =
+        new Thread(
+            () -> {
+              threadStarted.countDown();
+              result.set(iterator.next());
+            });
+    fetchThread.start();
+
+    try {
+      assertThat(threadStarted.await(2, TimeUnit.SECONDS)).isTrue();
+      Thread.sleep(200);
+      assertThat(fetchThread.isAlive()).as("Thread should be blocked on exhausted pool").isTrue();
+
+      // This is what Flink does during shutdown.
+      ((WakeableIterator<?>) iterator).wakeUp();
+
+      fetchThread.join(2000);
+      assertThat(fetchThread.isAlive()).as("Thread should exit after wakeUp").isFalse();
+
+      // A woken read returns an empty batch (no records, no finished splits) so fetch() stays
+      // reentrant.
+      RecordsWithSplitIds<RecordAndPosition<RowData>> batch = result.get();
+      assertThat(batch).isNotNull();
+      assertThat(batch.nextSplit()).isNull();
+      assertThat(batch.finishedSplits()).isEmpty();
+    } finally {
+      if (fetchThread.isAlive()) {
+        ((WakeableIterator<?>) iterator).wakeUp();
+        fetchThread.join(1000);
+      }
+    }
+  }
+
+  /**
+   * After a wakeup the iterator must be reentrant: a subsequent {@code next()} blocks again while
+   * the pool stays exhausted (this is the watermark-alignment pause).
+   */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testReentrantAfterWakeUp() throws Exception {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    batcher.setPoolForTesting(new PoolWithWakeup<>(2));
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    when(mockIterator.hasNext()).thenReturn(true);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+
+    // First call: wake it up, get an empty batch.
+    Thread t1 = new Thread(iterator::next);
+    t1.start();
+    Thread.sleep(200);
+    ((WakeableIterator<?>) iterator).wakeUp();
+    t1.join(2000);
+    assertThat(t1.isAlive()).isFalse();
+
+    // Second call must block again (the wakeup was consumed), proving the pause still holds.
+    Thread t2 = new Thread(iterator::next);
+    t2.start();
+    Thread.sleep(300);
+    assertThat(t2.isAlive()).as("Second next() should block again after the wakeup").isTrue();
+
+    ((WakeableIterator<?>) iterator).wakeUp();
+    t2.join(2000);
+    assertThat(t2.isAlive()).isFalse();
+  }
+
+  /** Normal operation: when the pool has an entry, {@code next()} returns a real batch. */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testNormalReadWhenEntryAvailable() {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    PoolWithWakeup<RowData[]> pool = new PoolWithWakeup<>(2);
+    pool.add(new RowData[2]);
+    batcher.setPoolForTesting(pool);
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    // true for next()'s guard check, false for the fill loop so we don't exercise record cloning.
+    when(mockIterator.hasNext()).thenReturn(true, false);
+    when(mockIterator.fileOffset()).thenReturn(0);
+    when(mockIterator.recordOffset()).thenReturn(0L);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+
+    RecordsWithSplitIds<RecordAndPosition<RowData>> batch = iterator.next();
+    assertThat(batch).isNotNull();
+    // A real batch carries the split id.
+    assertThat(batch.nextSplit()).isEqualTo("test-split");
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestPoolWithWakeup.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestPoolWithWakeup.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/** Tests for {@link PoolWithWakeup}, the wakeable object pool that fixes issue #16426. */
+class TestPoolWithWakeup {
+
+  @Test
+  void testPollReturnsAvailableEntry() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+    Object entry = new Object();
+    pool.add(entry);
+
+    assertThat(pool.pollEntry()).isSameAs(entry);
+  }
+
+  @Test
+  @Timeout(10)
+  void testWakeUpUnblocksEmptyPoll() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+
+    CountDownLatch started = new CountDownLatch(1);
+    AtomicBoolean returned = new AtomicBoolean(false);
+    AtomicReference<Object> result = new AtomicReference<>();
+
+    Thread blocked =
+        new Thread(
+            () -> {
+              started.countDown();
+              try {
+                result.set(pool.pollEntry());
+                returned.set(true);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    blocked.start();
+
+    assertThat(started.await(2, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(200);
+    assertThat(blocked.isAlive()).as("Thread should block on empty pool").isTrue();
+
+    pool.wakeUp();
+
+    blocked.join(2000);
+    assertThat(blocked.isAlive()).isFalse();
+    assertThat(returned.get()).isTrue();
+    assertThat(result.get()).as("pollEntry returns null when woken up").isNull();
+  }
+
+  @Test
+  @Timeout(10)
+  void testRecycleUnblocksPoll() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+    Object entry = new Object();
+
+    CountDownLatch started = new CountDownLatch(1);
+    AtomicReference<Object> result = new AtomicReference<>();
+
+    Thread blocked =
+        new Thread(
+            () -> {
+              started.countDown();
+              try {
+                result.set(pool.pollEntry());
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    blocked.start();
+
+    assertThat(started.await(2, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(200);
+    assertThat(blocked.isAlive()).as("Thread should block on empty pool").isTrue();
+
+    // Recycling an entry must wake the blocked poll and hand it the entry.
+    pool.recycler().recycle(entry);
+
+    blocked.join(2000);
+    assertThat(blocked.isAlive()).isFalse();
+    assertThat(result.get()).isSameAs(entry);
+  }
+
+  @Test
+  void testWakeUpWithoutBlockedThreadReturnsNullOnce() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+
+    // No thread is blocked; the signal is latched and consumed by the next poll on an empty pool.
+    pool.wakeUp();
+    assertThat(pool.pollEntry()).isNull();
+
+    // The signal is only consumed once: an available entry is still returned afterwards.
+    Object entry = new Object();
+    pool.add(entry);
+    assertThat(pool.pollEntry()).isSameAs(entry);
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayBatchRecords.java
@@ -168,4 +168,12 @@ class ArrayBatchRecords<T> implements RecordsWithSplitIds<RecordAndPosition<T>> 
   public static <T> ArrayBatchRecords<T> finishedSplit(String splitId) {
     return new ArrayBatchRecords<>(null, null, null, 0, 0, 0, Collections.singleton(splitId));
   }
+
+  /**
+   * Create an empty ArrayBatchRecords with no records and no finished splits. This is returned when
+   * the reader is woken up (e.g. during shutdown) while waiting for an array-pool entry.
+   */
+  public static <T> ArrayBatchRecords<T> emptyBatch() {
+    return new ArrayBatchRecords<>(null, null, null, 0, 0, 0, Collections.emptySet());
+  }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ArrayPoolDataIteratorBatcher.java
@@ -23,10 +23,10 @@ import java.util.NoSuchElementException;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
 import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
-import org.apache.flink.connector.file.src.util.Pool;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /** This implementation stores record batch in array from recyclable pool */
@@ -35,12 +35,25 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
   private final int handoverQueueSize;
   private final RecordFactory<T> recordFactory;
 
-  private transient Pool<T[]> pool;
+  private transient PoolWithWakeup<T[]> pool;
 
   ArrayPoolDataIteratorBatcher(ReadableConfig config, RecordFactory<T> recordFactory) {
     this.batchSize = config.get(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT);
     this.handoverQueueSize = config.get(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY);
     this.recordFactory = recordFactory;
+  }
+
+  /**
+   * Sets the pool for testing purposes.
+   *
+   * <p>This allows tests to inject a pool in a controlled state (e.g. empty) to verify the blocking
+   * and wakeup behavior without requiring real file I/O.
+   *
+   * @param testPool the pool to use for testing
+   */
+  @VisibleForTesting
+  void setPoolForTesting(PoolWithWakeup<T[]> testPool) {
+    this.pool = testPool;
   }
 
   @Override
@@ -54,8 +67,8 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
     return new ArrayPoolBatchIterator(splitId, inputIterator, pool);
   }
 
-  private Pool<T[]> createPoolOfBatches(int numBatches) {
-    Pool<T[]> poolOfBatches = new Pool<>(numBatches);
+  private PoolWithWakeup<T[]> createPoolOfBatches(int numBatches) {
+    PoolWithWakeup<T[]> poolOfBatches = new PoolWithWakeup<>(numBatches);
     for (int batchId = 0; batchId < numBatches; batchId++) {
       T[] batch = recordFactory.createBatch(batchSize);
       poolOfBatches.add(batch);
@@ -65,13 +78,14 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
   }
 
   private class ArrayPoolBatchIterator
-      implements CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> {
+      implements WakeableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> {
 
     private final String splitId;
     private final DataIterator<T> inputIterator;
-    private final Pool<T[]> pool;
+    private final PoolWithWakeup<T[]> pool;
 
-    ArrayPoolBatchIterator(String splitId, DataIterator<T> inputIterator, Pool<T[]> pool) {
+    ArrayPoolBatchIterator(
+        String splitId, DataIterator<T> inputIterator, PoolWithWakeup<T[]> pool) {
       this.splitId = splitId;
       this.inputIterator = inputIterator;
       this.pool = pool;
@@ -89,6 +103,12 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
       }
 
       T[] batch = getCachedEntry();
+      if (batch == null) {
+        // We were woken up (e.g. during shutdown) while waiting for a pool entry. Return an empty
+        // batch so that fetch() returns control and stays reentrant.
+        return ArrayBatchRecords.emptyBatch();
+      }
+
       int recordCount = 0;
       while (inputIterator.hasNext() && recordCount < batchSize) {
         // The record produced by inputIterator can be reused like for the RowData case.
@@ -118,6 +138,17 @@ class ArrayPoolDataIteratorBatcher<T> implements DataIteratorBatcher<T> {
       inputIterator.close();
     }
 
+    @Override
+    public void wakeUp() {
+      pool.wakeUp();
+    }
+
+    /**
+     * Gets a cached entry from the pool, blocking until an entry is recycled or the reader is woken
+     * up.
+     *
+     * @return a cached array from the pool, or {@code null} if woken up
+     */
     private T[] getCachedEntry() {
       try {
         return pool.pollEntry();

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/IcebergSourceSplitReader.java
@@ -48,7 +48,8 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   private final int indexOfSubtask;
   private final Queue<IcebergSourceSplit> splits;
 
-  private CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> currentReader;
+  // volatile because wakeUp() may read currentReader from a different thread than fetch()
+  private volatile CloseableIterator<RecordsWithSplitIds<RecordAndPosition<T>>> currentReader;
   private IcebergSourceSplit currentSplit;
   private String currentSplitId;
 
@@ -123,7 +124,15 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   }
 
   @Override
-  public void wakeUp() {}
+  public void wakeUp() {
+    // Flink calls wakeUp() to unblock a fetcher parked in fetch(). The only place fetch() can block
+    // is in ArrayPoolDataIteratorBatcher waiting for a pool entry (e.g. while the pool is exhausted
+    // during watermark alignment). Relay the signal so that thread can return control and exit
+    // cleanly on shutdown. fetch() stays reentrant: a woken read just returns an empty batch.
+    if (currentReader instanceof WakeableIterator wakeableIterator) {
+      wakeableIterator.wakeUp();
+    }
+  }
 
   @Override
   public void close() throws Exception {
@@ -136,11 +145,13 @@ class IcebergSourceSplitReader<T> implements SplitReader<RecordAndPosition<T>, I
   @Override
   public void pauseOrResumeSplits(
       Collection<IcebergSourceSplit> splitsToPause, Collection<IcebergSourceSplit> splitsToResume) {
-    // IcebergSourceSplitReader only reads splits sequentially. When waiting for watermark alignment
-    // the SourceOperator will stop processing and recycling the fetched batches. This exhausts the
-    // {@link ArrayPoolDataIteratorBatcher#pool} and the `currentReader.next()` call will be
-    // blocked even without split-level watermark alignment. Based on this the
-    // `pauseOrResumeSplits` and the `wakeUp` are left empty.
+    // Left empty intentionally. IcebergSourceSplitReader reads splits sequentially, so the pause
+    // needed for watermark alignment is achieved implicitly: when the SourceOperator stops
+    // processing and recycling the fetched batches, the {@link ArrayPoolDataIteratorBatcher#pool}
+    // exhausts and the `currentReader.next()` call blocks. We therefore do not need to pause/resume
+    // individual splits here. Note this method must not throw, because the SourceOperator can still
+    // invoke it (e.g. for a single split that drifted past the max allowed watermark), and Flink
+    // pairs such calls with wakeUp(); see wakeUp() for how that is handled reentrantly.
   }
 
   private long calculateBytes(IcebergSourceSplit split) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/PoolWithWakeup.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/PoolWithWakeup.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.flink.connector.file.src.util.Pool;
+
+/**
+ * A recyclable object pool similar to Flink's {@link Pool}, but whose blocking {@link #pollEntry()}
+ * can be unblocked by {@link #wakeUp()} without interrupting the waiting thread.
+ */
+class PoolWithWakeup<T> {
+
+  private final ReentrantLock lock = new ReentrantLock();
+  private final Condition notEmpty = lock.newCondition();
+  private final Deque<T> entries;
+  private final Pool.Recycler<T> recycler = this::addBack;
+
+  // Set by wakeUp() and consumed by pollEntry(). Guarded by lock.
+  private boolean wokenUp;
+
+  PoolWithWakeup(int poolCapacity) {
+    this.entries = new ArrayDeque<>(poolCapacity);
+  }
+
+  /** Adds an entry to the pool. Used to populate the pool initially. */
+  void add(T entry) {
+    addBack(entry);
+  }
+
+  /**
+   * Returns a recycler that adds entries back to the pool once they are no longer in use. A blocked
+   * {@link #pollEntry()} is woken up when an entry is recycled.
+   */
+  Pool.Recycler<T> recycler() {
+    return recycler;
+  }
+
+  /**
+   * Retrieves the next available entry, blocking until one is recycled or until {@link #wakeUp()}
+   * is called.
+   *
+   * @return the next entry, or {@code null} if the pool was woken up while waiting
+   */
+  T pollEntry() throws InterruptedException {
+    lock.lock();
+    try {
+      while (entries.isEmpty()) {
+        if (wokenUp) {
+          // Consume the wakeup signal and return without an entry.
+          wokenUp = false;
+          return null;
+        }
+
+        notEmpty.await();
+      }
+
+      return entries.pollFirst();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  /**
+   * Unblocks a thread currently waiting in {@link #pollEntry()} without interrupting it. If no
+   * thread is currently blocked, the next {@link #pollEntry()} call that would otherwise block
+   * returns {@code null} once. Safe to call from a thread other than the one blocked in {@code
+   * pollEntry()}.
+   */
+  void wakeUp() {
+    lock.lock();
+    try {
+      wokenUp = true;
+      notEmpty.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
+
+  private void addBack(T entry) {
+    lock.lock();
+    try {
+      entries.addLast(entry);
+      notEmpty.signal();
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/WakeableIterator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/WakeableIterator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.io.CloseableIterator;
+
+/**
+ * A {@link CloseableIterator} that can be woken up while it is blocked producing the next element.
+ *
+ * <p>This lets {@link IcebergSourceSplitReader#wakeUp()} unblock a fetcher thread that is waiting
+ * for an array-pool entry in {@link ArrayPoolDataIteratorBatcher} so that the thread can return
+ * control and exit cleanly during shutdown.
+ */
+@Internal
+interface WakeableIterator<T> extends CloseableIterator<T> {
+  /** Wake up the iterator if it is currently blocked in {@link #next()}. */
+  void wakeUp();
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherWakeup.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherWakeup.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.base.source.reader.RecordsWithSplitIds;
+import org.apache.flink.connector.base.source.reader.SourceReaderOptions;
+import org.apache.flink.table.data.RowData;
+import org.apache.iceberg.flink.FlinkConfigOptions;
+import org.apache.iceberg.flink.TestFixtures;
+import org.apache.iceberg.flink.source.DataIterator;
+import org.apache.iceberg.io.CloseableIterator;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/**
+ * Tests that {@link ArrayPoolDataIteratorBatcher}'s iterator reacts correctly to {@code wakeUp()},
+ * verifying the fix for issue #16426 (fetcher thread leak during cancellation). A real {@link
+ * PoolWithWakeup} is injected in a controlled state so no file I/O is needed.
+ */
+class TestArrayPoolDataIteratorBatcherWakeup {
+
+  private static Configuration config() {
+    Configuration config = new Configuration();
+    config.set(FlinkConfigOptions.SOURCE_READER_FETCH_BATCH_RECORD_COUNT, 2);
+    config.set(SourceReaderOptions.ELEMENT_QUEUE_CAPACITY, 2);
+    return config;
+  }
+
+  /**
+   * When the pool is exhausted, {@code next()} blocks. {@code wakeUp()} must unblock it and yield
+   * an empty batch so the fetcher thread can return control (and exit on shutdown) instead of
+   * leaking.
+   */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testWakeUpUnblocksExhaustedPoll() throws Exception {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    // Empty pool simulates exhaustion (watermark alignment / shutdown).
+    batcher.setPoolForTesting(new PoolWithWakeup<>(2));
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    when(mockIterator.hasNext()).thenReturn(true);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+    assertThat(iterator).isInstanceOf(WakeableIterator.class);
+
+    CountDownLatch threadStarted = new CountDownLatch(1);
+    AtomicReference<RecordsWithSplitIds<RecordAndPosition<RowData>>> result =
+        new AtomicReference<>();
+    Thread fetchThread =
+        new Thread(
+            () -> {
+              threadStarted.countDown();
+              result.set(iterator.next());
+            });
+    fetchThread.start();
+
+    try {
+      assertThat(threadStarted.await(2, TimeUnit.SECONDS)).isTrue();
+      Thread.sleep(200);
+      assertThat(fetchThread.isAlive()).as("Thread should be blocked on exhausted pool").isTrue();
+
+      // This is what Flink does during shutdown.
+      ((WakeableIterator<?>) iterator).wakeUp();
+
+      fetchThread.join(2000);
+      assertThat(fetchThread.isAlive()).as("Thread should exit after wakeUp").isFalse();
+
+      // A woken read returns an empty batch (no records, no finished splits) so fetch() stays
+      // reentrant.
+      RecordsWithSplitIds<RecordAndPosition<RowData>> batch = result.get();
+      assertThat(batch).isNotNull();
+      assertThat(batch.nextSplit()).isNull();
+      assertThat(batch.finishedSplits()).isEmpty();
+    } finally {
+      if (fetchThread.isAlive()) {
+        ((WakeableIterator<?>) iterator).wakeUp();
+        fetchThread.join(1000);
+      }
+    }
+  }
+
+  /**
+   * After a wakeup the iterator must be reentrant: a subsequent {@code next()} blocks again while
+   * the pool stays exhausted (this is the watermark-alignment pause).
+   */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testReentrantAfterWakeUp() throws Exception {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    batcher.setPoolForTesting(new PoolWithWakeup<>(2));
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    when(mockIterator.hasNext()).thenReturn(true);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+
+    // First call: wake it up, get an empty batch.
+    Thread t1 = new Thread(iterator::next);
+    t1.start();
+    Thread.sleep(200);
+    ((WakeableIterator<?>) iterator).wakeUp();
+    t1.join(2000);
+    assertThat(t1.isAlive()).isFalse();
+
+    // Second call must block again (the wakeup was consumed), proving the pause still holds.
+    Thread t2 = new Thread(iterator::next);
+    t2.start();
+    Thread.sleep(300);
+    assertThat(t2.isAlive()).as("Second next() should block again after the wakeup").isTrue();
+
+    ((WakeableIterator<?>) iterator).wakeUp();
+    t2.join(2000);
+    assertThat(t2.isAlive()).isFalse();
+  }
+
+  /** Normal operation: when the pool has an entry, {@code next()} returns a real batch. */
+  @Test
+  @Timeout(10)
+  @SuppressWarnings("unchecked")
+  void testNormalReadWhenEntryAvailable() {
+    ArrayPoolDataIteratorBatcher<RowData> batcher =
+        new ArrayPoolDataIteratorBatcher<>(
+            config(), new RowDataRecordFactory(TestFixtures.ROW_TYPE));
+    PoolWithWakeup<RowData[]> pool = new PoolWithWakeup<>(2);
+    pool.add(new RowData[2]);
+    batcher.setPoolForTesting(pool);
+
+    DataIterator<RowData> mockIterator = mock(DataIterator.class);
+    // true for next()'s guard check, false for the fill loop so we don't exercise record cloning.
+    when(mockIterator.hasNext()).thenReturn(true, false);
+    when(mockIterator.fileOffset()).thenReturn(0);
+    when(mockIterator.recordOffset()).thenReturn(0L);
+
+    CloseableIterator<RecordsWithSplitIds<RecordAndPosition<RowData>>> iterator =
+        batcher.batch("test-split", mockIterator);
+
+    RecordsWithSplitIds<RecordAndPosition<RowData>> batch = iterator.next();
+    assertThat(batch).isNotNull();
+    // A real batch carries the split id.
+    assertThat(batch.nextSplit()).isEqualTo("test-split");
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestPoolWithWakeup.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestPoolWithWakeup.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source.reader;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+/** Tests for {@link PoolWithWakeup}, the wakeable object pool that fixes issue #16426. */
+class TestPoolWithWakeup {
+
+  @Test
+  void testPollReturnsAvailableEntry() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+    Object entry = new Object();
+    pool.add(entry);
+
+    assertThat(pool.pollEntry()).isSameAs(entry);
+  }
+
+  @Test
+  @Timeout(10)
+  void testWakeUpUnblocksEmptyPoll() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+
+    CountDownLatch started = new CountDownLatch(1);
+    AtomicBoolean returned = new AtomicBoolean(false);
+    AtomicReference<Object> result = new AtomicReference<>();
+
+    Thread blocked =
+        new Thread(
+            () -> {
+              started.countDown();
+              try {
+                result.set(pool.pollEntry());
+                returned.set(true);
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    blocked.start();
+
+    assertThat(started.await(2, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(200);
+    assertThat(blocked.isAlive()).as("Thread should block on empty pool").isTrue();
+
+    pool.wakeUp();
+
+    blocked.join(2000);
+    assertThat(blocked.isAlive()).isFalse();
+    assertThat(returned.get()).isTrue();
+    assertThat(result.get()).as("pollEntry returns null when woken up").isNull();
+  }
+
+  @Test
+  @Timeout(10)
+  void testRecycleUnblocksPoll() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+    Object entry = new Object();
+
+    CountDownLatch started = new CountDownLatch(1);
+    AtomicReference<Object> result = new AtomicReference<>();
+
+    Thread blocked =
+        new Thread(
+            () -> {
+              started.countDown();
+              try {
+                result.set(pool.pollEntry());
+              } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+              }
+            });
+    blocked.start();
+
+    assertThat(started.await(2, TimeUnit.SECONDS)).isTrue();
+    Thread.sleep(200);
+    assertThat(blocked.isAlive()).as("Thread should block on empty pool").isTrue();
+
+    // Recycling an entry must wake the blocked poll and hand it the entry.
+    pool.recycler().recycle(entry);
+
+    blocked.join(2000);
+    assertThat(blocked.isAlive()).isFalse();
+    assertThat(result.get()).isSameAs(entry);
+  }
+
+  @Test
+  void testWakeUpWithoutBlockedThreadReturnsNullOnce() throws Exception {
+    PoolWithWakeup<Object> pool = new PoolWithWakeup<>(2);
+
+    // No thread is blocked; the signal is latched and consumed by the next poll on an empty pool.
+    pool.wakeUp();
+    assertThat(pool.pollEntry()).isNull();
+
+    // The signal is only consumed once: an available entry is still returned afterwards.
+    Object entry = new Object();
+    pool.add(entry);
+    assertThat(pool.pollEntry()).isSameAs(entry);
+  }
+}


### PR DESCRIPTION
Backport of #16545 to Flink v1.20 and v2.0.