### PR TITLE
API, Parquet: Map geometry and geography to Parquet logical types

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -680,18 +680,19 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      return Objects.equals(crs, that.crs) && Objects.equals(algorithm, that.algorithm);
+      // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
+      return crs().equals(that.crs()) && algorithm() == that.algorithm();
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeographyType.class, crs, algorithm);
+      return Objects.hash(GeographyType.class, crs(), algorithm());
     }
 
     @Override
     public String toString() {
-      if (algorithm != null) {
-        return String.format("geography(%s, %s)", crs != null ? crs : DEFAULT_CRS, algorithm);
+      if (algorithm() != DEFAULT_ALGORITHM) {
+        return String.format("geography(%s, %s)", crs(), algorithm());
       } else if (crs != null) {
         return String.format("geography(%s)", crs);
       } else {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -570,6 +570,13 @@ public class Types {
     }
   }
 
+  /**
+   * A geometry type, optionally parameterized by a CRS (default {@code OGC:CRS84}).
+   *
+   * <p>CRS values are compared case-insensitively, so two geometry types whose CRS differ only in
+   * case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its original
+   * casing in {@link #toString()} and in serialized metadata.
+   */
   public static class GeometryType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
     private static final String NAME = "geometry";
@@ -600,13 +607,6 @@ public class Types {
       return TypeID.GEOMETRY;
     }
 
-    /**
-     * Returns this type's CRS, preserving the casing it was created with.
-     *
-     * <p>CRS values are compared case-insensitively, so two {@code geometry} types whose CRS differ
-     * only in case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its
-     * original casing in {@link #toString()} and in serialized metadata.
-     */
     public String crs() {
       return crs;
     }
@@ -636,6 +636,14 @@ public class Types {
     }
   }
 
+  /**
+   * A geography type, optionally parameterized by a CRS (default {@code OGC:CRS84}) and an
+   * edge-interpolation algorithm (default {@code spherical}).
+   *
+   * <p>CRS values are compared case-insensitively, so two geography types whose CRS differ only in
+   * case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its original
+   * casing in {@link #toString()} and in serialized metadata.
+   */
   public static class GeographyType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
     public static final EdgeAlgorithm DEFAULT_ALGORITHM = EdgeAlgorithm.SPHERICAL;
@@ -673,13 +681,6 @@ public class Types {
       return TypeID.GEOGRAPHY;
     }
 
-    /**
-     * Returns this type's CRS, preserving the casing it was created with.
-     *
-     * <p>CRS values are compared case-insensitively, so two {@code geography} types whose CRS
-     * differ only in case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps
-     * its original casing in {@link #toString()} and in serialized metadata.
-     */
     public String crs() {
       return crs;
     }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -590,7 +590,8 @@ public class Types {
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      // an omitted CRS canonicalizes to the default; a provided value is kept as-is (case preserved)
+      // an omitted CRS canonicalizes to the default; a provided value is kept as-is (case
+      // preserved)
       this.crs = crs == null ? DEFAULT_CRS : crs;
     }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -625,7 +625,8 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("%s(%s)", NAME, crs);
+      // format from the resolved getter so equal types serialize identically and CRS is canonical
+      return String.format("%s(%s)", NAME, crs());
     }
   }
 
@@ -697,7 +698,8 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("%s(%s, %s)", NAME, crs, algorithm);
+      // format from the resolved getters so equal types serialize identically and CRS is canonical
+      return String.format("%s(%s, %s)", NAME, crs(), algorithm());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -570,13 +570,7 @@ public class Types {
     }
   }
 
-  /**
-   * A geometry type, optionally parameterized by a CRS (default {@code OGC:CRS84}).
-   *
-   * <p>CRS values are compared case-insensitively, so two geometry types whose CRS differ only in
-   * case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its original
-   * casing in {@link #toString()} and in serialized metadata.
-   */
+  /** A geometry type, optionally parameterized by a CRS. The default CRS is {@code OGC:CRS84}. */
   public static class GeometryType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
     private static final String NAME = "geometry";
@@ -611,6 +605,10 @@ public class Types {
       return crs;
     }
 
+    /**
+     * Two geometry types are equal when their CRS match case-insensitively, so {@code OGC:CRS84}
+     * and {@code ogc:crs84} are equal.
+     */
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -620,7 +618,6 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      // CRS is compared case-insensitively
       return crs.equalsIgnoreCase(that.crs);
     }
 
@@ -637,12 +634,8 @@ public class Types {
   }
 
   /**
-   * A geography type, optionally parameterized by a CRS (default {@code OGC:CRS84}) and an
-   * edge-interpolation algorithm (default {@code spherical}).
-   *
-   * <p>CRS values are compared case-insensitively, so two geography types whose CRS differ only in
-   * case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its original
-   * casing in {@link #toString()} and in serialized metadata.
+   * A geography type, optionally parameterized by a CRS and an edge-interpolation algorithm. The
+   * default CRS is {@code OGC:CRS84} and the default algorithm is {@code spherical}.
    */
   public static class GeographyType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
@@ -689,6 +682,10 @@ public class Types {
       return algorithm;
     }
 
+    /**
+     * Two geography types are equal when their edge algorithms are equal and their CRS match
+     * case-insensitively, so {@code OGC:CRS84} and {@code ogc:crs84} are equal.
+     */
     @Override
     public boolean equals(Object o) {
       if (this == o) {
@@ -698,7 +695,6 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      // CRS is compared case-insensitively
       return crs.equalsIgnoreCase(that.crs) && Objects.equals(algorithm, that.algorithm);
     }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -59,8 +59,8 @@ public class Types {
           .put(BinaryType.get().toString(), BinaryType.get())
           .put(UnknownType.get().toString(), UnknownType.get())
           .put(VariantType.get().toString(), VariantType.get())
-          .put(GeometryType.crs84().toString(), GeometryType.crs84())
-          .put(GeographyType.crs84().toString(), GeographyType.crs84())
+          .put("geometry", GeometryType.crs84())
+          .put("geography", GeographyType.crs84())
           .buildOrThrow();
 
   private static final Pattern FIXED = Pattern.compile("fixed\\[\\s*(\\d+)\\s*\\]");
@@ -584,12 +584,12 @@ public class Types {
     private final String crs;
 
     private GeometryType() {
-      crs = null;
+      crs = DEFAULT_CRS;
     }
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs;
+      this.crs = crs != null ? crs : DEFAULT_CRS;
     }
 
     @Override
@@ -598,7 +598,7 @@ public class Types {
     }
 
     public String crs() {
-      if (crs == null || DEFAULT_CRS.equalsIgnoreCase(crs)) {
+      if (DEFAULT_CRS.equalsIgnoreCase(crs)) {
         return DEFAULT_CRS;
       }
 
@@ -624,10 +624,6 @@ public class Types {
 
     @Override
     public String toString() {
-      if (crs == null) {
-        return "geometry";
-      }
-
       return String.format("geometry(%s)", crs);
     }
   }
@@ -652,14 +648,14 @@ public class Types {
     private final EdgeAlgorithm algorithm;
 
     private GeographyType() {
-      this.crs = null;
-      this.algorithm = null;
+      this.crs = DEFAULT_CRS;
+      this.algorithm = DEFAULT_ALGORITHM;
     }
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs;
-      this.algorithm = algorithm;
+      this.crs = crs != null ? crs : DEFAULT_CRS;
+      this.algorithm = algorithm != null ? algorithm : DEFAULT_ALGORITHM;
     }
 
     @Override
@@ -668,7 +664,7 @@ public class Types {
     }
 
     public String crs() {
-      if (crs == null || DEFAULT_CRS.equalsIgnoreCase(crs)) {
+      if (DEFAULT_CRS.equalsIgnoreCase(crs)) {
         return DEFAULT_CRS;
       }
 
@@ -676,7 +672,7 @@ public class Types {
     }
 
     public EdgeAlgorithm algorithm() {
-      return algorithm != null ? algorithm : DEFAULT_ALGORITHM;
+      return algorithm;
     }
 
     @Override
@@ -699,13 +695,7 @@ public class Types {
 
     @Override
     public String toString() {
-      if (algorithm != null) {
-        return String.format("geography(%s, %s)", crs(), algorithm());
-      } else if (crs != null) {
-        return String.format("geography(%s)", crs);
-      } else {
-        return "geography";
-      }
+      return String.format("geography(%s, %s)", crs, algorithm);
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -585,13 +585,12 @@ public class Types {
     private final String crs;
 
     private GeometryType() {
-      crs = DEFAULT_CRS;
+      crs = null;
     }
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      // canonicalize the default CRS (any casing or omitted) so the stored field is comparable
-      this.crs = crs == null || DEFAULT_CRS.equalsIgnoreCase(crs) ? DEFAULT_CRS : crs;
+      this.crs = crs;
     }
 
     @Override
@@ -600,7 +599,7 @@ public class Types {
     }
 
     public String crs() {
-      return crs;
+      return crs != null ? crs : DEFAULT_CRS;
     }
 
     @Override
@@ -612,17 +611,17 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      return Objects.equals(crs, that.crs);
+      return crs().equals(that.crs());
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeometryType.class, crs);
+      return Objects.hash(GeometryType.class, crs());
     }
 
     @Override
     public String toString() {
-      return String.format("%s(%s)", NAME, crs);
+      return String.format("%s(%s)", NAME, crs());
     }
   }
 
@@ -647,16 +646,14 @@ public class Types {
     private final EdgeAlgorithm algorithm;
 
     private GeographyType() {
-      this.crs = DEFAULT_CRS;
-      this.algorithm = DEFAULT_ALGORITHM;
+      this.crs = null;
+      this.algorithm = null;
     }
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      // canonicalize the default CRS and algorithm (any casing or omitted) so the stored fields
-      // are comparable
-      this.crs = crs == null || DEFAULT_CRS.equalsIgnoreCase(crs) ? DEFAULT_CRS : crs;
-      this.algorithm = algorithm != null ? algorithm : DEFAULT_ALGORITHM;
+      this.crs = crs;
+      this.algorithm = algorithm;
     }
 
     @Override
@@ -665,11 +662,11 @@ public class Types {
     }
 
     public String crs() {
-      return crs;
+      return crs != null ? crs : DEFAULT_CRS;
     }
 
     public EdgeAlgorithm algorithm() {
-      return algorithm;
+      return algorithm != null ? algorithm : DEFAULT_ALGORITHM;
     }
 
     @Override
@@ -681,17 +678,18 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      return Objects.equals(crs, that.crs) && Objects.equals(algorithm, that.algorithm);
+      // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
+      return crs().equals(that.crs()) && algorithm() == that.algorithm();
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeographyType.class, crs, algorithm);
+      return Objects.hash(GeographyType.class, crs(), algorithm());
     }
 
     @Override
     public String toString() {
-      return String.format("%s(%s, %s)", NAME, crs, algorithm);
+      return String.format("%s(%s, %s)", NAME, crs(), algorithm());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -590,7 +590,8 @@ public class Types {
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs;
+      // an omitted CRS canonicalizes to the default; a provided value is kept as-is (case preserved)
+      this.crs = crs == null ? DEFAULT_CRS : crs;
     }
 
     @Override
@@ -599,7 +600,7 @@ public class Types {
     }
 
     public String crs() {
-      return crs != null ? crs : DEFAULT_CRS;
+      return crs;
     }
 
     @Override
@@ -611,17 +612,17 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      return crs().equals(that.crs());
+      return crs.equalsIgnoreCase(that.crs);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeometryType.class, crs());
+      return Objects.hash(GeometryType.class, crs.toUpperCase(Locale.ROOT));
     }
 
     @Override
     public String toString() {
-      return String.format("%s(%s)", NAME, crs());
+      return String.format("%s(%s)", NAME, crs);
     }
   }
 
@@ -651,8 +652,10 @@ public class Types {
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs;
-      this.algorithm = algorithm;
+      // an omitted CRS/algorithm canonicalizes to the default; a provided CRS is kept as-is (case
+      // preserved)
+      this.crs = crs == null ? DEFAULT_CRS : crs;
+      this.algorithm = algorithm == null ? DEFAULT_ALGORITHM : algorithm;
     }
 
     @Override
@@ -661,11 +664,11 @@ public class Types {
     }
 
     public String crs() {
-      return crs != null ? crs : DEFAULT_CRS;
+      return crs;
     }
 
     public EdgeAlgorithm algorithm() {
-      return algorithm != null ? algorithm : DEFAULT_ALGORITHM;
+      return algorithm;
     }
 
     @Override
@@ -677,18 +680,17 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
-      return crs().equals(that.crs()) && algorithm() == that.algorithm();
+      return crs.equalsIgnoreCase(that.crs) && algorithm == that.algorithm;
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeographyType.class, crs(), algorithm());
+      return Objects.hash(GeographyType.class, crs.toUpperCase(Locale.ROOT), algorithm);
     }
 
     @Override
     public String toString() {
-      return String.format("%s(%s, %s)", NAME, crs(), algorithm());
+      return String.format("%s(%s, %s)", NAME, crs, algorithm);
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -590,7 +590,8 @@ public class Types {
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs != null ? crs : DEFAULT_CRS;
+      // canonicalize the default CRS (any casing or omitted) so the stored field is comparable
+      this.crs = crs == null || DEFAULT_CRS.equalsIgnoreCase(crs) ? DEFAULT_CRS : crs;
     }
 
     @Override
@@ -599,10 +600,6 @@ public class Types {
     }
 
     public String crs() {
-      if (DEFAULT_CRS.equalsIgnoreCase(crs)) {
-        return DEFAULT_CRS;
-      }
-
       return crs;
     }
 
@@ -615,18 +612,17 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      return Objects.equals(crs(), that.crs());
+      return Objects.equals(crs, that.crs);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeometryType.class, crs());
+      return Objects.hash(GeometryType.class, crs);
     }
 
     @Override
     public String toString() {
-      // format from the resolved getter so equal types serialize identically and CRS is canonical
-      return String.format("%s(%s)", NAME, crs());
+      return String.format("%s(%s)", NAME, crs);
     }
   }
 
@@ -657,7 +653,9 @@ public class Types {
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = crs != null ? crs : DEFAULT_CRS;
+      // canonicalize the default CRS and algorithm (any casing or omitted) so the stored fields
+      // are comparable
+      this.crs = crs == null || DEFAULT_CRS.equalsIgnoreCase(crs) ? DEFAULT_CRS : crs;
       this.algorithm = algorithm != null ? algorithm : DEFAULT_ALGORITHM;
     }
 
@@ -667,10 +665,6 @@ public class Types {
     }
 
     public String crs() {
-      if (DEFAULT_CRS.equalsIgnoreCase(crs)) {
-        return DEFAULT_CRS;
-      }
-
       return crs;
     }
 
@@ -687,19 +681,17 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
-      return Objects.equals(crs(), that.crs()) && Objects.equals(algorithm(), that.algorithm());
+      return Objects.equals(crs, that.crs) && Objects.equals(algorithm, that.algorithm);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeographyType.class, crs(), algorithm());
+      return Objects.hash(GeographyType.class, crs, algorithm);
     }
 
     @Override
     public String toString() {
-      // format from the resolved getters so equal types serialize identically and CRS is canonical
-      return String.format("%s(%s, %s)", NAME, crs(), algorithm());
+      return String.format("%s(%s, %s)", NAME, crs, algorithm);
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -695,7 +695,7 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      return crs.equalsIgnoreCase(that.crs) && algorithm == that.algorithm;
+      return crs.equalsIgnoreCase(that.crs) && Objects.equals(algorithm, that.algorithm);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -600,6 +600,13 @@ public class Types {
       return TypeID.GEOMETRY;
     }
 
+    /**
+     * Returns this type's CRS, preserving the casing it was created with.
+     *
+     * <p>CRS values are compared case-insensitively, so two {@code geometry} types whose CRS differ
+     * only in case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps its
+     * original casing in {@link #toString()} and in serialized metadata.
+     */
     public String crs() {
       return crs;
     }
@@ -664,6 +671,13 @@ public class Types {
       return TypeID.GEOGRAPHY;
     }
 
+    /**
+     * Returns this type's CRS, preserving the casing it was created with.
+     *
+     * <p>CRS values are compared case-insensitively, so two {@code geography} types whose CRS
+     * differ only in case (e.g. {@code OGC:CRS84} vs {@code ogc:crs84}) are equal. Each value keeps
+     * its original casing in {@link #toString()} and in serialized metadata.
+     */
     public String crs() {
       return crs;
     }

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -620,11 +620,13 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
+      // CRS is compared case-insensitively
       return crs.equalsIgnoreCase(that.crs);
     }
 
     @Override
     public int hashCode() {
+      // hash the upper-cased CRS so it stays consistent with the case-insensitive equals
       return Objects.hash(GeometryType.class, crs.toUpperCase(Locale.ROOT));
     }
 
@@ -695,11 +697,13 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
+      // CRS is compared case-insensitively
       return crs.equalsIgnoreCase(that.crs) && Objects.equals(algorithm, that.algorithm);
     }
 
     @Override
     public int hashCode() {
+      // hash the upper-cased CRS so it stays consistent with the case-insensitive equals
       return Objects.hash(GeographyType.class, crs.toUpperCase(Locale.ROOT), algorithm);
     }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -632,7 +632,7 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("%s(%s)", NAME, crs);
+      return String.format("%s(%s)", NAME, crs());
     }
   }
 
@@ -709,7 +709,7 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("%s(%s, %s)", NAME, crs, algorithm);
+      return String.format("%s(%s, %s)", NAME, crs(), algorithm());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -589,7 +589,7 @@ public class Types {
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = DEFAULT_CRS.equalsIgnoreCase(crs) ? null : crs;
+      this.crs = crs;
     }
 
     @Override
@@ -598,7 +598,11 @@ public class Types {
     }
 
     public String crs() {
-      return crs != null ? crs : DEFAULT_CRS;
+      if (crs == null || DEFAULT_CRS.equalsIgnoreCase(crs)) {
+        return DEFAULT_CRS;
+      }
+
+      return crs;
     }
 
     @Override
@@ -610,12 +614,12 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      return Objects.equals(crs, that.crs);
+      return crs().equals(that.crs());
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeometryType.class, crs);
+      return Objects.hash(GeometryType.class, crs());
     }
 
     @Override
@@ -654,7 +658,7 @@ public class Types {
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
-      this.crs = DEFAULT_CRS.equalsIgnoreCase(crs) ? null : crs;
+      this.crs = crs;
       this.algorithm = algorithm;
     }
 
@@ -664,7 +668,11 @@ public class Types {
     }
 
     public String crs() {
-      return crs != null ? crs : DEFAULT_CRS;
+      if (crs == null || DEFAULT_CRS.equalsIgnoreCase(crs)) {
+        return DEFAULT_CRS;
+      }
+
+      return crs;
     }
 
     public EdgeAlgorithm algorithm() {
@@ -691,7 +699,7 @@ public class Types {
 
     @Override
     public String toString() {
-      if (algorithm() != DEFAULT_ALGORITHM) {
+      if (algorithm != null) {
         return String.format("geography(%s, %s)", crs(), algorithm());
       } else if (crs != null) {
         return String.format("geography(%s)", crs);

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -615,7 +615,7 @@ public class Types {
       }
 
       GeometryType that = (GeometryType) o;
-      return crs().equals(that.crs());
+      return Objects.equals(crs(), that.crs());
     }
 
     @Override
@@ -687,7 +687,7 @@ public class Types {
 
       GeographyType that = (GeographyType) o;
       // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
-      return crs().equals(that.crs()) && algorithm() == that.algorithm();
+      return Objects.equals(crs(), that.crs()) && Objects.equals(algorithm(), that.algorithm());
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -585,7 +585,7 @@ public class Types {
     private final String crs;
 
     private GeometryType() {
-      crs = null;
+      this(null);
     }
 
     private GeometryType(String crs) {
@@ -646,8 +646,7 @@ public class Types {
     private final EdgeAlgorithm algorithm;
 
     private GeographyType() {
-      this.crs = null;
-      this.algorithm = null;
+      this(null, null);
     }
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -59,8 +59,8 @@ public class Types {
           .put(BinaryType.get().toString(), BinaryType.get())
           .put(UnknownType.get().toString(), UnknownType.get())
           .put(VariantType.get().toString(), VariantType.get())
-          .put("geometry", GeometryType.crs84())
-          .put("geography", GeographyType.crs84())
+          .put(GeometryType.NAME, GeometryType.crs84())
+          .put(GeographyType.NAME, GeographyType.crs84())
           .buildOrThrow();
 
   private static final Pattern FIXED = Pattern.compile("fixed\\[\\s*(\\d+)\\s*\\]");
@@ -572,6 +572,7 @@ public class Types {
 
   public static class GeometryType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
+    private static final String NAME = "geometry";
 
     public static GeometryType crs84() {
       return new GeometryType();
@@ -624,13 +625,14 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("geometry(%s)", crs);
+      return String.format("%s(%s)", NAME, crs);
     }
   }
 
   public static class GeographyType extends PrimitiveType {
     public static final String DEFAULT_CRS = "OGC:CRS84";
     public static final EdgeAlgorithm DEFAULT_ALGORITHM = EdgeAlgorithm.SPHERICAL;
+    private static final String NAME = "geography";
 
     public static GeographyType crs84() {
       return new GeographyType();
@@ -695,7 +697,7 @@ public class Types {
 
     @Override
     public String toString() {
-      return String.format("geography(%s, %s)", crs, algorithm);
+      return String.format("%s(%s, %s)", NAME, crs, algorithm);
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
+++ b/api/src/test/java/org/apache/iceberg/TestPartitionSpecValidation.java
@@ -351,8 +351,12 @@ public class TestPartitionSpecValidation {
   private static Object[][] unsupportedFieldsProvider() {
     return new Object[][] {
       {7, "variant_partition1", "Cannot partition by non-primitive source field: variant"},
-      {8, "geom_partition1", "Invalid source type geometry for transform: bucket[5]"},
-      {9, "geog_partition1", "Invalid source type geography for transform: bucket[5]"},
+      {8, "geom_partition1", "Invalid source type geometry(OGC:CRS84) for transform: bucket[5]"},
+      {
+        9,
+        "geog_partition1",
+        "Invalid source type geography(OGC:CRS84, spherical) for transform: bucket[5]"
+      },
       {10, "unknown_partition1", "Invalid source type unknown for transform: bucket[5]"}
     };
   }

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -169,8 +169,7 @@ public class TestTypes {
     assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS).toString())
         .isEqualTo("geometry(OGC:CRS84)");
     assertThat(Types.GeometryType.of("srid:4326").toString()).isEqualTo("geometry(srid:4326)");
-    assertThat(Types.GeographyType.crs84().toString())
-        .isEqualTo("geography(OGC:CRS84, spherical)");
+    assertThat(Types.GeographyType.crs84().toString()).isEqualTo("geography(OGC:CRS84, spherical)");
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY).toString())
         .isEqualTo("geography(srid:4326, karney)");
     assertThat(Types.GeographyType.of(null, EdgeAlgorithm.KARNEY).toString())

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -166,6 +166,8 @@ public class TestTypes {
   @Test
   public void testGeospatialTypeToString() {
     assertThat(Types.GeometryType.crs84().toString()).isEqualTo("geometry");
+    assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS).toString())
+        .isEqualTo("geometry(OGC:CRS84)");
     assertThat(Types.GeometryType.of("srid:4326").toString()).isEqualTo("geometry(srid:4326)");
     assertThat(Types.GeographyType.crs84().toString()).isEqualTo("geography");
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY).toString())
@@ -175,9 +177,9 @@ public class TestTypes {
     assertThat(
             Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.SPHERICAL)
                 .toString())
-        .isEqualTo("geography");
+        .isEqualTo("geography(OGC:CRS84, spherical)");
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
-        .isEqualTo("geography(srid:4326)");
+        .isEqualTo("geography(srid:4326, spherical)");
   }
 
   @Test
@@ -185,6 +187,9 @@ public class TestTypes {
     // the default CRS and edge algorithm normalize so that equivalent type specs are equal
     assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS))
         .isEqualTo(Types.GeometryType.crs84());
+    assertThat(Types.GeometryType.of("ogc:crs84"))
+        .isEqualTo(Types.GeometryType.crs84())
+        .hasSameHashCodeAs(Types.GeometryType.crs84());
     assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS))
         .isEqualTo(Types.GeographyType.crs84());
     assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.SPHERICAL))

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -181,7 +181,7 @@ public class TestTypes {
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
         .isEqualTo("geography(srid:4326, spherical)");
 
-    // a non-canonical CRS string is passed through verbatim (no case normalization)
+    // the CRS keeps its original casing in toString even though comparison is case-insensitive
     assertThat(Types.GeometryType.of("ogc:crs84").toString()).isEqualTo("geometry(ogc:crs84)");
     assertThat(Types.GeographyType.of("ogc:crs84").toString())
         .isEqualTo("geography(ogc:crs84, spherical)");
@@ -206,9 +206,13 @@ public class TestTypes {
         .isNotEqualTo(Types.GeographyType.of("srid:4326"));
     assertThat(Types.GeographyType.of("srid:4326")).isNotEqualTo(Types.GeographyType.crs84());
 
-    // only the exact default CRS collapses; a different casing is a distinct CRS (not normalized)
-    assertThat(Types.GeometryType.of("ogc:crs84")).isNotEqualTo(Types.GeometryType.crs84());
-    assertThat(Types.GeographyType.of("ogc:crs84")).isNotEqualTo(Types.GeographyType.crs84());
+    // CRS comparison is case-insensitive: any casing of a CRS is equal and hashes the same
+    assertThat(Types.GeometryType.of("ogc:crs84"))
+        .isEqualTo(Types.GeometryType.crs84())
+        .hasSameHashCodeAs(Types.GeometryType.crs84());
+    assertThat(Types.GeographyType.of("ogc:crs84"))
+        .isEqualTo(Types.GeographyType.crs84())
+        .hasSameHashCodeAs(Types.GeographyType.crs84());
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -180,6 +180,12 @@ public class TestTypes {
         .isEqualTo("geography(OGC:CRS84, spherical)");
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
         .isEqualTo("geography(srid:4326, spherical)");
+
+    // a default CRS supplied with non-canonical casing serializes in canonical form, matching
+    // equals
+    assertThat(Types.GeometryType.of("ogc:crs84").toString()).isEqualTo("geometry(OGC:CRS84)");
+    assertThat(Types.GeographyType.of("ogc:crs84").toString())
+        .isEqualTo("geography(OGC:CRS84, spherical)");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -165,11 +165,12 @@ public class TestTypes {
 
   @Test
   public void testGeospatialTypeToString() {
-    assertThat(Types.GeometryType.crs84().toString()).isEqualTo("geometry");
+    assertThat(Types.GeometryType.crs84().toString()).isEqualTo("geometry(OGC:CRS84)");
     assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS).toString())
         .isEqualTo("geometry(OGC:CRS84)");
     assertThat(Types.GeometryType.of("srid:4326").toString()).isEqualTo("geometry(srid:4326)");
-    assertThat(Types.GeographyType.crs84().toString()).isEqualTo("geography");
+    assertThat(Types.GeographyType.crs84().toString())
+        .isEqualTo("geography(OGC:CRS84, spherical)");
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY).toString())
         .isEqualTo("geography(srid:4326, karney)");
     assertThat(Types.GeographyType.of(null, EdgeAlgorithm.KARNEY).toString())

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -172,6 +172,32 @@ public class TestTypes {
         .isEqualTo("geography(srid:4326, karney)");
     assertThat(Types.GeographyType.of(null, EdgeAlgorithm.KARNEY).toString())
         .isEqualTo("geography(OGC:CRS84, karney)");
+    assertThat(
+            Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.SPHERICAL)
+                .toString())
+        .isEqualTo("geography");
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
+        .isEqualTo("geography(srid:4326)");
+  }
+
+  @Test
+  public void testGeospatialTypeDefaultNormalization() {
+    // the default CRS and edge algorithm normalize so that equivalent type specs are equal
+    assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS))
+        .isEqualTo(Types.GeometryType.crs84());
+    assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS))
+        .isEqualTo(Types.GeographyType.crs84());
+    assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.SPHERICAL))
+        .isEqualTo(Types.GeographyType.crs84())
+        .hasSameHashCodeAs(Types.GeographyType.crs84());
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL))
+        .isEqualTo(Types.GeographyType.of("srid:4326"))
+        .hasSameHashCodeAs(Types.GeographyType.of("srid:4326"));
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).algorithm())
+        .isEqualTo(EdgeAlgorithm.SPHERICAL);
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY))
+        .isNotEqualTo(Types.GeographyType.of("srid:4326"));
+    assertThat(Types.GeographyType.of("srid:4326")).isNotEqualTo(Types.GeographyType.crs84());
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -181,21 +181,17 @@ public class TestTypes {
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
         .isEqualTo("geography(srid:4326, spherical)");
 
-    // a default CRS supplied with non-canonical casing serializes in canonical form, matching
-    // equals
-    assertThat(Types.GeometryType.of("ogc:crs84").toString()).isEqualTo("geometry(OGC:CRS84)");
+    // a non-canonical CRS string is passed through verbatim (no case normalization)
+    assertThat(Types.GeometryType.of("ogc:crs84").toString()).isEqualTo("geometry(ogc:crs84)");
     assertThat(Types.GeographyType.of("ogc:crs84").toString())
-        .isEqualTo("geography(OGC:CRS84, spherical)");
+        .isEqualTo("geography(ogc:crs84, spherical)");
   }
 
   @Test
   public void testGeospatialTypeDefaultNormalization() {
-    // the default CRS and edge algorithm normalize so that equivalent type specs are equal
+    // an omitted default and an explicit default (exact CRS / spherical algorithm) are equal
     assertThat(Types.GeometryType.of(Types.GeometryType.DEFAULT_CRS))
         .isEqualTo(Types.GeometryType.crs84());
-    assertThat(Types.GeometryType.of("ogc:crs84"))
-        .isEqualTo(Types.GeometryType.crs84())
-        .hasSameHashCodeAs(Types.GeometryType.crs84());
     assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS))
         .isEqualTo(Types.GeographyType.crs84());
     assertThat(Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.SPHERICAL))
@@ -209,6 +205,10 @@ public class TestTypes {
     assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY))
         .isNotEqualTo(Types.GeographyType.of("srid:4326"));
     assertThat(Types.GeographyType.of("srid:4326")).isNotEqualTo(Types.GeographyType.crs84());
+
+    // only the exact default CRS collapses; a different casing is a distinct CRS (not normalized)
+    assertThat(Types.GeometryType.of("ogc:crs84")).isNotEqualTo(Types.GeometryType.crs84());
+    assertThat(Types.GeographyType.of("ogc:crs84")).isNotEqualTo(Types.GeographyType.crs84());
   }
 
   @Test

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -267,6 +267,22 @@ abstract class BaseParquetWriter<T> {
 
     @Override
     public Optional<ParquetValueWriter<?>> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      // reject geometry so it does not silently fall through to the generic binary writer; the
+      // geospatial value path is a separate follow-up
+      throw new UnsupportedOperationException("Cannot write geometry value to Parquet");
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      // reject geography so it does not silently fall through to the generic binary writer; the
+      // geospatial value path is a separate follow-up
+      throw new UnsupportedOperationException("Cannot write geography value to Parquet");
+    }
+
+    @Override
+    public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
       return Optional.of(ParquetValueWriters.uuids(desc));
     }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -29,9 +29,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.TimestampType;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -253,6 +255,25 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     @Override
     public Optional<Type> visit(LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonType) {
       return Optional.of(Types.BinaryType.get());
+    }
+
+    @Override
+    public Optional<Type> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      String crs = geometryType.getCrs();
+      return Optional.of(Types.GeometryType.of(crs != null ? crs : Types.GeometryType.DEFAULT_CRS));
+    }
+
+    @Override
+    public Optional<Type> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      String crs = geographyType.getCrs();
+      EdgeInterpolationAlgorithm algorithm = geographyType.getAlgorithm();
+      return Optional.of(
+          Types.GeographyType.of(
+              crs != null ? crs : Types.GeographyType.DEFAULT_CRS,
+              algorithm != null
+                  ? EdgeAlgorithm.fromName(algorithm.name())
+                  : Types.GeographyType.DEFAULT_ALGORITHM));
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -259,21 +259,19 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
 
     @Override
     public Optional<Type> visit(LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
-      String crs = geometryType.getCrs();
-      return Optional.of(Types.GeometryType.of(crs != null ? crs : Types.GeometryType.DEFAULT_CRS));
+      // a null crs resolves to the Iceberg default in GeometryType.of
+      return Optional.of(Types.GeometryType.of(geometryType.getCrs()));
     }
 
     @Override
     public Optional<Type> visit(
         LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
-      String crs = geographyType.getCrs();
+      // a null crs / algorithm resolves to the Iceberg default in GeographyType.of
       EdgeInterpolationAlgorithm algorithm = geographyType.getAlgorithm();
       return Optional.of(
           Types.GeographyType.of(
-              crs != null ? crs : Types.GeographyType.DEFAULT_CRS,
-              algorithm != null
-                  ? EdgeAlgorithm.fromName(algorithm.name())
-                  : Types.GeographyType.DEFAULT_ALGORITHM));
+              geographyType.getCrs(),
+              algorithm != null ? EdgeAlgorithm.fromName(algorithm.name()) : null));
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -30,12 +30,15 @@ import java.util.function.BiFunction;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type.NestedType;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.FixedType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
@@ -43,6 +46,7 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
@@ -280,9 +284,31 @@ public class TypeToMessageType {
             .id(id)
             .named(name);
 
+      case GEOMETRY:
+        GeometryType geometry = (GeometryType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(LogicalTypeAnnotation.geometryType(geometry.crs()))
+            .id(id)
+            .named(name);
+
+      case GEOGRAPHY:
+        GeographyType geography = (GeographyType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(
+                LogicalTypeAnnotation.geographyType(
+                    geography.crs(), toParquet(geography.algorithm())))
+            .id(id)
+            .named(name);
+
       default:
         throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);
     }
+  }
+
+  private static EdgeInterpolationAlgorithm toParquet(EdgeAlgorithm algorithm) {
+    // Iceberg and Parquet use the same algorithm names (SPHERICAL, VINCENTY, THOMAS, ANDOYER,
+    // KARNEY) so the algorithm is mapped by name
+    return EdgeInterpolationAlgorithm.valueOf(algorithm.name());
   }
 
   private static LogicalTypeAnnotation decimalAnnotation(int precision, int scale) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -100,6 +101,39 @@ public class TestParquetDataWriter {
   @Test
   public void testDataWriter() throws IOException {
     testDataWriter(SCHEMA, (id, name) -> null);
+  }
+
+  @Test
+  public void testGeospatialWriteIsRejected() {
+    Schema geometrySchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "geom", Types.GeometryType.crs84()));
+    assertThatThrownBy(
+            () ->
+                Parquet.writeData(Files.localOutput(createTempFile(temp)))
+                    .schema(geometrySchema)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .overwrite()
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .build())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot write geometry value to Parquet");
+
+    Schema geographySchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "geog", Types.GeographyType.crs84()));
+    assertThatThrownBy(
+            () ->
+                Parquet.writeData(Files.localOutput(createTempFile(temp)))
+                    .schema(geographySchema)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .overwrite()
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .build())
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot write geography value to Parquet");
   }
 
   private void testDataWriter(Schema schema, VariantShreddingFunction variantShreddingFunc)

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -417,8 +417,11 @@ public class TestParquetSchemaUtil {
     assertThat(actualSchema.asStruct())
         .as("Geometry and geography annotations must convert to the expected Iceberg types")
         .isEqualTo(expectedSchema.asStruct());
+    assertThat(actualSchema.findType("geom_bare").toString()).isEqualTo("geometry(OGC:CRS84)");
     assertThat(actualSchema.findType("geom_explicit_default").toString())
         .isEqualTo("geometry(OGC:CRS84)");
+    assertThat(actualSchema.findType("geog_bare").toString())
+        .isEqualTo("geography(OGC:CRS84, spherical)");
     assertThat(actualSchema.findType("geog_explicit_spherical").toString())
         .isEqualTo("geography(EPSG:4326, spherical)");
   }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -417,6 +417,10 @@ public class TestParquetSchemaUtil {
     assertThat(actualSchema.asStruct())
         .as("Geometry and geography annotations must convert to the expected Iceberg types")
         .isEqualTo(expectedSchema.asStruct());
+    assertThat(actualSchema.findType("geom_explicit_default").toString())
+        .isEqualTo("geometry(OGC:CRS84)");
+    assertThat(actualSchema.findType("geog_explicit_spherical").toString())
+        .isEqualTo("geography(EPSG:4326, spherical)");
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetSchemaUtil.java
@@ -22,13 +22,17 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.MappingUtil;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
@@ -335,6 +339,83 @@ public class TestParquetSchemaUtil {
     Schema actualSchema = ParquetSchemaUtil.convertAndPrune(messageType);
     assertThat(actualSchema.asStruct())
         .as("Schema must match")
+        .isEqualTo(expectedSchema.asStruct());
+  }
+
+  @Test
+  public void testGeospatialTypeRoundTrip() {
+    List<Types.NestedField> fields =
+        Lists.newArrayList(
+            required(1, "geom_default", Types.GeometryType.crs84()),
+            optional(2, "geom_3857", Types.GeometryType.of("EPSG:3857")),
+            required(3, "geog_default", Types.GeographyType.crs84()));
+    // cover the by-name algorithm mapping for every edge algorithm in both directions
+    int nextId = fields.size() + 1;
+    for (EdgeAlgorithm algorithm : EdgeAlgorithm.values()) {
+      fields.add(
+          optional(nextId++, "geog_" + algorithm, Types.GeographyType.of("EPSG:4326", algorithm)));
+    }
+
+    Schema schema = new Schema(fields);
+    MessageType messageType = ParquetSchemaUtil.convert(schema, "geo_table");
+    Schema actualSchema = ParquetSchemaUtil.convert(messageType);
+    assertThat(actualSchema.asStruct())
+        .as("Schema must round-trip through Parquet geometry/geography logical types")
+        .isEqualTo(schema.asStruct());
+  }
+
+  @Test
+  public void testGeospatialAnnotationsWithOmittedParameters() {
+    // unset CRS and algorithm parameters must map to Iceberg's defaults, and explicit values
+    // (including explicit default values) must be preserved
+    MessageType messageType =
+        org.apache.parquet.schema.Types.buildMessage()
+            .required(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType(null))
+            .id(1)
+            .named("geom_bare")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType("OGC:CRS84"))
+            .id(2)
+            .named("geom_explicit_default")
+            .required(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geographyType(null, null))
+            .id(3)
+            .named("geog_bare")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geographyType("EPSG:4326", null))
+            .id(4)
+            .named("geog_crs_only")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geographyType(null, EdgeInterpolationAlgorithm.ANDOYER))
+            .id(5)
+            .named("geog_algorithm_only")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(
+                LogicalTypeAnnotation.geographyType(
+                    "EPSG:4326", EdgeInterpolationAlgorithm.SPHERICAL))
+            .id(6)
+            .named("geog_explicit_spherical")
+            .named("geo_table");
+
+    Schema expectedSchema =
+        new Schema(
+            required(1, "geom_bare", Types.GeometryType.crs84()),
+            optional(2, "geom_explicit_default", Types.GeometryType.crs84()),
+            required(3, "geog_bare", Types.GeographyType.crs84()),
+            optional(4, "geog_crs_only", Types.GeographyType.of("EPSG:4326")),
+            optional(
+                5,
+                "geog_algorithm_only",
+                Types.GeographyType.of(Types.GeographyType.DEFAULT_CRS, EdgeAlgorithm.ANDOYER)),
+            optional(
+                6,
+                "geog_explicit_spherical",
+                Types.GeographyType.of("EPSG:4326", EdgeAlgorithm.SPHERICAL)));
+
+    Schema actualSchema = ParquetSchemaUtil.convert(messageType);
+    assertThat(actualSchema.asStruct())
+        .as("Geometry and geography annotations must convert to the expected Iceberg types")
         .isEqualTo(expectedSchema.asStruct());
   }
 


### PR DESCRIPTION
## Summary

Map Iceberg `geometry` and `geography` primitive types to and from Parquet's geometry / geography logical type annotations on a `BINARY` column, so the geo types survive a schema round-trip through `ParquetSchemaUtil.convert` in both directions.

- `TypeToMessageType`: emit `geometry` / `geography` as `BINARY` annotated with `LogicalTypeAnnotation.geometryType` / `geographyType`, passing the resolved CRS and edge-interpolation algorithm through directly. Iceberg and Parquet use the same algorithm names (`SPHERICAL`, `VINCENTY`, `THOMAS`, `ANDOYER`, `KARNEY`), so the algorithm is mapped by name.
- `MessageTypeToType`: read those annotations back into `Types.GeometryType` / `Types.GeographyType`. An unset `crs` / `algorithm` maps to the Iceberg default (the Parquet defaults are the same: `OGC:CRS84` / `SPHERICAL`), and algorithm names are resolved with `EdgeAlgorithm.fromName`, the same conversion used when parsing geography type strings (`Types.fromPrimitiveString`).
- `Types.GeometryType` / `Types.GeographyType`: serialize with explicit CRS / edge algorithm defaults (`geometry(OGC:CRS84)`, `geography(OGC:CRS84, spherical)`) so table metadata preserves the concrete defaults being used, while `equals` / `hashCode` compare resolved defaults so default-equivalent forms remain semantically equal. No public signature changes.

This is the first step of plumbing the geo value path through Parquet. It is intentionally **schema mapping only** — the generic value read/write path (`BaseParquetReaders` / `BaseParquetWriter`) and the `ParquetMetrics` guard for geo columns are separate follow-ups, so this PR stays small and easy to review. It is purely additive: no behavior changes for non-geo types.

This is 1/N for https://github.com/apache/iceberg/pull/16650

## Test plan

- [x] `TestParquetSchemaUtil#testGeospatialTypeRoundTrip` round-trips a schema with default-CRS geometry, an explicit-CRS geometry, default geography, and a geography per edge algorithm (all five, so the by-name mapping is exercised for every constant in both directions) through `ParquetSchemaUtil.convert`.
- [x] `TestParquetSchemaUtil#testGeospatialAnnotationsWithOmittedParameters` reads hand-built `MessageType`s with unset / explicit / explicit-default CRS and algorithm — covering files written by engines that omit defaults — and confirms each maps to the expected Iceberg type and serializes with explicit defaults.
- [x] `TestTypes#testGeospatialTypeDefaultNormalization` covers `equals()` / `hashCode()` parity for the default-CRS and default-algorithm geography forms, that `algorithm()` still reports `SPHERICAL`, and that a non-default algorithm stays distinct; `testGeospatialTypeToString` covers explicit-default rendering.
- [x] `./gradlew :iceberg-api:check :iceberg-parquet:check` — clean (tests, checkstyle, revapi, spotless).
- [x] `./gradlew :iceberg-core:test` — full core suite green; no regressions in `TestSchemaParser` / `TestSingleValueParser` / `TestGeospatialTable` or anywhere geography types are serialized.