### PR TITLE
Core: Cache manifest list files in manifest content cache

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -184,7 +184,7 @@ class BaseSnapshot implements Snapshot {
       // if manifests isn't set, then the snapshotFile is set and should be read to get the list
       this.allManifests =
           ManifestLists.read(
-              ManifestFiles.newInputFile(
+              ManifestLists.newInputFile(
                   fileIO, new BaseManifestListFile(manifestListLocation, keyId)));
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -184,7 +184,8 @@ class BaseSnapshot implements Snapshot {
       // if manifests isn't set, then the snapshotFile is set and should be read to get the list
       this.allManifests =
           ManifestLists.read(
-              fileIO.newInputFile(new BaseManifestListFile(manifestListLocation, keyId)));
+              ManifestFiles.newInputFile(
+                  fileIO, new BaseManifestListFile(manifestListLocation, keyId)));
     }
 
     if (dataManifests == null || deleteManifests == null) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -562,6 +562,15 @@ public class ManifestFiles {
     return writer.toManifestFile();
   }
 
+  static InputFile newInputFile(FileIO io, ManifestListFile manifestList) {
+    InputFile input = io.newInputFile(manifestList);
+    if (cachingEnabled(io)) {
+      return contentCache(io).tryCache(input);
+    }
+
+    return input;
+  }
+
   private static InputFile newInputFile(FileIO io, ManifestFile manifest) {
     InputFile input = io.newInputFile(manifest);
     if (cachingEnabled(io)) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -562,15 +562,6 @@ public class ManifestFiles {
     return writer.toManifestFile();
   }
 
-  static InputFile newInputFile(FileIO io, ManifestListFile manifestList) {
-    InputFile input = io.newInputFile(manifestList);
-    if (cachingEnabled(io)) {
-      return contentCache(io).tryCache(input);
-    }
-
-    return input;
-  }
-
   private static InputFile newInputFile(FileIO io, ManifestFile manifest) {
     InputFile input = io.newInputFile(manifest);
     if (cachingEnabled(io)) {

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -30,6 +31,15 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 class ManifestLists {
   private ManifestLists() {}
+
+  static InputFile newInputFile(FileIO io, ManifestListFile manifestList) {
+    InputFile input = io.newInputFile(manifestList);
+    if (ManifestFiles.cachingEnabled(io)) {
+      return ManifestFiles.contentCache(io).tryCache(input);
+    }
+
+    return input;
+  }
 
   static List<ManifestFile> read(InputFile manifestList) {
     try (CloseableIterable<ManifestFile> files =

--- a/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestCaching.java
@@ -75,21 +75,60 @@ public class TestManifestCaching {
     TableScan scan1 =
         table.newScan().option(TableProperties.SPLIT_SIZE, String.valueOf(8 * 1024 * 1024));
     assertThat(scan1.planTasks()).hasSize(numFiles * 2);
+    // each append commit caches one manifest and one manifest list: parent manifest lists are
+    // read while committing, and the current snapshot's manifest list is read while planning
     assertThat(cache.estimatedCacheSize())
-        .as("All manifest files should be cached")
-        .isEqualTo(numFiles);
+        .as("All manifest files and manifest lists should be cached")
+        .isEqualTo(numFiles * 2);
     assertThat(cache.stats().loadSuccessCount())
-        .as("All manifest files should be recently loaded")
-        .isEqualTo(numFiles);
+        .as("All manifest files and manifest lists should be recently loaded")
+        .isEqualTo(numFiles * 2);
     long missCount = ManifestFiles.contentCacheStats(table.io()).missCount();
 
     // planFiles and verify that cache size still the same
     TableScan scan2 = table.newScan();
     assertThat(scan2.planFiles()).hasSize(numFiles);
-    assertThat(cache.estimatedCacheSize()).isEqualTo(numFiles);
+    assertThat(cache.estimatedCacheSize()).isEqualTo(numFiles * 2);
     assertThat(ManifestFiles.contentCacheStats(table.io()).missCount())
         .as("All manifest file reads should hit cache")
         .isEqualTo(missCount);
+
+    ManifestFiles.dropCache(table.io());
+  }
+
+  @Test
+  public void testManifestListCaching() throws Exception {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            CatalogProperties.FILE_IO_IMPL,
+            HadoopFileIO.class.getName(),
+            CatalogProperties.IO_MANIFEST_CACHE_ENABLED,
+            "true");
+    Table table = createTable(properties);
+    appendFiles(newFiles(1, 1024), table);
+    String metadataLocation =
+        ((HasTableOperations) table).operations().current().metadataFileLocation();
+
+    // start from an empty cache because the commit above may have already populated it
+    ManifestFiles.dropCache(table.io());
+    ContentCache cache = ManifestFiles.contentCache(table.io());
+    assertThat(cache.estimatedCacheSize()).isEqualTo(0);
+
+    // a freshly parsed snapshot reads the manifest list through the content cache
+    TableMetadata firstMetadata = TableMetadataParser.read(table.io(), metadataLocation);
+    assertThat(firstMetadata.currentSnapshot().allManifests(table.io())).hasSize(1);
+    assertThat(cache.estimatedCacheSize()).as("Manifest list should be cached").isEqualTo(1);
+    assertThat(ManifestFiles.contentCacheStats(table.io()).missCount()).isEqualTo(1);
+    long hits = ManifestFiles.contentCacheStats(table.io()).hitCount();
+
+    // a new snapshot instance reading the same manifest list is served from the cache
+    TableMetadata secondMetadata = TableMetadataParser.read(table.io(), metadataLocation);
+    assertThat(secondMetadata.currentSnapshot().allManifests(table.io())).hasSize(1);
+    assertThat(cache.estimatedCacheSize()).isEqualTo(1);
+    assertThat(ManifestFiles.contentCacheStats(table.io()).missCount())
+        .as("Manifest list read should be served from the cache")
+        .isEqualTo(1);
+    assertThat(ManifestFiles.contentCacheStats(table.io()).hitCount()).isGreaterThan(hits);
 
     ManifestFiles.dropCache(table.io());
   }


### PR DESCRIPTION
## Summary

When `io.manifest.cache.enabled` is set, manifest files are served through `ContentCache`, but manifest **list** files are not — `BaseSnapshot.cacheManifests` reads the list with a raw `FileIO.newInputFile` call. Every freshly loaded `Snapshot` (table refresh, new table handle, streaming poll) therefore re-fetches the same immutable manifest-list file from object storage, even when the content cache is enabled and warm.

This change routes the manifest-list read through the same content cache used for manifests:

- `ManifestFiles.newInputFile(FileIO, ManifestListFile)` — package-private twin of the existing `newInputFile(FileIO, ManifestFile)` helper: wraps the input with `ContentCache.tryCache` when caching is enabled for the `FileIO`.
- `BaseSnapshot.cacheManifests` uses it for the manifest-list read.

Manifest lists are immutable and location-unique like manifests, so the existing cache keying and invalidation semantics apply unchanged. Encrypted manifest lists follow the same contract as manifests today: the `FileIO` (e.g. `EncryptingFileIO`) controls decryption, and caching behavior is identical to the manifest path.

## Test plan

- New `TestManifestCaching.testManifestListCaching`: a freshly parsed snapshot loads the manifest list through the cache (miss + cache-size increase), and a second snapshot instance reading the same list is served from the cache (no new miss, hit count increases).
- Updated `testPlanWithCache` expectations: with the change, each append commit also caches one manifest list (parent lists are read while committing, and the current snapshot's list while planning), so the cache holds `numFiles * 2` entries.
- Verified locally: `TestManifestCaching` (6/6), `TestManifestListVersions`, `TestSnapshot`, `TestCommitReporting`, `TestManifestListEncryption`, plus spotless and checkstyle.
