### PR TITLE
Core: Make InMemoryLockManager heartbeat map thread-safe

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -179,10 +179,15 @@ public class LockManagers {
     private static final Logger LOG = LoggerFactory.getLogger(InMemoryLockManager.class);
 
     private static final Map<String, InMemoryLockContent> LOCKS = Maps.newConcurrentMap();
-    private static final Map<String, ScheduledFuture<?>> HEARTBEATS = Maps.newHashMap();
+    private static final Map<String, ScheduledFuture<?>> HEARTBEATS = Maps.newConcurrentMap();
 
     InMemoryLockManager(Map<String, String> properties) {
       initialize(properties);
+    }
+
+    @VisibleForTesting
+    static int heartbeatCount() {
+      return HEARTBEATS.size();
     }
 
     @VisibleForTesting
@@ -206,9 +211,10 @@ public class LockManagers {
       }
 
       if (succeed) {
-        // cleanup old heartbeat
-        if (HEARTBEATS.containsKey(entityId)) {
-          HEARTBEATS.remove(entityId).cancel(false);
+        // cleanup old heartbeat, using an atomic remove to avoid a check-then-act race
+        ScheduledFuture<?> previousHeartbeat = HEARTBEATS.remove(entityId);
+        if (previousHeartbeat != null) {
+          previousHeartbeat.cancel(false);
         }
 
         HEARTBEATS.put(

--- a/core/src/main/java/org/apache/iceberg/util/LockManagers.java
+++ b/core/src/main/java/org/apache/iceberg/util/LockManagers.java
@@ -191,6 +191,11 @@ public class LockManagers {
     }
 
     @VisibleForTesting
+    static ScheduledFuture<?> heartbeat(String entityId) {
+      return HEARTBEATS.get(entityId);
+    }
+
+    @VisibleForTesting
     void acquireOnce(String entityId, String ownerId) {
       InMemoryLockContent content = LOCKS.get(entityId);
       if (content != null && content.expireMs() > System.currentTimeMillis()) {

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -330,6 +330,8 @@ public class TestInMemoryLockManager {
         .as("a fresh heartbeat should replace the orphaned one")
         .isNotNull()
         .isNotSameAs(orphaned);
-    assertThat(LockManagers.InMemoryLockManager.heartbeatCount()).isOne();
+    assertThat(LockManagers.InMemoryLockManager.heartbeatCount())
+        .as("exactly one heartbeat should remain after takeover")
+        .isOne();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -24,10 +24,16 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -174,5 +180,119 @@ public class TestInMemoryLockManager {
     assertThat(results.stream().filter(s -> s).count())
         .as("only 1 thread should have acquired the lock")
         .isOne();
+  }
+
+  @Test
+  @Timeout(value = 30)
+  public void testConcurrentAcquireReleaseDistinctEntities()
+      throws InterruptedException, ExecutionException {
+    // Each thread locks its own entity, so every acquire succeeds and the threads contend only on
+    // the shared, static heartbeat map. A CyclicBarrier starts them together and the storm repeats
+    // over many rounds to widen the race window, so a non-thread-safe map that loses a put/remove
+    // (or spins in a resize loop) is caught by the per-round heartbeatCount() assertion below.
+    int threadCount = 16;
+    int iterationsPerThread = 50;
+    int rounds = 50;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      for (int round = 0; round < rounds; round++) {
+        CyclicBarrier startGate = new CyclicBarrier(threadCount);
+        List<Future<Boolean>> futures =
+            IntStream.range(0, threadCount)
+                .mapToObj(
+                    i ->
+                        executor.submit(
+                            () -> {
+                              String entityId = UUID.randomUUID().toString();
+                              String owner = UUID.randomUUID().toString();
+                              startGate.await();
+                              for (int j = 0; j < iterationsPerThread; j++) {
+                                if (!lockManager.acquire(entityId, owner)
+                                    || !lockManager.release(entityId, owner)) {
+                                  return false;
+                                }
+                              }
+                              return true;
+                            }))
+                .collect(Collectors.toList());
+
+        List<Boolean> results = Lists.newArrayList();
+        for (Future<Boolean> future : futures) {
+          results.add(future.get());
+        }
+
+        assertThat(results)
+            .as("every thread should acquire and release its own lock without interference")
+            .hasSize(threadCount)
+            .containsOnly(true);
+
+        // Every entity ends its loop with a release, which atomically removes its heartbeat. The
+        // thread-safe map is therefore empty after each round; a non-thread-safe map could leave a
+        // stale or lost entry that surfaces here as a non-empty map.
+        assertThat(LockManagers.InMemoryLockManager.heartbeatCount())
+            .as("all heartbeats should be removed after round %d", round)
+            .isZero();
+      }
+    } finally {
+      executor.shutdownNow();
+    }
+  }
+
+  @Test
+  @Timeout(value = 30)
+  public void testConcurrentAcquireReleaseSharedEntity()
+      throws InterruptedException, ExecutionException {
+    // All threads contend on the SAME entity, so the lock serializes acquires: only the winner
+    // runs the acquireOnce cleanup (HEARTBEATS.remove + put) while the others retry. This stresses
+    // the heartbeat bookkeeping over serialized acquire/release cycles, not concurrently on a key.
+    // Since the map is keyed by entityId it holds at most one entry, so the in-flight check below
+    // guards against a leaked heartbeat rather than testing atomicity.
+    lockManager.initialize(
+        ImmutableMap.of(
+            CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, "10",
+            CatalogProperties.LOCK_ACQUIRE_TIMEOUT_MS, "25000",
+            CatalogProperties.LOCK_HEARTBEAT_INTERVAL_MS, "100"));
+    int threadCount = 16;
+    int iterationsPerThread = 50;
+    String entityId = UUID.randomUUID().toString();
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    try {
+      CyclicBarrier startGate = new CyclicBarrier(threadCount);
+      List<Future<Integer>> futures =
+          IntStream.range(0, threadCount)
+              .mapToObj(
+                  i ->
+                      executor.submit(
+                          () -> {
+                            String owner = UUID.randomUUID().toString();
+                            startGate.await();
+                            int successes = 0;
+                            for (int j = 0; j < iterationsPerThread; j++) {
+                              assertThat(lockManager.acquire(entityId, owner))
+                                  .as("acquire should succeed under contention")
+                                  .isTrue();
+                              // a single shared entity is backed by at most one heartbeat
+                              assertThat(LockManagers.InMemoryLockManager.heartbeatCount())
+                                  .as("a held lock has at most one heartbeat")
+                                  .isLessThanOrEqualTo(1);
+                              assertThat(lockManager.release(entityId, owner)).isTrue();
+                              successes++;
+                            }
+                            return successes;
+                          }))
+              .collect(Collectors.toList());
+
+      for (Future<Integer> future : futures) {
+        assertThat(future.get())
+            .as("every thread should run all acquire/release cycles")
+            .isEqualTo(iterationsPerThread);
+      }
+
+      assertThat(LockManagers.InMemoryLockManager.heartbeatCount())
+          .as("no heartbeat should remain after the shared entity is fully released")
+          .isZero();
+    } finally {
+      executor.shutdownNow();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestInMemoryLockManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledFuture;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.iceberg.CatalogProperties;
@@ -294,5 +295,41 @@ public class TestInMemoryLockManager {
     } finally {
       executor.shutdownNow();
     }
+  }
+
+  @Test
+  @Timeout(value = 30)
+  public void testAcquireCancelsOrphanedHeartbeatOnTakeover() {
+    // A holder that never releases leaves its heartbeat tracked in HEARTBEATS. Once the lock
+    // expires, another owner can take it over, and acquireOnce must cancel the stale heartbeat and
+    // replace it. This is the only path that reaches the non-null branch of the cleanup, since
+    // release() always removes the heartbeat first.
+    lockManager.initialize(
+        ImmutableMap.of(
+            CatalogProperties.LOCK_HEARTBEAT_TIMEOUT_MS, "10",
+            CatalogProperties.LOCK_HEARTBEAT_INTERVAL_MS, "60000",
+            CatalogProperties.LOCK_ACQUIRE_INTERVAL_MS, "10",
+            CatalogProperties.LOCK_ACQUIRE_TIMEOUT_MS, "10000"));
+
+    // Acquire without releasing so the heartbeat is left behind; the long heartbeat interval means
+    // the lock is renewed once and then expires for good.
+    lockManager.acquireOnce(lockEntityId, ownerId);
+    ScheduledFuture<?> orphaned = LockManagers.InMemoryLockManager.heartbeat(lockEntityId);
+    assertThat((Object) orphaned).as("the first acquire should track a heartbeat").isNotNull();
+
+    // acquire() retries until the lock expires, then a new owner takes it over.
+    String newOwner = UUID.randomUUID().toString();
+    assertThat(lockManager.acquire(lockEntityId, newOwner))
+        .as("takeover of an expired lock should succeed")
+        .isTrue();
+
+    assertThat(orphaned.isCancelled())
+        .as("the orphaned heartbeat should be cancelled on takeover")
+        .isTrue();
+    assertThat((Object) LockManagers.InMemoryLockManager.heartbeat(lockEntityId))
+        .as("a fresh heartbeat should replace the orphaned one")
+        .isNotNull()
+        .isNotSameAs(orphaned);
+    assertThat(LockManagers.InMemoryLockManager.heartbeatCount()).isOne();
   }
 }


### PR DESCRIPTION
`InMemoryLockManager.HEARTBEATS` is a static map shared by every lock manager in the JVM and is written whenever a lock is acquired or released. The sibling `LOCKS` map is already a `ConcurrentMap`, but `HEARTBEATS` was left as a plain `HashMap`, so threads acquiring or releasing locks on different entities mutate it without synchronization. That can corrupt the map and leak the scheduled heartbeat futures it tracks.

This makes `HEARTBEATS` a `ConcurrentMap` and replaces the non-atomic `containsKey`/`remove` cleanup in `acquireOnce` with a single atomic `remove`.

Tests:
- distinct entities: many rounds of concurrent acquire/release across separate keys, asserting no heartbeat is left behind;
- shared entity: 16 threads contend on one key, asserting at most one heartbeat while it is held and none after release;
- takeover: a lock whose holder never releases is re-acquired by a new owner once it expires, asserting the stale heartbeat is cancelled and replaced. This is the only path that reaches the non-null cleanup branch the change touches.
