### PR TITLE
Flink: Backport: Add equality delete conversion operators (#16844)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel operator that maintains a shard of the primary key index. Keyed by the full serialized
+ * primary key ({@link SerializedEqualityValues}), each instance handles a subset of PK values.
+ *
+ * <p>Existing main data is indexed immediately on arrival. A staging snapshot's new data rows
+ * ({@link IndexCommand.Type#ADD_STAGING_DATA_ROW}) and every RESOLVE_DELETE instead register an
+ * event-time timer at their phase timestamp and act only when the watermark reaches it. Flink fires
+ * timers in timestamp order, so a delete resolves before the cycle's own new staging rows (a
+ * strictly later phase) join the index: a re-inserted key survives a same-cycle delete regardless
+ * of the order the parallel readers deliver records. Main data is safe to apply eagerly because its
+ * phase precedes the delete, so the delete's watermark only advances once every main row has
+ * arrived.
+ *
+ * <p>On a shared staging/target branch, resolution is sequence-number aware: an equality delete
+ * deletes an indexed row only when the row's data sequence number is below the delete's. A
+ * re-insert of the same key with a higher sequence survives and stays indexed for a later delete.
+ * On a separate target branch the committer reassigns data sequence numbers, so every match is
+ * deleted; event-time ordering prevents over-deletion.
+ *
+ * <p>Stale-index protection runs on two levels. Each key tracks the main sequence number its stored
+ * positions were indexed against. The sequence number is unique and monotonic per snapshot, so it
+ * serves both the equality test below and the ordering test:
+ *
+ * <ul>
+ *   <li><b>Lazy (per-key)</b>: any keyed command at the top of {@link #processElement} whose {@link
+ *       IndexCommand#mainSequenceNumber()} differs from the stored one clears stale state and
+ *       adopts the command's sequence number. Equality suffices here. Required because the
+ *       broadcast and keyed inputs are independent streams with no ordering guarantee; without it,
+ *       an ADD_DATA_ROW that arrived before the broadcast would be wrongly evicted.
+ *   <li><b>Eager (all keys)</b>: a CLEAR_INDEX broadcast iterates all keys on the subtask via
+ *       {@link KeyedBroadcastProcessFunction.Context#applyToKeyedState} and clears any whose stored
+ *       sequence number is older than the broadcast's. Staleness is ordered by sequence number.
+ *       Bounds state size for PKs that were removed from main by an external CoW commit and won't
+ *       receive any keyed command next cycle.
+ * </ul>
+ */
+@Internal
+public class EqualityConvertPKIndex
+    extends KeyedBroadcastProcessFunction<
+        SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPKIndex.class);
+
+  private static final String RESOLVED_DELETE_NUM_METRIC = "resolvedDeleteNum";
+  private static final String INDEXED_KEY_NUM_METRIC = "indexedKeyNum";
+  private static final String EAGERLY_EVICTED_KEY_NUM_METRIC = "eagerlyEvictedKeyNum";
+
+  public static final MapStateDescriptor<Void, Void> CLEAR_BROADCAST_DESCRIPTOR =
+      new MapStateDescriptor<>("eq-convert-clear-broadcast", Types.VOID, Types.VOID);
+
+  private static final ValueStateDescriptor<Long> MAIN_SEQUENCE_VERSION_DESCRIPTOR =
+      new ValueStateDescriptor<>("mainSequenceVersion", Types.LONG);
+  private static final ListStateDescriptor<DVPosition> DATA_ROW_POSITIONS_DESCRIPTOR =
+      new ListStateDescriptor<>("filePositions", TypeInformation.of(DVPosition.class));
+  private static final ListStateDescriptor<DVPosition> BUFFERED_ROWS_DESCRIPTOR =
+      new ListStateDescriptor<>("bufferedRows", TypeInformation.of(DVPosition.class));
+  private static final ValueStateDescriptor<Long> RESOLVE_TIMESTAMP_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveTimestamp", Types.LONG);
+  private static final ValueStateDescriptor<Long> RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveSequenceNumber", Types.LONG);
+
+  private transient ValueState<Long> mainSequenceVersion;
+  // Resolvable rows for this key. Populated immediately for main data, or from onTimer for
+  // staging rows once their phase watermark passes, so a delete never resolves against a row from a
+  // later phase.
+  private transient ListState<DVPosition> dataRowPositions;
+  // Deferred staging-snapshot rows awaiting their event-time timer. onTimer moves them into
+  // dataRowPositions after this cycle's delete has resolved.
+  private transient ListState<DVPosition> bufferedRows;
+  // Phase timestamp of the pending RESOLVE_DELETE; onTimer resolves when the firing timer matches.
+  private transient ValueState<Long> resolveTimestamp;
+  // Maximum sequence number among the cycle's RESOLVE_DELETEs for this key. Deletes a
+  // data row only when the row's sequence number is below it.
+  private transient ValueState<Long> resolveSequenceNumber;
+
+  private transient Counter resolvedDeleteNumCounter;
+  private transient Counter indexedKeyNumCounter;
+  private transient Counter eagerlyEvictedKeyNumCounter;
+
+  private final boolean stagingOnTargetBranch;
+
+  public EqualityConvertPKIndex(boolean stagingOnTargetBranch) {
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext context) throws Exception {
+    super.open(context);
+    mainSequenceVersion = getRuntimeContext().getState(MAIN_SEQUENCE_VERSION_DESCRIPTOR);
+    dataRowPositions = getRuntimeContext().getListState(DATA_ROW_POSITIONS_DESCRIPTOR);
+    bufferedRows = getRuntimeContext().getListState(BUFFERED_ROWS_DESCRIPTOR);
+    resolveTimestamp = getRuntimeContext().getState(RESOLVE_TIMESTAMP_DESCRIPTOR);
+    resolveSequenceNumber = getRuntimeContext().getState(RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR);
+    resolvedDeleteNumCounter =
+        getRuntimeContext().getMetricGroup().counter(RESOLVED_DELETE_NUM_METRIC);
+    indexedKeyNumCounter = getRuntimeContext().getMetricGroup().counter(INDEXED_KEY_NUM_METRIC);
+    eagerlyEvictedKeyNumCounter =
+        getRuntimeContext().getMetricGroup().counter(EAGERLY_EVICTED_KEY_NUM_METRIC);
+  }
+
+  @Override
+  public void processElement(IndexCommand cmd, ReadOnlyContext ctx, Collector<DVPosition> out)
+      throws Exception {
+    try {
+      Long storedSequence = mainSequenceVersion.value();
+      if (!Objects.equals(storedSequence, cmd.mainSequenceNumber())) {
+        LOG.info(
+            "Main sequence changed from {} to {} (snapshot {}), clearing state",
+            storedSequence,
+            cmd.mainSequenceNumber(),
+            cmd.mainSnapshotId());
+        clearKeyState();
+        mainSequenceVersion.update(cmd.mainSequenceNumber());
+      }
+
+      long ts = ctx.timestamp();
+
+      if (cmd.type() == IndexCommand.Type.ADD_DATA_ROW) {
+        // Existing main data: index immediately so this cycle's delete can remove it.
+        dataRowPositions.add(cmd.rowPosition());
+        indexedKeyNumCounter.inc();
+      } else if (cmd.type() == IndexCommand.Type.ADD_STAGING_DATA_ROW) {
+        // Staging snapshot's new data: defer until after this cycle's delete resolves so a
+        // re-inserted key survives. Applied by the event-time timer at this phase.
+        bufferedRows.add(cmd.rowPosition());
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else if (cmd.type() == IndexCommand.Type.RESOLVE_DELETE) {
+        Long resolveTs = resolveTimestamp.value();
+        if (resolveTs == null || ts > resolveTs) {
+          resolveTimestamp.update(ts);
+        }
+
+        Long currentSeq = resolveSequenceNumber.value();
+        if (currentSeq == null || cmd.deleteSequenceNumber() > currentSeq) {
+          resolveSequenceNumber.update(cmd.deleteSequenceNumber());
+        }
+
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else {
+        throw new IllegalStateException("Unexpected command type in keyed stream: " + cmd.type());
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to process command of type {}", cmd.type(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void processBroadcastElement(IndexCommand cmd, Context ctx, Collector<DVPosition> out) {
+    Preconditions.checkArgument(
+        cmd.type() == IndexCommand.Type.CLEAR_INDEX,
+        "Broadcast element must be %s",
+        IndexCommand.Type.CLEAR_INDEX);
+
+    final long broadcastSequenceNumber = cmd.mainSequenceNumber();
+    try {
+      ctx.applyToKeyedState(
+          MAIN_SEQUENCE_VERSION_DESCRIPTOR,
+          (key, sequenceState) -> {
+            Long storedSequenceNumber = sequenceState.value();
+            if (storedSequenceNumber != null && storedSequenceNumber < broadcastSequenceNumber) {
+              clearKeyState();
+              sequenceState.update(broadcastSequenceNumber);
+              eagerlyEvictedKeyNumCounter.inc();
+            }
+          });
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to apply CLEAR_INDEX for snapshot {}", cmd.mainSnapshotId(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void onTimer(long timestamp, OnTimerContext ctx, Collector<DVPosition> out) {
+    try {
+      // Timers fire in ascending timestamp order. The delete-phase timer resolves against the
+      // index; any other timer is a staging phase whose buffered rows now join the index.
+      // The delete fires before the (strictly later) staging phase, so the cycle's own new rows are
+      // applied only after the delete and survive it.
+      Long resolveTs = resolveTimestamp.value();
+      if (resolveTs != null && timestamp == resolveTs) {
+        resolveDeletes(out);
+        resolveTimestamp.clear();
+        resolveSequenceNumber.clear();
+      } else {
+        applyBufferedRows();
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed in onTimer at ts={}", timestamp, e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  private void applyBufferedRows() throws Exception {
+    for (DVPosition position : bufferedRows.get()) {
+      dataRowPositions.add(position);
+      indexedKeyNumCounter.inc();
+    }
+
+    bufferedRows.clear();
+  }
+
+  private void resolveDeletes(Collector<DVPosition> out) throws Exception {
+    // An equality delete with sequence S deletes only data rows with sequence < S. Rows at or
+    // above S are re-inserts the delete does not affect; keep them indexed for a later delete.
+    // Only valid on a shared staging/target branch, where data and deletes share one sequence
+    // space. On a separate target branch the committer reassigns data sequence numbers, so the
+    // indexed sequence is not comparable to the staging delete's; event-time ordering already
+    // prevents false deletion.
+    Long deleteSeq = resolveSequenceNumber.value();
+    List<DVPosition> nonEligible = Lists.newArrayList();
+    int count = 0;
+    for (DVPosition pos : dataRowPositions.get()) {
+      if (stagingOnTargetBranch && deleteSeq != null && pos.dataSequenceNumber() >= deleteSeq) {
+        nonEligible.add(pos);
+      } else {
+        out.collect(pos);
+        count++;
+      }
+    }
+
+    resolvedDeleteNumCounter.inc(count);
+    dataRowPositions.update(nonEligible);
+  }
+
+  private void clearKeyState() {
+    dataRowPositions.clear();
+    bufferedRows.clear();
+    resolveTimestamp.clear();
+    resolveSequenceNumber.clear();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.ReadBuilder;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel reader that processes {@link ReadCommand}s from the planner and emits {@link
+ * IndexCommand}s. Dispatches on the wrapped {@link ContentScanTask} subtype: {@link FileScanTask}
+ * (data file) emits {@code ADD_DATA_ROW} per row, our equality-delete task emits {@code
+ * RESOLVE_DELETE} per row.
+ */
+@Internal
+public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertReader.class);
+
+  public static final OutputTag<DVPosition> READER_ABORT_STREAM =
+      new OutputTag<>("reader-abort-stream") {};
+
+  private final TableLoader tableLoader;
+  private final Set<Integer> eqFieldIds;
+  private final boolean stagingOnTargetBranch;
+
+  private transient Table table;
+  private transient Schema keySchema;
+  private transient StructLikeSerializer fieldSerializer;
+  private transient DeleteLoader deleteLoader;
+
+  public EqualityConvertReader(
+      TableLoader tableLoader, Set<Integer> eqFieldIds, boolean stagingOnTargetBranch) {
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.tableLoader = tableLoader;
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+    // Equality fields resolve against the current schema at build time, so it covers all ids.
+    // Fail fast on a missing id rather than silently widening the key.
+    keySchema = TypeUtil.select(table.schema(), eqFieldIds);
+    Preconditions.checkArgument(
+        TypeUtil.getProjectedIds(keySchema).containsAll(eqFieldIds),
+        "Equality field IDs %s not present in table schema",
+        eqFieldIds);
+    fieldSerializer = new StructLikeSerializer();
+    deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+  }
+
+  @Override
+  public void processElement(ReadCommand cmd, Context ctx, Collector<IndexCommand> out)
+      throws Exception {
+    ContentScanTask<?> task = cmd.task();
+    ContentFile<?> file = task.file();
+    try {
+      if (task instanceof FileScanTask dataTask) {
+        processDataFile(
+            dataTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            cmd.staging(),
+            out);
+      } else if (task instanceof EqualityDeleteFileScanTask deleteTask) {
+        processDeleteFile(
+            deleteTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            out);
+      } else {
+        throw new IllegalStateException(
+            "Unexpected ContentScanTask type: " + task.getClass().getName());
+      }
+    } catch (Exception e) {
+      LOG.error("Reader failed to process command for file={}", file.location(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      ctx.output(READER_ABORT_STREAM, DVPosition.ABORT);
+    }
+  }
+
+  private void processDataFile(
+      FileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      boolean staging,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+    Schema readSchema = appendRowPosition(keySchema);
+    PositionDeleteIndex existingDeletes = loadExistingDVs(task, file.location());
+
+    int specId = file.specId();
+    StructLike partition = file.partition();
+    Types.StructType partitionType = table.specs().get(specId).partitionType();
+    byte[] partitionBytes = fieldSerializer.encodePartition(partition, partitionType);
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records =
+        builder.project(readSchema).reuseContainers().build()) {
+      Accessor<StructLike> posAccessor =
+          readSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
+      for (Record record : records) {
+        long position = (long) posAccessor.get(record);
+        if (existingDeletes != null && existingDeletes.isDeleted(position)) {
+          continue;
+        }
+
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.addDataRow(
+                mainSnapshotId,
+                mainSequenceNumber,
+                key,
+                file.location(),
+                position,
+                specId,
+                partitionBytes,
+                dataSequenceNumber,
+                staging));
+      }
+    }
+  }
+
+  private void processDeleteFile(
+      EqualityDeleteFileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+
+    int specId = file.specId();
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records = builder.project(keySchema).reuseContainers().build()) {
+      for (Record record : records) {
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.resolveDelete(
+                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber));
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  private Schema appendRowPosition(Schema schema) {
+    List<Types.NestedField> columns = Lists.newArrayList(schema.columns());
+    columns.add(MetadataColumns.ROW_POSITION);
+    return new Schema(columns);
+  }
+
+  private PositionDeleteIndex loadExistingDVs(FileScanTask task, String dataFilePath) {
+    List<DeleteFile> dvs = Lists.newArrayList();
+    for (DeleteFile deleteFile : task.deletes()) {
+      if (ContentFileUtil.isDV(deleteFile)) {
+        dvs.add(deleteFile);
+      } else if (deleteFile.content() == FileContent.POSITION_DELETES) {
+        throw new IllegalStateException(
+            String.format(
+                "V2 positional delete file %s attached to main data file %s; "
+                    + "the converter expects a V3 target with deletion vectors only.",
+                deleteFile.location(), dataFilePath));
+      } else if (deleteFile.content() == FileContent.EQUALITY_DELETES && !stagingOnTargetBranch) {
+        // When stagingBranch == targetBranch the target carries unconverted equality deletes; they
+        // are indexed as rows here and converted via the planner's RESOLVE_DELETE commands. On a
+        // separate target branch an attached equality delete means an unconverted delete leaked
+        // onto the target, which the converter cannot reason about.
+        throw new IllegalStateException(
+            String.format(
+                "Equality delete file %s attached to main data file %s; the converter expects "
+                    + "equality deletes only on the staging branch, converted to DVs on the target.",
+                deleteFile.location(), dataFilePath));
+      }
+    }
+
+    if (dvs.isEmpty()) {
+      return null;
+    }
+
+    return deleteLoader.loadPositionDeletes(dvs, dataFilePath);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -453,6 +453,19 @@ public class OperatorTestBase {
         SCHEMA_WITH_PRIMARY_KEY);
   }
 
+  protected DeleteFile writePosDeleteFile(Table table, String dataFilePath, long pos)
+      throws IOException {
+    File file = File.createTempFile("junit", null, warehouseDir.toFile());
+    assertThat(file.delete()).isTrue();
+    PositionDelete<GenericRecord> posDelete = PositionDelete.create();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    nested.set(0, 1);
+    nested.set(1, "a");
+    posDelete.set(dataFilePath, pos, nested);
+    return FileHelpers.writePosDeleteFile(
+        table, Files.localOutput(file), null, Lists.newArrayList(posDelete), 2);
+  }
+
   private DeleteFile writePosDelete(
       Table table, CharSequence path, Integer pos, Integer id, String oldData, int formatVersion)
       throws IOException {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
@@ -1,0 +1,675 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedBroadcastOperatorTestHarness;
+import org.junit.jupiter.api.Test;
+
+class TestEqualityConvertPKIndex {
+
+  private static final SerializedEqualityValues KEY_1 =
+      new SerializedEqualityValues(new byte[] {1, 2, 3});
+  private static final SerializedEqualityValues KEY_2 =
+      new SerializedEqualityValues(new byte[] {4, 5, 6});
+  private static final Long MAIN_SNAPSHOT = 100L;
+  private static final Long MAIN_SEQ = 10L;
+  private static final Long NEW_MAIN_SNAPSHOT = 200L;
+  private static final Long NEW_MAIN_SEQ = 20L;
+  private static final byte[] EMPTY_PARTITION = new byte[0];
+  // Data-row sequence below the delete sequence, so existing tests still tombstone on resolve.
+  private static final long DATA_SEQ = 1L;
+  private static final long DELETE_SEQ = 2L;
+
+  @Test
+  void addDataRowProducesNoOutput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPosition() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(5);
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsMultipleDVPositionsForDuplicateKeys() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file2.parquet",
+                  3,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(0);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file2.parquet");
+                assertThat(pos.position()).isEqualTo(3);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteClearsEntries() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+    }
+  }
+
+  @Test
+  void resolveDeleteWithNoMatchEmitsNothing() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void mainSnapshotChangeClearsState() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexEvictsOrphanKeyWithoutKeyedInput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed against the old main; KEY_2 left untouched.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // External commit removed KEY_1's data file; planner advances main and broadcasts CLEAR.
+      // No keyed input arrives for KEY_1 in the new cycle.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      // Resolving KEY_1 against the (now-empty) index emits nothing.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexAfterAddPreservesEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // ADD with the new generation arrives before the broadcast.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  7,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void clearBeforeReindexThenAddIndexesAtNewVersion() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "old.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // Broadcast arrives before the new ADD (race direction 2): old entry is wiped, then the
+      // reindex re-emits KEY_1 at its new file/position.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  4,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              2));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("new.parquet");
+      assertThat(output.get(0).position()).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void olderBroadcastDoesNotEvictNewerEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed at the newer generation: higher sequence number (20) but a lower snapshot id
+      // (50) than the stale broadcast below.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  50L, 20L, KEY_1, "file1.parquet", 7, 0, EMPTY_PARTITION, DATA_SEQ, false),
+              0));
+
+      // A stale CLEAR_INDEX from an older generation arrives late: higher snapshot id (999) but
+      // lower sequence number (10). Ordering by snapshot id would wrongly evict (50 < 999);
+      // ordering
+      // by sequence number keeps the entry (20 is not < 10).
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(999L, 10L), 1));
+
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void differentKeysAreIndependent() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_2,
+                  "file2.parquet",
+                  1,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  @Test
+  void phaseAwareBufferingProcessesInCorrectOrder() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // A main row (ts 0) is indexed and the cycle's delete (ts 1) removes it. The next cycle's new
+      // row (ts 2) arrives before that delete fires; event-time ordering keeps it out of the index
+      // until after the delete, so it survives.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "main.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      assertThat(harness.extractOutputValues().get(0).dataFilePath()).isEqualTo("main.parquet");
+
+      // A later cycle's delete (ts 3) removes the now-indexed new row.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+      assertThat(harness.extractOutputValues()).hasSize(2);
+      assertThat(harness.extractOutputValues().get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void laterPhaseAddArrivingBeforeResolveSurvives() throws Exception {
+    // The next cycle's new row (ts 2) is delivered before the current cycle's
+    // delete (ts 1) is processed; the new row must not be affected by the delete.
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPositionsForSameFileDifferentPositions() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(5);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(10);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteSparesReinsertWithHigherSequence() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // Same key indexed twice: an older row (seq 1) and a re-insert (seq 3).
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "old.parquet", 0, 0, EMPTY_PARTITION, 1L, false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "new.parquet", 0, 0, EMPTY_PARTITION, 3L, false),
+              0));
+
+      // Delete at seq 2 tombstones only the older row; the re-insert (seq 3) survives.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("old.parquet");
+
+      // The survivor stays indexed: a later delete with a higher sequence removes it.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L), 2));
+      harness.watermark(2);
+
+      List<DVPosition> afterSecond = harness.extractOutputValues();
+      assertThat(afterSecond).hasSize(2);
+      assertThat(afterSecond.get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void deletesHigherSequenceWhenStagingNotOnTargetBranch() throws Exception {
+    // On a separate target branch the committer reassigns data sequence numbers, so the worker must
+    // not spare rows by sequence: every key match is deleted (phase ordering prevents
+    // over-deletion across cycles).
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      // Row sequence (5) above the delete sequence (2) would survive on a shared branch.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  5L,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness() throws Exception {
+    return createHarness(true);
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness(boolean stagingOnTargetBranch) throws Exception {
+    return new KeyedBroadcastOperatorTestHarness<>(
+        new CoBroadcastWithKeyedOperator<>(
+            new EqualityConvertPKIndex(stagingOnTargetBranch),
+            Collections.singletonList(EqualityConvertPKIndex.CLEAR_BROADCAST_DESCRIPTOR)),
+        IndexCommand::key,
+        TypeInformation.of(SerializedEqualityValues.class),
+        1,
+        1,
+        0);
+  }
+}

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertReader extends OperatorTestBase {
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void emitsAddStagingDataRowForDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      // stagingDataFile marks a staging snapshot's new data, so the reader emits
+      // ADD_STAGING_DATA_ROW.
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(0).rowPosition().dataFilePath()).isEqualTo(dataFile.location());
+      assertThat(output.get(0).rowPosition().position()).isZero();
+    }
+  }
+
+  @Test
+  void emitsAddDataRowWhenNotStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Same task type as the staging test: the command's staging flag, not the task type, decides
+      // that main reindex data is indexed immediately as ADD_DATA_ROW.
+      ReadCommand cmd =
+          ReadCommand.dataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_DATA_ROW);
+    }
+  }
+
+  @Test
+  void emitsResolveDeleteForEqDeleteFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd = ReadCommand.eqDeleteFile(eqDelete, spec, 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).rowPosition()).isNull();
+    }
+  }
+
+  @Test
+  void tracksPositionsAcrossRecords() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void skipsDeletedPositionsWhenCreatingIndexFromMain() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(
+                Lists.newArrayList(
+                    createRecord(1, "a"), createRecord(2, "b"), createRecord(3, "c")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    // DV marks position 1 (id=2) as deleted on main. When the reader creates the worker's index
+    // from this data file, it must skip position 1 and emit rows only for positions 0 and 2.
+    DeleteFile dv = writeDV(table, dataFile.location(), 1L);
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(dv)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void sameKeyFromDataAndDeleteProducesEqualSerializedValues() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec dataSpec = table.specs().get(dataFile.specId());
+    PartitionSpec deleteSpec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      harness.processElement(
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, dataSpec), 0L, 0L, 0L),
+          0);
+      harness.processElement(ReadCommand.eqDeleteFile(eqDelete, deleteSpec, 0L, 0L, 0L), 1);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(1).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).key()).isEqualTo(output.get(1).key());
+    }
+  }
+
+  @Test
+  void propagatesMainSnapshotId() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+    long mainSnapshotId = 42L;
+    long mainSequenceNumber = 7L;
+    long dataSequenceNumber = 9L;
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec),
+              mainSnapshotId,
+              mainSequenceNumber,
+              dataSequenceNumber);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).mainSnapshotId()).isEqualTo(mainSnapshotId);
+      assertThat(output.get(0).mainSequenceNumber()).isEqualTo(mainSequenceNumber);
+      assertThat(output.get(0).rowPosition().dataSequenceNumber()).isEqualTo(dataSequenceNumber);
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    DataFile missing =
+        DataFiles.builder(table.spec())
+            .copy(dataFile)
+            .withPath(dataFile.location() + ".missing")
+            .build();
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Non-existent file path causes the reader to throw.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(missing, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenEqualityFieldMissingFromCurrentSchema() throws Exception {
+    // Field ids from SimpleDataUtil.SCHEMA: 1=id, 2=data.
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+
+    // Drop `data`. Static equality fields resolve against the current schema at build time, so an
+    // equality field id missing from the current schema is a misconfiguration.
+    table.updateSchema().deleteColumn("data").commit();
+    table.refresh();
+
+    List<Integer> fieldIds = Lists.newArrayList(1, 2);
+
+    assertThatThrownBy(
+            () -> {
+              try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+                  createHarness(fieldIds)) {
+                harness.open();
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not present in table schema");
+  }
+
+  @Test
+  void throwsOnEqualityDeleteAttachedToMainDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // An equality delete attached to a main data file is unexpected on a separate target branch
+      // (stagingOnTargetBranch=false): the reader must route the error rather than silently ignore.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(eqDelete)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void throwsOnV2PositionalDeleteAttachedToMainDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile posDelete = writePosDeleteFile(table, dataFile.location(), 0L);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // A V2 positional delete attached to a main data file means the target is not a DV-only V3
+      // target, the reader must route to the error output.
+      ReadCommand cmd =
+          ReadCommand.dataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(posDelete)),
+              0L,
+              0L,
+              0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> createHarness(
+      List<Integer> fieldIds) throws Exception {
+    return ProcessFunctionTestHarnesses.forProcessFunction(
+        new EqualityConvertReader(tableLoader(), Sets.newHashSet(fieldIds), false));
+  }
+
+  private static DataFile getFirstDataFile(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          return file.copy();
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data files found");
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private static DeleteFile writeDV(Table table, String dataFilePath, long... positions)
+      throws IOException {
+    List<PositionDelete<?>> deletes = Lists.newArrayList();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    for (long pos : positions) {
+      PositionDelete<GenericRecord> delete = PositionDelete.create();
+      delete.set(dataFilePath, pos, nested);
+      deletes.add(delete);
+    }
+
+    return FileHelpers.writePosDeleteFile(table, null, null, deletes, 3);
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPKIndex.java
@@ -1,0 +1,274 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.MapStateDescriptor;
+import org.apache.flink.api.common.state.ValueState;
+import org.apache.flink.api.common.state.ValueStateDescriptor;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.streaming.api.functions.co.KeyedBroadcastProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel operator that maintains a shard of the primary key index. Keyed by the full serialized
+ * primary key ({@link SerializedEqualityValues}), each instance handles a subset of PK values.
+ *
+ * <p>Existing main data is indexed immediately on arrival. A staging snapshot's new data rows
+ * ({@link IndexCommand.Type#ADD_STAGING_DATA_ROW}) and every RESOLVE_DELETE instead register an
+ * event-time timer at their phase timestamp and act only when the watermark reaches it. Flink fires
+ * timers in timestamp order, so a delete resolves before the cycle's own new staging rows (a
+ * strictly later phase) join the index: a re-inserted key survives a same-cycle delete regardless
+ * of the order the parallel readers deliver records. Main data is safe to apply eagerly because its
+ * phase precedes the delete, so the delete's watermark only advances once every main row has
+ * arrived.
+ *
+ * <p>On a shared staging/target branch, resolution is sequence-number aware: an equality delete
+ * deletes an indexed row only when the row's data sequence number is below the delete's. A
+ * re-insert of the same key with a higher sequence survives and stays indexed for a later delete.
+ * On a separate target branch the committer reassigns data sequence numbers, so every match is
+ * deleted; event-time ordering prevents over-deletion.
+ *
+ * <p>Stale-index protection runs on two levels. Each key tracks the main sequence number its stored
+ * positions were indexed against. The sequence number is unique and monotonic per snapshot, so it
+ * serves both the equality test below and the ordering test:
+ *
+ * <ul>
+ *   <li><b>Lazy (per-key)</b>: any keyed command at the top of {@link #processElement} whose {@link
+ *       IndexCommand#mainSequenceNumber()} differs from the stored one clears stale state and
+ *       adopts the command's sequence number. Equality suffices here. Required because the
+ *       broadcast and keyed inputs are independent streams with no ordering guarantee; without it,
+ *       an ADD_DATA_ROW that arrived before the broadcast would be wrongly evicted.
+ *   <li><b>Eager (all keys)</b>: a CLEAR_INDEX broadcast iterates all keys on the subtask via
+ *       {@link KeyedBroadcastProcessFunction.Context#applyToKeyedState} and clears any whose stored
+ *       sequence number is older than the broadcast's. Staleness is ordered by sequence number.
+ *       Bounds state size for PKs that were removed from main by an external CoW commit and won't
+ *       receive any keyed command next cycle.
+ * </ul>
+ */
+@Internal
+public class EqualityConvertPKIndex
+    extends KeyedBroadcastProcessFunction<
+        SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPKIndex.class);
+
+  private static final String RESOLVED_DELETE_NUM_METRIC = "resolvedDeleteNum";
+  private static final String INDEXED_KEY_NUM_METRIC = "indexedKeyNum";
+  private static final String EAGERLY_EVICTED_KEY_NUM_METRIC = "eagerlyEvictedKeyNum";
+
+  public static final MapStateDescriptor<Void, Void> CLEAR_BROADCAST_DESCRIPTOR =
+      new MapStateDescriptor<>("eq-convert-clear-broadcast", Types.VOID, Types.VOID);
+
+  private static final ValueStateDescriptor<Long> MAIN_SEQUENCE_VERSION_DESCRIPTOR =
+      new ValueStateDescriptor<>("mainSequenceVersion", Types.LONG);
+  private static final ListStateDescriptor<DVPosition> DATA_ROW_POSITIONS_DESCRIPTOR =
+      new ListStateDescriptor<>("filePositions", TypeInformation.of(DVPosition.class));
+  private static final ListStateDescriptor<DVPosition> BUFFERED_ROWS_DESCRIPTOR =
+      new ListStateDescriptor<>("bufferedRows", TypeInformation.of(DVPosition.class));
+  private static final ValueStateDescriptor<Long> RESOLVE_TIMESTAMP_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveTimestamp", Types.LONG);
+  private static final ValueStateDescriptor<Long> RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR =
+      new ValueStateDescriptor<>("resolveSequenceNumber", Types.LONG);
+
+  private transient ValueState<Long> mainSequenceVersion;
+  // Resolvable rows for this key. Populated immediately for main data, or from onTimer for
+  // staging rows once their phase watermark passes, so a delete never resolves against a row from a
+  // later phase.
+  private transient ListState<DVPosition> dataRowPositions;
+  // Deferred staging-snapshot rows awaiting their event-time timer. onTimer moves them into
+  // dataRowPositions after this cycle's delete has resolved.
+  private transient ListState<DVPosition> bufferedRows;
+  // Phase timestamp of the pending RESOLVE_DELETE; onTimer resolves when the firing timer matches.
+  private transient ValueState<Long> resolveTimestamp;
+  // Maximum sequence number among the cycle's RESOLVE_DELETEs for this key. Deletes a
+  // data row only when the row's sequence number is below it.
+  private transient ValueState<Long> resolveSequenceNumber;
+
+  private transient Counter resolvedDeleteNumCounter;
+  private transient Counter indexedKeyNumCounter;
+  private transient Counter eagerlyEvictedKeyNumCounter;
+
+  private final boolean stagingOnTargetBranch;
+
+  public EqualityConvertPKIndex(boolean stagingOnTargetBranch) {
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext context) throws Exception {
+    super.open(context);
+    mainSequenceVersion = getRuntimeContext().getState(MAIN_SEQUENCE_VERSION_DESCRIPTOR);
+    dataRowPositions = getRuntimeContext().getListState(DATA_ROW_POSITIONS_DESCRIPTOR);
+    bufferedRows = getRuntimeContext().getListState(BUFFERED_ROWS_DESCRIPTOR);
+    resolveTimestamp = getRuntimeContext().getState(RESOLVE_TIMESTAMP_DESCRIPTOR);
+    resolveSequenceNumber = getRuntimeContext().getState(RESOLVE_SEQUENCE_NUMBER_DESCRIPTOR);
+    resolvedDeleteNumCounter =
+        getRuntimeContext().getMetricGroup().counter(RESOLVED_DELETE_NUM_METRIC);
+    indexedKeyNumCounter = getRuntimeContext().getMetricGroup().counter(INDEXED_KEY_NUM_METRIC);
+    eagerlyEvictedKeyNumCounter =
+        getRuntimeContext().getMetricGroup().counter(EAGERLY_EVICTED_KEY_NUM_METRIC);
+  }
+
+  @Override
+  public void processElement(IndexCommand cmd, ReadOnlyContext ctx, Collector<DVPosition> out)
+      throws Exception {
+    try {
+      Long storedSequence = mainSequenceVersion.value();
+      if (!Objects.equals(storedSequence, cmd.mainSequenceNumber())) {
+        LOG.info(
+            "Main sequence changed from {} to {} (snapshot {}), clearing state",
+            storedSequence,
+            cmd.mainSequenceNumber(),
+            cmd.mainSnapshotId());
+        clearKeyState();
+        mainSequenceVersion.update(cmd.mainSequenceNumber());
+      }
+
+      long ts = ctx.timestamp();
+
+      if (cmd.type() == IndexCommand.Type.ADD_DATA_ROW) {
+        // Existing main data: index immediately so this cycle's delete can remove it.
+        dataRowPositions.add(cmd.rowPosition());
+        indexedKeyNumCounter.inc();
+      } else if (cmd.type() == IndexCommand.Type.ADD_STAGING_DATA_ROW) {
+        // Staging snapshot's new data: defer until after this cycle's delete resolves so a
+        // re-inserted key survives. Applied by the event-time timer at this phase.
+        bufferedRows.add(cmd.rowPosition());
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else if (cmd.type() == IndexCommand.Type.RESOLVE_DELETE) {
+        Long resolveTs = resolveTimestamp.value();
+        if (resolveTs == null || ts > resolveTs) {
+          resolveTimestamp.update(ts);
+        }
+
+        Long currentSeq = resolveSequenceNumber.value();
+        if (currentSeq == null || cmd.deleteSequenceNumber() > currentSeq) {
+          resolveSequenceNumber.update(cmd.deleteSequenceNumber());
+        }
+
+        ctx.timerService().registerEventTimeTimer(ts);
+      } else {
+        throw new IllegalStateException("Unexpected command type in keyed stream: " + cmd.type());
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to process command of type {}", cmd.type(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void processBroadcastElement(IndexCommand cmd, Context ctx, Collector<DVPosition> out) {
+    Preconditions.checkArgument(
+        cmd.type() == IndexCommand.Type.CLEAR_INDEX,
+        "Broadcast element must be %s",
+        IndexCommand.Type.CLEAR_INDEX);
+
+    final long broadcastSequenceNumber = cmd.mainSequenceNumber();
+    try {
+      ctx.applyToKeyedState(
+          MAIN_SEQUENCE_VERSION_DESCRIPTOR,
+          (key, sequenceState) -> {
+            Long storedSequenceNumber = sequenceState.value();
+            if (storedSequenceNumber != null && storedSequenceNumber < broadcastSequenceNumber) {
+              clearKeyState();
+              sequenceState.update(broadcastSequenceNumber);
+              eagerlyEvictedKeyNumCounter.inc();
+            }
+          });
+    } catch (Exception e) {
+      LOG.error("PKIndex failed to apply CLEAR_INDEX for snapshot {}", cmd.mainSnapshotId(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  @Override
+  public void onTimer(long timestamp, OnTimerContext ctx, Collector<DVPosition> out) {
+    try {
+      // Timers fire in ascending timestamp order. The delete-phase timer resolves against the
+      // index; any other timer is a staging phase whose buffered rows now join the index.
+      // The delete fires before the (strictly later) staging phase, so the cycle's own new rows are
+      // applied only after the delete and survive it.
+      Long resolveTs = resolveTimestamp.value();
+      if (resolveTs != null && timestamp == resolveTs) {
+        resolveDeletes(out);
+        resolveTimestamp.clear();
+        resolveSequenceNumber.clear();
+      } else {
+        applyBufferedRows();
+      }
+    } catch (Exception e) {
+      LOG.error("PKIndex failed in onTimer at ts={}", timestamp, e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      out.collect(DVPosition.ABORT);
+    }
+  }
+
+  private void applyBufferedRows() throws Exception {
+    for (DVPosition position : bufferedRows.get()) {
+      dataRowPositions.add(position);
+      indexedKeyNumCounter.inc();
+    }
+
+    bufferedRows.clear();
+  }
+
+  private void resolveDeletes(Collector<DVPosition> out) throws Exception {
+    // An equality delete with sequence S deletes only data rows with sequence < S. Rows at or
+    // above S are re-inserts the delete does not affect; keep them indexed for a later delete.
+    // Only valid on a shared staging/target branch, where data and deletes share one sequence
+    // space. On a separate target branch the committer reassigns data sequence numbers, so the
+    // indexed sequence is not comparable to the staging delete's; event-time ordering already
+    // prevents false deletion.
+    Long deleteSeq = resolveSequenceNumber.value();
+    List<DVPosition> nonEligible = Lists.newArrayList();
+    int count = 0;
+    for (DVPosition pos : dataRowPositions.get()) {
+      if (stagingOnTargetBranch && deleteSeq != null && pos.dataSequenceNumber() >= deleteSeq) {
+        nonEligible.add(pos);
+      } else {
+        out.collect(pos);
+        count++;
+      }
+    }
+
+    resolvedDeleteNumCounter.inc(count);
+    dataRowPositions.update(nonEligible);
+  }
+
+  private void clearKeyState() {
+    dataRowPositions.clear();
+    bufferedRows.clear();
+    resolveTimestamp.clear();
+    resolveSequenceNumber.clear();
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertReader.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.functions.OpenContext;
+import org.apache.flink.streaming.api.functions.ProcessFunction;
+import org.apache.flink.util.Collector;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.Accessor;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.ContentScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.BaseDeleteLoader;
+import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.formats.FormatModelRegistry;
+import org.apache.iceberg.formats.ReadBuilder;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Parallel reader that processes {@link ReadCommand}s from the planner and emits {@link
+ * IndexCommand}s. Dispatches on the wrapped {@link ContentScanTask} subtype: {@link FileScanTask}
+ * (data file) emits {@code ADD_DATA_ROW} per row, our equality-delete task emits {@code
+ * RESOLVE_DELETE} per row.
+ */
+@Internal
+public class EqualityConvertReader extends ProcessFunction<ReadCommand, IndexCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertReader.class);
+
+  public static final OutputTag<DVPosition> READER_ABORT_STREAM =
+      new OutputTag<>("reader-abort-stream") {};
+
+  private final TableLoader tableLoader;
+  private final Set<Integer> eqFieldIds;
+  private final boolean stagingOnTargetBranch;
+
+  private transient Table table;
+  private transient Schema keySchema;
+  private transient StructLikeSerializer fieldSerializer;
+  private transient DeleteLoader deleteLoader;
+
+  public EqualityConvertReader(
+      TableLoader tableLoader, Set<Integer> eqFieldIds, boolean stagingOnTargetBranch) {
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.tableLoader = tableLoader;
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+    this.stagingOnTargetBranch = stagingOnTargetBranch;
+  }
+
+  @Override
+  public void open(OpenContext openContext) throws Exception {
+    super.open(openContext);
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+    // Equality fields resolve against the current schema at build time, so it covers all ids.
+    // Fail fast on a missing id rather than silently widening the key.
+    keySchema = TypeUtil.select(table.schema(), eqFieldIds);
+    Preconditions.checkArgument(
+        TypeUtil.getProjectedIds(keySchema).containsAll(eqFieldIds),
+        "Equality field IDs %s not present in table schema",
+        eqFieldIds);
+    fieldSerializer = new StructLikeSerializer();
+    deleteLoader = new BaseDeleteLoader(deleteFile -> table.io().newInputFile(deleteFile));
+  }
+
+  @Override
+  public void processElement(ReadCommand cmd, Context ctx, Collector<IndexCommand> out)
+      throws Exception {
+    ContentScanTask<?> task = cmd.task();
+    ContentFile<?> file = task.file();
+    try {
+      if (task instanceof FileScanTask dataTask) {
+        processDataFile(
+            dataTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            cmd.staging(),
+            out);
+      } else if (task instanceof EqualityDeleteFileScanTask deleteTask) {
+        processDeleteFile(
+            deleteTask,
+            cmd.mainSnapshotId(),
+            cmd.mainSequenceNumber(),
+            cmd.dataSequenceNumber(),
+            out);
+      } else {
+        throw new IllegalStateException(
+            "Unexpected ContentScanTask type: " + task.getClass().getName());
+      }
+    } catch (Exception e) {
+      LOG.error("Reader failed to process command for file={}", file.location(), e);
+      ctx.output(TaskResultAggregator.ERROR_STREAM, e);
+      ctx.output(READER_ABORT_STREAM, DVPosition.ABORT);
+    }
+  }
+
+  private void processDataFile(
+      FileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      boolean staging,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+    Schema readSchema = appendRowPosition(keySchema);
+    PositionDeleteIndex existingDeletes = loadExistingDVs(task, file.location());
+
+    int specId = file.specId();
+    StructLike partition = file.partition();
+    Types.StructType partitionType = table.specs().get(specId).partitionType();
+    byte[] partitionBytes = fieldSerializer.encodePartition(partition, partitionType);
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records =
+        builder.project(readSchema).reuseContainers().build()) {
+      Accessor<StructLike> posAccessor =
+          readSchema.accessorForField(MetadataColumns.ROW_POSITION.fieldId());
+      for (Record record : records) {
+        long position = (long) posAccessor.get(record);
+        if (existingDeletes != null && existingDeletes.isDeleted(position)) {
+          continue;
+        }
+
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.addDataRow(
+                mainSnapshotId,
+                mainSequenceNumber,
+                key,
+                file.location(),
+                position,
+                specId,
+                partitionBytes,
+                dataSequenceNumber,
+                staging));
+      }
+    }
+  }
+
+  private void processDeleteFile(
+      EqualityDeleteFileScanTask task,
+      Long mainSnapshotId,
+      Long mainSequenceNumber,
+      long dataSequenceNumber,
+      Collector<IndexCommand> out)
+      throws IOException {
+    ContentFile<?> file = task.file();
+
+    int specId = file.specId();
+
+    InputFile input = table.io().newInputFile(file.location());
+    ReadBuilder<Record, Schema> builder =
+        FormatModelRegistry.readBuilder(file.format(), Record.class, input);
+    try (CloseableIterable<Record> records = builder.project(keySchema).reuseContainers().build()) {
+      for (Record record : records) {
+        SerializedEqualityValues key =
+            fieldSerializer.serializeKey(record, keySchema.asStruct(), specId);
+        out.collect(
+            IndexCommand.resolveDelete(
+                mainSnapshotId, mainSequenceNumber, key, dataSequenceNumber));
+      }
+    }
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  private Schema appendRowPosition(Schema schema) {
+    List<Types.NestedField> columns = Lists.newArrayList(schema.columns());
+    columns.add(MetadataColumns.ROW_POSITION);
+    return new Schema(columns);
+  }
+
+  private PositionDeleteIndex loadExistingDVs(FileScanTask task, String dataFilePath) {
+    List<DeleteFile> dvs = Lists.newArrayList();
+    for (DeleteFile deleteFile : task.deletes()) {
+      if (ContentFileUtil.isDV(deleteFile)) {
+        dvs.add(deleteFile);
+      } else if (deleteFile.content() == FileContent.POSITION_DELETES) {
+        throw new IllegalStateException(
+            String.format(
+                "V2 positional delete file %s attached to main data file %s; "
+                    + "the converter expects a V3 target with deletion vectors only.",
+                deleteFile.location(), dataFilePath));
+      } else if (deleteFile.content() == FileContent.EQUALITY_DELETES && !stagingOnTargetBranch) {
+        // When stagingBranch == targetBranch the target carries unconverted equality deletes; they
+        // are indexed as rows here and converted via the planner's RESOLVE_DELETE commands. On a
+        // separate target branch an attached equality delete means an unconverted delete leaked
+        // onto the target, which the converter cannot reason about.
+        throw new IllegalStateException(
+            String.format(
+                "Equality delete file %s attached to main data file %s; the converter expects "
+                    + "equality deletes only on the staging branch, converted to DVs on the target.",
+                deleteFile.location(), dataFilePath));
+      }
+    }
+
+    if (dvs.isEmpty()) {
+      return null;
+    }
+
+    return deleteLoader.loadPositionDeletes(dvs, dataFilePath);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/OperatorTestBase.java
@@ -450,6 +450,19 @@ public class OperatorTestBase {
         SCHEMA_WITH_PRIMARY_KEY);
   }
 
+  protected DeleteFile writePosDeleteFile(Table table, String dataFilePath, long pos)
+      throws IOException {
+    File file = File.createTempFile("junit", null, warehouseDir.toFile());
+    assertThat(file.delete()).isTrue();
+    PositionDelete<GenericRecord> posDelete = PositionDelete.create();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    nested.set(0, 1);
+    nested.set(1, "a");
+    posDelete.set(dataFilePath, pos, nested);
+    return FileHelpers.writePosDeleteFile(
+        table, Files.localOutput(file), null, Lists.newArrayList(posDelete), 2);
+  }
+
   private DeleteFile writePosDelete(
       Table table, CharSequence path, Integer pos, Integer id, String oldData, int formatVersion)
       throws IOException {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPKIndex.java
@@ -1,0 +1,675 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.operators.co.CoBroadcastWithKeyedOperator;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedBroadcastOperatorTestHarness;
+import org.junit.jupiter.api.Test;
+
+class TestEqualityConvertPKIndex {
+
+  private static final SerializedEqualityValues KEY_1 =
+      new SerializedEqualityValues(new byte[] {1, 2, 3});
+  private static final SerializedEqualityValues KEY_2 =
+      new SerializedEqualityValues(new byte[] {4, 5, 6});
+  private static final Long MAIN_SNAPSHOT = 100L;
+  private static final Long MAIN_SEQ = 10L;
+  private static final Long NEW_MAIN_SNAPSHOT = 200L;
+  private static final Long NEW_MAIN_SEQ = 20L;
+  private static final byte[] EMPTY_PARTITION = new byte[0];
+  // Data-row sequence below the delete sequence, so existing tests still tombstone on resolve.
+  private static final long DATA_SEQ = 1L;
+  private static final long DELETE_SEQ = 2L;
+
+  @Test
+  void addDataRowProducesNoOutput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPosition() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(5);
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsMultipleDVPositionsForDuplicateKeys() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file2.parquet",
+                  3,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(0);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file2.parquet");
+                assertThat(pos.position()).isEqualTo(3);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteClearsEntries() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+    }
+  }
+
+  @Test
+  void resolveDeleteWithNoMatchEmitsNothing() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void mainSnapshotChangeClearsState() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexEvictsOrphanKeyWithoutKeyedInput() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed against the old main; KEY_2 left untouched.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // External commit removed KEY_1's data file; planner advances main and broadcasts CLEAR.
+      // No keyed input arrives for KEY_1 in the new cycle.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      // Resolving KEY_1 against the (now-empty) index emits nothing.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void clearBeforeReindexAfterAddPreservesEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // ADD with the new generation arrives before the broadcast.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  7,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void clearBeforeReindexThenAddIndexesAtNewVersion() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "old.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      // Broadcast arrives before the new ADD (race direction 2): old entry is wiped, then the
+      // reindex re-emits KEY_1 at its new file/position.
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  NEW_MAIN_SNAPSHOT,
+                  NEW_MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  4,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              2));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(NEW_MAIN_SNAPSHOT, NEW_MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("new.parquet");
+      assertThat(output.get(0).position()).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void olderBroadcastDoesNotEvictNewerEntry() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // KEY_1 indexed at the newer generation: higher sequence number (20) but a lower snapshot id
+      // (50) than the stale broadcast below.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  50L, 20L, KEY_1, "file1.parquet", 7, 0, EMPTY_PARTITION, DATA_SEQ, false),
+              0));
+
+      // A stale CLEAR_INDEX from an older generation arrives late: higher snapshot id (999) but
+      // lower sequence number (10). Ordering by snapshot id would wrongly evict (50 < 999);
+      // ordering
+      // by sequence number keeps the entry (20 is not < 10).
+      harness.processBroadcastElement(
+          new StreamRecord<>(IndexCommand.clearBeforeReindex(999L, 10L), 1));
+
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(50L, 20L, KEY_1, DELETE_SEQ), 2));
+      harness.watermark(2);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+      assertThat(output.get(0).position()).isEqualTo(7);
+    }
+  }
+
+  @Test
+  void differentKeysAreIndependent() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_2,
+                  "file2.parquet",
+                  1,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  @Test
+  void phaseAwareBufferingProcessesInCorrectOrder() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // A main row (ts 0) is indexed and the cycle's delete (ts 1) removes it. The next cycle's new
+      // row (ts 2) arrives before that delete fires; event-time ordering keeps it out of the index
+      // until after the delete, so it survives.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "main.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+
+      harness.watermark(1);
+      assertThat(harness.extractOutputValues()).hasSize(1);
+      assertThat(harness.extractOutputValues().get(0).dataFilePath()).isEqualTo("main.parquet");
+
+      // A later cycle's delete (ts 3) removes the now-indexed new row.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 3));
+      harness.watermark(3);
+      assertThat(harness.extractOutputValues()).hasSize(2);
+      assertThat(harness.extractOutputValues().get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void laterPhaseAddArrivingBeforeResolveSurvives() throws Exception {
+    // The next cycle's new row (ts 2) is delivered before the current cycle's
+    // delete (ts 1) is processed; the new row must not be affected by the delete.
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "new.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  true),
+              2));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+      harness.watermark(2);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void resolveDeleteEmitsDVPositionsForSameFileDifferentPositions() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  5,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  10,
+                  0,
+                  EMPTY_PARTITION,
+                  DATA_SEQ,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, DELETE_SEQ), 1));
+
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output)
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(5);
+              })
+          .anySatisfy(
+              pos -> {
+                assertThat(pos.dataFilePath()).isEqualTo("file1.parquet");
+                assertThat(pos.position()).isEqualTo(10);
+              });
+    }
+  }
+
+  @Test
+  void resolveDeleteSparesReinsertWithHigherSequence() throws Exception {
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness()) {
+      harness.open();
+
+      // Same key indexed twice: an older row (seq 1) and a re-insert (seq 3).
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "old.parquet", 0, 0, EMPTY_PARTITION, 1L, false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, "new.parquet", 0, 0, EMPTY_PARTITION, 3L, false),
+              0));
+
+      // Delete at seq 2 tombstones only the older row; the re-insert (seq 3) survives.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("old.parquet");
+
+      // The survivor stays indexed: a later delete with a higher sequence removes it.
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 4L), 2));
+      harness.watermark(2);
+
+      List<DVPosition> afterSecond = harness.extractOutputValues();
+      assertThat(afterSecond).hasSize(2);
+      assertThat(afterSecond.get(1).dataFilePath()).isEqualTo("new.parquet");
+    }
+  }
+
+  @Test
+  void deletesHigherSequenceWhenStagingNotOnTargetBranch() throws Exception {
+    // On a separate target branch the committer reassigns data sequence numbers, so the worker must
+    // not spare rows by sequence: every key match is deleted (phase ordering prevents
+    // over-deletion across cycles).
+    try (KeyedBroadcastOperatorTestHarness<
+            SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+        harness = createHarness(false)) {
+      harness.open();
+
+      // Row sequence (5) above the delete sequence (2) would survive on a shared branch.
+      harness.processElement(
+          new StreamRecord<>(
+              IndexCommand.addDataRow(
+                  MAIN_SNAPSHOT,
+                  MAIN_SEQ,
+                  KEY_1,
+                  "file1.parquet",
+                  0,
+                  0,
+                  EMPTY_PARTITION,
+                  5L,
+                  false),
+              0));
+      harness.processElement(
+          new StreamRecord<>(IndexCommand.resolveDelete(MAIN_SNAPSHOT, MAIN_SEQ, KEY_1, 2L), 1));
+      harness.watermark(1);
+
+      List<DVPosition> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).dataFilePath()).isEqualTo("file1.parquet");
+    }
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness() throws Exception {
+    return createHarness(true);
+  }
+
+  private static KeyedBroadcastOperatorTestHarness<
+          SerializedEqualityValues, IndexCommand, IndexCommand, DVPosition>
+      createHarness(boolean stagingOnTargetBranch) throws Exception {
+    return new KeyedBroadcastOperatorTestHarness<>(
+        new CoBroadcastWithKeyedOperator<>(
+            new EqualityConvertPKIndex(stagingOnTargetBranch),
+            Collections.singletonList(EqualityConvertPKIndex.CLEAR_BROADCAST_DESCRIPTOR)),
+        IndexCommand::key,
+        TypeInformation.of(SerializedEqualityValues.class),
+        1,
+        1,
+        0);
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertReader.java
@@ -1,0 +1,421 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.flink.streaming.util.ProcessFunctionTestHarnesses;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertReader extends OperatorTestBase {
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void emitsAddStagingDataRowForDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      // stagingDataFile marks a staging snapshot's new data, so the reader emits
+      // ADD_STAGING_DATA_ROW.
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(0).rowPosition().dataFilePath()).isEqualTo(dataFile.location());
+      assertThat(output.get(0).rowPosition().position()).isZero();
+    }
+  }
+
+  @Test
+  void emitsAddDataRowWhenNotStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Same task type as the staging test: the command's staging flag, not the task type, decides
+      // that main reindex data is indexed immediately as ADD_DATA_ROW.
+      ReadCommand cmd =
+          ReadCommand.dataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_DATA_ROW);
+    }
+  }
+
+  @Test
+  void emitsResolveDeleteForEqDeleteFile() throws Exception {
+    Table table = createTableWithDelete(3);
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd = ReadCommand.eqDeleteFile(eqDelete, spec, 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).rowPosition()).isNull();
+    }
+  }
+
+  @Test
+  void tracksPositionsAcrossRecords() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void skipsDeletedPositionsWhenCreatingIndexFromMain() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(
+                Lists.newArrayList(
+                    createRecord(1, "a"), createRecord(2, "b"), createRecord(3, "c")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    // DV marks position 1 (id=2) as deleted on main. When the reader creates the worker's index
+    // from this data file, it must skip position 1 and emit rows only for positions 0 and 2.
+    DeleteFile dv = writeDV(table, dataFile.location(), 1L);
+
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(dv)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).rowPosition().position()).isZero();
+      assertThat(output.get(1).rowPosition().position()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void sameKeyFromDataAndDeleteProducesEqualSerializedValues() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec dataSpec = table.specs().get(dataFile.specId());
+    PartitionSpec deleteSpec = table.specs().get(eqDelete.specId());
+    List<Integer> fieldIds = eqDelete.equalityFieldIds();
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      harness.processElement(
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(dataFile, dataSpec), 0L, 0L, 0L),
+          0);
+      harness.processElement(ReadCommand.eqDeleteFile(eqDelete, deleteSpec, 0L, 0L, 0L), 1);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(2);
+      assertThat(output.get(0).type()).isEqualTo(IndexCommand.Type.ADD_STAGING_DATA_ROW);
+      assertThat(output.get(1).type()).isEqualTo(IndexCommand.Type.RESOLVE_DELETE);
+      assertThat(output.get(0).key()).isEqualTo(output.get(1).key());
+    }
+  }
+
+  @Test
+  void propagatesMainSnapshotId() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+    long mainSnapshotId = 42L;
+    long mainSequenceNumber = 7L;
+    long dataSequenceNumber = 9L;
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec),
+              mainSnapshotId,
+              mainSequenceNumber,
+              dataSequenceNumber);
+      harness.processElement(cmd, 0);
+
+      List<IndexCommand> output = harness.extractOutputValues();
+      assertThat(output).hasSize(1);
+      assertThat(output.get(0).mainSnapshotId()).isEqualTo(mainSnapshotId);
+      assertThat(output.get(0).mainSequenceNumber()).isEqualTo(mainSequenceNumber);
+      assertThat(output.get(0).rowPosition().dataSequenceNumber()).isEqualTo(dataSequenceNumber);
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+    DataFile missing =
+        DataFiles.builder(table.spec())
+            .copy(dataFile)
+            .withPath(dataFile.location() + ".missing")
+            .build();
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // Non-existent file path causes the reader to throw.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(new FlinkAddedRowsScanTask(missing, spec), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenEqualityFieldMissingFromCurrentSchema() throws Exception {
+    // Field ids from SimpleDataUtil.SCHEMA: 1=id, 2=data.
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+
+    // Drop `data`. Static equality fields resolve against the current schema at build time, so an
+    // equality field id missing from the current schema is a misconfiguration.
+    table.updateSchema().deleteColumn("data").commit();
+    table.refresh();
+
+    List<Integer> fieldIds = Lists.newArrayList(1, 2);
+
+    assertThatThrownBy(
+            () -> {
+              try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+                  createHarness(fieldIds)) {
+                harness.open();
+              }
+            })
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not present in table schema");
+  }
+
+  @Test
+  void throwsOnEqualityDeleteAttachedToMainDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // An equality delete attached to a main data file is unexpected on a separate target branch
+      // (stagingOnTargetBranch=false): the reader must route the error rather than silently ignore.
+      ReadCommand cmd =
+          ReadCommand.stagingDataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(eqDelete)), 0L, 0L, 0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void throwsOnV2PositionalDeleteAttachedToMainDataFile() throws Exception {
+    Table table = createTableWithDelete(3);
+
+    DataFile dataFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a")));
+    table.newAppend().appendFile(dataFile).commit();
+    table.refresh();
+
+    DeleteFile posDelete = writePosDeleteFile(table, dataFile.location(), 0L);
+    PartitionSpec spec = table.specs().get(dataFile.specId());
+    List<Integer> fieldIds = Lists.newArrayList(1);
+
+    try (OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> harness =
+        createHarness(fieldIds)) {
+      harness.open();
+
+      // A V2 positional delete attached to a main data file means the target is not a DV-only V3
+      // target, the reader must route to the error output.
+      ReadCommand cmd =
+          ReadCommand.dataFile(
+              new FlinkAddedRowsScanTask(dataFile, spec, Lists.newArrayList(posDelete)),
+              0L,
+              0L,
+              0L);
+      harness.processElement(cmd, 0);
+
+      assertThat(harness.extractOutputValues()).isEmpty();
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(harness.getSideOutput(EqualityConvertReader.READER_ABORT_STREAM)).hasSize(1);
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<ReadCommand, IndexCommand> createHarness(
+      List<Integer> fieldIds) throws Exception {
+    return ProcessFunctionTestHarnesses.forProcessFunction(
+        new EqualityConvertReader(tableLoader(), Sets.newHashSet(fieldIds), false));
+  }
+
+  private static DataFile getFirstDataFile(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile file : reader) {
+          return file.copy();
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    throw new IllegalStateException("No data files found");
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private static DeleteFile writeDV(Table table, String dataFilePath, long... positions)
+      throws IOException {
+    List<PositionDelete<?>> deletes = Lists.newArrayList();
+    GenericRecord nested = GenericRecord.create(table.schema());
+    for (long pos : positions) {
+      PositionDelete<GenericRecord> delete = PositionDelete.create();
+      delete.set(dataFilePath, pos, nested);
+      deletes.add(delete);
+    }
+
+    return FileHelpers.writePosDeleteFile(table, null, null, deletes, 3);
+  }
+}


### PR DESCRIPTION
This is a clean backport of #16844 for Flink versions 1.20 and 2.0.