### PR TITLE
AWS: Inject Glue catalog ID via interceptor instead of per-call

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -76,6 +76,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     return GlueClient.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsProperties::applyGlueCatalogIdConfigurations)
         .applyMutation(awsClientProperties::applyRetryConfigurations)
         .build();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -81,6 +81,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     return GlueClient.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsProperties::applyGlueCatalogIdConfigurations)
         .applyMutation(awsClientProperties::applyRetryConfigurations)
         .build();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -147,6 +147,7 @@ public class AwsClientFactories {
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(httpClientProperties::applyHttpClientConfigurations)
           .applyMutation(awsProperties::applyGlueEndpointConfigurations)
+          .applyMutation(awsProperties::applyGlueCatalogIdConfigurations)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
           .applyMutation(awsClientProperties::applyRetryConfigurations)
           .build();

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -411,6 +411,22 @@ public class AwsProperties implements Serializable {
   }
 
   /**
+   * Add the interceptor to assign a catalog id to a glue client.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     GlueClient.builder().applyMutation(awsProperties::applyGlueCatalogIdConfigurations)
+   * </pre>
+   */
+  public <T extends GlueClientBuilder> void applyGlueCatalogIdConfigurations(T builder) {
+    if (!Strings.isNullOrEmpty(glueCatalogId)) {
+      builder.overrideConfiguration(
+          c -> c.addExecutionInterceptor(new GlueCatalogIdInterceptor(glueCatalogId)));
+    }
+  }
+
+  /**
    * Override the endpoint for a dynamoDb client.
    *
    * <p>Sample usage:

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -428,6 +428,22 @@ public class AwsProperties implements Serializable {
   }
 
   /**
+   * Add the interceptor to assign a catalog id to a glue client.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     GlueClient.builder().applyMutation(awsProperties::applyGlueCatalogIdConfigurations)
+   * </pre>
+   */
+  public <T extends GlueClientBuilder> void applyGlueCatalogIdConfigurations(T builder) {
+    if (!Strings.isNullOrEmpty(glueCatalogId)) {
+      builder.overrideConfiguration(
+          c -> c.addExecutionInterceptor(new GlueCatalogIdInterceptor(glueCatalogId)));
+    }
+  }
+
+  /**
    * Override the endpoint for a dynamoDb client.
    *
    * <p>Sample usage:

--- a/aws/src/main/java/org/apache/iceberg/aws/GlueCatalogIdInterceptor.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/GlueCatalogIdInterceptor.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context.ModifyRequest;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.core.interceptor.ExecutionInterceptor;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+import software.amazon.awssdk.services.glue.model.GlueRequest;
+import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+
+class GlueCatalogIdInterceptor implements ExecutionInterceptor {
+
+  private final String catalogId;
+
+  GlueCatalogIdInterceptor(String catalogId) {
+    Preconditions.checkArgument(
+        !Strings.isNullOrEmpty(catalogId), "Invalid catalog id: null or empty");
+    this.catalogId = catalogId;
+  }
+
+  @Override
+  public SdkRequest modifyRequest(ModifyRequest context, ExecutionAttributes executionAttributes) {
+    SdkRequest request = context.request();
+    if (!(request instanceof GlueRequest)) {
+      return request;
+    }
+
+    if (request instanceof GetDatabaseRequest) {
+      return ((GetDatabaseRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof GetDatabasesRequest) {
+      return ((GetDatabasesRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof CreateDatabaseRequest) {
+      return ((CreateDatabaseRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof DeleteDatabaseRequest) {
+      return ((DeleteDatabaseRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof UpdateDatabaseRequest) {
+      return ((UpdateDatabaseRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof GetTableRequest) {
+      return ((GetTableRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof GetTablesRequest) {
+      return ((GetTablesRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof CreateTableRequest) {
+      return ((CreateTableRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof UpdateTableRequest) {
+      return ((UpdateTableRequest) request).toBuilder().catalogId(catalogId).build();
+    } else if (request instanceof DeleteTableRequest) {
+      return ((DeleteTableRequest) request).toBuilder().catalogId(catalogId).build();
+    } else {
+      throw new IllegalArgumentException("Unexpected request: " + request.getClass().getName());
+    }
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -289,7 +289,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
     GetDatabaseResponse response =
         glue.getDatabase(
             GetDatabaseRequest.builder()
-                .catalogId(awsProperties.glueCatalogId())
                 .name(
                     IcebergToGlueConverter.getDatabaseName(
                         tableIdentifier, awsProperties.glueCatalogSkipNameValidation()))
@@ -323,7 +322,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
       GetTablesResponse response =
           glue.getTables(
               GetTablesRequest.builder()
-                  .catalogId(awsProperties.glueCatalogId())
                   .databaseName(
                       IcebergToGlueConverter.toDatabaseName(
                           namespace, awsProperties.glueCatalogSkipNameValidation()))
@@ -366,7 +364,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
       }
       glue.deleteTable(
           DeleteTableRequest.builder()
-              .catalogId(awsProperties.glueCatalogId())
               .databaseName(
                   IcebergToGlueConverter.getDatabaseName(
                       identifier, awsProperties.glueCatalogSkipNameValidation()))
@@ -415,11 +412,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     try {
       GetTableResponse response =
           glue.getTable(
-              GetTableRequest.builder()
-                  .catalogId(awsProperties.glueCatalogId())
-                  .databaseName(fromTableDbName)
-                  .name(fromTableName)
-                  .build());
+              GetTableRequest.builder().databaseName(fromTableDbName).name(fromTableName).build());
       fromTable = response.table();
     } catch (EntityNotFoundException e) {
       throw new NoSuchTableException(
@@ -436,7 +429,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
     glue.createTable(
         CreateTableRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
             .databaseName(toTableDbName)
             .tableInput(tableInputBuilder.name(toTableName).build())
             .build());
@@ -452,11 +444,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
           to,
           e);
       glue.deleteTable(
-          DeleteTableRequest.builder()
-              .catalogId(awsProperties.glueCatalogId())
-              .databaseName(toTableDbName)
-              .name(toTableName)
-              .build());
+          DeleteTableRequest.builder().databaseName(toTableDbName).name(toTableName).build());
       throw e;
     }
 
@@ -468,7 +456,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
     try {
       glue.createDatabase(
           CreateDatabaseRequest.builder()
-              .catalogId(awsProperties.glueCatalogId())
               .databaseInput(
                   IcebergToGlueConverter.toDatabaseInput(
                       namespace, metadata, awsProperties.glueCatalogSkipNameValidation()))
@@ -496,11 +483,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
     List<Namespace> results = Lists.newArrayList();
     do {
       GetDatabasesResponse response =
-          glue.getDatabases(
-              GetDatabasesRequest.builder()
-                  .catalogId(awsProperties.glueCatalogId())
-                  .nextToken(nextToken)
-                  .build());
+          glue.getDatabases(GetDatabasesRequest.builder().nextToken(nextToken).build());
       nextToken = response.nextToken();
       if (response.hasDatabaseList()) {
         results.addAll(
@@ -522,12 +505,7 @@ public class GlueCatalog extends BaseMetastoreCatalog
             namespace, awsProperties.glueCatalogSkipNameValidation());
     try {
       Database database =
-          glue.getDatabase(
-                  GetDatabaseRequest.builder()
-                      .catalogId(awsProperties.glueCatalogId())
-                      .name(databaseName)
-                      .build())
-              .database();
+          glue.getDatabase(GetDatabaseRequest.builder().name(databaseName).build()).database();
       Map<String, String> result = Maps.newHashMap(database.parameters());
 
       if (database.locationUri() != null) {
@@ -559,7 +537,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
     GetTablesResponse response =
         glue.getTables(
             GetTablesRequest.builder()
-                .catalogId(awsProperties.glueCatalogId())
                 .databaseName(
                     IcebergToGlueConverter.toDatabaseName(
                         namespace, awsProperties.glueCatalogSkipNameValidation()))
@@ -578,7 +555,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
     glue.deleteDatabase(
         DeleteDatabaseRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
             .name(
                 IcebergToGlueConverter.toDatabaseName(
                     namespace, awsProperties.glueCatalogSkipNameValidation()))
@@ -596,7 +572,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
     newProperties.putAll(properties);
     glue.updateDatabase(
         UpdateDatabaseRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
             .name(
                 IcebergToGlueConverter.toDatabaseName(
                     namespace, awsProperties.glueCatalogSkipNameValidation()))
@@ -619,7 +594,6 @@ public class GlueCatalog extends BaseMetastoreCatalog
 
     glue.updateDatabase(
         UpdateDatabaseRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
             .name(
                 IcebergToGlueConverter.toDatabaseName(
                     namespace, awsProperties.glueCatalogSkipNameValidation()))

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -277,11 +277,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
     try {
       GetTableResponse response =
           glue.getTable(
-              GetTableRequest.builder()
-                  .catalogId(awsProperties.glueCatalogId())
-                  .databaseName(databaseName)
-                  .name(tableName)
-                  .build());
+              GetTableRequest.builder().databaseName(databaseName).name(tableName).build());
       return response.table();
     } catch (EntityNotFoundException e) {
       return null;
@@ -311,7 +307,6 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       UpdateTableRequest.Builder updateTableRequest =
           UpdateTableRequest.builder()
               .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
-              .catalogId(awsProperties.glueCatalogId())
               .databaseName(databaseName)
               .skipArchive(awsProperties.glueCatalogSkipArchive())
               .tableInput(
@@ -335,7 +330,6 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
       glue.createTable(
           CreateTableRequest.builder()
               .overrideConfiguration(c -> c.addMetricPublisher(retryDetector))
-              .catalogId(awsProperties.glueCatalogId())
               .databaseName(databaseName)
               .tableInput(
                   TableInput.builder()

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -54,7 +54,6 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
 
   private String dbName;
   private String tableName;
-  private String glueCatalogId;
   private String glueAccountId;
 
   public LakeFormationAwsClientFactory() {}
@@ -70,7 +69,6 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
         AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX);
     this.dbName = catalogProperties.get(AwsProperties.LAKE_FORMATION_DB_NAME);
     this.tableName = catalogProperties.get(AwsProperties.LAKE_FORMATION_TABLE_NAME);
-    this.glueCatalogId = catalogProperties.get(AwsProperties.GLUE_CATALOG_ID);
     this.glueAccountId = catalogProperties.get(AwsProperties.GLUE_ACCOUNT_ID);
   }
 
@@ -114,13 +112,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
         tableName != null && !tableName.isEmpty(), "Table name can not be empty");
 
     GetTableResponse response =
-        glue()
-            .getTable(
-                GetTableRequest.builder()
-                    .catalogId(glueCatalogId)
-                    .databaseName(dbName)
-                    .name(tableName)
-                    .build());
+        glue().getTable(GetTableRequest.builder().databaseName(dbName).name(tableName).build());
     return response.table().isRegisteredWithLakeFormation();
   }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/TestGlueCatalogIdInterceptor.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestGlueCatalogIdInterceptor.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.core.SdkRequest;
+import software.amazon.awssdk.core.interceptor.Context;
+import software.amazon.awssdk.core.interceptor.ExecutionAttributes;
+import software.amazon.awssdk.services.glue.model.CreateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.CreateTableRequest;
+import software.amazon.awssdk.services.glue.model.DeleteDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.DeleteTableRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.GetDatabasesRequest;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTablesRequest;
+import software.amazon.awssdk.services.glue.model.UpdateDatabaseRequest;
+import software.amazon.awssdk.services.glue.model.UpdateTableRequest;
+
+class TestGlueCatalogIdInterceptor {
+
+  private static final String CATALOG_ID = "testCatalogId";
+  private static final ExecutionAttributes EMPTY_ATTRS = ExecutionAttributes.builder().build();
+
+  @Test
+  void getDatabaseRequest() {
+    SdkRequest result = intercept(GetDatabaseRequest.builder().name("db").build());
+    assertThat(((GetDatabaseRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void getDatabasesRequest() {
+    SdkRequest result = intercept(GetDatabasesRequest.builder().build());
+    assertThat(((GetDatabasesRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void createDatabaseRequest() {
+    SdkRequest result = intercept(CreateDatabaseRequest.builder().build());
+    assertThat(((CreateDatabaseRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void deleteDatabaseRequest() {
+    SdkRequest result = intercept(DeleteDatabaseRequest.builder().name("db").build());
+    assertThat(((DeleteDatabaseRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void updateDatabaseRequest() {
+    SdkRequest result = intercept(UpdateDatabaseRequest.builder().name("db").build());
+    assertThat(((UpdateDatabaseRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void getTableRequest() {
+    SdkRequest result = intercept(GetTableRequest.builder().databaseName("db").name("t").build());
+    assertThat(((GetTableRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void getTablesRequest() {
+    SdkRequest result = intercept(GetTablesRequest.builder().databaseName("db").build());
+    assertThat(((GetTablesRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void createTableRequest() {
+    SdkRequest result = intercept(CreateTableRequest.builder().databaseName("db").build());
+    assertThat(((CreateTableRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void updateTableRequest() {
+    SdkRequest result = intercept(UpdateTableRequest.builder().databaseName("db").build());
+    assertThat(((UpdateTableRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void deleteTableRequest() {
+    SdkRequest result =
+        intercept(DeleteTableRequest.builder().databaseName("db").name("t").build());
+    assertThat(((DeleteTableRequest) result).catalogId()).isEqualTo(CATALOG_ID);
+  }
+
+  @Test
+  void nonGlueRequestPassedThrough() {
+    SdkRequest nonGlueRequest = mock(SdkRequest.class);
+    GlueCatalogIdInterceptor interceptor = new GlueCatalogIdInterceptor(CATALOG_ID);
+    Context.ModifyRequest ctx = mock(Context.ModifyRequest.class);
+    when(ctx.request()).thenReturn(nonGlueRequest);
+    assertThat(interceptor.modifyRequest(ctx, EMPTY_ATTRS)).isSameAs(nonGlueRequest);
+  }
+
+  @Test
+  void invalidCatalogIdRejected() {
+    assertThatThrownBy(() -> new GlueCatalogIdInterceptor(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid catalog id");
+
+    assertThatThrownBy(() -> new GlueCatalogIdInterceptor(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid catalog id");
+  }
+
+  private static SdkRequest intercept(SdkRequest request) {
+    GlueCatalogIdInterceptor interceptor = new GlueCatalogIdInterceptor(CATALOG_ID);
+    Context.ModifyRequest context = mock(Context.ModifyRequest.class);
+    when(context.request()).thenReturn(request);
+    return interceptor.modifyRequest(context, EMPTY_ATTRS);
+  }
+}

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -167,34 +167,6 @@ public class TestGlueCatalog {
   }
 
   @Test
-  public void testDefaultWarehouseLocationCustomCatalogId() {
-    GlueCatalog catalogWithCustomCatalogId = new GlueCatalog();
-    String catalogId = "myCatalogId";
-    AwsProperties awsProperties = new AwsProperties();
-    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
-    awsProperties.setGlueCatalogId(catalogId);
-    catalogWithCustomCatalogId.initialize(
-        CATALOG_NAME,
-        WAREHOUSE_PATH + "/",
-        awsProperties,
-        s3FileIOProperties,
-        glue,
-        LockManagers.defaultLockManager(),
-        ImmutableMap.of());
-
-    Mockito.doReturn(
-            GetDatabaseResponse.builder()
-                .database(Database.builder().name("db").locationUri("s3://bucket2/db").build())
-                .build())
-        .when(glue)
-        .getDatabase(Mockito.any(GetDatabaseRequest.class));
-    catalogWithCustomCatalogId.defaultWarehouseLocation(TableIdentifier.of("db", "table"));
-    Mockito.verify(glue)
-        .getDatabase(
-            Mockito.argThat((GetDatabaseRequest req) -> req.catalogId().equals(catalogId)));
-  }
-
-  @Test
   public void testDefaultWarehouseLocationUnique() {
     GlueCatalog catalog = new GlueCatalog();
     catalog.initialize(


### PR DESCRIPTION
Setting Glue catalog ID at every call site is error-prone - new request types can silently miss it. 

This introduces GlueCatalogIdInterceptor registered on the GlueClient builder, which injects the catalog ID into every outgoing Glue request automatically, replacing ~17 scattered `.catalogId()` call sites. The interceptor throws on unknown request types to catch gaps at the source.

- Supersedes #16873