### PR TITLE
Core: Only add required encrypted keys to metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -23,9 +23,13 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ManifestListFile;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.OutputFile;
@@ -179,6 +183,37 @@ public class EncryptionUtil {
         "Retrieving encryption keys requires a StandardEncryptionManager");
     StandardEncryptionManager sem = (StandardEncryptionManager) em;
     return sem.encryptionKeys();
+  }
+
+  /**
+   * Returns {@link TableMetadata} with encrypted keys from an {@param encryptionManager} that are
+   * required to read the snapshots in the given {@param metadata}. Only adds keys that are still
+   * referenced in metadata.
+   */
+  public static TableMetadata addEmKeysToMetadata(
+      TableMetadata metadata, EncryptionManager encryptionManager) {
+    if (!(encryptionManager instanceof StandardEncryptionManager standardEncryptionManager)) {
+      return metadata;
+    }
+    Set<String> referencedEncryptionKeys =
+        Sets.union(
+            metadata.snapshots().stream()
+                .map(Snapshot::keyId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet()),
+            metadata.encryptionKeys().stream()
+                .map(EncryptedKey::encryptedById)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toUnmodifiableSet()));
+    TableMetadata.Builder metadataBuilder = TableMetadata.buildFrom(metadata);
+    standardEncryptionManager.encryptionKeys().values().stream()
+        .filter(
+            encryptedKey ->
+                referencedEncryptionKeys.contains(encryptedKey.keyId())
+                    // The KEK may not be referenced but must still be saved in the metadata.
+                    || standardEncryptionManager.keyEncryptionKeyID().equals(encryptedKey.keyId()))
+        .forEach(metadataBuilder::addEncryptionKey);
+    return metadataBuilder.build();
   }
 
   /**

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -245,18 +244,7 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
     String newMetadataLocation;
     EncryptionManager encrManager = encryption();
-    if (encrManager instanceof StandardEncryptionManager) {
-      // Add new encryption keys to the metadata
-      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
-      for (Map.Entry<String, EncryptedKey> entry :
-          EncryptionUtil.encryptionKeys(encrManager).entrySet()) {
-        builder.addEncryptionKey(entry.getValue());
-      }
-
-      tableMetadata = builder.build();
-    } else {
-      tableMetadata = metadata;
-    }
+    tableMetadata = EncryptionUtil.addEmKeysToMetadata(metadata, encrManager);
 
     newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -41,10 +41,12 @@ import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.encryption.Ciphers;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
@@ -54,6 +56,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
+import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.crypto.ParquetCryptoRuntimeException;
 import org.apache.spark.SparkException;
@@ -218,6 +221,50 @@ public class TestTableEncryption extends CatalogTestBase {
 
     assertEquals(
         "Should return all expected rows",
+        expected,
+        sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @TestTemplate
+  public void testExpireSnapshotsRemovesEncryptionKeysAtCommitTime() {
+    sql("INSERT INTO %s VALUES (4, 'd', 4.0)", tableName);
+
+    validationCatalog.initialize(catalogName, catalogConfig);
+    Table table = validationCatalog.loadTable(tableIdent);
+
+    Snapshot current = table.currentSnapshot();
+
+    Snapshot snapshotToExpire =
+        Streams.stream(table.snapshots())
+            .filter(snapshot -> snapshot.parentId() == null)
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("Expected a root snapshot"));
+
+    assertThat(((HasTableOperations) table).operations().current().encryptionKeys())
+        .as("Encryption key for snapshotToExpire is in metadata before expiry.")
+        .extracting(EncryptedKey::keyId)
+        .contains(snapshotToExpire.keyId(), current.keyId());
+
+    SparkActions.get()
+        .expireSnapshots(table)
+        .expireSnapshotId(snapshotToExpire.snapshotId())
+        .execute();
+
+    assertThat(
+            ((HasTableOperations) validationCatalog.loadTable(tableIdent))
+                .operations()
+                .current()
+                .encryptionKeys())
+        .as("Expiring snapshot removes encryption key for that snapshot.")
+        .extracting(EncryptedKey::keyId)
+        .doesNotContain(snapshotToExpire.keyId())
+        .contains(current.keyId());
+
+    ImmutableList<Object[]> expected =
+        ImmutableList.of(
+            row(1L, "a", 1.0F), row(2L, "b", 2.0F), row(3L, "c", Float.NaN), row(4L, "d", 4.0F));
+    assertEquals(
+        "Encrypted table is still readable after its expired snapshot's key is removed",
         expected,
         sql("SELECT * FROM %s ORDER BY id", tableName));
   }


### PR DESCRIPTION
Addresses: https://github.com/apache/iceberg/issues/16352

After putting up:  https://github.com/apache/iceberg/pull/16353 which cleaned encryption keys at `expire_snapshot` time by removing the encryption key associated with the removed snapshot. (In `TableMetadata::RemoveSnapshot` also `RemoveEncryptionKey` for the keyId of the removed snapshot).

When writing E2E tests for above, it wasn't working due to [HiveTableOperations::doCommit](https://github.com/apache/iceberg/blob/69063fb162e835c3dc1ff7bbcf5526029771c6d0/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java#L253) always adding all keys from the EncryptionManager into the TableMetadata.

From my rough understanding, sorry if this is wrong 😅, `EncryptionManager` is independent of `TableMetadata`, they "branch off" at metadata load time, and at commit time they are "reconciled".
The current "reconciliation" logic is to add all keys in `EncryptionManager` to `TableMetadata`.

This leads to issues when trying to remove keys. Even if the EncryptedKey is removed from the base metadata and the new `metadata` does not have the key, removal of EncryptionKeys from metadata is never propagated to the EncryptionManager.

This PR proposes to change the "reconciliation" logic to only add keys that are still referenced/needed by the new metadata file.

This effectively does cleanup at runtime.

Ideas for alternative solutions (Open to ideas here, I think I have a rather limited view here of how things are correlated with each-other):
- Rewrite EncryptionManager to be built on top of TableMetadata. Use TableMetadata as source of truth.
  - EncryptionManager does not store state, delegates to TableMetadata. 
  - Alterations to EncryptionManager are immediately reflected within its version of TableMetadata
    - E.g. adding encryption keys or removing encryption keys.
- Rewrite EncryptionManager to be more tightly coupled with TableMetadata.
  - Such that when RemoveSnapshot -> remove encryption key from EncryptionManager. 
  - Keep the "adding of all encryption keys from EncryptionManager" at commit time.


This also related to the REST catalog implementation of encryption: https://github.com/apache/iceberg/pull/13225
The above PR has the same issue as the Hive implementation, where it will always add all keys from the `EncryptionManager`.