### PR TITLE
Core: Disallow setting main branch ref to a tag

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1327,6 +1327,11 @@ public class TableMetadata implements Serializable {
       Snapshot snapshot = snapshotsById.get(snapshotId);
       ValidationException.check(
           snapshot != null, "Cannot set %s to unknown snapshot: %s", name, snapshotId);
+      ValidationException.check(
+          !SnapshotRef.MAIN_BRANCH.equals(name) || ref.isBranch(),
+          "Cannot set %s to a tag: %s must be a branch",
+          SnapshotRef.MAIN_BRANCH,
+          SnapshotRef.MAIN_BRANCH);
 
       if (SnapshotRef.MAIN_BRANCH.equals(name)) {
         this.currentSnapshotId = ref.snapshotId();

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1329,8 +1329,7 @@ public class TableMetadata implements Serializable {
           snapshot != null, "Cannot set %s to unknown snapshot: %s", name, snapshotId);
       ValidationException.check(
           !SnapshotRef.MAIN_BRANCH.equals(name) || ref.isBranch(),
-          "Cannot set %s to a tag: %s must be a branch",
-          SnapshotRef.MAIN_BRANCH,
+          "Cannot set %s to a tag, it must be a branch",
           SnapshotRef.MAIN_BRANCH);
 
       if (SnapshotRef.MAIN_BRANCH.equals(name)) {

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -336,7 +336,7 @@ public class TestSnapshotManager extends TestBase {
                     .createTag(SnapshotRef.MAIN_BRANCH, stagedSnapshot.snapshotId())
                     .commit())
         .isInstanceOf(ValidationException.class)
-        .hasMessage("Cannot set main to a tag: main must be a branch");
+        .hasMessage("Cannot set main to a tag, it must be a branch");
 
     // the failed commit must not have created the main ref
     assertThat(table.ops().refresh().ref(SnapshotRef.MAIN_BRANCH)).isNull();

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotManager.java
@@ -324,6 +324,25 @@ public class TestSnapshotManager extends TestBase {
   }
 
   @TestTemplate
+  public void testCreateTagNamedMainFails() {
+    // stage a snapshot so that the table has a snapshot but no main branch ref yet
+    table.newAppend().appendFile(FILE_A).stageOnly().commit();
+    Snapshot stagedSnapshot = Iterables.getOnlyElement(table.snapshots());
+
+    assertThatThrownBy(
+            () ->
+                table
+                    .manageSnapshots()
+                    .createTag(SnapshotRef.MAIN_BRANCH, stagedSnapshot.snapshotId())
+                    .commit())
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot set main to a tag: main must be a branch");
+
+    // the failed commit must not have created the main ref
+    assertThat(table.ops().refresh().ref(SnapshotRef.MAIN_BRANCH)).isNull();
+  }
+
+  @TestTemplate
   public void testRemoveBranch() {
     table.newAppend().appendFile(FILE_A).commit();
     long snapshotId = table.currentSnapshot().snapshotId();

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -2148,4 +2148,42 @@ public class TestTableMetadata {
         .isInstanceOf(RetryableValidationException.class)
         .hasMessageContaining("Cannot add a snapshot, first-row-id is behind table next-row-id");
   }
+
+  @Test
+  public void testSetRefRejectsTagForMainBranch() {
+    TableMetadata base =
+        TableMetadata.newTableMetadata(
+            TEST_SCHEMA, PartitionSpec.unpartitioned(), "location", ImmutableMap.of());
+
+    Snapshot snapshot =
+        new BaseSnapshot(
+            1,
+            1L,
+            null,
+            System.currentTimeMillis(),
+            null,
+            null,
+            null,
+            "file:/s1.avro",
+            null,
+            null,
+            null);
+    TableMetadata withSnapshot = TableMetadata.buildFrom(base).addSnapshot(snapshot).build();
+
+    assertThatThrownBy(
+            () ->
+                TableMetadata.buildFrom(withSnapshot)
+                    .setRef(
+                        SnapshotRef.MAIN_BRANCH,
+                        SnapshotRef.tagBuilder(snapshot.snapshotId()).build()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessage("Cannot set main to a tag: main must be a branch");
+
+    // any other ref name can still be a tag
+    TableMetadata withTag =
+        TableMetadata.buildFrom(withSnapshot)
+            .setRef("tag1", SnapshotRef.tagBuilder(snapshot.snapshotId()).build())
+            .build();
+    assertThat(withTag.ref("tag1").isTag()).isTrue();
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
+++ b/core/src/test/java/org/apache/iceberg/TestTableMetadata.java
@@ -2177,7 +2177,7 @@ public class TestTableMetadata {
                         SnapshotRef.MAIN_BRANCH,
                         SnapshotRef.tagBuilder(snapshot.snapshotId()).build()))
         .isInstanceOf(ValidationException.class)
-        .hasMessage("Cannot set main to a tag: main must be a branch");
+        .hasMessage("Cannot set main to a tag, it must be a branch");
 
     // any other ref name can still be a tag
     TableMetadata withTag =


### PR DESCRIPTION
## Summary

`TableMetadata.Builder#setRef` accepts a tag ref named `main`: the main-branch special case sets `currentSnapshotId` and appends to the snapshot log without checking the ref type, and `validateRefs` only verifies that main's snapshot id matches `current-snapshot-id` — never its type. The spec requires main to be a branch (format/spec.md, `refs`: "There is always a `main` branch reference pointing to the `current-snapshot-id`").

Once such metadata is committed the table can no longer be written: every subsequent commit fails in `setBranchSnapshotInternal` with `Cannot update branch: main is a tag` — which also shows the builder already assumes main is a branch elsewhere.

This is reachable on any table whose metadata has snapshots but no `main` ref yet:
- `newAppend().stageOnly().commit()` (WAP) followed by `manageSnapshots().createTag("main", stagedSnapshotId).commit()`
- after `CREATE OR REPLACE` (replacement metadata drops refs but keeps snapshots)
- via REST `set-snapshot-ref` updates applied through `TableMetadata.Builder` (update requirements assert ref snapshot ids, not ref types)

This change rejects the tag in `Builder#setRef` with a `ValidationException` before any builder state is mutated. The check is deliberately not added to `validateRefs` so that already-written metadata files containing this corruption can still be read (and repaired by committing a branch ref for main).

## Test plan

- `TestTableMetadata#testSetRefRejectsTagForMainBranch` — builder-level: `setRef("main", tag)` throws; tag refs under any other name still work
- `TestSnapshotManager#testCreateTagNamedMainFails` — end-to-end repro via `ManageSnapshots` on a staged-only table; also asserts the failed commit did not create the main ref
- Ran `:iceberg-core:test --tests TestTableMetadata --tests TestSnapshotManager` plus spotless/checkstyle locally

This pull request and its description were written by Isaac.
