### PR TITLE
Flink: Add data model and key serialization for equality delete conversion

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * A deletion vector position emitted by {@link EqualityConvertPKIndex} when resolving an equality
+ * delete. Identifies a specific row (by file path and position) to be marked as deleted, and
+ * carries the data file's {@code specId} + encoded partition so the downstream resolver can write
+ * the DV without re-reading data manifests.
+ *
+ * <p>{@code dataSequenceNumber} is the data file's sequence number. The worker keeps it in its
+ * index so a resolving equality delete only deletes rows older than itself (only applies an
+ * equality delete with sequence {@code S} to data with sequence {@code < S}).
+ *
+ * <p>{@code partition} is a {@code byte[]} (see {@link StructLikeSerializer#encodePartition}) so
+ * Flink serializes it natively rather than falling back to Kryo, including in the worker's keyed
+ * state.
+ */
+@Internal
+public record DVPosition(
+    String dataFilePath, long position, int specId, byte[] partition, long dataSequenceNumber)
+    implements Serializable {
+
+  /**
+   * Sentinel filePath for the {@link #ABORT} record so {@code keyBy(dataFilePath)} can route it.
+   */
+  private static final String ABORT_FILE_PATH = "";
+
+  public static final DVPosition ABORT =
+      new DVPosition(ABORT_FILE_PATH, -1, -1, StructLikeSerializer.EMPTY_PARTITION, -1);
+
+  public boolean isAbort() {
+    return ABORT_FILE_PATH.equals(dataFilePath);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVPosition.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 import org.apache.flink.annotation.Internal;
 
 /**
- * A deletion vector position emitted by {@link EqualityConvertPKIndex} when resolving an equality
+ * A deletion vector position emitted by {@code EqualityConvertPKIndex} when resolving an equality
  * delete. Identifies a specific row (by file path and position) to be marked as deleted, and
  * carries the data file's {@code specId} + encoded partition so the downstream resolver can write
  * the DV without re-reading data manifests.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
@@ -24,7 +24,7 @@ import org.apache.flink.annotation.Internal;
 import org.apache.iceberg.DeleteFile;
 
 /**
- * Result from the {@link EqualityConvertDVWriter} containing new and rewritten DV files written by
+ * Result from the {@code EqualityConvertDVWriter} containing new and rewritten DV files written by
  * a single resolver task. A result with {@link #hasError()} signals that the writer failed; the
  * committer must not commit data files in that case.
  */

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DVWriteResult.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DeleteFile;
+
+/**
+ * Result from the {@link EqualityConvertDVWriter} containing new and rewritten DV files written by
+ * a single resolver task. A result with {@link #hasError()} signals that the writer failed; the
+ * committer must not commit data files in that case.
+ */
+@Internal
+public record DVWriteResult(
+    List<DeleteFile> dvFiles, List<DeleteFile> rewrittenDvFiles, boolean hasError)
+    implements Serializable {
+
+  public DVWriteResult(List<DeleteFile> dvFiles, List<DeleteFile> rewrittenDvFiles) {
+    this(dvFiles, rewrittenDvFiles, false);
+  }
+
+  /** Sentinel result that tells the committer to abort the current cycle. */
+  public static final DVWriteResult ABORT = new DVWriteResult(null, null, true);
+
+  public boolean isAbort() {
+    return hasError;
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
@@ -26,8 +26,8 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 
 /**
- * Result of equality convert planning. Produced by {@link EqualityConvertPlanner} and consumed by
- * both {@link EqualityConvertDVWriter} (for partition info and DV merge gating) and {@link
+ * Result of equality convert planning. Produced by {@code EqualityConvertPlanner} and consumed by
+ * both {@code EqualityConvertDVWriter} (for partition info and DV merge gating) and {@code
  * EqualityConvertCommitter} (for data files and staging deletes to commit).
  *
  * <p>A no-op cycle is encoded by {@link #stagingSnapshotId()} == {@link

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+
+/**
+ * Result of equality convert planning. Produced by {@link EqualityConvertPlanner} and consumed by
+ * both {@link EqualityConvertDVWriter} (for partition info and DV merge gating) and {@link
+ * EqualityConvertCommitter} (for data files and staging deletes to commit).
+ *
+ * <p>A no-op cycle is encoded by {@link #stagingSnapshotId()} == {@link
+ * #NO_OP_STAGING_SNAPSHOT_ID}. Use {@link #noOp(Long, long, long)} to construct one and {@link
+ * #noOp()} to check.
+ *
+ * @param dataFiles new staging data files committed in the cycle
+ * @param stagingDVFiles staging DVs passed through to main, used by DVWriter to merge with
+ *     newly-created DVs
+ * @param stagingSnapshotId staging snapshot the cycle resolved against, or {@link
+ *     #NO_OP_STAGING_SNAPSHOT_ID} for a no-op cycle
+ * @param mainSnapshotId main branch snapshot ID the index was resolved against, used for commit
+ *     validation
+ * @param triggerTimestamp original trigger timestamp, forwarded by the Committer to the Aggregator
+ * @param doneTimestamp timestamp after which all phase watermarks have been emitted; the DVWriter
+ *     should only process the result when the watermark reaches or exceeds this value
+ */
+@Internal
+public record EqualityConvertPlan(
+    List<DataFile> dataFiles,
+    List<DeleteFile> stagingDVFiles,
+    long stagingSnapshotId,
+    Long mainSnapshotId,
+    long triggerTimestamp,
+    long doneTimestamp)
+    implements Serializable {
+
+  public static final long NO_OP_STAGING_SNAPSHOT_ID = -1L;
+
+  /** Returns {@code true} if this cycle has nothing to commit. */
+  public boolean noOp() {
+    return stagingSnapshotId == NO_OP_STAGING_SNAPSHOT_ID;
+  }
+
+  /** No-op cycle: empty file lists, sentinel staging snapshot id. */
+  public static EqualityConvertPlan noOp(
+      Long mainSnapshotId, long triggerTimestamp, long doneTimestamp) {
+    return new EqualityConvertPlan(
+        ImmutableList.of(),
+        ImmutableList.of(),
+        NO_OP_STAGING_SNAPSHOT_ID,
+        mainSnapshotId,
+        triggerTimestamp,
+        doneTimestamp);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+
+/**
+ * {@link ContentScanTask} for reading a single equality delete file standalone. The {@link
+ * DeleteFile#equalityFieldIds()} on {@link #file()} carries the PK field IDs the worker resolves
+ * against.
+ */
+@Internal
+record EqualityDeleteFileScanTask(DeleteFile file, PartitionSpec spec)
+    implements ContentScanTask<DeleteFile> {
+
+  @Override
+  public long start() {
+    return 0L;
+  }
+
+  @Override
+  public long length() {
+    return file.fileSizeInBytes();
+  }
+
+  @Override
+  public Expression residual() {
+    return Expressions.alwaysTrue();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Minimal {@link FileScanTask} wrapper used when we have a bare {@link DataFile} (e.g. a new
+ * staging data file from {@code SnapshotChanges#addedDataFiles}) and need to feed it into the
+ * reader. For data files that already come from a planned scan, we pass the native {@link
+ * FileScanTask} through directly.
+ */
+@Internal
+record FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec, List<DeleteFile> deletes)
+    implements FileScanTask {
+
+  FlinkAddedRowsScanTask {
+    // Iceberg's scan APIs return Guava ImmutableList (see BaseAddedRowsScanTask#deletes), which
+    // does not round-trip through Flink's Kryo fallback. Copy into a plain ArrayList so the record
+    // serializes cleanly regardless of what the caller passes.
+    deletes = Lists.newArrayList(deletes);
+  }
+
+  FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec) {
+    this(file, spec, Collections.emptyList());
+  }
+
+  @Override
+  public long start() {
+    return 0L;
+  }
+
+  @Override
+  public long length() {
+    return file.fileSizeInBytes();
+  }
+
+  @Override
+  public Expression residual() {
+    return Expressions.alwaysTrue();
+  }
+
+  @Override
+  public Iterable<FileScanTask> split(long targetSplitSize) {
+    return Collections.singletonList(this);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Command from the {@link EqualityConvertPlanner} to the {@link EqualityConvertPKIndex}.
+ *
+ * <p>{@link Type#ADD_DATA_ROW} adds an existing main-data row to the worker's PK index shard
+ * immediately, so this cycle's delete can remove it. {@link Type#ADD_STAGING_DATA_ROW} adds a
+ * staging snapshot's new data row; the index applies it only after this cycle's delete resolves, so
+ * a re-inserted key survives a same-cycle delete. Both carry the row location as {@link
+ * #rowPosition}. {@link Type#RESOLVE_DELETE} resolves an equality delete key against the index and
+ * emits {@link DVPosition}s for all matching rows. All three flow through the keyed stream and
+ * route via {@link #key}.
+ *
+ * <p>{@link Type#CLEAR_INDEX} is emitted on the broadcast side when an external commit has advanced
+ * the main branch and the worker must evict keyed entries that won't be re-added by the upcoming
+ * reindex (e.g. PKs whose data file was removed by CoW). Has no {@link #key} or row position.
+ * Carries the new {@link #mainSequenceNumber} as the staleness threshold.
+ *
+ * <p>{@link #rowPosition} is the data row's location, set for the two add types and null otherwise;
+ * the data sequence number it carries lets the worker apply a delete only to older rows. {@code
+ * deleteSequenceNumber} is the equality delete's sequence number, set for {@link
+ * Type#RESOLVE_DELETE} and unused (-1) otherwise.
+ */
+@Internal
+public record IndexCommand(
+    Type type,
+    Long mainSnapshotId,
+    Long mainSequenceNumber,
+    SerializedEqualityValues key,
+    DVPosition rowPosition,
+    long deleteSequenceNumber)
+    implements Serializable {
+
+  public enum Type {
+    ADD_DATA_ROW,
+    ADD_STAGING_DATA_ROW,
+    RESOLVE_DELETE,
+    CLEAR_INDEX
+  }
+
+  public static IndexCommand addDataRow(
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      SerializedEqualityValues key,
+      String filePath,
+      long position,
+      int specId,
+      byte[] partition,
+      long dataSequenceNumber,
+      boolean staging) {
+    return new IndexCommand(
+        staging ? Type.ADD_STAGING_DATA_ROW : Type.ADD_DATA_ROW,
+        mainSnapshotId,
+        mainSequenceNumber,
+        key,
+        new DVPosition(filePath, position, specId, partition, dataSequenceNumber),
+        -1);
+  }
+
+  public static IndexCommand resolveDelete(
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      SerializedEqualityValues key,
+      long deleteSequenceNumber) {
+    return new IndexCommand(
+        Type.RESOLVE_DELETE, mainSnapshotId, mainSequenceNumber, key, null, deleteSequenceNumber);
+  }
+
+  public static IndexCommand clearBeforeReindex(long mainSnapshotId, long mainSequenceNumber) {
+    return new IndexCommand(Type.CLEAR_INDEX, mainSnapshotId, mainSequenceNumber, null, null, -1);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/IndexCommand.java
@@ -22,7 +22,7 @@ import java.io.Serializable;
 import org.apache.flink.annotation.Internal;
 
 /**
- * Command from the {@link EqualityConvertPlanner} to the {@link EqualityConvertPKIndex}.
+ * Command from the {@code EqualityConvertPlanner} to the {@code EqualityConvertPKIndex}.
  *
  * <p>{@link Type#ADD_DATA_ROW} adds an existing main-data row to the worker's PK index shard
  * immediately, so this cycle's delete can remove it. {@link Type#ADD_STAGING_DATA_ROW} adds a

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.Serializable;
+import org.apache.flink.annotation.Internal;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+
+/**
+ * Envelope from the {@link EqualityConvertPlanner} to the {@link EqualityConvertReader}, wrapping
+ * an Iceberg {@link ContentScanTask} plus the metadata the reader needs to process it.
+ *
+ * <p>The wrapped task is either:
+ *
+ * <ul>
+ *   <li>A {@link FileScanTask} for data files: native tasks from {@code table.newScan()} for main
+ *       reindex, or a {@link FlinkAddedRowsScanTask} wrapper for bare {@link
+ *       org.apache.iceberg.DataFile}s from {@code SnapshotChanges#addedDataFiles}.
+ *   <li>An {@link EqualityDeleteFileScanTask} for equality delete files.
+ * </ul>
+ *
+ * <p>The equality field IDs are static for the lifetime of the job and carried on the reader
+ * itself, not per-record.
+ *
+ * <p>{@code mainSnapshotId} is sent for diagnostic output.
+ *
+ * <p>{@code mainSequenceNumber} is used by the index to order eager evictions by.
+ *
+ * <p>{@code dataSequenceNumber} is the wrapped file's sequence number (data file or equality
+ * delete), propagated to the worker so a delete only deletes rows older than itself.
+ *
+ * <p>{@code staging} is true for a staging snapshot's new data rows, which the index defers until
+ * after this cycle's delete resolves; false for main reindex data and equality deletes.
+ */
+@Internal
+public record ReadCommand(
+    ContentScanTask<?> task,
+    Long mainSnapshotId,
+    Long mainSequenceNumber,
+    long dataSequenceNumber,
+    boolean staging)
+    implements Serializable {
+
+  public static ReadCommand dataFile(
+      FileScanTask task, Long mainSnapshotId, Long mainSequenceNumber, long dataSequenceNumber) {
+    return new ReadCommand(task, mainSnapshotId, mainSequenceNumber, dataSequenceNumber, false);
+  }
+
+  public static ReadCommand stagingDataFile(
+      FileScanTask task, Long mainSnapshotId, Long mainSequenceNumber, long dataSequenceNumber) {
+    return new ReadCommand(task, mainSnapshotId, mainSequenceNumber, dataSequenceNumber, true);
+  }
+
+  public static ReadCommand eqDeleteFile(
+      DeleteFile file,
+      PartitionSpec spec,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber) {
+    return new ReadCommand(
+        new EqualityDeleteFileScanTask(file, spec),
+        mainSnapshotId,
+        mainSequenceNumber,
+        dataSequenceNumber,
+        false);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ReadCommand.java
@@ -26,7 +26,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpec;
 
 /**
- * Envelope from the {@link EqualityConvertPlanner} to the {@link EqualityConvertReader}, wrapping
+ * Envelope from the {@code EqualityConvertPlanner} to the {@code EqualityConvertReader}, wrapping
  * an Iceberg {@link ContentScanTask} plus the metadata the reader needs to process it.
  *
  * <p>The wrapped task is either:

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SerializedEqualityValues.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/SerializedEqualityValues.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.Arrays;
+import org.apache.flink.annotation.Internal;
+
+/**
+ * Serialized primary key used as a Flink keyed state key. Wraps the raw bytes with content-based
+ * {@code equals}/{@code hashCode} so that Flink's keyBy partitions by key value, not by reference.
+ *
+ * <p>Using the full serialized key (instead of a hash) eliminates hash collisions: two distinct
+ * primary keys always map to separate Flink state entries.
+ */
+@Internal
+public record SerializedEqualityValues(byte[] data) {
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (!(o instanceof SerializedEqualityValues other)) {
+      return false;
+    }
+
+    return Arrays.equals(data, other.data);
+  }
+
+  @Override
+  public int hashCode() {
+    return Arrays.hashCode(data);
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/StructLikeSerializer.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Serializer for {@link StructLike} tuples. Two entry points:
+ *
+ * <ul>
+ *   <li>{@link #serializeKey} builds a Flink keyed-state key ({@link SerializedEqualityValues}),
+ *       prefixed with the partition spec id so partition evolution keeps specs disjoint.
+ *   <li>{@link #encodePartition} / {@link #decodePartition} serialize partition tuples into bytes.
+ * </ul>
+ */
+class StructLikeSerializer {
+
+  static final byte[] EMPTY_PARTITION = new byte[0];
+
+  private final ByteArrayOutputStream baos = new ByteArrayOutputStream();
+  private final DataOutputStream dos = new DataOutputStream(baos);
+
+  public SerializedEqualityValues serializeKey(
+      StructLike key, Types.StructType keyType, int specId) {
+    baos.reset();
+    try {
+      dos.writeInt(specId);
+
+      List<Types.NestedField> fields = keyType.fields();
+      dos.writeInt(fields.size());
+      for (Types.NestedField field : fields) {
+        dos.writeInt(field.fieldId());
+      }
+
+      for (int i = 0; i < fields.size(); i++) {
+        writeField(key, i, fields.get(i).type());
+      }
+
+      dos.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to serialize PK index key", e);
+    }
+
+    return new SerializedEqualityValues(baos.toByteArray());
+  }
+
+  public byte[] encodePartition(StructLike partition, Types.StructType partitionType) {
+    List<Types.NestedField> fields = partitionType.fields();
+    if (fields.isEmpty()) {
+      return EMPTY_PARTITION;
+    }
+
+    baos.reset();
+    try {
+      for (int i = 0; i < fields.size(); i++) {
+        writeField(partition, i, fields.get(i).type());
+      }
+
+      dos.flush();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to encode partition", e);
+    }
+
+    return baos.toByteArray();
+  }
+
+  public static StructLike decodePartition(byte[] encoded, Types.StructType partitionType) {
+    PartitionData partition = new PartitionData(partitionType);
+    List<Types.NestedField> fields = partitionType.fields();
+    if (fields.isEmpty()) {
+      return partition;
+    }
+
+    try (DataInputStream dis = new DataInputStream(new ByteArrayInputStream(encoded))) {
+      for (int i = 0; i < fields.size(); i++) {
+        boolean isNull = dis.readBoolean();
+        if (isNull) {
+          partition.set(i, null);
+        } else {
+          int length = dis.readInt();
+          byte[] bytes = new byte[length];
+          dis.readFully(bytes);
+          Object value = Conversions.fromByteBuffer(fields.get(i).type(), ByteBuffer.wrap(bytes));
+          // Conversions returns CharBuffer for STRING; PartitionData (and the manifest writer)
+          // expects String.
+          if (value instanceof CharSequence cs && !(value instanceof String)) {
+            value = cs.toString();
+          }
+
+          partition.set(i, value);
+        }
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to decode partition", e);
+    }
+
+    return partition;
+  }
+
+  private void writeField(StructLike struct, int pos, Type fieldType) throws IOException {
+    Object value = struct.get(pos, Object.class);
+    if (value == null) {
+      dos.writeBoolean(true);
+      return;
+    }
+
+    dos.writeBoolean(false);
+    ByteBuffer buf = Conversions.toByteBuffer(fieldType, value);
+    dos.writeInt(buf.remaining());
+    dos.write(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining());
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestFlinkPojoTypes.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestFlinkPojoTypes.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.typeutils.PojoTypeInfo;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Verifies that the hot-path classes used as Flink stream element types are valid POJO types. Flink
+ * POJO serialization requires a public no-arg constructor and public setters for all fields.
+ */
+class TestFlinkPojoTypes {
+
+  @Test
+  void testSerializedEqualityValues() {
+    assertThat(TypeInformation.of(SerializedEqualityValues.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+
+  @Test
+  void testDVPosition() {
+    assertThat(TypeInformation.of(DVPosition.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+
+  @Test
+  void testIndexCommand() {
+    assertThat(TypeInformation.of(IndexCommand.class)).isInstanceOf(PojoTypeInfo.class);
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestStructLikeSerializer.java
@@ -1,0 +1,176 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestStructLikeSerializer {
+
+  private static final Types.StructType KEY_TYPE =
+      Types.StructType.of(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  private static final int SPEC_0 = PartitionSpec.unpartitioned().specId();
+
+  private final StructLikeSerializer serializer = new StructLikeSerializer();
+
+  @Test
+  void serializeKeyIsDeterministic() {
+    GenericRecord key = GenericRecord.create(KEY_TYPE);
+    key.set(0, 42);
+    key.set(1, "hello");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(key, KEY_TYPE, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyDiffersForDifferentKeys() {
+    GenericRecord record1 = GenericRecord.create(KEY_TYPE);
+    record1.set(0, 1);
+    record1.set(1, "a");
+
+    GenericRecord record2 = GenericRecord.create(KEY_TYPE);
+    record2.set(0, 2);
+    record2.set(1, "b");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record2, KEY_TYPE, SPEC_0);
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  @Test
+  void sameValuesDifferentFieldSetsAreNotEqual() {
+    Types.StructType typeWithField1 =
+        Types.StructType.of(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+    Types.StructType typeWithField3 =
+        Types.StructType.of(Types.NestedField.required(3, "other", Types.IntegerType.get()));
+
+    GenericRecord record1 = GenericRecord.create(typeWithField1);
+    record1.set(0, 42);
+
+    GenericRecord record3 = GenericRecord.create(typeWithField3);
+    record3.set(0, 42);
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record1, typeWithField1, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record3, typeWithField3, SPEC_0);
+    assertThat(key1).isNotEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyWithDecimal() {
+    Types.StructType decimalKeyType =
+        Types.StructType.of(
+            Types.NestedField.required(1, "id", Types.DecimalType.of(10, 2)),
+            Types.NestedField.required(2, "name", Types.StringType.get()));
+
+    GenericRecord record = GenericRecord.create(decimalKeyType);
+    record.set(0, new BigDecimal("123.45"));
+    record.set(1, "test");
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, decimalKeyType, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void serializeKeyHandlesNulls() {
+    GenericRecord record = GenericRecord.create(KEY_TYPE);
+    record.set(0, 1);
+    record.set(1, null);
+
+    SerializedEqualityValues key1 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    SerializedEqualityValues key2 = serializer.serializeKey(record, KEY_TYPE, SPEC_0);
+    assertThat(key1).isEqualTo(key2);
+  }
+
+  @Test
+  void nullDiffersFromNonNull() {
+    GenericRecord withNull = GenericRecord.create(KEY_TYPE);
+    withNull.set(0, 1);
+    withNull.set(1, null);
+
+    GenericRecord withValue = GenericRecord.create(KEY_TYPE);
+    withValue.set(0, 1);
+    withValue.set(1, "");
+
+    assertThat(serializer.serializeKey(withNull, KEY_TYPE, SPEC_0))
+        .isNotEqualTo(serializer.serializeKey(withValue, KEY_TYPE, SPEC_0));
+  }
+
+  @Test
+  void samePkDifferentSpecsAreNotEqual() {
+    GenericRecord pk = GenericRecord.create(KEY_TYPE);
+    pk.set(0, 42);
+    pk.set(1, "x");
+
+    assertThat(serializer.serializeKey(pk, KEY_TYPE, 0))
+        .isNotEqualTo(serializer.serializeKey(pk, KEY_TYPE, 1));
+  }
+
+  @Test
+  void encodeDecodeRoundTripsAcrossTypes() {
+    Types.StructType partitionType =
+        Types.StructType.of(
+            Types.NestedField.required(100, "p_int", Types.IntegerType.get()),
+            Types.NestedField.required(101, "p_str", Types.StringType.get()),
+            Types.NestedField.required(102, "p_dec", Types.DecimalType.of(10, 2)),
+            Types.NestedField.required(103, "p_date", Types.DateType.get()),
+            Types.NestedField.optional(104, "p_null", Types.StringType.get()));
+
+    PartitionData partition = new PartitionData(partitionType);
+    partition.set(0, 7);
+    partition.set(1, "abc");
+    partition.set(2, new BigDecimal("12.34"));
+    partition.set(3, 19000);
+    partition.set(4, null);
+
+    StructLike decoded =
+        StructLikeSerializer.decodePartition(
+            serializer.encodePartition(partition, partitionType), partitionType);
+
+    assertThat(decoded.get(0, Integer.class)).isEqualTo(7);
+    assertThat(decoded.get(1, String.class)).isEqualTo("abc");
+    assertThat(decoded.get(2, BigDecimal.class)).isEqualTo(new BigDecimal("12.34"));
+    assertThat(decoded.get(3, Integer.class)).isEqualTo(19000);
+    assertThat(decoded.get(4, String.class)).isNull();
+  }
+
+  @Test
+  void unpartitionedEncodesToEmpty() {
+    Types.StructType empty = PartitionSpec.unpartitioned().partitionType();
+    PartitionData partition = new PartitionData(empty);
+
+    byte[] encoded = serializer.encodePartition(partition, empty);
+    assertThat(encoded).isEmpty();
+
+    StructLike decoded = StructLikeSerializer.decodePartition(encoded, empty);
+    assertThat(decoded.size()).isZero();
+  }
+}


### PR DESCRIPTION
This is the first of six commits factored out from #15996, implementing the ConvertEqualityDeletes maintenance task. The task converts equality-delete files written to a staging branch into deletion vectors on a target branch, running inside a Flink job: Planner, Reader, PK index, DV writer, Committer. This PR adds only the shared data model and key serialization those operators exchange. The operators and public API follow in later PRs which depend on this one.

The records are the messages passed along the graph:

  - ReadCommand: Planner to Reader. Wraps a ContentScanTask (a native FileScanTask, the FlinkAddedRowsScanTask wrapper for added DataFiles, or an EqualityDeleteFileScanTask) plus sequence numbers and a staging flag.
  - IndexCommand: Reader to PK index, keyed by primary key. ADD_DATA_ROW and ADD_STAGING_DATA_ROW index rows; RESOLVE_DELETE resolve deletes against the index; CLEAR_INDEX (broadcast) evicts stale keys after an external main commit.
  - DVPosition: PK index to DV writer, keyed by data file path. Specifies a row to mark it deleted and carries the data file's spec id and encoded partition so the writer needs no manifest scan.
  - DVWriteResult: DV writer to Committer, the DVs written or an abort.
  - EqualityConvertPlan: Plan for DV writer and Committer, per-cycle metadata.

StructLikeSerializer encodes equality keys and partition tuples via Conversions.toByteBuffer. serializeKey prefixes each key with the partition spec id and the equality field ids, so rows under different specs or different equality-field sets never collide.

We try to use Java records so Flink's record serializer handles the keyed-stream types (IndexCommand, DVPosition, SerializedEqualityValues) without falling back to Kryo (TestFlinkPojoTypes asserts this).