### PR TITLE
Core, AWS, GCP, Dell, Hive: Fix FileIO leaks and standardize close() across Catalog implementations

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbCatalog.java
@@ -499,7 +499,9 @@ public class DynamoDbCatalog extends BaseMetastoreCatalog
 
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
   }
 
   /**

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -649,7 +649,9 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
   }
 
   @Override

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Configurable;
+import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -86,6 +87,7 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
   private BigQueryMetastoreClient client;
   private boolean listAllTables;
   private String warehouseLocation;
+  private CloseableGroup closeableGroup;
 
   public BigQueryMetastoreCatalog() {}
 
@@ -138,6 +140,11 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
                 CatalogProperties.FILE_IO_IMPL, "org.apache.iceberg.io.ResolvingFileIO"),
             properties,
             conf);
+
+    this.closeableGroup = new CloseableGroup();
+    closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(metricsReporter());
+    closeableGroup.setSuppressCloseFailure(true);
   }
 
   @Override
@@ -295,6 +302,13 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
   @Override
   public String name() {
     return catalogName;
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopCatalog.java
@@ -121,6 +121,7 @@ public class HadoopCatalog extends BaseMetastoreCatalog
 
     this.closeableGroup = new CloseableGroup();
     closeableGroup.addCloseable(lockManager);
+    closeableGroup.addCloseable(fileIO);
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
 
@@ -379,7 +380,9 @@ public class HadoopCatalog extends BaseMetastoreCatalog
 
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/inmemory/InMemoryCatalog.java
@@ -101,6 +101,7 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
     this.warehouseLocation = warehouse.replaceAll("/*$", "");
     this.io = CatalogUtil.loadFileIO(InMemoryFileIO.class.getName(), properties, null);
     this.closeableGroup = new CloseableGroup();
+    closeableGroup.addCloseable(io);
     closeableGroup.addCloseable(metricsReporter());
     closeableGroup.setSuppressCloseFailure(true);
   }
@@ -332,7 +333,9 @@ public class InMemoryCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
     namespaces.clear();
     tables.clear();
     views.clear();

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -500,7 +500,9 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   @Override
   public void close() throws IOException {
-    closeableGroup.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
+    }
   }
 
   @Override

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.exceptions.NoSuchViewException;
 import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
+import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
@@ -97,6 +98,7 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   private boolean listAllTables = false;
   private boolean uniqueTableLocation;
   private Map<String, String> catalogProperties;
+  private CloseableGroup closeableGroup;
 
   public HiveCatalog() {}
 
@@ -140,6 +142,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
             CatalogProperties.UNIQUE_TABLE_LOCATION_DEFAULT);
 
     this.clients = new CachedClientPool(conf, properties);
+
+    this.closeableGroup = new CloseableGroup();
+    closeableGroup.addCloseable(fileIO);
+    closeableGroup.addCloseable(keyManagementClient);
+    closeableGroup.addCloseable(metricsReporter());
+    closeableGroup.setSuppressCloseFailure(true);
   }
 
   @Override
@@ -833,10 +841,8 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   @Override
   public void close() throws IOException {
-    super.close();
-
-    if (keyManagementClient != null) {
-      keyManagementClient.close();
+    if (closeableGroup != null) {
+      closeableGroup.close();
     }
   }
 


### PR DESCRIPTION
## What

Make every `Catalog` implementation release its resources the same way, through a single `CloseableGroup`, and close the `FileIO` instances that a few catalogs were leaking. No public API changes.

## Why

While working on #16861 I audited how each `Catalog` releases its resources on `close()`. That PR makes `close()` reach the wrapped Iceberg catalog, but it only helps if each catalog actually releases everything it holds when closed. The audit turned up both inconsistencies and leaks:

- `HadoopCatalog` and `HiveCatalog` create a `FileIO` but never register it for closing, so it leaks every time the catalog is closed.
- `BigQueryMetastoreCatalog` had no `close()` at all, leaking both its `FileIO` and its metrics reporter.
- The rest were inconsistent: some drained their `CloseableGroup` directly, some also went through `super.close()`, and null-guarding of the group varied.

## Changes

- `core`: `HadoopCatalog` and `InMemoryCatalog` register their `FileIO` in the `CloseableGroup` (`HadoopCatalog` previously leaked it).
- `bigquery`: `BigQueryMetastoreCatalog` gains a `close()` backed by a `CloseableGroup` holding its `FileIO` and metrics reporter.
- `hive-metastore`: `HiveCatalog` closes its `FileIO`, key management client, and metrics reporter through a `CloseableGroup`, and no longer overrides `close()` to call `super`. The shared, process-wide `CachedClientPool` is intentionally excluded, since closing it would break other catalogs sharing it.
- `core` / `aws` / `dell`: add null guards before `closeableGroup.close()` in `HadoopCatalog`, `InMemoryCatalog`, `GlueCatalog`, `DynamoDbCatalog`, and `EcsCatalog`.

In every catalog the metrics reporter stays inside the `CloseableGroup` rather than being closed via `super.close()`, so each catalog releases all of its resources through one path and a failure closing one does not strand the rest.

## Compatibility

No public API or `close()` method signatures change. `JdbcCatalog.close()` keeps its existing signature (no checked `IOException`, wrapping in `UncheckedIOException`); widening it would be source-incompatible for callers of the concrete type. `JdbcCatalog`, `SnowflakeCatalog`, and `NessieCatalog` already followed the pattern and are unchanged, and `RESTCatalog` already delegates to `RESTSessionCatalog`.

## Tests

No new tests: the change is mechanical and is covered by the existing catalog test suites, which construct and close catalogs. Correctness is verified by this PR's CI checks, which compile the affected modules and run their catalog test suites.

## Notes

I noticed this while working on #16861, which handles the complementary problem of propagating `close()` through `CachingCatalog` and the Spark catalogs. That close-propagation work, including `CachingCatalog`, stays in #16861 and is out of scope here.

AI assistance was used during brainstorming and exploration of the catalogs and to check the change for completeness. The implementation, design decisions, and review were done manually.