### PR TITLE
Infra: Add GitHub Copilot and openspec files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,13 @@ derby.log
 
 # claude code
 .claude/
+
+# For GitHub Copilot
+.github/copilot-instructions.md
+.github/agents/
+.github/instructions/
+.github/prompts/
+.github/skills/
+
+# openspec
+openspec/


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add GitHub Copilot agent configuration files and `openspec/` directory to `.gitignore`.

The following paths are added:
- `.github/copilot-instructions.md`
- `.github/agents/`
- `.github/instructions/`
- `.github/prompts/`
- `.github/skills/`
- `openspec/`

## Why are the changes needed?

GitHub Copilot's agent/instruction/prompt/skill files are user-specific or workspace-specific configurations that individual developers create locally to customize Copilot's behavior. They should not be tracked in the shared repository, similar to how Apache Spark handled this in [SPARK-50935](https://github.com/apache/spark/pull/53781).

The [`openspec/`](https://github.com/Fission-AI/OpenSpec/) directory is a local workspace tool directory that also should be excluded from version control.

## Does this PR introduce _any_ user-facing change?

No.

## How was this patch tested?

N/A — `.gitignore` change only.