### PR TITLE
Kafka Connect: evolve table schema when record schema is updated but value is null

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -80,8 +80,12 @@ import org.apache.iceberg.variants.Variants;
 import org.apache.kafka.connect.data.Field;
 import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.errors.ConnectException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class RecordConverter {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RecordConverter.class);
 
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -277,9 +281,12 @@ class RecordConverter {
   }
 
   /**
-   * This method evolves schemas when the value is null. Note: logic should be kept consistent with
-   * equivalent method used when value is not null: {@link #convertToStruct(Struct, StructType, int,
-   * SchemaUpdate.Consumer)}
+   * Recursively traverses the Connect schema and emits all evolution events (addColumn, updateType,
+   * and makeOptional) at every nested level.
+   *
+   * <p>Unlike {@link #convertToStruct(Struct, StructType, int, SchemaUpdate.Consumer)} which skips
+   * a field's children once an update is detected (deferring nested discovery to re-conversion),
+   * this method always recurses through the full schema.
    */
   private void evolveSchemaFromConnectSchema(
       org.apache.kafka.connect.data.Schema recordSchema,
@@ -315,6 +322,8 @@ class RecordConverter {
                   field.schema(), nestedField.type(), nestedField.fieldId(), schemaUpdateConsumer);
             }
           }
+        } else {
+          logMismatchedType(recordSchema.type(), tableType);
         }
         break;
       case ARRAY:
@@ -325,6 +334,8 @@ class RecordConverter {
               listType.elementType(),
               listType.elementId(),
               schemaUpdateConsumer);
+        } else {
+          logMismatchedType(recordSchema.type(), tableType);
         }
         break;
       case MAP:
@@ -337,11 +348,19 @@ class RecordConverter {
               mapType.valueType(),
               mapType.valueId(),
               schemaUpdateConsumer);
+        } else {
+          logMismatchedType(recordSchema.type(), tableType);
         }
         break;
       default:
         break;
     }
+  }
+
+  private void logMismatchedType(
+      org.apache.kafka.connect.data.Schema.Type recordSchemaType, Type tableType) {
+    LOG.warn(
+        "Record schema of type {} does not match table of type {}", recordSchemaType, tableType);
   }
 
   private NestedField lookupStructField(String fieldName, StructType schema, int structFieldId) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -255,17 +255,90 @@ class RecordConverter {
                   }
                 }
                 if (!hasSchemaUpdates) {
-                  result.setField(
-                      tableField.name(),
-                      convertValue(
-                          struct.get(recordField),
-                          tableField.type(),
-                          tableField.fieldId(),
-                          schemaUpdateConsumer));
+                  Object recordFieldValue = struct.get(recordField);
+                  // If the value is null and schema evolution is on, then evolve the table schema
+                  // from the connect record schema
+                  if (recordFieldValue == null && schemaUpdateConsumer != null) {
+                    evolveSchemaFromConnectSchema(
+                        recordField.schema(),
+                        tableField.type(),
+                        tableField.fieldId(),
+                        schemaUpdateConsumer);
+                  } else {
+                    // If the value is not null, then convert the value (and handle any schema
+                    // updates)
+                    result.setField(
+                        tableField.name(),
+                        convertValue(
+                            recordFieldValue,
+                            tableField.type(),
+                            tableField.fieldId(),
+                            schemaUpdateConsumer));
+                  }
                 }
               }
             });
     return result;
+  }
+
+  private void evolveSchemaFromConnectSchema(
+      org.apache.kafka.connect.data.Schema recordSchema,
+      Type tableType,
+      int tableFieldId,
+      SchemaUpdate.Consumer schemaUpdateConsumer) {
+    if (recordSchema == null) {
+      return;
+    }
+    switch (recordSchema.type()) {
+      case STRUCT:
+        if (tableType.isStructType()) {
+          StructType structType = tableType.asStructType();
+          for (Field field : recordSchema.fields()) {
+            NestedField nestedField = lookupStructField(field.name(), structType, tableFieldId);
+            if (nestedField == null) {
+              String parentFieldName = tableSchema.findColumnName(tableFieldId);
+              Type type = SchemaUtils.toIcebergType(field.schema(), config);
+              schemaUpdateConsumer.addColumn(parentFieldName, field.name(), type);
+            } else {
+              PrimitiveType evolveDataType =
+                  SchemaUtils.needsDataTypeUpdate(nestedField.type(), field.schema());
+              if (evolveDataType != null) {
+                String fieldName = tableSchema.findColumnName(nestedField.fieldId());
+                schemaUpdateConsumer.updateType(fieldName, evolveDataType);
+              }
+              if (nestedField.isRequired() && field.schema().isOptional()) {
+                String fieldName = tableSchema.findColumnName(nestedField.fieldId());
+                schemaUpdateConsumer.makeOptional(fieldName);
+              }
+              evolveSchemaFromConnectSchema(
+                  field.schema(), nestedField.type(), nestedField.fieldId(), schemaUpdateConsumer);
+            }
+          }
+        }
+        break;
+      case ARRAY:
+        if (tableType.isListType()) {
+          ListType listType = tableType.asListType();
+          evolveSchemaFromConnectSchema(
+              recordSchema.valueSchema(),
+              listType.elementType(),
+              listType.elementId(),
+              schemaUpdateConsumer);
+        }
+        break;
+      case MAP:
+        if (tableType.isMapType()) {
+          MapType mapType = tableType.asMapType();
+          evolveSchemaFromConnectSchema(
+              recordSchema.valueSchema(),
+              mapType.valueType(),
+              mapType.valueId(),
+              schemaUpdateConsumer);
+        }
+        break;
+      default:
+        break;
+    }
   }
 
   private NestedField lookupStructField(String fieldName, StructType schema, int structFieldId) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -254,33 +254,33 @@ class RecordConverter {
                     hasSchemaUpdates = true;
                   }
                 }
+                Object recordFieldValue = struct.get(recordField);
+                if (recordFieldValue == null && schemaUpdateConsumer != null) {
+                  evolveSchemaFromConnectSchema(
+                      recordField.schema(),
+                      tableField.type(),
+                      tableField.fieldId(),
+                      schemaUpdateConsumer);
+                }
                 if (!hasSchemaUpdates) {
-                  Object recordFieldValue = struct.get(recordField);
-                  // If the value is null and schema evolution is on, then evolve the table schema
-                  // from the connect record schema
-                  if (recordFieldValue == null && schemaUpdateConsumer != null) {
-                    evolveSchemaFromConnectSchema(
-                        recordField.schema(),
-                        tableField.type(),
-                        tableField.fieldId(),
-                        schemaUpdateConsumer);
-                  } else {
-                    // If the value is not null, then convert the value (and handle any schema
-                    // updates)
-                    result.setField(
-                        tableField.name(),
-                        convertValue(
-                            recordFieldValue,
-                            tableField.type(),
-                            tableField.fieldId(),
-                            schemaUpdateConsumer));
-                  }
+                  result.setField(
+                      tableField.name(),
+                      convertValue(
+                          recordFieldValue,
+                          tableField.type(),
+                          tableField.fieldId(),
+                          schemaUpdateConsumer));
                 }
               }
             });
     return result;
   }
 
+  /**
+   * This method evolves schemas when the value is null. Note: logic should be kept consistent
+   * with equivalent method used when value is not null:
+   * {@link #convertToStruct(Struct, StructType, int, SchemaUpdate.Consumer)}
+   */
   private void evolveSchemaFromConnectSchema(
       org.apache.kafka.connect.data.Schema recordSchema,
       Type tableType,
@@ -296,7 +296,8 @@ class RecordConverter {
           for (Field field : recordSchema.fields()) {
             NestedField nestedField = lookupStructField(field.name(), structType, tableFieldId);
             if (nestedField == null) {
-              String parentFieldName = tableSchema.findColumnName(tableFieldId);
+              String parentFieldName =
+                  tableFieldId < 0 ? null : tableSchema.findColumnName(tableFieldId);
               Type type = SchemaUtils.toIcebergType(field.schema(), config);
               schemaUpdateConsumer.addColumn(parentFieldName, field.name(), type);
             } else {
@@ -329,6 +330,11 @@ class RecordConverter {
       case MAP:
         if (tableType.isMapType()) {
           MapType mapType = tableType.asMapType();
+          evolveSchemaFromConnectSchema(
+              recordSchema.keySchema(),
+              mapType.keyType(),
+              mapType.keyId(),
+              schemaUpdateConsumer);
           evolveSchemaFromConnectSchema(
               recordSchema.valueSchema(),
               mapType.valueType(),

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -277,9 +277,9 @@ class RecordConverter {
   }
 
   /**
-   * This method evolves schemas when the value is null. Note: logic should be kept consistent
-   * with equivalent method used when value is not null:
-   * {@link #convertToStruct(Struct, StructType, int, SchemaUpdate.Consumer)}
+   * This method evolves schemas when the value is null. Note: logic should be kept consistent with
+   * equivalent method used when value is not null: {@link #convertToStruct(Struct, StructType, int,
+   * SchemaUpdate.Consumer)}
    */
   private void evolveSchemaFromConnectSchema(
       org.apache.kafka.connect.data.Schema recordSchema,
@@ -331,10 +331,7 @@ class RecordConverter {
         if (tableType.isMapType()) {
           MapType mapType = tableType.asMapType();
           evolveSchemaFromConnectSchema(
-              recordSchema.keySchema(),
-              mapType.keyType(),
-              mapType.keyId(),
-              schemaUpdateConsumer);
+              recordSchema.keySchema(), mapType.keyType(), mapType.keyId(), schemaUpdateConsumer);
           evolveSchemaFromConnectSchema(
               recordSchema.valueSchema(),
               mapType.valueType(),

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -259,7 +259,7 @@ class RecordConverter {
                   }
                 }
                 Object recordFieldValue = struct.get(recordField);
-                if (recordFieldValue == null && schemaUpdateConsumer != null) {
+                if (recordFieldValue == null && schemaUpdateConsumer != null && !hasSchemaUpdates) {
                   evolveSchemaFromConnectSchema(
                       recordField.schema(),
                       tableField.type(),
@@ -341,8 +341,6 @@ class RecordConverter {
       case MAP:
         if (tableType.isMapType()) {
           MapType mapType = tableType.asMapType();
-          evolveSchemaFromConnectSchema(
-              recordSchema.keySchema(), mapType.keyType(), mapType.keyId(), schemaUpdateConsumer);
           evolveSchemaFromConnectSchema(
               recordSchema.valueSchema(),
               mapType.valueType(),

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -932,6 +932,7 @@ public class TestRecordConverter {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testNestedSchemaEvolutionListOfStructsWithNullValue() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(
@@ -985,6 +986,7 @@ public class TestRecordConverter {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testNestedSchemaEvolutionMapOfStructsWithNullValue() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(
@@ -1177,7 +1179,7 @@ public class TestRecordConverter {
   }
 
   @Test
-  public void testSchemaEvolutionForFieldAndNestedFields() {
+  public void testSchemaEvolutionForFieldAndNestedFieldsAcrossTwoRecords() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(
             NestedField.required(1, "id", IntegerType.get()),
@@ -1213,15 +1215,32 @@ public class TestRecordConverter {
     assertThat(makeOptionals.iterator().next().name()).isEqualTo("nested");
 
     Collection<AddColumn> addCols = consumer.addColumns();
-    assertThat(addCols).hasSize(1);
-    AddColumn addCol = addCols.iterator().next();
-    assertThat(addCol.parentName()).isEqualTo("nested");
-    assertThat(addCol.name()).isEqualTo("y");
-    assertThat(addCol.type()).isInstanceOf(StringType.class);
+    assertThat(addCols).hasSize(0);
+
+    org.apache.iceberg.Schema updatedSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2, "nested", StructType.of(NestedField.required(3, "x", IntegerType.get()))));
+    when(table.schema()).thenReturn(updatedSchema);
+    RecordConverter converter2 = new RecordConverter(table, config);
+
+    SchemaUpdate.Consumer consumer2 = new SchemaUpdate.Consumer();
+    Record result2 = converter2.convert(data, consumer2);
+
+    assertThat(result2.getField("id")).isEqualTo(1);
+    assertThat(result2.getField("nested")).isNull();
+
+    Collection<AddColumn> addCols2 = consumer2.addColumns();
+    assertThat(addCols2).hasSize(1);
+    AddColumn addCol2 = addCols2.iterator().next();
+    assertThat(addCol2.parentName()).isEqualTo("nested");
+    assertThat(addCol2.name()).isEqualTo("y");
+    assertThat(addCol2.type()).isInstanceOf(StringType.class);
   }
 
   @Test
-  public void testNestedSchemaEvolutionMapKeyWithNullValue() {
+  public void testNoNestedSchemaEvolutionMapKeyWithNullValue() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(
             NestedField.required(1, "id", IntegerType.get()),
@@ -1257,11 +1276,7 @@ public class TestRecordConverter {
     assertThat(result.getField("data")).isNull();
 
     Collection<AddColumn> addCols = consumer.addColumns();
-    assertThat(addCols).hasSize(1);
-    AddColumn addCol = addCols.iterator().next();
-    assertThat(addCol.parentName()).isEqualTo("data.key");
-    assertThat(addCol.name()).isEqualTo("k2");
-    assertThat(addCol.type()).isInstanceOf(StringType.class);
+    assertThat(addCols).hasSize(0);
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -899,6 +899,39 @@ public class TestRecordConverter {
   }
 
   @Test
+  public void testNoSchemaEvolutionStructWithNullValue() {
+    org.apache.iceberg.Schema nestedStructSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2, "nested", StructType.of(NestedField.required(3, "a", IntegerType.get()))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(nestedStructSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema connectNestedSchema =
+        SchemaBuilder.struct().optional().field("a", Schema.INT32_SCHEMA).build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("nested", connectNestedSchema)
+            .build();
+    Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    Record result = converter.convert(data, consumer);
+
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("nested")).isNull();
+
+    assertThat(consumer.addColumns()).isEmpty();
+    assertThat(consumer.makeOptionals()).isEmpty();
+    assertThat(consumer.updateTypes()).isEmpty();
+    assertThat(consumer.empty()).isTrue();
+  }
+
+  @Test
   public void testNestedSchemaEvolutionListOfStructsWithNullValue() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -1149,9 +1149,7 @@ public class TestRecordConverter {
         new org.apache.iceberg.Schema(
             NestedField.required(1, "id", IntegerType.get()),
             NestedField.required(
-                2,
-                "nested",
-                StructType.of(NestedField.required(3, "x", IntegerType.get()))));
+                2, "nested", StructType.of(NestedField.required(3, "x", IntegerType.get()))));
 
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(tableSchema);
@@ -1212,12 +1210,10 @@ public class TestRecordConverter {
             .field("k1", Schema.STRING_SCHEMA)
             .field("k2", Schema.OPTIONAL_STRING_SCHEMA)
             .build();
-    Schema mapSchema = SchemaBuilder.map(keySchema, Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+    Schema mapSchema =
+        SchemaBuilder.map(keySchema, Schema.OPTIONAL_STRING_SCHEMA).optional().build();
     Schema connectSchema =
-        SchemaBuilder.struct()
-            .field("id", Schema.INT32_SCHEMA)
-            .field("data", mapSchema)
-            .build();
+        SchemaBuilder.struct().field("id", Schema.INT32_SCHEMA).field("data", mapSchema).build();
 
     Struct data = new Struct(connectSchema).put("id", 1).put("data", null);
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -885,9 +885,12 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<AddColumn> addCols = consumer.addColumns();
+    Record result = converter.convert(data, consumer);
 
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("nested")).isNull();
+
+    Collection<AddColumn> addCols = consumer.addColumns();
     assertThat(addCols).hasSize(1);
     AddColumn addCol = addCols.iterator().next();
     assertThat(addCol.parentName()).isEqualTo("nested");
@@ -933,9 +936,14 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("items", ImmutableList.of(item));
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<AddColumn> addCols = consumer.addColumns();
+    Record result = converter.convert(data, consumer);
 
+    List<Record> items = (List<Record>) result.getField("items");
+    assertThat(items).hasSize(1);
+    assertThat(items.get(0).getField("product_id")).isEqualTo(101);
+    assertThat(items.get(0).getField("details")).isNull();
+
+    Collection<AddColumn> addCols = consumer.addColumns();
     assertThat(addCols).hasSize(1);
     AddColumn addCol = addCols.iterator().next();
     assertThat(addCol.parentName()).isEqualTo("items.element.details");
@@ -982,9 +990,14 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("metadata", ImmutableMap.of("source", mapValue));
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<AddColumn> addCols = consumer.addColumns();
+    Record result = converter.convert(data, consumer);
 
+    Map<String, Record> metadata = (Map<String, Record>) result.getField("metadata");
+    assertThat(metadata).containsKey("source");
+    assertThat(metadata.get("source").getField("key")).isEqualTo("source_system");
+    assertThat(metadata.get("source").getField("info")).isNull();
+
+    Collection<AddColumn> addCols = consumer.addColumns();
     assertThat(addCols).hasSize(1);
     AddColumn addCol = addCols.iterator().next();
     assertThat(addCol.parentName()).isEqualTo("metadata.value.info");
@@ -1031,9 +1044,12 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("id", 1).put("customer", null);
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<AddColumn> addCols = consumer.addColumns();
+    Record result = converter.convert(data, consumer);
 
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("customer")).isNull();
+
+    Collection<AddColumn> addCols = consumer.addColumns();
     assertThat(addCols).hasSize(1);
     AddColumn addCol = addCols.iterator().next();
     assertThat(addCol.parentName()).isEqualTo("customer.details");
@@ -1071,9 +1087,12 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<UpdateType> updates = consumer.updateTypes();
+    Record result = converter.convert(data, consumer);
 
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("nested")).isNull();
+
+    Collection<UpdateType> updates = consumer.updateTypes();
     assertThat(updates).hasSize(2);
     Map<String, UpdateType> updateMap = Maps.newHashMap();
     updates.forEach(update -> updateMap.put(update.name(), update));
@@ -1111,14 +1130,109 @@ public class TestRecordConverter {
     Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
 
     SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
-    converter.convert(data, consumer);
-    Collection<SchemaUpdate.MakeOptional> makeOptionals = consumer.makeOptionals();
+    Record result = converter.convert(data, consumer);
 
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("nested")).isNull();
+
+    Collection<SchemaUpdate.MakeOptional> makeOptionals = consumer.makeOptionals();
     assertThat(makeOptionals).hasSize(2);
     Map<String, SchemaUpdate.MakeOptional> optionalMap = Maps.newHashMap();
     makeOptionals.forEach(mo -> optionalMap.put(mo.name(), mo));
     assertThat(optionalMap).containsKey("nested.a");
     assertThat(optionalMap).containsKey("nested.b");
+  }
+
+  @Test
+  public void testSchemaEvolutionForFieldAndNestedFields() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.required(
+                2,
+                "nested",
+                StructType.of(NestedField.required(3, "x", IntegerType.get()))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema nestedSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("x", Schema.INT32_SCHEMA)
+            .field("y", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("nested", nestedSchema)
+            .build();
+
+    Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    Record result = converter.convert(data, consumer);
+
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("nested")).isNull();
+
+    Collection<SchemaUpdate.MakeOptional> makeOptionals = consumer.makeOptionals();
+    assertThat(makeOptionals).hasSize(1);
+    assertThat(makeOptionals.iterator().next().name()).isEqualTo("nested");
+
+    Collection<AddColumn> addCols = consumer.addColumns();
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("nested");
+    assertThat(addCol.name()).isEqualTo("y");
+    assertThat(addCol.type()).isInstanceOf(StringType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionMapKeyWithNullValue() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2,
+                "data",
+                MapType.ofRequired(
+                    3,
+                    4,
+                    StructType.of(NestedField.required(5, "k1", StringType.get())),
+                    StringType.get())));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema keySchema =
+        SchemaBuilder.struct()
+            .field("k1", Schema.STRING_SCHEMA)
+            .field("k2", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapSchema = SchemaBuilder.map(keySchema, Schema.OPTIONAL_STRING_SCHEMA).optional().build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("data", mapSchema)
+            .build();
+
+    Struct data = new Struct(connectSchema).put("id", 1).put("data", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    Record result = converter.convert(data, consumer);
+
+    assertThat(result.getField("id")).isEqualTo(1);
+    assertThat(result.getField("data")).isNull();
+
+    Collection<AddColumn> addCols = consumer.addColumns();
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("data.key");
+    assertThat(addCol.name()).isEqualTo("k2");
+    assertThat(addCol.type()).isInstanceOf(StringType.class);
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -860,6 +860,268 @@ public class TestRecordConverter {
   }
 
   @Test
+  public void testNestedSchemaEvolutionStructWithNullValue() {
+    org.apache.iceberg.Schema nestedStructSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2, "nested", StructType.of(NestedField.required(3, "a", IntegerType.get()))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(nestedStructSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema connectNestedSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("a", Schema.INT32_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("nested", connectNestedSchema)
+            .build();
+    Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<AddColumn> addCols = consumer.addColumns();
+
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("nested");
+    assertThat(addCol.name()).isEqualTo("b");
+    assertThat(addCol.type()).isInstanceOf(StringType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionListOfStructsWithNullValue() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(
+                1,
+                "items",
+                ListType.ofRequired(
+                    2,
+                    StructType.of(
+                        NestedField.required(3, "product_id", IntegerType.get()),
+                        NestedField.optional(
+                            4,
+                            "details",
+                            StructType.of(NestedField.required(5, "name", StringType.get())))))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema detailsSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("price", Schema.OPTIONAL_FLOAT64_SCHEMA)
+            .build();
+    Schema itemSchema =
+        SchemaBuilder.struct()
+            .field("product_id", Schema.INT32_SCHEMA)
+            .field("details", detailsSchema)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct().field("items", SchemaBuilder.array(itemSchema).build()).build();
+
+    Struct item = new Struct(itemSchema).put("product_id", 101).put("details", null);
+    Struct data = new Struct(connectSchema).put("items", ImmutableList.of(item));
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<AddColumn> addCols = consumer.addColumns();
+
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("items.element.details");
+    assertThat(addCol.name()).isEqualTo("price");
+    assertThat(addCol.type()).isInstanceOf(DoubleType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionMapOfStructsWithNullValue() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.optional(
+                1,
+                "metadata",
+                MapType.ofRequired(
+                    2,
+                    3,
+                    StringType.get(),
+                    StructType.of(
+                        NestedField.required(4, "key", StringType.get()),
+                        NestedField.optional(
+                            5,
+                            "info",
+                            StructType.of(NestedField.required(6, "name", StringType.get())))))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema infoSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("value", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema mapValueSchema =
+        SchemaBuilder.struct().field("key", Schema.STRING_SCHEMA).field("info", infoSchema).build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("metadata", SchemaBuilder.map(Schema.STRING_SCHEMA, mapValueSchema).build())
+            .build();
+
+    Struct mapValue = new Struct(mapValueSchema).put("key", "source_system").put("info", null);
+    Struct data = new Struct(connectSchema).put("metadata", ImmutableMap.of("source", mapValue));
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<AddColumn> addCols = consumer.addColumns();
+
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("metadata.value.info");
+    assertThat(addCol.name()).isEqualTo("value");
+    assertThat(addCol.type()).isInstanceOf(StringType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionStructInStructWithNullParent() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2,
+                "customer",
+                StructType.of(
+                    NestedField.required(3, "customer_id", IntegerType.get()),
+                    NestedField.optional(
+                        4,
+                        "details",
+                        StructType.of(NestedField.required(5, "name", StringType.get()))))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema detailsSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("name", Schema.OPTIONAL_STRING_SCHEMA)
+            .field("email", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema customerSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("customer_id", Schema.INT32_SCHEMA)
+            .field("details", detailsSchema)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("customer", customerSchema)
+            .build();
+    Struct data = new Struct(connectSchema).put("id", 1).put("customer", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<AddColumn> addCols = consumer.addColumns();
+
+    assertThat(addCols).hasSize(1);
+    AddColumn addCol = addCols.iterator().next();
+    assertThat(addCol.parentName()).isEqualTo("customer.details");
+    assertThat(addCol.name()).isEqualTo("email");
+    assertThat(addCol.type()).isInstanceOf(StringType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionTypePromotionWithNullValue() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2,
+                "nested",
+                StructType.of(
+                    NestedField.required(3, "a", IntegerType.get()),
+                    NestedField.required(4, "b", FloatType.get()))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema connectNestedSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("a", Schema.INT64_SCHEMA)
+            .field("b", Schema.FLOAT64_SCHEMA)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("nested", connectNestedSchema)
+            .build();
+    Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<UpdateType> updates = consumer.updateTypes();
+
+    assertThat(updates).hasSize(2);
+    Map<String, UpdateType> updateMap = Maps.newHashMap();
+    updates.forEach(update -> updateMap.put(update.name(), update));
+    assertThat(updateMap.get("nested.a").type()).isInstanceOf(LongType.class);
+    assertThat(updateMap.get("nested.b").type()).isInstanceOf(DoubleType.class);
+  }
+
+  @Test
+  public void testNestedSchemaEvolutionMakeOptionalWithNullValue() {
+    org.apache.iceberg.Schema tableSchema =
+        new org.apache.iceberg.Schema(
+            NestedField.required(1, "id", IntegerType.get()),
+            NestedField.optional(
+                2,
+                "nested",
+                StructType.of(
+                    NestedField.required(3, "a", IntegerType.get()),
+                    NestedField.required(4, "b", StringType.get()))));
+
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(tableSchema);
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema connectNestedSchema =
+        SchemaBuilder.struct()
+            .optional()
+            .field("a", Schema.OPTIONAL_INT32_SCHEMA)
+            .field("b", Schema.OPTIONAL_STRING_SCHEMA)
+            .build();
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT32_SCHEMA)
+            .field("nested", connectNestedSchema)
+            .build();
+    Struct data = new Struct(connectSchema).put("id", 1).put("nested", null);
+
+    SchemaUpdate.Consumer consumer = new SchemaUpdate.Consumer();
+    converter.convert(data, consumer);
+    Collection<SchemaUpdate.MakeOptional> makeOptionals = consumer.makeOptionals();
+
+    assertThat(makeOptionals).hasSize(2);
+    Map<String, SchemaUpdate.MakeOptional> optionalMap = Maps.newHashMap();
+    makeOptionals.forEach(mo -> optionalMap.put(mo.name(), mo));
+    assertThat(optionalMap).containsKey("nested.a");
+    assertThat(optionalMap).containsKey("nested.b");
+  }
+
+  @Test
   public void testEvolveTypeDetectionStruct() {
     org.apache.iceberg.Schema tableSchema =
         new org.apache.iceberg.Schema(


### PR DESCRIPTION
## Description

Fix for kafka-connect sink.

Closes https://github.com/apache/iceberg/issues/15395

When the connect record value is not null, table schema is updated and evolved correctly. However, when connect record value is null, no evolution takes place (even if the record schema has been evolved), causing issues reported in https://github.com/apache/iceberg/issues/15395 and https://github.com/apache/iceberg/issues/16212. Fix this behavior by adding a new method for handling the recursive evolution using the connect record schema when the value of convertToStruct is null. This additional evolution is only done when a call to convertToStruct contains a null record field value. The method `evolveSchemaFromConnectSchema` performs recursive evolution using the connect record schema (rather than the value, since it is null) and reports the evolved types to the schema update consumer.

There was a previous PR https://github.com/apache/iceberg/pull/15396 that was closed which was a larger refactor, changing package API (eg change IcebergWriter). This PR takes a minimal approach, and simply extends the recursive call where it would have fallen short.

## Verification
Add tests to verify the behavior including the cases:
- null value with nested evolved schema
- list/map of structs with evolution
- type promotion & optionality change

The integration test failure is flakey for azure and is unrelated to these changes (failing for other PRs as well)