### PR TITLE
Arrow: Read a column missing from a data file as a constant

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowBatchReader.java
@@ -19,8 +19,12 @@
 package org.apache.iceberg.arrow.vectorized;
 
 import java.util.List;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.arrow.ArrowAllocation;
+import org.apache.iceberg.arrow.vectorized.VectorHolder.ConstantVectorHolder;
 import org.apache.iceberg.parquet.VectorizedReader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Types;
 
 /**
  * A collection of vectorized readers per column (in the expected read schema) and Arrow Vector
@@ -28,8 +32,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  */
 class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
 
-  ArrowBatchReader(List<VectorizedReader<?>> readers) {
+  private final List<Types.NestedField> fields;
+
+  ArrowBatchReader(List<VectorizedReader<?>> readers, Schema expectedSchema) {
     super(readers);
+    this.fields = expectedSchema.asStruct().fields();
   }
 
   @Override
@@ -43,16 +50,41 @@ class ArrowBatchReader extends BaseBatchReader<ColumnarBatch> {
 
     ColumnVector[] columnVectors = new ColumnVector[readers.length];
     for (int i = 0; i < readers.length; i += 1) {
-      vectorHolders[i] = readers[i].read(vectorHolders[i], numRowsToRead);
-      int numRowsInVector = vectorHolders[i].numValues();
+      VectorHolder holder = readers[i].read(vectorHolders[i], numRowsToRead);
+      if (holder.isDummy()) {
+        // The column is not in the data file, so the reader returns the value it should be read as
+        // instead of a vector. Build a vector holding that value because callers read a batch as an
+        // Arrow VectorSchemaRoot, which has no way to represent a column without a vector.
+        closeVector(vectorHolders[i]);
+        holder = constantHolder(fields.get(i), holder, numRowsToRead);
+      }
+
+      vectorHolders[i] = holder;
+      int numRowsInVector = holder.numValues();
       Preconditions.checkState(
           numRowsInVector == numRowsToRead,
           "Number of rows in the vector %s didn't match expected %s ",
           numRowsInVector,
           numRowsToRead);
-      // Handle null vector for constant case
-      columnVectors[i] = new ColumnVector(vectorHolders[i]);
+      columnVectors[i] = new ColumnVector(holder);
     }
     return new ColumnarBatch(numRowsToRead, columnVectors);
+  }
+
+  private VectorHolder constantHolder(
+      Types.NestedField field, VectorHolder dummyHolder, int numRows) {
+    Object constant =
+        dummyHolder instanceof ConstantVectorHolder
+            ? ((ConstantVectorHolder<?>) dummyHolder).getConstant()
+            : null;
+
+    return ConstantVectors.holder(field, constant, numRows, ArrowAllocation.rootAllocator());
+  }
+
+  /** Releases a vector built by {@link #constantHolder} for an earlier batch. */
+  private void closeVector(VectorHolder holder) {
+    if (holder != null && holder.vector() != null) {
+      holder.vector().close();
+    }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ArrowReader.java
@@ -382,7 +382,7 @@ public class ArrowReader extends CloseableGroup {
                   fileSchema,
                   setArrowValidityVector,
                   ImmutableMap.of(),
-                  ArrowBatchReader::new));
+                  readers -> new ArrowBatchReader(readers, expectedSchema)));
     }
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ConstantVectors.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ConstantVectors.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+import java.util.function.IntConsumer;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BigIntVector;
+import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.DateDayVector;
+import org.apache.arrow.vector.DecimalVector;
+import org.apache.arrow.vector.FieldVector;
+import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.Float4Vector;
+import org.apache.arrow.vector.Float8Vector;
+import org.apache.arrow.vector.IntVector;
+import org.apache.arrow.vector.TimeMicroVector;
+import org.apache.arrow.vector.TimeStampMicroTZVector;
+import org.apache.arrow.vector.TimeStampMicroVector;
+import org.apache.arrow.vector.TimeStampNanoTZVector;
+import org.apache.arrow.vector.TimeStampNanoVector;
+import org.apache.arrow.vector.VarBinaryVector;
+import org.apache.arrow.vector.VarCharVector;
+import org.apache.iceberg.arrow.ArrowSchemaUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.UUIDUtil;
+
+/**
+ * Builds an Arrow vector whose rows all hold the same value.
+ *
+ * <p>A column that is missing from a data file, either because it was added by a schema change or
+ * because it has a default value, is read as a constant instead of from the file. Spark represents
+ * such a column with a virtual vector that never allocates memory, but the Arrow reader hands out
+ * {@link org.apache.arrow.vector.VectorSchemaRoot}, so it needs a real vector holding the value
+ * repeated once per row.
+ */
+class ConstantVectors {
+
+  private ConstantVectors() {}
+
+  /**
+   * Creates a holder for a vector of {@code numRows} rows that all hold {@code constant}.
+   *
+   * @param field the Iceberg field the vector is read for, used to derive the Arrow type
+   * @param constant the value every row holds, or null to produce an all-null vector
+   * @param numRows the number of rows in the vector
+   * @param allocator the allocator that owns the vector's memory
+   * @return a holder whose vector the caller is responsible for closing
+   */
+  static VectorHolder holder(
+      Types.NestedField field, Object constant, int numRows, BufferAllocator allocator) {
+    FieldVector vector = createVector(field, constant, numRows, allocator);
+
+    NullabilityHolder nullabilityHolder = new NullabilityHolder(numRows);
+    if (constant == null) {
+      nullabilityHolder.setNulls(0, numRows);
+    } else {
+      nullabilityHolder.setNotNulls(0, numRows);
+    }
+
+    return VectorHolder.vectorHolder(vector, field, nullabilityHolder);
+  }
+
+  private static FieldVector createVector(
+      Types.NestedField field, Object constant, int numRows, BufferAllocator allocator) {
+    FieldVector vector = ArrowSchemaUtil.convert(field).createVector(allocator);
+    try {
+      vector.setInitialCapacity(numRows);
+      vector.allocateNew();
+
+      if (constant != null) {
+        IntConsumer setter = setter(vector, field.type(), constant);
+        for (int row = 0; row < numRows; row += 1) {
+          setter.accept(row);
+        }
+      }
+
+      // rows that were never set keep the validity bit allocateNew cleared, so they read as null
+      vector.setValueCount(numRows);
+      return vector;
+    } catch (RuntimeException e) {
+      vector.close();
+      throw e;
+    }
+  }
+
+  private static IntConsumer setter(FieldVector vector, Type type, Object constant) {
+    switch (type.typeId()) {
+      case BOOLEAN:
+        {
+          BitVector bits = (BitVector) vector;
+          int bit = (Boolean) constant ? 1 : 0;
+          return row -> bits.setSafe(row, bit);
+        }
+      case INTEGER:
+        {
+          IntVector ints = (IntVector) vector;
+          int intValue = (Integer) constant;
+          return row -> ints.setSafe(row, intValue);
+        }
+      case LONG:
+        {
+          BigIntVector longs = (BigIntVector) vector;
+          long longValue = (Long) constant;
+          return row -> longs.setSafe(row, longValue);
+        }
+      case FLOAT:
+        {
+          Float4Vector floats = (Float4Vector) vector;
+          float floatValue = (Float) constant;
+          return row -> floats.setSafe(row, floatValue);
+        }
+      case DOUBLE:
+        {
+          Float8Vector doubles = (Float8Vector) vector;
+          double doubleValue = (Double) constant;
+          return row -> doubles.setSafe(row, doubleValue);
+        }
+      case DATE:
+        {
+          DateDayVector days = (DateDayVector) vector;
+          int dayValue = (Integer) constant;
+          return row -> days.setSafe(row, dayValue);
+        }
+      case TIME:
+        {
+          TimeMicroVector times = (TimeMicroVector) vector;
+          long timeValue = (Long) constant;
+          return row -> times.setSafe(row, timeValue);
+        }
+      case TIMESTAMP:
+        {
+          long micros = (Long) constant;
+          if (vector instanceof TimeStampMicroTZVector) {
+            TimeStampMicroTZVector timestamps = (TimeStampMicroTZVector) vector;
+            return row -> timestamps.setSafe(row, micros);
+          } else {
+            TimeStampMicroVector timestamps = (TimeStampMicroVector) vector;
+            return row -> timestamps.setSafe(row, micros);
+          }
+        }
+      case TIMESTAMP_NANO:
+        {
+          long nanos = (Long) constant;
+          if (vector instanceof TimeStampNanoTZVector) {
+            TimeStampNanoTZVector timestamps = (TimeStampNanoTZVector) vector;
+            return row -> timestamps.setSafe(row, nanos);
+          } else {
+            TimeStampNanoVector timestamps = (TimeStampNanoVector) vector;
+            return row -> timestamps.setSafe(row, nanos);
+          }
+        }
+      case STRING:
+        {
+          VarCharVector strings = (VarCharVector) vector;
+          byte[] utf8 = constant.toString().getBytes(StandardCharsets.UTF_8);
+          return row -> strings.setSafe(row, utf8);
+        }
+      case UUID:
+        {
+          FixedSizeBinaryVector uuids = (FixedSizeBinaryVector) vector;
+          byte[] uuidBytes = UUIDUtil.convert((UUID) constant);
+          return row -> uuids.setSafe(row, uuidBytes);
+        }
+      case FIXED:
+        {
+          FixedSizeBinaryVector fixed = (FixedSizeBinaryVector) vector;
+          byte[] fixedBytes = toByteArray(constant);
+          return row -> fixed.setSafe(row, fixedBytes);
+        }
+      case BINARY:
+        {
+          VarBinaryVector binary = (VarBinaryVector) vector;
+          byte[] bytes = toByteArray(constant);
+          return row -> binary.setSafe(row, bytes);
+        }
+      case DECIMAL:
+        {
+          DecimalVector decimals = (DecimalVector) vector;
+          BigDecimal decimal = (BigDecimal) constant;
+          return row -> decimals.setSafe(row, decimal);
+        }
+      default:
+        throw new UnsupportedOperationException("Unsupported constant type: " + type);
+    }
+  }
+
+  private static byte[] toByteArray(Object constant) {
+    if (constant instanceof ByteBuffer) {
+      return ByteBuffers.toByteArray((ByteBuffer) constant);
+    }
+    return (byte[]) constant;
+  }
+}

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
@@ -231,7 +231,8 @@ public class GenericArrowVectorAccessorFactory<
       return new FixedSizeBinaryAccessor<>(
           (FixedSizeBinaryVector) vector, stringFactorySupplier.get());
     }
-    throw new UnsupportedOperationException("Unsupported vector: " + vector.getClass());
+    String vectorName = (vector == null) ? "null" : vector.getClass().toString();
+    throw new UnsupportedOperationException("Unsupported vector: " + vectorName);
   }
 
   private static boolean isDecimal(PrimitiveType primitive) {

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/GenericArrowVectorAccessorFactory.java
@@ -231,8 +231,7 @@ public class GenericArrowVectorAccessorFactory<
       return new FixedSizeBinaryAccessor<>(
           (FixedSizeBinaryVector) vector, stringFactorySupplier.get());
     }
-    String vectorName = (vector == null) ? "null" : vector.getClass().toString();
-    throw new UnsupportedOperationException("Unsupported vector: " + vectorName);
+    throw new UnsupportedOperationException("Unsupported vector: " + vector.getClass());
   }
 
   private static boolean isDecimal(PrimitiveType primitive) {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -742,6 +742,60 @@ public class TestArrowReader {
     assertThat(actualValues).containsExactlyInAnyOrderElementsOf(allExpectedValues);
   }
 
+  /**
+   * Reading a column added by ALTER TABLE after the data files were written produces a constant
+   * holder with a null vector. This used to throw a confusing NullPointerException because the
+   * accessor factory called {@code vector.getClass()} on the null vector. Reading such a column is
+   * not supported yet (see issue #10275), so the reader must fail with a clear message instead.
+   */
+  @Test
+  public void testReadAddedColumnFailsWithClearMessage() throws Exception {
+    tables = new HadoopTables();
+    Schema schema = new Schema(Types.NestedField.required(1, "col", Types.IntegerType.get()));
+    Table table = tables.create(schema, tableLocation);
+
+    GenericRecord record = GenericRecord.create(schema);
+    record.setField("col", 1);
+
+    File parquetFile = File.createTempFile("added-column", ".parquet", tempDir);
+    assertThat(parquetFile.delete()).isTrue();
+    FileAppender<GenericRecord> appender =
+        Parquet.write(Files.localOutput(parquetFile))
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build();
+    try {
+      appender.add(record);
+    } finally {
+      appender.close();
+    }
+
+    DataFile dataFile =
+        DataFiles.builder(PartitionSpec.unpartitioned())
+            .withInputFile(localInput(parquetFile))
+            .withMetrics(appender.metrics())
+            .withFormat(FileFormat.PARQUET)
+            .build();
+    table.newAppend().appendFile(dataFile).commit();
+
+    // Add a column after the data file was written. The added column has no data in the file, so
+    // the reader produces a constant holder with a null vector.
+    table.updateSchema().addColumn("added", Types.IntegerType.get()).commit();
+    Table reloaded = tables.load(tableLocation);
+
+    assertThatThrownBy(
+            () -> {
+              try (VectorizedTableScanIterable vectorizedReader =
+                  new VectorizedTableScanIterable(reloaded.newScan(), 1024, false)) {
+                for (ColumnarBatch batch : vectorizedReader) {
+                  batch.createVectorSchemaRootFromVectors().close();
+                }
+              }
+            })
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Unsupported vector: null");
+  }
+
   private static Stream<Arguments> rejectedUnsignedIntegerCases() {
     return Stream.of(
         Arguments.of(

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -743,13 +743,13 @@ public class TestArrowReader {
   }
 
   /**
-   * Reading a column added by ALTER TABLE after the data files were written produces a constant
-   * holder with a null vector. This used to throw a confusing NullPointerException because the
-   * accessor factory called {@code vector.getClass()} on the null vector. Reading such a column is
-   * not supported yet (see issue #10275), so the reader must fail with a clear message instead.
+   * A column added by ALTER TABLE is not present in the data files written before it, so it is read
+   * as a constant rather than from the file. The reader used to fail on such a column with a
+   * NullPointerException because it passed the missing vector straight to the accessor factory. It
+   * now builds a vector holding the value for every row, so the column reads as null.
    */
   @Test
-  public void testReadAddedColumnFailsWithClearMessage() throws Exception {
+  public void testReadColumnAddedAfterDataFileWasWritten() throws Exception {
     tables = new HadoopTables();
     Schema schema = new Schema(Types.NestedField.required(1, "col", Types.IntegerType.get()));
     Table table = tables.create(schema, tableLocation);
@@ -778,22 +778,29 @@ public class TestArrowReader {
             .build();
     table.newAppend().appendFile(dataFile).commit();
 
-    // Add a column after the data file was written. The added column has no data in the file, so
-    // the reader produces a constant holder with a null vector.
     table.updateSchema().addColumn("added", Types.IntegerType.get()).commit();
     Table reloaded = tables.load(tableLocation);
 
-    assertThatThrownBy(
-            () -> {
-              try (VectorizedTableScanIterable vectorizedReader =
-                  new VectorizedTableScanIterable(reloaded.newScan(), 1024, false)) {
-                for (ColumnarBatch batch : vectorizedReader) {
-                  batch.createVectorSchemaRootFromVectors().close();
-                }
-              }
-            })
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Unsupported vector: null");
+    int rowsRead = 0;
+    try (VectorizedTableScanIterable vectorizedReader =
+        new VectorizedTableScanIterable(reloaded.newScan(), 1024, false)) {
+      for (ColumnarBatch batch : vectorizedReader) {
+        assertThat(batch.numCols()).isEqualTo(2);
+        assertThat(batch.column(1).isNullAt(0)).isTrue();
+
+        try (VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors()) {
+          IntVector existing = (IntVector) root.getVector("col");
+          IntVector added = (IntVector) root.getVector("added");
+          assertThat(existing.getObject(0)).isEqualTo(1);
+          assertThat(added.getValueCount()).isEqualTo(batch.numRows());
+          assertThat(added.isNull(0)).isTrue();
+        }
+
+        rowsRead += batch.numRows();
+      }
+    }
+
+    assertThat(rowsRead).isEqualTo(1);
   }
 
   private static Stream<Arguments> rejectedUnsignedIntegerCases() {

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestConstantVectors.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestConstantVectors.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import java.util.UUID;
+import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.UUIDUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that a column read as a constant produces a vector holding that value in every row. Values
+ * are read back through {@link ColumnVector} because that is how the batch reader hands them out.
+ */
+public class TestConstantVectors {
+
+  private static final int NUM_ROWS = 3;
+
+  private BufferAllocator allocator;
+
+  @BeforeEach
+  public void before() {
+    this.allocator = new RootAllocator(Long.MAX_VALUE);
+  }
+
+  @AfterEach
+  public void after() {
+    allocator.close();
+  }
+
+  @Test
+  public void testNullConstantIsNullInEveryRow() {
+    try (ColumnVector column = constantColumn(Types.IntegerType.get(), null)) {
+      assertThat(column.hasNull()).isTrue();
+      assertThat(column.numNulls()).isEqualTo(NUM_ROWS);
+      for (int row = 0; row < NUM_ROWS; row += 1) {
+        assertThat(column.isNullAt(row)).isTrue();
+      }
+    }
+  }
+
+  @Test
+  public void testNullConstantForEveryPrimitiveType() {
+    // a column added by a schema change has no default, so it is read as a null of its own type
+    for (Type type : primitiveTypes()) {
+      try (ColumnVector column = constantColumn(type, null)) {
+        assertThat(column.isNullAt(0)).as("null constant of %s", type).isTrue();
+        assertThat(column.getFieldVector().getValueCount()).isEqualTo(NUM_ROWS);
+      }
+    }
+  }
+
+  @Test
+  public void testNumericConstants() {
+    try (ColumnVector booleans = constantColumn(Types.BooleanType.get(), true);
+        ColumnVector ints = constantColumn(Types.IntegerType.get(), 42);
+        ColumnVector longs = constantColumn(Types.LongType.get(), 42L);
+        ColumnVector floats = constantColumn(Types.FloatType.get(), 1.5f);
+        ColumnVector doubles = constantColumn(Types.DoubleType.get(), 2.5d)) {
+      for (int row = 0; row < NUM_ROWS; row += 1) {
+        assertThat(booleans.getBoolean(row)).isTrue();
+        assertThat(ints.getInt(row)).isEqualTo(42);
+        assertThat(longs.getLong(row)).isEqualTo(42L);
+        assertThat(floats.getFloat(row)).isEqualTo(1.5f);
+        assertThat(doubles.getDouble(row)).isEqualTo(2.5d);
+        assertThat(ints.isNullAt(row)).isFalse();
+      }
+    }
+  }
+
+  @Test
+  public void testTemporalConstants() {
+    // dates are days from the epoch, times and timestamps are microseconds, nano timestamps are
+    // nanoseconds
+    try (ColumnVector dates = constantColumn(Types.DateType.get(), 19_000);
+        ColumnVector times = constantColumn(Types.TimeType.get(), 3_600_000_000L);
+        ColumnVector timestamptz = constantColumn(Types.TimestampType.withZone(), 1_600_000_000L);
+        ColumnVector timestamp = constantColumn(Types.TimestampType.withoutZone(), 1_600_000_000L);
+        ColumnVector nanotz =
+            constantColumn(Types.TimestampNanoType.withZone(), 1_600_000_000_000L);
+        ColumnVector nanos =
+            constantColumn(Types.TimestampNanoType.withoutZone(), 1_600_000_000_000L)) {
+      for (int row = 0; row < NUM_ROWS; row += 1) {
+        assertThat(dates.getInt(row)).isEqualTo(19_000);
+        assertThat(times.getLong(row)).isEqualTo(3_600_000_000L);
+        assertThat(timestamptz.getLong(row)).isEqualTo(1_600_000_000L);
+        assertThat(timestamp.getLong(row)).isEqualTo(1_600_000_000L);
+        assertThat(nanotz.getLong(row)).isEqualTo(1_600_000_000_000L);
+        assertThat(nanos.getLong(row)).isEqualTo(1_600_000_000_000L);
+      }
+    }
+  }
+
+  @Test
+  public void testStringAndBinaryConstants() {
+    UUID uuid = UUID.fromString("9b9e2b46-9b53-4bcb-a1a5-4f0b0a15d5c1");
+    byte[] fixed = new byte[] {1, 2, 3, 4};
+    byte[] binary = new byte[] {5, 6, 7};
+
+    try (ColumnVector strings = constantColumn(Types.StringType.get(), "iceberg");
+        ColumnVector uuids = constantColumn(Types.UUIDType.get(), uuid);
+        ColumnVector fixedValues = constantColumn(Types.FixedType.ofLength(4), fixed);
+        ColumnVector binaryValues =
+            constantColumn(Types.BinaryType.get(), ByteBuffer.wrap(binary))) {
+      for (int row = 0; row < NUM_ROWS; row += 1) {
+        assertThat(strings.getString(row)).isEqualTo("iceberg");
+        assertThat(uuids.getBinary(row)).isEqualTo(UUIDUtil.convert(uuid));
+        assertThat(fixedValues.getBinary(row)).isEqualTo(fixed);
+        assertThat(binaryValues.getBinary(row)).isEqualTo(binary);
+      }
+    }
+  }
+
+  @Test
+  public void testDecimalConstant() {
+    BigDecimal decimal = new BigDecimal("123.45");
+    try (ColumnVector decimals = constantColumn(Types.DecimalType.of(9, 2), decimal)) {
+      for (int row = 0; row < NUM_ROWS; row += 1) {
+        assertThat(decimals.getDecimal(row, 9, 2)).isEqualTo(decimal);
+      }
+    }
+  }
+
+  @Test
+  public void testStringConstantAcceptsAnyCharSequence() {
+    CharSequence value = new StringBuilder("iceberg");
+    try (ColumnVector strings = constantColumn(Types.StringType.get(), value)) {
+      assertThat(strings.getString(0)).isEqualTo("iceberg");
+    }
+  }
+
+  @Test
+  public void testUnsupportedConstantType() {
+    Types.NestedField field =
+        Types.NestedField.optional(
+            1,
+            "c",
+            Types.StructType.of(Types.NestedField.optional(2, "n", Types.IntegerType.get())));
+
+    assertThatThrownBy(() -> ConstantVectors.holder(field, "value", NUM_ROWS, allocator))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageStartingWith("Unsupported constant type:");
+  }
+
+  private ColumnVector constantColumn(Type type, Object constant) {
+    Types.NestedField field = Types.NestedField.optional(1, "c", type);
+    return new ColumnVector(ConstantVectors.holder(field, constant, NUM_ROWS, allocator));
+  }
+
+  private static Type[] primitiveTypes() {
+    return new Type[] {
+      Types.BooleanType.get(),
+      Types.IntegerType.get(),
+      Types.LongType.get(),
+      Types.FloatType.get(),
+      Types.DoubleType.get(),
+      Types.DateType.get(),
+      Types.TimeType.get(),
+      Types.TimestampType.withZone(),
+      Types.TimestampType.withoutZone(),
+      Types.TimestampNanoType.withZone(),
+      Types.TimestampNanoType.withoutZone(),
+      Types.StringType.get(),
+      Types.UUIDType.get(),
+      Types.FixedType.ofLength(4),
+      Types.BinaryType.get(),
+      Types.DecimalType.of(9, 2),
+    };
+  }
+}


### PR DESCRIPTION
Related to #10275

## Summary

- When a column is added with `ALTER TABLE ... ADD COLUMN` after data files were written, the arrow vectorized reader produces a dummy `VectorHolder` with no backing vector, and reading that column fails.
- The Spark path already handles this in `ColumnVectorBuilder`, which checks `isDummy()`/`ConstantVectorHolder` and builds a `ConstantColumnVector` instead of going through the accessor factory. The Arrow `ColumnVector` has no such branch, so the dummy holder flows straight in.
- Fix it at the caller. A new `ConstantVectors` builds a `FieldVector` and a `NullabilityHolder` from the field, the constant and the row count, and `ArrowBatchReader` swaps a dummy holder for one of those before the batch is assembled. Spark can use a virtual column because its `ColumnVector` is an interface, but Arrow hands the batch out as a `VectorSchemaRoot`, so a real vector has to exist.
- Supported constant types are the primitives Arrow already reads: boolean, int, long, float, double, date, time, timestamp, timestamp_ns, string, uuid, fixed, binary and decimal. Anything else throws `UnsupportedOperationException` rather than failing later.
- `GenericArrowVectorAccessorFactory` is unchanged from `main`, so the Spark path is unaffected.
- Revives the stale fix from #10284, closed by the stale bot rather than rejected by design.

## Testing done

- `TestArrowReader#testReadColumnAddedAfterDataFileWasWritten`: writes one row, adds a column via `updateSchema().addColumn`, scans with `VectorizedTableScanIterable`, and asserts the added column reads as null instead of failing.
- New `TestConstantVectors`: 8 tests covering null constants for every supported primitive type, constant values for numeric, temporal, string/binary and decimal types, and the unsupported-type error.
- `./gradlew :iceberg-arrow:check` — passed on JDK 21.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
