### PR TITLE
Aliyun: Pass known file length through OSSFileIO.newInputFile

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSFileIO.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSFileIO.java
@@ -77,6 +77,11 @@ public class OSSFileIO implements FileIO {
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return new OSSInputFile(client(), new OSSURI(path), aliyunProperties, length, metrics);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return new OSSOutputFile(client(), new OSSURI(path), aliyunProperties, metrics);
   }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSFileIO.java
@@ -19,6 +19,10 @@
 package org.apache.iceberg.aliyun.oss;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import com.aliyun.oss.OSS;
 import com.aliyun.oss.OSSClient;
@@ -97,6 +101,29 @@ public class TestOSSFileIO extends AliyunOSSTestBase {
     assertThat(in.location()).as("Should have expected location").isEqualTo(location);
     assertThat(in.getLength()).as("Should have expected length").isEqualTo(dataSize);
     assertThat(inFileContent(in, dataSize)).as("Should have expected content").isEqualTo(data);
+  }
+
+  @Test
+  public void testNewInputFileWithLength() throws IOException {
+    String location = randomLocation();
+    int dataSize = 1024 * 10;
+    byte[] data = randomData(dataSize);
+    OutputFile out = fileIO().newOutputFile(location);
+    writeOSSData(out, data);
+
+    OSSURI uri = new OSSURI(location);
+    OSS ossMock = mock(OSS.class, delegatesTo(ossClient().get()));
+    try (FileIO io = new OSSFileIO(() -> ossMock)) {
+      InputFile in = io.newInputFile(location, dataSize);
+      assertThat(in.getLength()).as("Should return the known length").isEqualTo(dataSize);
+      verify(ossMock, times(0)).getSimplifiedObjectMeta(uri.bucket(), uri.key());
+
+      InputFile inWithoutLength = io.newInputFile(location);
+      assertThat(inWithoutLength.getLength())
+          .as("Should return the actual length")
+          .isEqualTo(dataSize);
+      verify(ossMock, times(1)).getSimplifiedObjectMeta(uri.bucket(), uri.key());
+    }
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Override `newInputFile(String, long)` in `OSSFileIO`. Without it, the `FileIO` default (`api/.../io/FileIO.java:46`) drops the length, so OSS issues a HEAD request (`getSimplifiedObjectMeta`) on `getLength()` even when the caller already knows the size.
- The override passes the length to the existing `OSSInputFile` length constructor, removing that HEAD round trip.
- Matches the sibling FileIO implementations that already override this method: `S3FileIO.java:156`, `GCSFileIO.java:111`, `ADLSFileIO.java:100`.

## Testing done

- Added `TestOSSFileIO#testNewInputFileWithLength`: `newInputFile(location, length).getLength()` returns the known length with zero `getSimplifiedObjectMeta` calls, and `newInputFile(location).getLength()` still issues one HEAD call.
- `./gradlew :iceberg-aliyun:check` — passed (TestOSSFileIO 6, TestOSSInputFile 4, 0 failures; includes spotlessCheck + checkstyle + errorProne).
- No integrationTest: aliyun has no `integrationTest` source set; OSS tests run against the in-memory mock under `:check`, so no real OSS backend or Docker is needed.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
