### PR TITLE
Parquet: Fix variant BINARY upper bound to truncate up

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -367,7 +367,7 @@ class ParquetVariantUtil {
           return truncatedString != null ? Variants.of(PhysicalType.STRING, truncatedString) : null;
         case BINARY:
           ByteBuffer truncatedBuffer =
-              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16);
+              BinaryUtil.truncateBinaryMax((ByteBuffer) value.asPrimitive().get(), 16);
           return truncatedBuffer != null ? Variants.of(PhysicalType.BINARY, truncatedBuffer) : null;
         default:
           return value;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -242,6 +242,31 @@ public class TestVariantMetrics {
   }
 
   @Test
+  public void testShreddedBinaryUpperBoundOverflow() throws IOException {
+    // an all-0xFF binary cannot be truncated up so the upper bound is omitted
+    byte[] bytes = new byte[20];
+    for (int i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (byte) 0xFF;
+    }
+    VariantValue value = Variants.of(ByteBuffer.wrap(bytes));
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMin(ByteBuffer.wrap(bytes), 16)));
+
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isNull();
+  }
+
+  @Test
   public void testVariantFloatNaN() throws IOException {
     // NaN values are not counted because there is no ID for FieldMetrics
     VariantValue floatValue = Variants.of(1.0F);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -217,6 +217,31 @@ public class TestVariantMetrics {
   }
 
   @Test
+  public void testShreddedBinaryBoundsTruncation() throws IOException {
+    // binary longer than the 16-byte truncation length so the bounds are truncated
+    byte[] bytes = new byte[20];
+    for (int i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (byte) (i + 1);
+    }
+    VariantValue value = Variants.of(ByteBuffer.wrap(bytes));
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMin(ByteBuffer.wrap(bytes), 16)));
+
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMax(ByteBuffer.wrap(bytes), 16)));
+  }
+
+  @Test
   public void testVariantFloatNaN() throws IOException {
     // NaN values are not counted because there is no ID for FieldMetrics
     VariantValue floatValue = Variants.of(1.0F);


### PR DESCRIPTION
### Rationale for this change

  For each column, Iceberg records the smallest and largest value in a file so queries can
  skip files that can't contain a match. Long values are shortened to 16 bytes to save space
  but when shortening the **largest** value, it has to round **up**, so the stored "max" stays
  at least as big as the real maximum. (If it rounded down, the stored max could be smaller
  than a real value, which breaks file skipping.)
  
  For `BINARY` values inside a Variant column, this rounds the wrong way: the upper bound is
  shortened with `truncateBinaryMin` (rounds down) instead of `truncateBinaryMax` (rounds up).
  So the stored max can come out **smaller than a value actually in the file**, and a query like
  `binaryColumn > X` may decide the file can't match and skip it silently returning wrong
  (missing) results. The lower bound is correct.
 
  This also disagrees with the code around it: the `STRING` branch uses `truncateStringMax`,
  the lower-bound method uses `truncateBinaryMin`, and the non-variant
  `ParquetMetrics.truncateUpperBound` uses `truncateBinaryMax`. Introduced in #12496.
  
  ### What changes are included in this PR?
  
  Use `truncateBinaryMax` for the BINARY upper bound. One-line change.
  
  ### Are these changes tested?
  
  Yes. `TestVariantMetrics.testShreddedBinaryBoundsTruncation` writes a binary Variant value
  longer than 16 bytes and checks the upper bound rounds up. Fails before the fix (`…0F10`,
  smaller than the value), passes after. Existing tests only used a 4-byte value (under the
  16-byte threshold), so the path was untested.

  ### Are there any user-facing changes?

  No API changes.