### PR TITLE
Spark, Core: Use in-memory FileIO/Catalog in Spark tests for faster runs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentMap;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -45,9 +46,9 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.LocationUtil;
@@ -69,13 +70,20 @@ import org.apache.iceberg.view.ViewUtil;
  * to others, and {@link #close()} leaves the shared store intact so the remaining instances
  * continue to observe it. The shared store survives for the lifetime of the JVM unless {@link
  * #clearSharedStore} is called explicitly.
+ *
+ * <p>Mutating operations synchronize on the backing store rather than on this catalog instance, so
+ * all instances pointing at the same shared store serialize through the same monitor. The catalog
+ * instance's intrinsic lock is not the synchronization root and must not be relied on for external
+ * coordination.
  */
 public class InMemoryCatalog extends BaseMetastoreViewCatalog
     implements SupportsNamespaces, Closeable {
   /**
    * Catalog property whose value identifies a JVM-wide shared store. Two {@link InMemoryCatalog}
    * instances initialized with the same value of this property share the same namespaces, tables,
-   * views, and synchronization monitor. When unset, each instance keeps a private store.
+   * views, and synchronization monitor. When unset, each instance keeps a private store. Empty or
+   * whitespace-only values are rejected because they are typically a misconfiguration produced by
+   * config layers that map "missing" to the empty string.
    */
   public static final String SHARED_STORE_ID = "in-memory-catalog.shared-store-id";
 
@@ -91,7 +99,6 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
    * shared store is a no-op. Intended for harnesses that need to release accumulated state between
    * runs.
    */
-  @VisibleForTesting
   public static void clearSharedStore(String sharedStoreId) {
     SHARED_STORES.remove(sharedStoreId);
   }
@@ -115,8 +122,24 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     return catalogName;
   }
 
+  /**
+   * Initializes the catalog. May be called more than once on the same instance: a subsequent call
+   * closes the previous {@link CloseableGroup} (and the {@link FileIO} / metrics reporter it holds)
+   * and reselects the backing store from the new properties. There is no thread-safety guarantee
+   * for re-initialization concurrent with in-flight catalog operations.
+   */
   @Override
   public void initialize(String name, Map<String, String> properties) {
+    String sharedStoreId = properties.get(SHARED_STORE_ID);
+    if (sharedStoreId != null) {
+      Preconditions.checkArgument(
+          !sharedStoreId.trim().isEmpty(),
+          "%s must not be empty or whitespace; either omit the property or provide a non-blank value",
+          SHARED_STORE_ID);
+    }
+
+    closePreviousCloseableGroup();
+
     this.catalogName = name != null ? name : InMemoryCatalog.class.getSimpleName();
     this.catalogProperties = ImmutableMap.copyOf(properties);
     this.uniqueTableLocation =
@@ -128,7 +151,6 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
 
-    String sharedStoreId = properties.get(SHARED_STORE_ID);
     if (sharedStoreId != null) {
       this.store = SHARED_STORES.computeIfAbsent(sharedStoreId, k -> new Store());
       this.ownsStore = false;
@@ -137,17 +159,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       this.ownsStore = true;
     }
 
-    // Close any resources from a prior initialize() to avoid leaking the previous FileIO and
-    // metrics reporter when this catalog is re-initialized in place.
-    closePreviousResources();
-
     this.io = CatalogUtil.loadFileIO(InMemoryFileIO.class.getName(), properties, null);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
   }
 
-  private void closePreviousResources() {
+  private void closePreviousCloseableGroup() {
     CloseableGroup previous = this.closeableGroup;
     this.closeableGroup = null;
     if (previous != null) {
@@ -278,7 +296,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
         return false;
       }
 
-      long childNamespaces = countChildNamespaces(currentStore, namespace);
+      long childNamespaces = childNamespacesOf(currentStore, namespace).count();
       if (childNamespaces > 0) {
         throw new NamespaceNotEmptyException(
             "Namespace %s is not empty. Contains %d child namespace(s).",
@@ -301,13 +319,18 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     }
   }
 
-  private static long countChildNamespaces(Store snapshot, Namespace parent) {
-    String prefix = parent.isEmpty() ? "" : DOT.join(parent.levels()) + ".";
-    return snapshot.namespaces.keySet().stream()
-        .filter(n -> !n.isEmpty())
-        .filter(n -> DOT.join(n.levels()).startsWith(prefix))
-        .filter(n -> n.levels().length > parent.levels().length)
-        .count();
+  /**
+   * Returns the namespaces that are strict descendants of {@code parent} in {@code currentStore}.
+   * Implemented as a single shared traversal so that {@link #dropNamespace(Namespace)} and {@link
+   * #listNamespaces(Namespace)} cannot drift apart on prefix-collision edge cases (for example,
+   * {@code a.b} as a parent must not match {@code a.bb.c}).
+   */
+  private static Stream<Namespace> childNamespacesOf(Store currentStore, Namespace parent) {
+    int parentLength = parent.levels().length;
+    String[] parentLevels = parent.levels();
+    return currentStore.namespaces.keySet().stream()
+        .filter(n -> n.levels().length > parentLength)
+        .filter(n -> Arrays.equals(Arrays.copyOf(n.levels(), parentLength), parentLevels));
   }
 
   private static long countIdentifiersInNamespace(
@@ -381,26 +404,21 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) throws NoSuchNamespaceException {
-    final String searchNamespaceString =
-        namespace.isEmpty() ? "" : DOT.join(namespace.levels()) + ".";
-    final int searchNumberOfLevels = namespace.levels().length;
-
     Store currentStore = store;
-    List<Namespace> filteredNamespaces =
-        currentStore.namespaces.keySet().stream()
-            .filter(n -> !n.isEmpty())
-            .filter(n -> DOT.join(n.levels()).startsWith(searchNamespaceString))
-            .collect(Collectors.toList());
+    int rootLength = namespace.levels().length;
+
+    List<Namespace> descendants =
+        childNamespacesOf(currentStore, namespace).collect(Collectors.toList());
 
     // If the namespace does not exist and the namespace is not a prefix of another namespace,
     // throw an exception.
-    if (!currentStore.namespaces.containsKey(namespace) && filteredNamespaces.isEmpty()) {
+    if (!currentStore.namespaces.containsKey(namespace) && descendants.isEmpty()) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
 
-    return filteredNamespaces.stream()
+    return descendants.stream()
         // List only the child-namespaces roots.
-        .map(n -> Namespace.of(Arrays.copyOf(n.levels(), searchNumberOfLevels + 1)))
+        .map(n -> Namespace.of(Arrays.copyOf(n.levels(), rootLength + 1)))
         .distinct()
         .sorted(Comparator.comparing(n -> DOT.join(n.levels())))
         .collect(Collectors.toList());
@@ -418,10 +436,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       closeableGroup.close();
     }
     if (ownsStore) {
-      Store currentStore = store;
-      currentStore.namespaces.clear();
-      currentStore.tables.clear();
-      currentStore.views.clear();
+      store.clear();
     }
   }
 
@@ -637,5 +652,11 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
         Maps.newConcurrentMap();
     private final ConcurrentMap<TableIdentifier, String> tables = Maps.newConcurrentMap();
     private final ConcurrentMap<TableIdentifier, String> views = Maps.newConcurrentMap();
+
+    void clear() {
+      namespaces.clear();
+      tables.clear();
+      views.clear();
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -57,18 +58,32 @@ import org.apache.iceberg.view.ViewOperations;
 import org.apache.iceberg.view.ViewUtil;
 
 /**
- * Catalog implementation that uses in-memory data-structures to store the namespaces and tables.
- * This class doesn't touch external resources and can be utilized to write unit tests without side
- * effects. It uses {@link InMemoryFileIO}.
+ * Catalog implementation that uses in-memory data-structures to store namespaces, tables, and
+ * views. It uses {@link InMemoryFileIO} so it does not touch external resources, which makes it
+ * well-suited to writing unit tests.
+ *
+ * <p>By default each instance owns a private store, and {@link #close()} drops it. Setting the
+ * {@link #INSTANCE_ID} catalog property links instances initialized with the same value to a
+ * shared, JVM-wide store: namespaces, tables, and views committed through one instance are visible
+ * to others, and {@link #close()} leaves the shared store intact so the remaining instances
+ * continue to observe it. The shared store survives until {@link #clearInstanceState} is called or
+ * the JVM exits.
  */
 public class InMemoryCatalog extends BaseMetastoreViewCatalog
     implements SupportsNamespaces, Closeable {
+  /**
+   * Catalog property identifying a JVM-wide shared store. Two {@link InMemoryCatalog} instances
+   * initialized with the same value of this property share the same namespaces, tables, views, and
+   * synchronization monitor. When unset, each instance keeps its own private store.
+   */
+  public static final String INSTANCE_ID = "in-memory-catalog.instance-id";
+
   private static final Joiner SLASH = Joiner.on("/");
   private static final Joiner DOT = Joiner.on(".");
 
-  private final ConcurrentMap<Namespace, Map<String, String>> namespaces;
-  private final ConcurrentMap<TableIdentifier, String> tables;
-  private final ConcurrentMap<TableIdentifier, String> views;
+  private static final ConcurrentMap<String, Storage> SHARED_STORES = Maps.newConcurrentMap();
+
+  private volatile Storage storage;
   private FileIO io;
   private String catalogName;
   private String warehouseLocation;
@@ -77,9 +92,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   private Map<String, String> catalogProperties;
 
   public InMemoryCatalog() {
-    this.namespaces = Maps.newConcurrentMap();
-    this.tables = Maps.newConcurrentMap();
-    this.views = Maps.newConcurrentMap();
+    this.storage = new Storage(false);
   }
 
   @Override
@@ -99,10 +112,28 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
+
+    String instanceId = properties.get(INSTANCE_ID);
+    if (instanceId != null) {
+      this.storage = SHARED_STORES.computeIfAbsent(instanceId, k -> new Storage(true));
+    } else {
+      this.storage = new Storage(false);
+    }
+
     this.io = CatalogUtil.loadFileIO(InMemoryFileIO.class.getName(), properties, null);
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
+  }
+
+  /**
+   * Drops the shared store associated with the given {@link #INSTANCE_ID} value. After this call,
+   * subsequent instances initialized with that value start with an empty store. Calling this with
+   * an unknown value is a no-op.
+   */
+  @VisibleForTesting
+  static void clearInstanceState(String instanceId) {
+    SHARED_STORES.remove(instanceId);
   }
 
   @Override
@@ -134,8 +165,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       lastMetadata = null;
     }
 
-    synchronized (this) {
-      if (null == tables.remove(tableIdentifier)) {
+    Storage current = storage;
+    synchronized (current) {
+      if (null == current.tables.remove(tableIdentifier)) {
         return false;
       }
     }
@@ -154,7 +186,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
           "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
     }
 
-    return tables.keySet().stream()
+    return storage.tables.keySet().stream()
         .filter(t -> t.namespace().equals(namespace))
         .sorted(Comparator.comparing(TableIdentifier::toString))
         .collect(Collectors.toList());
@@ -166,27 +198,28 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       return;
     }
 
-    synchronized (this) {
-      if (!namespaceExists(to.namespace())) {
+    Storage current = storage;
+    synchronized (current) {
+      if (!current.namespaces.containsKey(to.namespace())) {
         throw new NoSuchNamespaceException(
             "Cannot rename %s to %s. Namespace does not exist: %s", from, to, to.namespace());
       }
 
-      String fromLocation = tables.get(from);
+      String fromLocation = current.tables.get(from);
       if (null == fromLocation) {
         throw new NoSuchTableException("Cannot rename %s to %s. Table does not exist", from, to);
       }
 
-      if (tables.containsKey(to)) {
+      if (current.tables.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. Table already exists", from, to);
       }
 
-      if (views.containsKey(to)) {
+      if (current.views.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
       }
 
-      tables.put(to, fromLocation);
-      tables.remove(from);
+      current.tables.put(to, fromLocation);
+      current.tables.remove(from);
     }
   }
 
@@ -197,25 +230,27 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
-    synchronized (this) {
-      if (namespaceExists(namespace)) {
+    Storage current = storage;
+    synchronized (current) {
+      if (current.namespaces.containsKey(namespace)) {
         throw new AlreadyExistsException(
             "Cannot create namespace %s. Namespace already exists", namespace);
       }
 
-      namespaces.put(namespace, ImmutableMap.copyOf(metadata));
+      current.namespaces.put(namespace, ImmutableMap.copyOf(metadata));
     }
   }
 
   @Override
   public boolean namespaceExists(Namespace namespace) {
-    return namespaces.containsKey(namespace);
+    return storage.namespaces.containsKey(namespace);
   }
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    synchronized (this) {
-      if (!namespaceExists(namespace)) {
+    Storage current = storage;
+    synchronized (current) {
+      if (!current.namespaces.containsKey(namespace)) {
         return false;
       }
 
@@ -238,19 +273,20 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
             "Namespace %s is not empty. Contains %d view(s).", namespace, viewIdentifiers.size());
       }
 
-      return namespaces.remove(namespace) != null;
+      return current.namespaces.remove(namespace) != null;
     }
   }
 
   @Override
   public boolean setProperties(Namespace namespace, Map<String, String> properties)
       throws NoSuchNamespaceException {
-    synchronized (this) {
-      if (!namespaceExists(namespace)) {
+    Storage current = storage;
+    synchronized (current) {
+      if (!current.namespaces.containsKey(namespace)) {
         throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
       }
 
-      namespaces.computeIfPresent(
+      current.namespaces.computeIfPresent(
           namespace,
           (k, v) ->
               ImmutableMap.<String, String>builder()
@@ -265,12 +301,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   @Override
   public boolean removeProperties(Namespace namespace, Set<String> properties)
       throws NoSuchNamespaceException {
-    synchronized (this) {
-      if (!namespaceExists(namespace)) {
+    Storage current = storage;
+    synchronized (current) {
+      if (!current.namespaces.containsKey(namespace)) {
         throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
       }
 
-      namespaces.computeIfPresent(
+      current.namespaces.computeIfPresent(
           namespace,
           (k, v) -> {
             Map<String, String> newProperties = Maps.newHashMap(v);
@@ -285,7 +322,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   @Override
   public Map<String, String> loadNamespaceMetadata(Namespace namespace)
       throws NoSuchNamespaceException {
-    Map<String, String> properties = namespaces.get(namespace);
+    Map<String, String> properties = storage.namespaces.get(namespace);
     if (properties == null) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
@@ -295,7 +332,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<Namespace> listNamespaces() {
-    return namespaces.keySet().stream()
+    return storage.namespaces.keySet().stream()
         .filter(n -> !n.isEmpty())
         .map(n -> n.level(0))
         .distinct()
@@ -310,32 +347,41 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
         namespace.isEmpty() ? "" : DOT.join(namespace.levels()) + ".";
     final int searchNumberOfLevels = namespace.levels().length;
 
+    Storage current = storage;
     List<Namespace> filteredNamespaces =
-        namespaces.keySet().stream()
+        current.namespaces.keySet().stream()
             .filter(n -> !n.isEmpty())
             .filter(n -> DOT.join(n.levels()).startsWith(searchNamespaceString))
             .collect(Collectors.toList());
 
     // If the namespace does not exist and the namespace is not a prefix of another namespace,
     // throw an exception.
-    if (!namespaces.containsKey(namespace) && filteredNamespaces.isEmpty()) {
+    if (!current.namespaces.containsKey(namespace) && filteredNamespaces.isEmpty()) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
 
     return filteredNamespaces.stream()
-        // List only the child-namespaces roots.
         .map(n -> Namespace.of(Arrays.copyOf(n.levels(), searchNumberOfLevels + 1)))
         .distinct()
         .sorted(Comparator.comparing(n -> DOT.join(n.levels())))
         .collect(Collectors.toList());
   }
 
+  /**
+   * Closes resources held by this catalog. When the instance owns a private store the in-memory
+   * namespaces, tables, and views are dropped. When it shares a store (initialized with {@link
+   * #INSTANCE_ID}) the store is left intact so other instances continue to observe it; use {@link
+   * #clearInstanceState} to drop it explicitly.
+   */
   @Override
   public void close() throws IOException {
     closeableGroup.close();
-    namespaces.clear();
-    tables.clear();
-    views.clear();
+    Storage current = storage;
+    if (!current.shared) {
+      current.namespaces.clear();
+      current.tables.clear();
+      current.views.clear();
+    }
   }
 
   @Override
@@ -345,7 +391,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
           "Cannot list views for namespace. Namespace does not exist: %s", namespace);
     }
 
-    return views.keySet().stream()
+    return storage.views.keySet().stream()
         .filter(v -> v.namespace().equals(namespace))
         .sorted(Comparator.comparing(TableIdentifier::toString))
         .collect(Collectors.toList());
@@ -358,8 +404,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public boolean dropView(TableIdentifier identifier) {
-    synchronized (this) {
-      return null != views.remove(identifier);
+    Storage current = storage;
+    synchronized (current) {
+      return null != current.views.remove(identifier);
     }
   }
 
@@ -369,27 +416,28 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       return;
     }
 
-    synchronized (this) {
-      if (!namespaceExists(to.namespace())) {
+    Storage current = storage;
+    synchronized (current) {
+      if (!current.namespaces.containsKey(to.namespace())) {
         throw new NoSuchNamespaceException(
             "Cannot rename %s to %s. Namespace does not exist: %s", from, to, to.namespace());
       }
 
-      String fromViewLocation = views.get(from);
+      String fromViewLocation = current.views.get(from);
       if (null == fromViewLocation) {
         throw new NoSuchViewException("Cannot rename %s to %s. View does not exist", from, to);
       }
 
-      if (tables.containsKey(to)) {
+      if (current.tables.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. Table already exists", from, to);
       }
 
-      if (views.containsKey(to)) {
+      if (current.views.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
       }
 
-      views.put(to, fromViewLocation);
-      views.remove(from);
+      current.views.put(to, fromViewLocation);
+      current.views.remove(from);
     }
   }
 
@@ -411,7 +459,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     @Override
     public void doRefresh() {
-      String latestLocation = tables.get(tableIdentifier);
+      String latestLocation = storage.tables.get(tableIdentifier);
       if (latestLocation == null) {
         disableRefresh();
       } else {
@@ -424,19 +472,20 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeNewMetadataIfRequired(base == null, metadata);
       String oldLocation = base == null ? null : base.metadataFileLocation();
 
-      synchronized (InMemoryCatalog.this) {
-        if (null == base && !namespaceExists(tableIdentifier.namespace())) {
+      Storage current = storage;
+      synchronized (current) {
+        if (null == base && !current.namespaces.containsKey(tableIdentifier.namespace())) {
           throw new NoSuchNamespaceException(
               "Cannot create table %s. Namespace does not exist: %s",
               tableIdentifier, tableIdentifier.namespace());
         }
 
-        if (views.containsKey(tableIdentifier)) {
+        if (current.views.containsKey(tableIdentifier)) {
           throw new AlreadyExistsException(
               "View with same name already exists: %s", tableIdentifier);
         }
 
-        tables.compute(
+        current.tables.compute(
             tableIdentifier,
             (k, existingLocation) -> {
               if (!Objects.equal(existingLocation, oldLocation)) {
@@ -482,7 +531,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     @Override
     public void doRefresh() {
-      String latestLocation = views.get(identifier);
+      String latestLocation = storage.views.get(identifier);
       if (latestLocation == null) {
         disableRefresh();
       } else {
@@ -495,18 +544,19 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeNewMetadataIfRequired(metadata);
       String oldLocation = base == null ? null : currentMetadataLocation();
 
-      synchronized (InMemoryCatalog.this) {
-        if (null == base && !namespaceExists(identifier.namespace())) {
+      Storage current = storage;
+      synchronized (current) {
+        if (null == base && !current.namespaces.containsKey(identifier.namespace())) {
           throw new NoSuchNamespaceException(
               "Cannot create view %s. Namespace does not exist: %s",
               identifier, identifier.namespace());
         }
 
-        if (tables.containsKey(identifier)) {
+        if (current.tables.containsKey(identifier)) {
           throw new AlreadyExistsException("Table with same name already exists: %s", identifier);
         }
 
-        views.compute(
+        current.views.compute(
             identifier,
             (k, existingLocation) -> {
               if (!Objects.equal(existingLocation, oldLocation)) {
@@ -537,6 +587,18 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     @Override
     protected String viewName() {
       return fullViewName;
+    }
+  }
+
+  private static final class Storage {
+    private final boolean shared;
+    private final ConcurrentMap<Namespace, Map<String, String>> namespaces =
+        Maps.newConcurrentMap();
+    private final ConcurrentMap<TableIdentifier, String> tables = Maps.newConcurrentMap();
+    private final ConcurrentMap<TableIdentifier, String> views = Maps.newConcurrentMap();
+
+    Storage(boolean shared) {
+      this.shared = shared;
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.inmemory;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -62,28 +63,41 @@ import org.apache.iceberg.view.ViewUtil;
  * views. It uses {@link InMemoryFileIO} so it does not touch external resources, which makes it
  * well-suited to writing unit tests.
  *
- * <p>By default each instance owns a private store, and {@link #close()} drops it. Setting the
- * {@link #INSTANCE_ID} catalog property links instances initialized with the same value to a
+ * <p>By default each instance owns a private store and {@link #close()} clears it. Setting the
+ * {@link #SHARED_STORE_ID} catalog property links instances initialized with the same value to a
  * shared, JVM-wide store: namespaces, tables, and views committed through one instance are visible
  * to others, and {@link #close()} leaves the shared store intact so the remaining instances
- * continue to observe it. The shared store survives until {@link #clearInstanceState} is called or
- * the JVM exits.
+ * continue to observe it. The shared store survives for the lifetime of the JVM unless {@link
+ * #clearSharedStore} is called explicitly.
  */
 public class InMemoryCatalog extends BaseMetastoreViewCatalog
     implements SupportsNamespaces, Closeable {
   /**
-   * Catalog property identifying a JVM-wide shared store. Two {@link InMemoryCatalog} instances
-   * initialized with the same value of this property share the same namespaces, tables, views, and
-   * synchronization monitor. When unset, each instance keeps its own private store.
+   * Catalog property whose value identifies a JVM-wide shared store. Two {@link InMemoryCatalog}
+   * instances initialized with the same value of this property share the same namespaces, tables,
+   * views, and synchronization monitor. When unset, each instance keeps a private store.
    */
-  public static final String INSTANCE_ID = "in-memory-catalog.instance-id";
+  public static final String SHARED_STORE_ID = "in-memory-catalog.shared-store-id";
 
   private static final Joiner SLASH = Joiner.on("/");
   private static final Joiner DOT = Joiner.on(".");
 
-  private static final ConcurrentMap<String, Storage> SHARED_STORES = Maps.newConcurrentMap();
+  private static final ConcurrentMap<String, Store> SHARED_STORES = Maps.newConcurrentMap();
 
-  private volatile Storage storage;
+  /**
+   * Drops the shared store associated with the given {@link #SHARED_STORE_ID} value. Subsequent
+   * instances initialized with that value start with an empty store; live instances that already
+   * hold a reference to the previous store keep observing it. Calling this with a value that has no
+   * shared store is a no-op. Intended for harnesses that need to release accumulated state between
+   * runs.
+   */
+  @VisibleForTesting
+  public static void clearSharedStore(String sharedStoreId) {
+    SHARED_STORES.remove(sharedStoreId);
+  }
+
+  private volatile Store store;
+  private boolean ownsStore;
   private FileIO io;
   private String catalogName;
   private String warehouseLocation;
@@ -92,7 +106,8 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   private Map<String, String> catalogProperties;
 
   public InMemoryCatalog() {
-    this.storage = new Storage(false);
+    this.store = new Store();
+    this.ownsStore = true;
   }
 
   @Override
@@ -113,12 +128,18 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     String warehouse = properties.getOrDefault(CatalogProperties.WAREHOUSE_LOCATION, "");
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
 
-    String instanceId = properties.get(INSTANCE_ID);
-    if (instanceId != null) {
-      this.storage = SHARED_STORES.computeIfAbsent(instanceId, k -> new Storage(true));
+    String sharedStoreId = properties.get(SHARED_STORE_ID);
+    if (sharedStoreId != null) {
+      this.store = SHARED_STORES.computeIfAbsent(sharedStoreId, k -> new Store());
+      this.ownsStore = false;
     } else {
-      this.storage = new Storage(false);
+      this.store = new Store();
+      this.ownsStore = true;
     }
+
+    // Close any resources from a prior initialize() to avoid leaking the previous FileIO and
+    // metrics reporter when this catalog is re-initialized in place.
+    closePreviousResources();
 
     this.io = CatalogUtil.loadFileIO(InMemoryFileIO.class.getName(), properties, null);
     this.closeableGroup = new CloseableGroup();
@@ -126,14 +147,16 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     closeableGroup.setSuppressCloseFailure(true);
   }
 
-  /**
-   * Drops the shared store associated with the given {@link #INSTANCE_ID} value. After this call,
-   * subsequent instances initialized with that value start with an empty store. Calling this with
-   * an unknown value is a no-op.
-   */
-  @VisibleForTesting
-  static void clearInstanceState(String instanceId) {
-    SHARED_STORES.remove(instanceId);
+  private void closePreviousResources() {
+    CloseableGroup previous = this.closeableGroup;
+    this.closeableGroup = null;
+    if (previous != null) {
+      try {
+        previous.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to close previous catalog resources", e);
+      }
+    }
   }
 
   @Override
@@ -165,9 +188,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       lastMetadata = null;
     }
 
-    Storage current = storage;
-    synchronized (current) {
-      if (null == current.tables.remove(tableIdentifier)) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (null == currentStore.tables.remove(tableIdentifier)) {
         return false;
       }
     }
@@ -181,12 +204,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<TableIdentifier> listTables(Namespace namespace) {
-    if (!namespaceExists(namespace) && !namespace.isEmpty()) {
+    Store currentStore = store;
+    if (!currentStore.namespaces.containsKey(namespace) && !namespace.isEmpty()) {
       throw new NoSuchNamespaceException(
           "Cannot list tables for namespace. Namespace does not exist: %s", namespace);
     }
 
-    return storage.tables.keySet().stream()
+    return currentStore.tables.keySet().stream()
         .filter(t -> t.namespace().equals(namespace))
         .sorted(Comparator.comparing(TableIdentifier::toString))
         .collect(Collectors.toList());
@@ -198,28 +222,28 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       return;
     }
 
-    Storage current = storage;
-    synchronized (current) {
-      if (!current.namespaces.containsKey(to.namespace())) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (!currentStore.namespaces.containsKey(to.namespace())) {
         throw new NoSuchNamespaceException(
             "Cannot rename %s to %s. Namespace does not exist: %s", from, to, to.namespace());
       }
 
-      String fromLocation = current.tables.get(from);
+      String fromLocation = currentStore.tables.get(from);
       if (null == fromLocation) {
         throw new NoSuchTableException("Cannot rename %s to %s. Table does not exist", from, to);
       }
 
-      if (current.tables.containsKey(to)) {
+      if (currentStore.tables.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. Table already exists", from, to);
       }
 
-      if (current.views.containsKey(to)) {
+      if (currentStore.views.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
       }
 
-      current.tables.put(to, fromLocation);
-      current.tables.remove(from);
+      currentStore.tables.put(to, fromLocation);
+      currentStore.tables.remove(from);
     }
   }
 
@@ -230,63 +254,77 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void createNamespace(Namespace namespace, Map<String, String> metadata) {
-    Storage current = storage;
-    synchronized (current) {
-      if (current.namespaces.containsKey(namespace)) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (currentStore.namespaces.containsKey(namespace)) {
         throw new AlreadyExistsException(
             "Cannot create namespace %s. Namespace already exists", namespace);
       }
 
-      current.namespaces.put(namespace, ImmutableMap.copyOf(metadata));
+      currentStore.namespaces.put(namespace, ImmutableMap.copyOf(metadata));
     }
   }
 
   @Override
   public boolean namespaceExists(Namespace namespace) {
-    return storage.namespaces.containsKey(namespace);
+    return store.namespaces.containsKey(namespace);
   }
 
   @Override
   public boolean dropNamespace(Namespace namespace) throws NamespaceNotEmptyException {
-    Storage current = storage;
-    synchronized (current) {
-      if (!current.namespaces.containsKey(namespace)) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (!currentStore.namespaces.containsKey(namespace)) {
         return false;
       }
 
-      List<Namespace> childNamespaces = listNamespaces(namespace);
-      if (!childNamespaces.isEmpty()) {
+      long childNamespaces = countChildNamespaces(currentStore, namespace);
+      if (childNamespaces > 0) {
         throw new NamespaceNotEmptyException(
             "Namespace %s is not empty. Contains %d child namespace(s).",
-            namespace, childNamespaces.size());
+            namespace, childNamespaces);
       }
 
-      List<TableIdentifier> tableIdentifiers = listTables(namespace);
-      if (!tableIdentifiers.isEmpty()) {
+      long tablesInNamespace = countIdentifiersInNamespace(currentStore.tables, namespace);
+      if (tablesInNamespace > 0) {
         throw new NamespaceNotEmptyException(
-            "Namespace %s is not empty. Contains %d table(s).", namespace, tableIdentifiers.size());
+            "Namespace %s is not empty. Contains %d table(s).", namespace, tablesInNamespace);
       }
 
-      List<TableIdentifier> viewIdentifiers = listViews(namespace);
-      if (!viewIdentifiers.isEmpty()) {
+      long viewsInNamespace = countIdentifiersInNamespace(currentStore.views, namespace);
+      if (viewsInNamespace > 0) {
         throw new NamespaceNotEmptyException(
-            "Namespace %s is not empty. Contains %d view(s).", namespace, viewIdentifiers.size());
+            "Namespace %s is not empty. Contains %d view(s).", namespace, viewsInNamespace);
       }
 
-      return current.namespaces.remove(namespace) != null;
+      return currentStore.namespaces.remove(namespace) != null;
     }
+  }
+
+  private static long countChildNamespaces(Store snapshot, Namespace parent) {
+    String prefix = parent.isEmpty() ? "" : DOT.join(parent.levels()) + ".";
+    return snapshot.namespaces.keySet().stream()
+        .filter(n -> !n.isEmpty())
+        .filter(n -> DOT.join(n.levels()).startsWith(prefix))
+        .filter(n -> n.levels().length > parent.levels().length)
+        .count();
+  }
+
+  private static long countIdentifiersInNamespace(
+      ConcurrentMap<TableIdentifier, String> identifiers, Namespace namespace) {
+    return identifiers.keySet().stream().filter(id -> id.namespace().equals(namespace)).count();
   }
 
   @Override
   public boolean setProperties(Namespace namespace, Map<String, String> properties)
       throws NoSuchNamespaceException {
-    Storage current = storage;
-    synchronized (current) {
-      if (!current.namespaces.containsKey(namespace)) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (!currentStore.namespaces.containsKey(namespace)) {
         throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
       }
 
-      current.namespaces.computeIfPresent(
+      currentStore.namespaces.computeIfPresent(
           namespace,
           (k, v) ->
               ImmutableMap.<String, String>builder()
@@ -301,13 +339,13 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   @Override
   public boolean removeProperties(Namespace namespace, Set<String> properties)
       throws NoSuchNamespaceException {
-    Storage current = storage;
-    synchronized (current) {
-      if (!current.namespaces.containsKey(namespace)) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (!currentStore.namespaces.containsKey(namespace)) {
         throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
       }
 
-      current.namespaces.computeIfPresent(
+      currentStore.namespaces.computeIfPresent(
           namespace,
           (k, v) -> {
             Map<String, String> newProperties = Maps.newHashMap(v);
@@ -322,7 +360,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
   @Override
   public Map<String, String> loadNamespaceMetadata(Namespace namespace)
       throws NoSuchNamespaceException {
-    Map<String, String> properties = storage.namespaces.get(namespace);
+    Map<String, String> properties = store.namespaces.get(namespace);
     if (properties == null) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
@@ -332,7 +370,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public List<Namespace> listNamespaces() {
-    return storage.namespaces.keySet().stream()
+    return store.namespaces.keySet().stream()
         .filter(n -> !n.isEmpty())
         .map(n -> n.level(0))
         .distinct()
@@ -347,20 +385,21 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
         namespace.isEmpty() ? "" : DOT.join(namespace.levels()) + ".";
     final int searchNumberOfLevels = namespace.levels().length;
 
-    Storage current = storage;
+    Store currentStore = store;
     List<Namespace> filteredNamespaces =
-        current.namespaces.keySet().stream()
+        currentStore.namespaces.keySet().stream()
             .filter(n -> !n.isEmpty())
             .filter(n -> DOT.join(n.levels()).startsWith(searchNamespaceString))
             .collect(Collectors.toList());
 
     // If the namespace does not exist and the namespace is not a prefix of another namespace,
     // throw an exception.
-    if (!current.namespaces.containsKey(namespace) && filteredNamespaces.isEmpty()) {
+    if (!currentStore.namespaces.containsKey(namespace) && filteredNamespaces.isEmpty()) {
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
 
     return filteredNamespaces.stream()
+        // List only the child-namespaces roots.
         .map(n -> Namespace.of(Arrays.copyOf(n.levels(), searchNumberOfLevels + 1)))
         .distinct()
         .sorted(Comparator.comparing(n -> DOT.join(n.levels())))
@@ -369,29 +408,32 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   /**
    * Closes resources held by this catalog. When the instance owns a private store the in-memory
-   * namespaces, tables, and views are dropped. When it shares a store (initialized with {@link
-   * #INSTANCE_ID}) the store is left intact so other instances continue to observe it; use {@link
-   * #clearInstanceState} to drop it explicitly.
+   * namespaces, tables, and views are cleared. When it shares a store (initialized with {@link
+   * #SHARED_STORE_ID}) the store is left intact so other instances continue to observe it; use
+   * {@link #clearSharedStore} to drop it explicitly.
    */
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
-    Storage current = storage;
-    if (!current.shared) {
-      current.namespaces.clear();
-      current.tables.clear();
-      current.views.clear();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
+    if (ownsStore) {
+      Store currentStore = store;
+      currentStore.namespaces.clear();
+      currentStore.tables.clear();
+      currentStore.views.clear();
     }
   }
 
   @Override
   public List<TableIdentifier> listViews(Namespace namespace) {
-    if (!namespaceExists(namespace) && !namespace.isEmpty()) {
+    Store currentStore = store;
+    if (!currentStore.namespaces.containsKey(namespace) && !namespace.isEmpty()) {
       throw new NoSuchNamespaceException(
           "Cannot list views for namespace. Namespace does not exist: %s", namespace);
     }
 
-    return storage.views.keySet().stream()
+    return currentStore.views.keySet().stream()
         .filter(v -> v.namespace().equals(namespace))
         .sorted(Comparator.comparing(TableIdentifier::toString))
         .collect(Collectors.toList());
@@ -404,9 +446,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public boolean dropView(TableIdentifier identifier) {
-    Storage current = storage;
-    synchronized (current) {
-      return null != current.views.remove(identifier);
+    Store currentStore = store;
+    synchronized (currentStore) {
+      return null != currentStore.views.remove(identifier);
     }
   }
 
@@ -416,28 +458,28 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       return;
     }
 
-    Storage current = storage;
-    synchronized (current) {
-      if (!current.namespaces.containsKey(to.namespace())) {
+    Store currentStore = store;
+    synchronized (currentStore) {
+      if (!currentStore.namespaces.containsKey(to.namespace())) {
         throw new NoSuchNamespaceException(
             "Cannot rename %s to %s. Namespace does not exist: %s", from, to, to.namespace());
       }
 
-      String fromViewLocation = current.views.get(from);
+      String fromViewLocation = currentStore.views.get(from);
       if (null == fromViewLocation) {
         throw new NoSuchViewException("Cannot rename %s to %s. View does not exist", from, to);
       }
 
-      if (current.tables.containsKey(to)) {
+      if (currentStore.tables.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. Table already exists", from, to);
       }
 
-      if (current.views.containsKey(to)) {
+      if (currentStore.views.containsKey(to)) {
         throw new AlreadyExistsException("Cannot rename %s to %s. View already exists", from, to);
       }
 
-      current.views.put(to, fromViewLocation);
-      current.views.remove(from);
+      currentStore.views.put(to, fromViewLocation);
+      currentStore.views.remove(from);
     }
   }
 
@@ -459,7 +501,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     @Override
     public void doRefresh() {
-      String latestLocation = storage.tables.get(tableIdentifier);
+      String latestLocation = store.tables.get(tableIdentifier);
       if (latestLocation == null) {
         disableRefresh();
       } else {
@@ -472,20 +514,20 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeNewMetadataIfRequired(base == null, metadata);
       String oldLocation = base == null ? null : base.metadataFileLocation();
 
-      Storage current = storage;
-      synchronized (current) {
-        if (null == base && !current.namespaces.containsKey(tableIdentifier.namespace())) {
+      Store currentStore = store;
+      synchronized (currentStore) {
+        if (null == base && !currentStore.namespaces.containsKey(tableIdentifier.namespace())) {
           throw new NoSuchNamespaceException(
               "Cannot create table %s. Namespace does not exist: %s",
               tableIdentifier, tableIdentifier.namespace());
         }
 
-        if (current.views.containsKey(tableIdentifier)) {
+        if (currentStore.views.containsKey(tableIdentifier)) {
           throw new AlreadyExistsException(
               "View with same name already exists: %s", tableIdentifier);
         }
 
-        current.tables.compute(
+        currentStore.tables.compute(
             tableIdentifier,
             (k, existingLocation) -> {
               if (!Objects.equal(existingLocation, oldLocation)) {
@@ -531,7 +573,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
     @Override
     public void doRefresh() {
-      String latestLocation = storage.views.get(identifier);
+      String latestLocation = store.views.get(identifier);
       if (latestLocation == null) {
         disableRefresh();
       } else {
@@ -544,19 +586,19 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
       String newLocation = writeNewMetadataIfRequired(metadata);
       String oldLocation = base == null ? null : currentMetadataLocation();
 
-      Storage current = storage;
-      synchronized (current) {
-        if (null == base && !current.namespaces.containsKey(identifier.namespace())) {
+      Store currentStore = store;
+      synchronized (currentStore) {
+        if (null == base && !currentStore.namespaces.containsKey(identifier.namespace())) {
           throw new NoSuchNamespaceException(
               "Cannot create view %s. Namespace does not exist: %s",
               identifier, identifier.namespace());
         }
 
-        if (current.tables.containsKey(identifier)) {
+        if (currentStore.tables.containsKey(identifier)) {
           throw new AlreadyExistsException("Table with same name already exists: %s", identifier);
         }
 
-        current.views.compute(
+        currentStore.views.compute(
             identifier,
             (k, existingLocation) -> {
               if (!Objects.equal(existingLocation, oldLocation)) {
@@ -590,15 +632,10 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     }
   }
 
-  private static final class Storage {
-    private final boolean shared;
+  private static final class Store {
     private final ConcurrentMap<Namespace, Map<String, String>> namespaces =
         Maps.newConcurrentMap();
     private final ConcurrentMap<TableIdentifier, String> tables = Maps.newConcurrentMap();
     private final ConcurrentMap<TableIdentifier, String> views = Maps.newConcurrentMap();
-
-    Storage(boolean shared) {
-      this.shared = shared;
-    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -133,7 +134,7 @@ public class InMemoryFileIO implements FileIO {
     if (file == null || !file.exists()) {
       return null;
     }
-    return Files.localInput(file);
+    return new LocationPreservingInputFile(location, Files.localInput(file));
   }
 
   private static boolean deleteLocalIfExists(String location) {
@@ -153,5 +154,46 @@ public class InMemoryFileIO implements FileIO {
     }
     String path = location.startsWith("file:") ? location.substring("file:".length()) : location;
     return new File(path);
+  }
+
+  /**
+   * Delegates an {@link InputFile} while preserving the requested {@code location} string. The
+   * delegate may canonicalize paths (for example, stripping a {@code file:} scheme), but Iceberg
+   * components key {@code InputFile} maps off the original location, so callers expect {@link
+   * #location()} to return the value passed to {@link #newInputFile(String)} verbatim.
+   */
+  private static final class LocationPreservingInputFile implements InputFile {
+    private final String location;
+    private final InputFile delegate;
+
+    private LocationPreservingInputFile(String location, InputFile delegate) {
+      this.location = location;
+      this.delegate = delegate;
+    }
+
+    @Override
+    public long getLength() {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return delegate.newStream();
+    }
+
+    @Override
+    public String location() {
+      return location;
+    }
+
+    @Override
+    public boolean exists() {
+      return delegate.exists();
+    }
+
+    @Override
+    public String toString() {
+      return location;
+    }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryFileIO.java
@@ -18,7 +18,11 @@
  */
 package org.apache.iceberg.inmemory;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Map;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -26,17 +30,29 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 
 public class InMemoryFileIO implements FileIO {
 
+  /**
+   * When set to {@code true}, reads and deletes for unknown locations fall back to local disk. This
+   * is useful in test environments that mix in-memory writes (through this {@link FileIO}) with
+   * files that were written to local disk through another path (for example, Spark's native {@code
+   * DataFrameWriter} writing to a JUnit {@code @TempDir}). New writes always go to the in-memory
+   * store regardless of this setting.
+   */
+  public static final String DISK_FALLBACK = "in-memory-file-io.disk-fallback";
+
   private static final Map<String, byte[]> IN_MEMORY_FILES = Maps.newConcurrentMap();
   private boolean closed = false;
+  private boolean diskFallback = false;
   private SerializableMap<String, String> properties = SerializableMap.copyOf(ImmutableMap.of());
 
   @Override
   public void initialize(Map<String, String> props) {
     this.properties = SerializableMap.copyOf(props);
+    this.diskFallback = PropertyUtil.propertyAsBoolean(props, DISK_FALLBACK, false);
   }
 
   @Override
@@ -53,14 +69,36 @@ public class InMemoryFileIO implements FileIO {
     return IN_MEMORY_FILES.containsKey(location);
   }
 
+  /**
+   * Renames the in-memory entry at {@code from} to {@code to}, returning {@code true} on success
+   * and {@code false} if no in-memory content is registered at {@code from}. The map is shared
+   * across all {@link InMemoryFileIO} instances in the JVM, so callers do not need a specific
+   * instance reference. This is intended for tests that need to swap or hide an Iceberg-managed
+   * file written through this {@link FileIO}.
+   */
+  public static boolean tryRename(String from, String to) {
+    byte[] contents = IN_MEMORY_FILES.remove(from);
+    if (contents == null) {
+      return false;
+    }
+    IN_MEMORY_FILES.put(to, contents);
+    return true;
+  }
+
   @Override
   public InputFile newInputFile(String location) {
     Preconditions.checkState(!closed, "Cannot call newInputFile after calling close()");
     byte[] contents = IN_MEMORY_FILES.get(location);
-    if (null == contents) {
-      throw new NotFoundException("No in-memory file found for location: %s", location);
+    if (contents != null) {
+      return new InMemoryInputFile(location, contents);
     }
-    return new InMemoryInputFile(location, contents);
+    if (diskFallback) {
+      InputFile diskInput = localInputIfExists(location);
+      if (diskInput != null) {
+        return diskInput;
+      }
+    }
+    throw new NotFoundException("No in-memory file found for location: %s", location);
   }
 
   @Override
@@ -72,9 +110,13 @@ public class InMemoryFileIO implements FileIO {
   @Override
   public void deleteFile(String location) {
     Preconditions.checkState(!closed, "Cannot call deleteFile after calling close()");
-    if (null == IN_MEMORY_FILES.remove(location)) {
-      throw new NotFoundException("No in-memory file found for location: %s", location);
+    if (IN_MEMORY_FILES.remove(location) != null) {
+      return;
     }
+    if (diskFallback && deleteLocalIfExists(location)) {
+      return;
+    }
+    throw new NotFoundException("No in-memory file found for location: %s", location);
   }
 
   public boolean isClosed() {
@@ -84,5 +126,32 @@ public class InMemoryFileIO implements FileIO {
   @Override
   public void close() {
     closed = true;
+  }
+
+  private static InputFile localInputIfExists(String location) {
+    File file = localFile(location);
+    if (file == null || !file.exists()) {
+      return null;
+    }
+    return Files.localInput(file);
+  }
+
+  private static boolean deleteLocalIfExists(String location) {
+    File file = localFile(location);
+    if (file == null || !file.exists()) {
+      return false;
+    }
+    if (!file.delete()) {
+      throw new UncheckedIOException(new IOException("Failed to delete file: " + location));
+    }
+    return true;
+  }
+
+  private static File localFile(String location) {
+    if (location == null) {
+      return null;
+    }
+    String path = location.startsWith("file:") ? location.substring("file:".length()) : location;
+    return new File(path);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -26,15 +26,21 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -117,11 +123,10 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   }
 
   @Test
-  public void instanceIdSharesNamespacesAndTablesAcrossInstances() throws IOException {
-    String instanceId = "shared-state-tables";
-    InMemoryCatalog.clearInstanceState(instanceId);
-
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+  public void sharedStoreSharesNamespacesAndTablesFromFirstToSecond() throws IOException {
+    String storeId = "shared-store-tables-forward";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     InMemoryCatalog first = new InMemoryCatalog();
     first.initialize("first", sharedProps);
@@ -141,10 +146,29 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
       assertThat(second.loadTable(TBL).schema().asStruct())
           .as("Schema observed via second instance should match first")
           .isEqualTo(first.loadTable(TBL).schema().asStruct());
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+  }
 
-      TableIdentifier other = TableIdentifier.of(TBL.namespace(), "other");
-      second.buildTable(other, SCHEMA).create();
-      assertThat(first.tableExists(other))
+  @Test
+  public void sharedStoreSharesWritesFromSecondBackToFirst() throws IOException {
+    String storeId = "shared-store-tables-reverse";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", sharedProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", sharedProps);
+
+    try {
+      second.createNamespace(TBL.namespace());
+      second.buildTable(TBL, SCHEMA).create();
+
+      assertThat(first.tableExists(TBL))
           .as("Table created via second instance should be visible to first")
           .isTrue();
 
@@ -155,16 +179,15 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     } finally {
       first.close();
       second.close();
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
-  public void instanceIdSharesViewsAcrossInstances() throws IOException {
-    String instanceId = "shared-state-views";
-    InMemoryCatalog.clearInstanceState(instanceId);
-
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+  public void sharedStoreSharesViewsAcrossInstances() throws IOException {
+    String storeId = "shared-store-views";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     InMemoryCatalog first = new InMemoryCatalog();
     first.initialize("first", sharedProps);
@@ -197,42 +220,113 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     } finally {
       first.close();
       second.close();
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
-  public void distinctInstanceIdsKeepStateIsolated() throws IOException {
+  public void sharedStoreSharesRenameTableAndNamespacePropertyEdits() throws IOException {
+    String storeId = "shared-store-rename-and-props";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", sharedProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", sharedProps);
+
+    TableIdentifier renamed = TableIdentifier.of(TBL.namespace(), "renamed");
+    try {
+      first.createNamespace(TBL.namespace());
+      first.buildTable(TBL, SCHEMA).create();
+
+      first.renameTable(TBL, renamed);
+      assertThat(second.tableExists(renamed))
+          .as("renameTable on first should be observed at the new identifier on second")
+          .isTrue();
+      assertThat(second.tableExists(TBL))
+          .as("renameTable on first should remove the old identifier from second")
+          .isFalse();
+
+      second.setProperties(TBL.namespace(), ImmutableMap.of("origin", "second"));
+      assertThat(first.loadNamespaceMetadata(TBL.namespace()))
+          .as("setProperties on second should be observable from first")
+          .containsEntry("origin", "second");
+
+      second.removeProperties(TBL.namespace(), java.util.Collections.singleton("origin"));
+      assertThat(first.loadNamespaceMetadata(TBL.namespace()))
+          .as("removeProperties on second should be observable from first")
+          .doesNotContainKey("origin");
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+  }
+
+  @Test
+  public void sharedStoreDropNamespaceEnforcesEmptiness() throws IOException {
+    String storeId = "shared-store-drop-namespace";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", sharedProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", sharedProps);
+
+    try {
+      first.createNamespace(TBL.namespace());
+      first.buildTable(TBL, SCHEMA).create();
+
+      assertThatThrownBy(() -> second.dropNamespace(TBL.namespace()))
+          .as("dropNamespace from second must see the table created via first")
+          .isInstanceOf(NamespaceNotEmptyException.class)
+          .hasMessageContaining("not empty");
+
+      first.dropTable(TBL, false);
+      assertThat(second.dropNamespace(TBL.namespace()))
+          .as("dropNamespace from second should succeed once the table is removed via first")
+          .isTrue();
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+  }
+
+  @Test
+  public void distinctSharedStoreIdsKeepStateIsolated() throws IOException {
     String firstId = "isolated-first";
     String secondId = "isolated-second";
-    InMemoryCatalog.clearInstanceState(firstId);
-    InMemoryCatalog.clearInstanceState(secondId);
+    InMemoryCatalog.clearSharedStore(firstId);
+    InMemoryCatalog.clearSharedStore(secondId);
 
     InMemoryCatalog firstCatalog = new InMemoryCatalog();
-    firstCatalog.initialize("first", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, firstId));
+    firstCatalog.initialize("first", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, firstId));
     InMemoryCatalog secondCatalog = new InMemoryCatalog();
-    secondCatalog.initialize("second", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, secondId));
+    secondCatalog.initialize("second", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, secondId));
 
     try {
       firstCatalog.createNamespace(TBL.namespace());
       firstCatalog.buildTable(TBL, SCHEMA).create();
 
       assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Namespace from first instance must not leak to a different instance id")
+          .as("Namespace from first instance must not leak to a different shared-store id")
           .isFalse();
       assertThat(secondCatalog.tableExists(TBL))
-          .as("Table from first instance must not leak to a different instance id")
+          .as("Table from first instance must not leak to a different shared-store id")
           .isFalse();
     } finally {
       firstCatalog.close();
       secondCatalog.close();
-      InMemoryCatalog.clearInstanceState(firstId);
-      InMemoryCatalog.clearInstanceState(secondId);
+      InMemoryCatalog.clearSharedStore(firstId);
+      InMemoryCatalog.clearSharedStore(secondId);
     }
   }
 
   @Test
-  public void instancesWithoutInstanceIdKeepStateIsolated() throws IOException {
+  public void instancesWithoutSharedStoreIdKeepStateIsolated() throws IOException {
     InMemoryCatalog firstCatalog = new InMemoryCatalog();
     firstCatalog.initialize("first", ImmutableMap.of());
     InMemoryCatalog secondCatalog = new InMemoryCatalog();
@@ -243,10 +337,10 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
       firstCatalog.buildTable(TBL, SCHEMA).create();
 
       assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Two catalogs without an instance id must not share state")
+          .as("Two catalogs without a shared-store id must not share namespaces")
           .isFalse();
       assertThat(secondCatalog.tableExists(TBL))
-          .as("Two catalogs without an instance id must not share tables")
+          .as("Two catalogs without a shared-store id must not share tables")
           .isFalse();
     } finally {
       firstCatalog.close();
@@ -255,7 +349,7 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   }
 
   @Test
-  public void closeClearsPrivateStateButPreservesSharedState() throws IOException {
+  public void closeOnPrivateInstanceClearsState() throws IOException {
     InMemoryCatalog privateCatalog = new InMemoryCatalog();
     privateCatalog.initialize("private", ImmutableMap.of());
     privateCatalog.createNamespace(TBL.namespace());
@@ -266,15 +360,18 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     reopened.initialize("private", ImmutableMap.of());
     try {
       assertThat(reopened.namespaceExists(TBL.namespace()))
-          .as("Private state should be dropped on close")
+          .as("Private state should be cleared on close")
           .isFalse();
     } finally {
       reopened.close();
     }
+  }
 
-    String instanceId = "shared-survives-close";
-    InMemoryCatalog.clearInstanceState(instanceId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+  @Test
+  public void closeOnSharedInstancePreservesStore() throws IOException {
+    String storeId = "shared-survives-close";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
     try {
       InMemoryCatalog firstShared = new InMemoryCatalog();
       firstShared.initialize("first", sharedProps);
@@ -292,15 +389,15 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
         secondShared.close();
       }
     } finally {
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
-  public void clearInstanceStateRemovesSharedStore() throws IOException {
-    String instanceId = "clear-state";
-    InMemoryCatalog.clearInstanceState(instanceId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+  public void clearSharedStoreRemovesStateForFutureInstances() throws IOException {
+    String storeId = "clear-store";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     InMemoryCatalog firstCatalog = new InMemoryCatalog();
     firstCatalog.initialize("first", sharedProps);
@@ -308,80 +405,141 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     firstCatalog.buildTable(TBL, SCHEMA).create();
     firstCatalog.close();
 
-    InMemoryCatalog.clearInstanceState(instanceId);
+    InMemoryCatalog.clearSharedStore(storeId);
 
     InMemoryCatalog secondCatalog = new InMemoryCatalog();
     secondCatalog.initialize("second", sharedProps);
     try {
       assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Shared store should be empty after clearInstanceState")
+          .as("Shared store should be empty for new instances after clearSharedStore")
           .isFalse();
       assertThat(secondCatalog.tableExists(TBL))
-          .as("Shared store should drop tables after clearInstanceState")
+          .as("Shared store should drop tables for new instances after clearSharedStore")
           .isFalse();
     } finally {
       secondCatalog.close();
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
-  public void clearInstanceStateIsNoOpForUnknownId() {
-    assertThatCode(() -> InMemoryCatalog.clearInstanceState("never-registered"))
-        .as("Clearing an unknown instance id should be a safe no-op")
+  public void clearSharedStoreLeavesLiveInstancesPointingAtTheirStore() throws IOException {
+    String storeId = "clear-while-live";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+
+    InMemoryCatalog live = new InMemoryCatalog();
+    live.initialize("live", sharedProps);
+    try {
+      live.createNamespace(TBL.namespace());
+      live.buildTable(TBL, SCHEMA).create();
+
+      InMemoryCatalog.clearSharedStore(storeId);
+
+      assertThat(live.tableExists(TBL))
+          .as("Live instances retain a reference to the prior store after clearSharedStore")
+          .isTrue();
+
+      InMemoryCatalog freshlyOpened = new InMemoryCatalog();
+      freshlyOpened.initialize("fresh", sharedProps);
+      try {
+        assertThat(freshlyOpened.tableExists(TBL))
+            .as("Newly initialized instances see a fresh store after clearSharedStore")
+            .isFalse();
+      } finally {
+        freshlyOpened.close();
+      }
+    } finally {
+      live.close();
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+  }
+
+  @Test
+  public void clearSharedStoreIsNoOpForUnknownId() {
+    assertThatCode(() -> InMemoryCatalog.clearSharedStore("never-registered"))
+        .as("Clearing an unknown shared-store id should be a safe no-op")
         .doesNotThrowAnyException();
   }
 
   @Test
-  public void initializeIsIdempotentWhenInstanceIdRemoved() throws IOException {
-    String instanceId = "idempotent-init";
-    InMemoryCatalog.clearInstanceState(instanceId);
+  public void emptySharedStoreIdValuePartitionsItsOwnStore() throws IOException {
+    InMemoryCatalog.clearSharedStore("");
+    Map<String, String> emptyKeyProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, "");
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", emptyKeyProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", emptyKeyProps);
+
+    try {
+      first.createNamespace(TBL.namespace());
+      first.buildTable(TBL, SCHEMA).create();
+
+      assertThat(second.tableExists(TBL))
+          .as("Two instances using the empty-string shared-store id should share that store")
+          .isTrue();
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearSharedStore("");
+    }
+  }
+
+  @Test
+  public void reinitializeWithoutSharedStoreIdSwitchesToPrivateStore() throws IOException {
+    String storeId = "reinit-to-private";
+    InMemoryCatalog.clearSharedStore(storeId);
 
     InMemoryCatalog reusable = new InMemoryCatalog();
     try {
-      reusable.initialize("reusable", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId));
+      reusable.initialize("reusable", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId));
       reusable.createNamespace(TBL.namespace());
       reusable.buildTable(TBL, SCHEMA).create();
 
       reusable.initialize("reusable", ImmutableMap.of());
 
       assertThat(reusable.namespaceExists(TBL.namespace()))
-          .as("Re-initializing without an instance id must switch to a fresh private store")
+          .as("Reinitializing without a shared-store id must switch to a fresh private store")
           .isFalse();
       assertThat(reusable.tableExists(TBL))
-          .as("Re-initializing without an instance id must not see the previously shared table")
+          .as("Reinitializing without a shared-store id must not see the previously shared table")
           .isFalse();
     } finally {
       reusable.close();
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
-  public void concurrentInitializeWithSameInstanceIdSharesStorage()
-      throws IOException, InterruptedException, ExecutionException {
-    String instanceId = "concurrent-init";
-    InMemoryCatalog.clearInstanceState(instanceId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+  public void concurrentInitializeWithSameSharedStoreIdConvergesOnOneStore()
+      throws InterruptedException, ExecutionException {
+    String storeId = "concurrent-init";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     int parallelism = 8;
     ExecutorService executor = Executors.newFixedThreadPool(parallelism);
     List<InMemoryCatalog> catalogs = Lists.newArrayList();
+    boolean threw = true;
     try {
+      CountDownLatch start = new CountDownLatch(1);
       List<Future<InMemoryCatalog>> futures = Lists.newArrayList();
       for (int i = 0; i < parallelism; i++) {
-        final String name = "catalog-" + i;
+        String name = "catalog-" + i;
         futures.add(
             executor.submit(
                 () -> {
+                  start.await();
                   InMemoryCatalog cat = new InMemoryCatalog();
                   cat.initialize(name, sharedProps);
                   return cat;
                 }));
       }
 
+      start.countDown();
       for (Future<InMemoryCatalog> future : futures) {
-        catalogs.add(future.get());
+        catalogs.add(future.get(30, TimeUnit.SECONDS));
       }
 
       InMemoryCatalog writer = catalogs.get(0);
@@ -390,15 +548,99 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
 
       for (InMemoryCatalog reader : catalogs) {
         assertThat(reader.tableExists(TBL))
-            .as("All instances racing to initialize with the same id should observe shared writes")
+            .as("All instances racing to initialize on the same shared-store id share state")
             .isTrue();
       }
+      threw = false;
+    } catch (java.util.concurrent.TimeoutException e) {
+      throw new RuntimeException("Concurrent initialize timed out", e);
     } finally {
       executor.shutdownNow();
       for (InMemoryCatalog cat : catalogs) {
-        cat.close();
+        try {
+          cat.close();
+        } catch (IOException closeError) {
+          if (!threw) {
+            throw new RuntimeException(closeError);
+          }
+        }
       }
-      InMemoryCatalog.clearInstanceState(instanceId);
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+  }
+
+  @Test
+  public void concurrentCreateOfSameTableThroughSharedStoreSerializes()
+      throws InterruptedException, ExecutionException {
+    String storeId = "concurrent-create";
+    InMemoryCatalog.clearSharedStore(storeId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+
+    Namespace namespace = Namespace.of("ns");
+    TableIdentifier shared = TableIdentifier.of(namespace, "racey");
+
+    int parallelism = 6;
+    ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+    List<InMemoryCatalog> catalogs = Lists.newArrayList();
+    boolean threw = true;
+    try {
+      for (int i = 0; i < parallelism; i++) {
+        InMemoryCatalog cat = new InMemoryCatalog();
+        cat.initialize("racer-" + i, sharedProps);
+        catalogs.add(cat);
+      }
+      catalogs.get(0).createNamespace(namespace);
+
+      CountDownLatch start = new CountDownLatch(1);
+      AtomicInteger successes = new AtomicInteger();
+      AtomicInteger alreadyExists = new AtomicInteger();
+      List<Future<?>> futures = Lists.newArrayList();
+      for (InMemoryCatalog cat : catalogs) {
+        futures.add(
+            executor.submit(
+                () -> {
+                  try {
+                    start.await();
+                    cat.buildTable(shared, SCHEMA).create();
+                    successes.incrementAndGet();
+                  } catch (AlreadyExistsException expected) {
+                    alreadyExists.incrementAndGet();
+                  } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                  }
+                  return null;
+                }));
+      }
+
+      start.countDown();
+      for (Future<?> future : futures) {
+        future.get(30, TimeUnit.SECONDS);
+      }
+
+      assertThat(successes.get())
+          .as("Exactly one racer should successfully create the shared table")
+          .isEqualTo(1);
+      assertThat(alreadyExists.get())
+          .as("Every other racer should observe the AlreadyExistsException")
+          .isEqualTo(parallelism - 1);
+      assertThat(catalogs.get(0).tableExists(shared))
+          .as("The shared table should be visible from any racer")
+          .isTrue();
+      threw = false;
+    } catch (java.util.concurrent.TimeoutException e) {
+      throw new RuntimeException("Concurrent create timed out", e);
+    } finally {
+      executor.shutdownNow();
+      for (InMemoryCatalog cat : catalogs) {
+        try {
+          cat.close();
+        } catch (IOException closeError) {
+          if (!threw) {
+            throw new RuntimeException(closeError);
+          }
+        }
+      }
+      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -24,14 +24,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.HasTableOperations;
@@ -44,13 +47,61 @@ import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.view.View;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   private InMemoryCatalog catalog;
+  private final List<InMemoryCatalog> trackedCatalogs = Lists.newArrayList();
+  private final Set<String> trackedSharedStoreIds = Sets.newHashSet();
+
+  @AfterEach
+  public void cleanupTrackedResources() throws IOException {
+    IOException firstFailure = null;
+    for (InMemoryCatalog tracked : trackedCatalogs) {
+      try {
+        tracked.close();
+      } catch (IOException e) {
+        if (firstFailure == null) {
+          firstFailure = e;
+        }
+      }
+    }
+    trackedCatalogs.clear();
+    for (String storeId : trackedSharedStoreIds) {
+      InMemoryCatalog.clearSharedStore(storeId);
+    }
+    trackedSharedStoreIds.clear();
+    if (firstFailure != null) {
+      throw firstFailure;
+    }
+  }
+
+  /**
+   * Initializes a fresh {@link InMemoryCatalog} and registers it for {@link AfterEach} close. The
+   * registration is best-effort: if the test asserts before reaching the registration call the
+   * normal JVM cleanup still applies.
+   */
+  private InMemoryCatalog newTrackedCatalog(String name, Map<String, String> properties) {
+    InMemoryCatalog tracked = new InMemoryCatalog();
+    tracked.initialize(name, properties);
+    trackedCatalogs.add(tracked);
+    return tracked;
+  }
+
+  /**
+   * Marks a shared-store ID for {@link AfterEach} cleanup and clears any leftover state from a
+   * previous run before returning the same id. Returning the id keeps tests one-liner.
+   */
+  private String reservedSharedStoreId(String storeId) {
+    InMemoryCatalog.clearSharedStore(storeId);
+    trackedSharedStoreIds.add(storeId);
+    return storeId;
+  }
 
   @BeforeEach
   public void before() {
@@ -123,229 +174,218 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   }
 
   @Test
-  public void sharedStoreSharesNamespacesAndTablesFromFirstToSecond() throws IOException {
-    String storeId = "shared-store-tables-forward";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+  public void sharedStoreSharesNamespacesAndTablesFromFirstToSecond() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-tables-forward"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", sharedProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", sharedProps);
+    first.createNamespace(TBL.namespace());
+    first.buildTable(TBL, SCHEMA).create();
 
-    try {
-      first.createNamespace(TBL.namespace());
-      first.buildTable(TBL, SCHEMA).create();
-
-      assertThat(second.namespaceExists(TBL.namespace()))
-          .as("Namespace created via first instance should be visible to second")
-          .isTrue();
-      assertThat(second.tableExists(TBL))
-          .as("Table created via first instance should be visible to second")
-          .isTrue();
-      assertThat(second.loadTable(TBL).schema().asStruct())
-          .as("Schema observed via second instance should match first")
-          .isEqualTo(first.loadTable(TBL).schema().asStruct());
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    assertThat(second.namespaceExists(TBL.namespace()))
+        .as("Namespace created via first instance should be visible to second")
+        .isTrue();
+    assertThat(second.tableExists(TBL))
+        .as("Table created via first instance should be visible to second")
+        .isTrue();
+    assertThat(second.loadTable(TBL).schema().asStruct())
+        .as("Schema observed via second instance should match first")
+        .isEqualTo(first.loadTable(TBL).schema().asStruct());
   }
 
   @Test
-  public void sharedStoreSharesWritesFromSecondBackToFirst() throws IOException {
-    String storeId = "shared-store-tables-reverse";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+  public void sharedStoreSharesWritesFromSecondBackToFirst() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-tables-reverse"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", sharedProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", sharedProps);
+    second.createNamespace(TBL.namespace());
+    second.buildTable(TBL, SCHEMA).create();
+    assertThat(first.tableExists(TBL))
+        .as("Table created via second instance should be visible to first")
+        .isTrue();
 
-    try {
-      second.createNamespace(TBL.namespace());
-      second.buildTable(TBL, SCHEMA).create();
-
-      assertThat(first.tableExists(TBL))
-          .as("Table created via second instance should be visible to first")
-          .isTrue();
-
-      second.dropTable(TBL, false);
-      assertThat(first.tableExists(TBL))
-          .as("Table dropped via second instance should disappear from first")
-          .isFalse();
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    second.dropTable(TBL, false);
+    assertThat(first.tableExists(TBL))
+        .as("Table dropped via second instance should disappear from first")
+        .isFalse();
   }
 
   @Test
-  public void sharedStoreSharesViewsAcrossInstances() throws IOException {
-    String storeId = "shared-store-views";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
-
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", sharedProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", sharedProps);
+  public void sharedStoreSharesViewsAcrossInstances() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-views"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
     TableIdentifier viewIdentifier = TableIdentifier.of(TBL.namespace(), "vw");
-    try {
-      first.createNamespace(TBL.namespace());
-      first
-          .buildView(viewIdentifier)
-          .withSchema(SCHEMA)
-          .withDefaultNamespace(TBL.namespace())
-          .withQuery("spark", "SELECT 1")
-          .create();
+    first.createNamespace(TBL.namespace());
+    first
+        .buildView(viewIdentifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(TBL.namespace())
+        .withQuery("spark", "SELECT 1")
+        .create();
 
-      assertThat(second.viewExists(viewIdentifier))
-          .as("View created via first instance should be visible to second")
-          .isTrue();
+    assertThat(second.viewExists(viewIdentifier))
+        .as("View created via first instance should be visible to second")
+        .isTrue();
 
-      View viewFromSecond = second.loadView(viewIdentifier);
-      assertThat(viewFromSecond.schema().asStruct())
-          .as("View schema observed via second instance should match first")
-          .isEqualTo(SCHEMA.asStruct());
+    View viewFromSecond = second.loadView(viewIdentifier);
+    assertThat(viewFromSecond.schema().asStruct())
+        .as("View schema observed via second instance should match first")
+        .isEqualTo(SCHEMA.asStruct());
 
-      second.dropView(viewIdentifier);
-      assertThat(first.viewExists(viewIdentifier))
-          .as("View dropped via second instance should disappear from first")
-          .isFalse();
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    second.dropView(viewIdentifier);
+    assertThat(first.viewExists(viewIdentifier))
+        .as("View dropped via second instance should disappear from first")
+        .isFalse();
   }
 
   @Test
-  public void sharedStoreSharesRenameTableAndNamespacePropertyEdits() throws IOException {
-    String storeId = "shared-store-rename-and-props";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
-
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", sharedProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", sharedProps);
+  public void sharedStoreSharesRenameTable() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-rename"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
     TableIdentifier renamed = TableIdentifier.of(TBL.namespace(), "renamed");
-    try {
-      first.createNamespace(TBL.namespace());
-      first.buildTable(TBL, SCHEMA).create();
+    first.createNamespace(TBL.namespace());
+    first.buildTable(TBL, SCHEMA).create();
 
-      first.renameTable(TBL, renamed);
-      assertThat(second.tableExists(renamed))
-          .as("renameTable on first should be observed at the new identifier on second")
-          .isTrue();
-      assertThat(second.tableExists(TBL))
-          .as("renameTable on first should remove the old identifier from second")
-          .isFalse();
-
-      second.setProperties(TBL.namespace(), ImmutableMap.of("origin", "second"));
-      assertThat(first.loadNamespaceMetadata(TBL.namespace()))
-          .as("setProperties on second should be observable from first")
-          .containsEntry("origin", "second");
-
-      second.removeProperties(TBL.namespace(), java.util.Collections.singleton("origin"));
-      assertThat(first.loadNamespaceMetadata(TBL.namespace()))
-          .as("removeProperties on second should be observable from first")
-          .doesNotContainKey("origin");
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    first.renameTable(TBL, renamed);
+    assertThat(second.tableExists(renamed))
+        .as("renameTable on first should be observed at the new identifier on second")
+        .isTrue();
+    assertThat(second.tableExists(TBL))
+        .as("renameTable on first should remove the old identifier from second")
+        .isFalse();
   }
 
   @Test
-  public void sharedStoreDropNamespaceEnforcesEmptiness() throws IOException {
-    String storeId = "shared-store-drop-namespace";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
+  public void sharedStoreSharesSetProperties() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-set-props"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", sharedProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", sharedProps);
+    first.createNamespace(TBL.namespace());
 
-    try {
-      first.createNamespace(TBL.namespace());
-      first.buildTable(TBL, SCHEMA).create();
-
-      assertThatThrownBy(() -> second.dropNamespace(TBL.namespace()))
-          .as("dropNamespace from second must see the table created via first")
-          .isInstanceOf(NamespaceNotEmptyException.class)
-          .hasMessageContaining("not empty");
-
-      first.dropTable(TBL, false);
-      assertThat(second.dropNamespace(TBL.namespace()))
-          .as("dropNamespace from second should succeed once the table is removed via first")
-          .isTrue();
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    second.setProperties(TBL.namespace(), ImmutableMap.of("origin", "second"));
+    assertThat(first.loadNamespaceMetadata(TBL.namespace()))
+        .as("setProperties on second should be observable from first")
+        .containsEntry("origin", "second");
   }
 
   @Test
-  public void distinctSharedStoreIdsKeepStateIsolated() throws IOException {
-    String firstId = "isolated-first";
-    String secondId = "isolated-second";
-    InMemoryCatalog.clearSharedStore(firstId);
-    InMemoryCatalog.clearSharedStore(secondId);
+  public void sharedStoreSharesRemoveProperties() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-remove-props"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
-    InMemoryCatalog firstCatalog = new InMemoryCatalog();
-    firstCatalog.initialize("first", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, firstId));
-    InMemoryCatalog secondCatalog = new InMemoryCatalog();
-    secondCatalog.initialize("second", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, secondId));
+    first.createNamespace(TBL.namespace(), ImmutableMap.of("origin", "first"));
 
-    try {
-      firstCatalog.createNamespace(TBL.namespace());
-      firstCatalog.buildTable(TBL, SCHEMA).create();
-
-      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Namespace from first instance must not leak to a different shared-store id")
-          .isFalse();
-      assertThat(secondCatalog.tableExists(TBL))
-          .as("Table from first instance must not leak to a different shared-store id")
-          .isFalse();
-    } finally {
-      firstCatalog.close();
-      secondCatalog.close();
-      InMemoryCatalog.clearSharedStore(firstId);
-      InMemoryCatalog.clearSharedStore(secondId);
-    }
+    second.removeProperties(TBL.namespace(), Collections.singleton("origin"));
+    assertThat(first.loadNamespaceMetadata(TBL.namespace()))
+        .as("removeProperties on second should be observable from first")
+        .doesNotContainKey("origin");
   }
 
   @Test
-  public void instancesWithoutSharedStoreIdKeepStateIsolated() throws IOException {
-    InMemoryCatalog firstCatalog = new InMemoryCatalog();
-    firstCatalog.initialize("first", ImmutableMap.of());
-    InMemoryCatalog secondCatalog = new InMemoryCatalog();
-    secondCatalog.initialize("second", ImmutableMap.of());
+  public void sharedStoreDropNamespaceEnforcesEmptiness() {
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-store-drop-namespace"));
+    InMemoryCatalog first = newTrackedCatalog("first", sharedProps);
+    InMemoryCatalog second = newTrackedCatalog("second", sharedProps);
 
-    try {
-      firstCatalog.createNamespace(TBL.namespace());
-      firstCatalog.buildTable(TBL, SCHEMA).create();
+    first.createNamespace(TBL.namespace());
+    first.buildTable(TBL, SCHEMA).create();
 
-      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Two catalogs without a shared-store id must not share namespaces")
-          .isFalse();
-      assertThat(secondCatalog.tableExists(TBL))
-          .as("Two catalogs without a shared-store id must not share tables")
-          .isFalse();
-    } finally {
-      firstCatalog.close();
-      secondCatalog.close();
-    }
+    assertThatThrownBy(() -> second.dropNamespace(TBL.namespace()))
+        .as("dropNamespace from second must see the table created via first")
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessageContaining("not empty");
+
+    first.dropTable(TBL, false);
+    assertThat(second.dropNamespace(TBL.namespace()))
+        .as("dropNamespace from second should succeed once the table is removed via first")
+        .isTrue();
+  }
+
+  @Test
+  public void dropNamespaceRejectsSiblingPrefixCollisions() {
+    InMemoryCatalog cat = newTrackedCatalog("prefix-collision", ImmutableMap.of());
+    Namespace parent = Namespace.of("a", "b");
+    Namespace siblingPrefix = Namespace.of("a", "bb");
+    Namespace nestedUnderSibling = Namespace.of("a", "bb", "c");
+    cat.createNamespace(Namespace.of("a"));
+    cat.createNamespace(parent);
+    cat.createNamespace(siblingPrefix);
+    cat.createNamespace(nestedUnderSibling);
+
+    assertThat(cat.dropNamespace(parent))
+        .as("dropNamespace must succeed for an empty namespace despite a sibling-prefix neighbor")
+        .isTrue();
+
+    assertThatThrownBy(() -> cat.dropNamespace(siblingPrefix))
+        .as("dropNamespace must reject a parent that still has nested children")
+        .isInstanceOf(NamespaceNotEmptyException.class)
+        .hasMessageContaining("child namespace");
+
+    assertThat(cat.dropNamespace(nestedUnderSibling)).isTrue();
+    assertThat(cat.dropNamespace(siblingPrefix))
+        .as("Once nested namespace is removed, the sibling parent drops cleanly")
+        .isTrue();
+  }
+
+  @Test
+  public void distinctSharedStoreIdsKeepStateIsolated() {
+    InMemoryCatalog firstCatalog =
+        newTrackedCatalog(
+            "first",
+            ImmutableMap.of(
+                InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("isolated-first")));
+    InMemoryCatalog secondCatalog =
+        newTrackedCatalog(
+            "second",
+            ImmutableMap.of(
+                InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("isolated-second")));
+
+    firstCatalog.createNamespace(TBL.namespace());
+    firstCatalog.buildTable(TBL, SCHEMA).create();
+
+    assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+        .as("Namespace from first instance must not leak to a different shared-store ID")
+        .isFalse();
+    assertThat(secondCatalog.tableExists(TBL))
+        .as("Table from first instance must not leak to a different shared-store ID")
+        .isFalse();
+  }
+
+  @Test
+  public void instancesWithoutSharedStoreIdKeepStateIsolated() {
+    InMemoryCatalog firstCatalog = newTrackedCatalog("first", ImmutableMap.of());
+    InMemoryCatalog secondCatalog = newTrackedCatalog("second", ImmutableMap.of());
+
+    firstCatalog.createNamespace(TBL.namespace());
+    firstCatalog.buildTable(TBL, SCHEMA).create();
+
+    assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+        .as("Two catalogs without a shared-store ID must not share namespaces")
+        .isFalse();
+    assertThat(secondCatalog.tableExists(TBL))
+        .as("Two catalogs without a shared-store ID must not share tables")
+        .isFalse();
   }
 
   @Test
@@ -354,49 +394,41 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
     privateCatalog.initialize("private", ImmutableMap.of());
     privateCatalog.createNamespace(TBL.namespace());
     privateCatalog.buildTable(TBL, SCHEMA).create();
+    assertThat(privateCatalog.namespaceExists(TBL.namespace()))
+        .as("Sanity: namespace must be present before close()")
+        .isTrue();
+
     privateCatalog.close();
 
-    InMemoryCatalog reopened = new InMemoryCatalog();
-    reopened.initialize("private", ImmutableMap.of());
-    try {
-      assertThat(reopened.namespaceExists(TBL.namespace()))
-          .as("Private state should be cleared on close")
-          .isFalse();
-    } finally {
-      reopened.close();
-    }
+    assertThat(privateCatalog.namespaceExists(TBL.namespace()))
+        .as("close() on a private instance must clear its store entries")
+        .isFalse();
+    assertThat(privateCatalog.tableExists(TBL))
+        .as("close() on a private instance must clear its table entries")
+        .isFalse();
   }
 
   @Test
   public void closeOnSharedInstancePreservesStore() throws IOException {
-    String storeId = "shared-survives-close";
-    InMemoryCatalog.clearSharedStore(storeId);
-    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
-    try {
-      InMemoryCatalog firstShared = new InMemoryCatalog();
-      firstShared.initialize("first", sharedProps);
-      firstShared.createNamespace(TBL.namespace());
-      firstShared.buildTable(TBL, SCHEMA).create();
-      firstShared.close();
+    Map<String, String> sharedProps =
+        ImmutableMap.of(
+            InMemoryCatalog.SHARED_STORE_ID, reservedSharedStoreId("shared-survives-close"));
 
-      InMemoryCatalog secondShared = new InMemoryCatalog();
-      secondShared.initialize("second", sharedProps);
-      try {
-        assertThat(secondShared.tableExists(TBL))
-            .as("Closing one shared instance must not drop the shared store")
-            .isTrue();
-      } finally {
-        secondShared.close();
-      }
-    } finally {
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    InMemoryCatalog firstShared = new InMemoryCatalog();
+    firstShared.initialize("first", sharedProps);
+    firstShared.createNamespace(TBL.namespace());
+    firstShared.buildTable(TBL, SCHEMA).create();
+    firstShared.close();
+
+    InMemoryCatalog secondShared = newTrackedCatalog("second", sharedProps);
+    assertThat(secondShared.tableExists(TBL))
+        .as("Closing one shared instance must not drop the shared store")
+        .isTrue();
   }
 
   @Test
   public void clearSharedStoreRemovesStateForFutureInstances() throws IOException {
-    String storeId = "clear-store";
-    InMemoryCatalog.clearSharedStore(storeId);
+    String storeId = reservedSharedStoreId("clear-store");
     Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     InMemoryCatalog firstCatalog = new InMemoryCatalog();
@@ -407,115 +439,109 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
 
     InMemoryCatalog.clearSharedStore(storeId);
 
-    InMemoryCatalog secondCatalog = new InMemoryCatalog();
-    secondCatalog.initialize("second", sharedProps);
-    try {
-      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
-          .as("Shared store should be empty for new instances after clearSharedStore")
-          .isFalse();
-      assertThat(secondCatalog.tableExists(TBL))
-          .as("Shared store should drop tables for new instances after clearSharedStore")
-          .isFalse();
-    } finally {
-      secondCatalog.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    InMemoryCatalog secondCatalog = newTrackedCatalog("second", sharedProps);
+    assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+        .as("Shared store should be empty for new instances after clearSharedStore")
+        .isFalse();
+    assertThat(secondCatalog.tableExists(TBL))
+        .as("Shared store should drop tables for new instances after clearSharedStore")
+        .isFalse();
   }
 
   @Test
-  public void clearSharedStoreLeavesLiveInstancesPointingAtTheirStore() throws IOException {
-    String storeId = "clear-while-live";
-    InMemoryCatalog.clearSharedStore(storeId);
+  public void clearSharedStoreLeavesLiveInstancesPointingAtTheirStore() {
+    String storeId = reservedSharedStoreId("clear-while-live");
     Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
-    InMemoryCatalog live = new InMemoryCatalog();
-    live.initialize("live", sharedProps);
-    try {
-      live.createNamespace(TBL.namespace());
-      live.buildTable(TBL, SCHEMA).create();
+    InMemoryCatalog live = newTrackedCatalog("live", sharedProps);
+    live.createNamespace(TBL.namespace());
+    live.buildTable(TBL, SCHEMA).create();
 
-      InMemoryCatalog.clearSharedStore(storeId);
+    InMemoryCatalog.clearSharedStore(storeId);
 
-      assertThat(live.tableExists(TBL))
-          .as("Live instances retain a reference to the prior store after clearSharedStore")
-          .isTrue();
+    assertThat(live.tableExists(TBL))
+        .as("Live instances retain a reference to the prior store after clearSharedStore")
+        .isTrue();
 
-      InMemoryCatalog freshlyOpened = new InMemoryCatalog();
-      freshlyOpened.initialize("fresh", sharedProps);
-      try {
-        assertThat(freshlyOpened.tableExists(TBL))
-            .as("Newly initialized instances see a fresh store after clearSharedStore")
-            .isFalse();
-      } finally {
-        freshlyOpened.close();
-      }
-    } finally {
-      live.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    InMemoryCatalog freshlyOpened = newTrackedCatalog("fresh", sharedProps);
+    assertThat(freshlyOpened.tableExists(TBL))
+        .as("Newly initialized instances see a fresh store after clearSharedStore")
+        .isFalse();
   }
 
   @Test
   public void clearSharedStoreIsNoOpForUnknownId() {
     assertThatCode(() -> InMemoryCatalog.clearSharedStore("never-registered"))
-        .as("Clearing an unknown shared-store id should be a safe no-op")
+        .as("Clearing an unknown shared-store ID should be a safe no-op")
         .doesNotThrowAnyException();
   }
 
   @Test
-  public void emptySharedStoreIdValuePartitionsItsOwnStore() throws IOException {
-    InMemoryCatalog.clearSharedStore("");
-    Map<String, String> emptyKeyProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, "");
-
-    InMemoryCatalog first = new InMemoryCatalog();
-    first.initialize("first", emptyKeyProps);
-    InMemoryCatalog second = new InMemoryCatalog();
-    second.initialize("second", emptyKeyProps);
-
-    try {
-      first.createNamespace(TBL.namespace());
-      first.buildTable(TBL, SCHEMA).create();
-
-      assertThat(second.tableExists(TBL))
-          .as("Two instances using the empty-string shared-store id should share that store")
-          .isTrue();
-    } finally {
-      first.close();
-      second.close();
-      InMemoryCatalog.clearSharedStore("");
-    }
+  public void emptyStringSharedStoreIdIsRejected() {
+    assertThatThrownBy(
+            () -> newTrackedCatalog("empty", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, "")))
+        .as("Empty-string shared-store ID is rejected to prevent silent shared-mode misconfig")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(InMemoryCatalog.SHARED_STORE_ID);
   }
 
   @Test
-  public void reinitializeWithoutSharedStoreIdSwitchesToPrivateStore() throws IOException {
-    String storeId = "reinit-to-private";
-    InMemoryCatalog.clearSharedStore(storeId);
+  public void whitespaceSharedStoreIdIsRejected() {
+    assertThatThrownBy(
+            () ->
+                newTrackedCatalog(
+                    "whitespace", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, "   ")))
+        .as("Whitespace-only shared-store ID is rejected to prevent silent shared-mode misconfig")
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(InMemoryCatalog.SHARED_STORE_ID);
+  }
 
-    InMemoryCatalog reusable = new InMemoryCatalog();
-    try {
-      reusable.initialize("reusable", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId));
-      reusable.createNamespace(TBL.namespace());
-      reusable.buildTable(TBL, SCHEMA).create();
+  @Test
+  public void reinitializeWithoutSharedStoreIdSwitchesToPrivateStore() {
+    String storeId = reservedSharedStoreId("reinit-to-private");
+    InMemoryCatalog reusable =
+        newTrackedCatalog("reusable", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId));
+    reusable.createNamespace(TBL.namespace());
+    reusable.buildTable(TBL, SCHEMA).create();
 
-      reusable.initialize("reusable", ImmutableMap.of());
+    reusable.initialize("reusable", ImmutableMap.of());
 
-      assertThat(reusable.namespaceExists(TBL.namespace()))
-          .as("Reinitializing without a shared-store id must switch to a fresh private store")
-          .isFalse();
-      assertThat(reusable.tableExists(TBL))
-          .as("Reinitializing without a shared-store id must not see the previously shared table")
-          .isFalse();
-    } finally {
-      reusable.close();
-      InMemoryCatalog.clearSharedStore(storeId);
-    }
+    assertThat(reusable.namespaceExists(TBL.namespace()))
+        .as("Reinitializing without a shared-store ID must switch to a fresh private store")
+        .isFalse();
+    assertThat(reusable.tableExists(TBL))
+        .as("Reinitializing without a shared-store ID must not see the previously shared table")
+        .isFalse();
+  }
+
+  @Test
+  public void reinitializeAcrossSharedStoreIdsRetargetsBackingStore() {
+    String first = reservedSharedStoreId("reinit-source");
+    String second = reservedSharedStoreId("reinit-target");
+
+    InMemoryCatalog reusable =
+        newTrackedCatalog("reusable", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, first));
+    reusable.createNamespace(TBL.namespace());
+    reusable.buildTable(TBL, SCHEMA).create();
+
+    reusable.initialize("reusable", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, second));
+
+    assertThat(reusable.tableExists(TBL))
+        .as("Reinitializing onto a different shared-store ID must not carry state across")
+        .isFalse();
+
+    InMemoryCatalog observerOnFirst =
+        newTrackedCatalog(
+            "observer-first", ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, first));
+    assertThat(observerOnFirst.tableExists(TBL))
+        .as("The original shared store must still hold state after the source instance moves away")
+        .isTrue();
   }
 
   @Test
   public void concurrentInitializeWithSameSharedStoreIdConvergesOnOneStore()
       throws InterruptedException, ExecutionException {
-    String storeId = "concurrent-init";
-    InMemoryCatalog.clearSharedStore(storeId);
+    String storeId = reservedSharedStoreId("concurrent-init");
     Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     int parallelism = 8;
@@ -548,11 +574,11 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
 
       for (InMemoryCatalog reader : catalogs) {
         assertThat(reader.tableExists(TBL))
-            .as("All instances racing to initialize on the same shared-store id share state")
+            .as("All instances racing to initialize on the same shared-store ID share state")
             .isTrue();
       }
       threw = false;
-    } catch (java.util.concurrent.TimeoutException e) {
+    } catch (TimeoutException e) {
       throw new RuntimeException("Concurrent initialize timed out", e);
     } finally {
       executor.shutdownNow();
@@ -565,15 +591,13 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
           }
         }
       }
-      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 
   @Test
   public void concurrentCreateOfSameTableThroughSharedStoreSerializes()
       throws InterruptedException, ExecutionException {
-    String storeId = "concurrent-create";
-    InMemoryCatalog.clearSharedStore(storeId);
+    String storeId = reservedSharedStoreId("concurrent-create");
     Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.SHARED_STORE_ID, storeId);
 
     Namespace namespace = Namespace.of("ns");
@@ -594,6 +618,7 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
       CountDownLatch start = new CountDownLatch(1);
       AtomicInteger successes = new AtomicInteger();
       AtomicInteger alreadyExists = new AtomicInteger();
+      AtomicInteger unexpected = new AtomicInteger();
       List<Future<?>> futures = Lists.newArrayList();
       for (InMemoryCatalog cat : catalogs) {
         futures.add(
@@ -605,8 +630,11 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
                     successes.incrementAndGet();
                   } catch (AlreadyExistsException expected) {
                     alreadyExists.incrementAndGet();
-                  } catch (InterruptedException ex) {
+                  } catch (InterruptedException expected) {
                     Thread.currentThread().interrupt();
+                  } catch (RuntimeException unexpectedError) {
+                    unexpected.incrementAndGet();
+                    throw unexpectedError;
                   }
                   return null;
                 }));
@@ -617,6 +645,9 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
         future.get(30, TimeUnit.SECONDS);
       }
 
+      assertThat(unexpected.get())
+          .as("No racer should fail with anything other than AlreadyExistsException")
+          .isEqualTo(0);
       assertThat(successes.get())
           .as("Exactly one racer should successfully create the shared table")
           .isEqualTo(1);
@@ -627,7 +658,7 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
           .as("The shared table should be visible from any racer")
           .isTrue();
       threw = false;
-    } catch (java.util.concurrent.TimeoutException e) {
+    } catch (TimeoutException e) {
       throw new RuntimeException("Concurrent create timed out", e);
     } finally {
       executor.shutdownNow();
@@ -640,7 +671,6 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
           }
         }
       }
-      InMemoryCatalog.clearSharedStore(storeId);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -19,17 +19,26 @@
 package org.apache.iceberg.inmemory;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.CatalogTests;
+import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.view.View;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -105,5 +114,291 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
         .isInstanceOf(NotFoundException.class)
         .hasMessage("No in-memory file found for location: " + metadataFileLocation);
     table.io().newOutputFile(metadataFileLocation).create();
+  }
+
+  @Test
+  public void instanceIdSharesNamespacesAndTablesAcrossInstances() throws IOException {
+    String instanceId = "shared-state-tables";
+    InMemoryCatalog.clearInstanceState(instanceId);
+
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", sharedProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", sharedProps);
+
+    try {
+      first.createNamespace(TBL.namespace());
+      first.buildTable(TBL, SCHEMA).create();
+
+      assertThat(second.namespaceExists(TBL.namespace()))
+          .as("Namespace created via first instance should be visible to second")
+          .isTrue();
+      assertThat(second.tableExists(TBL))
+          .as("Table created via first instance should be visible to second")
+          .isTrue();
+      assertThat(second.loadTable(TBL).schema().asStruct())
+          .as("Schema observed via second instance should match first")
+          .isEqualTo(first.loadTable(TBL).schema().asStruct());
+
+      TableIdentifier other = TableIdentifier.of(TBL.namespace(), "other");
+      second.buildTable(other, SCHEMA).create();
+      assertThat(first.tableExists(other))
+          .as("Table created via second instance should be visible to first")
+          .isTrue();
+
+      second.dropTable(TBL, false);
+      assertThat(first.tableExists(TBL))
+          .as("Table dropped via second instance should disappear from first")
+          .isFalse();
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
+  }
+
+  @Test
+  public void instanceIdSharesViewsAcrossInstances() throws IOException {
+    String instanceId = "shared-state-views";
+    InMemoryCatalog.clearInstanceState(instanceId);
+
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+
+    InMemoryCatalog first = new InMemoryCatalog();
+    first.initialize("first", sharedProps);
+    InMemoryCatalog second = new InMemoryCatalog();
+    second.initialize("second", sharedProps);
+
+    TableIdentifier viewIdentifier = TableIdentifier.of(TBL.namespace(), "vw");
+    try {
+      first.createNamespace(TBL.namespace());
+      first
+          .buildView(viewIdentifier)
+          .withSchema(SCHEMA)
+          .withDefaultNamespace(TBL.namespace())
+          .withQuery("spark", "SELECT 1")
+          .create();
+
+      assertThat(second.viewExists(viewIdentifier))
+          .as("View created via first instance should be visible to second")
+          .isTrue();
+
+      View viewFromSecond = second.loadView(viewIdentifier);
+      assertThat(viewFromSecond.schema().asStruct())
+          .as("View schema observed via second instance should match first")
+          .isEqualTo(SCHEMA.asStruct());
+
+      second.dropView(viewIdentifier);
+      assertThat(first.viewExists(viewIdentifier))
+          .as("View dropped via second instance should disappear from first")
+          .isFalse();
+    } finally {
+      first.close();
+      second.close();
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
+  }
+
+  @Test
+  public void distinctInstanceIdsKeepStateIsolated() throws IOException {
+    String firstId = "isolated-first";
+    String secondId = "isolated-second";
+    InMemoryCatalog.clearInstanceState(firstId);
+    InMemoryCatalog.clearInstanceState(secondId);
+
+    InMemoryCatalog firstCatalog = new InMemoryCatalog();
+    firstCatalog.initialize("first", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, firstId));
+    InMemoryCatalog secondCatalog = new InMemoryCatalog();
+    secondCatalog.initialize("second", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, secondId));
+
+    try {
+      firstCatalog.createNamespace(TBL.namespace());
+      firstCatalog.buildTable(TBL, SCHEMA).create();
+
+      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+          .as("Namespace from first instance must not leak to a different instance id")
+          .isFalse();
+      assertThat(secondCatalog.tableExists(TBL))
+          .as("Table from first instance must not leak to a different instance id")
+          .isFalse();
+    } finally {
+      firstCatalog.close();
+      secondCatalog.close();
+      InMemoryCatalog.clearInstanceState(firstId);
+      InMemoryCatalog.clearInstanceState(secondId);
+    }
+  }
+
+  @Test
+  public void instancesWithoutInstanceIdKeepStateIsolated() throws IOException {
+    InMemoryCatalog firstCatalog = new InMemoryCatalog();
+    firstCatalog.initialize("first", ImmutableMap.of());
+    InMemoryCatalog secondCatalog = new InMemoryCatalog();
+    secondCatalog.initialize("second", ImmutableMap.of());
+
+    try {
+      firstCatalog.createNamespace(TBL.namespace());
+      firstCatalog.buildTable(TBL, SCHEMA).create();
+
+      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+          .as("Two catalogs without an instance id must not share state")
+          .isFalse();
+      assertThat(secondCatalog.tableExists(TBL))
+          .as("Two catalogs without an instance id must not share tables")
+          .isFalse();
+    } finally {
+      firstCatalog.close();
+      secondCatalog.close();
+    }
+  }
+
+  @Test
+  public void closeClearsPrivateStateButPreservesSharedState() throws IOException {
+    InMemoryCatalog privateCatalog = new InMemoryCatalog();
+    privateCatalog.initialize("private", ImmutableMap.of());
+    privateCatalog.createNamespace(TBL.namespace());
+    privateCatalog.buildTable(TBL, SCHEMA).create();
+    privateCatalog.close();
+
+    InMemoryCatalog reopened = new InMemoryCatalog();
+    reopened.initialize("private", ImmutableMap.of());
+    try {
+      assertThat(reopened.namespaceExists(TBL.namespace()))
+          .as("Private state should be dropped on close")
+          .isFalse();
+    } finally {
+      reopened.close();
+    }
+
+    String instanceId = "shared-survives-close";
+    InMemoryCatalog.clearInstanceState(instanceId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+    try {
+      InMemoryCatalog firstShared = new InMemoryCatalog();
+      firstShared.initialize("first", sharedProps);
+      firstShared.createNamespace(TBL.namespace());
+      firstShared.buildTable(TBL, SCHEMA).create();
+      firstShared.close();
+
+      InMemoryCatalog secondShared = new InMemoryCatalog();
+      secondShared.initialize("second", sharedProps);
+      try {
+        assertThat(secondShared.tableExists(TBL))
+            .as("Closing one shared instance must not drop the shared store")
+            .isTrue();
+      } finally {
+        secondShared.close();
+      }
+    } finally {
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
+  }
+
+  @Test
+  public void clearInstanceStateRemovesSharedStore() throws IOException {
+    String instanceId = "clear-state";
+    InMemoryCatalog.clearInstanceState(instanceId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+
+    InMemoryCatalog firstCatalog = new InMemoryCatalog();
+    firstCatalog.initialize("first", sharedProps);
+    firstCatalog.createNamespace(TBL.namespace());
+    firstCatalog.buildTable(TBL, SCHEMA).create();
+    firstCatalog.close();
+
+    InMemoryCatalog.clearInstanceState(instanceId);
+
+    InMemoryCatalog secondCatalog = new InMemoryCatalog();
+    secondCatalog.initialize("second", sharedProps);
+    try {
+      assertThat(secondCatalog.namespaceExists(TBL.namespace()))
+          .as("Shared store should be empty after clearInstanceState")
+          .isFalse();
+      assertThat(secondCatalog.tableExists(TBL))
+          .as("Shared store should drop tables after clearInstanceState")
+          .isFalse();
+    } finally {
+      secondCatalog.close();
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
+  }
+
+  @Test
+  public void clearInstanceStateIsNoOpForUnknownId() {
+    assertThatCode(() -> InMemoryCatalog.clearInstanceState("never-registered"))
+        .as("Clearing an unknown instance id should be a safe no-op")
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  public void initializeIsIdempotentWhenInstanceIdRemoved() throws IOException {
+    String instanceId = "idempotent-init";
+    InMemoryCatalog.clearInstanceState(instanceId);
+
+    InMemoryCatalog reusable = new InMemoryCatalog();
+    try {
+      reusable.initialize("reusable", ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId));
+      reusable.createNamespace(TBL.namespace());
+      reusable.buildTable(TBL, SCHEMA).create();
+
+      reusable.initialize("reusable", ImmutableMap.of());
+
+      assertThat(reusable.namespaceExists(TBL.namespace()))
+          .as("Re-initializing without an instance id must switch to a fresh private store")
+          .isFalse();
+      assertThat(reusable.tableExists(TBL))
+          .as("Re-initializing without an instance id must not see the previously shared table")
+          .isFalse();
+    } finally {
+      reusable.close();
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
+  }
+
+  @Test
+  public void concurrentInitializeWithSameInstanceIdSharesStorage()
+      throws IOException, InterruptedException, ExecutionException {
+    String instanceId = "concurrent-init";
+    InMemoryCatalog.clearInstanceState(instanceId);
+    Map<String, String> sharedProps = ImmutableMap.of(InMemoryCatalog.INSTANCE_ID, instanceId);
+
+    int parallelism = 8;
+    ExecutorService executor = Executors.newFixedThreadPool(parallelism);
+    List<InMemoryCatalog> catalogs = Lists.newArrayList();
+    try {
+      List<Future<InMemoryCatalog>> futures = Lists.newArrayList();
+      for (int i = 0; i < parallelism; i++) {
+        final String name = "catalog-" + i;
+        futures.add(
+            executor.submit(
+                () -> {
+                  InMemoryCatalog cat = new InMemoryCatalog();
+                  cat.initialize(name, sharedProps);
+                  return cat;
+                }));
+      }
+
+      for (Future<InMemoryCatalog> future : futures) {
+        catalogs.add(future.get());
+      }
+
+      InMemoryCatalog writer = catalogs.get(0);
+      writer.createNamespace(TBL.namespace());
+      writer.buildTable(TBL, SCHEMA).create();
+
+      for (InMemoryCatalog reader : catalogs) {
+        assertThat(reader.tableExists(TBL))
+            .as("All instances racing to initialize with the same id should observe shared writes")
+            .isTrue();
+      }
+    } finally {
+      executor.shutdownNow();
+      for (InMemoryCatalog cat : catalogs) {
+        cat.close();
+      }
+      InMemoryCatalog.clearInstanceState(instanceId);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -21,15 +21,20 @@ package org.apache.iceberg.inmemory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NotFoundException;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class TestInMemoryFileIO {
 
@@ -137,6 +142,78 @@ public class TestInMemoryFileIO {
     Map<String, String> properties = ImmutableMap.of("key1", "value1", "key2", "value2");
     io.initialize(properties);
     assertThat(io.properties()).isEqualTo(properties);
+  }
+
+  @Test
+  public void tryRenameMovesInMemoryEntry() {
+    String from = randomLocation();
+    String to = randomLocation();
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.addFile(from, "payload".getBytes());
+
+    assertThat(InMemoryFileIO.tryRename(from, to)).isTrue();
+    assertThat(fileIO.fileExists(from)).isFalse();
+    assertThat(fileIO.fileExists(to)).isTrue();
+  }
+
+  @Test
+  public void tryRenameReturnsFalseWhenSourceMissing() {
+    assertThat(InMemoryFileIO.tryRename("s3://nope/" + UUID.randomUUID(), "s3://nope/other"))
+        .isFalse();
+  }
+
+  @Test
+  public void diskFallbackReadsLocalFileWhenNotInMemory(@TempDir Path tempDir) throws IOException {
+    File diskFile = tempDir.resolve("payload.bin").toFile();
+    Files.write(diskFile.toPath(), "from-disk".getBytes());
+
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.initialize(ImmutableMap.of(InMemoryFileIO.DISK_FALLBACK, "true"));
+
+    InputFile input = fileIO.newInputFile("file:" + diskFile.getAbsolutePath());
+    try (InputStream stream = input.newStream()) {
+      byte[] buf = new byte[(int) input.getLength()];
+      assertThat(stream.read(buf)).isEqualTo(buf.length);
+      assertThat(new String(buf)).isEqualTo("from-disk");
+    }
+  }
+
+  @Test
+  public void diskFallbackDoesNotShadowInMemoryReads(@TempDir Path tempDir) throws IOException {
+    File diskFile = tempDir.resolve("shared.bin").toFile();
+    Files.write(diskFile.toPath(), "from-disk".getBytes());
+    String location = "file:" + diskFile.getAbsolutePath();
+
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.initialize(ImmutableMap.of(InMemoryFileIO.DISK_FALLBACK, "true"));
+    fileIO.addFile(location, "from-memory".getBytes());
+
+    InputFile input = fileIO.newInputFile(location);
+    try (InputStream stream = input.newStream()) {
+      byte[] buf = new byte[(int) input.getLength()];
+      assertThat(stream.read(buf)).isEqualTo(buf.length);
+      assertThat(new String(buf)).isEqualTo("from-memory");
+    }
+  }
+
+  @Test
+  public void diskFallbackOffStillThrowsForUnknownLocation() {
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    assertThatExceptionOfType(NotFoundException.class)
+        .isThrownBy(() -> fileIO.newInputFile("file:/var/empty/" + UUID.randomUUID()))
+        .withMessageContaining("No in-memory file found");
+  }
+
+  @Test
+  public void diskFallbackDeleteRemovesLocalFile(@TempDir Path tempDir) throws IOException {
+    File diskFile = tempDir.resolve("delete-me.bin").toFile();
+    Files.write(diskFile.toPath(), "bytes".getBytes());
+
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.initialize(ImmutableMap.of(InMemoryFileIO.DISK_FALLBACK, "true"));
+    fileIO.deleteFile("file:" + diskFile.getAbsolutePath());
+
+    assertThat(diskFile).doesNotExist();
   }
 
   private String randomLocation() {

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryFileIO.java
@@ -197,6 +197,22 @@ public class TestInMemoryFileIO {
   }
 
   @Test
+  public void diskFallbackPreservesRequestedLocation(@TempDir Path tempDir) throws IOException {
+    File diskFile = tempDir.resolve("preserve.bin").toFile();
+    Files.write(diskFile.toPath(), "bytes".getBytes());
+    String requestedLocation = "file:" + diskFile.getAbsolutePath();
+
+    InMemoryFileIO fileIO = new InMemoryFileIO();
+    fileIO.initialize(ImmutableMap.of(InMemoryFileIO.DISK_FALLBACK, "true"));
+
+    // Iceberg components key InputFile maps off the requested location string. The disk-backed
+    // delegate would otherwise drop the file: scheme and break those lookups.
+    InputFile input = fileIO.newInputFile(requestedLocation);
+    assertThat(input.location()).isEqualTo(requestedLocation);
+    assertThat(input.toString()).isEqualTo(requestedLocation);
+  }
+
+  @Test
   public void diskFallbackOffStillThrowsForUnknownLocation() {
     InMemoryFileIO fileIO = new InMemoryFileIO();
     assertThatExceptionOfType(NotFoundException.class)

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/SparkRowLevelOperationsTestBase.java
@@ -65,6 +65,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.parquet.GenericParquetWriter;
 import org.apache.iceberg.deletes.DeleteGranularity;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.DataWriter;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.parquet.Parquet;
@@ -114,8 +115,14 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         "testhive",
         SparkCatalog.class.getName(),
         ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default"),
+            "type",
+            "hive",
+            "default-namespace",
+            "default",
+            CatalogProperties.FILE_IO_IMPL,
+            InMemoryFileIO.class.getName(),
+            InMemoryFileIO.DISK_FALLBACK,
+            "true"),
         FileFormat.ORC,
         true,
         WRITE_DISTRIBUTION_MODE_NONE,
@@ -128,8 +135,14 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
         "testhive",
         SparkCatalog.class.getName(),
         ImmutableMap.of(
-            "type", "hive",
-            "default-namespace", "default"),
+            "type",
+            "hive",
+            "default-namespace",
+            "default",
+            CatalogProperties.FILE_IO_IMPL,
+            InMemoryFileIO.class.getName(),
+            InMemoryFileIO.DISK_FALLBACK,
+            "true"),
         FileFormat.PARQUET,
         true,
         WRITE_DISTRIBUTION_MODE_HASH,
@@ -141,16 +154,15 @@ public abstract class SparkRowLevelOperationsTestBase extends ExtensionsTestBase
       {
         "spark_catalog",
         SparkSessionCatalog.class.getName(),
-        ImmutableMap.of(
-            "type",
-            "rest",
-            CatalogProperties.URI,
-            restCatalog.properties().get(CatalogProperties.URI),
-            "default-namespace",
-            "default",
-            "cache-enabled",
-            "false" // Spark will delete tables using v1, leaving the cache out of sync
-            ),
+        ImmutableMap.<String, String>builder()
+            .put("type", "rest")
+            .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
+            .put("default-namespace", "default")
+            // Spark will delete tables using v1, leaving the cache out of sync
+            .put("cache-enabled", "false")
+            .put(CatalogProperties.FILE_IO_IMPL, InMemoryFileIO.class.getName())
+            .put(InMemoryFileIO.DISK_FALLBACK, "true")
+            .build(),
         FileFormat.AVRO,
         false,
         WRITE_DISTRIBUTION_MODE_RANGE,

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestComputePartitionStatsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestComputePartitionStatsProcedure.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.File;
 import java.util.List;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Namespace;
@@ -37,6 +38,13 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestComputePartitionStatsProcedure extends ExtensionsTestBase {
+
+  // This procedure writes statistics files via table.io() and then asserts they exist on disk via
+  // java.io.File. Run with disk-backed FileIOs so the writes round-trip through real storage.
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return catalogParametersWithDiskBackedFileIo();
+  }
 
   @AfterEach
   public void removeTable() {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestExpireSnapshotsProcedure.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.StatisticsFile;
@@ -59,6 +60,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestExpireSnapshotsProcedure extends ExtensionsTestBase {
+
+  // Several tests assert that statistics, partition stats, and manifest files exist on disk via
+  // java.io.File after writing through table.io(). Run with disk-backed FileIOs so the writes
+  // round-trip through real storage.
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return catalogParametersWithDiskBackedFileIo();
+  }
 
   @AfterEach
   public void removeTables() {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.ReachableFileUtil;
@@ -70,6 +71,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
+
+  // Orphan-file detection enumerates the table directory through Hadoop FileSystem, which only
+  // sees files written to local disk. Run with disk-backed FileIOs so the listing matches the
+  // files Iceberg manages.
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return catalogParametersWithDiskBackedFileIo();
+  }
 
   @AfterEach
   public void removeTable() {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRewriteTablePathProcedure.java
@@ -29,6 +29,7 @@ import java.util.List;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.RewriteTablePathUtil;
 import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
@@ -47,6 +48,15 @@ import org.junit.jupiter.api.io.TempDir;
 public class TestRewriteTablePathProcedure extends ExtensionsTestBase {
   @TempDir private Path staging;
   @TempDir private Path targetTableDir;
+
+  // RewriteTablePathUtil enforces a path-prefix relationship between the table location and
+  // each file location (delete, manifest, metadata). InMemoryCatalog uses an empty warehouse,
+  // which produces bare paths like "/default/table" while writers emit "file:/default/table/..."
+  // and break the prefix check. Run with disk-backed FileIOs so paths line up.
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return catalogParametersWithDiskBackedFileIo();
+  }
 
   @BeforeEach
   public void setupTableLocation() {

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSnapshotTableProcedure.java
@@ -33,6 +33,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.commons.io.FileUtils;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -50,6 +51,14 @@ import org.junit.jupiter.api.extension.ExtendWith;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestSnapshotTableProcedure extends ExtensionsTestBase {
   private static final String SOURCE_NAME = "spark_catalog.default.source";
+
+  // Snapshot procedure copies parquet files from a Hive source table that lives on disk, and
+  // several tests open Iceberg-managed manifests directly through Files.localInput(...). Both
+  // require disk-backed FileIOs. Run with disk-backed FileIOs so files round-trip on disk.
+  @Parameters(name = "catalogName = {0}, implementation = {1}, config = {2}")
+  public static Object[][] parameters() {
+    return catalogParametersWithDiskBackedFileIo();
+  }
 
   // Currently we can only Snapshot only out of the Spark Session Catalog
   @AfterEach

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
@@ -56,4 +56,34 @@ public abstract class CatalogTestBase extends TestBaseWithCatalog {
       }
     };
   }
+
+  /**
+   * Catalog parameters for tests that must inspect files on disk (for example, asserting that an
+   * Iceberg-managed file exists via {@code java.io.File#exists()} or listing a directory with
+   * Hadoop {@code FileSystem}). Drops the {@code testinmemory} catalog (its {@link
+   * org.apache.iceberg.inmemory.InMemoryCatalog} cannot back a real filesystem) and the {@code
+   * testrest} catalog (the shared REST server writes initial metadata through its own in-memory
+   * {@link org.apache.iceberg.inmemory.InMemoryFileIO}, which a disk-only client cannot read).
+   * Remaining catalogs strip the in-memory {@code FileIO} so {@code table.io()} round-trips through
+   * real on-disk storage.
+   */
+  protected static Object[][] catalogParametersWithDiskBackedFileIo() {
+    return new Object[][] {
+      {
+        SparkCatalogConfig.HIVE.catalogName(),
+        SparkCatalogConfig.HIVE.implementation(),
+        SparkCatalogConfig.HIVE.propertiesWithoutFileIo()
+      },
+      {
+        SparkCatalogConfig.HADOOP.catalogName(),
+        SparkCatalogConfig.HADOOP.implementation(),
+        SparkCatalogConfig.HADOOP.properties()
+      },
+      {
+        SparkCatalogConfig.SPARK_SESSION.catalogName(),
+        SparkCatalogConfig.SPARK_SESSION.implementation(),
+        SparkCatalogConfig.SPARK_SESSION.propertiesWithoutFileIo()
+      }
+    };
+  }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/CatalogTestBase.java
@@ -37,9 +37,9 @@ public abstract class CatalogTestBase extends TestBaseWithCatalog {
         SparkCatalogConfig.HIVE.properties()
       },
       {
-        SparkCatalogConfig.HADOOP.catalogName(),
-        SparkCatalogConfig.HADOOP.implementation(),
-        SparkCatalogConfig.HADOOP.properties()
+        SparkCatalogConfig.INMEMORY.catalogName(),
+        SparkCatalogConfig.INMEMORY.implementation(),
+        SparkCatalogConfig.INMEMORY.properties()
       },
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -21,39 +21,71 @@ package org.apache.iceberg.spark;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public enum SparkCatalogConfig {
   HIVE(
       "testhive",
       SparkCatalog.class.getName(),
       ImmutableMap.of(
-          "type", "hive",
-          "default-namespace", "default")),
+          "type",
+          "hive",
+          "default-namespace",
+          "default",
+          CatalogProperties.FILE_IO_IMPL,
+          InMemoryFileIO.class.getName(),
+          InMemoryFileIO.DISK_FALLBACK,
+          "true")),
   HADOOP(
       "testhadoop",
       SparkCatalog.class.getName(),
       ImmutableMap.of("type", "hadoop", "cache-enabled", "false")),
+  INMEMORY(
+      "testinmemory",
+      SparkCatalog.class.getName(),
+      ImmutableMap.of(
+          CatalogProperties.CATALOG_IMPL,
+          InMemoryCatalog.class.getName(),
+          InMemoryCatalog.SHARED_STORE_ID,
+          "testinmemory",
+          "default-namespace",
+          "default",
+          "cache-enabled",
+          "false")),
   REST(
       "testrest",
       SparkCatalog.class.getName(),
-      ImmutableMap.of("type", "rest", "cache-enabled", "false")),
+      ImmutableMap.of(
+          "type",
+          "rest",
+          "cache-enabled",
+          "false",
+          CatalogProperties.FILE_IO_IMPL,
+          InMemoryFileIO.class.getName(),
+          InMemoryFileIO.DISK_FALLBACK,
+          "true")),
   SPARK_SESSION(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),
-      ImmutableMap.of(
-          "type", "hive",
-          "default-namespace", "default",
-          "parquet-enabled", "true",
-          "cache-enabled",
-              "false" // Spark will delete tables using v1, leaving the cache out of sync
-          )),
+      ImmutableMap.<String, String>builder()
+          .put("type", "hive")
+          .put("default-namespace", "default")
+          .put("parquet-enabled", "true")
+          // Spark will delete tables using v1, leaving the cache out of sync
+          .put("cache-enabled", "false")
+          .put(CatalogProperties.FILE_IO_IMPL, InMemoryFileIO.class.getName())
+          .put(InMemoryFileIO.DISK_FALLBACK, "true")
+          .build()),
   SPARK_WITH_VIEWS(
       "spark_with_views",
       SparkCatalog.class.getName(),
       ImmutableMap.of(
           CatalogProperties.CATALOG_IMPL,
           InMemoryCatalog.class.getName(),
+          InMemoryCatalog.SHARED_STORE_ID,
+          "spark_with_views",
           "default-namespace",
           "default",
           "cache-enabled",
@@ -61,27 +93,57 @@ public enum SparkCatalogConfig {
   SPARK_SESSION_WITH_VIEWS(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),
-      ImmutableMap.of("type", "rest", "default-namespace", "default", "cache-enabled", "false")),
+      ImmutableMap.of(
+          "type",
+          "rest",
+          "default-namespace",
+          "default",
+          "cache-enabled",
+          "false",
+          CatalogProperties.FILE_IO_IMPL,
+          InMemoryFileIO.class.getName(),
+          InMemoryFileIO.DISK_FALLBACK,
+          "true")),
   SPARK_WITH_HIVE_VIEWS(
       "spark_hive_with_views",
       SparkCatalog.class.getName(),
-      ImmutableMap.of("type", "hive", "default-namespace", "default", "cache-enabled", "false")),
+      ImmutableMap.of(
+          "type",
+          "hive",
+          "default-namespace",
+          "default",
+          "cache-enabled",
+          "false",
+          CatalogProperties.FILE_IO_IMPL,
+          InMemoryFileIO.class.getName(),
+          InMemoryFileIO.DISK_FALLBACK,
+          "true")),
   SPARK_SESSION_WITH_UNIQUE_LOCATION(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),
-      ImmutableMap.of(
-          "type", "hive",
-          "default-namespace", "default",
-          "parquet-enabled", "true",
-          "unique-table-location", "true",
-          "cache-enabled", "false")),
+      ImmutableMap.<String, String>builder()
+          .put("type", "hive")
+          .put("default-namespace", "default")
+          .put("parquet-enabled", "true")
+          .put("unique-table-location", "true")
+          .put("cache-enabled", "false")
+          .put(CatalogProperties.FILE_IO_IMPL, InMemoryFileIO.class.getName())
+          .put(InMemoryFileIO.DISK_FALLBACK, "true")
+          .build()),
   HIVE_WITH_UNIQUE_LOCATION(
       "hive_with_unique_location",
       SparkCatalog.class.getName(),
       ImmutableMap.of(
-          "type", "hive",
-          "default-namespace", "default",
-          "unique-table-location", "true"));
+          "type",
+          "hive",
+          "default-namespace",
+          "default",
+          "unique-table-location",
+          "true",
+          CatalogProperties.FILE_IO_IMPL,
+          InMemoryFileIO.class.getName(),
+          InMemoryFileIO.DISK_FALLBACK,
+          "true"));
 
   private final String catalogName;
   private final String implementation;
@@ -103,5 +165,17 @@ public enum SparkCatalogConfig {
 
   public Map<String, String> properties() {
     return properties;
+  }
+
+  /**
+   * Returns this config's properties without the in-memory {@code FileIO} entries. Tests that rely
+   * on raw on-disk file inspection (for example, opening Parquet, ORC, or Avro files directly
+   * through Hadoop readers) use this overload to opt out of the in-memory swap.
+   */
+  public Map<String, String> propertiesWithoutFileIo() {
+    Map<String, String> withoutFileIo = Maps.newHashMap(properties);
+    withoutFileIo.remove(CatalogProperties.FILE_IO_IMPL);
+    withoutFileIo.remove(InMemoryFileIO.DISK_FALLBACK);
+    return ImmutableMap.copyOf(withoutFileIo);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/SparkCatalogConfig.java
@@ -45,15 +45,16 @@ public enum SparkCatalogConfig {
   INMEMORY(
       "testinmemory",
       SparkCatalog.class.getName(),
-      ImmutableMap.of(
-          CatalogProperties.CATALOG_IMPL,
-          InMemoryCatalog.class.getName(),
-          InMemoryCatalog.SHARED_STORE_ID,
-          "testinmemory",
-          "default-namespace",
-          "default",
-          "cache-enabled",
-          "false")),
+      ImmutableMap.<String, String>builder()
+          .put(CatalogProperties.CATALOG_IMPL, InMemoryCatalog.class.getName())
+          .put(InMemoryCatalog.SHARED_STORE_ID, "testinmemory")
+          .put("default-namespace", "default")
+          .put("cache-enabled", "false")
+          // InMemoryCatalog forwards its catalog properties to the FileIO it constructs; turning
+          // disk fallback on lets it round-trip Spark's native (on-disk) writes alongside the
+          // Iceberg-managed in-memory files.
+          .put(InMemoryFileIO.DISK_FALLBACK, "true")
+          .build()),
   REST(
       "testrest",
       SparkCatalog.class.getName(),
@@ -81,15 +82,13 @@ public enum SparkCatalogConfig {
   SPARK_WITH_VIEWS(
       "spark_with_views",
       SparkCatalog.class.getName(),
-      ImmutableMap.of(
-          CatalogProperties.CATALOG_IMPL,
-          InMemoryCatalog.class.getName(),
-          InMemoryCatalog.SHARED_STORE_ID,
-          "spark_with_views",
-          "default-namespace",
-          "default",
-          "cache-enabled",
-          "false")),
+      ImmutableMap.<String, String>builder()
+          .put(CatalogProperties.CATALOG_IMPL, InMemoryCatalog.class.getName())
+          .put(InMemoryCatalog.SHARED_STORE_ID, "spark_with_views")
+          .put("default-namespace", "default")
+          .put("cache-enabled", "false")
+          .put(InMemoryFileIO.DISK_FALLBACK, "true")
+          .build()),
   SPARK_SESSION_WITH_VIEWS(
       "spark_catalog",
       SparkSessionCatalog.class.getName(),

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -40,6 +40,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.hive.TestHiveMetastore;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -158,6 +159,12 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   private void move(String location, String newLocation) {
+    // Iceberg-managed files written through InMemoryFileIO live in a JVM-wide map rather
+    // than on disk, so swap them in place there before falling through to a disk move.
+    if (InMemoryFileIO.tryRename(location, newLocation)) {
+      return;
+    }
+
     Path path = Paths.get(URI.create(location));
     Path tempPath = Paths.get(URI.create(newLocation));
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -41,6 +42,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
+import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTCatalogServer;
@@ -52,6 +54,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.io.TempDir;
+import scala.collection.JavaConverters;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public abstract class TestBaseWithCatalog extends TestBase {
@@ -81,9 +84,9 @@ public abstract class TestBaseWithCatalog extends TestBase {
   protected static Object[][] parameters() {
     return new Object[][] {
       {
-        SparkCatalogConfig.HADOOP.catalogName(),
-        SparkCatalogConfig.HADOOP.implementation(),
-        SparkCatalogConfig.HADOOP.properties()
+        SparkCatalogConfig.INMEMORY.catalogName(),
+        SparkCatalogConfig.INMEMORY.implementation(),
+        SparkCatalogConfig.INMEMORY.properties()
       },
     };
   }
@@ -132,7 +135,17 @@ public abstract class TestBaseWithCatalog extends TestBase {
           this.validationCatalog = restCatalog;
           break;
         case ICEBERG_CATALOG_TYPE_HIVE:
-          this.validationCatalog = catalog;
+          // If the test's catalogConfig overrides FileIO, the shared TestBase.catalog (which
+          // uses HadoopFileIO) won't see files written through Spark's HiveCatalog. Build a
+          // fresh HiveCatalog with the same FileIO so reads round-trip.
+          if (catalogConfig.containsKey(CatalogProperties.FILE_IO_IMPL)) {
+            this.validationCatalog =
+                (HiveCatalog)
+                    CatalogUtil.loadCatalog(
+                        HiveCatalog.class.getName(), "hive", catalogConfig, hiveConf);
+          } else {
+            this.validationCatalog = catalog;
+          }
           break;
         default:
           throw new IllegalArgumentException("Unknown catalog type: " + catalogType);
@@ -140,7 +153,11 @@ public abstract class TestBaseWithCatalog extends TestBase {
     } else if (catalogConfig.containsKey(CATALOG_IMPL)) {
       switch (catalogConfig.get(CATALOG_IMPL)) {
         case "org.apache.iceberg.inmemory.InMemoryCatalog":
-          this.validationCatalog = new InMemoryCatalog();
+          // Initialize a separate InMemoryCatalog instance with the same SHARED_STORE_ID so
+          // that it shares namespaces, tables, and views with Spark's catalog.
+          InMemoryCatalog inMemoryCatalog = new InMemoryCatalog();
+          inMemoryCatalog.initialize(catalogName, catalogConfig);
+          this.validationCatalog = inMemoryCatalog;
           break;
         default:
           throw new IllegalArgumentException("Unknown catalog impl");
@@ -151,7 +168,20 @@ public abstract class TestBaseWithCatalog extends TestBase {
 
   @BeforeEach
   public void before() {
-    configureValidationCatalog();
+    // Clear any stale Spark catalog properties left over from a previous parameterization.
+    // The shared static SparkSession persists configuration across test classes, so a leftover
+    // key like spark.sql.catalog.<name>.io-impl from a previous run would silently override the
+    // current test's catalog configuration and cause cross-FileIO contamination.
+    String prefix = "spark.sql.catalog." + catalogName + ".";
+    Map<String, String> currentConf = JavaConverters.mapAsJavaMap(spark.conf().getAll());
+    currentConf
+        .keySet()
+        .forEach(
+            key -> {
+              if (key.equals("spark.sql.catalog." + catalogName) || key.startsWith(prefix)) {
+                spark.conf().unset(key);
+              }
+            });
 
     spark.conf().set("spark.sql.catalog." + catalogName, implementation);
     catalogConfig.forEach(
@@ -161,10 +191,14 @@ public abstract class TestBaseWithCatalog extends TestBase {
       spark.conf().set("spark.sql.catalog." + catalogName + ".warehouse", "file:" + warehouse);
     }
 
+    configureValidationCatalog();
+
     this.tableName =
         (catalogName.equals("spark_catalog") ? "" : catalogName + ".") + "default.table";
 
-    sql("CREATE NAMESPACE IF NOT EXISTS default");
+    if (!validationNamespaceCatalog.namespaceExists(Namespace.of("default"))) {
+      validationNamespaceCatalog.createNamespace(Namespace.of("default"));
+    }
   }
 
   protected String tableName(String name) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBaseWithCatalog.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.hadoop.HadoopCatalog;
 import org.apache.iceberg.hive.HiveCatalog;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.rest.RESTCatalogServer;
 import org.apache.iceberg.rest.RESTServerExtension;
@@ -76,7 +77,15 @@ public abstract class TestBaseWithCatalog extends TestBase {
               "include-credentials",
               "true",
               "gcs.oauth2.token",
-              "dummyToken"));
+              "dummyToken",
+              // Server-side reads (server-side scan planning, snapshot validation) must use the
+              // same FileIO as Spark clients so that JVM-wide in-memory writes are visible from
+              // both sides. Disk fallback covers tests that mix Spark's native (on-disk) writes
+              // with Iceberg-managed in-memory metadata.
+              CatalogProperties.FILE_IO_IMPL,
+              InMemoryFileIO.class.getName(),
+              InMemoryFileIO.DISK_FALLBACK,
+              "true"));
 
   protected static RESTCatalog restCatalog;
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestCompressionSettings.java
@@ -99,6 +99,11 @@ public class TestCompressionSettings extends CatalogTestBase {
 
   @TempDir private java.nio.file.Path temp;
 
+  // Compression checks read raw Parquet/ORC/Avro files via Hadoop, so they require on-disk
+  // data and cannot use SPARK_SESSION's default InMemoryFileIO.
+  private static final Map<String, String> SESSION_PROPS_ON_DISK =
+      SparkCatalogConfig.SPARK_SESSION.propertiesWithoutFileIo();
+
   @Parameters(
       name =
           "catalogName = {0}, implementation = {1}, config = {2}, format = {3}, properties = {4}")
@@ -107,35 +112,35 @@ public class TestCompressionSettings extends CatalogTestBase {
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),
         SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
+        SESSION_PROPS_ON_DISK,
         PARQUET,
         ImmutableMap.of(COMPRESSION_CODEC, "zstd", COMPRESSION_LEVEL, "1")
       },
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),
         SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
+        SESSION_PROPS_ON_DISK,
         PARQUET,
         ImmutableMap.of(COMPRESSION_CODEC, "gzip")
       },
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),
         SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
+        SESSION_PROPS_ON_DISK,
         ORC,
         ImmutableMap.of(COMPRESSION_CODEC, "zstd", COMPRESSION_STRATEGY, "speed")
       },
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),
         SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
+        SESSION_PROPS_ON_DISK,
         ORC,
         ImmutableMap.of(COMPRESSION_CODEC, "zstd", COMPRESSION_STRATEGY, "compression")
       },
       {
         SparkCatalogConfig.SPARK_SESSION.catalogName(),
         SparkCatalogConfig.SPARK_SESSION.implementation(),
-        SparkCatalogConfig.SPARK_SESSION.properties(),
+        SESSION_PROPS_ON_DISK,
         AVRO,
         ImmutableMap.of(COMPRESSION_CODEC, "snappy", COMPRESSION_LEVEL, "3")
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestDataFrameWriterV2.java
@@ -113,7 +113,9 @@ public class TestDataFrameWriterV2 extends TestBaseWithCatalog {
     assertThatThrownBy(() -> threeColDF.writeTo(tableName).option("merge-schema", "true").append())
         .isInstanceOf(AnalysisException.class)
         .hasMessageContaining(
-            "Cannot write to `testhadoop`.`default`.`table`, the reason is too many data columns");
+            String.format(
+                "Cannot write to `%s`.`default`.`table`, the reason is too many data columns",
+                catalogName));
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestMetadataTableReadableMetrics.java
@@ -83,10 +83,13 @@ public class TestMetadataTableReadableMetrics extends TestBaseWithCatalog {
   protected static Object[][] parameters() {
     return new Object[][] {
       {
+        // This test creates tables via TestBase.catalog (HadoopFileIO) and writes data files
+        // via Files.localOutput (on disk), so Spark must use HadoopFileIO too for reads to
+        // round-trip; opt out of the in-memory FileIO that HIVE applies by default.
         // only SparkCatalog supports metadata table sql queries
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
-        SparkCatalogConfig.HIVE.properties()
+        SparkCatalogConfig.HIVE.propertiesWithoutFileIo()
       },
     };
   }


### PR DESCRIPTION
## Summary

Make Spark integration tests run against in-memory storage so they finish faster, and fix the test plumbing so previously disk-bound flows still work end-to-end.

This PR currently includes the core changes from #16841 (the new `InMemoryCatalog` shared-store mechanism). Once #16841 merges, this PR will rebase onto `main` so only the Spark-side changes remain.

### Core
- **`InMemoryCatalog` shared store** (#16841): `SHARED_STORE_ID` lets multiple `InMemoryCatalog` instances share one JVM-wide store, so cloned Spark sessions and validation catalogs see each other's writes.
- **`InMemoryFileIO` extensions**:
  - New `in-memory-file-io.disk-fallback` property — when enabled, `newInputFile` / `deleteFile` fall back to the local disk for locations not in the in-memory map. Default off. Disk-fallback `InputFile`s are wrapped to preserve the requested `location()` string verbatim (Iceberg components key `InputFile` maps off the requested location, so a `LocalInputFile` that drops the `file:` scheme would otherwise break `BatchDataReader`).
  - New `static boolean tryRename(from, to)` helper — renames the in-memory entry for `from` to `to`, returning `false` if no in-memory content is registered. Used by `TestBase.move` to swap Iceberg-managed files in place.

### Spark
- **`SparkCatalogConfig`**: `HIVE` / `REST` / `SPARK_SESSION` / `INMEMORY` and friends use `InMemoryFileIO` with `disk-fallback=true`; new `INMEMORY` config is backed by `InMemoryCatalog` with `SHARED_STORE_ID`. New `propertiesWithoutFileIo()` helper for tests that need raw on-disk file inspection.
- **`TestBase.move`**: tries `InMemoryFileIO.tryRename` first, then falls back to a disk move. This unblocks `withUnavailableLocations` (used by `TestSystemFunctionPushDownInRowLevelOperations`) when Iceberg data files live in the in-memory map.
- **`TestBaseWithCatalog`**: clears stale `spark.sql.catalog.<name>.*` props from the shared `SparkSession` between tests, builds the validation `HiveCatalog` with the same `FileIO` when a test overrides `io-impl`, initializes a separate `InMemoryCatalog` validation instance with the same configuration so it shares state, and configures the shared REST server extension with `InMemoryFileIO` + disk fallback so server-side scan planning and snapshot validation can read in-memory metadata.
- **`SparkRowLevelOperationsTestBase`**: adds `io-impl` + `disk-fallback` to the three hardcoded catalog configs so they agree with the REST server on storage.
- **`CatalogTestBase`**: replaces the `HADOOP` parameter with `INMEMORY` for the broad-coverage tests, and adds a `catalogParametersWithDiskBackedFileIo()` helper for tests that fundamentally need disk semantics.
- **Test opt-outs** (via `catalogParametersWithDiskBackedFileIo`): `TestComputePartitionStatsProcedure`, `TestExpireSnapshotsProcedure`, `TestRemoveOrphanFilesProcedure`, `TestRewriteTablePathProcedure`, `TestSnapshotTableProcedure`, `TestCompressionSettings`, `TestMetadataTableReadableMetrics`. These either assert file existence via `java.io.File`, list directories through Hadoop FileSystem, or open files directly through Hadoop / Iceberg `Files.localInput` (bypassing the table's `FileIO`).
- **`TestDataFrameWriterV2`**: parameterizes the error-message assertion by catalog name (since the parameterized catalog is no longer hard-coded to `testhadoop`).

## Test plan
- [x] `:iceberg-core:test --tests TestInMemoryFileIO` — 14/14 pass (incl. new `tryRename`, `disk-fallback`, and location-preserving coverage).
- [x] `:iceberg-core:test --tests TestInMemoryCatalog` — pass.
- [x] All nine previously-failing extension classes pass locally: `TestAddFilesProcedure`, `TestSnapshotTableProcedure`, `TestMigrateTableProcedure`, `TestExpireSnapshotsProcedure`, `TestComputePartitionStatsProcedure`, `TestRemoveOrphanFilesProcedure`, `TestRewriteTablePathProcedure`, `TestRewriteManifestsProcedure`, `TestRewritePositionDeleteFilesProcedure`, `TestRewriteDataFilesProcedure`.
- [x] Previously-fixed copy-on-write / merge-on-read tests still pass (`TestCopyOnWriteDelete`, `TestCopyOnWriteMerge`, `TestMergeOnReadDelete`).
- [x] `:iceberg-spark:iceberg-spark-extensions-4.1_2.13:test --tests TestSystemFunctionPushDownInRowLevelOperations` — 24/24 pass.
- [x] `:iceberg-spark:iceberg-spark-extensions-4.1_2.13:test --tests TestTempViewRefresh` — 28/28 pass.
- [x] `:iceberg-spark:iceberg-spark-extensions-4.1_2.13:test --tests TestRemoteScanPlanning` — pass.
- [x] `spotlessApply`, core `checkstyle*`, core `revapi` clean.
- [ ] Full CI run on this branch (in progress — see checks).

## Notes
- This PR is currently stacked on top of #16841. Reviewers should review #16841 first; the core diff in this PR will disappear once #16841 lands.
