### PR TITLE
Flink: Avoid per-row field getter allocation in RowDataWrapper

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -48,7 +48,14 @@ public class RowDataWrapper implements StructLike {
 
     for (int i = 0; i < size; i++) {
       types[i] = rowType.getTypeAt(i);
-      getters[i] = buildGetter(types[i], struct.fields().get(i).type());
+      PositionalGetter<?> getter = buildGetter(types[i], struct.fields().get(i).type());
+      if (getter == null) {
+        // Pre-build the Flink field getter once instead of recreating it on every access.
+        RowData.FieldGetter fieldGetter = FlinkRowData.createFieldGetter(types[i], i);
+        getter = (row, pos) -> fieldGetter.getFieldOrNull(row);
+      }
+
+      getters[i] = getter;
     }
   }
 
@@ -66,12 +73,9 @@ public class RowDataWrapper implements StructLike {
   public <T> T get(int pos, Class<T> javaClass) {
     if (rowData.isNullAt(pos)) {
       return null;
-    } else if (getters[pos] != null) {
-      return javaClass.cast(getters[pos].get(rowData, pos));
     }
 
-    Object value = FlinkRowData.createFieldGetter(types[pos], pos).getFieldOrNull(rowData);
-    return javaClass.cast(value);
+    return javaClass.cast(getters[pos].get(rowData, pos));
   }
 
   @Override


### PR DESCRIPTION
`RowDataWrapper` adapts a Flink `RowData` to an Iceberg `StructLike` and sits on the hot path of every partitioned write (`PartitionKey.partition`), equality-delete key extraction, and range-shuffle sort-key computation. Its constructor pre-builds a getter for most types, but `buildGetter` returns `null` for the `default` case, which covers the most common primitive types: `INT`, `BIGINT`, `BOOLEAN`, `FLOAT`, `DOUBLE`, and `DATE`. For those fields, `get(pos, javaClass)` falls back to constructing a fresh Flink field getter on every access:

```java
Object value = FlinkRowData.createFieldGetter(types[pos], pos).getFieldOrNull(rowData);
```

`FlinkRowData.createFieldGetter` allocates two lambdas per call (Flink's `RowData.createFieldGetter` plus the null-checking wrapper around it), so every row that is partitioned, keyed, or shuffled on a primitive column allocates two short-lived objects for each such field.

This pre-builds the fallback getter once in the constructor, the same way the wrapper already pre-builds getters for the handled types, so `get` no longer allocates. Behavior is unchanged: the raw Flink value is already the correct Iceberg representation for every default-case type, which is exactly what the previous fallback returned.

The change is identical across the supported Flink versions. This PR applies it to v2.1 only; a backport PR for v1.20 and v2.0 will follow.

### Benchmark

JMH microbenchmark (JDK 17, `-prof gc`) that wraps a row and reads its fields. The schema has seven columns; `readPrimitiveKey` reads only the five primitive columns, representative of a typical partition or equality key.

| Benchmark | Metric | Before | After | Delta |
| --- | --- | --- | --- | --- |
| readPrimitiveKey | time | 64.04 ns/op | 45.31 ns/op | -29.3% |
| readPrimitiveKey | alloc | 275.0 B/op | 75.0 B/op | -72.7% |
| readAllFields | time | 84.25 ns/op | 81.37 ns/op | -3.4% |
| readAllFields | alloc | 275.0 B/op | 75.0 B/op | -72.7% |

The remaining 75 B/op is return-value boxing that this change does not touch.

Existing `TestRowDataWrapper` coverage passes unchanged.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Avoid allocating a field getter per row in RowDataWrapper.

