### PR TITLE
Lazily initialize Avro 1.12-only LogicalType helpers to maintain compat with Avro 1.11

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -21,13 +21,11 @@ package org.apache.iceberg.avro;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Type;
@@ -72,21 +70,15 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
     TIMESTAMP_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     TIMESTAMPTZ_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
 
-    final Optional<String> runtimeAvroVersion =
-        Optional.ofNullable(Schema.Parser.class.getPackage().getImplementationVersion());
-
-    // NanoTimestamp and UUID logical types are only supported in Avro 1.12 and above;
-    // Gate initialization to avoid runtime errors for users on earlier Avro versions
-    if (runtimeAvroVersion
-        .map(semVer -> Pattern.compile("^\\d+\\.(\\d+)").matcher(semVer))
-        .filter(Matcher::find)
-        .filter(matcher -> Integer.parseInt(matcher.group(1)) < 12)
-        .isEmpty()) {
+    try {
+      Class.forName("org.apache.avro.LogicalTypes$TimestampNanos");
       initializeTimestampNanoSchema();
       initializeTimestampTzNanoSchema();
 
       timestampNanoSchema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
       timestampTzNanoSchema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
+    } catch (ClassNotFoundException | LinkageError e) {
+      // TimestampNanos not available (Avro < 1.12)
     }
   }
 
@@ -274,9 +266,15 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
         break;
       case TIMESTAMP_NANO:
         if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
-          primitiveSchema = timestampTzNanoSchema;
+          primitiveSchema =
+              Preconditions.checkNotNull(
+                  timestampTzNanoSchema,
+                  "TimestampNano is not supported with Avro versions older than 1.12");
         } else {
-          primitiveSchema = timestampNanoSchema;
+          primitiveSchema =
+              Preconditions.checkNotNull(
+                  timestampNanoSchema,
+                  "TimestampNano is not supported with Avro versions older than 1.12");
         }
         break;
       case STRING:

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -55,16 +55,16 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   private static final Schema BINARY_SCHEMA = Schema.create(Schema.Type.BYTES);
 
   // Logical types available in Avro 1.12 only; evaluate lazily to keep compat with Avro 1.11
-  private static Schema TIMESTAMP_NANO_SCHEMA;
-  private static Schema TIMESTAMPTZ_NANO_SCHEMA;
+  private static Schema timestampNanoSchema;
+  private static Schema timestampTzNanoSchema;
 
   private static void initializeTimestampNanoSchema() {
-    TIMESTAMP_NANO_SCHEMA =
+    timestampNanoSchema =
         LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   }
 
   private static void initializeTimestampTzNanoSchema() {
-    TIMESTAMPTZ_NANO_SCHEMA =
+    timestampTzNanoSchema =
         LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   }
 
@@ -85,8 +85,8 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       initializeTimestampNanoSchema();
       initializeTimestampTzNanoSchema();
 
-      TIMESTAMP_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
-      TIMESTAMPTZ_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
+      timestampNanoSchema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      timestampTzNanoSchema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
     }
   }
 
@@ -274,9 +274,9 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
         break;
       case TIMESTAMP_NANO:
         if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
-          primitiveSchema = TIMESTAMPTZ_NANO_SCHEMA;
+          primitiveSchema = timestampTzNanoSchema;
         } else {
-          primitiveSchema = TIMESTAMP_NANO_SCHEMA;
+          primitiveSchema = timestampNanoSchema;
         }
         break;
       case STRING:

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -21,7 +21,10 @@ package org.apache.iceberg.avro;
 import java.util.Deque;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.BiFunction;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.avro.JsonProperties;
 import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema;
@@ -46,20 +49,45 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMPTZ_SCHEMA =
       LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
-  private static final Schema TIMESTAMP_NANO_SCHEMA =
-      LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
-  private static final Schema TIMESTAMPTZ_NANO_SCHEMA =
-      LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema STRING_SCHEMA = Schema.create(Schema.Type.STRING);
   private static final Schema UUID_SCHEMA =
       LogicalTypes.uuid().addToSchema(Schema.createFixed("uuid_fixed", null, null, 16));
   private static final Schema BINARY_SCHEMA = Schema.create(Schema.Type.BYTES);
 
+  // Logical types available in Avro 1.12 only; evaluate lazily to keep compat with Avro 1.11
+  private static Schema TIMESTAMP_NANO_SCHEMA;
+  private static Schema TIMESTAMPTZ_NANO_SCHEMA;
+
+  private static void initializeTimestampNanoSchema() {
+    TIMESTAMP_NANO_SCHEMA =
+        LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+  }
+
+  private static void initializeTimestampTzNanoSchema() {
+    TIMESTAMPTZ_NANO_SCHEMA =
+        LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+  }
+
   static {
     TIMESTAMP_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
     TIMESTAMPTZ_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
-    TIMESTAMP_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
-    TIMESTAMPTZ_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
+
+    final Optional<String> runtimeAvroVersion =
+        Optional.ofNullable(Schema.Parser.class.getPackage().getImplementationVersion());
+
+    // NanoTimestamp and UUID logical types are only supported in Avro 1.12 and above;
+    // Gate initialization to avoid runtime errors for users on earlier Avro versions
+    if (runtimeAvroVersion
+        .map(semVer -> Pattern.compile("^\\d+\\.(\\d+)").matcher(semVer))
+        .filter(Matcher::find)
+        .filter(matcher -> Integer.parseInt(matcher.group(1)) < 12)
+        .isEmpty()) {
+      initializeTimestampNanoSchema();
+      initializeTimestampTzNanoSchema();
+
+      TIMESTAMP_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, false);
+      TIMESTAMPTZ_NANO_SCHEMA.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, true);
+    }
   }
 
   private final Deque<Integer> fieldIds = Lists.newLinkedList();


### PR DESCRIPTION
See: https://github.com/apache/iceberg/issues/16781

`LogicalTypes.timestampNanos()` does not exist in Avro <= 1.11, since `timestamp-nanos` type is new to 1.12. Upgrading Avro versions can be nontrivial for many use cases, so this PR offers a workaround of initializing these fields lazily, only after checking runtime Avro version.

let me know what you think! happy to iterate on the approach