### PR TITLE
Spark 4.1: Add scoped replacement writes (INSERT INTO ... REPLACE USING)

### DIFF
--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -36,6 +36,7 @@ Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog impleme
 | [SQL update](#update)                            | ✔️      | ⚠ Requires Iceberg Spark extensions                                         |
 | [DataFrame append](#appending-data)              | ✔️      |                                                                             |
 | [DataFrame overwrite](#overwriting-data)         | ✔️      |                                                                             |
+| [DataFrame scoped replace](#scoped-replacement)  | ✔️      | ⚠ Requires Iceberg Spark extensions and Spark 4.1 or higher                 |
 | [DataFrame CTAS and RTAS](#creating-tables)      | ✔️      | ⚠ Requires DSv2 API                                                         |
 | [DataFrame merge into](#merging-data)            | ✔️      | ⚠ Requires DSv2 API (Spark 4.0 and later)                                   |
 
@@ -338,6 +339,34 @@ To explicitly overwrite partitions, use `overwrite` to supply a filter:
 ```scala
 data.writeTo("prod.db.table").overwrite($"level" === "INFO")
 ```
+
+### Scoped replacement
+
+Iceberg Spark extensions in Spark 4.1 and higher support scoped replacement writes through the
+`DataFrameWriterV2` API. A scoped replace deletes existing target rows whose replacement scope
+appears in the source `DataFrame`, then inserts all rows from the source in the same commit.
+
+```scala
+val staged: DataFrame = ...
+
+staged.writeTo("prod.db.sample")
+    .option("replace-using", "category")
+    .overwrite(lit(true))
+```
+
+Use the `replace-using` write option to list the target columns that define the replacement scope.
+Multiple columns are comma-separated:
+
+```scala
+staged.writeTo("prod.db.sample")
+    .option("replace-using", "tenant_id,business_date")
+    .option("target-file-size-bytes", "134217728")
+    .overwrite(lit(true))
+```
+
+The `overwrite(lit(true))` call is required so Spark applies overwrite privileges and Iceberg can
+replace matching target rows. Other Iceberg write options, such as target file size, compression,
+distribution, snapshot properties, and branch selection, can be supplied with `option` as usual.
 
 ### Creating tables
 

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -29,6 +29,7 @@ Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog impleme
 | Feature support                                  | Spark | Notes                                                                       |
 |--------------------------------------------------|---------|-----------------------------------------------------------------------------|
 | [SQL insert into](#insert-into)                  | ✔️      | ⚠ Requires `spark.sql.storeAssignmentPolicy=ANSI` (default since Spark 3.0) |
+| [SQL scoped replace](#insert-into--replace-using) | ✔️      | ⚠ Requires Iceberg Spark extensions and Spark 4.1 or higher                 |
 | [SQL merge into](#merge-into)                    | ✔️      | ⚠ Requires Iceberg Spark extensions                                         |
 | [SQL insert overwrite](#insert-overwrite)        | ✔️      | ⚠ Requires `spark.sql.storeAssignmentPolicy=ANSI` (default since Spark 3.0) |
 | [SQL delete from](#delete-from)                  | ✔️      | ⚠ Row-level delete requires Iceberg Spark extensions                        |
@@ -40,7 +41,7 @@ Iceberg uses Apache Spark's DataSourceV2 API for data source and catalog impleme
 
 ## Writing with SQL
 
-Spark supports SQL `INSERT INTO`, `MERGE INTO`, and `INSERT OVERWRITE`, as well as the new `DataFrameWriterV2` API.
+Spark supports SQL `INSERT INTO`, `INSERT INTO ... REPLACE USING`, `MERGE INTO`, and `INSERT OVERWRITE`, as well as the new `DataFrameWriterV2` API.
 
 ### `INSERT INTO`
 
@@ -52,6 +53,31 @@ INSERT INTO prod.db.table VALUES (1, 'a'), (2, 'b')
 ```sql
 INSERT INTO prod.db.table SELECT ...
 ```
+
+### `INSERT INTO ... REPLACE USING`
+
+Iceberg supports scoped replacement writes with Iceberg Spark extensions in Spark 4.1 and higher. A scoped replace deletes existing target rows whose replacement scope appears in the source query, then inserts all rows from the source query in the same commit.
+
+```sql
+INSERT INTO prod.db.table
+REPLACE USING (scope_col_1, scope_col_2)
+SELECT ...
+```
+
+The columns listed in `REPLACE USING` define the replacement scope. For each distinct tuple of scope values produced by the source query, matching target rows are removed using null-safe equality, and the full source query output is appended.
+
+For example, this query replaces all existing rows for categories present in `prod.db.staged_rows` and keeps rows for other categories:
+
+```sql
+INSERT INTO prod.db.sample
+REPLACE USING (category)
+SELECT id, data, category, ts
+FROM prod.db.staged_rows
+```
+
+`REPLACE USING` is useful when incoming data contains complete replacement slices for one or more logical groups, such as tenants, departments, dates, or regions. Unlike `INSERT OVERWRITE`, the replacement scope is based on table columns in the source data and does not depend on the table's partition spec.
+
+The source query must produce the same number of columns as the target table, using the same assignment rules as `INSERT INTO`. Each `REPLACE USING` column must exist in both the target table and the source query output.
 
 ### `MERGE INTO`
 

--- a/spark/v4.1/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
+++ b/spark/v4.1/spark-extensions/src/main/antlr/org.apache.spark.sql.catalyst.parser.extensions/IcebergSqlExtensions.g4
@@ -131,6 +131,13 @@ singleOrder
     : order EOF
     ;
 
+// Parses only the command head of `INSERT INTO t REPLACE USING (cols) <query>`.
+// The query tail remains Spark SQL and is delegated to Spark's parser until this syntax
+// can be represented directly in Spark's `insertInto` grammar.
+singleScopedReplaceHead
+    : INSERT INTO TABLE? multipartIdentifier REPLACE USING '(' fieldList ')' EOF
+    ;
+
 order
     : fields+=orderField (',' fields+=orderField)*
     | '(' fields+=orderField (',' fields+=orderField)* ')'
@@ -211,6 +218,7 @@ nonReserved
     | DISTRIBUTED | LOCALLY | MINUTES | MONTHS | UNORDERED | REPLACE | RETAIN | VERSION | WITH | IDENTIFIER_KW | FIELDS | SET | SNAPSHOT | SNAPSHOTS
     | TAG | TRUE | FALSE
     | MAP
+    | INSERT | INTO | USING
     ;
 
 snapshotId
@@ -243,6 +251,8 @@ FIELDS: 'FIELDS';
 FIRST: 'FIRST';
 HOURS: 'HOURS';
 IF : 'IF';
+INSERT: 'INSERT';
+INTO: 'INTO';
 LAST: 'LAST';
 LOCALLY: 'LOCALLY';
 MINUTES: 'MINUTES';
@@ -264,6 +274,7 @@ SNAPSHOTS: 'SNAPSHOTS';
 TABLE: 'TABLE';
 TAG: 'TAG';
 UNORDERED: 'UNORDERED';
+USING: 'USING';
 VERSION: 'VERSION';
 WITH: 'WITH';
 WRITE: 'WRITE';

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.analysis.CheckViews
 import org.apache.spark.sql.catalyst.analysis.ResolveBranch
 import org.apache.spark.sql.catalyst.analysis.ResolveViews
+import org.apache.spark.sql.catalyst.analysis.RewriteScopedReplace
 import org.apache.spark.sql.catalyst.optimizer.ReplaceStaticInvoke
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
 import org.apache.spark.sql.execution.datasources.v2.ExtendedDataSourceV2Strategy
@@ -35,6 +36,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     // analyzer extensions
     extensions.injectResolutionRule { spark => ResolveViews(spark) }
     extensions.injectPostHocResolutionRule { spark => ResolveBranch(spark) }
+    extensions.injectPostHocResolutionRule { _ => RewriteScopedReplace }
     extensions.injectCheckRule(_ => CheckViews)
 
     // optimizer extensions

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/iceberg/spark/extensions/IcebergSparkSessionExtensions.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.SparkSessionExtensions
 import org.apache.spark.sql.catalyst.analysis.CheckViews
 import org.apache.spark.sql.catalyst.analysis.ResolveBranch
 import org.apache.spark.sql.catalyst.analysis.ResolveViews
+import org.apache.spark.sql.catalyst.analysis.RewriteDataFrameScopedReplace
 import org.apache.spark.sql.catalyst.analysis.RewriteScopedReplace
 import org.apache.spark.sql.catalyst.optimizer.ReplaceStaticInvoke
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSparkSqlExtensionsParser
@@ -36,6 +37,7 @@ class IcebergSparkSessionExtensions extends (SparkSessionExtensions => Unit) {
     // analyzer extensions
     extensions.injectResolutionRule { spark => ResolveViews(spark) }
     extensions.injectPostHocResolutionRule { spark => ResolveBranch(spark) }
+    extensions.injectPostHocResolutionRule { spark => RewriteDataFrameScopedReplace(spark) }
     extensions.injectPostHocResolutionRule { _ => RewriteScopedReplace }
     extensions.injectCheckRule(_ => CheckViews)
 

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDataFrameScopedReplace.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteDataFrameScopedReplace.scala
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.iceberg.relocated.com.google.common.base.Splitter
+import org.apache.iceberg.spark.SparkTableUtil
+import org.apache.iceberg.spark.source.SparkTable
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.plans.logical.AppendData
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.OverwriteByExpression
+import org.apache.spark.sql.catalyst.plans.logical.OverwritePartitionsDynamic
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceScopedData
+import org.apache.spark.sql.catalyst.rules.Rule
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+import scala.jdk.CollectionConverters._
+
+/**
+ * Rewrites the DataFrameWriterV2 scoped-replace API into the shared logical command.
+ *
+ * The API is carried by a write option on `overwrite(true)`, so Spark resolves the query using the
+ * standard DataFrameWriterV2 by-name write path before this rule runs. Normal Iceberg write options
+ * are moved onto the relation because Spark's row-level write planning reads options from the
+ * relation after [[ReplaceScopedData]] is lowered to [[org.apache.spark.sql.catalyst.plans.logical.ReplaceData]]
+ * or [[org.apache.spark.sql.catalyst.plans.logical.WriteDelta]].
+ */
+case class RewriteDataFrameScopedReplace(spark: SparkSession) extends Rule[LogicalPlan] {
+
+  import RewriteDataFrameScopedReplace._
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case overwrite @ OverwriteByExpression(
+          r @ DataSourceV2Relation(table: SparkTable, _, _, _, relationOptions, _),
+          deleteExpr,
+          query,
+          writeOptions,
+          _,
+          None,
+          _) if overwrite.resolved && replaceUsing(writeOptions).isDefined =>
+
+      if (!deleteExpr.semanticEquals(TrueLiteral)) {
+        throw analysisError(
+          s"Scoped replace must be invoked with overwrite(true), found: ${deleteExpr.sql}")
+      }
+
+      if (query.isStreaming) {
+        throw analysisError("Scoped replace is not supported for streaming DataFrames")
+      }
+
+      val mergedOptions = writeOptionsWithoutReplaceUsing(writeOptions, relationOptions)
+      val targetBranch = SparkTableUtil.determineWriteBranch(spark, table, mergedOptions)
+      val targetTable =
+        if (table.branch() == targetBranch) table else table.copyWithBranch(targetBranch)
+      val scopeColumns = parseScopeColumns(replaceUsing(writeOptions).get)
+
+      ReplaceScopedData(r.copy(table = targetTable, options = mergedOptions), scopeColumns, query)
+
+    case append @ AppendData(
+          DataSourceV2Relation(_: SparkTable, _, _, _, _, _),
+          _,
+          writeOptions,
+          _,
+          _,
+          _) if append.resolved && replaceUsing(writeOptions).isDefined =>
+      throw analysisError("Scoped replace must be invoked with overwrite(true), not append()")
+
+    case overwritePartitions @ OverwritePartitionsDynamic(
+          DataSourceV2Relation(_: SparkTable, _, _, _, _, _),
+          _,
+          writeOptions,
+          _,
+          _) if overwritePartitions.resolved && replaceUsing(writeOptions).isDefined =>
+      throw analysisError(
+        "Scoped replace must be invoked with overwrite(true), not overwritePartitions()")
+  }
+
+  private def writeOptionsWithoutReplaceUsing(
+      writeOptions: Map[String, String],
+      relationOptions: CaseInsensitiveStringMap): CaseInsensitiveStringMap = {
+    val relationMap = relationOptions.asCaseSensitiveMap.asScala.toMap
+    val merged = removeReplaceUsing(relationMap) ++ removeReplaceUsing(writeOptions)
+    new CaseInsensitiveStringMap(merged.asJava)
+  }
+
+  private def removeReplaceUsing(options: Map[String, String]): Map[String, String] = {
+    options.filterNot { case (key, _) => key.equalsIgnoreCase(ReplaceUsingOption) }
+  }
+
+  private def replaceUsing(options: Map[String, String]): Option[String] = {
+    Option(new CaseInsensitiveStringMap(options.asJava).get(ReplaceUsingOption))
+  }
+
+  // `replace-using` follows the standard Iceberg comma-separated option convention, so the list is
+  // split on commas and each token is parsed as a multi-part identifier by the session parser (the
+  // same parser the SQL `REPLACE USING` path delegates to). A consequence of splitting first is that
+  // a column whose quoted name itself contains a comma cannot be expressed through this option; such
+  // names are not representable in a comma-delimited option and must use the SQL `REPLACE USING` form.
+  private def parseScopeColumns(columns: String): Seq[Seq[String]] = {
+    Splitter
+      .on(',')
+      .trimResults()
+      .splitToList(columns)
+      .asScala
+      .map { column =>
+        spark.sessionState.sqlParser.parseMultipartIdentifier(column)
+      }
+      .toSeq
+  }
+
+  private def analysisError(message: String): AnalysisException = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_ICEBERG_SCOPED_REPLACE",
+      sqlState = null,
+      messageTemplate = message,
+      messageParameters = Map.empty[String, String],
+      cause = None,
+      message = Some(message))
+  }
+}
+
+object RewriteDataFrameScopedReplace {
+  private val ReplaceUsingOption = "replace-using"
+}

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteScopedReplace.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteScopedReplace.scala
@@ -1,0 +1,399 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.catalyst.analysis
+
+import org.apache.spark.sql.AnalysisException
+import org.apache.spark.sql.catalyst.ProjectingInternalRow
+import org.apache.spark.sql.catalyst.expressions.Alias
+import org.apache.spark.sql.catalyst.expressions.And
+import org.apache.spark.sql.catalyst.expressions.Attribute
+import org.apache.spark.sql.catalyst.expressions.AttributeSet
+import org.apache.spark.sql.catalyst.expressions.EqualNullSafe
+import org.apache.spark.sql.catalyst.expressions.Exists
+import org.apache.spark.sql.catalyst.expressions.Expression
+import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.catalyst.expressions.Literal.TrueLiteral
+import org.apache.spark.sql.catalyst.expressions.NamedExpression
+import org.apache.spark.sql.catalyst.expressions.OuterReference
+import org.apache.spark.sql.catalyst.plans.LeftAnti
+import org.apache.spark.sql.catalyst.plans.LeftSemi
+import org.apache.spark.sql.catalyst.plans.logical.CTERelationDef
+import org.apache.spark.sql.catalyst.plans.logical.CTERelationRef
+import org.apache.spark.sql.catalyst.plans.logical.Filter
+import org.apache.spark.sql.catalyst.plans.logical.Join
+import org.apache.spark.sql.catalyst.plans.logical.JoinHint
+import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.Project
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceData
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceScopedData
+import org.apache.spark.sql.catalyst.plans.logical.Union
+import org.apache.spark.sql.catalyst.plans.logical.WithCTE
+import org.apache.spark.sql.catalyst.plans.logical.WriteDelta
+import org.apache.spark.sql.catalyst.util.ReplaceDataProjections
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.DELETE_OPERATION
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.INSERT_OPERATION
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.OPERATION_COLUMN
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.WRITE_OPERATION
+import org.apache.spark.sql.catalyst.util.RowDeltaUtils.WRITE_WITH_METADATA_OPERATION
+import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
+import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
+import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
+import org.apache.spark.sql.connector.write.RowLevelOperationTable
+import org.apache.spark.sql.connector.write.SupportsDelta
+import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
+import org.apache.spark.sql.types.StructField
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.util.CaseInsensitiveStringMap
+
+/**
+ * Lowers a [[ReplaceScopedData]] command into Iceberg's row-level write path.
+ *
+ * Scoped replace deletes target rows whose scope columns match a source row, then appends the full
+ * source. Unlike MERGE, every source row must be inserted whether or not it matches a target row, so
+ * the replacement state is computed from separate carryover and insert branches instead of from
+ * per-match joined rows.
+ *
+ * The source is shared through a CTE so non-deterministic expressions are evaluated consistently by
+ * the carryover branch and insert branch. Runtime file pruning is only applied for deterministic
+ * sources because Spark requires row-level operation conditions to be deterministic.
+ *
+ * The row-level operation is requested as [[MERGE]] so copy-on-write vs merge-on-read selection
+ * follows the same table configuration path as MERGE.
+ */
+object RewriteScopedReplace extends RewriteRowLevelCommand {
+
+  override def apply(plan: LogicalPlan): LogicalPlan = plan resolveOperators {
+    case rsd @ ReplaceScopedData(aliasedTable, scopeColumns, source)
+        if rsd.resolved && source.resolved =>
+
+      EliminateSubqueryAliases(aliasedTable) match {
+        case r @ DataSourceV2Relation(tbl: SupportsRowLevelOperations, _, _, _, _, _) =>
+          if (source.output.size != r.output.size) {
+            throw analysisError(
+              "The source query of a scoped replace must produce the same number of columns as " +
+                s"the target table ${r.name}: expected ${r.output.size}, got ${source.output.size}")
+          }
+
+          val operationTable = buildOperationTable(tbl, MERGE, CaseInsensitiveStringMap.empty())
+          val alignedSource = alignSourceColumns(r, source)
+          operationTable.operation match {
+            case deltaOperation: SupportsDelta =>
+              buildWriteDeltaPlan(r, operationTable, deltaOperation, scopeColumns, alignedSource)
+            case _ =>
+              buildReplaceDataPlan(r, operationTable, scopeColumns, alignedSource)
+          }
+
+        case other =>
+          throw analysisError(
+            s"Scoped replace is only supported on Iceberg tables, found: ${other.simpleString(2)}")
+      }
+  }
+
+  private def buildReplaceDataPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      scopeColumns: Seq[Seq[String]],
+      source: LogicalPlan): LogicalPlan = {
+
+    // Scoped replace uses INSERT-style positional alignment between source and target columns.
+    val scopeOrdinals = resolveScopeOrdinals(relation, scopeColumns)
+
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operationTable.operation)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs)
+    val rowAttrs = relation.output
+
+    val sourceCte = CTERelationDef(source)
+    val scopeSource = newSourceRef(sourceCte)
+    val insertSource = newSourceRef(sourceCte)
+    val filterSource = newSourceRef(sourceCte)
+
+    val antiJoinCondition = scopeEquality(readRelation.output, scopeSource.output, scopeOrdinals)
+    val carryoverJoin =
+      Join(readRelation, scopeSource, LeftAnti, Some(antiJoinCondition), JoinHint.NONE)
+    val carryoverOutput =
+      operationAlias(WRITE_WITH_METADATA_OPERATION) +: readRelation.output
+    val carryover = Project(carryoverOutput, carryoverJoin)
+
+    val insertData = alignedSourceData(insertSource, rowAttrs)
+    val insertMetadata = metadataAttrs.map { attr =>
+      Alias(Literal(null, attr.dataType), attr.name)()
+    }
+    val insertOutput = operationAlias(WRITE_OPERATION) +: (insertData ++ insertMetadata)
+    val inserts = Project(insertOutput, insertSource)
+
+    val replacementQuery = Union(carryover :: inserts :: Nil)
+    val projections = buildUnionProjections(replacementQuery, rowAttrs, metadataAttrs)
+
+    val groupFilterCond = runtimeCondition(source, rowAttrs, filterSource, scopeOrdinals)
+
+    // ReplaceData's condition (2nd arg) is the planning-time pushdown filter; groupFilterCond
+    // (6th) is the runtime group filter. The replaced scope set is dynamic: it comes from the
+    // source, so there is no static target-only predicate to push down, the same as a MERGE whose
+    // ON condition is purely join keys. That is why the condition is TrueLiteral. File pruning
+    // instead comes from groupFilterCond, which RowLevelOperationRuntimeGroupFiltering turns into a
+    // dynamic IN-subquery, so deterministic sources still rewrite only the groups that hold a match.
+    val writeRelation = relation.copy(table = operationTable)
+    val replaceData =
+      ReplaceData(
+        writeRelation,
+        TrueLiteral,
+        replacementQuery,
+        relation,
+        projections,
+        Some(groupFilterCond))
+
+    WithCTE(replaceData, sourceCte :: Nil)
+  }
+
+  private def buildWriteDeltaPlan(
+      relation: DataSourceV2Relation,
+      operationTable: RowLevelOperationTable,
+      operation: SupportsDelta,
+      scopeColumns: Seq[Seq[String]],
+      source: LogicalPlan): LogicalPlan = {
+
+    val scopeOrdinals = resolveScopeOrdinals(relation, scopeColumns)
+    val rowAttrs = relation.output
+    val rowIdAttrs = resolveRowIdAttrs(relation, operation)
+    val metadataAttrs = resolveRequiredMetadataAttrs(relation, operation)
+    val readRelation = buildRelationWithAttrs(relation, operationTable, metadataAttrs, rowIdAttrs)
+
+    val sourceCte = CTERelationDef(source)
+    val scopeSource = newSourceRef(sourceCte)
+    val insertSource = newSourceRef(sourceCte)
+    val filterSource = newSourceRef(sourceCte)
+
+    val semiJoinCondition = scopeEquality(readRelation.output, scopeSource.output, scopeOrdinals)
+    val matchingRows =
+      Join(readRelation, scopeSource, LeftSemi, Some(semiJoinCondition), JoinHint.NONE)
+
+    val rowIdSet = AttributeSet(rowIdAttrs)
+    val deleteData = rowAttrs.map {
+      case attr if rowIdSet.contains(attr) => attr
+      case attr => Alias(Literal(null, attr.dataType), attr.name)()
+    }
+    val deleteMetadata = nullifyMetadataOnDelete(metadataAttrs)
+    val deletePayload = deleteData ++ rowIdAttrs ++ deleteMetadata
+    val deleteOutput = operationAlias(DELETE_OPERATION) +: deletePayload
+    val deletes = Project(deleteOutput, matchingRows)
+
+    val insertData = alignedSourceData(insertSource, rowAttrs)
+    val insertRowIds = rowIdAttrs.map { attr =>
+      Alias(Literal(null, attr.dataType), attr.name)()
+    }
+    val insertMetadata = metadataAttrs.map { attr =>
+      Alias(Literal(null, attr.dataType), attr.name)()
+    }
+    val insertOutput =
+      operationAlias(INSERT_OPERATION) +: (insertData ++ insertRowIds ++ insertMetadata)
+    val inserts = Project(insertOutput, insertSource)
+
+    val deltaQuery = Union(deletes :: inserts :: Nil)
+    val projections = buildDeltaUnionProjections(
+      rowAttrs,
+      rowIdAttrs,
+      metadataAttrs,
+      insertData,
+      rowIdAttrs,
+      deleteMetadata)
+    val condition = runtimeCondition(source, rowAttrs, filterSource, scopeOrdinals)
+
+    val writeRelation = relation.copy(table = operationTable)
+    val writeDelta = WriteDelta(writeRelation, condition, deltaQuery, relation, projections)
+
+    WithCTE(writeDelta, sourceCte :: Nil)
+  }
+
+  private def operationAlias(operation: Int): NamedExpression = {
+    Alias(Literal(operation), OPERATION_COLUMN)()
+  }
+
+  private def runtimeCondition(
+      source: LogicalPlan,
+      rowAttrs: Seq[Attribute],
+      filterSource: CTERelationRef,
+      scopeOrdinals: Seq[Int]): Expression = {
+    if (source.deterministic) {
+      scopeExists(rowAttrs, filterSource, scopeOrdinals)
+    } else {
+      // A non-deterministic source cannot be used as a row-level operation condition: Spark requires
+      // that condition to be deterministic (it is evaluated during scan planning, separately from the
+      // write query, so it could disagree with the rows the write actually produces). Falling back to
+      // an unconditional operation keeps the result correct because the carryover/delete joins remain
+      // the sole arbiter of which rows survive, but it disables file pruning, so the whole table is
+      // read and rewritten and the operation's conflict surface widens accordingly.
+      logWarning(
+        "Scoped replace source is non-deterministic; skipping runtime file pruning. The entire " +
+          "target table will be read and rewritten, which may significantly increase write " +
+          "amplification and the operation's conflict surface.")
+      TrueLiteral
+    }
+  }
+
+  // ReplaceData projections require fixed ordinals, but the replacement query is a Union over two
+  // sources. Both branches therefore use the same [operation, data..., metadata...] layout.
+  private def buildUnionProjections(
+      query: LogicalPlan,
+      rowAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute]): ReplaceDataProjections = {
+
+    val output = query.output
+    val rowOrdinals = rowAttrs.indices.map(_ + 1)
+    val rowSchema = StructType(rowAttrs.zipWithIndex.map { case (attr, i) =>
+      StructField(attr.name, attr.dataType, output(rowOrdinals(i)).nullable, attr.metadata)
+    })
+    val rowProjection = ProjectingInternalRow(rowSchema, rowOrdinals.toIndexedSeq)
+
+    val metadataProjection = if (metadataAttrs.nonEmpty) {
+      val metadataBaseOrdinal = 1 + rowAttrs.size
+      val metadataOrdinals = metadataAttrs.indices.map(_ + metadataBaseOrdinal)
+      // Insert rows null out metadata; carryover rows preserve the target metadata contract.
+      val metadataSchema = StructType(metadataAttrs.map { attr =>
+        StructField(attr.name, attr.dataType, attr.nullable, attr.metadata)
+      })
+      Some(ProjectingInternalRow(metadataSchema, metadataOrdinals.toIndexedSeq))
+    } else {
+      None
+    }
+
+    ReplaceDataProjections(rowProjection, metadataProjection)
+  }
+
+  private def buildDeltaUnionProjections(
+      rowAttrs: Seq[Attribute],
+      rowIdAttrs: Seq[Attribute],
+      metadataAttrs: Seq[Attribute],
+      rowOutputs: Seq[NamedExpression],
+      rowIdOutputs: Seq[Expression],
+      metadataOutputs: Seq[Expression]): WriteDeltaProjections = {
+
+    val rowProjection = if (rowAttrs.nonEmpty) {
+      val rowOrdinals = rowAttrs.indices.map(_ + 1)
+      val rowSchema = StructType(rowAttrs.zipWithIndex.map { case (attr, i) =>
+        StructField(attr.name, attr.dataType, rowOutputs(i).nullable, attr.metadata)
+      })
+      Some(ProjectingInternalRow(rowSchema, rowOrdinals.toIndexedSeq))
+    } else {
+      None
+    }
+
+    val rowIdBaseOrdinal = 1 + rowAttrs.size
+    val rowIdOrdinals = rowIdAttrs.indices.map(_ + rowIdBaseOrdinal)
+    val rowIdSchema = StructType(rowIdAttrs.zipWithIndex.map { case (attr, i) =>
+      StructField(attr.name, attr.dataType, rowIdOutputs(i).nullable, attr.metadata)
+    })
+    val rowIdProjection = ProjectingInternalRow(rowIdSchema, rowIdOrdinals.toIndexedSeq)
+
+    val metadataProjection = if (metadataAttrs.nonEmpty) {
+      val metadataBaseOrdinal = rowIdBaseOrdinal + rowIdAttrs.size
+      val metadataOrdinals = metadataAttrs.indices.map(_ + metadataBaseOrdinal)
+      val metadataSchema = StructType(metadataAttrs.zipWithIndex.map { case (attr, i) =>
+        StructField(attr.name, attr.dataType, metadataOutputs(i).nullable, attr.metadata)
+      })
+      Some(ProjectingInternalRow(metadataSchema, metadataOrdinals.toIndexedSeq))
+    } else {
+      None
+    }
+
+    WriteDeltaProjections(rowProjection, rowIdProjection, metadataProjection)
+  }
+
+  // Aligns the source query to the target table positionally, applying the same store-assignment
+  // policy (ANSI/strict/legacy) Spark uses for INSERT INTO ... SELECT. This rejects or permits casts
+  // identically to a plain insert, enforces target nullability/char-varchar contracts, and gives the
+  // aligned columns the target's types so the scope-matching joins compare like-typed values.
+  private def alignSourceColumns(
+      relation: DataSourceV2Relation,
+      source: LogicalPlan): LogicalPlan = {
+    TableOutputResolver.resolveOutputColumns(
+      relation.name,
+      relation.output,
+      source,
+      byName = false,
+      conf)
+  }
+
+  // The source is aligned to the target schema before the CTE is built, so the insert branch only
+  // needs to expose the target column names (no further casting happens here).
+  private def alignedSourceData(
+      source: CTERelationRef,
+      rowAttrs: Seq[Attribute]): Seq[NamedExpression] = {
+    rowAttrs.indices.map { i =>
+      Alias(source.output(i), rowAttrs(i).name)()
+    }
+  }
+
+  private def resolveScopeOrdinals(
+      relation: DataSourceV2Relation,
+      scopeColumns: Seq[Seq[String]]): Seq[Int] = {
+    scopeColumns.map { nameParts =>
+      val resolved = relation.resolve(nameParts, conf.resolver).getOrElse {
+        throw analysisError(
+          s"Cannot resolve scope column '${nameParts.mkString(".")}' in target table ${relation.name}")
+      }
+      val ordinal = relation.output.indexWhere(_.exprId == resolved.toAttribute.exprId)
+      if (ordinal < 0) {
+        throw analysisError(
+          s"Scope column '${nameParts.mkString(".")}' is not a top-level column of ${relation.name}")
+      }
+      ordinal
+    }
+  }
+
+  private def newSourceRef(sourceDef: CTERelationDef): CTERelationRef = {
+    val ref = CTERelationRef(
+      sourceDef.id,
+      _resolved = true,
+      sourceDef.child.output,
+      sourceDef.child.isStreaming)
+    ref.newInstance().asInstanceOf[CTERelationRef]
+  }
+
+  private def scopeEquality(
+      targetOutput: Seq[Attribute],
+      sourceOutput: Seq[Attribute],
+      scopeOrdinals: Seq[Int]): Expression = {
+    scopeOrdinals
+      .map(ordinal => EqualNullSafe(targetOutput(ordinal), sourceOutput(ordinal)): Expression)
+      .reduce(And)
+  }
+
+  private def scopeExists(
+      targetOutput: Seq[Attribute],
+      sourceRef: CTERelationRef,
+      scopeOrdinals: Seq[Int]): Expression = {
+    val cond = scopeOrdinals
+      .map { ordinal =>
+        EqualNullSafe(OuterReference(targetOutput(ordinal)), sourceRef.output(ordinal)): Expression
+      }
+      .reduce(And)
+    val outerRefs = scopeOrdinals.map(ordinal => targetOutput(ordinal))
+    Exists(Filter(cond, sourceRef), outerRefs)
+  }
+
+  private def analysisError(message: String): AnalysisException = {
+    new AnalysisException(
+      errorClass = "_LEGACY_ERROR_TEMP_ICEBERG_SCOPED_REPLACE",
+      sqlState = null,
+      messageTemplate = message,
+      messageParameters = Map.empty[String, String],
+      cause = None,
+      message = Some(message))
+  }
+}

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteScopedReplace.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/analysis/RewriteScopedReplace.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.spark.sql.catalyst.analysis
 
+import org.apache.iceberg.spark.source.SparkTable
 import org.apache.spark.sql.AnalysisException
 import org.apache.spark.sql.catalyst.ProjectingInternalRow
 import org.apache.spark.sql.catalyst.expressions.Alias
@@ -52,14 +53,12 @@ import org.apache.spark.sql.catalyst.util.RowDeltaUtils.OPERATION_COLUMN
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.WRITE_OPERATION
 import org.apache.spark.sql.catalyst.util.RowDeltaUtils.WRITE_WITH_METADATA_OPERATION
 import org.apache.spark.sql.catalyst.util.WriteDeltaProjections
-import org.apache.spark.sql.connector.catalog.SupportsRowLevelOperations
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command.MERGE
 import org.apache.spark.sql.connector.write.RowLevelOperationTable
 import org.apache.spark.sql.connector.write.SupportsDelta
 import org.apache.spark.sql.execution.datasources.v2.DataSourceV2Relation
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
-import org.apache.spark.sql.util.CaseInsensitiveStringMap
 
 /**
  * Lowers a [[ReplaceScopedData]] command into Iceberg's row-level write path.
@@ -83,14 +82,14 @@ object RewriteScopedReplace extends RewriteRowLevelCommand {
         if rsd.resolved && source.resolved =>
 
       EliminateSubqueryAliases(aliasedTable) match {
-        case r @ DataSourceV2Relation(tbl: SupportsRowLevelOperations, _, _, _, _, _) =>
+        case r @ DataSourceV2Relation(tbl: SparkTable, _, _, _, options, _) =>
           if (source.output.size != r.output.size) {
             throw analysisError(
               "The source query of a scoped replace must produce the same number of columns as " +
                 s"the target table ${r.name}: expected ${r.output.size}, got ${source.output.size}")
           }
 
-          val operationTable = buildOperationTable(tbl, MERGE, CaseInsensitiveStringMap.empty())
+          val operationTable = buildOperationTable(tbl, MERGE, options)
           val alignedSource = alignSourceColumns(r, source)
           operationTable.operation match {
             case deltaOperation: SupportsDelta =>

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSparkSqlExtensionsParser.scala
@@ -32,12 +32,14 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.FunctionIdentifier
 import org.apache.spark.sql.catalyst.TableIdentifier
 import org.apache.spark.sql.catalyst.analysis.RewriteViewCommands
+import org.apache.spark.sql.catalyst.analysis.UnresolvedRelation
 import org.apache.spark.sql.catalyst.expressions.Expression
 import org.apache.spark.sql.catalyst.parser.ParameterContext
 import org.apache.spark.sql.catalyst.parser.ParserInterface
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.NonReservedContext
 import org.apache.spark.sql.catalyst.parser.extensions.IcebergSqlExtensionsParser.QuotedIdentifierContext
 import org.apache.spark.sql.catalyst.plans.logical.LogicalPlan
+import org.apache.spark.sql.catalyst.plans.logical.ReplaceScopedData
 import org.apache.spark.sql.catalyst.trees.Origin
 import org.apache.spark.sql.internal.SQLConf
 import org.apache.spark.sql.internal.VariableSubstitution
@@ -139,12 +141,152 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
   private def parsePlanWithDelegate(sqlText: String)(
       delegateParse: String => LogicalPlan): LogicalPlan = {
     val sqlTextAfterSubstitution = substitutor.substitute(sqlText)
-    if (isIcebergCommand(sqlTextAfterSubstitution)) {
+    if (isScopedReplaceCommand(sqlTextAfterSubstitution)) {
+      parseScopedReplace(sqlTextAfterSubstitution)(delegateParse)
+    } else if (isIcebergCommand(sqlTextAfterSubstitution)) {
       parse(sqlTextAfterSubstitution) { parser => astBuilder.visit(parser.singleStatement()) }
         .asInstanceOf[LogicalPlan]
     } else {
       RewriteViewCommands(SparkSession.active).apply(delegateParse(sqlText))
     }
+  }
+
+  /**
+   * Parse `INSERT INTO t REPLACE USING (cols) <query>`.
+   *
+   * Spark's grammar does not yet accept `REPLACE USING` in `INSERT INTO`, while the Iceberg
+   * extension grammar cannot own an arbitrary trailing Spark query. Keep the workaround narrow: the
+   * Iceberg grammar parses only the command head, and the wrapped Spark parser parses the query.
+   *
+   * TODO: Propose Spark to add `REPLACE USING` / `REPLACE ON` to `insertInto`, remove this text
+   * split, and build [[ReplaceScopedData]] from the native Spark parse tree instead.
+   */
+  private def parseScopedReplace(sqlText: String)(
+      delegateParse: String => LogicalPlan): LogicalPlan = {
+    val scopeListEnd = scopeListEndIndex(sqlText)
+    val headText = sqlText.substring(0, scopeListEnd + 1)
+    val queryText = sqlText.substring(scopeListEnd + 1)
+    val (tableParts, scopeColumns) = parse(headText) { parser =>
+      astBuilder.visitSingleScopedReplaceHead(parser.singleScopedReplaceHead())
+    }
+    val source = delegateParse(queryText)
+    ReplaceScopedData(UnresolvedRelation(tableParts), scopeColumns, source)
+  }
+
+  /**
+   * Find the index of the `)` that closes the scope column list of `REPLACE USING (...)`.
+   *
+   * String literals and SQL comments are masked out first so the keyword search and parenthesis
+   * matching cannot be fooled by `replace using` text or parentheses appearing inside a literal or
+   * comment.
+   */
+  private def scopeListEndIndex(sqlText: String): Int = {
+    val masked = maskLiteralsAndComments(sqlText)
+    val matcher = ReplaceUsingOpenParen.pattern.matcher(masked)
+    if (!matcher.find()) {
+      throw new IcebergParseException(
+        Option(sqlText),
+        "Could not locate the REPLACE USING (...) scope column list",
+        Origin(),
+        Origin())
+    }
+    var depth = 1
+    var idx = matcher.end()
+    while (idx < masked.length && depth > 0) {
+      masked.charAt(idx) match {
+        case '(' => depth += 1
+        case ')' => depth -= 1
+        case _ =>
+      }
+      if (depth == 0) {
+        return idx
+      }
+      idx += 1
+    }
+    throw new IcebergParseException(
+      Option(sqlText),
+      "Unbalanced parentheses in REPLACE USING (...) scope column list",
+      Origin(),
+      Origin())
+  }
+
+  /**
+   * Blanks out literals and comments with spaces, preserving input offsets for later string scans.
+   *
+   * By default this also blanks backquoted identifiers, which keeps parentheses inside quoted names
+   * from affecting scope-list matching. Command-head detection opts out so backquoted table names
+   * remain visible to the head pattern.
+   */
+  private def maskLiteralsAndComments(sql: String, maskBackquotes: Boolean = true): String = {
+    val out = sql.toCharArray
+    val n = out.length
+    var i = 0
+    while (i < n) {
+      sql.charAt(i) match {
+        case '`' if !maskBackquotes =>
+          i += 1
+          while (i < n && sql.charAt(i) != '`') {
+            i += 1
+          }
+          if (i < n) {
+            i += 1
+          }
+        case '\'' | '"' | '`' =>
+          val quote = sql.charAt(i)
+          out(i) = ' '
+          i += 1
+          while (i < n && sql.charAt(i) != quote) {
+            // Backslash escapes apply only inside the SQL string literals, not backquotes.
+            if (quote != '`' && sql.charAt(i) == '\\' && i + 1 < n) {
+              out(i) = ' '
+              i += 1
+            }
+            out(i) = ' '
+            i += 1
+          }
+          if (i < n) {
+            out(i) = ' '
+            i += 1
+          }
+        case '-' if i + 1 < n && sql.charAt(i + 1) == '-' =>
+          while (i < n && sql.charAt(i) != '\n') {
+            out(i) = ' '
+            i += 1
+          }
+        case '/' if i + 1 < n && sql.charAt(i + 1) == '*' =>
+          // Spark's lexer treats block comments as nesting (see SqlBaseLexer's BRACKETED_COMMENT,
+          // which recurses), so a comment only closes once every opener has a matching `*/`. Track
+          // the nesting depth here so an inner `*/` does not prematurely unmask trailing text.
+          var depth = 1
+          out(i) = ' '
+          out(i + 1) = ' '
+          i += 2
+          while (i + 1 < n && depth > 0) {
+            if (sql.charAt(i) == '/' && sql.charAt(i + 1) == '*') {
+              depth += 1
+              out(i) = ' '
+              out(i + 1) = ' '
+              i += 2
+            } else if (sql.charAt(i) == '*' && sql.charAt(i + 1) == '/') {
+              depth -= 1
+              out(i) = ' '
+              out(i + 1) = ' '
+              i += 2
+            } else {
+              out(i) = ' '
+              i += 1
+            }
+          }
+          // Blank any trailing char of an unterminated comment (depth never reached 0).
+          if (depth > 0 && i < n) {
+            out(i) = ' '
+            i += 1
+          }
+        case _ =>
+          i += 1
+      }
+    }
+    new String(out)
   }
 
   private def isIcebergCommand(sqlText: String): Boolean = {
@@ -172,6 +314,18 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
       normalized.contains("set identifier fields") ||
       normalized.contains("drop identifier fields") ||
       isSnapshotRefDdl(normalized))
+  }
+
+  /**
+   * Detect `INSERT INTO [TABLE] <identifier> REPLACE USING (...)` by anchoring on the statement
+   * head, so `REPLACE USING (` appearing later in the query body (e.g. a join alias `replace`
+   * with a `USING (...)` clause) is left for Spark to parse as an ordinary insert. Matching runs
+   * on text with literals and comments masked so they cannot fabricate a head match; backquoted
+   * table identifiers are preserved so the head pattern can see the target table.
+   */
+  private def isScopedReplaceCommand(sqlText: String): Boolean = {
+    val masked = maskLiteralsAndComments(sqlText, maskBackquotes = false)
+    ScopedReplaceCommandHead.pattern.matcher(masked).find()
   }
 
   private def isSnapshotRefDdl(normalized: String): Boolean = {
@@ -231,6 +385,22 @@ class IcebergSparkSqlExtensionsParser(delegate: ParserInterface)
 }
 
 object IcebergSparkSqlExtensionsParser {
+
+  /** Matches the `REPLACE USING (` opener (case-insensitive, whitespace-tolerant). */
+  private val ReplaceUsingOpenParen = "(?i)replace\\s+using\\s*\\(".r
+
+  /**
+   * Anchors scoped-replace detection to the statement head: `INSERT INTO [TABLE]
+   * <multipartIdentifier> REPLACE USING (`. The identifier is a dotted chain of unquoted (`\w+`)
+   * or backquoted parts; word-character parts separated only by whitespace (i.e. ordinary query
+   * keywords like `SELECT ... FROM`) cannot match, so a `REPLACE USING (` appearing later in the
+   * query body does not trigger the scoped-replace path.
+   */
+  private val ScopedReplaceCommandHead =
+    ("(?i)^\\s*insert\\s+into\\s+(?:table\\s+)?" +
+      "(?:\\w+|`(?:[^`]|``)*`)(?:\\s*\\.\\s*(?:\\w+|`(?:[^`]|``)*`))*" +
+      "\\s+replace\\s+using\\s*\\(").r
+
   private val substitutorCtor: DynConstructors.Ctor[VariableSubstitution] =
     DynConstructors
       .builder()

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -328,6 +328,18 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       toSeq(ctx.order.fields).map(typedVisit[(Term, SortDirection, NullOrder)])
     }
 
+  /**
+   * Parse the head of an `INSERT INTO t REPLACE USING (cols) <query>` statement into the target
+   * table name and its replace-scope columns. The trailing `<query>` is split off by the parser
+   * and delegated to Spark, so it is not part of this rule.
+   */
+  override def visitSingleScopedReplaceHead(
+      ctx: SingleScopedReplaceHeadContext): (Seq[String], Seq[Seq[String]]) = withOrigin(ctx) {
+    val table = typedVisit[Seq[String]](ctx.multipartIdentifier)
+    val scopeColumns = toSeq(ctx.fieldList.fields).map(typedVisit[Seq[String]])
+    (table, scopeColumns)
+  }
+
   override def visitSingleStatement(ctx: SingleStatementContext): LogicalPlan = withOrigin(ctx) {
     visit(ctx.statement).asInstanceOf[LogicalPlan]
   }

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceScopedData.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/plans/logical/ReplaceScopedData.scala
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.spark.sql.catalyst.plans.logical
+
+import org.apache.spark.sql.catalyst.expressions.Attribute
+
+/**
+ * Logical node for the scoped-replace command:
+ * {{{INSERT INTO t REPLACE USING (c1, .., cn) <query>}}}
+ *
+ * Semantics: delete target rows whose scope columns match a source row, then append the full
+ * source in the same write. This node records the parsed command; the rewrite rule asks the table's
+ * row-level operation builder to choose the configured implementation, such as group replacement
+ * for copy-on-write tables or row deltas for merge-on-read tables.
+ *
+ * Scope columns are kept as raw multi-part names rather than resolved expressions so that they can
+ * be resolved explicitly against the (resolved) target relation in the rewrite rule, avoiding
+ * cross-child ambiguity when a name is present in both the target and the source.
+ *
+ * @param table the target relation
+ * @param scopeColumns the replace-scope columns, as raw multi-part identifiers over the target
+ * @param query the source plan whose rows are appended
+ */
+case class ReplaceScopedData(table: LogicalPlan, scopeColumns: Seq[Seq[String]], query: LogicalPlan)
+    extends BinaryCommand {
+
+  override def left: LogicalPlan = table
+
+  override def right: LogicalPlan = query
+
+  override def output: Seq[Attribute] = Nil
+
+  override protected def withNewChildrenInternal(
+      newLeft: LogicalPlan,
+      newRight: LogicalPlan): ReplaceScopedData =
+    copy(table = newLeft, query = newRight)
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceScopedData.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceScopedData.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.iceberg.SnapshotSummary.ADDED_DELETE_FILES_PROP;
+import static org.apache.iceberg.SnapshotSummary.DELETED_FILES_PROP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestCopyOnWriteReplaceScopedData extends TestReplaceScopedData {
+
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+
+  @TestTemplate
+  public void testScopedReplaceRewritesDataFiles() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "PARTITIONED BY (dep)",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snapshot = SnapshotUtil.latestSnapshot(table, branch);
+    assertThat(snapshot.summary()).containsKey(DELETED_FILES_PROP);
+    assertThat(snapshot.summary()).doesNotContainKey(ADDED_DELETE_FILES_PROP);
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceScopedDataDataFrame.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestCopyOnWriteReplaceScopedDataDataFrame.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.util.Map;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class TestCopyOnWriteReplaceScopedDataDataFrame extends TestReplaceScopedDataDataFrame {
+
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.COPY_ON_WRITE.modeName());
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceScopedData.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceScopedData.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.iceberg.SnapshotSummary.ADDED_DELETE_FILES_PROP;
+import static org.apache.iceberg.SnapshotSummary.ADDED_DVS_PROP;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.junit.jupiter.api.TestTemplate;
+
+public class TestMergeOnReadReplaceScopedData extends TestReplaceScopedData {
+
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName());
+  }
+
+  @TestTemplate
+  public void testScopedReplaceWritesRowDeltas() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "PARTITIONED BY (dep)",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snapshot = SnapshotUtil.latestSnapshot(table, branch);
+    assertThat(snapshot.summary()).containsKey(ADDED_DELETE_FILES_PROP);
+    if (formatVersion >= 3) {
+      assertThat(snapshot.summary()).containsKey(ADDED_DVS_PROP);
+    }
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceScopedDataDataFrame.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMergeOnReadReplaceScopedDataDataFrame.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import java.util.Map;
+import org.apache.iceberg.RowLevelOperationMode;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+
+public class TestMergeOnReadReplaceScopedDataDataFrame extends TestReplaceScopedDataDataFrame {
+
+  @Override
+  protected Map<String, String> extraTableProperties() {
+    return ImmutableMap.of(
+        TableProperties.MERGE_MODE, RowLevelOperationMode.MERGE_ON_READ.modeName());
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceScopedData.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceScopedData.java
@@ -1,0 +1,303 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.spark.sql.functions.udf;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.internal.SQLConf;
+import org.apache.spark.sql.types.DataTypes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public abstract class TestReplaceScopedData extends SparkRowLevelOperationsTestBase {
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS source");
+    sql("DROP VIEW IF EXISTS left_src");
+    sql("DROP VIEW IF EXISTS right_src");
+  }
+
+  @TestTemplate
+  public void testScopedReplace() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "PARTITIONED BY (dep)",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 2, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 3, \"dep\": \"it\" }\n"
+            + "{ \"id\": 4, \"dep\": \"sales\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING",
+        "{ \"id\": 10, \"dep\": \"hr\" }\n" + "{ \"id\": 11, \"dep\": \"sales\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should replace rows with matching scope values and retain the rest",
+        ImmutableList.of(row(3, "it"), row(10, "hr"), row(11, "sales")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testDuplicateSourceScopesDeleteTargetRowsOnce() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 2, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 3, \"dep\": \"it\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING",
+        "{ \"id\": 10, \"dep\": \"hr\" }\n" + "{ \"id\": 11, \"dep\": \"hr\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should delete the target scope once and append all source rows",
+        ImmutableList.of(row(3, "it"), row(10, "hr"), row(11, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testNullScopeMatchesNullScope() {
+    createAndInitTable("id INT, dep STRING");
+    sql("INSERT INTO %s VALUES (1, NULL), (2, 'hr'), (3, NULL)", tableName);
+    createBranchIfNeeded();
+
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": null }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should use null-safe equality for replace-scope values",
+        ImmutableList.of(row(2, "hr"), row(10, null)),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testNondeterministicSourceIsEvaluatedOnce() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    AtomicInteger depIndex = new AtomicInteger();
+    spark
+        .udf()
+        .register(
+            "replace_scoped_data_dep",
+            udf(() -> depIndex.getAndIncrement() == 0 ? "hr" : "it", DataTypes.StringType)
+                .asNondeterministic()
+                .asNonNullable());
+
+    sql(
+        "INSERT INTO %s REPLACE USING (dep) " + "SELECT 10 AS id, replace_scoped_data_dep() AS dep",
+        commitTarget());
+
+    assertEquals(
+        "Should evaluate the source once for deletes and inserts",
+        ImmutableList.of(row(2, "it"), row(10, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testNewSourceScopesAppendWithoutDeletingTargetRows() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING",
+        "{ \"id\": 10, \"dep\": \"sales\" }\n" + "{ \"id\": 11, \"dep\": \"eng\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should append new scopes and keep every existing row when no scope matches",
+        ImmutableList.of(row(1, "hr"), row(2, "it"), row(10, "sales"), row(11, "eng")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testMixedMatchingAndNewSourceScopes() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 2, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 3, \"dep\": \"it\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING",
+        "{ \"id\": 10, \"dep\": \"hr\" }\n" + "{ \"id\": 11, \"dep\": \"sales\" }");
+
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should replace matching scopes, append new scopes, and retain untouched scopes",
+        ImmutableList.of(row(3, "it"), row(10, "hr"), row(11, "sales")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testEmptySourceLeavesTargetUnchanged() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }");
+
+    // An empty source has no scope values to match and no rows to append, so the target must be
+    // left exactly as it was.
+    sql(
+        "INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source WHERE id < 0",
+        commitTarget());
+
+    assertEquals(
+        "Empty source should delete nothing and append nothing",
+        ImmutableList.of(row(1, "hr"), row(2, "it")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testMultiColumnScopeMatchesOnTheFullTuple() {
+    createAndInitTable(
+        "id INT, dep STRING, subdep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\", \"subdep\": \"a\" }\n"
+            + "{ \"id\": 2, \"dep\": \"hr\", \"subdep\": \"b\" }\n"
+            + "{ \"id\": 3, \"dep\": \"it\", \"subdep\": \"a\" }");
+
+    createOrReplaceView(
+        "source",
+        "id INT, dep STRING, subdep STRING",
+        "{ \"id\": 10, \"dep\": \"hr\", \"subdep\": \"a\" }\n"
+            + "{ \"id\": 11, \"dep\": \"it\", \"subdep\": \"a\" }");
+
+    sql(
+        "INSERT INTO %s REPLACE USING (dep, subdep) SELECT id, dep, subdep FROM source",
+        commitTarget());
+
+    // Only rows whose (dep, subdep) tuple appears in the source are replaced; (hr, b) is retained
+    // even though its dep matches a replaced scope.
+    assertEquals(
+        "Should match the full scope tuple instead of any single scope column",
+        ImmutableList.of(row(2, "hr", "b"), row(10, "hr", "a"), row(11, "it", "a")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testReplaceUsingTextInRegularInsertQueryDoesNotTriggerScopedReplaceParser() {
+    createAndInitTable("id INT, dep STRING");
+
+    sql("INSERT INTO %s SELECT 1, 'replace using ('", tableName);
+
+    assertThat(sql("SELECT * FROM %s", tableName)).containsExactly(row(1, "replace using ("));
+  }
+
+  @TestTemplate
+  public void testJoinAliasNamedReplaceDoesNotTriggerScopedReplaceParser() {
+    createAndInitTable("id INT, dep STRING");
+    createOrReplaceView("left_src", "id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+    createOrReplaceView("right_src", "id INT", "{ \"id\": 1 }");
+
+    // Scoped-replace detection must stay at the command head. Valid Spark query bodies can contain
+    // the same token sequence, for example a join alias named `replace` followed by a USING join.
+    sql(
+        "INSERT INTO %s SELECT id, left_src.dep FROM left_src JOIN right_src replace USING (id)",
+        tableName);
+
+    assertThat(sql("SELECT * FROM %s", tableName)).containsExactly(row(1, "hr"));
+  }
+
+  @TestTemplate
+  public void testNestedBlockCommentDoesNotTriggerScopedReplaceParser() {
+    createAndInitTable("id INT, dep STRING");
+
+    // Spark treats block comments as nesting, so the inner `*/` does not close the comment and the
+    // whole `REPLACE USING (dep)` text stays commented out. The router must mask it the same way
+    // and leave this as an ordinary insert for Spark to parse.
+    sql("INSERT INTO %s /* outer /* inner */ REPLACE USING (dep) */ SELECT 1, 'hr'", tableName);
+
+    assertThat(sql("SELECT * FROM %s", tableName)).containsExactly(row(1, "hr"));
+  }
+
+  @TestTemplate
+  public void testCommentInCommandHeadStillRoutesToScopedReplace() {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }");
+
+    // A (terminated) comment in the command head is masked for detection and skipped by the head
+    // grammar, so this must still be recognized and executed as a scoped replace.
+    sql(
+        "INSERT INTO %s /* reload hr */ REPLACE USING (dep) SELECT id, dep FROM source",
+        commitTarget());
+
+    assertEquals(
+        "A comment in the head should not prevent scoped replace detection",
+        ImmutableList.of(row(2, "it"), row(10, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testStoreAssignmentPolicyRejectsUnsafeSourceCast() {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    // Scoped replace uses the same store-assignment rules as INSERT. Under ANSI, unsafe source
+    // values must fail during analysis instead of slipping through the row-level rewrite.
+    withSQLConf(
+        ImmutableMap.of(SQLConf.STORE_ASSIGNMENT_POLICY().key(), "ansi"),
+        () ->
+            assertThatThrownBy(
+                    () ->
+                        sql(
+                            "INSERT INTO %s REPLACE USING (dep) SELECT 'x' AS id, 'hr' AS dep",
+                            commitTarget()))
+                .isInstanceOf(AnalysisException.class)
+                .hasMessageContaining("INCOMPATIBLE_DATA_FOR_TABLE"));
+  }
+
+  @TestTemplate
+  public void testSafeSourceCastIsAligned() {
+    createAndInitTable("id BIGINT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+    createOrReplaceView("source", "id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }");
+
+    // Valid store-assignment casts still need to be preserved when the rewrite aligns the source to
+    // the target output.
+    sql("INSERT INTO %s REPLACE USING (dep) SELECT id, dep FROM source", commitTarget());
+
+    assertEquals(
+        "Should align the source column to the target type",
+        ImmutableList.of(row(10L, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceScopedDataDataFrame.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestReplaceScopedDataDataFrame.java
@@ -1,0 +1,259 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.apache.spark.sql.functions.expr;
+import static org.apache.spark.sql.functions.lit;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkWriteOptions;
+import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.AnalysisException;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.catalyst.parser.ParseException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.TestTemplate;
+
+public abstract class TestReplaceScopedDataDataFrame extends SparkRowLevelOperationsTestBase {
+
+  @AfterEach
+  public void removeTables() {
+    sql("DROP TABLE IF EXISTS %s", tableName);
+    sql("DROP TABLE IF EXISTS parquet_replace_scoped_data");
+  }
+
+  @TestTemplate
+  public void testScopedReplace() throws Exception {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "PARTITIONED BY (dep)",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 2, \"dep\": \"hr\" }\n"
+            + "{ \"id\": 3, \"dep\": \"it\" }\n"
+            + "{ \"id\": 4, \"dep\": \"sales\" }");
+
+    source(
+            "id INT, dep STRING",
+            "{ \"id\": 10, \"dep\": \"hr\" }\n{ \"id\": 11, \"dep\": \"sales\" }")
+        .writeTo(commitTarget())
+        .option("replace-using", "dep")
+        .overwrite(lit(true));
+
+    assertEquals(
+        "Should replace rows with matching scope values and retain the rest",
+        Arrays.asList(row(3, "it"), row(10, "hr"), row(11, "sales")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testDataFrameColumnsAreAlignedByName() throws Exception {
+    createAndInitTable(
+        "id INT, dep STRING, note STRING",
+        "{ \"id\": 1, \"dep\": \"hr\", \"note\": \"old\" }\n"
+            + "{ \"id\": 2, \"dep\": \"it\", \"note\": \"keep\" }");
+
+    Dataset<Row> reorderedSource = spark.sql("SELECT 'new' AS note, 'hr' AS dep, 10 AS id");
+    reorderedSource.writeTo(commitTarget()).option("replace-using", "dep").overwrite(lit(true));
+
+    assertEquals(
+        "Should preserve Spark DataFrameWriterV2 by-name column alignment",
+        Arrays.asList(row(2, "it", "keep"), row(10, "hr", "new")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testNormalWriteOptionsArePreserved() throws Exception {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+        .writeTo(commitTarget())
+        .option("Replace-Using", "dep")
+        .option(SparkWriteOptions.SNAPSHOT_PROPERTY_PREFIX + ".df-scoped-replace", "passed")
+        .overwrite(lit(true));
+
+    Table table = validationCatalog.loadTable(tableIdent);
+    Snapshot snapshot = SnapshotUtil.latestSnapshot(table, branch);
+    assertThat(snapshot.summary()).containsEntry("df-scoped-replace", "passed");
+  }
+
+  @TestTemplate
+  public void testBranchWriteOptionIsHonored() throws Exception {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+    sql("ALTER TABLE %s CREATE BRANCH df_branch", tableName);
+
+    source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+        .writeTo(tableName)
+        .option(SparkWriteOptions.BRANCH, "df_branch")
+        .option("replace-using", "dep")
+        .overwrite(lit(true));
+
+    assertEquals(
+        "Main branch should be unchanged",
+        ImmutableList.of(row(1, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+    assertEquals(
+        "Configured write branch should receive the scoped replace",
+        ImmutableList.of(row(10, "hr")),
+        sql("SELECT * FROM %s VERSION AS OF 'df_branch' ORDER BY id", tableName));
+  }
+
+  @TestTemplate
+  public void testDuplicateScopeColumnsAreAccepted() throws Exception {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+        .writeTo(commitTarget())
+        .option("replace-using", "dep, dep")
+        .overwrite(lit(true));
+
+    assertEquals(
+        "Duplicate scope columns should behave as redundant predicates",
+        Arrays.asList(row(2, "it"), row(10, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testEmptyScopeTokenIsRejected() {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    assertThatThrownBy(
+            () ->
+                source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+                    .writeTo(commitTarget())
+                    .option("replace-using", "dep,")
+                    .overwrite(lit(true)))
+        .isInstanceOf(ParseException.class)
+        .hasMessageContaining("Syntax error");
+  }
+
+  @TestTemplate
+  public void testNonTrueOverwritePredicateIsRejected() {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    assertThatThrownBy(
+            () ->
+                source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+                    .writeTo(commitTarget())
+                    .option("replace-using", "dep")
+                    .overwrite(expr("id = 1")))
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("overwrite(true)");
+  }
+
+  @TestTemplate
+  public void testAppendWithReplaceUsingIsRejectedForIceberg() {
+    createAndInitTable("id INT, dep STRING", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    assertThatThrownBy(
+            () ->
+                source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+                    .writeTo(commitTarget())
+                    .option("replace-using", "dep")
+                    .append())
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("not append");
+  }
+
+  @TestTemplate
+  public void testDynamicOverwriteWithReplaceUsingIsRejectedForIceberg() {
+    createAndInitTable(
+        "id INT, dep STRING", "PARTITIONED BY (dep)", "{ \"id\": 1, \"dep\": \"hr\" }");
+
+    assertThatThrownBy(
+            () ->
+                source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+                    .writeTo(commitTarget())
+                    .option("replace-using", "dep")
+                    .overwritePartitions())
+        .isInstanceOf(Exception.class)
+        .hasMessageContaining("not overwritePartitions");
+  }
+
+  @TestTemplate
+  public void testPlainOverwriteIsUnaffected() throws Exception {
+    createAndInitTable(
+        "id INT, dep STRING",
+        "{ \"id\": 1, \"dep\": \"hr\" }\n" + "{ \"id\": 2, \"dep\": \"it\" }");
+
+    source("id INT, dep STRING", "{ \"id\": 10, \"dep\": \"hr\" }")
+        .writeTo(commitTarget())
+        .overwrite(lit(true));
+
+    assertEquals(
+        "Plain overwrite should keep existing DataFrameWriterV2 semantics",
+        ImmutableList.of(row(10, "hr")),
+        sql("SELECT * FROM %s ORDER BY id", selectTarget()));
+  }
+
+  @TestTemplate
+  public void testNonIcebergAppendIsUnchangedByIcebergRule() throws Exception {
+    sql("CREATE TABLE parquet_replace_scoped_data (id INT) USING parquet");
+    sql("INSERT INTO parquet_replace_scoped_data VALUES (1)");
+
+    assertThatThrownBy(
+            () ->
+                spark
+                    .sql("SELECT 2 AS id")
+                    .writeTo("parquet_replace_scoped_data")
+                    .option("replace-using", "id")
+                    .append())
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageContaining("Cannot write into v1 table")
+        .hasMessageNotContaining("not append");
+  }
+
+  @TestTemplate
+  public void testNonIcebergOverwriteIsUnchangedByIcebergRule() throws Exception {
+    sql("CREATE TABLE parquet_replace_scoped_data (id INT) USING parquet");
+    sql("INSERT INTO parquet_replace_scoped_data VALUES (1)");
+
+    // The rewrite is gated to Iceberg SparkTable targets, so a non-Iceberg overwrite carrying
+    // replace-using must fall through to Spark's standard write path rather than being intercepted
+    // and lowered into a scoped replace.
+    assertThatThrownBy(
+            () ->
+                spark
+                    .sql("SELECT 2 AS id")
+                    .writeTo("parquet_replace_scoped_data")
+                    .option("replace-using", "id")
+                    .overwrite(lit(true)))
+        .isInstanceOf(AnalysisException.class)
+        .hasMessageContaining("Cannot write into v1 table")
+        .hasMessageNotContaining("overwrite(true)");
+  }
+
+  private Dataset<Row> source(String schema, String jsonData) {
+    List<String> jsonRows =
+        Arrays.stream(jsonData.split("\n"))
+            .filter(str -> !str.trim().isEmpty())
+            .collect(Collectors.toList());
+    Dataset<String> jsonDS = spark.createDataset(jsonRows, org.apache.spark.sql.Encoders.STRING());
+    return spark.read().schema(schema).json(jsonDS);
+  }
+}


### PR DESCRIPTION
Part 1 work of #16785.

## What

This adds scoped replacement writes to the Iceberg Spark 4.1 extensions. A scoped replacement treats the source as the complete replacement for the scopes it touches: it reads the distinct scope tuples from the source, deletes target rows whose scope shows up in the source, appends every source row once, and commits the delete and append as a single Iceberg snapshot. Scopes that the source never mentions are left alone. This is the "full group refresh" operation from #16785: atomic, with no two-commit DELETE + INSERT and no stretched `MERGE INTO ... WHEN NOT MATCHED BY SOURCE`.

There are two ways to invoke it.

### DataFrame API (merge-eligible API for spark 4.1)

Dataframe API - `DataFrameWriterV2` with the `replace-using` write option and an unconditional overwrite:

```scala
source.writeTo("target_table")
  .option("replace-using", "scope_col_1, scope_col_2")
  .overwrite(lit(true))
```

`overwrite(lit(true))` is required: the option only converts a full overwrite into a scoped replacement, so any other overwrite filter (or `append` / `overwritePartitions`) is rejected with a clear error rather than silently ignoring the option. Normal Iceberg write options are preserved and flow through unchanged — for example target file size, compression, distribution mode, and `branch` selection:

```scala
source.writeTo("target_table")
  .option("replace-using", "scope_col_1, scope_col_2")
  .option("branch", "audit")
  .option(SparkWriteOptions.TARGET_FILE_SIZE_BYTES, "134217728")
  .overwrite(lit(true))
```

This surface works uniformly from Scala, Java, and PySpark because all three route through the same `DataFrameWriterV2` → `OverwriteByExpression` logical plan. It is gated strictly to Iceberg tables; a `replace-using` option on a non-Iceberg DSv2 table is left untouched.

### SQL (demonstration only, need Spark grammar addition ideally)

```sql
INSERT INTO target_table
REPLACE USING (scope_col_1, scope_col_2)
<query>
```

## Scope of this PR

This PR covers part of #16785. A few things are left for later on purpose:

- Only the column-list form (`REPLACE USING (cols)` / `replace-using`) is implemented. The arbitrary-condition form (`REPLACE ON <expr>`) from the issue is not here yet.
- There is no native Spark grammar for the SQL form. Spark's `insertInto` grammar does not accept `REPLACE USING`, and the Iceberg extension grammar cannot own an arbitrary trailing Spark query. So the SQL path uses an in-place text split as a stopgap: the Iceberg ANTLR grammar parses only the command head (`singleScopedReplaceHead`: `INSERT INTO t REPLACE USING (cols)`), and the remaining query tail goes to the wrapped Spark parser. Detection is anchored to the statement head with literals and comments masked, so a `REPLACE USING (` later in the query body (say, a join alias) does not trigger the path.

> [!NOTE]
> The DataFrame API is self-contained and does not depend on the SQL grammar. Both DF and SQL reuses the same underlying `ReplaceScopedData` and`RewriteScopedReplace`. Because the `.g4` text-split SQL parsing is a stopgap (the real end state is to propose `REPLACE USING` / `REPLACE ON` for Spark's native `insertInto` grammar), **the SQL grammar / parser / AST-builder pieces and the SQL-only tests may be removed before this PR is merged** to keep it focused on the DataFrame API.

## How it works

- A new logical node, `ReplaceScopedData(table, scopeColumns, source)`.
- `RewriteDataFrameScopedReplace` detects a `replace-using` `OverwriteByExpression` on an Iceberg table, validates the unconditional overwrite, merges the command and relation write options, eagerly resolves the write branch (Spark's post-hoc resolution batch runs only once, so the branch is pinned here rather than relying on a later pass), parses the scope columns, and emits `ReplaceScopedData`.
- `RewriteScopedReplace` lowers `ReplaceScopedData` through Iceberg's existing row-level write path. It requests the operation as `MERGE` so the table configuration decides between copy-on-write and merge-on-read (and deletion vectors):
  - COW → `ReplaceData`
  - MOR → `WriteDelta`
- It reuses the standard row-level group filtering and runtime filtering for performance. Note that there is no planning-time static pruning yet.

## Tests

- `TestReplaceScopedDataDataFrame` covers the DataFrame surface: scope deletion, full source append, untouched scopes, empty source, duplicate scope keys, null scope values, multi-column scopes, write-option and branch passthrough, and validation (non-`true` overwrite, append/overwritePartitions, non-Iceberg tables, empty scope tokens). `TestCopyOnWriteReplaceScopedDataDataFrame` and `TestMergeOnReadReplaceScopedDataDataFrame` exercise both write modes.
- `TestReplaceScopedData` covers the shared semantics via SQL; `TestCopyOnWriteReplaceScopedData` and `TestMergeOnReadReplaceScopedData` exercise both write modes. (These SQL-only suites go away if the SQL grammar path is dropped per the note above.)

## Docs

- `docs/docs/spark-writes.md` documents the scoped replacement DataFrame API and the supported `REPLACE USING` SQL form, and notes that `REPLACE ON` and native Spark grammar support are future work.

## Follow-ups

1. Decide whether to drop the SQL text-split grammar from this PR (keeping the DataFrame API) and propose native Spark grammar for `REPLACE USING` / `REPLACE ON` separately.
2. Implement the `REPLACE ON <boolean_expr>` form.
3. When the source's distinct scope values are small/known, pre-evaluate them and synthesize a static scope `IN (...)` predicate to feed Iceberg's static filter.
