### PR TITLE
Core: Skip deleted position delete files in rewrite_table_path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -465,7 +465,9 @@ public class RewriteTablePathUtil {
                       stagingPath(file.location(), sourcePrefix, stagingLocation),
                       posDeleteFile.location()));
         }
-        result.toRewrite().add(file.copy());
+        if (entry.isLive()) {
+          result.toRewrite().add(file.copy());
+        }
         return result;
       case EQUALITY_DELETES:
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);


### PR DESCRIPTION
### Summary

Fixes #16662.

`rewrite_table_path` could queue deleted position delete files for physical rewrite. If those files had already been removed (for example after `rewrite_position_delete_files` and `expire_snapshots`), the rewrite would fail with `FileNotFoundException`.

This change gates `result.toRewrite().add()` on `entry.isLive()`, so that only live position delete files are scheduled for physical rewrite. Deleted entries are still preserved in the rewritten manifest metadata.

### Testing

```bash
./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestRewriteTablePathUtil"
```