### PR TITLE
Spark 4.1: Map geo Spark types

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -37,6 +37,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType$;
+import org.apache.spark.sql.types.EdgeInterpolationAlgorithm;
 import org.apache.spark.sql.types.FloatType$;
 import org.apache.spark.sql.types.GeographyType;
 import org.apache.spark.sql.types.GeometryType;
@@ -225,6 +226,33 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
             "Cannot project decimal with incompatible precision: %s < %s",
             requestedDecimal.precision(),
             decimal.precision());
+        break;
+      case GEOMETRY:
+        Types.GeometryType geometry = (Types.GeometryType) primitive;
+        GeometryType requestedGeometry = (GeometryType) current;
+        Preconditions.checkArgument(
+            geometry.crs().equalsIgnoreCase(requestedGeometry.crs()),
+            "Cannot project geometry with incompatible CRS: %s != %s",
+            requestedGeometry.crs(),
+            geometry.crs());
+        break;
+      case GEOGRAPHY:
+        Types.GeographyType geography = (Types.GeographyType) primitive;
+        GeographyType requestedGeography = (GeographyType) current;
+        Preconditions.checkArgument(
+            geography.crs().equalsIgnoreCase(requestedGeography.crs()),
+            "Cannot project geography with incompatible CRS: %s != %s",
+            requestedGeography.crs(),
+            geography.crs());
+        // algorithm() is EdgeAlgorithm on Iceberg and EdgeInterpolationAlgorithm on Spark, so
+        // translate the table's algorithm into Spark's type and compare within one type system.
+        EdgeInterpolationAlgorithm tableAlgorithm =
+            TypeToSparkType.convertAlgorithm(geography.algorithm());
+        Preconditions.checkArgument(
+            tableAlgorithm == requestedGeography.algorithm(),
+            "Cannot project geography with incompatible edge algorithm: %s != %s",
+            requestedGeography.algorithm(),
+            tableAlgorithm);
         break;
       default:
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/PruneColumnsWithoutReordering.java
@@ -38,6 +38,8 @@ import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType$;
 import org.apache.spark.sql.types.FloatType$;
+import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType;
@@ -244,6 +246,8 @@ public class PruneColumnsWithoutReordering extends TypeUtil.CustomOrderSchemaVis
           .put(TypeID.STRING, ImmutableSet.of(StringType$.class))
           .put(TypeID.FIXED, ImmutableSet.of(BinaryType$.class))
           .put(TypeID.BINARY, ImmutableSet.of(BinaryType$.class))
+          .put(TypeID.GEOMETRY, ImmutableSet.of(GeometryType.class))
+          .put(TypeID.GEOGRAPHY, ImmutableSet.of(GeographyType.class))
           .put(TypeID.UNKNOWN, ImmutableSet.of(NullType$.class))
           .buildOrThrow();
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -167,6 +167,9 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
     } else if (atomic instanceof GeometryType) {
       return Types.GeometryType.of(((GeometryType) atomic).crs());
     } else if (atomic instanceof GeographyType) {
+      // Spark only supports the spherical edge-interpolation algorithm, which matches the Iceberg
+      // default, so the Spark algorithm is intentionally not propagated here. Revisit if Spark
+      // starts supporting additional algorithms.
       return Types.GeographyType.of(((GeographyType) atomic).crs());
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -188,7 +188,7 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
     throw new UnsupportedOperationException("Not a supported type: " + atomic.catalogString());
   }
 
-  // Translates Spark's edge-interpolation algorithm to Iceberg's, mirroring the forward direction in
+  // Translates Spark's edge-interpolation algorithm to Iceberg's, mirroring
   // TypeToSparkType#convertAlgorithm. Spark supports only the spherical algorithm today; anything
   // else is rejected loudly rather than silently defaulting, so a new Spark algorithm surfaces here
   // instead of being dropped.

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -165,12 +165,22 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
     } else if (atomic instanceof BinaryType) {
       return Types.BinaryType.get();
     } else if (atomic instanceof GeometryType) {
-      return Types.GeometryType.of(((GeometryType) atomic).crs());
+      GeometryType geometry = (GeometryType) atomic;
+      if (geometry.isMixedSrid()) {
+        throw new UnsupportedOperationException(
+            "Cannot convert Spark geometry with mixed SRID to Iceberg");
+      }
+      return Types.GeometryType.of(geometry.crs());
     } else if (atomic instanceof GeographyType) {
+      GeographyType geography = (GeographyType) atomic;
+      if (geography.isMixedSrid()) {
+        throw new UnsupportedOperationException(
+            "Cannot convert Spark geography with mixed SRID to Iceberg");
+      }
       // Spark only supports the spherical edge-interpolation algorithm, which matches the Iceberg
       // default, so the Spark algorithm is intentionally not propagated here. Revisit if Spark
       // starts supporting additional algorithms.
-      return Types.GeographyType.of(((GeographyType) atomic).crs());
+      return Types.GeographyType.of(geography.crs());
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -32,6 +32,8 @@ import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
@@ -162,6 +164,10 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
           ((DecimalType) atomic).precision(), ((DecimalType) atomic).scale());
     } else if (atomic instanceof BinaryType) {
       return Types.BinaryType.get();
+    } else if (atomic instanceof GeometryType) {
+      return Types.GeometryType.of(((GeometryType) atomic).crs());
+    } else if (atomic instanceof GeographyType) {
+      return Types.GeographyType.of(((GeographyType) atomic).crs());
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark;
 
 import java.util.List;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.types.ArrayType;
@@ -177,10 +178,10 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
         throw new UnsupportedOperationException(
             "Cannot convert Spark geography with mixed SRID to Iceberg");
       }
-      // Spark only supports the spherical edge-interpolation algorithm, which matches the Iceberg
-      // default, so the Spark algorithm is intentionally not propagated here. Revisit if Spark
-      // starts supporting additional algorithms.
-      return Types.GeographyType.of(geography.crs());
+      // Propagate the edge algorithm, translating by name since Iceberg and Spark share algorithm
+      // names.
+      return Types.GeographyType.of(
+          geography.crs(), EdgeAlgorithm.fromName(geography.algorithm().toString()));
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTypeToType.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
+import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
@@ -32,6 +33,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType;
+import org.apache.spark.sql.types.EdgeInterpolationAlgorithm;
 import org.apache.spark.sql.types.FloatType;
 import org.apache.spark.sql.types.GeographyType;
 import org.apache.spark.sql.types.GeometryType;
@@ -178,14 +180,25 @@ class SparkTypeToType extends SparkTypeVisitor<Type> {
         throw new UnsupportedOperationException(
             "Cannot convert Spark geography with mixed SRID to Iceberg");
       }
-      // Propagate the edge algorithm, translating by name since Iceberg and Spark share algorithm
-      // names.
-      return Types.GeographyType.of(
-          geography.crs(), EdgeAlgorithm.fromName(geography.algorithm().toString()));
+      return Types.GeographyType.of(geography.crs(), convertAlgorithm(geography.algorithm()));
     } else if (atomic instanceof NullType) {
       return Types.UnknownType.get();
     }
 
     throw new UnsupportedOperationException("Not a supported type: " + atomic.catalogString());
+  }
+
+  // Translates Spark's edge-interpolation algorithm to Iceberg's, mirroring the forward direction in
+  // TypeToSparkType#convertAlgorithm. Spark supports only the spherical algorithm today; anything
+  // else is rejected loudly rather than silently defaulting, so a new Spark algorithm surfaces here
+  // instead of being dropped.
+  private static EdgeAlgorithm convertAlgorithm(EdgeInterpolationAlgorithm algorithm) {
+    switch (algorithm.toString().toUpperCase(Locale.ROOT)) {
+      case "SPHERICAL":
+        return EdgeAlgorithm.SPHERICAL;
+      default:
+        throw new UnsupportedOperationException(
+            "Iceberg does not support Spark geography edge algorithm: " + algorithm);
+    }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -60,9 +60,16 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
   public static final String METADATA_COL_ATTR_KEY = "__metadata_col";
 
   // Spark's only edge-interpolation algorithm. Spark exposes no Java-accessible constant for it, so
-  // it is resolved once by name through the companion's case-insensitive parser.
+  // it is resolved once by name through the companion's case-insensitive parser. If Spark ever
+  // renames this value the lookup fails fast at class-load time with a clear message.
   private static final EdgeInterpolationAlgorithm SPARK_SPHERICAL =
-      EdgeInterpolationAlgorithm$.MODULE$.fromString("SPHERICAL").get();
+      EdgeInterpolationAlgorithm$.MODULE$
+          .fromString("SPHERICAL")
+          .getOrElse(
+              () -> {
+                throw new IllegalStateException(
+                    "Spark EdgeInterpolationAlgorithm SPHERICAL not found");
+              });
 
   @Override
   public DataType schema(Schema schema, DataType structType) {
@@ -199,8 +206,9 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
   }
 
   // Translates Iceberg's edge-interpolation algorithm to Spark's. Spark supports only the spherical
-  // algorithm (the Iceberg default); every other algorithm is rejected with a clear error.
-  private static EdgeInterpolationAlgorithm convertAlgorithm(EdgeAlgorithm algorithm) {
+  // algorithm (the Iceberg default); every other algorithm is rejected with a clear error. Shared
+  // with PruneColumnsWithoutReordering, which compares algorithms across the two type systems.
+  static EdgeInterpolationAlgorithm convertAlgorithm(EdgeAlgorithm algorithm) {
     switch (algorithm) {
       case SPHERICAL:
         return SPARK_SPHERICAL;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
-import java.util.function.Supplier;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -27,7 +26,6 @@ import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.spark.SparkIllegalArgumentException;
 import org.apache.spark.sql.catalyst.expressions.Literal$;
 import org.apache.spark.sql.types.ArrayType$;
 import org.apache.spark.sql.types.BinaryType$;
@@ -37,7 +35,7 @@ import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType$;
 import org.apache.spark.sql.types.DoubleType$;
 import org.apache.spark.sql.types.EdgeInterpolationAlgorithm;
-import org.apache.spark.sql.types.EdgeInterpolationAlgorithm$;
+import org.apache.spark.sql.types.EdgeInterpolationAlgorithm.SPHERICAL$;
 import org.apache.spark.sql.types.FloatType$;
 import org.apache.spark.sql.types.GeographyType$;
 import org.apache.spark.sql.types.GeometryType$;
@@ -59,17 +57,8 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
 
   public static final String METADATA_COL_ATTR_KEY = "__metadata_col";
 
-  // Spark's only edge-interpolation algorithm. Spark exposes no Java-accessible constant for it, so
-  // it is resolved once by name through the companion's case-insensitive parser. If Spark ever
-  // renames this value the lookup fails fast at class-load time with a clear message.
-  private static final EdgeInterpolationAlgorithm SPARK_SPHERICAL =
-      EdgeInterpolationAlgorithm$.MODULE$
-          .fromString("SPHERICAL")
-          .getOrElse(
-              () -> {
-                throw new IllegalStateException(
-                    "Spark EdgeInterpolationAlgorithm SPHERICAL not found");
-              });
+  // Spark's only edge-interpolation algorithm.
+  private static final EdgeInterpolationAlgorithm SPARK_SPHERICAL = SPHERICAL$.MODULE$;
 
   @Override
   public DataType schema(Schema schema, DataType structType) {
@@ -181,28 +170,15 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
 
   private DataType geometryType(Types.GeometryType geometry) {
     // The spec lets a geometry CRS be any string identifying a CRS, but Spark recognizes only a
-    // fixed set; a CRS Spark cannot resolve becomes a clear unsupported-CRS error below.
-    String crs = geometry.crs();
-    return convertAndValidate("geometry", crs, () -> GeometryType$.MODULE$.apply(crs));
+    // fixed set; a CRS Spark cannot resolve throws SparkIllegalArgumentException (an
+    // IllegalArgumentException).
+    return GeometryType$.MODULE$.apply(geometry.crs());
   }
 
   private DataType geographyType(Types.GeographyType geography) {
     // The spec requires a geography CRS to be geographic; Spark recognizes only OGC:CRS84, so any
-    // other CRS becomes a clear unsupported-CRS error below.
-    EdgeInterpolationAlgorithm algorithm = convertAlgorithm(geography.algorithm());
-    String crs = geography.crs();
-    return convertAndValidate("geography", crs, () -> GeographyType$.MODULE$.apply(crs, algorithm));
-  }
-
-  // Builds a Spark geo type, translating Spark's opaque ST_INVALID_CRS_VALUE for an unrecognized
-  // CRS into a clear Iceberg error.
-  private static DataType convertAndValidate(
-      String kind, String crs, Supplier<DataType> conversion) {
-    try {
-      return conversion.get();
-    } catch (SparkIllegalArgumentException e) {
-      throw new UnsupportedOperationException("Spark does not support " + kind + " CRS: " + crs, e);
-    }
+    // other CRS throws SparkIllegalArgumentException (an IllegalArgumentException).
+    return GeographyType$.MODULE$.apply(geography.crs(), convertAlgorithm(geography.algorithm()));
   }
 
   // Translates Iceberg's edge-interpolation algorithm to Spark's. Spark supports only the spherical

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.spark.SparkIllegalArgumentException;
 import org.apache.spark.sql.catalyst.expressions.Literal$;
 import org.apache.spark.sql.types.ArrayType$;
 import org.apache.spark.sql.types.BinaryType$;
@@ -150,14 +151,14 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
         return BinaryType$.MODULE$;
       case GEOMETRY:
         Types.GeometryType geometry = (Types.GeometryType) primitive;
-        return GeometryType$.MODULE$.apply(geometry.crs());
+        return geometryType(geometry.crs());
       case GEOGRAPHY:
         Types.GeographyType geography = (Types.GeographyType) primitive;
         if (geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
           throw new UnsupportedOperationException(
               "Spark does not support geography edge algorithm: " + geography.algorithm());
         }
-        return GeographyType$.MODULE$.apply(geography.crs());
+        return geographyType(geography.crs());
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());
@@ -166,6 +167,24 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unsupported type to Spark: " + primitive);
+    }
+  }
+
+  private DataType geometryType(String crs) {
+    // Iceberg allows any non-empty CRS, but Spark only recognizes a fixed set and throws an opaque
+    // ST_INVALID_CRS_VALUE for the rest; surface it as a clear unsupported-CRS error instead.
+    try {
+      return GeometryType$.MODULE$.apply(crs);
+    } catch (SparkIllegalArgumentException e) {
+      throw new UnsupportedOperationException("Spark does not support geometry CRS: " + crs, e);
+    }
+  }
+
+  private DataType geographyType(String crs) {
+    try {
+      return GeographyType$.MODULE$.apply(crs);
+    } catch (SparkIllegalArgumentException e) {
+      throw new UnsupportedOperationException("Spark does not support geography CRS: " + crs, e);
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -22,6 +22,7 @@ import java.util.List;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
@@ -152,6 +153,10 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
         return GeometryType$.MODULE$.apply(geometry.crs());
       case GEOGRAPHY:
         Types.GeographyType geography = (Types.GeographyType) primitive;
+        if (geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
+          throw new UnsupportedOperationException(
+              "Spark does not support geography edge algorithm: " + geography.algorithm());
+        }
         return GeographyType$.MODULE$.apply(geography.crs());
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -34,6 +34,8 @@ import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType$;
 import org.apache.spark.sql.types.DoubleType$;
 import org.apache.spark.sql.types.FloatType$;
+import org.apache.spark.sql.types.GeographyType$;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.types.IntegerType$;
 import org.apache.spark.sql.types.LongType$;
 import org.apache.spark.sql.types.MapType$;
@@ -145,6 +147,12 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
         return BinaryType$.MODULE$;
       case BINARY:
         return BinaryType$.MODULE$;
+      case GEOMETRY:
+        Types.GeometryType geometry = (Types.GeometryType) primitive;
+        return GeometryType$.MODULE$.apply(geometry.crs());
+      case GEOGRAPHY:
+        Types.GeographyType geography = (Types.GeographyType) primitive;
+        return GeographyType$.MODULE$.apply(geography.crs());
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/TypeToSparkType.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import java.util.List;
+import java.util.function.Supplier;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -35,6 +36,8 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DateType$;
 import org.apache.spark.sql.types.DecimalType$;
 import org.apache.spark.sql.types.DoubleType$;
+import org.apache.spark.sql.types.EdgeInterpolationAlgorithm;
+import org.apache.spark.sql.types.EdgeInterpolationAlgorithm$;
 import org.apache.spark.sql.types.FloatType$;
 import org.apache.spark.sql.types.GeographyType$;
 import org.apache.spark.sql.types.GeometryType$;
@@ -55,6 +58,11 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
   TypeToSparkType() {}
 
   public static final String METADATA_COL_ATTR_KEY = "__metadata_col";
+
+  // Spark's only edge-interpolation algorithm. Spark exposes no Java-accessible constant for it, so
+  // it is resolved once by name through the companion's case-insensitive parser.
+  private static final EdgeInterpolationAlgorithm SPARK_SPHERICAL =
+      EdgeInterpolationAlgorithm$.MODULE$.fromString("SPHERICAL").get();
 
   @Override
   public DataType schema(Schema schema, DataType structType) {
@@ -150,15 +158,9 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
       case BINARY:
         return BinaryType$.MODULE$;
       case GEOMETRY:
-        Types.GeometryType geometry = (Types.GeometryType) primitive;
-        return geometryType(geometry.crs());
+        return geometryType((Types.GeometryType) primitive);
       case GEOGRAPHY:
-        Types.GeographyType geography = (Types.GeographyType) primitive;
-        if (geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
-          throw new UnsupportedOperationException(
-              "Spark does not support geography edge algorithm: " + geography.algorithm());
-        }
-        return geographyType(geography.crs());
+        return geographyType((Types.GeographyType) primitive);
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return DecimalType$.MODULE$.apply(decimal.precision(), decimal.scale());
@@ -170,21 +172,41 @@ class TypeToSparkType extends TypeUtil.SchemaVisitor<DataType> {
     }
   }
 
-  private DataType geometryType(String crs) {
-    // Iceberg allows any non-empty CRS, but Spark only recognizes a fixed set and throws an opaque
-    // ST_INVALID_CRS_VALUE for the rest; surface it as a clear unsupported-CRS error instead.
+  private DataType geometryType(Types.GeometryType geometry) {
+    // The spec lets a geometry CRS be any string identifying a CRS, but Spark recognizes only a
+    // fixed set; a CRS Spark cannot resolve becomes a clear unsupported-CRS error below.
+    String crs = geometry.crs();
+    return convertAndValidate("geometry", crs, () -> GeometryType$.MODULE$.apply(crs));
+  }
+
+  private DataType geographyType(Types.GeographyType geography) {
+    // The spec requires a geography CRS to be geographic; Spark recognizes only OGC:CRS84, so any
+    // other CRS becomes a clear unsupported-CRS error below.
+    EdgeInterpolationAlgorithm algorithm = convertAlgorithm(geography.algorithm());
+    String crs = geography.crs();
+    return convertAndValidate("geography", crs, () -> GeographyType$.MODULE$.apply(crs, algorithm));
+  }
+
+  // Builds a Spark geo type, translating Spark's opaque ST_INVALID_CRS_VALUE for an unrecognized
+  // CRS into a clear Iceberg error.
+  private static DataType convertAndValidate(
+      String kind, String crs, Supplier<DataType> conversion) {
     try {
-      return GeometryType$.MODULE$.apply(crs);
+      return conversion.get();
     } catch (SparkIllegalArgumentException e) {
-      throw new UnsupportedOperationException("Spark does not support geometry CRS: " + crs, e);
+      throw new UnsupportedOperationException("Spark does not support " + kind + " CRS: " + crs, e);
     }
   }
 
-  private DataType geographyType(String crs) {
-    try {
-      return GeographyType$.MODULE$.apply(crs);
-    } catch (SparkIllegalArgumentException e) {
-      throw new UnsupportedOperationException("Spark does not support geography CRS: " + crs, e);
+  // Translates Iceberg's edge-interpolation algorithm to Spark's. Spark supports only the spherical
+  // algorithm (the Iceberg default); every other algorithm is rejected with a clear error.
+  private static EdgeInterpolationAlgorithm convertAlgorithm(EdgeAlgorithm algorithm) {
+    switch (algorithm) {
+      case SPHERICAL:
+        return SPARK_SPHERICAL;
+      default:
+        throw new UnsupportedOperationException(
+            "Spark does not support geography edge algorithm: " + algorithm);
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -38,6 +38,7 @@ import org.apache.spark.sql.catalyst.expressions.MetadataAttribute;
 import org.apache.spark.sql.catalyst.types.DataTypeUtils;
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils$;
 import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.GeographyType;
 import org.apache.spark.sql.types.GeographyType$;
 import org.apache.spark.sql.types.GeometryType;
@@ -102,6 +103,14 @@ public class TestSparkSchemaUtil {
 
   @Test
   public void testGeospatialTypeConversion() {
+    // a default-CRS geometry round-trips through the null <-> OGC:CRS84 normalization
+    Types.GeometryType defaultGeometry = Types.GeometryType.crs84();
+    DataType sparkDefaultGeometry = SparkSchemaUtil.convert(defaultGeometry);
+    assertThat(sparkDefaultGeometry).isInstanceOf(GeometryType.class);
+    assertThat(((GeometryType) sparkDefaultGeometry).crs())
+        .isEqualTo(Types.GeometryType.DEFAULT_CRS);
+    assertThat(SparkSchemaUtil.convert(sparkDefaultGeometry)).isEqualTo(defaultGeometry);
+
     Types.GeometryType geometry = Types.GeometryType.of("EPSG:3857");
     DataType sparkGeometry = SparkSchemaUtil.convert(geometry);
     assertThat(sparkGeometry).isInstanceOf(GeometryType.class);
@@ -138,6 +147,19 @@ public class TestSparkSchemaUtil {
     Schema pruned = SparkSchemaUtil.prune(schema, requestedType);
 
     assertThat(pruned.asStruct()).isEqualTo(schema.asStruct());
+  }
+
+  @Test
+  public void testPruneGeospatialTypeWithIncompatibleRequestedType() {
+    Schema schema = new Schema(optional(1, "geom", Types.GeometryType.of("EPSG:3857")));
+
+    // requesting a non-geo Spark type for a geometry column must be rejected
+    StructType incompatibleType = new StructType().add("geom", DataTypes.BinaryType, true);
+
+    assertThatThrownBy(() -> SparkSchemaUtil.prune(schema, incompatibleType))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project")
+        .hasMessageContaining("incompatible type");
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -111,6 +111,14 @@ public class TestSparkSchemaUtil {
         .isEqualTo(Types.GeometryType.DEFAULT_CRS);
     assertThat(SparkSchemaUtil.convert(sparkDefaultGeometry)).isEqualTo(defaultGeometry);
 
+    // a default-CRS geography round-trips through the null <-> OGC:CRS84 normalization
+    Types.GeographyType defaultGeography = Types.GeographyType.crs84();
+    DataType sparkDefaultGeography = SparkSchemaUtil.convert(defaultGeography);
+    assertThat(sparkDefaultGeography).isInstanceOf(GeographyType.class);
+    assertThat(((GeographyType) sparkDefaultGeography).crs())
+        .isEqualTo(Types.GeographyType.DEFAULT_CRS);
+    assertThat(SparkSchemaUtil.convert(sparkDefaultGeography)).isEqualTo(defaultGeography);
+
     Types.GeometryType geometry = Types.GeometryType.of("EPSG:3857");
     DataType sparkGeometry = SparkSchemaUtil.convert(geometry);
     assertThat(sparkGeometry).isInstanceOf(GeometryType.class);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -136,6 +136,36 @@ public class TestSparkSchemaUtil {
   }
 
   @Test
+  public void testGeospatialCrsUnsupportedBySparkIsRejected() {
+    // Iceberg permits any non-empty CRS, but Spark only recognizes a fixed set; a CRS Spark cannot
+    // resolve must fail with a clear Iceberg error rather than an opaque Spark exception.
+    Types.GeometryType geometry = Types.GeometryType.of("EPSG:4269");
+    assertThatThrownBy(() -> SparkSchemaUtil.convert(geometry))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Spark does not support geometry CRS: EPSG:4269");
+
+    Types.GeographyType geography = Types.GeographyType.of("EPSG:4269");
+    assertThatThrownBy(() -> SparkSchemaUtil.convert(geography))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Spark does not support geography CRS: EPSG:4269");
+  }
+
+  @Test
+  public void testGeospatialMixedSridIsRejected() {
+    // Spark models a mixed-SRID column with a sentinel CRS ("SRID:ANY"); Iceberg requires a
+    // concrete column-level CRS, so a mixed-SRID Spark type must be rejected, not persisted.
+    DataType mixedGeometry = GeometryType$.MODULE$.apply("ANY");
+    assertThatThrownBy(() -> SparkSchemaUtil.convert(mixedGeometry))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot convert Spark geometry with mixed SRID to Iceberg");
+
+    DataType mixedGeography = GeographyType$.MODULE$.apply("ANY");
+    assertThatThrownBy(() -> SparkSchemaUtil.convert(mixedGeography))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot convert Spark geography with mixed SRID to Iceberg");
+  }
+
+  @Test
   public void testPruneGeospatialTypes() {
     Schema schema =
         new Schema(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark;
 
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -29,6 +30,7 @@ import java.util.stream.Stream;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.catalyst.expressions.AttributeReference;
@@ -116,6 +118,12 @@ public class TestSparkSchemaUtil {
         .isEqualTo(geometry);
     assertThat(SparkSchemaUtil.convert(GeographyType$.MODULE$.apply("EPSG:4326")))
         .isEqualTo(geography);
+
+    Types.GeographyType vincentyGeography =
+        Types.GeographyType.of("EPSG:4326", EdgeAlgorithm.VINCENTY);
+    assertThatThrownBy(() -> SparkSchemaUtil.convert(vincentyGeography))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Spark does not support geography edge algorithm: vincenty");
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -35,6 +35,11 @@ import org.apache.spark.sql.catalyst.expressions.AttributeReference;
 import org.apache.spark.sql.catalyst.expressions.MetadataAttribute;
 import org.apache.spark.sql.catalyst.types.DataTypeUtils;
 import org.apache.spark.sql.catalyst.util.ResolveDefaultColumnsUtils$;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.GeographyType;
+import org.apache.spark.sql.types.GeographyType$;
+import org.apache.spark.sql.types.GeometryType;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
@@ -91,6 +96,40 @@ public class TestSparkSchemaUtil {
             .isFalse();
       }
     }
+  }
+
+  @Test
+  public void testGeospatialTypeConversion() {
+    Types.GeometryType geometry = Types.GeometryType.of("EPSG:3857");
+    DataType sparkGeometry = SparkSchemaUtil.convert(geometry);
+    assertThat(sparkGeometry).isInstanceOf(GeometryType.class);
+    assertThat(((GeometryType) sparkGeometry).crs()).isEqualTo("EPSG:3857");
+    assertThat(SparkSchemaUtil.convert(sparkGeometry)).isEqualTo(geometry);
+
+    Types.GeographyType geography = Types.GeographyType.of("EPSG:4326");
+    DataType sparkGeography = SparkSchemaUtil.convert(geography);
+    assertThat(sparkGeography).isInstanceOf(GeographyType.class);
+    assertThat(((GeographyType) sparkGeography).crs()).isEqualTo("EPSG:4326");
+    assertThat(SparkSchemaUtil.convert(sparkGeography)).isEqualTo(geography);
+
+    assertThat(SparkSchemaUtil.convert(GeometryType$.MODULE$.apply("EPSG:3857")))
+        .isEqualTo(geometry);
+    assertThat(SparkSchemaUtil.convert(GeographyType$.MODULE$.apply("EPSG:4326")))
+        .isEqualTo(geography);
+  }
+
+  @Test
+  public void testPruneGeospatialTypes() {
+    Schema schema =
+        new Schema(
+            optional(1, "geom", Types.GeometryType.of("EPSG:3857")),
+            optional(2, "geog", Types.GeographyType.of("EPSG:4326")),
+            optional(3, "id", Types.LongType.get()));
+
+    StructType requestedType = SparkSchemaUtil.convert(schema);
+    Schema pruned = SparkSchemaUtil.prune(schema, requestedType);
+
+    assertThat(pruned.asStruct()).isEqualTo(schema.asStruct());
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -146,16 +146,16 @@ public class TestSparkSchemaUtil {
   @Test
   public void testGeospatialCrsUnsupportedBySparkIsRejected() {
     // Iceberg permits any non-empty CRS, but Spark only recognizes a fixed set; a CRS Spark cannot
-    // resolve must fail with a clear Iceberg error rather than an opaque Spark exception.
+    // resolve is rejected by Spark's SparkIllegalArgumentException (an IllegalArgumentException).
     Types.GeometryType geometry = Types.GeometryType.of("EPSG:4269");
     assertThatThrownBy(() -> SparkSchemaUtil.convert(geometry))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Spark does not support geometry CRS: EPSG:4269");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("EPSG:4269");
 
     Types.GeographyType geography = Types.GeographyType.of("EPSG:4269");
     assertThatThrownBy(() -> SparkSchemaUtil.convert(geography))
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Spark does not support geography CRS: EPSG:4269");
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("EPSG:4269");
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -201,6 +201,22 @@ public class TestSparkSchemaUtil {
   }
 
   @Test
+  public void testPruneGeospatialTypeWithIncompatibleCrs() {
+    // Spark normally copies the type from the table schema, so this defends against a requested geo
+    // type whose CRS disagrees with the table's rather than a case reachable through normal reads.
+    // Both CRS values must be ones Spark recognizes (else construction fails first); OGC:CRS84 and
+    // EPSG:3857 are both valid and differ, exercising the prune-time CRS check.
+    Schema schema = new Schema(optional(1, "geom", Types.GeometryType.of("EPSG:3857")));
+
+    StructType mismatchedCrs =
+        new StructType().add("geom", GeometryType$.MODULE$.apply("OGC:CRS84"), true);
+
+    assertThatThrownBy(() -> SparkSchemaUtil.prune(schema, mismatchedCrs))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project geometry with incompatible CRS");
+  }
+
+  @Test
   public void testSchemaConversionWithOnlyWriteDefault() {
     Schema schema =
         new Schema(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkSchemaUtil.java
@@ -108,19 +108,19 @@ public class TestSparkSchemaUtil {
     assertThat(((GeometryType) sparkGeometry).crs()).isEqualTo("EPSG:3857");
     assertThat(SparkSchemaUtil.convert(sparkGeometry)).isEqualTo(geometry);
 
-    Types.GeographyType geography = Types.GeographyType.of("EPSG:4326");
+    Types.GeographyType geography = Types.GeographyType.of("OGC:CRS84");
     DataType sparkGeography = SparkSchemaUtil.convert(geography);
     assertThat(sparkGeography).isInstanceOf(GeographyType.class);
-    assertThat(((GeographyType) sparkGeography).crs()).isEqualTo("EPSG:4326");
+    assertThat(((GeographyType) sparkGeography).crs()).isEqualTo("OGC:CRS84");
     assertThat(SparkSchemaUtil.convert(sparkGeography)).isEqualTo(geography);
 
     assertThat(SparkSchemaUtil.convert(GeometryType$.MODULE$.apply("EPSG:3857")))
         .isEqualTo(geometry);
-    assertThat(SparkSchemaUtil.convert(GeographyType$.MODULE$.apply("EPSG:4326")))
+    assertThat(SparkSchemaUtil.convert(GeographyType$.MODULE$.apply("OGC:CRS84")))
         .isEqualTo(geography);
 
     Types.GeographyType vincentyGeography =
-        Types.GeographyType.of("EPSG:4326", EdgeAlgorithm.VINCENTY);
+        Types.GeographyType.of("OGC:CRS84", EdgeAlgorithm.VINCENTY);
     assertThatThrownBy(() -> SparkSchemaUtil.convert(vincentyGeography))
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage("Spark does not support geography edge algorithm: vincenty");
@@ -131,7 +131,7 @@ public class TestSparkSchemaUtil {
     Schema schema =
         new Schema(
             optional(1, "geom", Types.GeometryType.of("EPSG:3857")),
-            optional(2, "geog", Types.GeographyType.of("EPSG:4326")),
+            optional(2, "geog", Types.GeographyType.of("OGC:CRS84")),
             optional(3, "id", Types.LongType.get()));
 
     StructType requestedType = SparkSchemaUtil.convert(schema);


### PR DESCRIPTION
## Summary

- Add Spark 4.1 schema conversion for Iceberg `geometry` / `geography` to Spark `GeometryType` / `GeographyType` while preserving CRS.
- Add reverse conversion from Spark geospatial DataTypes back to Iceberg geospatial types.
- Allow `PruneColumnsWithoutReordering` to project geospatial columns.

This is split out from #16650 and intentionally does not include Parquet read/write or end-to-end SQL tests.

## Test plan

- [ ] `./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:test --tests org.apache.iceberg.spark.TestSparkSchemaUtil.testGeospatialTypeConversion --tests org.apache.iceberg.spark.TestSparkSchemaUtil.testPruneGeospatialTypes`