### PR TITLE
API: Fix misleading error message in predicate()

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -248,7 +248,7 @@ public class Expressions {
             && op != Operation.NOT_NULL
             && op != Operation.IS_NAN
             && op != Operation.NOT_NAN,
-        "Cannot create %s predicate inclusive a value",
+        "Cannot create %s predicate with a value",
         op);
     Preconditions.checkArgument(
         !NaNUtil.isNaN(lit.value()),

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -236,13 +236,6 @@ public class TestExpressionHelpers {
   }
 
   @Test
-  public void testPredicateWithValueForUnaryOperation() {
-    assertThatThrownBy(() -> predicate(Expression.Operation.IS_NULL, "x", 5))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot create IS_NULL predicate with a value");
-  }
-
-  @Test
   public void testMultiAnd() {
     Expression expected = and(and(equal("a", 1), equal("b", 2)), equal("c", 3));
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionHelpers.java
@@ -236,6 +236,13 @@ public class TestExpressionHelpers {
   }
 
   @Test
+  public void testPredicateWithValueForUnaryOperation() {
+    assertThatThrownBy(() -> predicate(Expression.Operation.IS_NULL, "x", 5))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create IS_NULL predicate with a value");
+  }
+
+  @Test
   public void testMultiAnd() {
     Expression expected = and(and(equal("a", 1), equal("b", 2)), equal("c", 3));
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestExpressionUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.expressions;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -1450,6 +1451,13 @@ public class TestExpressionUtil {
                 + "(hash-event_timestamp_tz_nanos): (timestamp), "
                 + "(hash-event_uuid): (hash-54e07fa7)}"),
         ExpressionUtil.sanitize(bound));
+  }
+
+  @Test
+  public void testPredicateWithValueForUnaryOperation() {
+    assertThatThrownBy(() -> Expressions.predicate(Expression.Operation.IS_NULL, "x", 5))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create IS_NULL predicate with a value");
   }
 
   private static VariantPrimitive<?> createTimestampNanos(int primitiveHeader) {


### PR DESCRIPTION
<!-- No issue: minor bug fix, issue not required -->

## Summary

- `Expressions.predicate(Operation, String, Literal)` rejects the unary operations IS_NULL, NOT_NULL, IS_NAN, NOT_NAN (which take no value) with the message `Cannot create %s predicate inclusive a value`.
- `inclusive a value` is not grammatical and does not describe the failure.
- The sibling method `predicate(Operation, String)` rejects value-taking operations with `Cannot create %s predicate without a value`. This is the mirror case — a value passed to a unary op — so the message should read `with a value`.
- Fix: change the literal to `Cannot create %s predicate with a value`. No signature, branch, or ABI change.

## Testing done

- Added `TestExpressionHelpers#testPredicateWithValueForUnaryOperation` asserting `predicate(IS_NULL, "x", 5)` throws `IllegalArgumentException` with message `Cannot create IS_NULL predicate with a value`.
- `./gradlew :iceberg-api:check` — passed (TestExpressionHelpers: 14 tests, 0 failures; includes spotlessCheck, checkstyle, errorProne).
- `./gradlew :iceberg-api:revapi` — passed (backward compatible; only an error-message string changed).

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix the misleading error message in `predicate()` and cover it with a test.
