### PR TITLE
Docs: Explain Spark write file sizing for skewed tables and link to compaction

### DIFF
--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -441,6 +441,17 @@ sorted columns are used during queries. This mode is used by default if a table 
 sort-order. Further division and coalescing of tasks may take place because of
 [Spark's Adaptive Query planning](#controlling-file-sizes).
 
+### Choosing a distribution mode for skewed data
+
+Real datasets are often skewed: a few "hot" partitions hold most of the rows while a long tail of
+partitions hold very little. The distribution mode strongly affects the resulting file sizes in this case.
+The `hash` mode routes every row of a given partition value to a single Spark task, so each small partition
+produces roughly one file, while a hot partition's task is still split into target-sized files by AQE. The
+`range` mode builds global range boundaries over the sort key; unless the sort order leads with the
+partition columns, the rows of a small partition can be scattered across many range tasks, producing many
+tiny files. When the primary goal is well-sized files for a partitioned table (rather than global
+clustering of a non-partition column to speed up reads), prefer `hash`.
+
 ## Controlling File Sizes
 
 When writing data to Iceberg with Spark, it's important to note that Spark cannot write a file larger than a Spark
@@ -464,3 +475,24 @@ compressed with a lower ratio) and not the write file size (typically, is column
 ratio), so a larger value than the target file size will need to be specified. The ratio of these two kinds of
 size is data dependent. Future work in Spark should allow Iceberg to automatically adjust this parameter at
 write time to match the `write.target-file-size-bytes`.
+
+The initial number of write tasks is set by `spark.sql.shuffle.partitions`; AQE then coalesces and splits
+those tasks toward `spark.sql.adaptive.advisoryPartitionSizeInBytes`. Both therefore influence how many
+files each partition is split into, while `write.target-file-size-bytes` does not enter this calculation -
+it is applied only later, inside each task.
+
+Keep in mind that `write.target-file-size-bytes` is only ever an *upper* bound applied within a single
+Spark task: Iceberg rolls over to a new file once a task has written that many bytes, but it never merges
+data across tasks and never enlarges a file whose task simply ran out of input. Raising the target
+therefore only affects partitions large enough to exceed it; it cannot increase the size of files written
+for small partitions. Because a file also cannot span a partition boundary, a table with many small
+partitions will always produce at least one (small) file per such partition at write time, regardless of
+distribution mode or target size.
+
+When write-side tuning cannot reach the file sizes you want - for example a table with a long tail of small
+partitions - run compaction after writing. The [`rewrite_data_files`](spark-procedures.md#rewrite_data_files)
+Spark procedure (or the [`rewriteDataFiles` action](maintenance.md#compact-data-files)) bin-packs small
+files into larger ones independently per partition and is built to scale to large tables. For a table with
+thousands of partitions, use `partial-progress.enabled` to commit incrementally,
+`max-concurrent-file-group-rewrites` to bound parallelism, `rewrite-job-order=files-desc` to attack the
+worst partitions first, and the `where` filter to compact partition-by-partition.

--- a/docs/docs/spark-writes.md
+++ b/docs/docs/spark-writes.md
@@ -441,6 +441,21 @@ sorted columns are used during queries. This mode is used by default if a table 
 sort-order. Further division and coalescing of tasks may take place because of
 [Spark's Adaptive Query planning](#controlling-file-sizes).
 
+### Distribution modes and skewed data
+
+Real datasets are often skewed: a few "hot" partitions hold most of the rows while a long tail of
+partitions hold very little. Changing the distribution mode does not consolidate that long tail. Both
+`hash` and `range` cluster on the table's partition columns first - Iceberg prepends the partition
+fields to the write ordering - and a data file can never span a partition boundary, so every partition
+that receives rows still produces at least one file of its own.
+
+What the mode does change is how a *hot* partition is written. With `hash`, all rows of one partition
+value are routed to a single task, which writes them as a sequence of files rolled over at
+`write.target-file-size-bytes`; that task can become a straggler. With `range`, a hot partition is
+spread over several range tasks and is written in parallel, at the cost of a global sampling pass. To
+reduce the number of small files in the long tail, compact after writing rather than changing the
+distribution mode.
+
 ## Controlling File Sizes
 
 When writing data to Iceberg with Spark, it's important to note that Spark cannot write a file larger than a Spark
@@ -464,3 +479,24 @@ compressed with a lower ratio) and not the write file size (typically, is column
 ratio), so a larger value than the target file size will need to be specified. The ratio of these two kinds of
 size is data dependent. Future work in Spark should allow Iceberg to automatically adjust this parameter at
 write time to match the `write.target-file-size-bytes`.
+
+The initial number of write tasks is set by `spark.sql.shuffle.partitions`; AQE then coalesces and splits
+those tasks toward `spark.sql.adaptive.advisoryPartitionSizeInBytes`. Both therefore influence how many
+files each partition is split into, while `write.target-file-size-bytes` does not enter this calculation -
+it is applied only later, inside each task.
+
+Keep in mind that `write.target-file-size-bytes` is only ever an *upper* bound applied within a single
+Spark task: Iceberg rolls over to a new file once a task has written that many bytes, but it never merges
+data across tasks and never enlarges a file whose task simply ran out of input. Raising the target
+therefore only affects partitions large enough to exceed it; it cannot increase the size of files written
+for small partitions. Because a file also cannot span a partition boundary, a table with many small
+partitions will always produce at least one (small) file per such partition at write time, regardless of
+distribution mode or target size.
+
+When write-side tuning cannot reach the file sizes you want - for example a table with a long tail of small
+partitions - run compaction after writing. The [`rewrite_data_files`](spark-procedures.md#rewrite_data_files)
+Spark procedure (or the [`rewriteDataFiles` action](maintenance.md#compact-data-files)) bin-packs small
+files into larger ones independently per partition and is built to scale to large tables. For a table with
+thousands of partitions, use `partial-progress.enabled` to commit incrementally,
+`max-concurrent-file-group-rewrites` to bound parallelism, `rewrite-job-order=files-desc` to attack the
+worst partitions first, and the `where` filter to compact partition-by-partition.


### PR DESCRIPTION
## What changed

Documents how output Parquet file sizes are determined on the Spark write path for skewed tables, and points users to compaction when write-side tuning is not enough. All edits are in `docs/docs/spark-writes.md`:

- A new "Distribution modes and skewed data" subsection under "Writing Distribution Modes": neither `hash` nor `range` can consolidate a long tail of small partitions, because both cluster on the partition columns first (Iceberg prepends the partition fields to the write ordering in `SortOrderUtil.buildSortOrder`) and a data file cannot span a partition boundary. What the mode does change is how a hot partition is written: `hash` routes it to a single task that rolls files over at the target size, while `range` spreads it across several tasks and writes it in parallel.
- An expanded "Controlling File Sizes" section: clarifies that `write.target-file-size-bytes` is only a per-task upper bound (it never merges across tasks, never enlarges a file whose task ran out of input, and a file cannot span a partition boundary), notes that `spark.sql.shuffle.partitions` and the AQE advisory size are what actually control write file counts, and bridges to the `rewrite_data_files` procedure (mirroring the link already used in the structured-streaming docs) with the scale knobs `partial-progress.enabled`, `max-concurrent-file-group-rewrites`, `rewrite-job-order`, and `where` for large tables.

## Why

Reported in #16854 (https://github.com/apache/iceberg/issues/16854): a user with a bimodal table (a few hot partitions, a long tail of tiny ones) raised `write.target-file-size-bytes` and saw no change, because the target is a per-task upper bound and cannot consolidate small partitions. The Spark docs already explained that a file cannot exceed a Spark task or span a partition boundary, but never stated this asymmetry, never mentioned skew (all such guidance lived only in the Flink docs), and the "Controlling File Sizes" section never pointed to compaction as the remedy. This closes that documentation gap.

Closes #16854

---
**AI Disclosure**
- Model: Claude Opus 4.8, Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Document how Spark determines output Parquet file sizes for skewed tables, and point users to compaction when write-side tuning is not enough.
