### PR TITLE
Docs: Add guidelines for tests

### DIFF
--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -481,8 +481,8 @@ This helps separate logical sections of the code, making it easier to read and d
 ### Conventions and recommendations
 
 - Test class names must start with `Test`, for example `TestExample`.
-- Recommend omitting the `public` modifier for test classes, test methods, and lifecycle methods.
-- Recommend omitting the `test` prefix for test methods.
+- Omit the `public` modifier for test classes, test methods, and lifecycle methods for newly added tests.
+- Omit the `test` prefix for newly added test methods.
 
 ### AssertJ
 

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -478,6 +478,12 @@ This helps separate logical sections of the code, making it easier to read and d
 
 ## Testing
 
+### Conventions and recommendations
+
+- Test class names must start with `Test`, for example `TestExample`.
+- Recommend omitting the `public` modifier for test classes, test methods, and lifecycle methods.
+- Recommend omitting the `test` prefix for test methods.
+
 ### AssertJ
 
 Prefer using [AssertJ](https://github.com/assertj/assertj) assertions as those provide a rich and intuitive set of strongly-typed assertions.


### PR DESCRIPTION
Currently, the naming conventions for test methods are inconsistent, with some using the `test` prefix and others not.
This PR document outlines the naming convention and its visibility. 

<img width="851" height="242" alt="Screenshot 2026-06-12 at 11 50 10" src="https://github.com/user-attachments/assets/0027a944-e000-4396-9b80-00fe41eeca32" />
