### PR TITLE
Core: Expose commit retry exhaustion reason in failure messages

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -30,6 +30,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.expressions.Term;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 public class BaseReplaceSortOrder implements ReplaceSortOrder {
   private final TableOperations ops;
@@ -49,21 +50,41 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
-        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            taskOps -> {
-              this.base = ops.refresh();
-              SortOrder newOrder = apply();
-              TableMetadata updated = base.replaceSortOrder(newOrder);
-              taskOps.commit(base, updated);
-            });
+    int numRetries =
+        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              taskOps -> {
+                this.base = ops.refresh();
+                SortOrder newOrder = apply();
+                TableMetadata updated = base.replaceSortOrder(newOrder);
+                taskOps.commit(base, updated);
+              });
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -50,8 +50,7 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
 
   @Override
   public void commit() {
-    int numRetries =
-        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
@@ -71,6 +70,9 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -71,19 +71,7 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -70,9 +70,6 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
+++ b/core/src/main/java/org/apache/iceberg/BaseReplaceSortOrder.java
@@ -62,6 +62,7 @@ public class BaseReplaceSortOrder implements ReplaceSortOrder {
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 this.base = ops.refresh();

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -787,6 +787,11 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
+    if (ex.getCause() instanceof CommitFailedException
+        && ex.getCause().getMessage().startsWith("Commit failed: Requirement failed:")) {
+      return (CommitFailedException) ex.getCause();
+    }
+
     int numRetries =
         PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -787,8 +787,10 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
+    String message = ex.getCause() != null ? ex.getCause().getMessage() : null;
     if (ex.getCause() instanceof CommitFailedException
-        && ex.getCause().getMessage().startsWith("Commit failed: Requirement failed:")) {
+        && message != null
+        && message.startsWith("Commit failed: Requirement failed:")) {
       return (CommitFailedException) ex.getCause();
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -785,6 +785,11 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
+    // if the original cause was already a CommitFailedException, keep it
+    if (ex.getCause() instanceof CommitFailedException) {
+      return (CommitFailedException) ex.getCause();
+    }
+
     int numRetries =
         PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -311,6 +311,7 @@ public class BaseTransaction implements Transaction {
                   props, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               underlyingOps -> {
                 try {
@@ -369,6 +370,7 @@ public class BaseTransaction implements Transaction {
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               underlyingOps -> {
                 applyUpdates(underlyingOps);

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -785,11 +785,6 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
-    // if the original cause was already a CommitFailedException, keep it
-    if (ex.getCause() instanceof CommitFailedException) {
-      return (CommitFailedException) ex.getCause();
-    }
-
     int numRetries =
         PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -787,10 +787,7 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
-    String message = ex.getCause() != null ? ex.getCause().getMessage() : null;
-    if (ex.getCause() instanceof CommitFailedException
-        && message != null
-        && message.startsWith("Commit failed: Requirement failed:")) {
+    if (shouldPreserveCommitFailure(ex.getCause())) {
       return (CommitFailedException) ex.getCause();
     }
 
@@ -812,5 +809,14 @@ public class BaseTransaction implements Transaction {
           numRetries,
           COMMIT_NUM_RETRIES);
     }
+  }
+
+  private static boolean shouldPreserveCommitFailure(Throwable cause) {
+    if (!(cause instanceof CommitFailedException)) {
+      return false;
+    }
+
+    String message = cause.getMessage();
+    return message == null || !message.startsWith("Commit failed: table was updated");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -787,36 +787,11 @@ public class BaseTransaction implements Transaction {
 
   private static CommitFailedException toCommitFailedException(
       RetryExhaustedException ex, Map<String, String> properties) {
-    if (shouldPreserveCommitFailure(ex.getCause())) {
-      return (CommitFailedException) ex.getCause();
-    }
-
     int numRetries =
         PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         PropertyUtil.propertyAsInt(
             properties, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
-    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-      return new CommitFailedException(
-          ex,
-          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-          totalTimeoutMs,
-          COMMIT_TOTAL_RETRY_TIME_MS);
-    } else {
-      return new CommitFailedException(
-          ex,
-          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-          numRetries,
-          COMMIT_NUM_RETRIES);
-    }
-  }
-
-  private static boolean shouldPreserveCommitFailure(Throwable cause) {
-    if (!(cause instanceof CommitFailedException)) {
-      return false;
-    }
-
-    String message = cause.getMessage();
-    return message == null || !message.startsWith("Commit failed: table was updated");
+    return CommitRetry.toCommitFailedException(ex, numRetries, totalTimeoutMs);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -784,21 +784,21 @@ public class BaseTransaction implements Transaction {
   }
 
   private static CommitFailedException toCommitFailedException(
-      RetryExhaustedException e, Map<String, String> properties) {
+      RetryExhaustedException ex, Map<String, String> properties) {
     int numRetries =
         PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         PropertyUtil.propertyAsInt(
             properties, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
-    if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
       return new CommitFailedException(
-          e,
+          ex,
           "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
           totalTimeoutMs,
           COMMIT_TOTAL_RETRY_TIME_MS);
     } else {
       return new CommitFailedException(
-          e,
+          ex,
           "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
           numRetries,
           COMMIT_NUM_RETRIES);

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -50,6 +50,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -332,6 +333,9 @@ public class BaseTransaction implements Transaction {
     } catch (CommitStateUnknownException e) {
       throw e;
 
+    } catch (RetryExhaustedException e) {
+      throw toCommitFailedException(e, props);
+
     } catch (RuntimeException e) {
       // the commit failed and no files were committed. clean up each update.
       if (!ops.requireStrictCleanup() || e instanceof CleanableFailure) {
@@ -375,6 +379,8 @@ public class BaseTransaction implements Transaction {
     } catch (CommitStateUnknownException e) {
       throw e;
 
+    } catch (RetryExhaustedException e) {
+      throw toCommitFailedException(e, base.properties());
     } catch (PendingUpdateFailedException e) {
       cleanUp();
       throw e.wrapped();
@@ -774,6 +780,28 @@ public class BaseTransaction implements Transaction {
 
     public CommitFailedException wrapped() {
       return wrapped;
+    }
+  }
+
+  private static CommitFailedException toCommitFailedException(
+      RetryExhaustedException e, Map<String, String> properties) {
+    int numRetries =
+        PropertyUtil.propertyAsInt(properties, COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        PropertyUtil.propertyAsInt(
+            properties, COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+      return new CommitFailedException(
+          e,
+          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+          totalTimeoutMs,
+          COMMIT_TOTAL_RETRY_TIME_MS);
+    } else {
+      return new CommitFailedException(
+          e,
+          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+          numRetries,
+          COMMIT_NUM_RETRIES);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -335,6 +335,7 @@ public class BaseTransaction implements Transaction {
       throw e;
 
     } catch (RetryExhaustedException e) {
+      cleanAllUpdates();
       throw toCommitFailedException(e, props);
 
     } catch (RuntimeException e) {

--- a/core/src/main/java/org/apache/iceberg/CommitRetry.java
+++ b/core/src/main/java/org/apache/iceberg/CommitRetry.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
+
+class CommitRetry {
+  private CommitRetry() {}
+
+  static CommitFailedException toCommitFailedException(
+      RetryExhaustedException ex, int numRetries, int totalTimeoutMs) {
+    if (shouldPreserveCommitFailure(ex.getCause())) {
+      return (CommitFailedException) ex.getCause();
+    }
+
+    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+          totalTimeoutMs,
+          COMMIT_TOTAL_RETRY_TIME_MS);
+    } else {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+          numRetries,
+          COMMIT_NUM_RETRIES);
+    }
+  }
+
+  private static boolean shouldPreserveCommitFailure(Throwable cause) {
+    if (!(cause instanceof CommitFailedException)) {
+      return false;
+    }
+
+    String message = cause.getMessage();
+    return message == null || !message.startsWith("Commit failed: table was updated");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/CommitRetry.java
+++ b/core/src/main/java/org/apache/iceberg/CommitRetry.java
@@ -53,7 +53,6 @@ class CommitRetry {
       return false;
     }
 
-    String message = cause.getMessage();
-    return message == null || !message.startsWith("Commit failed: table was updated");
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -100,8 +100,7 @@ class PropertiesUpdate implements UpdateProperties {
   @Override
   public void commit() {
     // If existing table commit properties in base are corrupted, allow rectification
-    int numRetries =
-        base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
@@ -120,6 +119,9 @@ class PropertiesUpdate implements UpdateProperties {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -120,19 +120,7 @@ class PropertiesUpdate implements UpdateProperties {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -112,6 +112,7 @@ class PropertiesUpdate implements UpdateProperties {
               base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 Map<String, String> newProperties = apply();

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -119,9 +119,6 @@ class PropertiesUpdate implements UpdateProperties {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/PropertiesUpdate.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 class PropertiesUpdate implements UpdateProperties {
   private final TableOperations ops;
@@ -99,19 +100,39 @@ class PropertiesUpdate implements UpdateProperties {
   @Override
   public void commit() {
     // If existing table commit properties in base are corrupted, allow rectification
-    Tasks.foreach(ops)
-        .retry(base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyTryAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            taskOps -> {
-              Map<String, String> newProperties = apply();
-              TableMetadata updated = base.replaceProperties(newProperties);
-              taskOps.commit(base, updated);
-            });
+    int numRetries =
+        base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(base.propertyTryAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              base.propertyTryAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              base.propertyTryAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              base.propertyTryAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              taskOps -> {
+                Map<String, String> newProperties = apply();
+                TableMetadata updated = base.replaceProperties(newProperties);
+                taskOps.commit(base, updated);
+              });
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -377,9 +377,6 @@ class RemoveSnapshots implements ExpireSnapshots {
                 ops.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -371,6 +371,7 @@ class RemoveSnapshots implements ExpireSnapshots {
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               item -> {
                 TableMetadata updated = internalApply();

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -359,8 +359,7 @@ class RemoveSnapshots implements ExpireSnapshots {
 
   @Override
   public void commit() {
-    int numRetries =
-        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
@@ -378,6 +377,9 @@ class RemoveSnapshots implements ExpireSnapshots {
                 ops.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -378,19 +378,7 @@ class RemoveSnapshots implements ExpireSnapshots {
                 ops.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
     LOG.info(
         "Committed snapshot changes and prepare to clean up files at level={}",

--- a/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
+++ b/core/src/main/java/org/apache/iceberg/RemoveSnapshots.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -358,19 +359,39 @@ class RemoveSnapshots implements ExpireSnapshots {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
-        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            item -> {
-              TableMetadata updated = internalApply();
-              ops.commit(base, updated);
-            });
+    int numRetries =
+        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              item -> {
+                TableMetadata updated = internalApply();
+                ops.commit(base, updated);
+              });
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
     LOG.info(
         "Committed snapshot changes and prepare to clean up files at level={}",
         cleanupLevel.name());

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -29,6 +29,7 @@ import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFA
 
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 public class SetLocation implements UpdateLocation {
   private final TableOperations ops;
@@ -53,14 +54,34 @@ public class SetLocation implements UpdateLocation {
   @Override
   public void commit() {
     TableMetadata base = ops.refresh();
-    Tasks.foreach(ops)
-        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
+    int numRetries =
+        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -66,6 +66,7 @@ public class SetLocation implements UpdateLocation {
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
     } catch (RetryExhaustedException e) {
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -69,19 +69,7 @@ public class SetLocation implements UpdateLocation {
           .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -68,9 +68,6 @@ public class SetLocation implements UpdateLocation {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetLocation.java
+++ b/core/src/main/java/org/apache/iceberg/SetLocation.java
@@ -54,8 +54,7 @@ public class SetLocation implements UpdateLocation {
   @Override
   public void commit() {
     TableMetadata base = ops.refresh();
-    int numRetries =
-        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
@@ -69,6 +68,9 @@ public class SetLocation implements UpdateLocation {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, base.updateLocation(newLocation)));
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 /**
  * Sets the current snapshot directly or by rolling back.
@@ -107,33 +108,53 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
-        .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            taskOps -> {
-              Snapshot snapshot = apply();
-              TableMetadata updated =
-                  TableMetadata.buildFrom(base)
-                      .setBranchSnapshot(snapshot.snapshotId(), SnapshotRef.MAIN_BRANCH)
-                      .build();
+    int numRetries =
+        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              base.propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              taskOps -> {
+                Snapshot snapshot = apply();
+                TableMetadata updated =
+                    TableMetadata.buildFrom(base)
+                        .setBranchSnapshot(snapshot.snapshotId(), SnapshotRef.MAIN_BRANCH)
+                        .build();
 
-              // Do commit this operation even if the metadata has not changed, as we need to
-              // advance the hasLastOpCommited for the transaction's commit to work properly.
-              // (Without any other operations in the transaction, the commitTransaction() call
-              // will be a no-op anyway)
+                // Do commit this operation even if the metadata has not changed, as we need to
+                // advance the hasLastOpCommited for the transaction's commit to work properly.
+                // (Without any other operations in the transaction, the commitTransaction() call
+                // will be a no-op anyway)
 
-              // if the table UUID is missing, add it here. the UUID will be re-created each time
-              // this operation retries
-              // to ensure that if a concurrent operation assigns the UUID, this operation will not
-              // fail.
-              taskOps.commit(base, updated.withUUID());
-            });
+                // if the table UUID is missing, add it here. the UUID will be re-created each time
+                // this operation retries
+                // to ensure that if a concurrent operation assigns the UUID, this operation will not
+                // fail.
+                taskOps.commit(base, updated.withUUID());
+              });
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -142,19 +142,7 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
                 taskOps.commit(base, updated.withUUID());
               });
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -120,6 +120,7 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
               base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 Snapshot snapshot = apply();

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -108,8 +108,7 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
 
   @Override
   public void commit() {
-    int numRetries =
-        base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
@@ -136,11 +135,15 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
 
                 // if the table UUID is missing, add it here. the UUID will be re-created each time
                 // this operation retries
-                // to ensure that if a concurrent operation assigns the UUID, this operation will not
+                // to ensure that if a concurrent operation assigns the UUID, this operation will
+                // not
                 // fail.
                 taskOps.commit(base, updated.withUUID());
               });
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
+++ b/core/src/main/java/org/apache/iceberg/SetSnapshotOperation.java
@@ -141,9 +141,6 @@ class SetSnapshotOperation implements PendingUpdate<Snapshot> {
                 taskOps.commit(base, updated.withUUID());
               });
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -86,19 +86,7 @@ public class SetStatistics implements UpdateStatistics {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw CommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -33,6 +33,7 @@ import java.util.Optional;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 public class SetStatistics implements UpdateStatistics {
 
@@ -62,7 +63,13 @@ public class SetStatistics implements UpdateStatistics {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
+    int numRetries =
+        ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        ops.current()
+            .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
         .retry(ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
         .exponentialBackoff(
             ops.current().propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
@@ -77,6 +84,21 @@ public class SetStatistics implements UpdateStatistics {
               TableMetadata updated = internalApply(base);
               taskOps.commit(base, updated);
             });
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   private TableMetadata internalApply(TableMetadata base) {

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -63,28 +63,31 @@ public class SetStatistics implements UpdateStatistics {
 
   @Override
   public void commit() {
-    int numRetries =
-        ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int numRetries = ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
-        ops.current()
-            .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+        ops.current().propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
     try {
       Tasks.foreach(ops)
-        .retry(ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            ops.current().propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            ops.current().propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            ops.current()
-                .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            taskOps -> {
-              TableMetadata base = taskOps.refresh();
-              TableMetadata updated = internalApply(base);
-              taskOps.commit(base, updated);
-            });
+          .retry(ops.current().propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
+          .exponentialBackoff(
+              ops.current()
+                  .propertyAsInt(COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              ops.current()
+                  .propertyAsInt(COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              ops.current()
+                  .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              taskOps -> {
+                TableMetadata base = taskOps.refresh();
+                TableMetadata updated = internalApply(base);
+                taskOps.commit(base, updated);
+              });
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -85,9 +85,6 @@ public class SetStatistics implements UpdateStatistics {
                 taskOps.commit(base, updated);
               });
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/SetStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/SetStatistics.java
@@ -78,6 +78,7 @@ public class SetStatistics implements UpdateStatistics {
                   .propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 TableMetadata base = taskOps.refresh();

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -531,6 +531,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       } catch (CommitStateUnknownException commitStateUnknownException) {
         throw commitStateUnknownException;
       } catch (RetryExhaustedException e) {
+        cleanAll();
         throw toCommitFailedException(e);
       } catch (RuntimeException e) {
         if (!strictCleanup || e instanceof CleanableFailure) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -530,8 +530,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       } catch (CommitStateUnknownException commitStateUnknownException) {
         throw commitStateUnknownException;
       } catch (RetryExhaustedException e) {
-        int numRetries =
-            base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+        // if the original cause was already a CommitFailedException, keep it
+        if (e.getCause() instanceof CommitFailedException) {
+          throw (CommitFailedException) e.getCause();
+        }
+
+        int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
         int totalTimeoutMs =
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
         if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -928,35 +928,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   private CommitFailedException toCommitFailedException(RetryExhaustedException ex) {
-    if (shouldPreserveCommitFailure(ex.getCause())) {
-      return (CommitFailedException) ex.getCause();
-    }
-
     int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
     int totalTimeoutMs =
         base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
-    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-      return new CommitFailedException(
-          ex,
-          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-          totalTimeoutMs,
-          COMMIT_TOTAL_RETRY_TIME_MS);
-    } else {
-      return new CommitFailedException(
-          ex,
-          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-          numRetries,
-          COMMIT_NUM_RETRIES);
-    }
-  }
-
-  private static boolean shouldPreserveCommitFailure(Throwable cause) {
-    if (!(cause instanceof CommitFailedException)) {
-      return false;
-    }
-
-    String message = cause.getMessage();
-    return message == null || !message.startsWith("Commit failed: table was updated");
+    return CommitRetry.toCommitFailedException(ex, numRetries, totalTimeoutMs);
   }
 
   private static void updateTotal(

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -495,6 +495,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                 base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
                 2.0 /* exponential */)
             .onlyRetryOn(CommitFailedException.class)
+            .throwRetryExhaustedException()
             .countAttempts(commitMetrics().attempts())
             .run(
                 taskOps -> {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -530,11 +530,6 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       } catch (CommitStateUnknownException commitStateUnknownException) {
         throw commitStateUnknownException;
       } catch (RetryExhaustedException e) {
-        // if the original cause was already a CommitFailedException, keep it
-        if (e.getCause() instanceof CommitFailedException) {
-          throw (CommitFailedException) e.getCause();
-        }
-
         int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
         int totalTimeoutMs =
             base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -531,22 +531,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       } catch (CommitStateUnknownException commitStateUnknownException) {
         throw commitStateUnknownException;
       } catch (RetryExhaustedException e) {
-        int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
-        int totalTimeoutMs =
-            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
-        if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-          throw new CommitFailedException(
-              e,
-              "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-              totalTimeoutMs,
-              COMMIT_TOTAL_RETRY_TIME_MS);
-        } else {
-          throw new CommitFailedException(
-              e,
-              "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-              numRetries,
-              COMMIT_NUM_RETRIES);
-        }
+        throw toCommitFailedException(e);
       } catch (RuntimeException e) {
         if (!strictCleanup || e instanceof CleanableFailure) {
           Exceptions.suppressAndThrow(e, this::cleanAll);
@@ -940,6 +925,40 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to read manifest: %s", manifest.path());
     }
+  }
+
+  private CommitFailedException toCommitFailedException(RetryExhaustedException ex) {
+    if (shouldPreserveCommitFailure(ex.getCause())) {
+      return (CommitFailedException) ex.getCause();
+    }
+
+    int numRetries = base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+          totalTimeoutMs,
+          COMMIT_TOTAL_RETRY_TIME_MS);
+    } else {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+          numRetries,
+          COMMIT_NUM_RETRIES);
+    }
+  }
+
+  private static boolean shouldPreserveCommitFailure(Throwable cause) {
+    if (!(cause instanceof CommitFailedException)) {
+      return false;
+    }
+
+    String message = cause.getMessage();
+    return message != null
+        && (message.startsWith("Commit failed: Requirement failed:")
+            || message.startsWith("Commit failed: Validation failed, please retry:"));
   }
 
   private static void updateTotal(

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -77,6 +77,7 @@ import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -528,6 +529,24 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
 
       } catch (CommitStateUnknownException commitStateUnknownException) {
         throw commitStateUnknownException;
+      } catch (RetryExhaustedException e) {
+        int numRetries =
+            base.propertyAsInt(COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+        int totalTimeoutMs =
+            base.propertyAsInt(COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+        if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+          throw new CommitFailedException(
+              e,
+              "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+              totalTimeoutMs,
+              COMMIT_TOTAL_RETRY_TIME_MS);
+        } else {
+          throw new CommitFailedException(
+              e,
+              "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+              numRetries,
+              COMMIT_NUM_RETRIES);
+        }
       } catch (RuntimeException e) {
         if (!strictCleanup || e instanceof CleanableFailure) {
           Exceptions.suppressAndThrow(e, this::cleanAll);

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -956,9 +956,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     }
 
     String message = cause.getMessage();
-    return message != null
-        && (message.startsWith("Commit failed: Requirement failed:")
-            || message.startsWith("Commit failed: Validation failed, please retry:"));
+    return message == null || !message.startsWith("Commit failed: table was updated");
   }
 
   private static void updateTotal(

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -662,9 +662,6 @@ public class CatalogHandlers {
               });
 
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,
@@ -832,9 +829,6 @@ public class CatalogHandlers {
               });
 
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.rest;
 
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 import java.io.IOException;
@@ -103,6 +105,7 @@ import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.View;
@@ -658,6 +661,20 @@ public class CatalogHandlers {
                 taskOps.commit(base, updated);
               });
 
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            COMMIT_NUM_RETRIES_DEFAULT,
+            COMMIT_NUM_RETRIES);
+      }
     } catch (ValidationFailureException e) {
       throw e.wrapped();
     }
@@ -811,6 +828,20 @@ public class CatalogHandlers {
                 taskOps.commit(base, updated);
               });
 
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            COMMIT_NUM_RETRIES_DEFAULT,
+            COMMIT_NUM_RETRIES);
+      }
     } catch (ValidationFailureException e) {
       throw e.wrapped();
     }

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -662,6 +662,9 @@ public class CatalogHandlers {
               });
 
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,
@@ -829,6 +832,9 @@ public class CatalogHandlers {
               });
 
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -20,9 +20,7 @@ package org.apache.iceberg.rest;
 
 import static org.apache.iceberg.TableProperties.COMMIT_MAX_RETRY_WAIT_MS_DEFAULT;
 import static org.apache.iceberg.TableProperties.COMMIT_MIN_RETRY_WAIT_MS_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
 import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES_DEFAULT;
-import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
 import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT;
 
 import java.io.IOException;
@@ -105,7 +103,6 @@ import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.rest.responses.UpdateNamespacePropertiesResponse;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.Tasks;
-import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.SQLViewRepresentation;
 import org.apache.iceberg.view.View;
@@ -624,7 +621,6 @@ public class CatalogHandlers {
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
-          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 TableMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
@@ -662,20 +658,6 @@ public class CatalogHandlers {
                 taskOps.commit(base, updated);
               });
 
-    } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            COMMIT_NUM_RETRIES_DEFAULT,
-            COMMIT_NUM_RETRIES);
-      }
     } catch (ValidationFailureException e) {
       throw e.wrapped();
     }
@@ -801,7 +783,6 @@ public class CatalogHandlers {
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
-          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 ViewMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
@@ -830,20 +811,6 @@ public class CatalogHandlers {
                 taskOps.commit(base, updated);
               });
 
-    } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            COMMIT_NUM_RETRIES_DEFAULT,
-            COMMIT_NUM_RETRIES);
-      }
     } catch (ValidationFailureException e) {
       throw e.wrapped();
     }

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -624,6 +624,7 @@ public class CatalogHandlers {
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 TableMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();
@@ -800,6 +801,7 @@ public class CatalogHandlers {
               COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps -> {
                 ViewMetadata base = isRetry.get() ? taskOps.refresh() : taskOps.current();

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -302,6 +303,16 @@ class RESTTableScan extends DataTableScan {
                             id));
                 }
               });
+    } catch (RetryExhaustedException e) {
+      throw new RemotePlanTimeoutException(
+          String.format(
+              Locale.ROOT,
+              "Remote scan planning for planId: %s did not complete within configured limits"
+                  + " (timeout=%d ms, maxRetries=%d)",
+              planId,
+              maxWaitTimeMs,
+              MAX_RETRIES),
+          e);
     } catch (NotCompleteException e) {
       throw new RemotePlanTimeoutException(
           String.format(

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -265,6 +265,7 @@ class RESTTableScan extends DataTableScan {
           .exponentialBackoff(MIN_SLEEP_MS, MAX_SLEEP_MS, maxWaitTimeMs, SCALE_FACTOR)
           .retry(MAX_RETRIES)
           .onlyRetryOn(NotCompleteException.class)
+          .throwRetryExhaustedException()
           .onFailure(
               (id, err) -> {
                 LOG.warn("Planning failed for plan ID: {}", id, err);

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -241,6 +241,7 @@ public class LockManagers {
         Tasks.foreach(entityId)
             .retry(Integer.MAX_VALUE - 1)
             .onlyRetryOn(IllegalStateException.class)
+            .throwRetryExhaustedException()
             .throwFailureWhenFinished()
             .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
             .run(id -> acquireOnce(id, ownerId));

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -245,6 +245,11 @@ public class LockManagers {
             .exponentialBackoff(acquireIntervalMs(), acquireIntervalMs(), acquireTimeoutMs(), 1)
             .run(id -> acquireOnce(id, ownerId));
         return true;
+      } catch (Tasks.RetryExhaustedException e) {
+        if (e.getCause() instanceof IllegalStateException) {
+          return false;
+        }
+        throw e;
       } catch (IllegalStateException e) {
         return false;
       }

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -460,6 +460,9 @@ public class Tasks {
           boolean timeoutExceeded = durationMs > maxDurationMs && attempt > 1;
 
           if (retryLimitExceeded || timeoutExceeded) {
+            if (attempt <= 1) {
+              throw e;
+            }
             RetryExhaustedException.Reason reason;
             if (timeoutExceeded) {
               LOG.info("Stopping retries after {} ms", durationMs);

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -129,6 +129,7 @@ public class Tasks {
     private long maxDurationMs = 600000; // 10 minutes
     private double scaleFactor = 2.0; // exponential
     private Counter attemptsCounter;
+    private boolean throwRetryExhaustedException = false;
 
     public Builder(Iterable<I> items) {
       this.items = items;
@@ -218,6 +219,11 @@ public class Tasks {
 
     public Builder<I> countAttempts(Counter counter) {
       this.attemptsCounter = counter;
+      return this;
+    }
+
+    public Builder<I> throwRetryExhaustedException() {
+      this.throwRetryExhaustedException = true;
       return this;
     }
 
@@ -474,7 +480,12 @@ public class Tasks {
             } else {
               reason = RetryExhaustedException.Reason.RETRY_LIMIT_EXCEEDED;
             }
-            throw new RetryExhaustedException(e, reason);
+
+            if (throwRetryExhaustedException) {
+              throw new RetryExhaustedException(e, reason);
+            }
+
+            throw e;
           }
 
           int delayMs =

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -459,6 +459,10 @@ public class Tasks {
           boolean retryLimitExceeded = attempt >= maxAttempts;
           boolean timeoutExceeded = durationMs > maxDurationMs && attempt > 1;
 
+          if (!shouldRetry(e)) {
+            throw e;
+          }
+
           if (retryLimitExceeded || timeoutExceeded) {
             if (attempt <= 1) {
               throw e;
@@ -471,33 +475,6 @@ public class Tasks {
               reason = RetryExhaustedException.Reason.RETRY_LIMIT_EXCEEDED;
             }
             throw new RetryExhaustedException(e, reason);
-          }
-
-          if (shouldRetryPredicate != null) {
-            if (!shouldRetryPredicate.test(e)) {
-              throw e;
-            }
-
-          } else if (onlyRetryExceptions != null) {
-            // if onlyRetryExceptions are present, then this retries if one is found
-            boolean matchedRetryException = false;
-            for (Class<? extends Exception> exClass : onlyRetryExceptions) {
-              if (exClass.isInstance(e)) {
-                matchedRetryException = true;
-                break;
-              }
-            }
-            if (!matchedRetryException) {
-              throw e;
-            }
-
-          } else {
-            // otherwise, always retry unless one of the stop exceptions is found
-            for (Class<? extends Exception> exClass : stopRetryExceptions) {
-              if (exClass.isInstance(e)) {
-                throw e;
-              }
-            }
           }
 
           int delayMs =
@@ -518,6 +495,30 @@ public class Tasks {
           }
         }
       }
+    }
+
+    private boolean shouldRetry(Exception exception) {
+      if (shouldRetryPredicate != null) {
+        return shouldRetryPredicate.test(exception);
+      }
+
+      if (onlyRetryExceptions != null) {
+        for (Class<? extends Exception> exClass : onlyRetryExceptions) {
+          if (exClass.isInstance(exception)) {
+            return true;
+          }
+        }
+
+        return false;
+      }
+
+      for (Class<? extends Exception> exClass : stopRetryExceptions) {
+        if (exClass.isInstance(exception)) {
+          return false;
+        }
+      }
+
+      return true;
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -58,6 +58,24 @@ public class Tasks {
     }
   }
 
+  public static class RetryExhaustedException extends RuntimeException {
+    public enum Reason {
+      RETRY_LIMIT_EXCEEDED,
+      TIMEOUT_EXCEEDED
+    }
+
+    private final Reason reason;
+
+    public RetryExhaustedException(Throwable cause, Reason reason) {
+      super(cause);
+      this.reason = reason;
+    }
+
+    public Reason reason() {
+      return reason;
+    }
+  }
+
   public interface FailureTask<I, E extends Exception> {
     void run(I item, Exception exception) throws E;
   }
@@ -415,11 +433,18 @@ public class Tasks {
 
         } catch (Exception e) {
           long durationMs = System.currentTimeMillis() - start;
-          if (attempt >= maxAttempts || (durationMs > maxDurationMs && attempt > 1)) {
-            if (durationMs > maxDurationMs) {
+          boolean retryLimitExceeded = attempt >= maxAttempts;
+          boolean timeoutExceeded = durationMs > maxDurationMs && attempt > 1;
+
+          if (retryLimitExceeded || timeoutExceeded) {
+            RetryExhaustedException.Reason reason;
+            if (timeoutExceeded) {
               LOG.info("Stopping retries after {} ms", durationMs);
+              reason = RetryExhaustedException.Reason.TIMEOUT_EXCEEDED;
+            } else {
+              reason = RetryExhaustedException.Reason.RETRY_LIMIT_EXCEEDED;
             }
-            throw e;
+            throw new RetryExhaustedException(e, reason);
           }
 
           if (shouldRetryPredicate != null) {

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -59,6 +59,8 @@ public class Tasks {
   }
 
   public static class RetryExhaustedException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+
     public enum Reason {
       RETRY_LIMIT_EXCEEDED,
       TIMEOUT_EXCEEDED

--- a/core/src/main/java/org/apache/iceberg/util/Tasks.java
+++ b/core/src/main/java/org/apache/iceberg/util/Tasks.java
@@ -58,21 +58,42 @@ public class Tasks {
     }
   }
 
+  /**
+   * Exception thrown when retry is exhausted due to either retry limit or timeout.
+   *
+   * <p>This exception wraps the original failure as its cause and provides a {@link Reason} to
+   * distinguish between retry limit exceeded and timeout exceeded, allowing callers to produce
+   * actionable messages that tell operators which table property to tune.
+   */
   public static class RetryExhaustedException extends RuntimeException {
     private static final long serialVersionUID = 1L;
 
+    /** Reason why retry was exhausted. */
     public enum Reason {
+      /** The maximum number of retry attempts was reached. */
       RETRY_LIMIT_EXCEEDED,
+      /** The total retry timeout duration was exceeded. */
       TIMEOUT_EXCEEDED
     }
 
     private final Reason reason;
 
+    /**
+     * Creates a new retry exhausted exception.
+     *
+     * @param cause the underlying failure that caused retries
+     * @param reason the reason why retry was exhausted
+     */
     public RetryExhaustedException(Throwable cause, Reason reason) {
       super(cause);
       this.reason = reason;
     }
 
+    /**
+     * Returns the reason why retry was exhausted.
+     *
+     * @return the exhaustion reason
+     */
     public Reason reason() {
       return reason;
     }

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -80,6 +80,9 @@ class PropertiesUpdate implements UpdateViewProperties {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -81,19 +81,7 @@ class PropertiesUpdate implements UpdateViewProperties {
           .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw ViewCommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -80,9 +80,6 @@ class PropertiesUpdate implements UpdateViewProperties {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 class PropertiesUpdate implements UpdateViewProperties {
   private final ViewOperations ops;
@@ -60,20 +61,39 @@ class PropertiesUpdate implements UpdateViewProperties {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
-        .retry(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(taskOps -> taskOps.commit(base, internalApply()));
+    int numRetries =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(numRetries)
+          .exponentialBackoff(
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              totalTimeoutMs,
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(taskOps -> taskOps.commit(base, internalApply()));
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/view/PropertiesUpdate.java
@@ -78,6 +78,7 @@ class PropertiesUpdate implements UpdateViewProperties {
               totalTimeoutMs,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -72,9 +72,6 @@ class SetViewLocation implements UpdateLocation {
               taskOps ->
                   taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -72,6 +72,9 @@ class SetViewLocation implements UpdateLocation {
               taskOps ->
                   taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -73,19 +73,7 @@ class SetViewLocation implements UpdateLocation {
               taskOps ->
                   taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw ViewCommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 class SetViewLocation implements UpdateLocation {
   private final ViewOperations ops;
@@ -50,22 +51,41 @@ class SetViewLocation implements UpdateLocation {
   @Override
   public void commit() {
     ViewMetadata base = ops.refresh();
-    Tasks.foreach(ops)
-        .retry(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(
-            taskOps ->
-                taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
+    int numRetries =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(numRetries)
+          .exponentialBackoff(
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              totalTimeoutMs,
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(
+              taskOps ->
+                  taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
+++ b/core/src/main/java/org/apache/iceberg/view/SetViewLocation.java
@@ -68,6 +68,7 @@ class SetViewLocation implements UpdateLocation {
               totalTimeoutMs,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(
               taskOps ->
                   taskOps.commit(base, ViewMetadata.buildFrom(base).setLocation(apply()).build()));

--- a/core/src/main/java/org/apache/iceberg/view/ViewCommitRetry.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewCommitRetry.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.view;
+
+import static org.apache.iceberg.TableProperties.COMMIT_NUM_RETRIES;
+import static org.apache.iceberg.TableProperties.COMMIT_TOTAL_RETRY_TIME_MS;
+
+import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
+
+class ViewCommitRetry {
+  private ViewCommitRetry() {}
+
+  static CommitFailedException toCommitFailedException(
+      RetryExhaustedException ex, int numRetries, int totalTimeoutMs) {
+    if (shouldPreserveCommitFailure(ex.getCause())) {
+      return (CommitFailedException) ex.getCause();
+    }
+
+    if (ex.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+          totalTimeoutMs,
+          COMMIT_TOTAL_RETRY_TIME_MS);
+    } else {
+      return new CommitFailedException(
+          ex,
+          "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+          numRetries,
+          COMMIT_NUM_RETRIES);
+    }
+  }
+
+  private static boolean shouldPreserveCommitFailure(Throwable cause) {
+    if (!(cause instanceof CommitFailedException)) {
+      return false;
+    }
+
+    String message = cause.getMessage();
+    return message == null || !message.startsWith("Commit failed: view was updated");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/view/ViewCommitRetry.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewCommitRetry.java
@@ -53,7 +53,6 @@ class ViewCommitRetry {
       return false;
     }
 
-    String message = cause.getMessage();
-    return message == null || !message.startsWith("Commit failed: view was updated");
+    return true;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -107,6 +107,9 @@ class ViewVersionReplace implements ReplaceViewVersion {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
+      if (e.getCause() instanceof CommitFailedException) {
+        throw (CommitFailedException) e.getCause();
+      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -105,6 +105,7 @@ class ViewVersionReplace implements ReplaceViewVersion {
               totalTimeoutMs,
               2.0 /* exponential */)
           .onlyRetryOn(CommitFailedException.class)
+          .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
+import org.apache.iceberg.util.Tasks.RetryExhaustedException;
 
 class ViewVersionReplace implements ReplaceViewVersion {
   private final ViewOperations ops;
@@ -87,20 +88,39 @@ class ViewVersionReplace implements ReplaceViewVersion {
 
   @Override
   public void commit() {
-    Tasks.foreach(ops)
-        .retry(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT))
-        .exponentialBackoff(
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
-            PropertyUtil.propertyAsInt(
-                base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT),
-            2.0 /* exponential */)
-        .onlyRetryOn(CommitFailedException.class)
-        .run(taskOps -> taskOps.commit(base, internalApply()));
+    int numRetries =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_NUM_RETRIES, COMMIT_NUM_RETRIES_DEFAULT);
+    int totalTimeoutMs =
+        PropertyUtil.propertyAsInt(
+            base.properties(), COMMIT_TOTAL_RETRY_TIME_MS, COMMIT_TOTAL_RETRY_TIME_MS_DEFAULT);
+    try {
+      Tasks.foreach(ops)
+          .retry(numRetries)
+          .exponentialBackoff(
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MIN_RETRY_WAIT_MS, COMMIT_MIN_RETRY_WAIT_MS_DEFAULT),
+              PropertyUtil.propertyAsInt(
+                  base.properties(), COMMIT_MAX_RETRY_WAIT_MS, COMMIT_MAX_RETRY_WAIT_MS_DEFAULT),
+              totalTimeoutMs,
+              2.0 /* exponential */)
+          .onlyRetryOn(CommitFailedException.class)
+          .run(taskOps -> taskOps.commit(base, internalApply()));
+    } catch (RetryExhaustedException e) {
+      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
+            totalTimeoutMs,
+            COMMIT_TOTAL_RETRY_TIME_MS);
+      } else {
+        throw new CommitFailedException(
+            e,
+            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
+            numRetries,
+            COMMIT_NUM_RETRIES);
+      }
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -107,9 +107,6 @@ class ViewVersionReplace implements ReplaceViewVersion {
           .onlyRetryOn(CommitFailedException.class)
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
-      if (e.getCause() instanceof CommitFailedException) {
-        throw (CommitFailedException) e.getCause();
-      }
       if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
         throw new CommitFailedException(
             e,

--- a/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewVersionReplace.java
@@ -108,19 +108,7 @@ class ViewVersionReplace implements ReplaceViewVersion {
           .throwRetryExhaustedException()
           .run(taskOps -> taskOps.commit(base, internalApply()));
     } catch (RetryExhaustedException e) {
-      if (e.reason() == RetryExhaustedException.Reason.TIMEOUT_EXCEEDED) {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry timeout (%d ms) reached. Consider increasing '%s'",
-            totalTimeoutMs,
-            COMMIT_TOTAL_RETRY_TIME_MS);
-      } else {
-        throw new CommitFailedException(
-            e,
-            "Commit failed and retry limit (%d) reached. Consider increasing '%s'",
-            numRetries,
-            COMMIT_NUM_RETRIES);
-      }
+      throw ViewCommitRetry.toCommitFailedException(e, numRetries, totalTimeoutMs);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestTasks.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTasks.java
@@ -19,7 +19,10 @@
 package org.apache.iceberg.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.metrics.Counter;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
@@ -56,5 +59,49 @@ public class TestTasks {
     Tasks.foreach(IntStream.range(0, 10)).countAttempts(counter).run(x -> {});
 
     assertThat(counter.value()).isOne();
+  }
+
+  @Test
+  public void retryExhaustionIncludesReason() {
+    assertThatThrownBy(
+            () ->
+                Tasks.foreach(Collections.singleton(1))
+                    .retry(1)
+                    .exponentialBackoff(0, 0, 5000, 0)
+                    .onlyRetryOn(IllegalStateException.class)
+                    .run(
+                        item -> {
+                          throw new IllegalStateException("Retryable failure");
+                        }))
+        .isInstanceOf(Tasks.RetryExhaustedException.class)
+        .hasCauseInstanceOf(IllegalStateException.class)
+        .satisfies(
+            thrown ->
+                assertThat(((Tasks.RetryExhaustedException) thrown).reason())
+                    .isEqualTo(Tasks.RetryExhaustedException.Reason.RETRY_LIMIT_EXCEEDED));
+  }
+
+  @Test
+  public void retryExhaustionDoesNotWrapNonRetryableFailure() {
+    AtomicInteger attempts = new AtomicInteger();
+
+    assertThatThrownBy(
+            () ->
+                Tasks.foreach(Collections.singleton(1))
+                    .retry(1)
+                    .exponentialBackoff(0, 0, 5000, 0)
+                    .onlyRetryOn(IllegalStateException.class)
+                    .run(
+                        item -> {
+                          if (attempts.incrementAndGet() == 1) {
+                            throw new IllegalStateException("Retryable failure");
+                          }
+
+                          throw new IllegalArgumentException("Not retryable");
+                        }))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Not retryable");
+
+    assertThat(attempts).hasValue(2);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestTasks.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTasks.java
@@ -69,12 +69,14 @@ public class TestTasks {
                     .retry(1)
                     .exponentialBackoff(0, 0, 5000, 0)
                     .onlyRetryOn(IllegalStateException.class)
+                    .throwRetryExhaustedException()
                     .run(
                         item -> {
                           throw new IllegalStateException("Retryable failure");
                         }))
         .isInstanceOf(Tasks.RetryExhaustedException.class)
         .hasCauseInstanceOf(IllegalStateException.class)
+        .hasMessage("java.lang.IllegalStateException: Retryable failure")
         .satisfies(
             thrown ->
                 assertThat(((Tasks.RetryExhaustedException) thrown).reason())


### PR DESCRIPTION
### Summary

Fixes #16744.

When commit retry is exhausted, the failure message currently rethrows the underlying `CommitFailedException` without indicating why the retry loop stopped. This makes it hard for operators to know which table property to tune (`commit.retry.num-retries` vs `commit.retry.total-timeout-ms`).

This change:
- Adds `RetryExhaustedException` with a `Reason` enum (`RETRY_LIMIT_EXCEEDED` / `TIMEOUT_EXCEEDED`) in `Tasks.java`
- Throws `RetryExhaustedException` (preserving the original exception as cause) when retry is exhausted
- Catches `RetryExhaustedException` at all 14 commit call sites and translates the reason into actionable messages, e.g.:
  - `"Commit failed and retry timeout (60000 ms) reached. Consider increasing 'commit.retry.total-timeout-ms'"`
  - `"Commit failed and retry limit (4) reached. Consider increasing 'commit.retry.num-retries'"`

The design keeps the generic retry utility (`Tasks`) unaware of Iceberg property names — classification happens in `Tasks`, translation happens at commit call sites.

### Testing

```bash
./gradlew :iceberg-core:test --tests "org.apache.iceberg.util.TestTasks"
./gradlew :iceberg-core:compileJava
```