### PR TITLE
Spark: Return session catalog views

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -429,7 +429,7 @@ public class SparkSessionCatalog<
       if (null != asViewCatalog) {
         return asViewCatalog.listViews(namespace);
       } else if (isViewCatalog()) {
-        getSessionCatalog().listViews(namespace);
+        return getSessionCatalog().listViews(namespace);
       }
     } catch (NoSuchNamespaceException e) {
       throw new RuntimeException(e);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -21,7 +21,18 @@ package org.apache.iceberg.spark;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.Collections;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.connector.catalog.FunctionCatalog;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,5 +108,33 @@ public class TestSparkSessionCatalog extends TestBase {
         .isEqualTo("XYZ");
 
     // TODO: fix loading Iceberg built-in functions in SessionCatalog
+  }
+
+  @Test
+  public void listViewsReturnsSessionCatalogViews() throws NoSuchNamespaceException {
+    Identifier viewIdent = Identifier.of(new String[] {"default"}, "session_catalog_list_views");
+    Identifier[] views = new Identifier[] {viewIdent};
+    TableCatalog sessionCatalog =
+        mock(
+            TableCatalog.class,
+            withSettings()
+                .extraInterfaces(
+                    FunctionCatalog.class, SupportsNamespaces.class, ViewCatalog.class));
+    when(((ViewCatalog) sessionCatalog).listViews("default")).thenReturn(views);
+
+    SparkSessionCatalog<?> catalog = new NoViewCatalog<>();
+    catalog.initialize("spark_catalog", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    catalog.setDelegateCatalog(sessionCatalog);
+
+    assertThat(catalog.listViews("default")).containsExactly(viewIdent);
+  }
+
+  private static class NoViewCatalog<
+          T extends TableCatalog & FunctionCatalog & SupportsNamespaces & ViewCatalog>
+      extends SparkSessionCatalog<T> {
+    @Override
+    protected TableCatalog buildSparkCatalog(String name, CaseInsensitiveStringMap options) {
+      return mock(TableCatalog.class);
+    }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -430,7 +430,7 @@ public class SparkSessionCatalog<
       if (null != asViewCatalog) {
         return asViewCatalog.listViews(namespace);
       } else if (isViewCatalog()) {
-        getSessionCatalog().listViews(namespace);
+        return getSessionCatalog().listViews(namespace);
       }
     } catch (NoSuchNamespaceException e) {
       throw new RuntimeException(e);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -21,7 +21,18 @@ package org.apache.iceberg.spark;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.Collections;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.connector.catalog.FunctionCatalog;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,5 +108,33 @@ public class TestSparkSessionCatalog extends TestBase {
         .isEqualTo("XYZ");
 
     // TODO: fix loading Iceberg built-in functions in SessionCatalog
+  }
+
+  @Test
+  public void listViewsReturnsSessionCatalogViews() throws NoSuchNamespaceException {
+    Identifier viewIdent = Identifier.of(new String[] {"default"}, "session_catalog_list_views");
+    Identifier[] views = new Identifier[] {viewIdent};
+    TableCatalog sessionCatalog =
+        mock(
+            TableCatalog.class,
+            withSettings()
+                .extraInterfaces(
+                    FunctionCatalog.class, SupportsNamespaces.class, ViewCatalog.class));
+    when(((ViewCatalog) sessionCatalog).listViews("default")).thenReturn(views);
+
+    SparkSessionCatalog<?> catalog = new NoViewCatalog<>();
+    catalog.initialize("spark_catalog", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    catalog.setDelegateCatalog(sessionCatalog);
+
+    assertThat(catalog.listViews("default")).containsExactly(viewIdent);
+  }
+
+  private static class NoViewCatalog<
+          T extends TableCatalog & FunctionCatalog & SupportsNamespaces & ViewCatalog>
+      extends SparkSessionCatalog<T> {
+    @Override
+    protected TableCatalog buildSparkCatalog(String name, CaseInsensitiveStringMap options) {
+      return mock(TableCatalog.class);
+    }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -430,7 +430,7 @@ public class SparkSessionCatalog<
       if (null != asViewCatalog) {
         return asViewCatalog.listViews(namespace);
       } else if (isViewCatalog()) {
-        getSessionCatalog().listViews(namespace);
+        return getSessionCatalog().listViews(namespace);
       }
     } catch (NoSuchNamespaceException e) {
       throw new RuntimeException(e);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSessionCatalog.java
@@ -21,7 +21,18 @@ package org.apache.iceberg.spark;
 import static org.apache.hadoop.hive.conf.HiveConf.ConfVars.METASTOREURIS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.util.Collections;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
+import org.apache.spark.sql.connector.catalog.FunctionCatalog;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.SupportsNamespaces;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.ViewCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -97,5 +108,33 @@ public class TestSparkSessionCatalog extends TestBase {
         .isEqualTo("XYZ");
 
     // TODO: fix loading Iceberg built-in functions in SessionCatalog
+  }
+
+  @Test
+  public void listViewsReturnsSessionCatalogViews() throws NoSuchNamespaceException {
+    Identifier viewIdent = Identifier.of(new String[] {"default"}, "session_catalog_list_views");
+    Identifier[] views = new Identifier[] {viewIdent};
+    TableCatalog sessionCatalog =
+        mock(
+            TableCatalog.class,
+            withSettings()
+                .extraInterfaces(
+                    FunctionCatalog.class, SupportsNamespaces.class, ViewCatalog.class));
+    when(((ViewCatalog) sessionCatalog).listViews("default")).thenReturn(views);
+
+    SparkSessionCatalog<?> catalog = new NoViewCatalog<>();
+    catalog.initialize("spark_catalog", new CaseInsensitiveStringMap(Collections.emptyMap()));
+    catalog.setDelegateCatalog(sessionCatalog);
+
+    assertThat(catalog.listViews("default")).containsExactly(viewIdent);
+  }
+
+  private static class NoViewCatalog<
+          T extends TableCatalog & FunctionCatalog & SupportsNamespaces & ViewCatalog>
+      extends SparkSessionCatalog<T> {
+    @Override
+    protected TableCatalog buildSparkCatalog(String name, CaseInsensitiveStringMap options) {
+      return mock(TableCatalog.class);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Return delegated session catalog views from `SparkSessionCatalog.listViews` when the wrapped Iceberg catalog does not expose a Spark `ViewCatalog`.
- Apply the fix across Spark 3.5, Spark 4.0, and Spark 4.1.
- Add versioned regression coverage for the delegated session-catalog `listViews` path.

## Root Cause

`SparkSessionCatalog.listViews` called `getSessionCatalog().listViews(namespace)` in the `isViewCatalog()` branch but did not return the delegated result, so it fell through to an empty identifier array.

## Testing

- `./gradlew -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5_2.12:test --tests org.apache.iceberg.spark.TestSparkSessionCatalog.listViewsReturnsSessionCatalogViews`
- `./gradlew -DsparkVersions=4.0 :iceberg-spark:iceberg-spark-4.0_2.13:test --tests org.apache.iceberg.spark.TestSparkSessionCatalog.listViewsReturnsSessionCatalogViews`
- `./gradlew -DsparkVersions=4.1 :iceberg-spark:iceberg-spark-4.1_2.13:test --tests org.apache.iceberg.spark.TestSparkSessionCatalog.listViewsReturnsSessionCatalogViews`
