### PR TITLE
Core: Remove encryption key from keysById first to avoid removeIf

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -1519,10 +1519,10 @@ public class TableMetadata implements Serializable {
     }
 
     public Builder removeEncryptionKey(String keyId) {
-      boolean removed = encryptionKeys.removeIf(key -> key.keyId().equals(keyId));
-      keysById.remove(keyId);
+      EncryptedKey removedKey = keysById.remove(keyId);
 
-      if (removed) {
+      if (removedKey != null) {
+        encryptionKeys.remove(removedKey);
         changes.add(new MetadataUpdate.RemoveEncryptionKey(keyId));
       }
 


### PR DESCRIPTION
https://github.com/apache/iceberg/blob/a165b1c1551dcdb215fb10a610f7d29edfa25df3/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1018-L1020 and https://github.com/apache/iceberg/blob/a165b1c1551dcdb215fb10a610f7d29edfa25df3/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1508 are guarding against multiple `EncryptedKey` with the same `key-id`. 

As such it would be more efficient to remove `keyId` from `keysById` first, the result of which will determine whether the key exists or not. We can then use `encryptionKeys.remove` to remove the _first_ (and only) occurrence of `EncryptedKey` rather than `encryptionKeys.removeIf` which will iterate through the entire list of encryption keys unnecessarily even after removing the only occurrence.