### PR TITLE
AWS: Truncate column comments to 255 Glue limit

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -64,6 +64,7 @@ class IcebergToGlueConverter {
   public static final String GLUE_DB_LOCATION_KEY = "location";
   // Utilized for defining descriptions at both the Glue database and table levels.
   public static final String GLUE_DESCRIPTION_KEY = "comment";
+  public static final int GLUE_COLUMN_COMMENT_MAX_LENGTH = 255;
   public static final String ICEBERG_FIELD_ID = "iceberg.field.id";
   public static final String ICEBERG_FIELD_OPTIONAL = "iceberg.field.optional";
   public static final String ICEBERG_FIELD_CURRENT = "iceberg.field.current";
@@ -383,14 +384,28 @@ class IcebergToGlueConverter {
                       ICEBERG_FIELD_CURRENT, Boolean.toString(isCurrent)));
 
       if (field.doc() != null && !field.doc().isEmpty()) {
-        builder.comment(field.doc());
+        builder.comment(truncateColumnComment(field.name(), field.doc()));
       } else if (existingColumnNameToComment != null
           && existingColumnNameToComment.containsKey(field.name())) {
-        builder.comment(existingColumnNameToComment.get(field.name()));
+        builder.comment(
+            truncateColumnComment(field.name(), existingColumnNameToComment.get(field.name())));
       }
 
       columns.add(builder.build());
       dedupe.add(field.name());
     }
+  }
+
+  private static String truncateColumnComment(String columnName, String comment) {
+    if (comment.length() <= GLUE_COLUMN_COMMENT_MAX_LENGTH) {
+      return comment;
+    }
+
+    LOG.warn(
+        "Truncating comment length for column {} from {} to Glue's maximum {} characters",
+        columnName,
+        comment.length(),
+        GLUE_COLUMN_COMMENT_MAX_LENGTH);
+    return comment.substring(0, GLUE_COLUMN_COMMENT_MAX_LENGTH);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -386,6 +386,52 @@ public class TestIcebergToGlueConverter {
   }
 
   @Test
+  public void testSetColumnCommentTruncation() {
+    TableInput.Builder actualTableInputBuilder = TableInput.builder();
+    Schema schema =
+        new Schema(Types.NestedField.required(1, "x", Types.StringType.get(), "a".repeat(256)));
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), "s3://test", ImmutableMap.of());
+
+    IcebergToGlueConverter.setTableInputInformation(actualTableInputBuilder, tableMetadata);
+    TableInput actualTableInput = actualTableInputBuilder.build();
+
+    assertThat(actualTableInput.storageDescriptor().columns().get(0).comment())
+        .as("Column comment should be truncated")
+        .hasSize(IcebergToGlueConverter.GLUE_COLUMN_COMMENT_MAX_LENGTH);
+  }
+
+  @Test
+  public void testSetColumnCommentTruncationWithExistingTable() {
+    // Actual TableInput
+    TableInput.Builder actualTableInputBuilder = TableInput.builder();
+    Schema schema = new Schema(Types.NestedField.required(1, "x", Types.StringType.get()));
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(
+            schema, PartitionSpec.unpartitioned(), "s3://test", ImmutableMap.of());
+
+    // Existing Table
+    Table existingGlueTable =
+        Table.builder()
+            .storageDescriptor(
+                StorageDescriptor.builder()
+                    .columns(
+                        ImmutableList.of(
+                            Column.builder().name("x").comment("a".repeat(256)).build()))
+                    .build())
+            .build();
+
+    IcebergToGlueConverter.setTableInputInformation(
+        actualTableInputBuilder, tableMetadata, existingGlueTable);
+    TableInput actualTableInput = actualTableInputBuilder.build();
+
+    assertThat(actualTableInput.storageDescriptor().columns().get(0).comment())
+        .as("Column comment should be truncated")
+        .hasSize(IcebergToGlueConverter.GLUE_COLUMN_COMMENT_MAX_LENGTH);
+  }
+
+  @Test
   public void testDuplicateExistingColumnsKeepFirstComment() {
     TableInput.Builder actualTableInputBuilder = TableInput.builder();
     Schema schema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));


### PR DESCRIPTION
AWS Glue has a limit of 255 characters for column comments. If this limit is exceeded, the Glue API throws an error.

This change adds a check for column comments and automatically truncates them to 255 characters before the comments are sent to Glue. This matches a change that AWS has included on their internal fork of Iceberg that is deployed on EMR clusters.