### PR TITLE
Build: Remove duplicate jackson.databind declaration

### DIFF
--- a/kafka-connect/build.gradle
+++ b/kafka-connect/build.gradle
@@ -179,7 +179,6 @@ project(':iceberg-kafka-connect:iceberg-kafka-connect-runtime') {
     integrationImplementation platform(libs.jackson.bom)
     integrationImplementation libs.jackson.core
     integrationImplementation libs.jackson.databind
-    integrationImplementation libs.jackson.databind
     integrationImplementation libs.kafka.clients
     integrationImplementation libs.kafka.connect.api
     integrationImplementation libs.kafka.connect.json


### PR DESCRIPTION
The jackson.databind dependency appears twice in the dependencies closure. This change removes the duplicated line. It does not introduce any functional or behavioral changes to the Kafka Connect connector.