### PR TITLE
Core: Serialize commits in BaseCommitService

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -38,9 +38,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * An async service which allows for committing multiple file groups as their rewrites complete. The
- * service also allows for partial-progress since commits can fail. Once the service has been closed
- * no new file groups should not be offered.
+ * A service which commits file groups to the table as their rewrites complete. Commits are
+ * serialized so that concurrent callers cannot produce conflicting commits on the same table, and a
+ * commit triggered by {@link #offer(Object)} runs synchronously on the offering thread before that
+ * call returns. The service supports partial progress since individual commits are allowed to fail.
+ *
+ * <p>Once the service has been closed, no new file groups should be offered.
  *
  * <p>Specific implementations provide implementations for {@link #commitOrClean(Set)} and {@link
  * #abortFileGroup(Object)}
@@ -210,29 +213,33 @@ abstract class BaseCommitService<T> implements Closeable {
   }
 
   private void commitReadyCommitGroups() {
-    Set<T> batch = null;
     if (canCreateCommitGroup()) {
+      // Serialize commits by holding the lock across commitOrClean. Otherwise concurrent callers
+      // (e.g. rewrite threads offering completed groups under partial progress) would each take a
+      // batch and commit in parallel, producing conflicting commits on the table. Producers can
+      // still enqueue into completedRewrites while a commit runs; they only wait before starting
+      // another. Commits stay inline on the offering thread (not moved to a background thread)
+      // because some callers rely on a commit being visible synchronously once offer() returns.
       synchronized (completedRewrites) {
         if (canCreateCommitGroup()) {
-          batch = Sets.newHashSetWithExpectedSize(rewritesPerCommit);
+          Set<T> batch = Sets.newHashSetWithExpectedSize(rewritesPerCommit);
           for (int i = 0; i < rewritesPerCommit && !completedRewrites.isEmpty(); i++) {
             batch.add(completedRewrites.poll());
           }
+
+          String inProgressCommitToken = UUID.randomUUID().toString();
+          inProgressCommits.add(inProgressCommitToken);
+          try {
+            commitOrClean(batch);
+            committedRewrites.addAll(batch);
+            succeededCommits++;
+          } catch (Exception e) {
+            LOG.error(
+                "Failure during rewrite commit process, partial progress enabled. Ignoring", e);
+          }
+          inProgressCommits.remove(inProgressCommitToken);
         }
       }
-    }
-
-    if (batch != null) {
-      String inProgressCommitToken = UUID.randomUUID().toString();
-      inProgressCommits.add(inProgressCommitToken);
-      try {
-        commitOrClean(batch);
-        committedRewrites.addAll(batch);
-        succeededCommits++;
-      } catch (Exception e) {
-        LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
-      }
-      inProgressCommits.remove(inProgressCommitToken);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.IntStream;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -114,6 +115,53 @@ public class TestCommitService extends TestBase {
       assertThat(commitService.results()).containsExactly(0, 1, 2, 3, 4);
       assertThat(commitService.aborted).containsExactly(5, 6, 7);
     }
+  }
+
+  @TestTemplate
+  public void testCommitsAreSerialized() {
+    // With one group per commit, every offer is immediately committable on the offering thread, so
+    // without serialization the concurrent offers would run commitOrClean at the same time. Assert
+    // that commits never overlap.
+    ConcurrencyTrackingCommitService commitService =
+        new ConcurrencyTrackingCommitService(table, 1, 10000);
+    commitService.start();
+
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+    int numberOfFileGroups = 100;
+    Tasks.range(numberOfFileGroups).executeWith(executorService).run(commitService::offer);
+    commitService.close();
+
+    assertThat(commitService.maxConcurrentCommits.get())
+        .as("commitOrClean must never run on more than one thread at a time")
+        .isEqualTo(1);
+    Set<Integer> expected = Sets.newHashSet(IntStream.range(0, numberOfFileGroups).iterator());
+    assertThat(Sets.newHashSet(commitService.results())).isEqualTo(expected);
+  }
+
+  private static class ConcurrencyTrackingCommitService extends BaseCommitService<Integer> {
+    private final AtomicInteger activeCommits = new AtomicInteger(0);
+    private final AtomicInteger maxConcurrentCommits = new AtomicInteger(0);
+
+    ConcurrencyTrackingCommitService(Table table, int rewritesPerCommit, int timeoutInMs) {
+      super(table, rewritesPerCommit, timeoutInMs);
+    }
+
+    @Override
+    protected void commitOrClean(Set<Integer> batch) {
+      int active = activeCommits.incrementAndGet();
+      maxConcurrentCommits.accumulateAndGet(active, Math::max);
+      try {
+        // widen the window so any overlapping commit is observed
+        Thread.sleep(5);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
+      }
+      activeCommits.decrementAndGet();
+    }
+
+    @Override
+    protected void abortFileGroup(Integer group) {}
   }
 
   private static class CustomCommitService extends BaseCommitService<Integer> {


### PR DESCRIPTION
## Core: Serialize commits in `BaseCommitService`

Relates to #9521.

This is an **efficiency/robustness** change, not a change to partial-progress semantics. It stops a multi-threaded rewrite from generating commit conflicts *against itself*; it does **not** alter how failures from genuinely concurrent external operations are handled (see [Relationship to partial-progress tolerance](#relationship-to-partial-progress-tolerance-9521-vs-17202) below).

### Problem

`rewrite_data_files` with `partial-progress.enabled=true` and a high `max-concurrent-file-group-rewrites` hits repeated `CommitFailedException` retries on the table. As reported in #9521, the errors scale with concurrency and vanish when it is avoided:

| config | result |
|---|---|
| `max-concurrent-file-group-rewrites=4` + partial progress | **many errors** |
| `max-concurrent-file-group-rewrites=2` + partial progress | some errors |
| `max-concurrent-file-group-rewrites=1` + partial progress | no error |
| `max-concurrent-file-group-rewrites=4`, partial progress **off** | no error |

The tell-tale signature is that concurrency alone drives the errors — i.e. the rewrite is conflicting **with its own commits**, not with any other operation on the table.

### Root cause

`BaseCommitService.offer()` runs `commitReadyCommitGroups()` on the calling (rewrite-pool) thread. In the pre-fix code the `synchronized (completedRewrites)` block guarded only the *selection* of a batch; `commitOrClean()` — the actual `table.newRewrite().commit()` — ran **outside** the lock:

```java
if (canCreateCommitGroup()) {
  synchronized (completedRewrites) {
    if (canCreateCommitGroup()) {
      batch = ...poll rewritesPerCommit groups...
    }
  }
}
if (batch != null) {
  commitOrClean(batch);   // <-- OUTSIDE the lock: runs concurrently on every offering thread
  ...
}
```

So when several rewrite threads finish and offer completed groups at once (partial progress with a multi-threaded rewrite pool), each extracts its own batch and then commits to the *same table* in parallel. Those commits collide on Iceberg's atomic metadata swap — one wins, the rest get `CommitFailedException`, refresh, re-apply and retry under `SnapshotProducer`'s exponential backoff. This is exactly the stack trace in #9521:

```
CommitFailedException: Cannot commit ... because ... detected concurrent update
  at org.apache.iceberg.actions.RewriteDataFilesCommitManager.commitFileGroups
  at org.apache.iceberg.actions.RewriteDataFilesCommitManager.commitOrClean
  at org.apache.iceberg.actions.BaseCommitService.commitReadyCommitGroups
  at org.apache.iceberg.actions.BaseCommitService.offer
  at org.apache.iceberg.spark.actions.RewriteDataFilesSparkAction.lambda$doExecuteWithPartialProgress$4
```

### Fix

Hold the lock across `commitOrClean` so only one commit runs at a time. Commits stay **synchronous on the offering thread** — a minimal change that fixes the concurrency defect without altering any other behavior:

- Producers can still enqueue into `completedRewrites` while a commit is in progress (the queue is lock-free); they only wait before *starting* another commit.
- Batching, partial-progress semantics, `succeededCommits`, and the `close()` drain/abort/timeout logic are unchanged.
- Commits are deliberately kept **inline** on the offering thread (not moved to the background committer thread). Flink's `DataFileRewriteCommitter` offers from a single operator thread and relies on a commit being visible synchronously when `processElement` returns; an earlier async design broke `TestDataFileRewriteCommitter`.

### Why serializing is the right trade-off (overhead)

The non-obvious point: **commits to a single table were never actually running in parallel.** Iceberg serializes them at the atomic metadata swap — two commits can never both succeed at once; the first to swap wins and every other in-flight commit must refresh and retry under exponential backoff (`commit.retry.min-wait-ms` = 100 ms, doubling, up to `commit.retry.num-retries` = 4). So the old "concurrent commits" only ever converted mutual exclusion into **conflict-detection-plus-backoff**. This PR replaces that with a cheap mutex:

- **Before:** up to *P* commits race the swap. Each loser pays a metadata refresh **and a backoff sleep** (≥100 ms, doubling) per conflict, so total commit attempts ≫ number of commits. A commit that loses more than 4 races is aborted and its file group is dropped — an **entirely self-inflicted** loss of compaction progress (the group had nothing wrong with it; it failed only because the job fought itself).
- **After:** commit *i* starts when the table tip is exactly commit *(i-1)*'s snapshot, so its base equals current and it succeeds on the **first attempt**. Attempts = number of commits (optimal); zero conflicts, zero backoff, zero self-inflicted drops.

Crucially the fix does **not** reduce real parallelism. The expensive work — rewriting the data files — still runs fully in parallel across the rewrite pool; only the cheap metadata commit serializes, and that was *already* forced to serialize by the swap. With `rewritesPerCommit > 1` (the common case) most offers just enqueue and return immediately; a thread only ever blocks on the offer that actually triggers a commit. Serialization bites hardest precisely when `partial-progress.max-commits` is large (many single-group commits) — the same configuration that produced the worst retry storms before.

Net: strictly less work, fewer/zero backoff sleeps, no self-inflicted drops, and often a **wall-clock win** under contention; the worst case (a single commit, e.g. `max-commits=1`) is a no-op. There is no regime where it does net harm for a single-table rewrite.

### Relationship to partial-progress tolerance (#9521 vs #17202)

This change is orthogonal to the "partial progress intentionally tolerates commit failures" behavior discussed in #17202. It does not touch the catch-all in `commitReadyCommitGroups`, `max-failed-commits`, or the decision to keep going when a commit fails. Failures caused by *genuinely concurrent external operations* (another writer, `expire_snapshots`, etc.) are still tolerated exactly as before.

The distinction:

- **External conflict (#17202): tolerated by design.** The rewrite loses a race to an unrelated operation; the group may be uncommittable anyway. Nothing here changes that.
- **Self-conflict (#9521): pure waste, removed here.** The only other writer is the rewrite's *own* commit threads. Serializing them means the tolerance mechanism fires only for real external conflicts, not for conflicts the job manufactures against itself.

### Reproduction — before/after logs (#9521)

The committed unit test (`testCommitsAreSerialized`) asserts the mechanism (`commitOrClean` never runs on two threads at once). To show the *real* effect end-to-end I also ran the harness below, which drives `BaseCommitService` through the **real** Iceberg commit path (each offered group triggers a real `table.newAppend().commit()`), so concurrent offers exercise real optimistic-concurrency conflicts and the real `SnapshotProducer`/`Tasks` retry loop — the exact path in #9521. It is **not committed**; it is a reproduction you can paste into `core` and run.

<details>
<summary><code>TestCommitServiceConcurrencyDemo.java</code> (reproduction harness — not committed)</summary>

```java
package org.apache.iceberg.actions;

import static org.assertj.core.api.Assertions.assertThat;

import java.util.Arrays;
import java.util.List;
import java.util.Set;
import java.util.concurrent.ExecutorService;
import java.util.concurrent.Executors;
import java.util.concurrent.atomic.AtomicInteger;
import java.util.stream.IntStream;
import org.apache.iceberg.DataFile;
import org.apache.iceberg.DataFiles;
import org.apache.iceberg.ParameterizedTestExtension;
import org.apache.iceberg.Parameters;
import org.apache.iceberg.Table;
import org.apache.iceberg.TestBase;
import org.apache.iceberg.relocated.com.google.common.collect.Sets;
import org.apache.iceberg.util.Tasks;
import org.junit.jupiter.api.TestTemplate;
import org.junit.jupiter.api.extension.ExtendWith;

@ExtendWith(ParameterizedTestExtension.class)
public class TestCommitServiceConcurrencyDemo extends TestBase {

  @Parameters(name = "formatVersion = {0}")
  protected static List<Object> parameters() {
    return Arrays.asList(2);
  }

  @TestTemplate
  public void concurrentPartialProgressCommits() {
    // Mirrors #9521: max-concurrent-file-group-rewrites = 4, partial progress on. rewritesPerCommit
    // = 1 means every offer is immediately committable on the offering thread (the worst case for
    // conflicts, i.e. partial-progress.max-commits == totalGroupCount).
    int concurrency = 4;
    int numberOfFileGroups = 40;

    RealCommitService commitService = new RealCommitService(table, 1, 60000);
    commitService.start();

    ExecutorService executorService = Executors.newFixedThreadPool(concurrency);
    Tasks.range(numberOfFileGroups).executeWith(executorService).run(commitService::offer);
    commitService.close();
    executorService.shutdownNow();

    System.err.println(
        "DEMO-SUMMARY committedGroups="
            + commitService.results().size()
            + " snapshots="
            + Sets.newHashSet(table.snapshots().iterator()).size()
            + " maxConcurrentCommits="
            + commitService.maxConcurrentCommits.get());

    // These assertions PASS on the fixed code and FAIL on the pre-fix code (maxConcurrentCommits > 1
    // and, when retries are exhausted, committedGroups < numberOfFileGroups).
    assertThat(commitService.maxConcurrentCommits.get())
        .as("commitOrClean must never run on more than one thread at a time")
        .isEqualTo(1);
    assertThat(Sets.newHashSet(commitService.results()))
        .isEqualTo(Sets.newHashSet(IntStream.range(0, numberOfFileGroups).iterator()));
  }

  private static class RealCommitService extends BaseCommitService<Integer> {
    private final Table table;
    private final AtomicInteger activeCommits = new AtomicInteger(0);
    private final AtomicInteger maxConcurrentCommits = new AtomicInteger(0);

    RealCommitService(Table table, int rewritesPerCommit, int timeoutInMs) {
      super(table, rewritesPerCommit, timeoutInMs);
      this.table = table;
    }

    @Override
    protected void commitOrClean(Set<Integer> batch) {
      int active = activeCommits.incrementAndGet();
      maxConcurrentCommits.accumulateAndGet(active, Math::max);
      try {
        for (Integer group : batch) {
          DataFile file =
              DataFiles.builder(SPEC)
                  .withPath("/path/to/demo-data-" + group + ".parquet")
                  .withFileSizeInBytes(10)
                  .withPartitionPath("data_bucket=" + (group % 16))
                  .withRecordCount(1)
                  .build();
          // Real Iceberg append -> real optimistic-concurrency commit with SnapshotProducer's Tasks
          // retry loop. Without serialization the concurrent offers collide on the table's atomic
          // swap (CommitFailedException -> refresh -> retry under exponential backoff).
          table.newAppend().appendFile(file).commit();
        }
      } finally {
        activeCommits.decrementAndGet();
      }
    }

    @Override
    protected void abortFileGroup(Integer group) {}
  }
}
```

</details>

**BEFORE the fix** (commit runs *outside* the lock) — 4 threads, 40 groups, 1 group per commit. The test **fails**, and the log fills with the #9521 retry storm:

```
WARN  Tasks - Retrying task after failure: sleepTimeMs=204 Cannot commit changes based on stale metadata
WARN  Tasks - Retrying task after failure: sleepTimeMs=208 Cannot commit changes based on stale metadata
WARN  Tasks - Retrying task after failure: sleepTimeMs=107 Cannot commit changes based on stale metadata
WARN  Tasks - Retrying task after failure: sleepTimeMs=410 Cannot commit changes based on stale metadata
WARN  Tasks - Retrying task after failure: sleepTimeMs=841 Cannot commit changes based on stale metadata
... (21 retries total, backoff 100 -> 200 -> 400 -> 800 ms) ...
ERROR BaseCommitService - Failure during rewrite commit process, partial progress enabled. Ignoring

DEMO-SUMMARY committedGroups=39 snapshots=38 maxConcurrentCommits=4

org.opentest4j.AssertionFailedError:
  [commitOrClean must never run on more than one thread at a time]
  expected: 1 but was: 4
```

Aggregate over the run: **22 `CommitFailedException`, 21 backoff retries, 1 file group dropped** (39/40 committed) — all four rewrite threads committing at once, all of it self-inflicted.

**AFTER the fix** (commit runs *inside* the lock) — identical test. It **passes**, with no conflicts at all:

```
DEMO-SUMMARY committedGroups=40 snapshots=40 maxConcurrentCommits=1
```

Aggregate: **0 `CommitFailedException`, 0 retries, 0 dropped groups**, 40/40 committed, commits strictly serialized.

### Testing

- Adds `testCommitsAreSerialized` to `TestCommitService`: 10 threads offer 100 groups with one group per commit; asserts `commitOrClean` is never entered by more than one thread and that no group is lost. Fails on the pre-fix code, passes after.
- `./gradlew :iceberg-core:test --tests "org.apache.iceberg.actions.TestCommitService"` → 3/3 pass.
- Flink `TestDataFileRewriteCommitter` → 5/5 pass (verifies commits stay synchronous on the offering thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
