### PR TITLE
Flink: Validate missing watermark column in column stats watermark extractor

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -51,6 +51,8 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
   public ColumnStatsWatermarkExtractor(
       Schema schema, String eventTimeFieldName, TimeUnit timeUnit) {
     Types.NestedField field = schema.findField(eventTimeFieldName);
+    Preconditions.checkArgument(
+        field != null, "Cannot find watermark column: %s", eventTimeFieldName);
     TypeID typeID = field.type().typeId();
     Preconditions.checkArgument(
         typeID.equals(TypeID.LONG)

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -155,6 +156,13 @@ public class TestColumnStatsWatermarkExtractor {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Found STRING, expected a LONG, TIMESTAMP, or TIMESTAMP_NANO column for watermark generation.");
+  }
+
+  @Test
+  public void testMissingColumn() {
+    assertThatThrownBy(() -> new ColumnStatsWatermarkExtractor(SCHEMA, "missing_column", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find watermark column: missing_column");
   }
 
   @TestTemplate

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -51,6 +51,8 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
   public ColumnStatsWatermarkExtractor(
       Schema schema, String eventTimeFieldName, TimeUnit timeUnit) {
     Types.NestedField field = schema.findField(eventTimeFieldName);
+    Preconditions.checkArgument(
+        field != null, "Cannot find watermark column: %s", eventTimeFieldName);
     TypeID typeID = field.type().typeId();
     Preconditions.checkArgument(
         typeID.equals(TypeID.LONG)

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -155,6 +156,13 @@ public class TestColumnStatsWatermarkExtractor {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Found STRING, expected a LONG, TIMESTAMP, or TIMESTAMP_NANO column for watermark generation.");
+  }
+
+  @Test
+  public void testMissingColumn() {
+    assertThatThrownBy(() -> new ColumnStatsWatermarkExtractor(SCHEMA, "missing_column", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find watermark column: missing_column");
   }
 
   @TestTemplate

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -51,6 +51,8 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
   public ColumnStatsWatermarkExtractor(
       Schema schema, String eventTimeFieldName, TimeUnit timeUnit) {
     Types.NestedField field = schema.findField(eventTimeFieldName);
+    Preconditions.checkArgument(
+        field != null, "Cannot find watermark column: %s", eventTimeFieldName);
     TypeID typeID = field.type().typeId();
     Preconditions.checkArgument(
         typeID.equals(TypeID.LONG)

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -155,6 +156,13 @@ public class TestColumnStatsWatermarkExtractor {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining(
             "Found STRING, expected a LONG, TIMESTAMP, or TIMESTAMP_NANO column for watermark generation.");
+  }
+
+  @Test
+  public void testMissingColumn() {
+    assertThatThrownBy(() -> new ColumnStatsWatermarkExtractor(SCHEMA, "missing_column", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find watermark column: missing_column");
   }
 
   @TestTemplate


### PR DESCRIPTION
`ColumnStatsWatermarkExtractor` uses the configured watermark column to derive watermarks from Iceberg column statistics. When the configured column does not exist in the table schema, `schema.findField` returns null and the extractor fails with a `NullPointerException` while reading the field type.

This change validates that the watermark column exists before reading its type, so the failure is reported as an actionable `IllegalArgumentException`.
