### PR TITLE
Core: Don't bump DV snapshot ID for deleted_positions and replaced_positions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingBuilder.java
@@ -116,7 +116,6 @@ class TrackingBuilder {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set deleted positions on ADDED entry");
     this.deletedPositions = ByteBuffers.toByteArray(positions);
-    this.dvSnapshotId = newSnapshotId;
     this.status = EntryStatus.MODIFIED;
     return this;
   }
@@ -126,7 +125,6 @@ class TrackingBuilder {
     Preconditions.checkState(
         status != EntryStatus.ADDED, "Cannot set replaced positions on ADDED entry");
     this.replacedPositions = ByteBuffers.toByteArray(positions);
-    this.dvSnapshotId = newSnapshotId;
     this.status = EntryStatus.MODIFIED;
     return this;
   }

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -457,9 +457,10 @@ class TestTrackingStruct {
     Tracking modified =
         TrackingBuilder.from(addedSource, 999L).deletedPositions(deletedBytes).build();
     assertThat(modified.status()).isEqualTo(EntryStatus.MODIFIED);
-    // the entry snapshot id is preserved; only the DV snapshot id advances to the commit snapshot
+    // the entry snapshot id is preserved
     assertThat(modified.snapshotId()).isEqualTo(addedSource.snapshotId()).isNotEqualTo(999L);
-    assertThat(modified.dvSnapshotId()).isEqualTo(999L);
+    // DV snapshot ID must not be set for leaf manifest entries
+    assertThat(modified.dvSnapshotId()).isNull();
     assertThat(modified.deletedPositions()).isEqualTo(deletedBytes);
   }
 
@@ -538,7 +539,6 @@ class TestTrackingStruct {
     Tracking deserialized = TestHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }
@@ -567,7 +567,6 @@ class TestTrackingStruct {
     Tracking deserialized = TestHelpers.KryoHelpers.roundTripSerialize(tracking);
 
     assertThat(deserialized.status()).isEqualTo(EntryStatus.MODIFIED);
-    assertThat(deserialized.dvSnapshotId()).isEqualTo(1L);
     assertThat(deserialized.deletedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
     assertThat(deserialized.replacedPositions()).isEqualTo(ByteBuffer.wrap(new byte[] {3, 4}));
   }


### PR DESCRIPTION
Since deleted_positions and replaced_positions in Tracking are relevant only for the current snapshot, it is redundant to also bump the DV snapshot ID when setting these fields.