### PR TITLE
OpenAPI: Formalize remote signing configuration

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1120,6 +1120,34 @@ class RemoteSignResult(BaseModel):
     headers: MultiValuedMap
 
 
+class RemoteSigningConfig(BaseModel):
+    """
+    Configuration for the remote signer client.
+    When present, clients MUST use this structure instead of the deprecated `signer.uri` and
+    `signer.endpoint` properties in the `config` map.
+
+    """
+
+    base_uri: str = Field(
+        ...,
+        alias='base-uri',
+        description='The base URI of the signing service as perceived by the client, incorporating X-Forwarded-* headers set by proxies. When present, takes precedence over the deprecated `signer.uri` config property.\n',
+    )
+    endpoint_path: str = Field(
+        ...,
+        alias='endpoint-path',
+        description='Relative path to be resolved against `base-uri` to form the full signing endpoint URI. When present, overrides the deprecated `signer.endpoint` config property. The endpoint path SHOULD end with the canonical signing endpoint path defined in this specification, that is: `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`.\n',
+    )
+    properties: dict[str, str] | None = Field(
+        None,
+        description='Static key-value pairs the signer client MUST pass through unchanged in the `properties` field of every `RemoteSignRequest` sent to the signing endpoint.\n',
+    )
+    headers: MultiValuedMap | None = Field(
+        None,
+        description='Static headers the signer client MUST include unchanged in every request to the signing endpoint.\n',
+    )
+
+
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: dict[str, str] | None = Field(
@@ -1563,9 +1591,15 @@ class LoadTableResult(BaseModel):
 
     ## Remote Signing
 
-    If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
-     - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
-     - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+    If remote signing for a specific storage provider is enabled, the server SHOULD use the
+    `remote-signing` field to communicate all signer client settings. When the `remote-signing`
+    field is present, clients MUST use it instead of the deprecated `signer.uri` and
+    `signer.endpoint` config properties.
+
+    For backward compatibility, the following `config` properties are still supported but
+    **DEPRECATED** in favor of the `remote-signing` field:
+     - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing.endpoint-path` instead.
+     - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing.base-uri` instead.
 
     """
 
@@ -1579,6 +1613,7 @@ class LoadTableResult(BaseModel):
     storage_credentials: list[StorageCredential] | None = Field(
         None, alias='storage-credentials'
     )
+    remote_signing: RemoteSigningConfig | None = Field(None, alias='remote-signing')
 
 
 class ScanTasks(BaseModel):

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1131,12 +1131,12 @@ class RemoteSigningConfig(BaseModel):
     base_uri: str = Field(
         ...,
         alias='base-uri',
-        description='The base URI of the signing service as perceived by the client, incorporating X-Forwarded-* headers set by proxies. When present, takes precedence over the deprecated `signer.uri` config property.\n',
+        description='The base URI of the signing service as perceived by the client, incorporating X-Forwarded-* headers set by proxies. Takes precedence over the deprecated `signer.uri` config property.\n',
     )
     endpoint_path: str = Field(
         ...,
         alias='endpoint-path',
-        description='Relative path to be resolved against `base-uri` to form the full signing endpoint URI. When present, overrides the deprecated `signer.endpoint` config property. The endpoint path SHOULD end with the canonical signing endpoint path defined in this specification, that is: `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`.\n',
+        description='Relative path to be resolved against `base-uri` to form the full signing endpoint URI. Overrides the deprecated `signer.endpoint` config property. Convention exposes the signing endpoint at `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`, but clients SHOULD NOT assume this structure or recompose it themselves.\n',
     )
     properties: dict[str, str] | None = Field(
         None,

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1123,7 +1123,7 @@ class RemoteSignResult(BaseModel):
 class RemoteSigningConfig(BaseModel):
     """
     Configuration for the remote signer client.
-    When present, clients MUST use this structure instead of the deprecated `signer.uri` and
+    When present, clients SHOULD use this structure instead of the deprecated `signer.uri` and
     `signer.endpoint` properties in the `config` map.
 
     """
@@ -1592,14 +1592,14 @@ class LoadTableResult(BaseModel):
     ## Remote Signing
 
     If remote signing for a specific storage provider is enabled, the server SHOULD use the
-    `remote-signing` field to communicate all signer client settings. When the `remote-signing`
-    field is present, clients MUST use it instead of the deprecated `signer.uri` and
-    `signer.endpoint` config properties.
+    `remote-signing-config` field to communicate all signer client settings. When the
+    `remote-signing-config` field is present, clients SHOULD use it instead of the deprecated
+    `signer.uri` and `signer.endpoint` config properties.
 
     For backward compatibility, the following `config` properties are still supported but
-    **DEPRECATED** in favor of the `remote-signing` field:
-     - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing.endpoint-path` instead.
-     - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing.base-uri` instead.
+    **DEPRECATED** in favor of the `remote-signing-config` field:
+     - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing-config.endpoint-path` instead.
+     - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing-config.base-uri` instead.
 
     """
 
@@ -1613,7 +1613,9 @@ class LoadTableResult(BaseModel):
     storage_credentials: list[StorageCredential] | None = Field(
         None, alias='storage-credentials'
     )
-    remote_signing: RemoteSigningConfig | None = Field(None, alias='remote-signing')
+    remote_signing_config: RemoteSigningConfig | None = Field(
+        None, alias='remote-signing-config'
+    )
 
 
 class ScanTasks(BaseModel):

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1123,21 +1123,8 @@ class RemoteSignResult(BaseModel):
 class RemoteSigningConfig(BaseModel):
     """
     Configuration for the remote signer client.
-    When present, clients SHOULD use this structure instead of the deprecated `signer.uri` and
-    `signer.endpoint` properties in the `config` map.
-
     """
 
-    base_uri: str = Field(
-        ...,
-        alias='base-uri',
-        description='The base URI of the signing service as perceived by the client, incorporating X-Forwarded-* headers set by proxies. Takes precedence over the deprecated `signer.uri` config property.\n',
-    )
-    endpoint_path: str = Field(
-        ...,
-        alias='endpoint-path',
-        description='Relative path to be resolved against `base-uri` to form the full signing endpoint URI. Overrides the deprecated `signer.endpoint` config property. Convention exposes the signing endpoint at `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`, but clients SHOULD NOT assume this structure or recompose it themselves.\n',
-    )
     properties: dict[str, str] | None = Field(
         None,
         description='Static key-value pairs the signer client MUST pass through unchanged in the `properties` field of every `RemoteSignRequest` sent to the signing endpoint.\n',
@@ -1591,15 +1578,15 @@ class LoadTableResult(BaseModel):
 
     ## Remote Signing
 
-    If remote signing for a specific storage provider is enabled, the server SHOULD use the
-    `remote-signing-config` field to communicate all signer client settings. When the
-    `remote-signing-config` field is present, clients SHOULD use it instead of the deprecated
-    `signer.uri` and `signer.endpoint` config properties.
+    If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
+    field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
+    SHOULD take it into account.
 
-    For backward compatibility, the following `config` properties are still supported but
-    **DEPRECATED** in favor of the `remote-signing-config` field:
-     - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing-config.endpoint-path` instead.
-     - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing-config.base-uri` instead.
+    For backward compatibility, the following `config` properties are still supported but **DEPRECATED**:
+     - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+     - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+    If any of these properties is present, clients MUST use them to compute the actual remote signing endpoint URI to contact.
+    If none of these properties is present, clients MUST contact the default remote signing endpoint using the catalog's base URI.
 
     """
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1582,11 +1582,11 @@ class LoadTableResult(BaseModel):
     field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
     SHOULD take it into account.
 
-    For backward compatibility, the following `config` properties are still supported but **DEPRECATED**:
+    For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
      - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
      - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
-    If any of these properties is present, clients MUST use them to compute the actual remote signing endpoint URI to contact.
-    If none of these properties is present, clients MUST contact the default remote signing endpoint using the catalog's base URI.
+    If any of these properties is present, clients SHOULD use them to compute the actual remote signing endpoint URI to contact.
+    If none of these properties is present, clients SHOULD contact the default remote signing endpoint using the catalog's base URI.
 
     """
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1580,7 +1580,7 @@ class LoadTableResult(BaseModel):
 
     If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
     field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
-    SHOULD take it into account.
+    SHOULD respect the provided configuration.
 
     For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
      - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3680,15 +3680,16 @@ components:
 
         ## Remote Signing
 
-        If remote signing for a specific storage provider is enabled, the server SHOULD use the
-        `remote-signing-config` field to communicate all signer client settings. When the
-        `remote-signing-config` field is present, clients SHOULD use it instead of the deprecated
-        `signer.uri` and `signer.endpoint` config properties.
+        If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
+        field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
+        SHOULD take it into account.
 
-        For backward compatibility, the following `config` properties are still supported but
-        **DEPRECATED** in favor of the `remote-signing-config` field:
-         - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing-config.endpoint-path` instead.
-         - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing-config.base-uri` instead.
+        For backward compatibility, the following `config` properties are still supported but **DEPRECATED**:
+         - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+         - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+        If any of these properties is present, clients MUST use them to compute the actual remote signing endpoint URI to contact.
+        If none of these properties is present, clients MUST contact the default remote signing endpoint using the catalog's base URI.
+
       type: object
       required:
         - metadata
@@ -5256,27 +5257,12 @@ components:
           $ref: '#/components/schemas/MultiValuedMap'
 
     RemoteSigningConfig:
-      description: |
-        Configuration for the remote signer client.
-        When present, clients SHOULD use this structure instead of the deprecated `signer.uri` and
-        `signer.endpoint` properties in the `config` map.
+      description: Configuration for the remote signer client.
       type: object
       required:
         - base-uri
         - endpoint-path
       properties:
-        base-uri:
-          type: string
-          description: >
-            The base URI of the signing service as perceived by the client, incorporating X-Forwarded-*
-            headers set by proxies. Takes precedence over the deprecated `signer.uri` config property.
-        endpoint-path:
-          type: string
-          description: >
-            Relative path to be resolved against `base-uri` to form the full signing endpoint URI.
-            Overrides the deprecated `signer.endpoint` config property. Convention exposes the signing
-            endpoint at `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`, but clients
-            SHOULD NOT assume this structure or recompose it themselves.
         properties:
           type: object
           additionalProperties:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3684,11 +3684,11 @@ components:
         field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
         SHOULD take it into account.
 
-        For backward compatibility, the following `config` properties are still supported but **DEPRECATED**:
+        For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
          - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
          - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
-        If any of these properties is present, clients MUST use them to compute the actual remote signing endpoint URI to contact.
-        If none of these properties is present, clients MUST contact the default remote signing endpoint using the catalog's base URI.
+        If any of these properties is present, clients SHOULD use them to compute the actual remote signing endpoint URI to contact.
+        If none of these properties is present, clients SHOULD contact the default remote signing endpoint using the catalog's base URI.
 
       type: object
       required:
@@ -5259,9 +5259,6 @@ components:
     RemoteSigningConfig:
       description: Configuration for the remote signer client.
       type: object
-      required:
-        - base-uri
-        - endpoint-path
       properties:
         properties:
           type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3682,7 +3682,7 @@ components:
 
         If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
         field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
-        SHOULD take it into account.
+        SHOULD respect the provided configuration.
 
         For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
          - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3680,9 +3680,15 @@ components:
 
         ## Remote Signing
 
-        If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
-         - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
-         - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+        If remote signing for a specific storage provider is enabled, the server SHOULD use the
+        `remote-signing` field to communicate all signer client settings. When the `remote-signing`
+        field is present, clients MUST use it instead of the deprecated `signer.uri` and
+        `signer.endpoint` config properties.
+
+        For backward compatibility, the following `config` properties are still supported but
+        **DEPRECATED** in favor of the `remote-signing` field:
+         - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing.endpoint-path` instead.
+         - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing.base-uri` instead.
       type: object
       required:
         - metadata
@@ -3701,6 +3707,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageCredential'
+        remote-signing:
+          $ref: '#/components/schemas/RemoteSigningConfig'
 
     ScanTasks:
       type: object
@@ -5246,6 +5254,43 @@ components:
           type: string
         headers:
           $ref: '#/components/schemas/MultiValuedMap'
+
+    RemoteSigningConfig:
+      description: |
+        Configuration for the remote signer client.
+        When present, clients MUST use this structure instead of the deprecated `signer.uri` and
+        `signer.endpoint` properties in the `config` map.
+      type: object
+      required:
+        - base-uri
+        - endpoint-path
+      properties:
+        base-uri:
+          type: string
+          description: >
+            The base URI of the signing service as perceived by the client, incorporating X-Forwarded-*
+            headers set by proxies. When present, takes precedence over the deprecated `signer.uri`
+            config property.
+        endpoint-path:
+          type: string
+          description: >
+            Relative path to be resolved against `base-uri` to form the full signing endpoint URI.
+            When present, overrides the deprecated `signer.endpoint` config property. The endpoint path SHOULD
+            end with the canonical signing endpoint path defined in this specification, that is:
+            `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`.
+        properties:
+          type: object
+          additionalProperties:
+            type: string
+          description: >
+            Static key-value pairs the signer client MUST pass through unchanged in the `properties`
+            field of every `RemoteSignRequest` sent to the signing endpoint.
+        headers:
+          allOf:
+            - $ref: '#/components/schemas/MultiValuedMap'
+          description: >
+            Static headers the signer client MUST include unchanged in every request to the signing
+            endpoint.
 
   #############################
   # Reusable Response Objects #

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3681,14 +3681,14 @@ components:
         ## Remote Signing
 
         If remote signing for a specific storage provider is enabled, the server SHOULD use the
-        `remote-signing` field to communicate all signer client settings. When the `remote-signing`
-        field is present, clients MUST use it instead of the deprecated `signer.uri` and
-        `signer.endpoint` config properties.
+        `remote-signing-config` field to communicate all signer client settings. When the
+        `remote-signing-config` field is present, clients SHOULD use it instead of the deprecated
+        `signer.uri` and `signer.endpoint` config properties.
 
         For backward compatibility, the following `config` properties are still supported but
-        **DEPRECATED** in favor of the `remote-signing` field:
-         - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing.endpoint-path` instead.
-         - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing.base-uri` instead.
+        **DEPRECATED** in favor of the `remote-signing-config` field:
+         - `signer.endpoint`: **DEPRECATED**. The remote signer endpoint. Use `remote-signing-config.endpoint-path` instead.
+         - `signer.uri`: **DEPRECATED**. The base URI of the signing service. Use `remote-signing-config.base-uri` instead.
       type: object
       required:
         - metadata
@@ -3707,7 +3707,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageCredential'
-        remote-signing:
+        remote-signing-config:
           $ref: '#/components/schemas/RemoteSigningConfig'
 
     ScanTasks:
@@ -5258,7 +5258,7 @@ components:
     RemoteSigningConfig:
       description: |
         Configuration for the remote signer client.
-        When present, clients MUST use this structure instead of the deprecated `signer.uri` and
+        When present, clients SHOULD use this structure instead of the deprecated `signer.uri` and
         `signer.endpoint` properties in the `config` map.
       type: object
       required:

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5269,15 +5269,14 @@ components:
           type: string
           description: >
             The base URI of the signing service as perceived by the client, incorporating X-Forwarded-*
-            headers set by proxies. When present, takes precedence over the deprecated `signer.uri`
-            config property.
+            headers set by proxies. Takes precedence over the deprecated `signer.uri` config property.
         endpoint-path:
           type: string
           description: >
             Relative path to be resolved against `base-uri` to form the full signing endpoint URI.
-            When present, overrides the deprecated `signer.endpoint` config property. The endpoint path SHOULD
-            end with the canonical signing endpoint path defined in this specification, that is:
-            `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`.
+            Overrides the deprecated `signer.endpoint` config property. Convention exposes the signing
+            endpoint at `/v1/{prefix}/namespaces/{namespace}/tables/{table}/sign`, but clients
+            SHOULD NOT assume this structure or recompose it themselves.
         properties:
           type: object
           additionalProperties:


### PR DESCRIPTION
This PR introduces a new `remote-signing-config` field in the `LoadTableResult` schema, with the following content:

- `properties`: static key-value pairs the signer client MUST pass through unchanged in the `properties` field of every `RemoteSignRequest`
- `headers`: static headers the signer client MUST include unchanged in every request