### PR TITLE
Spec: Clarify geography type serialization

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -1685,7 +1685,7 @@ Types are serialized according to this table:
 |**`map`**|`JSON object: {`<br />&nbsp;&nbsp;`"type": "map",`<br />&nbsp;&nbsp;`"key-id": <key id int>,`<br />&nbsp;&nbsp;`"key": <type JSON>,`<br />&nbsp;&nbsp;`"value-id": <val id int>,`<br />&nbsp;&nbsp;`"value-required": <bool>`<br />&nbsp;&nbsp;`"value": <type JSON>`<br />`}`|`{`<br />&nbsp;&nbsp;`"type": "map",`<br />&nbsp;&nbsp;`"key-id": 4,`<br />&nbsp;&nbsp;`"key": "string",`<br />&nbsp;&nbsp;`"value-id": 5,`<br />&nbsp;&nbsp;`"value-required": false,`<br />&nbsp;&nbsp;`"value": "double"`<br />`}`|
 | **`variant`**| `JSON string: "variant"`|`"variant"`|
 | **`geometry(C)`** |`JSON string: "geometry(<C>)"`|`"geometry(srid:4326)"`|
-| **`geography(C, A)`** |`JSON string: "geography(<C>,<E>)"`|`"geography(srid:4326,spherical)"`|
+| **`geography(C, A)`** |`JSON string: "geography(<C>, <A>)"`|`"geography(srid:4326, spherical)"`|
 
 Note that default values are serialized using the JSON single-value serialization in [Appendix D](#appendix-d-single-value-serialization).
 


### PR DESCRIPTION
## Summary
Similar to #16798

- Clarify canonical schema JSON geography type strings as `geography(C, A)`.
- Align the JSON representation and example with Java writer output: [`SchemaParser` writes `type.toString()`](https://github.com/apache/iceberg/blob/51ee2cc0d993fe58de21b76613f350da97e9d3ef/core/src/main/java/org/apache/iceberg/SchemaParser.java#L143-L145), and [`GeographyType.toString()` formats `geography(%s, %s)`](https://github.com/apache/iceberg/blob/51ee2cc0d993fe58de21b76613f350da97e9d3ef/api/src/main/java/org/apache/iceberg/types/Types.java#L692-L695).

## Testing

- `git diff --check`
