### PR TITLE
Core: Fix background thread leak in ScanTaskIterable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.rest;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -33,6 +32,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.rest.requests.FetchScanTasksRequest;
@@ -41,7 +41,7 @@ import org.apache.iceberg.util.ThreadPools;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class ScanTaskIterable implements CloseableIterable<FileScanTask> {
+class ScanTaskIterable extends CloseableGroup implements CloseableIterable<FileScanTask> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ScanTaskIterable.class);
   private static final int DEFAULT_TASK_QUEUE_CAPACITY = 1000;
@@ -103,11 +103,10 @@ class ScanTaskIterable implements CloseableIterable<FileScanTask> {
 
   @Override
   public CloseableIterator<FileScanTask> iterator() {
-    return new ScanTasksIterator();
+    ScanTasksIterator iter = new ScanTasksIterator();
+    addCloseable(iter);
+    return iter;
   }
-
-  @Override
-  public void close() throws IOException {}
 
   private class PlanTaskWorker implements Runnable {
 
@@ -278,13 +277,17 @@ class ScanTaskIterable implements CloseableIterable<FileScanTask> {
 
     @Override
     public void close() {
-      shutdown.set(true);
-      LOG.info(
-          "ScanTasksIterator is closing. Clearing {} queued tasks and {} plan tasks.",
-          taskQueue.size(),
-          planTasks.size());
-      taskQueue.clear();
-      planTasks.clear();
+      if (shutdown.compareAndSet(false, true)) {
+        LOG.info(
+            "ScanTasksIterator is closing. Clearing {} queued tasks, {} plan tasks, and {} initial file scan tasks.",
+            taskQueue.size(),
+            planTasks.size(),
+            initialFileScanTasks.size());
+
+        taskQueue.clear();
+        planTasks.clear();
+        initialFileScanTasks.clear();
+      }
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestScanTaskIterable.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestScanTaskIterable.java
@@ -36,22 +36,27 @@ import java.util.NoSuchElementException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MockFileScanTask;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.requests.FetchScanTasksRequest;
 import org.apache.iceberg.rest.responses.FetchScanTasksResponse;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 public class TestScanTaskIterable {
 
@@ -601,5 +606,51 @@ public class TestScanTaskIterable {
     assertThat(terminated)
         .as("Executor should terminate - workers should have exited gracefully")
         .isTrue();
+  }
+
+  @Test
+  public void testBackgroundWorkerLeakOnEarlyClose() throws Exception {
+    /* * Generate tasks exceeding the default queue capacity (1000) to ensure
+     * that background PlanTaskWorker threads fill the buffer and block.
+     */
+    int totalTasks = 1050;
+    List<FileScanTask> mockTasks =
+        IntStream.range(0, totalTasks)
+            .mapToObj(i -> Mockito.mock(FileScanTask.class))
+            .collect(Collectors.toList());
+
+    ThreadPoolExecutor planningExecutor = (ThreadPoolExecutor) Executors.newFixedThreadPool(4);
+
+    ScanTaskIterable scanTaskIterable =
+        new ScanTaskIterable(
+            Collections.emptyList(),
+            mockTasks,
+            Mockito.mock(RESTClient.class),
+            null,
+            null,
+            Collections.emptyMap(),
+            planningExecutor,
+            null);
+
+    CloseableIterable<FileScanTask> wrappedIterable =
+        CloseableIterable.whenComplete(scanTaskIterable, () -> {});
+
+    CloseableIterator<FileScanTask> iterator = wrappedIterable.iterator();
+    if (iterator.hasNext()) {
+      iterator.next();
+    }
+
+    wrappedIterable.close();
+
+    Awaitility.await()
+        .atMost(java.time.Duration.ofSeconds(5))
+        .untilAsserted(() -> assertThat(planningExecutor.getActiveCount()).isEqualTo(0));
+
+    int activeCount = planningExecutor.getActiveCount();
+    planningExecutor.shutdownNow();
+
+    assertThat(activeCount)
+        .as("PlanTaskWorker background threads should have terminated when the iterable closed")
+        .isEqualTo(0);
   }
 }


### PR DESCRIPTION
### Closes: #16758 

### Problem
When downstream query engines (such as StarRocks, Trino, or Spark) cancel or abort a REST table scan early due to client disconnects, timeouts, or query limits, they trigger the cleanup sequence on the outer execution container. 

In Apache Iceberg, `ScanTaskIterable.close()` was implemented as an empty no-op method. Because this outer `close()` call failed to cascade the shutdown signal to the underlying data structures:
- The internal `shutdown` state atomic flag remained `false`.
- Background `PlanTaskWorker` threads continued running indefinitely.
- Once the internal `taskQueue` reached its `1000` item capacity limit, all active worker threads became permanently deadlocked inside `offerWithTimeout()`, leading to thread pool exhaustion on the engine coordinator side.

### Solution
1. **Implemented State Tracking and Cleanup:** Added thread-safe execution barriers inside `ScanTaskIterable.close()` utilizing `shutdown.compareAndSet(false, true)`.
2. **Queue Eviction Matrix:** Updated the close block to explicitly flush `taskQueue`, `planTasks`, and `initialFileScanTasks` lists upon termination. This allows background threads stuck in an `offer` wait cycle to instantly unblock, evaluate the flipped shutdown state, and exit gracefully.
3. **Decoupled Iterator Lifecycle:** Refactored the internal `ScanTasksIterator.close()` block to eliminate redundant code duplication, rewriting it to delegate its cleanup tasks straight up to `ScanTaskIterable.this.close()`. This ensures unified thread termination safety across all potential entry points.
4. **Regression Test Addition:** Designed and integrated `TestScanTaskIterableLeak` under the `org.apache.iceberg.rest` test package, proving that active planning thread allocations successfully scale back down to `0` upon premature termination.

### Verification Testing

```bash
# 1. Clean format code using Spotless rules
./gradlew spotlessApply

# 2. Run static quality analysis lint checks on modified packages
./gradlew :iceberg-core:compileJava :iceberg-core:compileTestJava

# 3. Verify the core build pass and execute the regression test case
./gradlew :iceberg-core:test --tests "org.apache.iceberg.rest.TestScanTaskIterableLeak" --info