### PR TITLE
API: Treat default edge algorithm as equal to an omitted one in GeographyType

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -680,18 +680,19 @@ public class Types {
       }
 
       GeographyType that = (GeographyType) o;
-      return Objects.equals(crs, that.crs) && Objects.equals(algorithm, that.algorithm);
+      // compare the resolved CRS and algorithm so an explicit default is equal to an omitted one
+      return crs().equals(that.crs()) && algorithm() == that.algorithm();
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(GeographyType.class, crs, algorithm);
+      return Objects.hash(GeographyType.class, crs(), algorithm());
     }
 
     @Override
     public String toString() {
-      if (algorithm != null) {
-        return String.format("geography(%s, %s)", crs != null ? crs : DEFAULT_CRS, algorithm);
+      if (algorithm() != DEFAULT_ALGORITHM) {
+        return String.format("geography(%s, %s)", crs(), algorithm());
       } else if (crs != null) {
         return String.format("geography(%s)", crs);
       } else {

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -172,6 +172,27 @@ public class TestTypes {
         .isEqualTo("geography(srid:4326, karney)");
     assertThat(Types.GeographyType.of(null, EdgeAlgorithm.KARNEY).toString())
         .isEqualTo("geography(OGC:CRS84, karney)");
+    assertThat(Types.GeographyType.of("OGC:CRS84", EdgeAlgorithm.SPHERICAL).toString())
+        .isEqualTo("geography");
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).toString())
+        .isEqualTo("geography(srid:4326)");
+  }
+
+  @Test
+  public void testGeospatialTypeDefaultNormalization() {
+    // the default CRS and edge algorithm normalize so that equivalent type specs are equal
+    assertThat(Types.GeometryType.of("OGC:CRS84")).isEqualTo(Types.GeometryType.crs84());
+    assertThat(Types.GeographyType.of("OGC:CRS84")).isEqualTo(Types.GeographyType.crs84());
+    assertThat(Types.GeographyType.of("OGC:CRS84", EdgeAlgorithm.SPHERICAL))
+        .isEqualTo(Types.GeographyType.crs84())
+        .hasSameHashCodeAs(Types.GeographyType.crs84());
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL))
+        .isEqualTo(Types.GeographyType.of("srid:4326"))
+        .hasSameHashCodeAs(Types.GeographyType.of("srid:4326"));
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.SPHERICAL).algorithm())
+        .isEqualTo(EdgeAlgorithm.SPHERICAL);
+    assertThat(Types.GeographyType.of("srid:4326", EdgeAlgorithm.KARNEY))
+        .isNotEqualTo(Types.GeographyType.of("srid:4326"));
   }
 
   @Test


### PR DESCRIPTION
## Summary

Make `Types.GeographyType` treat an explicit default edge-interpolation algorithm as equal to an omitted one, so semantically identical geography types compare equal.

`GeographyType` uses `null` internally to mean "default" for both `crs` and `algorithm`, but `equals` / `hashCode` / `toString` compared the raw nullable fields. As a result `GeographyType.of(crs, EdgeAlgorithm.SPHERICAL)` was **not** `equals()` to the equivalent `GeographyType.of(crs)`, even though `SPHERICAL` is the documented default and the `algorithm()` getter resolves to `SPHERICAL` for both. This also meant a plain `geography` did not round-trip through format conversions that omit default values — e.g. Parquet's geography logical type, where an unset `algorithm` defaults to `SPHERICAL` (#16765).

Rather than collapse the default in the constructor, this normalizes at the comparison/render boundary: `equals`, `hashCode`, and `toString` now use the resolved getters `crs()` / `algorithm()`, which already apply the defaults. So an explicit default and an omitted one compare equal and render the same compact form. The constructor is left untouched, and CRS — which already resolved this way through the getter — is brought in line with the algorithm. No public signature changes.

## Test plan

- [x] Extended `testGeospatialTypeToString` to confirm an explicit default `SPHERICAL` renders the same compact form as an omitted algorithm (`geography`, `geography(srid:4326)`).
- [x] New `testGeospatialTypeDefaultNormalization` covers `equals()` / `hashCode()` parity for the default-CRS and default-algorithm forms, that `algorithm()` still reports `SPHERICAL`, and that a non-default algorithm (`KARNEY`) stays distinct.
- [x] `./gradlew :iceberg-api:check` — clean (tests, checkstyle, revapi, spotless).
- [x] `./gradlew :iceberg-core:test` — full core suite green; no regressions in `TestSchemaParser` / `TestSingleValueParser` / `TestGeospatialTable` / `TestSchemaUnionByFieldName` or anywhere geography types are serialized.
