### PR TITLE
Flink: Build nested field getters once in RowDataProjection

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -109,16 +109,18 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
+        // Build the nested projection once instead of recreating it on every row.
+        RowDataProjection nestedProjection =
+            RowDataProjection.create(
+                nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
+        int nestedFieldCount = nestedRowType.getFieldCount();
         return row -> {
           // null nested struct value
           if (row.isNullAt(position)) {
             return null;
           }
 
-          RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
-          return RowDataProjection.create(
-                  nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
-              .wrap(nestedRow);
+          return nestedProjection.wrap(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -68,20 +68,24 @@ public class RowDataProjection implements RowData {
    */
   public static RowDataProjection create(
       RowType rowType, Types.StructType schema, Types.StructType projectedSchema) {
-    return new RowDataProjection(rowType, schema, projectedSchema);
+    return new RowDataProjection(createFieldGetters(rowType, schema, projectedSchema));
   }
 
   private final RowData.FieldGetter[] getters;
   private RowData rowData;
 
-  private RowDataProjection(
+  private RowDataProjection(RowData.FieldGetter[] getters) {
+    this.getters = getters;
+  }
+
+  private static RowData.FieldGetter[] createFieldGetters(
       RowType rowType, Types.StructType rowStruct, Types.StructType projectType) {
     Map<Integer, Integer> fieldIdToPosition = Maps.newHashMap();
     for (int i = 0; i < rowStruct.fields().size(); i++) {
       fieldIdToPosition.put(rowStruct.fields().get(i).fieldId(), i);
     }
 
-    this.getters = new RowData.FieldGetter[projectType.fields().size()];
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[projectType.fields().size()];
     for (int i = 0; i < getters.length; i++) {
       Types.NestedField projectField = projectType.fields().get(i);
       Types.NestedField rowField = rowStruct.field(projectField.fieldId());
@@ -96,10 +100,8 @@ public class RowDataProjection implements RowData {
           createFieldGetter(
               rowType, fieldIdToPosition.get(projectField.fieldId()), rowField, projectField);
     }
-  }
 
-  private RowDataProjection(RowData.FieldGetter[] getters) {
-    this.getters = getters;
+    return getters;
   }
 
   private static RowData.FieldGetter createFieldGetter(
@@ -113,8 +115,8 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
-        RowDataProjection nestedProjection =
-            RowDataProjection.create(
+        RowData.FieldGetter[] nestedGetters =
+            createFieldGetters(
                 nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
         int nestedFieldCount = nestedRowType.getFieldCount();
         return row -> {
@@ -124,7 +126,7 @@ public class RowDataProjection implements RowData {
           }
 
           // a new wrapper per access keeps nested rows valid after the parent is re-wrapped
-          return nestedProjection.copyFor(row.getRow(position, nestedFieldCount));
+          return new RowDataProjection(nestedGetters).wrap(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:
@@ -173,10 +175,6 @@ public class RowDataProjection implements RowData {
     Preconditions.checkArgument(row != null, "Invalid row data: null");
     this.rowData = row;
     return this;
-  }
-
-  private RowData copyFor(RowData row) {
-    return new RowDataProjection(getters).wrap(row);
   }
 
   private Object getValue(int pos) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/RowDataProjection.java
@@ -98,6 +98,10 @@ public class RowDataProjection implements RowData {
     }
   }
 
+  private RowDataProjection(RowData.FieldGetter[] getters) {
+    this.getters = getters;
+  }
+
   private static RowData.FieldGetter createFieldGetter(
       RowType rowType, int position, Types.NestedField rowField, Types.NestedField projectField) {
     Preconditions.checkArgument(
@@ -109,7 +113,6 @@ public class RowDataProjection implements RowData {
     switch (projectField.type().typeId()) {
       case STRUCT:
         RowType nestedRowType = (RowType) rowType.getTypeAt(position);
-        // Build the nested projection once instead of recreating it on every row.
         RowDataProjection nestedProjection =
             RowDataProjection.create(
                 nestedRowType, rowField.type().asStructType(), projectField.type().asStructType());
@@ -120,7 +123,8 @@ public class RowDataProjection implements RowData {
             return null;
           }
 
-          return nestedProjection.wrap(row.getRow(position, nestedFieldCount));
+          // a new wrapper per access keeps nested rows valid after the parent is re-wrapped
+          return nestedProjection.copyFor(row.getRow(position, nestedFieldCount));
         };
 
       case MAP:
@@ -169,6 +173,10 @@ public class RowDataProjection implements RowData {
     Preconditions.checkArgument(row != null, "Invalid row data: null");
     this.rowData = row;
     return this;
+  }
+
+  private RowData copyFor(RowData row) {
+    return new RowDataProjection(getters).wrap(row);
   }
 
   private Object getValue(int pos) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestRowDataProjection.java
@@ -211,6 +211,29 @@ public class TestRowDataProjection {
   }
 
   @Test
+  void nestedRowIsNotMutatedByNextWrap() {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(0, "id", Types.LongType.get()),
+            Types.NestedField.optional(
+                3,
+                "location",
+                Types.StructType.of(
+                    Types.NestedField.required(1, "lat", Types.FloatType.get()),
+                    Types.NestedField.required(2, "long", Types.FloatType.get()))));
+    RowDataProjection projection = RowDataProjection.create(schema, schema.select("location"));
+
+    RowData first =
+        projection.wrap(GenericRowData.of(1L, GenericRowData.of(1.0f, 1.0f))).getRow(0, 2);
+    RowData second =
+        projection.wrap(GenericRowData.of(2L, GenericRowData.of(9.0f, 9.0f))).getRow(0, 2);
+
+    assertThat(first).isNotSameAs(second);
+    assertThat(first.getFloat(0)).isEqualTo(1.0f);
+    assertThat(second.getFloat(0)).isEqualTo(9.0f);
+  }
+
+  @Test
   public void testPrimitivesFullProjection() {
     DataGenerator dataGenerator = new DataGenerators.Primitives();
     Schema schema = dataGenerator.icebergSchema();


### PR DESCRIPTION
`RowDataProjection` projects a Flink `RowData` to a subset schema. When a projected field is itself a struct, the field getter rebuilt a whole nested `RowDataProjection` on every row:

```java
RowData nestedRow = row.getRow(position, nestedRowType.getFieldCount());
return RowDataProjection.create(
        nestedRowType, rowField.type().asStructType(), projectField.type().asStructType())
    .wrap(nestedRow);
```

Each call allocates the nested projection's field-id-to-position map, its field-getter array, and the recursively built child getters, so every row with a projected nested struct pays for the full projection setup.

This builds the nested field getters once when the parent projection is constructed. Each access still returns a new wrapper around the nested row, but that wrapper only references those pre-built getters, so a nested row taken from one `wrap` call keeps its values after the projection moves on to the next row, as it did before this change. One side effect: an invalid nested projection now fails in `create()` instead of on the first access to a non-null struct, which matches `StructProjection`.

### When this runs

There are two production callers of `RowDataProjection`, and the nested-struct branch is taken only when a nested struct is present in the projected or equality-key schema:

- **Source reads** (`RowDataFileScanTaskReader`): reading a data file that has row-level deletes while projecting a nested struct column. The delete filter widens the read schema with `_pos` whenever position deletes or DVs apply, and with any equality-delete columns the projection does not already include. The reader then projects every row back to the requested schema, and the projected struct rebuilt its nested projection per row.
- **Upsert sinks** (`BaseDeltaTaskWriter`): when the equality / identifier fields include a nested sub-field. The delete-key schema is built with `TypeUtil.select`, which carries the enclosing struct, so the per-row `keyProjection.wrap(row)` projects that struct.

Flat-schema tables, and reads of files without deletes, never take this branch (they use native format projection or primitive getters), so they are unaffected. The per-row cost drops from a full projection setup to one small wrapper object. The change is the same in every supported Flink version; this PR applies it to v2.1 only, and a follow-up PR will port it to v1.20, v2.2 and v2.3.

### Benchmark

JMH microbenchmark (JDK 17, `-prof gc`). Source schema `id: long, location: struct<lat: double, lon: double, name: string>, ts: long`; projected schema `location: struct<lat: double, lon: double>` (the `name` subfield is dropped so the struct is projected rather than passed through). Each invocation wraps a pre-built row, reads the projected `location` struct, and reads its two `double` subfields.

| Benchmark | Metric | Before | After | Delta |
| --- | --- | --- | --- | --- |
| projectNestedStruct | time | 155.90 ns/op | 28.50 ns/op | -81.7% |
| projectNestedStruct | alloc | 448.0 B/op | 72.0 B/op | -83.9% |

`TestRowDataProjection#nestedRowIsNotMutatedByNextWrap` checks that a nested row taken from one `wrap` call keeps its values after the next `wrap`; the existing `TestRowDataProjection` tests pass unchanged.

---
**AI Disclosure**
- Model: Claude Opus 4.8, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Build nested RowDataProjection getters once instead of for every row, without sharing nested rows across wrap calls.

