### PR TITLE
AWS: Handle duplicate column names in IcebergToGlueConverter comment map

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -263,22 +263,22 @@ class IcebergToGlueConverter {
         Optional.ofNullable(existingTable.description()).ifPresent(tableInputBuilder::description);
       }
 
-      Map<String, String> existingColumnMap = null;
+      Map<String, String> existingColumnNameToComment = null;
       if (existingTable != null) {
         List<Column> existingColumns = existingTable.storageDescriptor().columns();
         // First-seen-wins on duplicate names. toColumns writes current-schema columns before
         // historical-schema columns. Preserve the current-schema comment.
-        existingColumnMap =
+        existingColumnNameToComment =
             existingColumns.stream()
                 .filter(column -> column.comment() != null)
                 .collect(
                     Collectors.toMap(
                         Column::name, Column::comment, (existing, duplicate) -> existing));
       } else {
-        existingColumnMap = Collections.emptyMap();
+        existingColumnNameToComment = Collections.emptyMap();
       }
 
-      List<Column> columns = toColumns(metadata, existingColumnMap);
+      List<Column> columns = toColumns(metadata, existingColumnNameToComment);
 
       tableInputBuilder.storageDescriptor(
           storageDescriptor.location(metadata.location()).columns(columns).build());
@@ -344,19 +344,20 @@ class IcebergToGlueConverter {
   }
 
   private static List<Column> toColumns(
-      TableMetadata metadata, Map<String, String> existingColumnMap) {
+      TableMetadata metadata, Map<String, String> existingColumnNameToComment) {
     List<Column> columns = Lists.newArrayList();
     Set<String> addedNames = Sets.newHashSet();
 
     for (NestedField field : metadata.schema().columns()) {
-      addColumnWithDedupe(columns, addedNames, field, true /* is current */, existingColumnMap);
+      addColumnWithDedupe(
+          columns, addedNames, field, true /* is current */, existingColumnNameToComment);
     }
 
     for (Schema schema : metadata.schemas()) {
       if (schema.schemaId() != metadata.currentSchemaId()) {
         for (NestedField field : schema.columns()) {
           addColumnWithDedupe(
-              columns, addedNames, field, false /* is not current */, existingColumnMap);
+              columns, addedNames, field, false /* is not current */, existingColumnNameToComment);
         }
       }
     }
@@ -369,7 +370,7 @@ class IcebergToGlueConverter {
       Set<String> dedupe,
       NestedField field,
       boolean isCurrent,
-      Map<String, String> existingColumnMap) {
+      Map<String, String> existingColumnNameToComment) {
     if (!dedupe.contains(field.name())) {
       Column.Builder builder =
           Column.builder()
@@ -383,8 +384,9 @@ class IcebergToGlueConverter {
 
       if (field.doc() != null && !field.doc().isEmpty()) {
         builder.comment(field.doc());
-      } else if (existingColumnMap != null && existingColumnMap.containsKey(field.name())) {
-        builder.comment(existingColumnMap.get(field.name()));
+      } else if (existingColumnNameToComment != null
+          && existingColumnNameToComment.containsKey(field.name())) {
+        builder.comment(existingColumnNameToComment.get(field.name()));
       }
 
       columns.add(builder.build());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -266,10 +266,14 @@ class IcebergToGlueConverter {
       Map<String, String> existingColumnMap = null;
       if (existingTable != null) {
         List<Column> existingColumns = existingTable.storageDescriptor().columns();
+        // First-seen-wins on duplicate names. toColumns writes current-schema columns before
+        // historical-schema columns. Preserve the current-schema comment.
         existingColumnMap =
             existingColumns.stream()
                 .filter(column -> column.comment() != null)
-                .collect(Collectors.toMap(Column::name, Column::comment));
+                .collect(
+                    Collectors.toMap(
+                        Column::name, Column::comment, (existing, duplicate) -> existing));
       } else {
         existingColumnMap = Collections.emptyMap();
       }

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestIcebergToGlueConverter.java
@@ -384,4 +384,57 @@ public class TestIcebergToGlueConverter {
         .as("Columns should match")
         .isEqualTo(expectedTableInput.storageDescriptor().columns());
   }
+
+  @Test
+  public void testDuplicateExistingColumnsKeepFirstComment() {
+    TableInput.Builder actualTableInputBuilder = TableInput.builder();
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.StringType.get()));
+    PartitionSpec partitionSpec =
+        PartitionSpec.builderFor(schema).identity("id").withSpecId(1000).build();
+    TableMetadata tableMetadata =
+        TableMetadata.newTableMetadata(schema, partitionSpec, "s3://test", tableLocationProperties);
+
+    Table existingGlueTable =
+        Table.builder()
+            .storageDescriptor(
+                StorageDescriptor.builder()
+                    .columns(
+                        ImmutableList.of(
+                            Column.builder().name("id").comment("current comment").build(),
+                            Column.builder().name("id").comment("historical comment").build()))
+                    .build())
+            .build();
+
+    IcebergToGlueConverter.setTableInputInformation(
+        actualTableInputBuilder, tableMetadata, existingGlueTable);
+    TableInput actualTableInput = actualTableInputBuilder.build();
+
+    TableInput expectedTableInput =
+        TableInput.builder()
+            .storageDescriptor(
+                StorageDescriptor.builder()
+                    .location("s3://test")
+                    .additionalLocations(Sets.newHashSet(tableLocationProperties.values()))
+                    .columns(
+                        ImmutableList.of(
+                            Column.builder()
+                                .name("id")
+                                .type("string")
+                                .comment("current comment")
+                                .parameters(
+                                    ImmutableMap.of(
+                                        IcebergToGlueConverter.ICEBERG_FIELD_ID, "1",
+                                        IcebergToGlueConverter.ICEBERG_FIELD_OPTIONAL, "false",
+                                        IcebergToGlueConverter.ICEBERG_FIELD_CURRENT, "true"))
+                                .build()))
+                    .build())
+            .build();
+
+    assertThat(actualTableInput.storageDescriptor())
+        .as("Storage descriptor should be set")
+        .isNotNull();
+    assertThat(actualTableInput.storageDescriptor().columns())
+        .as("Columns should match")
+        .isEqualTo(expectedTableInput.storageDescriptor().columns());
+  }
 }


### PR DESCRIPTION
## What
`IcebergToGlueConverter.setTableInputInformation` builds a `name → comment` map from the existing Glue table via `Collectors.toMap(Column::name, Column::comment)`, which throws `IllegalStateException` on duplicate keys. 

**Intended Fix:** Add an existing-entry-wins merge function so duplicates do not throw.

## How this happens
The following `RENAME COLUMN` cycle (`id → id__tmp → Id`): (Used SPARK with Glue Data Catalog)
Note how the First and Last column names are identical if lowercased

1. By design, `toColumns` walks `metadata.schemas()` and emits both historical and current names; case-sensitive dedupe lets `Id` and `id` through as distinct entries `columns=[Id, id, id__tmp]`. 
2. AWS Glue lowercases `Column.name` on persist, collapsing them into two `name="id"` rows that both carry a non-null comment `columns=[id, id, id__tmp]`. 
This is [expected AWS Behavior.](https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html)
3. The next commit hits `Collectors.toMap` → duplicate-key throws `IllegalStateException`.
4. The throw is swallowed by the outer `catch (RuntimeException e)`, leaving `tableInputBuilder.storageDescriptor` unset.
5. The engine calls`glue.updateTable()` with a null `StorageDescriptor` which deletes the tables StorageDescriptor.

The name collision itself isn't the bug trigger. Without comments, the `column.comment() != null` filter strips the colliding entries before `toMap` sees them.

## Fix
First-seen-wins: `toColumns` writes current-schema entries before historical ones, so the current entry's comment is preserved. 
Glue still receives duplicate-name `Columns[]` after a case-only rename, and `addColumnWithDedupe` is untouched.

## Test
Adds `testSetTableInputInformationWithDuplicateExistingColumnComments`: builds an `existingTable` with two `name="id"` entries (each with a comment) and asserts a non-null `StorageDescriptor` with the first-seen comment. 

Pre-fix fails on null `storageDescriptor()`; 
Post-fix passes. 

All 13 tests in `TestIcebergToGlueConverter` pass

----

*PR description drafted with AI*