### PR TITLE
Kafka Connect: make sink cleanup robust

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
@@ -61,20 +61,23 @@ public class IcebergSinkTask extends SinkTask {
   }
 
   private void close() {
-    if (committer != null) {
-      committer.close(List.of());
-      committer = null;
-    }
-
-    if (catalog != null) {
-      if (catalog instanceof AutoCloseable) {
-        try {
-          ((AutoCloseable) catalog).close();
-        } catch (Exception e) {
-          LOG.warn("An error occurred closing catalog instance, ignoring...", e);
-        }
+    try {
+      if (committer != null) {
+        committer.close(List.of());
       }
-      catalog = null;
+    } finally {
+      committer = null;
+
+      if (catalog != null) {
+        if (catalog instanceof AutoCloseable) {
+          try {
+            ((AutoCloseable) catalog).close();
+          } catch (Exception e) {
+            LOG.warn("An error occurred closing catalog instance, ignoring...", e);
+          }
+        }
+        catalog = null;
+      }
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -162,23 +162,28 @@ abstract class Channel {
     try {
       producer.close();
     } catch (RuntimeException e) {
-      failure = e;
+      failure = appendFailure(failure, e);
       LOG.warn("Error closing channel producer", e);
     }
 
     try {
       consumer.close();
     } catch (RuntimeException e) {
-      if (failure != null) {
-        failure.addSuppressed(e);
-      } else {
-        failure = e;
-      }
+      failure = appendFailure(failure, e);
       LOG.warn("Error closing channel consumer", e);
     }
 
     if (failure != null) {
       throw failure;
     }
+  }
+
+  static RuntimeException appendFailure(RuntimeException failure, RuntimeException next) {
+    if (failure == null) {
+      return next;
+    }
+
+    failure.addSuppressed(next);
+    return failure;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -30,7 +30,6 @@ import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -50,7 +49,6 @@ abstract class Channel {
   private final Producer<String, byte[]> producer;
   private final Consumer<String, byte[]> consumer;
   private final SinkTaskContext context;
-  private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
   private final String producerId;
 
@@ -67,7 +65,6 @@ abstract class Channel {
     String transactionalId = config.transactionalPrefix() + name + config.transactionalSuffix();
     this.producer = clientFactory.createProducer(transactionalId);
     this.consumer = clientFactory.createConsumer(consumerGroupId);
-    this.admin = clientFactory.createAdmin();
 
     this.producerId = UUID.randomUUID().toString();
   }
@@ -160,8 +157,28 @@ abstract class Channel {
 
   void stop() {
     LOG.info("Channel stopping");
-    producer.close();
-    consumer.close();
-    admin.close();
+    RuntimeException failure = null;
+
+    try {
+      producer.close();
+    } catch (RuntimeException e) {
+      failure = e;
+      LOG.warn("Error closing channel producer", e);
+    }
+
+    try {
+      consumer.close();
+    } catch (RuntimeException e) {
+      if (failure != null) {
+        failure.addSuppressed(e);
+      } else {
+        failure = e;
+      }
+      LOG.warn("Error closing channel consumer", e);
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -165,7 +165,7 @@ public class CommitterImpl implements Committer {
     try {
       stopWorker();
     } catch (RuntimeException e) {
-      failure = appendFailure(failure, e);
+      failure = Channel.appendFailure(failure, e);
       LOG.warn("Committer {} failed to stop worker, continuing cleanup", taskId, e);
     }
 
@@ -184,7 +184,7 @@ public class CommitterImpl implements Committer {
       try {
         stopCoordinator();
       } catch (RuntimeException e) {
-        failure = appendFailure(failure, e);
+        failure = Channel.appendFailure(failure, e);
         LOG.warn("Committer {} failed to stop coordinator", taskId, e);
       }
       if (failure != null) {
@@ -194,24 +194,24 @@ public class CommitterImpl implements Committer {
     }
 
     // Normal close: if leader partition is lost, stop coordinator.
-    boolean stopCoordinator = false;
+    boolean shouldStopCoordinator = false;
     try {
-      stopCoordinator = hasLeaderPartition(closedPartitions);
+      shouldStopCoordinator = hasLeaderPartition(closedPartitions);
     } catch (RuntimeException e) {
-      failure = appendFailure(failure, e);
-      stopCoordinator = true;
+      failure = Channel.appendFailure(failure, e);
+      shouldStopCoordinator = true;
       LOG.warn(
           "Committer {} could not determine whether leader partition was lost, stopping coordinator",
           taskId,
           e);
     }
 
-    if (stopCoordinator) {
+    if (shouldStopCoordinator) {
       LOG.info("Committer {} lost leader partition. Stopping coordinator.", taskId);
       try {
         stopCoordinator();
       } catch (RuntimeException e) {
-        failure = appendFailure(failure, e);
+        failure = Channel.appendFailure(failure, e);
         LOG.warn("Committer {} failed to stop coordinator", taskId, e);
       }
     }
@@ -221,7 +221,7 @@ public class CommitterImpl implements Committer {
     try {
       KafkaUtils.seekToLastCommittedOffsets(context);
     } catch (RuntimeException e) {
-      failure = appendFailure(failure, e);
+      failure = Channel.appendFailure(failure, e);
       LOG.warn("Committer {} failed to seek to last committed offsets", taskId, e);
     }
 
@@ -280,14 +280,5 @@ public class CommitterImpl implements Committer {
       coordinatorThread.terminate();
       coordinatorThread = null;
     }
-  }
-
-  private RuntimeException appendFailure(RuntimeException failure, RuntimeException next) {
-    if (failure == null) {
-      return next;
-    }
-
-    failure.addSuppressed(next);
-    return failure;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -159,31 +159,75 @@ public class CommitterImpl implements Committer {
 
   @Override
   public void close(Collection<TopicPartition> closedPartitions) {
+    RuntimeException failure = null;
+
     // Always try to stop the worker to avoid duplicates.
-    stopWorker();
+    try {
+      stopWorker();
+    } catch (RuntimeException e) {
+      failure = appendFailure(failure, e);
+      LOG.warn("Committer {} failed to stop worker, continuing cleanup", taskId, e);
+    }
 
     // Defensive: close called without prior initialization (should not happen).
     if (!isInitialized.get()) {
       LOG.warn("Close unexpectedly called on committer {} without partition assignment", taskId);
+      if (failure != null) {
+        throw failure;
+      }
       return;
     }
 
-    // Empty partitions → task was stopped explicitly. Stop coordinator if running.
+    // Empty partitions: task was stopped explicitly. Stop coordinator if running.
     if (closedPartitions.isEmpty()) {
       LOG.info("Committer {} stopped. Closing coordinator.", taskId);
-      stopCoordinator();
+      try {
+        stopCoordinator();
+      } catch (RuntimeException e) {
+        failure = appendFailure(failure, e);
+        LOG.warn("Committer {} failed to stop coordinator", taskId, e);
+      }
+      if (failure != null) {
+        throw failure;
+      }
       return;
     }
 
     // Normal close: if leader partition is lost, stop coordinator.
-    if (hasLeaderPartition(closedPartitions)) {
+    boolean stopCoordinator = false;
+    try {
+      stopCoordinator = hasLeaderPartition(closedPartitions);
+    } catch (RuntimeException e) {
+      failure = appendFailure(failure, e);
+      stopCoordinator = true;
+      LOG.warn(
+          "Committer {} could not determine whether leader partition was lost, stopping coordinator",
+          taskId,
+          e);
+    }
+
+    if (stopCoordinator) {
       LOG.info("Committer {} lost leader partition. Stopping coordinator.", taskId);
-      stopCoordinator();
+      try {
+        stopCoordinator();
+      } catch (RuntimeException e) {
+        failure = appendFailure(failure, e);
+        LOG.warn("Committer {} failed to stop coordinator", taskId, e);
+      }
     }
 
     // Reset offsets to last committed to avoid data loss.
     LOG.info("Seeking to last committed offsets for worker {}.", taskId);
-    KafkaUtils.seekToLastCommittedOffsets(context);
+    try {
+      KafkaUtils.seekToLastCommittedOffsets(context);
+    } catch (RuntimeException e) {
+      failure = appendFailure(failure, e);
+      LOG.warn("Committer {} failed to seek to last committed offsets", taskId, e);
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
   }
 
   @Override
@@ -236,5 +280,14 @@ public class CommitterImpl implements Committer {
       coordinatorThread.terminate();
       coordinatorThread = null;
     }
+  }
+
+  private RuntimeException appendFailure(RuntimeException failure, RuntimeException next) {
+    if (failure == null) {
+      return next;
+    }
+
+    failure.addSuppressed(next);
+    return failure;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -71,7 +71,7 @@ class CoordinatorThread extends Thread {
     try {
       coordinator.terminate();
     } catch (RuntimeException e) {
-      failure = e;
+      failure = Channel.appendFailure(failure, e);
     }
 
     if (Thread.currentThread() != this) {
@@ -80,21 +80,13 @@ class CoordinatorThread extends Thread {
         if (isAlive()) {
           ConnectException timeout =
               new ConnectException("Timed out waiting for coordinator thread shutdown");
-          if (failure != null) {
-            failure.addSuppressed(timeout);
-          } else {
-            failure = timeout;
-          }
+          failure = Channel.appendFailure(failure, timeout);
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         ConnectException interrupted =
             new ConnectException("Interrupted while waiting for coordinator thread shutdown", e);
-        if (failure != null) {
-          failure.addSuppressed(interrupted);
-        } else {
-          failure = interrupted;
-        }
+        failure = Channel.appendFailure(failure, interrupted);
       }
     }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import org.apache.kafka.connect.errors.ConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 class CoordinatorThread extends Thread {
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorThread.class);
   private static final String THREAD_NAME = "iceberg-coord";
+  private static final long TERMINATION_JOIN_TIMEOUT_MS = 60_000L;
 
   private final Coordinator coordinator;
   private volatile boolean terminated;
@@ -64,6 +66,40 @@ class CoordinatorThread extends Thread {
 
   void terminate() {
     this.terminated = true;
-    coordinator.terminate();
+    RuntimeException failure = null;
+
+    try {
+      coordinator.terminate();
+    } catch (RuntimeException e) {
+      failure = e;
+    }
+
+    if (Thread.currentThread() != this) {
+      try {
+        join(TERMINATION_JOIN_TIMEOUT_MS);
+        if (isAlive()) {
+          ConnectException timeout =
+              new ConnectException("Timed out waiting for coordinator thread shutdown");
+          if (failure != null) {
+            failure.addSuppressed(timeout);
+          } else {
+            failure = timeout;
+          }
+        }
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        ConnectException interrupted =
+            new ConnectException("Interrupted while waiting for coordinator thread shutdown", e);
+        if (failure != null) {
+          failure.addSuppressed(interrupted);
+        } else {
+          failure = interrupted;
+        }
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -115,8 +115,27 @@ class Worker extends Channel {
 
   @Override
   void stop() {
-    super.stop();
-    sinkWriter.close();
+    RuntimeException failure = null;
+
+    try {
+      super.stop();
+    } catch (RuntimeException e) {
+      failure = e;
+    }
+
+    try {
+      sinkWriter.close();
+    } catch (RuntimeException e) {
+      if (failure != null) {
+        failure.addSuppressed(e);
+      } else {
+        failure = e;
+      }
+    }
+
+    if (failure != null) {
+      throw failure;
+    }
   }
 
   void save(Collection<SinkRecord> sinkRecords) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -120,17 +120,13 @@ class Worker extends Channel {
     try {
       super.stop();
     } catch (RuntimeException e) {
-      failure = e;
+      failure = Channel.appendFailure(failure, e);
     }
 
     try {
       sinkWriter.close();
     } catch (RuntimeException e) {
-      if (failure != null) {
-        failure.addSuppressed(e);
-      } else {
-        failure = e;
-      }
+      failure = Channel.appendFailure(failure, e);
     }
 
     if (failure != null) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
@@ -32,6 +32,7 @@ import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -40,6 +41,8 @@ import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.connect.errors.ConnectException;
+import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
 
@@ -164,5 +167,51 @@ public class TestCommitterImpl {
     assertThatThrownBy(() -> committer.save(Collections.emptyList()))
         .isInstanceOf(NotRunningException.class)
         .hasMessageContaining("Coordinator unexpectedly terminated");
+  }
+
+  @Test
+  public void testCloseStopsCoordinatorWhenLeaderLookupFails()
+      throws NoSuchFieldException, IllegalAccessException {
+    CommitterImpl committer = new CommitterImpl();
+    setField(committer, "taskId", "demo1-foo-0");
+
+    Field initializedField = CommitterImpl.class.getDeclaredField("isInitialized");
+    initializedField.setAccessible(true);
+    ((AtomicBoolean) initializedField.get(committer)).set(true);
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.connectGroupId()).thenReturn("demo1-foo-iceberg");
+    setField(committer, "config", config);
+
+    KafkaClientFactory clientFactory = mock(KafkaClientFactory.class);
+    when(clientFactory.createAdmin()).thenReturn(mock(Admin.class));
+    setField(committer, "clientFactory", clientFactory);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    setField(committer, "context", context);
+
+    CoordinatorThread coordinatorThread = mock(CoordinatorThread.class);
+    setField(committer, "coordinatorThread", coordinatorThread);
+
+    try (MockedStatic<KafkaUtils> mockKafkaUtils = mockStatic(KafkaUtils.class)) {
+      mockKafkaUtils
+          .when(() -> KafkaUtils.consumerGroupDescription(any(), any()))
+          .thenThrow(new ConnectException("Cannot retrieve members for consumer group"));
+
+      assertThatThrownBy(
+              () -> committer.close(ImmutableList.of(new TopicPartition("demo1-foo", 0))))
+          .isInstanceOf(ConnectException.class)
+          .hasMessageContaining("Cannot retrieve members for consumer group");
+
+      verify(coordinatorThread).terminate();
+      mockKafkaUtils.verify(() -> KafkaUtils.seekToLastCommittedOffsets(context));
+    }
+  }
+
+  private static void setField(Object target, String fieldName, Object value)
+      throws NoSuchFieldException, IllegalAccessException {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
@@ -19,11 +19,14 @@
 package org.apache.iceberg.connect.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 public class TestCoordinatorThread {
@@ -44,5 +47,37 @@ public class TestCoordinatorThread {
 
     verify(coordinator, timeout(1000)).stop();
     assertThat(coordinatorThread.isTerminated()).isTrue();
+  }
+
+  @Test
+  public void testTerminateWaitsForCoordinatorStop() throws Exception {
+    Coordinator coordinator = mock(Coordinator.class);
+    CountDownLatch stopStarted = new CountDownLatch(1);
+    CountDownLatch stopCanFinish = new CountDownLatch(1);
+    doAnswer(
+            invocation -> {
+              stopStarted.countDown();
+              assertThat(stopCanFinish.await(5, TimeUnit.SECONDS)).isTrue();
+              return null;
+            })
+        .when(coordinator)
+        .stop();
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator);
+    coordinatorThread.start();
+
+    verify(coordinator, timeout(1000)).start();
+    verify(coordinator, timeout(1000).atLeast(1)).process();
+
+    Thread terminator = new Thread(coordinatorThread::terminate);
+    terminator.start();
+
+    assertThat(stopStarted.await(1, TimeUnit.SECONDS)).isTrue();
+    assertThat(terminator.isAlive()).isTrue();
+
+    stopCanFinish.countDown();
+    terminator.join(1000);
+
+    assertThat(terminator.isAlive()).isFalse();
+    assertThat(coordinatorThread.isAlive()).isFalse();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Map;
@@ -82,6 +84,7 @@ public class TestWorker extends ChannelTestBase {
 
       Worker worker = new Worker(config, clientFactory, sinkWriter, context);
       worker.start();
+      verify(clientFactory, never()).createAdmin();
 
       // init consumer after subscribe()
       initConsumer();


### PR DESCRIPTION
## Summary

This makes Iceberg Kafka Connect sink cleanup more robust when shutdown happens after an internal Kafka client or coordinator operation has already failed.

The change keeps the original failure visible to Kafka Connect, but it no longer lets that first failure skip the remaining cleanup steps. In particular:

- close the sink catalog even when committer shutdown throws
- close channel producer and consumer independently
- wait for the coordinator thread to finish after termination
- continue coordinator shutdown and offset seek after `CommitterImpl.close(...)` fails while checking leader ownership
- remove an unused `AdminClient` from `Channel`, avoiding one extra internal Kafka client per worker/coordinator channel
- close `Worker` channel resources and `SinkWriter` independently

## Report

We observed a connector deletion path where the REST delete succeeded, but task shutdown then failed in `CommitterImpl.close(...)`:

```text
DELETE /connectors/<connector> HTTP/1.1 204
WorkerSinkTask{id=<connector>-0} After being scheduled for shutdown, task threw an uncaught exception
ConnectException: Cannot retrieve members for consumer group: <connector>-iceberg
  at KafkaUtils.consumerGroupDescription
  at CommitterImpl.hasLeaderPartition
  at CommitterImpl.close
  at IcebergSinkTask.close
Caused by: GroupAuthorizationException
```

After that, the connector was gone from the REST API, but internal Kafka clients using the connector-derived client id continued logging authentication/metadata errors. The practical failure mode is similar to the "zombie coordinator" class of bugs: a shutdown path hits an exception and leaves internal resources alive longer than intended.

## Related Issues And PRs

This is related to, but not identical to, the existing Kafka Connect cleanup reports:

- #16016 reports a zombie coordinator thread after S3 write failures. The common point is that a sink task failure can leave coordinator-side resources operating after the task/catalog lifecycle has moved on. The difference is that this PR covers shutdown triggered by connector/task close, where leader detection fails during `CommitterImpl.close(...)`.
- #16020 proposes joining the coordinator thread after termination and closing the catalog in a `finally` block. This PR includes the same cleanup direction, and also continues cleanup across worker/channel close failures and the `hasLeaderPartition(...)` failure path.
- #16156 addresses a rebalance overlap where the previous coordinator is not fully stopped before another coordinator can start. This PR also makes coordinator shutdown synchronous, but the motivating failure here is connector deletion/task close with authorization failure during leader lookup.
- #12372 fixed no-coordinator/data-loss behavior around incremental cooperative rebalancing. That is why this PR does not silently swallow leader lookup failures: the original error is still propagated after cleanup, so real coordinator-election problems remain visible.
- #12610 discusses better diagnostics when the configured Iceberg connect group does not match the actual Kafka Connect consumer group. This PR does not change that behavior; it only prevents cleanup from being skipped once such a lookup fails.
- #17349 reports a phantom coordinator consumer remaining after a connector is stopped. This PR addresses the same coordinator shutdown race by waiting for `CoordinatorThread` to finish before task shutdown returns.
- #17350 proposes joining the coordinator thread in `CommitterImpl.stopCoordinator()` to fix #17349. This PR applies the same synchronization in `CoordinatorThread.terminate()` and additionally reports timeout and interruption failures.

## Tests

```bash
./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:test \
  --tests 'org.apache.iceberg.connect.channel.TestCommitterImpl' \
  --tests 'org.apache.iceberg.connect.channel.TestCoordinatorThread' \
  --tests 'org.apache.iceberg.connect.channel.TestWorker'

git diff --check
```
