### PR TITLE
AWS: Use assumed-role credentials for REST SigV4 signing

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.aws;
 
 import java.util.Map;
-import java.util.UUID;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import software.amazon.awssdk.awscore.client.builder.AwsClientBuilder;
@@ -32,15 +31,11 @@ import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
-import software.amazon.awssdk.services.sts.StsClient;
-import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
-import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   private AwsProperties awsProperties;
   private HttpClientProperties httpClientProperties;
   private S3FileIOProperties s3FileIOProperties;
-  private String roleSessionName;
   private AwsClientProperties awsClientProperties;
 
   @Override
@@ -110,7 +105,6 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     this.s3FileIOProperties = new S3FileIOProperties(properties);
     this.httpClientProperties = new HttpClientProperties(properties);
     this.awsClientProperties = new AwsClientProperties(properties);
-    this.roleSessionName = genSessionName();
     Preconditions.checkNotNull(
         awsProperties.clientAssumeRoleArn(),
         "Cannot initialize AssumeRoleClientConfigFactory with null role ARN");
@@ -122,21 +116,21 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
   protected <T extends AwsClientBuilder & AwsSyncClientBuilder> T applyAssumeRoleConfigurations(
       T clientBuilder) {
     clientBuilder
-        .credentialsProvider(createCredentialsProvider())
+        .credentialsProvider(awsProperties.assumeRoleCredentialsProvider())
         .region(Region.of(awsProperties.clientAssumeRoleRegion()));
     return clientBuilder;
   }
 
   protected S3AsyncClientBuilder applyAssumeRoleConfigurations(S3AsyncClientBuilder clientBuilder) {
     return clientBuilder
-        .credentialsProvider(createCredentialsProvider())
+        .credentialsProvider(awsProperties.assumeRoleCredentialsProvider())
         .region(Region.of(awsProperties.clientAssumeRoleRegion()));
   }
 
   protected S3CrtAsyncClientBuilder applyAssumeRoleConfigurations(
       S3CrtAsyncClientBuilder clientBuilder) {
     return clientBuilder
-        .credentialsProvider(createCredentialsProvider())
+        .credentialsProvider(awsProperties.assumeRoleCredentialsProvider())
         .region(Region.of(awsProperties.clientAssumeRoleRegion()));
   }
 
@@ -158,35 +152,5 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
 
   protected AwsClientProperties awsClientProperties() {
     return awsClientProperties;
-  }
-
-  private StsClient sts() {
-    return StsClient.builder()
-        .applyMutation(httpClientProperties::applyHttpClientConfigurations)
-        .build();
-  }
-
-  private String genSessionName() {
-    if (awsProperties.clientAssumeRoleSessionName() != null) {
-      return awsProperties.clientAssumeRoleSessionName();
-    }
-    return String.format("iceberg-aws-%s", UUID.randomUUID());
-  }
-
-  private StsAssumeRoleCredentialsProvider createCredentialsProvider() {
-    return StsAssumeRoleCredentialsProvider.builder()
-        .stsClient(sts())
-        .refreshRequest(createAssumeRoleRequest())
-        .build();
-  }
-
-  private AssumeRoleRequest createAssumeRoleRequest() {
-    return AssumeRoleRequest.builder()
-        .roleArn(awsProperties.clientAssumeRoleArn())
-        .roleSessionName(roleSessionName)
-        .durationSeconds(awsProperties.clientAssumeRoleTimeoutSec())
-        .externalId(awsProperties.clientAssumeRoleExternalId())
-        .tags(awsProperties.stsClientAssumeRoleTags())
-        .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -529,26 +529,33 @@ public class AwsProperties implements Serializable {
     return DefaultCredentialsProvider.builder().build();
   }
 
-  private StsAssumeRoleCredentialsProvider assumeRoleCredentialsProvider() {
-    String sessionName =
-        this.clientAssumeRoleSessionName != null
-            ? this.clientAssumeRoleSessionName
-            : String.format("iceberg-aws-%s", uuid);
-
+  StsAssumeRoleCredentialsProvider assumeRoleCredentialsProvider() {
+    Preconditions.checkNotNull(
+        this.clientAssumeRoleRegion,
+        "Cannot create StsAssumeRoleCredentialsProvider with null region");
     return StsAssumeRoleCredentialsProvider.builder()
         .stsClient(
             StsClient.builder()
                 .applyMutation(httpClientProperties::applyHttpClientConfigurations)
                 .region(Region.of(this.clientAssumeRoleRegion))
                 .build())
-        .refreshRequest(
-            AssumeRoleRequest.builder()
-                .roleArn(this.clientAssumeRoleArn)
-                .roleSessionName(sessionName)
-                .durationSeconds(this.clientAssumeRoleTimeoutSec)
-                .externalId(this.clientAssumeRoleExternalId)
-                .tags(this.stsClientAssumeRoleTags)
-                .build())
+        .refreshRequest(createAssumeRoleRequest())
+        .build();
+  }
+
+  private AssumeRoleRequest createAssumeRoleRequest() {
+    Preconditions.checkNotNull(
+        this.clientAssumeRoleArn, "Cannot create AssumeRoleRequest with null role ARN");
+    String sessionName =
+        this.clientAssumeRoleSessionName != null
+            ? this.clientAssumeRoleSessionName
+            : String.format("iceberg-aws-%s", uuid);
+    return AssumeRoleRequest.builder()
+        .roleArn(this.clientAssumeRoleArn)
+        .roleSessionName(sessionName)
+        .durationSeconds(this.clientAssumeRoleTimeoutSec)
+        .externalId(this.clientAssumeRoleExternalId)
+        .tags(this.stsClientAssumeRoleTags)
         .build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -265,6 +265,8 @@ public class AwsProperties implements Serializable {
   private EncryptionAlgorithmSpec kmsEncryptionAlgorithmSpec;
   private DataKeySpec kmsDataKeySpec;
 
+  private final UUID uuid;
+
   public AwsProperties() {
     this.stsClientAssumeRoleTags = Sets.newHashSet();
 
@@ -291,6 +293,8 @@ public class AwsProperties implements Serializable {
     this.kmsEndpoint = null;
     this.kmsEncryptionAlgorithmSpec = KMS_ENCRYPTION_ALGORITHM_SPEC_DEFAULT;
     this.kmsDataKeySpec = KMS_DATA_KEY_SPEC_DEFAULT;
+
+    this.uuid = UUID.randomUUID();
   }
 
   @SuppressWarnings("MethodLength")
@@ -342,6 +346,8 @@ public class AwsProperties implements Serializable {
     this.kmsDataKeySpec =
         DataKeySpec.fromValue(
             properties.getOrDefault(KMS_DATA_KEY_SPEC, KMS_DATA_KEY_SPEC_DEFAULT.toString()));
+
+    this.uuid = UUID.randomUUID();
   }
 
   public Set<software.amazon.awssdk.services.sts.model.Tag> stsClientAssumeRoleTags() {
@@ -527,7 +533,7 @@ public class AwsProperties implements Serializable {
     String sessionName =
         this.clientAssumeRoleSessionName != null
             ? this.clientAssumeRoleSessionName
-            : String.format("iceberg-aws-%s", UUID.randomUUID());
+            : String.format("iceberg-aws-%s", uuid);
 
     return StsAssumeRoleCredentialsProvider.builder()
         .stsClient(

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -32,6 +32,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
@@ -50,6 +52,8 @@ import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider
 import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AwsProperties implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(AwsProperties.class);
 
   /**
    * The ID of the Glue Data Catalog where the tables reside. If none is provided, Glue
@@ -504,7 +508,15 @@ public class AwsProperties implements Serializable {
     // with the assumed-role credentials so that they do not diverge from the credentials used for
     // S3, Glue, KMS and DynamoDB. See https://github.com/apache/iceberg/issues/16667.
     if (!Strings.isNullOrEmpty(this.clientAssumeRoleArn)) {
-      return assumeRoleCredentialsProvider();
+      if (!Strings.isNullOrEmpty(this.clientAssumeRoleRegion)) {
+        return assumeRoleCredentialsProvider();
+      }
+
+      LOG.warn(
+          "Cannot assume role {} to sign REST requests because {} is not set; "
+              + "falling back to the default credentials provider.",
+          this.clientAssumeRoleArn,
+          CLIENT_ASSUME_ROLE_REGION);
     }
 
     // Create a new credential provider for each client
@@ -512,12 +524,6 @@ public class AwsProperties implements Serializable {
   }
 
   private StsAssumeRoleCredentialsProvider assumeRoleCredentialsProvider() {
-    Preconditions.checkArgument(
-        !Strings.isNullOrEmpty(this.clientAssumeRoleRegion),
-        "Cannot assume role %s to sign REST requests: %s is required",
-        this.clientAssumeRoleArn,
-        CLIENT_ASSUME_ROLE_REGION);
-
     String sessionName =
         this.clientAssumeRoleSessionName != null
             ? this.clientAssumeRoleSessionName

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.aws.dynamodb.DynamoDbCatalog;
 import org.apache.iceberg.aws.lakeformation.LakeFormationAwsClientFactory;
@@ -44,6 +45,9 @@ import software.amazon.awssdk.services.glue.GlueClientBuilder;
 import software.amazon.awssdk.services.kms.KmsClientBuilder;
 import software.amazon.awssdk.services.kms.model.DataKeySpec;
 import software.amazon.awssdk.services.kms.model.EncryptionAlgorithmSpec;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
 
 public class AwsProperties implements Serializable {
 
@@ -237,6 +241,7 @@ public class AwsProperties implements Serializable {
   private final String clientAssumeRoleSessionName;
   private final String clientCredentialsProvider;
   private final Map<String, String> clientCredentialsProviderProperties;
+  private final HttpClientProperties httpClientProperties;
 
   private final String glueEndpoint;
   private String glueCatalogId;
@@ -266,6 +271,7 @@ public class AwsProperties implements Serializable {
     this.clientAssumeRoleSessionName = null;
     this.clientCredentialsProvider = null;
     this.clientCredentialsProviderProperties = null;
+    this.httpClientProperties = new HttpClientProperties();
 
     this.glueCatalogId = null;
     this.glueEndpoint = null;
@@ -298,6 +304,7 @@ public class AwsProperties implements Serializable {
     this.clientCredentialsProviderProperties =
         PropertyUtil.propertiesWithPrefix(
             properties, AwsClientProperties.CLIENT_CREDENTIAL_PROVIDER_PREFIX);
+    this.httpClientProperties = new HttpClientProperties(properties);
 
     this.glueEndpoint = properties.get(GLUE_CATALOG_ENDPOINT);
     this.glueCatalogId = properties.get(GLUE_CATALOG_ID);
@@ -493,8 +500,44 @@ public class AwsProperties implements Serializable {
       return credentialsProvider(this.clientCredentialsProvider);
     }
 
+    // When a role is configured to be assumed (e.g. via AssumeRoleAwsClientFactory), sign requests
+    // with the assumed-role credentials so that they do not diverge from the credentials used for
+    // S3, Glue, KMS and DynamoDB. See https://github.com/apache/iceberg/issues/16667.
+    if (!Strings.isNullOrEmpty(this.clientAssumeRoleArn)) {
+      return assumeRoleCredentialsProvider();
+    }
+
     // Create a new credential provider for each client
     return DefaultCredentialsProvider.builder().build();
+  }
+
+  private StsAssumeRoleCredentialsProvider assumeRoleCredentialsProvider() {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(this.clientAssumeRoleRegion),
+        "Cannot assume role %s to sign REST requests: %s is required",
+        this.clientAssumeRoleArn,
+        CLIENT_ASSUME_ROLE_REGION);
+
+    String sessionName =
+        this.clientAssumeRoleSessionName != null
+            ? this.clientAssumeRoleSessionName
+            : String.format("iceberg-aws-%s", UUID.randomUUID());
+
+    return StsAssumeRoleCredentialsProvider.builder()
+        .stsClient(
+            StsClient.builder()
+                .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+                .region(Region.of(this.clientAssumeRoleRegion))
+                .build())
+        .refreshRequest(
+            AssumeRoleRequest.builder()
+                .roleArn(this.clientAssumeRoleArn)
+                .roleSessionName(sessionName)
+                .durationSeconds(this.clientAssumeRoleTimeoutSec)
+                .externalId(this.clientAssumeRoleExternalId)
+                .tags(this.stsClientAssumeRoleTags)
+                .build())
+        .build();
   }
 
   private AwsCredentialsProvider credentialsProvider(String credentialsProviderClass) {

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -25,7 +25,6 @@ import static org.apache.iceberg.aws.AwsProperties.GLUE_CATALOG_ID;
 import static org.apache.iceberg.aws.AwsProperties.REST_ACCESS_KEY_ID;
 import static org.apache.iceberg.aws.AwsProperties.REST_SECRET_ACCESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import org.apache.iceberg.TestHelpers;
@@ -97,13 +96,13 @@ public class TestAwsProperties {
   }
 
   @Test
-  public void testRestCredentialsProviderRequiresRegionToAssumeRole() {
+  public void testRestCredentialsProviderFallsBackToDefaultWhenAssumeRoleRegionMissing() {
     AwsProperties awsProperties =
         new AwsProperties(
             ImmutableMap.of(CLIENT_ASSUME_ROLE_ARN, "arn:aws:iam::123456789012:role/test"));
 
-    assertThatThrownBy(awsProperties::restCredentialsProvider)
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining(CLIENT_ASSUME_ROLE_REGION);
+    assertThat(awsProperties.restCredentialsProvider())
+        .as("Missing assume-role region should fall back to the default credentials chain")
+        .isInstanceOf(DefaultCredentialsProvider.class);
   }
 }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsProperties.java
@@ -18,15 +18,24 @@
  */
 package org.apache.iceberg.aws;
 
+import static org.apache.iceberg.aws.AwsProperties.CLIENT_ASSUME_ROLE_ARN;
+import static org.apache.iceberg.aws.AwsProperties.CLIENT_ASSUME_ROLE_REGION;
 import static org.apache.iceberg.aws.AwsProperties.DYNAMODB_TABLE_NAME;
 import static org.apache.iceberg.aws.AwsProperties.GLUE_CATALOG_ID;
+import static org.apache.iceberg.aws.AwsProperties.REST_ACCESS_KEY_ID;
+import static org.apache.iceberg.aws.AwsProperties.REST_SECRET_ACCESS_KEY;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.services.sts.auth.StsAssumeRoleCredentialsProvider;
 
 public class TestAwsProperties {
 
@@ -42,5 +51,59 @@ public class TestAwsProperties {
         .isEqualTo(awsPropertiesWithProps.glueCatalogId());
     assertThat(deSerializedAwsPropertiesWithProps.dynamoDbTableName())
         .isEqualTo(awsPropertiesWithProps.dynamoDbTableName());
+  }
+
+  @Test
+  public void testRestCredentialsProviderAssumesRoleWhenConfigured() {
+    AwsProperties awsProperties =
+        new AwsProperties(
+            ImmutableMap.of(
+                CLIENT_ASSUME_ROLE_ARN,
+                "arn:aws:iam::123456789012:role/test",
+                CLIENT_ASSUME_ROLE_REGION,
+                "us-east-1"));
+
+    assertThat(awsProperties.restCredentialsProvider())
+        .as("REST requests should be signed with the assumed-role credentials")
+        .isInstanceOf(StsAssumeRoleCredentialsProvider.class);
+  }
+
+  @Test
+  public void testRestCredentialsProviderDefaultsWhenAssumeRoleNotConfigured() {
+    AwsProperties awsProperties = new AwsProperties(ImmutableMap.of());
+
+    assertThat(awsProperties.restCredentialsProvider())
+        .as("REST requests should fall back to the default credentials chain")
+        .isInstanceOf(DefaultCredentialsProvider.class);
+  }
+
+  @Test
+  public void testRestCredentialsProviderPrefersStaticRestCredentials() {
+    AwsProperties awsProperties =
+        new AwsProperties(
+            ImmutableMap.of(
+                REST_ACCESS_KEY_ID,
+                "accessKeyId",
+                REST_SECRET_ACCESS_KEY,
+                "secretAccessKey",
+                CLIENT_ASSUME_ROLE_ARN,
+                "arn:aws:iam::123456789012:role/test",
+                CLIENT_ASSUME_ROLE_REGION,
+                "us-east-1"));
+
+    assertThat(awsProperties.restCredentialsProvider())
+        .as("Explicit static REST credentials should take precedence over assume-role")
+        .isInstanceOf(StaticCredentialsProvider.class);
+  }
+
+  @Test
+  public void testRestCredentialsProviderRequiresRegionToAssumeRole() {
+    AwsProperties awsProperties =
+        new AwsProperties(
+            ImmutableMap.of(CLIENT_ASSUME_ROLE_ARN, "arn:aws:iam::123456789012:role/test"));
+
+    assertThatThrownBy(awsProperties::restCredentialsProvider)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(CLIENT_ASSUME_ROLE_REGION);
   }
 }

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -694,6 +694,8 @@ spark-sql --packages org.apache.iceberg:iceberg-spark-runtime-3.5_2.12:{{ iceber
     --conf spark.sql.catalog.my_catalog.client.assume-role.region=ap-northeast-1
 ```
 
+When assume-role credential configurations are provided, [REST catalogs configured with the `sigv4` authentication mechanism](catalog-properties.md#sigv4-auth-properties) will also assume the role to sign REST Catalog requests.
+
 ### HTTP Client Configurations
 AWS clients support two types of HTTP Client, [URL Connection HTTP Client](https://mvnrepository.com/artifact/software.amazon.awssdk/url-connection-client)
 and [Apache HTTP Client](https://mvnrepository.com/artifact/software.amazon.awssdk/apache-client).

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -94,6 +94,22 @@ Required and optional properties to include while using `oauth2` authentication
 | `audience`              | null              | Optional param to specify token `audience`                                                                                                                            |
 | `resource`              | null              | Optional param to specify `resource`                                                                                                                                  |
 
+#### SigV4 auth properties
+Required and optional properties to include while using `sigv4` authentication
+
+| Property                             | Default          | Description                                                                                                       |
+|--------------------------------------|------------------|-------------------------------------------------------------------------------------------------------------------|
+| `rest.signing-region`                     | null           | Region to be used by the SigV4 protocol for signing requests. |
+| `rest.signing-name`                       | `execute-api`  | The service name to be used by the SigV4 protocol for signing requests. |
+| `rest.access-key-id`                      | null           | Configure the static access key ID used for SigV4 signing. |
+| `rest.secret-access-key`                  | null           | Configure the static secret access key used for SigV4 signing. |
+| `rest.session-token`                      | null           | Configure the static session token used for SigV4. |
+| `client.credentials-provider`             | null           | When set, REST catalog requests will use this provider to get AWS credentials to sign the request instead of reading the default credential chain. |
+
+When `rest.access-key-id`, `rest.secret-access-key`, and optionally `rest.session-token` are set, REST Catalog requests will be signed with the provided basic or session credentials instead of using the default credential chain. If `rest.session-token` is set, session credential is used, otherwise basic credential is used. 
+
+When basic or session credentials are provided, the provided credentials will be used instead of `client.credentials-provider`. `client.credentials-provider` must contain a static `create` or `create(Map<String, String>)` method to be used by REST catalog requests.
+
 #### Google auth properties
 Required and optional properties to include while using `google` authentication
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -104,11 +104,17 @@ Required and optional properties to include while using `sigv4` authentication
 | `rest.access-key-id`                      | null           | Configure the static access key ID used for SigV4 signing. |
 | `rest.secret-access-key`                  | null           | Configure the static secret access key used for SigV4 signing. |
 | `rest.session-token`                      | null           | Configure the static session token used for SigV4. |
-| `client.credentials-provider`             | null           | When set, REST catalog requests will use this provider to get AWS credentials to sign the request instead of reading the default credential chain. |
+| `client.credentials-provider`             | null           | When configured, REST catalog requests will use this provider to get AWS credentials to sign the request instead of reading the default credential chain. |
+| `client.assume-role.arn`            | null, requires user input                | ARN of the role to assume, e.g. arn:aws:iam::123456789:role/myRoleToAssume  |
+| `client.assume-role.region`         | null, requires user input                | All AWS clients except the STS client will use the given region instead of the default region chain  |
+| `client.assume-role.external-id`    | null                                     | An optional [external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)  |
+| `client.assume-role.timeout-sec`    | 1 hour                                   | Timeout of each assume role session. At the end of the timeout, a new set of role session credentials will be fetched through an STS client.  |
 
-When `rest.access-key-id`, `rest.secret-access-key`, and optionally `rest.session-token` are set, REST Catalog requests will be signed with the provided basic or session credentials instead of using the default credential chain. If `rest.session-token` is set, session credential is used, otherwise basic credential is used. 
+When `rest.access-key-id`, `rest.secret-access-key`, and optionally `rest.session-token` are configured, REST Catalog requests will be signed with the provided basic or session credentials instead of using the default credential chain. If `rest.session-token` is set, session credential is used, otherwise basic credential is used.
 
 When basic or session credentials are provided, the provided credentials will be used instead of `client.credentials-provider`. `client.credentials-provider` must contain a static `create` or `create(Map<String, String>)` method to be used by REST catalog requests.
+
+When `client.assume-role.arn` and `client.assume-role.region` are configured, Iceberg will assume the role using the default credential chain to sign REST catalog requests. These parameters will have no effect if `rest.access-key-id`, `rest.secret-access-key`, or `client.credentials-provider` are configured.
 
 #### Google auth properties
 Required and optional properties to include while using `google` authentication


### PR DESCRIPTION
## What changed

`RESTSigV4AuthSession` signs catalog requests with `AwsProperties#restCredentialsProvider()`, whose decision chain only handled three cases:

1. explicit static `rest.*` keys → `StaticCredentialsProvider`
2. a custom `client.credentials-provider` → that provider
3. otherwise → `DefaultCredentialsProvider`

There was no branch for `client.assume-role.*`. So when the catalog is configured with `AssumeRoleAwsClientFactory`, the assumed role is applied to the S3/Glue/KMS/DynamoDB clients (via `applyAssumeRoleConfigurations`) but never to the SigV4 REST signing path — REST calls silently fall back to the default credential chain and diverge from the other AWS clients.

This adds an assume-role branch between the custom-provider and default-chain steps that returns an `StsAssumeRoleCredentialsProvider` built from the existing `client.assume-role.*` properties (arn, region, session name, timeout, external id, tags), mirroring `AssumeRoleAwsClientFactory#createCredentialsProvider`. Explicit static `rest.*` keys and `client.credentials-provider` keep precedence.

This is the "fastest path" described in the issue. Happy to instead extract the STS provider construction into a shared utility (option 3 in the issue) if reviewers prefer to avoid the small duplication with `AssumeRoleAwsClientFactory`.

Closes #16667

## Testing

New unit tests in `TestAwsProperties`:

- assume-role configured → `restCredentialsProvider()` returns an `StsAssumeRoleCredentialsProvider`
- no credentials configured → falls back to `DefaultCredentialsProvider`
- explicit static `rest.*` keys → still returns `StaticCredentialsProvider` (precedence preserved)

`./gradlew :iceberg-aws:test :iceberg-aws:spotlessJavaCheck :iceberg-aws:checkstyleMain :iceberg-aws:checkstyleTest` passes locally.
