### PR TITLE
Core, Spark: Propagate close() to wrapped catalogs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -23,6 +23,8 @@ import com.github.benmanes.caffeine.cache.Caffeine;
 import com.github.benmanes.caffeine.cache.RemovalCause;
 import com.github.benmanes.caffeine.cache.RemovalListener;
 import com.github.benmanes.caffeine.cache.Ticker;
+import java.io.Closeable;
+import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
 import java.util.Locale;
@@ -43,7 +45,7 @@ import org.slf4j.LoggerFactory;
  * <p>See {@link CatalogProperties#CACHE_EXPIRATION_INTERVAL_MS} for more details regarding special
  * values for {@code expirationIntervalMillis}.
  */
-public class CachingCatalog implements Catalog {
+public class CachingCatalog implements Catalog, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(CachingCatalog.class);
   private static final MetadataTableType[] METADATA_TABLE_TYPE_VALUES = MetadataTableType.values();
 
@@ -129,6 +131,13 @@ public class CachingCatalog implements Catalog {
   @Override
   public String name() {
     return catalog.name();
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (catalog instanceof Closeable) {
+      ((Closeable) catalog).close();
+    }
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -19,9 +19,14 @@
 package org.apache.iceberg.hadoop;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import com.github.benmanes.caffeine.cache.Cache;
+import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Arrays;
@@ -434,6 +439,24 @@ public class TestCachingCatalog extends HadoopTableTestBase {
 
     // cache should have been invalidated by registerTable
     assertThat(catalog.cache().asMap()).doesNotContainKey(targetIdent);
+  }
+
+  @Test
+  void closePropagatesToWrappedCatalog() throws IOException {
+    HadoopCatalog backing = spy(hadoopCatalog());
+    Closeable caching = (Closeable) CachingCatalog.wrap(backing);
+
+    caching.close();
+
+    verify(backing).close();
+  }
+
+  @Test
+  void closeIsSafeWhenWrappedCatalogIsNotCloseable() {
+    Catalog nonCloseable = mock(Catalog.class);
+    Closeable caching = (Closeable) CachingCatalog.wrap(nonCloseable);
+
+    assertThatCode(caching::close).doesNotThrowAnyException();
   }
 
   public static TableIdentifier[] metadataTables(TableIdentifier tableIdent) {

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
 import org.apache.iceberg.spark.procedures.SparkProcedures;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
@@ -38,7 +39,8 @@ abstract class BaseCatalog
         HasIcebergCatalog,
         SupportsFunctions,
         ViewCatalog,
-        SupportsReplaceView {
+        SupportsReplaceView,
+        Closeable {
   private static final String USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS = "use-nullable-query-schema";
   private static final boolean USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS_DEFAULT = true;
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1076,5 +1078,12 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public Catalog icebergCatalog() {
     return icebergCatalog;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
+    }
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -560,6 +562,13 @@ public class SparkSessionCatalog<
     } else {
       throw new UnsupportedOperationException(
           "Renaming a view is not supported by catalog: " + catalogName);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
     }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
 import org.apache.iceberg.spark.procedures.SparkProcedures;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
@@ -37,7 +38,8 @@ abstract class BaseCatalog
         HasIcebergCatalog,
         SupportsFunctions,
         ViewCatalog,
-        SupportsReplaceView {
+        SupportsReplaceView,
+        Closeable {
   private static final String USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS = "use-nullable-query-schema";
   private static final boolean USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS_DEFAULT = true;
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -1046,5 +1048,12 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public Catalog icebergCatalog() {
     return icebergCatalog;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
+    }
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -537,6 +539,13 @@ public class SparkSessionCatalog<
     } else {
       throw new UnsupportedOperationException(
           "Renaming a view is not supported by catalog: " + catalogName);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/BaseCatalog.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
 import org.apache.iceberg.spark.procedures.SparkProcedures;
 import org.apache.iceberg.spark.procedures.SparkProcedures.ProcedureBuilder;
 import org.apache.iceberg.spark.source.HasIcebergCatalog;
@@ -37,7 +38,8 @@ abstract class BaseCatalog
         HasIcebergCatalog,
         SupportsFunctions,
         ViewCatalog,
-        SupportsReplaceView {
+        SupportsReplaceView,
+        Closeable {
   private static final String USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS = "use-nullable-query-schema";
   private static final boolean USE_NULLABLE_QUERY_SCHEMA_CTAS_RTAS_DEFAULT = true;
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.spark;
 import static org.apache.iceberg.TableProperties.GC_ENABLED;
 import static org.apache.iceberg.TableProperties.GC_ENABLED_DEFAULT;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -959,5 +961,12 @@ public class SparkCatalog extends BaseCatalog {
   @Override
   public Catalog icebergCatalog() {
     return icebergCatalog;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
+    }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSessionCatalog.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.spark;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
@@ -537,6 +539,13 @@ public class SparkSessionCatalog<
     } else {
       throw new UnsupportedOperationException(
           "Renaming a view is not supported by catalog: " + catalogName);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (icebergCatalog instanceof Closeable) {
+      ((Closeable) icebergCatalog).close();
     }
   }
 }


### PR DESCRIPTION
## What

`CachingCatalog` and the Spark catalogs (`SparkCatalog`, `SparkSessionCatalog` via `BaseCatalog`) now implement `Closeable` and forward `close()` to the catalog they wrap. Each hop is guarded with an `instanceof Closeable` check.

## Why

A catalog that holds network clients needs its `close()` called to release them. The REST catalog, for instance, drains its pooled HTTP connections on `close()`. That call never made it through the Spark stack:

- `CachingCatalog` wraps a delegate `Catalog` but wasn't `Closeable`, so closing the wrapper did nothing to the delegate.
- `SparkCatalog` and `SparkSessionCatalog` (via `BaseCatalog`) weren't `Closeable` either, so the underlying Iceberg catalog never got closed.

We hit this on a long-running Spark cluster that changed catalogs often. Every discarded catalog kept its client connections and local ports open, and they piled up until the host ran out of ephemeral ports and started throwing `BindException`.

The fix isn't REST-specific. Any closeable backend gets its `close()` called through the same path now: REST, JDBC-backed, the cloud SDK catalogs, and `FileIO` implementations that hold their own pools. Delegates that aren't `Closeable` are skipped by the guard, so custom and in-memory catalogs are unaffected.

## Changes

- `core`: `CachingCatalog implements Closeable`, forwarding `close()` to its delegate.
- `spark` (v3.5 / v4.0 / v4.1): `BaseCatalog implements Closeable`; `SparkCatalog` and `SparkSessionCatalog` forward `close()` to their underlying Iceberg catalog.

## Tests

Two contract tests in `TestCachingCatalog`:

- `closePropagatesToWrappedCatalog` — `close()` reaches a closeable delegate (Mockito spy on a real `hadoopCatalog()`).
- `closeIsSafeWhenWrappedCatalogIsNotCloseable` — the `instanceof Closeable` guard makes `close()` a no-op when the delegate isn't closeable.

## Notes

I searched the issue tracker and didn't find an existing report for this, so there's no issue to link.

This only covers the close path. A catalog that never gets closed, orphaned by code paths we don't control, still leaks. Handling that would need an idle/TTL connection evictor, which is out of scope here.

AI assistance was used to draft the commit message and this PR description, and to evaluate the completeness of the fix. The implementation and design (`Closeable` for parity with the existing in-tree catalogs, plus the per-hop guard) were reviewed and verified manually.
