### PR TITLE
Core: Avoid HEAD on metadata file in synthetic metadata-table tasks

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -145,8 +145,7 @@ public class AllManifestsTable extends BaseMetadataTable {
                       snap.snapshotId());
                 } else {
                   return StaticDataTask.of(
-                      io.newInputFile(
-                          ((BaseTable) table()).operations().current().metadataFileLocation()),
+                      ((BaseTable) table()).operations().current().metadataFileLocation(),
                       MANIFEST_FILE_SCHEMA,
                       schema(),
                       snap.allManifests(io),

--- a/core/src/main/java/org/apache/iceberg/HistoryTable.java
+++ b/core/src/main/java/org/apache/iceberg/HistoryTable.java
@@ -66,7 +66,7 @@ public class HistoryTable extends BaseMetadataTable {
 
   private DataTask task(TableScan scan) {
     return StaticDataTask.of(
-        table().io().newInputFile(table().operations().current().metadataFileLocation()),
+        table().operations().current().metadataFileLocation(),
         schema(),
         scan.schema(),
         table().history(),

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -81,8 +81,7 @@ public class ManifestsTable extends BaseMetadataTable {
     Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
 
     return StaticDataTask.of(
-        io.newInputFile(
-            location != null ? location : table().operations().current().metadataFileLocation()),
+        location != null ? location : table().operations().current().metadataFileLocation(),
         schema(),
         scan.schema(),
         scan.snapshot().allManifests(io),

--- a/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataLogEntriesTable.java
@@ -65,7 +65,7 @@ public class MetadataLogEntriesTable extends BaseMetadataTable {
         new TableMetadata.MetadataLogEntry(
             current.lastUpdatedMillis(), current.metadataFileLocation()));
     return StaticDataTask.of(
-        table().io().newInputFile(current.metadataFileLocation()),
+        current.metadataFileLocation(),
         schema(),
         scan.schema(),
         metadataLogEntries,

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -153,7 +153,7 @@ public class PartitionsTable extends BaseMetadataTable {
     if (unpartitionedTable) {
       // the table is unpartitioned, partitions contains only the root partition
       return StaticDataTask.of(
-          io().newInputFile(table().operations().current().metadataFileLocation()),
+          table().operations().current().metadataFileLocation(),
           schema(),
           scan.schema(),
           partitions,
@@ -170,7 +170,7 @@ public class PartitionsTable extends BaseMetadataTable {
                   root.lastUpdatedSnapshotId));
     } else {
       return StaticDataTask.of(
-          io().newInputFile(table().operations().current().metadataFileLocation()),
+          table().operations().current().metadataFileLocation(),
           schema(),
           scan.schema(),
           partitions,

--- a/core/src/main/java/org/apache/iceberg/RefsTable.java
+++ b/core/src/main/java/org/apache/iceberg/RefsTable.java
@@ -60,7 +60,7 @@ public class RefsTable extends BaseMetadataTable {
   private DataTask task(BaseTableScan scan) {
     Collection<String> refNames = table().refs().keySet();
     return StaticDataTask.of(
-        table().io().newInputFile(table().operations().current().metadataFileLocation()),
+        table().operations().current().metadataFileLocation(),
         schema(),
         scan.schema(),
         refNames,

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -59,7 +59,7 @@ public class SnapshotsTable extends BaseMetadataTable {
 
   private DataTask task(BaseTableScan scan) {
     return StaticDataTask.of(
-        table().io().newInputFile(table().operations().current().metadataFileLocation()),
+        table().operations().current().metadataFileLocation(),
         schema(),
         scan.schema(),
         table().snapshots(),

--- a/core/src/main/java/org/apache/iceberg/StaticDataTask.java
+++ b/core/src/main/java/org/apache/iceberg/StaticDataTask.java
@@ -25,7 +25,6 @@ import java.util.function.Function;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -33,36 +32,33 @@ import org.apache.iceberg.util.StructProjection;
 
 class StaticDataTask implements DataTask {
 
+  /**
+   * Builds a {@link StaticDataTask} from in-memory rows. The {@code metadataLocation} is kept on
+   * the synthetic {@link DataFile} for identification only and is never read, so its size is
+   * reported as 0 rather than looked up.
+   */
   static <T> DataTask of(
-      InputFile metadata,
+      String metadataLocation,
       Schema tableSchema,
       Schema projectedSchema,
       Iterable<T> values,
       Function<T, Row> transform) {
-    return new StaticDataTask(
-        metadata,
-        tableSchema,
-        projectedSchema,
-        Lists.newArrayList(Iterables.transform(values, transform::apply)).toArray(new Row[0]));
+    Row[] rows =
+        Lists.newArrayList(Iterables.transform(values, transform::apply)).toArray(new Row[0]);
+    DataFile syntheticFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withPath(metadataLocation)
+            .withFileSizeInBytes(0L)
+            .withRecordCount(rows.length)
+            .withFormat(FileFormat.METADATA)
+            .build();
+    return new StaticDataTask(syntheticFile, tableSchema, projectedSchema, rows);
   }
 
   private final DataFile metadataFile;
   private final StructLike[] rows;
   private final Schema tableSchema;
   private final Schema projectedSchema;
-
-  private StaticDataTask(
-      InputFile metadata, Schema tableSchema, Schema projectedSchema, StructLike[] rows) {
-    this.tableSchema = tableSchema;
-    this.projectedSchema = projectedSchema;
-    this.metadataFile =
-        DataFiles.builder(PartitionSpec.unpartitioned())
-            .withInputFile(metadata)
-            .withRecordCount(rows.length)
-            .withFormat(FileFormat.METADATA)
-            .build();
-    this.rows = rows;
-  }
 
   StaticDataTask(
       DataFile metadataFile, Schema tableSchema, Schema projectedSchema, StructLike[] rows) {

--- a/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
@@ -236,7 +236,7 @@ public class TestDataTaskParser {
                 null));
 
     return StaticDataTask.of(
-        Files.localInput("file:/tmp/metadata2.json"),
+        "/tmp/metadata2.json",
         SNAPSHOT_SCHEMA,
         SNAPSHOT_SCHEMA,
         snapshots,

--- a/core/src/test/java/org/apache/iceberg/TestStaticDataTask.java
+++ b/core/src/test/java/org/apache/iceberg/TestStaticDataTask.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestStaticDataTask {
+
+  private static final Schema TEST_SCHEMA = new Schema(required(1, "value", Types.LongType.get()));
+
+  @Test
+  public void ofStringPathDoesNotReadFile() {
+    // Even a clearly-bogus path must be tolerated: the new overload promises no I/O against the
+    // location, only preserving it for identification. If the implementation regressed to building
+    // the DataFile via withInputFile (which calls InputFile.getLength()), this call would fail
+    // when the FileIO eventually tried to HEAD the path.
+    String bogusLocation = "file:///does/not/exist/never/HEADed.metadata.json";
+    List<Long> values = ImmutableList.of(1L, 2L, 3L);
+
+    DataTask task =
+        StaticDataTask.of(
+            bogusLocation, TEST_SCHEMA, TEST_SCHEMA, values, v -> StaticDataTask.Row.of(v));
+
+    assertThat(task.isDataTask()).as("should be a DataTask").isTrue();
+    assertThat(task.length()).as("length must be 0 (no file bytes processed)").isEqualTo(0L);
+    assertThat(task.file().fileSizeInBytes())
+        .as("DataFile size must be 0 (no HEAD on synthetic file)")
+        .isEqualTo(0L);
+    assertThat(task.file().format())
+        .as("DataFile format must be METADATA")
+        .isEqualTo(FileFormat.METADATA);
+    assertThat(task.file().location())
+        .as("DataFile path must preserve the supplied location for identification")
+        .isEqualTo(bogusLocation);
+    assertThat(task.file().recordCount())
+        .as("DataFile record count must reflect the row count")
+        .isEqualTo(values.size());
+  }
+
+  @Test
+  public void ofStringPathRowsProjectCorrectly() {
+    String location = "file:///irrelevant/path.metadata.json";
+    List<Long> values = ImmutableList.of(10L, 20L, 30L);
+
+    DataTask task =
+        StaticDataTask.of(
+            location, TEST_SCHEMA, TEST_SCHEMA, values, v -> StaticDataTask.Row.of(v));
+
+    try (CloseableIterable<StructLike> rows = task.rows()) {
+      List<Long> read =
+          ImmutableList.copyOf(
+              org.apache.iceberg.relocated.com.google.common.collect.Iterables.transform(
+                  rows, row -> row.get(0, Long.class)));
+      assertThat(read).containsExactlyElementsOf(values);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void ofStringPathWithNoValuesYieldsEmptyTask() {
+    String location = "file:///irrelevant/path.metadata.json";
+
+    DataTask task =
+        StaticDataTask.of(
+            location,
+            TEST_SCHEMA,
+            TEST_SCHEMA,
+            ImmutableList.<Long>of(),
+            v -> StaticDataTask.Row.of(v));
+
+    assertThat(task.length()).isEqualTo(0L);
+    assertThat(task.file().recordCount()).isEqualTo(0L);
+
+    try (CloseableIterable<StructLike> rows = task.rows()) {
+      assertThat(rows).isEmpty();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
## What

`HistoryTable`, `SnapshotsTable`, `MetadataLogEntriesTable`, `RefsTable`, `ManifestsTable`, `AllManifestsTable`, and `PartitionsTable` build a `StaticDataTask` whose rows are materialized from in-memory `TableMetadata` (or from pre-walked manifest data). The `DataFile` these tasks wrap exists only so `FileScanTask.file()` can return a path for identification — the file bytes are never read.

The previous `StaticDataTask.of(InputFile, ...)` entry point built that `DataFile` via `DataFiles.Builder.withInputFile`, which calls `InputFile.getLength()` to populate `fileSizeInBytes`. On object-store `FileIO` implementations that is a `HEAD`/`GetObject` round-trip against the table's `metadata.json` — one extra request on every metadata-table scan, for a value that is never consulted on the `DataTask` read path.

## Change

Replace `StaticDataTask.of(InputFile, ...)` with `StaticDataTask.of(String location, ...)`, which builds the synthetic `DataFile` via `withPath(location)` + `withFileSizeInBytes(0L)`. The seven metadata tables and `TestDataTaskParser` are migrated to it, and the old overload and its private constructor — the only remaining `getLength()` call site — are removed, so no construction path performs I/O against the synthetic location. `FileScanTask.length()` for these tasks now returns `0` instead of the `metadata.json` size.

## Why this is safe

`fileSizeInBytes` is never read for a `DataTask`. Engines branch on `ScanTask.isDataTask()` and obtain rows via `DataTask.rows()`; any file-size-aware logic (buffer sizing, split planning) lives on the `!isDataTask()` path — e.g. `RowDataReader.open` in iceberg-spark and `DataTaskReader.open` in iceberg-flink.

There is existing precedent in the same area: `AllManifestsTable.ManifestListReadTask.length()` already returns a hard-coded `8192` with the comment _"return a generic length to avoid looking up the actual length"_.

`StaticDataTask` is package-private, so this is not a public API change (no revapi impact).

## Related discussion

This is a small, concrete step in a direction the community has been discussing — reducing engines' dependence on the root `metadata.json` and the code paths that read it directly:

- [DISCUSS] metadata.json in v4? (dev@, Anton Okolnychyi) — making the root `metadata.json` optional: https://lists.apache.org/thread/l1onvv5p5cq2vtql9g8w5fbxc1hhd65l
- [DISCUSS] Offloading Snapshots from Metadata.json (dev@) — includes removing engine paths that read the metadata file directly: https://lists.apache.org/thread/5f5p4rcxyq7j6rt7yts68shoqmm75478

See also Yufei Gu's doc tracking clients/engines with hard dependencies on the metadata file in storage, shared in that thread: https://docs.google.com/document/d/17PBhJ0IBxHxMKvCW6CstGOp7cZnboMDdpO6BCPO2kmA/edit

The metadata tables never need any bytes from `metadata.json` — only a path for identification — yet today they issue a `HEAD` against it solely to populate an unused size field. This removes that one unnecessary read; it doesn't attempt the broader changes proposed in those threads.

## Testing

- New `TestStaticDataTask` pins the contract: a bogus, never-created location is tolerated with no I/O, `length()` and `DataFile.fileSizeInBytes()` are `0`, format is `METADATA`, and the supplied path is preserved for identification.
- `TestDataTaskParser` is migrated to the string overload; the serialized round-trip is byte-identical (the previous `Files.localInput(...)` already reported size `0` and stripped the URI scheme).
