### PR TITLE
Spark: Fail fast when metadata file location is null in BaseSparkAction

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -53,8 +53,8 @@ import org.apache.iceberg.io.ClosingIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
-import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
@@ -137,8 +137,8 @@ abstract class BaseSparkAction<ThisT> {
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
     Preconditions.checkArgument(
-            metadata.metadataFileLocation() != null,
-            "Cannot create static table: metadata file location is null");
+        metadata.metadataFileLocation() != null,
+        "Cannot create static table: metadata file location is null");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
     return new BaseTable(ops, metadata.metadataFileLocation());
   }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -136,8 +136,8 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
-    Preconditions.checkArgument(
-        metadata.metadataFileLocation() != null,
+    Preconditions.checkNotNull(
+        metadata.metadataFileLocation(),
         "Cannot create static table: metadata file location is null");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
     return new BaseTable(ops, metadata.metadataFileLocation());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -54,6 +54,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Splitter;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.ListMultimap;
@@ -135,6 +136,9 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
+    Preconditions.checkArgument(
+            metadata.metadataFileLocation() != null,
+            "Cannot create static table: metadata file location is null");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
     return new BaseTable(ops, metadata.metadataFileLocation());
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
@@ -1,0 +1,92 @@
+/*
+ *
+ *  * Licensed to the Apache Software Foundation (ASF) under one
+ *  * or more contributor license agreements.  See the NOTICE file
+ *  * distributed with this work for additional information
+ *  * regarding copyright ownership.  The ASF licenses this file
+ *  * to you under the Apache License, Version 2.0 (the
+ *  * "License"); you may not use this file except in compliance
+ *  * with the License.  You may obtain a copy of the License at
+ *  *
+ *  *   http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing,
+ *  * software distributed under the License is distributed on an
+ *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  * KIND, either express or implied.  See the License for the
+ *  * specific language governing permissions and limitations
+ *  * under the License.
+ *
+ */
+
+package org.apache.iceberg.spark.actions;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.spark.TestBase;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestBaseSparkAction extends TestBase {
+    private static final HadoopTables TABLES = new HadoopTables();
+
+    private static final Schema SCHEMA =
+            new Schema(required(1, "id", Types.LongType.get()));
+
+    @TempDir private Path temp;
+
+    @Test
+    public void testNewStaticTableFailsWhenMetadataLocationIsNull() throws IOException {
+        File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
+        assertThat(tableLocation.delete()).isTrue();
+
+        Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), tableLocation.toString());
+        TableOperations ops = ((HasTableOperations) table).operations();
+        TableMetadata metadata = spy(ops.current());
+        assertThat(metadata.metadataFileLocation()).isNotNull();
+
+        doReturn(null).when(metadata).metadataFileLocation();
+        assertThat(metadata.metadataFileLocation()).isNull();
+
+        TestAction action = new TestAction();
+        assertThatThrownBy(() -> action.callNewStaticTable(metadata, table.io()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("metadata file location is null");
+    }
+
+    private static class TestAction extends BaseSparkAction<TestAction> {
+        TestAction() {
+            super(spark);
+        }
+
+        Table callNewStaticTable(TableMetadata metadata, FileIO io) {
+            return newStaticTable(metadata, io);
+        }
+
+        @Override
+        protected TestAction self() {
+            return null;
+        }
+    }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
@@ -35,7 +35,6 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.hadoop.HadoopTables;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -62,8 +61,8 @@ class TestBaseSparkAction extends TestBase {
     assertThat(metadata.metadataFileLocation()).isNull();
 
     TestAction action = new TestAction();
-    assertThatThrownBy(() -> action.callNewStaticTable(metadata, table.io()))
-        .isInstanceOf(IllegalArgumentException.class)
+    assertThatThrownBy(() -> action.newStaticTable(metadata, table.io()))
+        .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("metadata file location is null");
   }
 
@@ -72,13 +71,9 @@ class TestBaseSparkAction extends TestBase {
       super(spark);
     }
 
-    Table callNewStaticTable(TableMetadata metadata, FileIO io) {
-      return newStaticTable(metadata, io);
-    }
-
     @Override
     protected TestAction self() {
-      return null;
+      return this;
     }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
@@ -1,30 +1,25 @@
 /*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
  *
- *  * Licensed to the Apache Software Foundation (ASF) under one
- *  * or more contributor license agreements.  See the NOTICE file
- *  * distributed with this work for additional information
- *  * regarding copyright ownership.  The ASF licenses this file
- *  * to you under the Apache License, Version 2.0 (the
- *  * "License"); you may not use this file except in compliance
- *  * with the License.  You may obtain a copy of the License at
- *  *
- *  *   http://www.apache.org/licenses/LICENSE-2.0
- *  *
- *  * Unless required by applicable law or agreed to in writing,
- *  * software distributed under the License is distributed on an
- *  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- *  * KIND, either express or implied.  See the License for the
- *  * specific language governing permissions and limitations
- *  * under the License.
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
-
 package org.apache.iceberg.spark.actions;
 
 import static org.apache.iceberg.types.Types.NestedField.required;
-
 import static org.assertj.core.api.Assertions.assertThat;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
@@ -33,7 +28,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -42,51 +36,49 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.spark.TestBase;
-
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
 public class TestBaseSparkAction extends TestBase {
-    private static final HadoopTables TABLES = new HadoopTables();
+  private static final HadoopTables TABLES = new HadoopTables();
 
-    private static final Schema SCHEMA =
-            new Schema(required(1, "id", Types.LongType.get()));
+  private static final Schema SCHEMA = new Schema(required(1, "id", Types.LongType.get()));
 
-    @TempDir private Path temp;
+  @TempDir private Path temp;
 
-    @Test
-    public void testNewStaticTableFailsWhenMetadataLocationIsNull() throws IOException {
-        File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
-        assertThat(tableLocation.delete()).isTrue();
+  @Test
+  public void testNewStaticTableFailsWhenMetadataLocationIsNull() throws IOException {
+    File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
+    assertThat(tableLocation.delete()).isTrue();
 
-        Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), tableLocation.toString());
-        TableOperations ops = ((HasTableOperations) table).operations();
-        TableMetadata metadata = spy(ops.current());
-        assertThat(metadata.metadataFileLocation()).isNotNull();
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), tableLocation.toString());
+    TableOperations ops = ((HasTableOperations) table).operations();
+    TableMetadata metadata = spy(ops.current());
+    assertThat(metadata.metadataFileLocation()).isNotNull();
 
-        doReturn(null).when(metadata).metadataFileLocation();
-        assertThat(metadata.metadataFileLocation()).isNull();
+    doReturn(null).when(metadata).metadataFileLocation();
+    assertThat(metadata.metadataFileLocation()).isNull();
 
-        TestAction action = new TestAction();
-        assertThatThrownBy(() -> action.callNewStaticTable(metadata, table.io()))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("metadata file location is null");
+    TestAction action = new TestAction();
+    assertThatThrownBy(() -> action.callNewStaticTable(metadata, table.io()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("metadata file location is null");
+  }
+
+  private static class TestAction extends BaseSparkAction<TestAction> {
+    TestAction() {
+      super(spark);
     }
 
-    private static class TestAction extends BaseSparkAction<TestAction> {
-        TestAction() {
-            super(spark);
-        }
-
-        Table callNewStaticTable(TableMetadata metadata, FileIO io) {
-            return newStaticTable(metadata, io);
-        }
-
-        @Override
-        protected TestAction self() {
-            return null;
-        }
+    Table callNewStaticTable(TableMetadata metadata, FileIO io) {
+      return newStaticTable(metadata, io);
     }
+
+    @Override
+    protected TestAction self() {
+      return null;
+    }
+  }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestBaseSparkAction.java
@@ -41,7 +41,7 @@ import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
-public class TestBaseSparkAction extends TestBase {
+class TestBaseSparkAction extends TestBase {
   private static final HadoopTables TABLES = new HadoopTables();
 
   private static final Schema SCHEMA = new Schema(required(1, "id", Types.LongType.get()));
@@ -49,7 +49,7 @@ public class TestBaseSparkAction extends TestBase {
   @TempDir private Path temp;
 
   @Test
-  public void testNewStaticTableFailsWhenMetadataLocationIsNull() throws IOException {
+  void rejectsNullMetadataLocation() throws IOException {
     File tableLocation = Files.createTempDirectory(temp, "junit").toFile();
     assertThat(tableLocation.delete()).isTrue();
 


### PR DESCRIPTION
## What changes are proposed in this pull request?

This PR adds a fail-fast validation in `BaseSparkAction.newStaticTable()` to ensure that `TableMetadata.metadataFileLocation()` is not null before constructing a `BaseTable`.

Currently, if the metadata file location is null, the Spark action proceeds further into execution and eventually fails with a `NullPointerException`, making the actual root cause difficult to diagnose.

The new validation makes this precondition explicit and produces a more meaningful error message.

## Why are the changes needed?

This improves diagnostics for invalid `TableMetadata` instances and prevents failures from surfacing much later during Spark job execution.

The intent is not to support invalid catalog implementations, but to fail earlier with a clearer message when the required precondition is violated.

## Does this PR introduce any user-facing change?

No.

## How was this patch tested?

Added a unit test covering the case where `metadataFileLocation()` is null and verified that `newStaticTable()` fails with an explicit exception.

## AI assistance disclosure:
I used AI assistance while drafting the PR description and exploring possible test implementations. The final implementation and testing were reviewed and verified manually.

Closes #16838