### PR TITLE
Core: Backport #16521 - Fix SerializableTable.sortOrders() on historical sort orders with dropped fields

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SerializableTable.java
+++ b/core/src/main/java/org/apache/iceberg/SerializableTable.java
@@ -58,6 +58,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
   private final int defaultSpecId;
   private final Map<Integer, String> specAsJsonMap;
   private final String sortOrderAsJson;
+  private final int defaultSortOrderId;
   private final Map<Integer, String> sortOrderAsJsonMap;
   private final FileIO io;
   private final EncryptionManager encryption;
@@ -83,6 +84,7 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
     Map<Integer, PartitionSpec> specs = table.specs();
     specs.forEach((specId, spec) -> specAsJsonMap.put(specId, PartitionSpecParser.toJson(spec)));
     this.sortOrderAsJson = SortOrderParser.toJson(table.sortOrder());
+    this.defaultSortOrderId = table.sortOrder().orderId();
     this.sortOrderAsJsonMap = Maps.newHashMap();
     table
         .sortOrders()
@@ -253,7 +255,8 @@ public class SerializableTable implements Table, HasTableOperations, Serializabl
           ImmutableMap.Builder<Integer, SortOrder> sortOrders =
               ImmutableMap.builderWithExpectedSize(sortOrderAsJsonMap.size());
           sortOrderAsJsonMap.forEach(
-              (id, json) -> sortOrders.put(id, SortOrderParser.fromJson(schema(), json)));
+              (id, json) ->
+                  sortOrders.put(id, SortOrderParser.fromJson(schema(), json, defaultSortOrderId)));
           this.lazySortOrders = sortOrders.build();
         } else if (lazySortOrders == null) {
           this.lazySortOrders = lazyTable.sortOrders();

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -112,6 +112,10 @@ public class SortOrderParser {
     return fromJson(json).bind(schema);
   }
 
+  public static SortOrder fromJson(Schema schema, String json, int defaultSortOrderId) {
+    return JsonUtil.parse(json, node -> fromJson(schema, node, defaultSortOrderId));
+  }
+
   public static SortOrder fromJson(Schema schema, JsonNode json, int defaultSortOrderId) {
     UnboundSortOrder unboundSortOrder = fromJson(json);
 

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestTableSerialization.java
@@ -80,6 +80,22 @@ public class TestTableSerialization extends HadoopTableTestBase {
   }
 
   @Test
+  public void testSerializableTableSortOrdersWithDroppedColumn()
+      throws IOException, ClassNotFoundException {
+    table.updateSchema().addColumn("ts", Types.LongType.get()).commit();
+    table.replaceSortOrder().asc("id").asc("ts").commit();
+
+    // historical sort order 1 still references "ts" after the column is dropped
+    table.replaceSortOrder().asc("id").commit();
+    table.updateSchema().deleteColumn("ts").commit();
+
+    TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));
+    Table serializableTable = SerializableTable.copyOf(table);
+    TestHelpers.assertSerializedAndLoadedMetadata(
+        serializableTable, TestHelpers.KryoHelpers.roundTripSerialize(serializableTable));
+  }
+
+  @Test
   public void testSerializableTableWithSnapshot() throws IOException, ClassNotFoundException {
     table.newAppend().appendFile(FILE_A).commit();
     TestHelpers.assertSerializedAndLoadedMetadata(table, TestHelpers.roundTripSerialize(table));


### PR DESCRIPTION
Clean backport to the 1.11.x branch