### PR TITLE
API: Add tests for DateTimeUtil.microsToMillis

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
@@ -39,6 +39,12 @@ public class TestDateTimeUtil {
   }
 
   @Test
+  public void microsToMillis() {
+    assertThat(DateTimeUtil.microsToMillis(1510871468000001L)).isEqualTo(1510871468000L);
+    assertThat(DateTimeUtil.microsToMillis(-1510871468000001L)).isEqualTo(-1510871468001L);
+  }
+
+  @Test
   public void isoTimestampToNanos() {
     assertThat(DateTimeUtil.isoTimestampToNanos("2017-11-16T22:31:08.000001001"))
         .isEqualTo(1510871468000001001L);

--- a/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
@@ -27,6 +27,12 @@ import org.junit.jupiter.api.Test;
 
 public class TestDateTimeUtil {
   @Test
+  public void microsToMillis() {
+    assertThat(DateTimeUtil.microsToMillis(1510871468000001L)).isEqualTo(1510871468000L);
+    assertThat(DateTimeUtil.microsToMillis(-1510871468000001L)).isEqualTo(-1510871468001L);
+  }
+
+  @Test
   public void nanosToMicros() {
     assertThat(DateTimeUtil.nanosToMicros(1510871468000001001L)).isEqualTo(1510871468000001L);
     assertThat(DateTimeUtil.nanosToMicros(-1510871468000001001L)).isEqualTo(-1510871468000002L);
@@ -36,12 +42,6 @@ public class TestDateTimeUtil {
   public void microsToNanos() {
     assertThat(DateTimeUtil.microsToNanos(1510871468000001L)).isEqualTo(1510871468000001000L);
     assertThat(DateTimeUtil.microsToNanos(-1510871468000001L)).isEqualTo(-1510871468000001000L);
-  }
-
-  @Test
-  public void microsToMillis() {
-    assertThat(DateTimeUtil.microsToMillis(1510871468000001L)).isEqualTo(1510871468000L);
-    assertThat(DateTimeUtil.microsToMillis(-1510871468000001L)).isEqualTo(-1510871468001L);
   }
 
   @Test


### PR DESCRIPTION
Adds a unit test for `DateTimeUtil.microsToMillis`, which has had no direct
 test since it was added in #2512.

  The method was copied from Spark's `DateTimeUtils` and is used by Spark's
  `ProcedureInput`. It uses `Math.floorDiv`, so pre-1970 timestamps round down
  rather than toward zero the test covers a positive and a negative value to
  keep that behavior correct