### PR TITLE
Core: Migrate switch statements to switch expressions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -240,21 +240,15 @@ abstract class BaseDistributedDataScan
       return true;
     }
 
-    switch (mode) {
-      case LOCAL:
-        return true;
-
-      case DISTRIBUTED:
-        return manifests.isEmpty();
-
-      case AUTO:
-        return remoteParallelism() <= localParallelism
-            || manifests.size() <= 2 * localParallelism
-            || totalSize(manifests) <= localPlanningSizeThreshold;
-
-      default:
-        throw new IllegalArgumentException("Unknown planning mode: " + mode);
-    }
+    return switch (mode) {
+      case LOCAL -> true;
+      case DISTRIBUTED -> manifests.isEmpty();
+      case AUTO ->
+          remoteParallelism() <= localParallelism
+              || manifests.size() <= 2 * localParallelism
+              || totalSize(manifests) <= localPlanningSizeThreshold;
+      default -> throw new IllegalArgumentException("Unknown planning mode: " + mode);
+    };
   }
 
   private long totalSize(List<ManifestFile> manifests) {

--- a/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseDistributedDataScan.java
@@ -247,7 +247,6 @@ abstract class BaseDistributedDataScan
           remoteParallelism() <= localParallelism
               || manifests.size() <= 2 * localParallelism
               || totalSize(manifests) <= localPlanningSizeThreshold;
-      default -> throw new IllegalArgumentException("Unknown planning mode: " + mode);
     };
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -316,99 +316,37 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0 -> {
-        this.content = value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
-        return;
-      }
-      case 1 -> {
-        // always coerce to String for Serializable
-        this.filePath = value.toString();
-        return;
-      }
-      case 2 -> {
-        this.format = FileFormat.fromString(value.toString());
-        return;
-      }
-      case 3 -> {
-        this.partitionSpecId = (value != null) ? (Integer) value : -1;
-        return;
-      }
+      case 0 ->
+          this.content = value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
+      case 1 -> this.filePath = value.toString(); // always coerce to String for Serializable
+      case 2 -> this.format = FileFormat.fromString(value.toString());
+      case 3 -> this.partitionSpecId = (value != null) ? (Integer) value : -1;
       case 4 -> {
         // Preserve the constructor-initialized partitionData when the reader returns null
         // (e.g., v4 Parquet manifests for unpartitioned tables omit the partition field).
         if (value != null) {
           this.partitionData = (PartitionData) value;
         }
-        return;
       }
-      case 5 -> {
-        this.recordCount = (Long) value;
-        return;
-      }
-      case 6 -> {
-        this.fileSizeInBytes = (Long) value;
-        return;
-      }
-      case 7 -> {
-        this.columnSizes = (Map<Integer, Long>) value;
-        return;
-      }
-      case 8 -> {
-        this.valueCounts = (Map<Integer, Long>) value;
-        return;
-      }
-      case 9 -> {
-        this.nullValueCounts = (Map<Integer, Long>) value;
-        return;
-      }
-      case 10 -> {
-        this.nanValueCounts = (Map<Integer, Long>) value;
-        return;
-      }
-      case 11 -> {
-        this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
-        return;
-      }
-      case 12 -> {
-        this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
-        return;
-      }
-      case 13 -> {
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      }
-      case 14 -> {
-        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
-        return;
-      }
-      case 15 -> {
-        this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
-        return;
-      }
-      case 16 -> {
-        this.sortOrderId = (Integer) value;
-        return;
-      }
-      case 17 -> {
-        this.firstRowId = (Long) value;
-        return;
-      }
-      case 18 -> {
-        this.referencedDataFile = value != null ? value.toString() : null;
-        return;
-      }
-      case 19 -> {
-        this.contentOffset = (Long) value;
-        return;
-      }
-      case 20 -> {
-        this.contentSizeInBytes = (Long) value;
-        return;
-      }
-      case 21 -> {
-        this.fileOrdinal = (long) value;
-        return;
-      }
+      case 5 -> this.recordCount = (Long) value;
+      case 6 -> this.fileSizeInBytes = (Long) value;
+      case 7 -> this.columnSizes = (Map<Integer, Long>) value;
+      case 8 -> this.valueCounts = (Map<Integer, Long>) value;
+      case 9 -> this.nullValueCounts = (Map<Integer, Long>) value;
+      case 10 -> this.nanValueCounts = (Map<Integer, Long>) value;
+      case 11 ->
+          this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+      case 12 ->
+          this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
+      case 13 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 14 -> this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+      case 15 -> this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
+      case 16 -> this.sortOrderId = (Integer) value;
+      case 17 -> this.firstRowId = (Long) value;
+      case 18 -> this.referencedDataFile = value != null ? value.toString() : null;
+      case 19 -> this.contentOffset = (Long) value;
+      case 20 -> this.contentSizeInBytes = (Long) value;
+      case 21 -> this.fileOrdinal = (long) value;
       default -> {
         // ignore the object, it must be from a newer version of the format
       }

--- a/core/src/main/java/org/apache/iceberg/BaseFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFile.java
@@ -316,79 +316,102 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
+      case 0 -> {
         this.content = value != null ? FileContent.fromId((Integer) value) : FileContent.DATA;
         return;
-      case 1:
+      }
+      case 1 -> {
         // always coerce to String for Serializable
         this.filePath = value.toString();
         return;
-      case 2:
+      }
+      case 2 -> {
         this.format = FileFormat.fromString(value.toString());
         return;
-      case 3:
+      }
+      case 3 -> {
         this.partitionSpecId = (value != null) ? (Integer) value : -1;
         return;
-      case 4:
+      }
+      case 4 -> {
         // Preserve the constructor-initialized partitionData when the reader returns null
         // (e.g., v4 Parquet manifests for unpartitioned tables omit the partition field).
         if (value != null) {
           this.partitionData = (PartitionData) value;
         }
         return;
-      case 5:
+      }
+      case 5 -> {
         this.recordCount = (Long) value;
         return;
-      case 6:
+      }
+      case 6 -> {
         this.fileSizeInBytes = (Long) value;
         return;
-      case 7:
+      }
+      case 7 -> {
         this.columnSizes = (Map<Integer, Long>) value;
         return;
-      case 8:
+      }
+      case 8 -> {
         this.valueCounts = (Map<Integer, Long>) value;
         return;
-      case 9:
+      }
+      case 9 -> {
         this.nullValueCounts = (Map<Integer, Long>) value;
         return;
-      case 10:
+      }
+      case 10 -> {
         this.nanValueCounts = (Map<Integer, Long>) value;
         return;
-      case 11:
+      }
+      case 11 -> {
         this.lowerBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
         return;
-      case 12:
+      }
+      case 12 -> {
         this.upperBounds = SerializableByteBufferMap.wrap((Map<Integer, ByteBuffer>) value);
         return;
-      case 13:
+      }
+      case 13 -> {
         this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
         return;
-      case 14:
+      }
+      case 14 -> {
         this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
         return;
-      case 15:
+      }
+      case 15 -> {
         this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
         return;
-      case 16:
+      }
+      case 16 -> {
         this.sortOrderId = (Integer) value;
         return;
-      case 17:
+      }
+      case 17 -> {
         this.firstRowId = (Long) value;
         return;
-      case 18:
+      }
+      case 18 -> {
         this.referencedDataFile = value != null ? value.toString() : null;
         return;
-      case 19:
+      }
+      case 19 -> {
         this.contentOffset = (Long) value;
         return;
-      case 20:
+      }
+      case 20 -> {
         this.contentSizeInBytes = (Long) value;
         return;
-      case 21:
+      }
+      case 21 -> {
         this.fileOrdinal = (long) value;
         return;
-      default:
+      }
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
@@ -398,54 +421,31 @@ abstract class BaseFile<F> extends SupportsIndexProjection
   }
 
   private Object getByPos(int basePos) {
-    switch (basePos) {
-      case 0:
-        return content.id();
-      case 1:
-        return filePath;
-      case 2:
-        return format != null ? format.toString() : null;
-      case 3:
-        return partitionSpecId;
-      case 4:
-        return partitionData;
-      case 5:
-        return recordCount;
-      case 6:
-        return fileSizeInBytes;
-      case 7:
-        return columnSizes;
-      case 8:
-        return valueCounts;
-      case 9:
-        return nullValueCounts;
-      case 10:
-        return nanValueCounts;
-      case 11:
-        return lowerBounds;
-      case 12:
-        return upperBounds;
-      case 13:
-        return keyMetadata();
-      case 14:
-        return splitOffsets();
-      case 15:
-        return equalityFieldIds();
-      case 16:
-        return sortOrderId;
-      case 17:
-        return firstRowId;
-      case 18:
-        return referencedDataFile;
-      case 19:
-        return contentOffset;
-      case 20:
-        return contentSizeInBytes;
-      case 21:
-        return fileOrdinal;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
-    }
+    return switch (basePos) {
+      case 0 -> content.id();
+      case 1 -> filePath;
+      case 2 -> format != null ? format.toString() : null;
+      case 3 -> partitionSpecId;
+      case 4 -> partitionData;
+      case 5 -> recordCount;
+      case 6 -> fileSizeInBytes;
+      case 7 -> columnSizes;
+      case 8 -> valueCounts;
+      case 9 -> nullValueCounts;
+      case 10 -> nanValueCounts;
+      case 11 -> lowerBounds;
+      case 12 -> upperBounds;
+      case 13 -> keyMetadata();
+      case 14 -> splitOffsets();
+      case 15 -> equalityFieldIds();
+      case 16 -> sortOrderId;
+      case 17 -> firstRowId;
+      case 18 -> referencedDataFile;
+      case 19 -> contentOffset;
+      case 20 -> contentSizeInBytes;
+      case 21 -> fileOrdinal;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseIncrementalChangelogScan.java
@@ -153,30 +153,28 @@ class BaseIncrementalChangelogScan
             int changeOrdinal = snapshotOrdinals.get(commitSnapshotId);
             DataFile dataFile = entry.file().copy(context.shouldKeepStats());
 
-            switch (entry.status()) {
-              case ADDED:
-                return new BaseAddedRowsScanTask(
-                    changeOrdinal,
-                    commitSnapshotId,
-                    dataFile,
-                    NO_DELETES,
-                    context.schemaAsString(),
-                    context.specAsString(),
-                    context.residuals());
-
-              case DELETED:
-                return new BaseDeletedDataFileScanTask(
-                    changeOrdinal,
-                    commitSnapshotId,
-                    dataFile,
-                    NO_DELETES,
-                    context.schemaAsString(),
-                    context.specAsString(),
-                    context.residuals());
-
-              default:
-                throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
-            }
+            return switch (entry.status()) {
+              case ADDED ->
+                  new BaseAddedRowsScanTask(
+                      changeOrdinal,
+                      commitSnapshotId,
+                      dataFile,
+                      NO_DELETES,
+                      context.schemaAsString(),
+                      context.specAsString(),
+                      context.residuals());
+              case DELETED ->
+                  new BaseDeletedDataFileScanTask(
+                      changeOrdinal,
+                      commitSnapshotId,
+                      dataFile,
+                      NO_DELETES,
+                      context.schemaAsString(),
+                      context.specAsString(),
+                      context.residuals());
+              default ->
+                  throw new IllegalArgumentException("Unexpected entry status: " + entry.status());
+            };
           });
     }
   }

--- a/core/src/main/java/org/apache/iceberg/BasePartitionStatistics.java
+++ b/core/src/main/java/org/apache/iceberg/BasePartitionStatistics.java
@@ -145,36 +145,22 @@ public class BasePartitionStatistics extends SupportsIndexProjection
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case PARTITION_POSITION:
-        return partition;
-      case SPEC_ID_POSITION:
-        return specId;
-      case DATA_RECORD_COUNT_POSITION:
-        return dataRecordCount;
-      case DATA_FILE_COUNT_POSITION:
-        return dataFileCount;
-      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION:
-        return totalDataFileSizeInBytes;
-      case POSITION_DELETE_RECORD_COUNT_POSITION:
-        return positionDeleteRecordCount;
-      case POSITION_DELETE_FILE_COUNT_POSITION:
-        return positionDeleteFileCount;
-      case EQUALITY_DELETE_RECORD_COUNT_POSITION:
-        return equalityDeleteRecordCount;
-      case EQUALITY_DELETE_FILE_COUNT_POSITION:
-        return equalityDeleteFileCount;
-      case TOTAL_RECORD_COUNT_POSITION:
-        return totalRecordCount;
-      case LAST_UPDATED_AT_POSITION:
-        return lastUpdatedAt;
-      case LAST_UPDATED_SNAPSHOT_ID_POSITION:
-        return lastUpdatedSnapshotId;
-      case DV_COUNT_POSITION:
-        return dvCount;
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
-    }
+    return switch (pos) {
+      case PARTITION_POSITION -> partition;
+      case SPEC_ID_POSITION -> specId;
+      case DATA_RECORD_COUNT_POSITION -> dataRecordCount;
+      case DATA_FILE_COUNT_POSITION -> dataFileCount;
+      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION -> totalDataFileSizeInBytes;
+      case POSITION_DELETE_RECORD_COUNT_POSITION -> positionDeleteRecordCount;
+      case POSITION_DELETE_FILE_COUNT_POSITION -> positionDeleteFileCount;
+      case EQUALITY_DELETE_RECORD_COUNT_POSITION -> equalityDeleteRecordCount;
+      case EQUALITY_DELETE_FILE_COUNT_POSITION -> equalityDeleteFileCount;
+      case TOTAL_RECORD_COUNT_POSITION -> totalRecordCount;
+      case LAST_UPDATED_AT_POSITION -> lastUpdatedAt;
+      case LAST_UPDATED_SNAPSHOT_ID_POSITION -> lastUpdatedSnapshotId;
+      case DV_COUNT_POSITION -> dvCount;
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
+    };
   }
 
   @Override
@@ -184,47 +170,20 @@ public class BasePartitionStatistics extends SupportsIndexProjection
     }
 
     switch (pos) {
-      case PARTITION_POSITION:
-        this.partition = (StructLike) value;
-        break;
-      case SPEC_ID_POSITION:
-        this.specId = (int) value;
-        break;
-      case DATA_RECORD_COUNT_POSITION:
-        this.dataRecordCount = (long) value;
-        break;
-      case DATA_FILE_COUNT_POSITION:
-        this.dataFileCount = (int) value;
-        break;
-      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION:
-        this.totalDataFileSizeInBytes = (long) value;
-        break;
-      case POSITION_DELETE_RECORD_COUNT_POSITION:
-        this.positionDeleteRecordCount = (long) value;
-        break;
-      case POSITION_DELETE_FILE_COUNT_POSITION:
-        this.positionDeleteFileCount = (int) value;
-        break;
-      case EQUALITY_DELETE_RECORD_COUNT_POSITION:
-        this.equalityDeleteRecordCount = (long) value;
-        break;
-      case EQUALITY_DELETE_FILE_COUNT_POSITION:
-        this.equalityDeleteFileCount = (int) value;
-        break;
-      case TOTAL_RECORD_COUNT_POSITION:
-        this.totalRecordCount = (Long) value;
-        break;
-      case LAST_UPDATED_AT_POSITION:
-        this.lastUpdatedAt = (Long) value;
-        break;
-      case LAST_UPDATED_SNAPSHOT_ID_POSITION:
-        this.lastUpdatedSnapshotId = (Long) value;
-        break;
-      case DV_COUNT_POSITION:
-        this.dvCount = (int) value;
-        break;
-      default:
-        throw new UnsupportedOperationException("Unknown position: " + pos);
+      case PARTITION_POSITION -> this.partition = (StructLike) value;
+      case SPEC_ID_POSITION -> this.specId = (int) value;
+      case DATA_RECORD_COUNT_POSITION -> this.dataRecordCount = (long) value;
+      case DATA_FILE_COUNT_POSITION -> this.dataFileCount = (int) value;
+      case TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION -> this.totalDataFileSizeInBytes = (long) value;
+      case POSITION_DELETE_RECORD_COUNT_POSITION -> this.positionDeleteRecordCount = (long) value;
+      case POSITION_DELETE_FILE_COUNT_POSITION -> this.positionDeleteFileCount = (int) value;
+      case EQUALITY_DELETE_RECORD_COUNT_POSITION -> this.equalityDeleteRecordCount = (long) value;
+      case EQUALITY_DELETE_FILE_COUNT_POSITION -> this.equalityDeleteFileCount = (int) value;
+      case TOTAL_RECORD_COUNT_POSITION -> this.totalRecordCount = (Long) value;
+      case LAST_UPDATED_AT_POSITION -> this.lastUpdatedAt = (Long) value;
+      case LAST_UPDATED_SNAPSHOT_ID_POSITION -> this.lastUpdatedSnapshotId = (Long) value;
+      case DV_COUNT_POSITION -> this.dvCount = (int) value;
+      default -> throw new UnsupportedOperationException("Unknown position: " + pos);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -322,8 +322,6 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
     return switch (content) {
       case DATA -> BaseScan.SCAN_COLUMNS;
       case DELETES -> BaseScan.DELETE_SCAN_COLUMNS;
-      default ->
-          throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
     };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseScan.java
+++ b/core/src/main/java/org/apache/iceberg/BaseScan.java
@@ -319,13 +319,11 @@ abstract class BaseScan<ThisT, T extends ScanTask, G extends ScanTaskGroup<T>>
    * @return a list of column names corresponding to the specified manifest content type.
    */
   static List<String> scanColumns(ManifestContent content) {
-    switch (content) {
-      case DATA:
-        return BaseScan.SCAN_COLUMNS;
-      case DELETES:
-        return BaseScan.DELETE_SCAN_COLUMNS;
-      default:
-        throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
-    }
+    return switch (content) {
+      case DATA -> BaseScan.SCAN_COLUMNS;
+      case DELETES -> BaseScan.DELETE_SCAN_COLUMNS;
+      default ->
+          throw new UnsupportedOperationException("Cannot read unknown manifest type: " + content);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -276,14 +276,11 @@ class BaseSnapshot implements Snapshot {
           ManifestFiles.readDeleteManifest(manifest, fileIO, null)) {
         for (ManifestEntry<DeleteFile> entry : reader.entries()) {
           switch (entry.status()) {
-            case ADDED:
-              adds.add(entry.file().copy());
-              break;
-            case DELETED:
-              deletes.add(entry.file().copyWithoutStats());
-              break;
-            default:
+            case ADDED -> adds.add(entry.file().copy());
+            case DELETED -> deletes.add(entry.file().copyWithoutStats());
+            default -> {
               // ignore existing
+            }
           }
         }
       } catch (IOException e) {
@@ -309,15 +306,11 @@ class BaseSnapshot implements Snapshot {
         new ManifestGroup(fileIO, changedManifests).ignoreExisting().entries()) {
       for (ManifestEntry<DataFile> entry : entries) {
         switch (entry.status()) {
-          case ADDED:
-            adds.add(entry.file().copy());
-            break;
-          case DELETED:
-            deletes.add(entry.file().copyWithoutStats());
-            break;
-          default:
-            throw new IllegalStateException(
-                "Unexpected entry status, not added or deleted: " + entry);
+          case ADDED -> adds.add(entry.file().copy());
+          case DELETED -> deletes.add(entry.file().copyWithoutStats());
+          default ->
+              throw new IllegalStateException(
+                  "Unexpected entry status, not added or deleted: " + entry);
         }
       }
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -253,21 +253,10 @@ public class BaseTransaction implements Transaction {
         hasLastOpCommitted, "Cannot commit transaction: last operation has not committed");
 
     switch (type) {
-      case CREATE_TABLE:
-        commitCreateTransaction();
-        break;
-
-      case REPLACE_TABLE:
-        commitReplaceTransaction(false);
-        break;
-
-      case CREATE_OR_REPLACE_TABLE:
-        commitReplaceTransaction(true);
-        break;
-
-      case SIMPLE:
-        commitSimpleTransaction();
-        break;
+      case CREATE_TABLE -> commitCreateTransaction();
+      case REPLACE_TABLE -> commitReplaceTransaction(false);
+      case CREATE_OR_REPLACE_TABLE -> commitReplaceTransaction(true);
+      case SIMPLE -> commitSimpleTransaction();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -314,31 +314,18 @@ public class CatalogUtil {
     if (catalogImpl == null) {
       String catalogType =
           PropertyUtil.propertyAsString(options, ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-      switch (catalogType.toLowerCase(Locale.ENGLISH)) {
-        case ICEBERG_CATALOG_TYPE_HIVE:
-          catalogImpl = ICEBERG_CATALOG_HIVE;
-          break;
-        case ICEBERG_CATALOG_TYPE_HADOOP:
-          catalogImpl = ICEBERG_CATALOG_HADOOP;
-          break;
-        case ICEBERG_CATALOG_TYPE_REST:
-          catalogImpl = ICEBERG_CATALOG_REST;
-          break;
-        case ICEBERG_CATALOG_TYPE_GLUE:
-          catalogImpl = ICEBERG_CATALOG_GLUE;
-          break;
-        case ICEBERG_CATALOG_TYPE_NESSIE:
-          catalogImpl = ICEBERG_CATALOG_NESSIE;
-          break;
-        case ICEBERG_CATALOG_TYPE_JDBC:
-          catalogImpl = ICEBERG_CATALOG_JDBC;
-          break;
-        case ICEBERG_CATALOG_TYPE_BIGQUERY:
-          catalogImpl = ICEBERG_CATALOG_BIGQUERY;
-          break;
-        default:
-          throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);
-      }
+      catalogImpl =
+          switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+            case ICEBERG_CATALOG_TYPE_HIVE -> ICEBERG_CATALOG_HIVE;
+            case ICEBERG_CATALOG_TYPE_HADOOP -> ICEBERG_CATALOG_HADOOP;
+            case ICEBERG_CATALOG_TYPE_REST -> ICEBERG_CATALOG_REST;
+            case ICEBERG_CATALOG_TYPE_GLUE -> ICEBERG_CATALOG_GLUE;
+            case ICEBERG_CATALOG_TYPE_NESSIE -> ICEBERG_CATALOG_NESSIE;
+            case ICEBERG_CATALOG_TYPE_JDBC -> ICEBERG_CATALOG_JDBC;
+            case ICEBERG_CATALOG_TYPE_BIGQUERY -> ICEBERG_CATALOG_BIGQUERY;
+            default ->
+                throw new UnsupportedOperationException("Unknown catalog type: " + catalogType);
+          };
     } else {
       String catalogType = options.get(ICEBERG_CATALOG_TYPE);
       Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -355,25 +355,19 @@ public class ContentFileParser {
   }
 
   private static FileContent fileContentFromJson(String content) {
-    switch (content) {
-      case CONTENT_DATA -> {
-        return FileContent.DATA;
-      }
-      case CONTENT_POSITION_DELETES -> {
-        return FileContent.POSITION_DELETES;
-      }
-      case CONTENT_EQUALITY_DELETES -> {
-        return FileContent.EQUALITY_DELETES;
-      }
+    return switch (content) {
+      case CONTENT_DATA -> FileContent.DATA;
+      case CONTENT_POSITION_DELETES -> FileContent.POSITION_DELETES;
+      case CONTENT_EQUALITY_DELETES -> FileContent.EQUALITY_DELETES;
       default -> {
         // In 1.10 and before, file content is serialized as the FileContent enum value
         try {
-          return FileContent.valueOf(content);
+          yield FileContent.valueOf(content);
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException(
               String.format("Invalid file content value: '%s'", content), e);
         }
       }
-    }
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -356,13 +356,16 @@ public class ContentFileParser {
 
   private static FileContent fileContentFromJson(String content) {
     switch (content) {
-      case CONTENT_DATA:
+      case CONTENT_DATA -> {
         return FileContent.DATA;
-      case CONTENT_POSITION_DELETES:
+      }
+      case CONTENT_POSITION_DELETES -> {
         return FileContent.POSITION_DELETES;
-      case CONTENT_EQUALITY_DELETES:
+      }
+      case CONTENT_EQUALITY_DELETES -> {
         return FileContent.EQUALITY_DELETES;
-      default:
+      }
+      default -> {
         // In 1.10 and before, file content is serialized as the FileContent enum value
         try {
           return FileContent.valueOf(content);
@@ -370,6 +373,7 @@ public class ContentFileParser {
           throw new IllegalArgumentException(
               String.format("Invalid file content value: '%s'", content), e);
         }
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -501,18 +501,16 @@ class DeleteFileIndex {
 
       for (DeleteFile file : files) {
         switch (file.content()) {
-          case POSITION_DELETES:
+          case POSITION_DELETES -> {
             if (ContentFileUtil.isDV(file)) {
               add(dvByPath, file);
             } else {
               add(posDeletesByPath, posDeletesByPartition, file);
             }
-            break;
-          case EQUALITY_DELETES:
-            add(globalDeletes, eqDeletesByPartition, file, fieldLookup);
-            break;
-          default:
-            throw new UnsupportedOperationException("Unsupported content: " + file.content());
+          }
+          case EQUALITY_DELETES -> add(globalDeletes, eqDeletesByPartition, file, fieldLookup);
+          default ->
+              throw new UnsupportedOperationException("Unsupported content: " + file.content());
         }
         ScanMetricsUtil.indexedDeleteFile(scanMetrics, file);
       }

--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -89,38 +89,27 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case 0:
-        return location;
-      case 1:
-        return offset;
-      case 2:
-        return sizeInBytes;
-      case 3:
-        return cardinality;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> location;
+      case 1 -> offset;
+      case 2 -> sizeInBytes;
+      case 3 -> cardinality;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        // always coerce to String for Serializable
-        this.location = value.toString();
-        break;
-      case 1:
-        this.offset = (Long) value;
-        break;
-      case 2:
-        this.sizeInBytes = (Long) value;
-        break;
-      case 3:
-        this.cardinality = (Long) value;
-        break;
-      default:
+      case 0 ->
+          // always coerce to String for Serializable
+          this.location = value.toString();
+      case 1 -> this.offset = (Long) value;
+      case 2 -> this.sizeInBytes = (Long) value;
+      case 3 -> this.cardinality = (Long) value;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/FileMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/FileMetadata.java
@@ -272,17 +272,15 @@ public class FileMetadata {
       }
 
       switch (content) {
-        case POSITION_DELETES:
-          Preconditions.checkArgument(
-              sortOrderId == null, "Position delete file should not have sort order");
-          break;
-        case EQUALITY_DELETES:
+        case POSITION_DELETES ->
+            Preconditions.checkArgument(
+                sortOrderId == null, "Position delete file should not have sort order");
+        case EQUALITY_DELETES -> {
           if (sortOrderId == null) {
             sortOrderId = SortOrder.unsorted().orderId();
           }
-          break;
-        default:
-          throw new IllegalStateException("Unknown content type " + content);
+        }
+        default -> throw new IllegalStateException("Unknown content type " + content);
       }
 
       return new GenericDeleteFile(

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -157,23 +157,29 @@ class GenericManifestEntry<F extends ContentFile<F>>
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
     switch (i) {
-      case 0:
+      case 0 -> {
         this.status = Status.fromId((Integer) v);
         return;
-      case 1:
+      }
+      case 1 -> {
         this.snapshotId = (Long) v;
         return;
-      case 2:
+      }
+      case 2 -> {
         this.dataSequenceNumber = (Long) v;
         return;
-      case 3:
+      }
+      case 3 -> {
         this.fileSequenceNumber = (Long) v;
         return;
-      case 4:
+      }
+      case 4 -> {
         this.file = (F) v;
         return;
-      default:
+      }
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
@@ -184,20 +190,14 @@ class GenericManifestEntry<F extends ContentFile<F>>
 
   @Override
   public Object get(int i) {
-    switch (i) {
-      case 0:
-        return status.id();
-      case 1:
-        return snapshotId;
-      case 2:
-        return dataSequenceNumber;
-      case 3:
-        return fileSequenceNumber;
-      case 4:
-        return file;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
-    }
+    return switch (i) {
+      case 0 -> status.id();
+      case 1 -> snapshotId;
+      case 2 -> dataSequenceNumber;
+      case 3 -> fileSequenceNumber;
+      case 4 -> file;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestEntry.java
@@ -157,26 +157,11 @@ class GenericManifestEntry<F extends ContentFile<F>>
   @SuppressWarnings("unchecked")
   public void put(int i, Object v) {
     switch (i) {
-      case 0 -> {
-        this.status = Status.fromId((Integer) v);
-        return;
-      }
-      case 1 -> {
-        this.snapshotId = (Long) v;
-        return;
-      }
-      case 2 -> {
-        this.dataSequenceNumber = (Long) v;
-        return;
-      }
-      case 3 -> {
-        this.fileSequenceNumber = (Long) v;
-        return;
-      }
-      case 4 -> {
-        this.file = (F) v;
-        return;
-      }
+      case 0 -> this.status = Status.fromId((Integer) v);
+      case 1 -> this.snapshotId = (Long) v;
+      case 2 -> this.dataSequenceNumber = (Long) v;
+      case 3 -> this.fileSequenceNumber = (Long) v;
+      case 4 -> this.file = (F) v;
       default -> {
         // ignore the object, it must be from a newer version of the format
       }

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -288,102 +288,102 @@ public class GenericManifestFile extends SupportsIndexProjection
   }
 
   private Object getByPos(int basePos) {
-    switch (basePos) {
-      case 0:
-        return manifestPath;
-      case 1:
-        return lazyLength();
-      case 2:
-        return specId;
-      case 3:
-        return content.id();
-      case 4:
-        return sequenceNumber;
-      case 5:
-        return minSequenceNumber;
-      case 6:
-        return snapshotId;
-      case 7:
-        return addedFilesCount;
-      case 8:
-        return existingFilesCount;
-      case 9:
-        return deletedFilesCount;
-      case 10:
-        return addedRowsCount;
-      case 11:
-        return existingRowsCount;
-      case 12:
-        return deletedRowsCount;
-      case 13:
-        return partitions();
-      case 14:
-        return keyMetadata();
-      case 15:
-        return firstRowId();
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
-    }
+    return switch (basePos) {
+      case 0 -> manifestPath;
+      case 1 -> lazyLength();
+      case 2 -> specId;
+      case 3 -> content.id();
+      case 4 -> sequenceNumber;
+      case 5 -> minSequenceNumber;
+      case 6 -> snapshotId;
+      case 7 -> addedFilesCount;
+      case 8 -> existingFilesCount;
+      case 9 -> deletedFilesCount;
+      case 10 -> addedRowsCount;
+      case 11 -> existingRowsCount;
+      case 12 -> deletedRowsCount;
+      case 13 -> partitions();
+      case 14 -> keyMetadata();
+      case 15 -> firstRowId();
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + basePos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int basePos, T value) {
     switch (basePos) {
-      case 0:
+      case 0 -> {
         // always coerce to String for Serializable
         this.manifestPath = value.toString();
         return;
-      case 1:
+      }
+      case 1 -> {
         this.length = (Long) value;
         return;
-      case 2:
+      }
+      case 2 -> {
         this.specId = (Integer) value;
         return;
-      case 3:
+      }
+      case 3 -> {
         this.content =
             value != null ? ManifestContent.fromId((Integer) value) : ManifestContent.DATA;
         return;
-      case 4:
+      }
+      case 4 -> {
         this.sequenceNumber = value != null ? (Long) value : 0;
         return;
-      case 5:
+      }
+      case 5 -> {
         this.minSequenceNumber = value != null ? (Long) value : 0;
         return;
-      case 6:
+      }
+      case 6 -> {
         this.snapshotId = (Long) value;
         return;
-      case 7:
+      }
+      case 7 -> {
         this.addedFilesCount = (Integer) value;
         return;
-      case 8:
+      }
+      case 8 -> {
         this.existingFilesCount = (Integer) value;
         return;
-      case 9:
+      }
+      case 9 -> {
         this.deletedFilesCount = (Integer) value;
         return;
-      case 10:
+      }
+      case 10 -> {
         this.addedRowsCount = (Long) value;
         return;
-      case 11:
+      }
+      case 11 -> {
         this.existingRowsCount = (Long) value;
         return;
-      case 12:
+      }
+      case 12 -> {
         this.deletedRowsCount = (Long) value;
         return;
-      case 13:
+      }
+      case 13 -> {
         this.partitions =
             value == null
                 ? null
                 : ((List<PartitionFieldSummary>) value).toArray(new PartitionFieldSummary[0]);
         return;
-      case 14:
+      }
+      case 14 -> {
         this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
         return;
-      case 15:
+      }
+      case 15 -> {
         this.firstRowId = (Long) value;
         return;
-      default:
+      }
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
+++ b/core/src/main/java/org/apache/iceberg/GenericManifestFile.java
@@ -312,75 +312,28 @@ public class GenericManifestFile extends SupportsIndexProjection
   @Override
   protected <T> void internalSet(int basePos, T value) {
     switch (basePos) {
-      case 0 -> {
-        // always coerce to String for Serializable
-        this.manifestPath = value.toString();
-        return;
-      }
-      case 1 -> {
-        this.length = (Long) value;
-        return;
-      }
-      case 2 -> {
-        this.specId = (Integer) value;
-        return;
-      }
-      case 3 -> {
-        this.content =
-            value != null ? ManifestContent.fromId((Integer) value) : ManifestContent.DATA;
-        return;
-      }
-      case 4 -> {
-        this.sequenceNumber = value != null ? (Long) value : 0;
-        return;
-      }
-      case 5 -> {
-        this.minSequenceNumber = value != null ? (Long) value : 0;
-        return;
-      }
-      case 6 -> {
-        this.snapshotId = (Long) value;
-        return;
-      }
-      case 7 -> {
-        this.addedFilesCount = (Integer) value;
-        return;
-      }
-      case 8 -> {
-        this.existingFilesCount = (Integer) value;
-        return;
-      }
-      case 9 -> {
-        this.deletedFilesCount = (Integer) value;
-        return;
-      }
-      case 10 -> {
-        this.addedRowsCount = (Long) value;
-        return;
-      }
-      case 11 -> {
-        this.existingRowsCount = (Long) value;
-        return;
-      }
-      case 12 -> {
-        this.deletedRowsCount = (Long) value;
-        return;
-      }
-      case 13 -> {
-        this.partitions =
-            value == null
-                ? null
-                : ((List<PartitionFieldSummary>) value).toArray(new PartitionFieldSummary[0]);
-        return;
-      }
-      case 14 -> {
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      }
-      case 15 -> {
-        this.firstRowId = (Long) value;
-        return;
-      }
+      case 0 -> this.manifestPath = value.toString(); // always coerce to String for Serializable
+      case 1 -> this.length = (Long) value;
+      case 2 -> this.specId = (Integer) value;
+      case 3 ->
+          this.content =
+              value != null ? ManifestContent.fromId((Integer) value) : ManifestContent.DATA;
+      case 4 -> this.sequenceNumber = value != null ? (Long) value : 0;
+      case 5 -> this.minSequenceNumber = value != null ? (Long) value : 0;
+      case 6 -> this.snapshotId = (Long) value;
+      case 7 -> this.addedFilesCount = (Integer) value;
+      case 8 -> this.existingFilesCount = (Integer) value;
+      case 9 -> this.deletedFilesCount = (Integer) value;
+      case 10 -> this.addedRowsCount = (Long) value;
+      case 11 -> this.existingRowsCount = (Long) value;
+      case 12 -> this.deletedRowsCount = (Long) value;
+      case 13 ->
+          this.partitions =
+              value == null
+                  ? null
+                  : ((List<PartitionFieldSummary>) value).toArray(new PartitionFieldSummary[0]);
+      case 14 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 15 -> this.firstRowId = (Long) value;
       default -> {
         // ignore the object, it must be from a newer version of the format
       }

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
@@ -149,18 +149,13 @@ public class GenericPartitionFieldSummary
     if (fromProjectionPos != null) {
       pos = fromProjectionPos[i];
     }
-    switch (pos) {
-      case 0:
-        return containsNull;
-      case 1:
-        return containsNaN;
-      case 2:
-        return lowerBound();
-      case 3:
-        return upperBound();
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> containsNull;
+      case 1 -> containsNaN;
+      case 2 -> lowerBound();
+      case 3 -> upperBound();
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
@@ -172,20 +167,25 @@ public class GenericPartitionFieldSummary
       pos = fromProjectionPos[i];
     }
     switch (pos) {
-      case 0:
+      case 0 -> {
         this.containsNull = (Boolean) value;
         return;
-      case 1:
+      }
+      case 1 -> {
         this.containsNaN = (Boolean) value;
         return;
-      case 2:
+      }
+      case 2 -> {
         this.lowerBound = ByteBuffers.toByteArray((ByteBuffer) value);
         return;
-      case 3:
+      }
+      case 3 -> {
         this.upperBound = ByteBuffers.toByteArray((ByteBuffer) value);
         return;
-      default:
+      }
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
+++ b/core/src/main/java/org/apache/iceberg/GenericPartitionFieldSummary.java
@@ -167,22 +167,10 @@ public class GenericPartitionFieldSummary
       pos = fromProjectionPos[i];
     }
     switch (pos) {
-      case 0 -> {
-        this.containsNull = (Boolean) value;
-        return;
-      }
-      case 1 -> {
-        this.containsNaN = (Boolean) value;
-        return;
-      }
-      case 2 -> {
-        this.lowerBound = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      }
-      case 3 -> {
-        this.upperBound = ByteBuffers.toByteArray((ByteBuffer) value);
-        return;
-      }
+      case 0 -> this.containsNull = (Boolean) value;
+      case 1 -> this.containsNaN = (Boolean) value;
+      case 2 -> this.lowerBound = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 3 -> this.upperBound = ByteBuffers.toByteArray((ByteBuffer) value);
       default -> {
         // ignore the object, it must be from a newer version of the format
       }

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -304,16 +304,20 @@ public class ManifestFiles {
       Long firstRowId,
       Map<String, String> writerProperties) {
     switch (formatVersion) {
-      case 1:
+      case 1 -> {
         return new ManifestWriter.V1Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
-      case 2:
+      }
+      case 2 -> {
         return new ManifestWriter.V2Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestWriter.V3Writer(
             spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestWriter.V4Writer(
             spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
+      }
     }
     throw new UnsupportedOperationException(
         "Cannot write manifest for table version: " + formatVersion);
@@ -409,14 +413,16 @@ public class ManifestFiles {
       Long snapshotId,
       Map<String, String> writerProperties) {
     switch (formatVersion) {
-      case 1:
-        throw new IllegalArgumentException("Cannot write delete files in a v1 table");
-      case 2:
+      case 1 -> throw new IllegalArgumentException("Cannot write delete files in a v1 table");
+      case 2 -> {
         return new ManifestWriter.V2DeleteWriter(spec, outputFile, snapshotId, writerProperties);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestWriter.V3DeleteWriter(spec, outputFile, snapshotId, writerProperties);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestWriter.V4DeleteWriter(spec, outputFile, snapshotId, writerProperties);
+      }
     }
     throw new UnsupportedOperationException(
         "Cannot write manifest for table version: " + formatVersion);
@@ -458,14 +464,10 @@ public class ManifestFiles {
 
   static ManifestReader<?> open(
       ManifestFile manifest, FileIO io, Map<Integer, PartitionSpec> specsById) {
-    switch (manifest.content()) {
-      case DATA:
-        return ManifestFiles.read(manifest, io, specsById);
-      case DELETES:
-        return ManifestFiles.readDeleteManifest(manifest, io, specsById);
-    }
-    throw new UnsupportedOperationException(
-        "Cannot read unknown manifest type: " + manifest.content());
+    return switch (manifest.content()) {
+      case DATA -> ManifestFiles.read(manifest, io, specsById);
+      case DELETES -> ManifestFiles.readDeleteManifest(manifest, io, specsById);
+    };
   }
 
   static ManifestFile copyAppendManifest(
@@ -543,17 +545,15 @@ public class ManifestFiles {
             entry.status(),
             allowedEntryStatus);
         switch (entry.status()) {
-          case ADDED:
+          case ADDED -> {
             summaryBuilder.addedFile(reader.spec(), entry.file());
             writer.add(entry);
-            break;
-          case EXISTING:
-            writer.existing(entry);
-            break;
-          case DELETED:
+          }
+          case EXISTING -> writer.existing(entry);
+          case DELETED -> {
             summaryBuilder.deletedFile(reader.spec(), entry.file());
             writer.delete(entry);
-            break;
+          }
         }
       }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -303,24 +303,21 @@ public class ManifestFiles {
       Long snapshotId,
       Long firstRowId,
       Map<String, String> writerProperties) {
-    switch (formatVersion) {
-      case 1 -> {
-        return new ManifestWriter.V1Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
-      }
-      case 2 -> {
-        return new ManifestWriter.V2Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
-      }
-      case 3 -> {
-        return new ManifestWriter.V3Writer(
-            spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
-      }
-      case 4 -> {
-        return new ManifestWriter.V4Writer(
-            spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
-      }
-    }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest for table version: " + formatVersion);
+    return switch (formatVersion) {
+      case 1 ->
+          new ManifestWriter.V1Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
+      case 2 ->
+          new ManifestWriter.V2Writer(spec, encryptedOutputFile, snapshotId, writerProperties);
+      case 3 ->
+          new ManifestWriter.V3Writer(
+              spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
+      case 4 ->
+          new ManifestWriter.V4Writer(
+              spec, encryptedOutputFile, snapshotId, firstRowId, writerProperties);
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest for table version: " + formatVersion);
+    };
   }
 
   /**
@@ -412,20 +409,15 @@ public class ManifestFiles {
       EncryptedOutputFile outputFile,
       Long snapshotId,
       Map<String, String> writerProperties) {
-    switch (formatVersion) {
+    return switch (formatVersion) {
       case 1 -> throw new IllegalArgumentException("Cannot write delete files in a v1 table");
-      case 2 -> {
-        return new ManifestWriter.V2DeleteWriter(spec, outputFile, snapshotId, writerProperties);
-      }
-      case 3 -> {
-        return new ManifestWriter.V3DeleteWriter(spec, outputFile, snapshotId, writerProperties);
-      }
-      case 4 -> {
-        return new ManifestWriter.V4DeleteWriter(spec, outputFile, snapshotId, writerProperties);
-      }
-    }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest for table version: " + formatVersion);
+      case 2 -> new ManifestWriter.V2DeleteWriter(spec, outputFile, snapshotId, writerProperties);
+      case 3 -> new ManifestWriter.V3DeleteWriter(spec, outputFile, snapshotId, writerProperties);
+      case 4 -> new ManifestWriter.V4DeleteWriter(spec, outputFile, snapshotId, writerProperties);
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest for table version: " + formatVersion);
+    };
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestInfoStruct.java
@@ -166,72 +166,39 @@ class ManifestInfoStruct extends SupportsIndexProjection implements ManifestInfo
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case 0:
-        return addedFilesCount;
-      case 1:
-        return existingFilesCount;
-      case 2:
-        return deletedFilesCount;
-      case 3:
-        return replacedFilesCount;
-      case 4:
-        return addedRowsCount;
-      case 5:
-        return existingRowsCount;
-      case 6:
-        return deletedRowsCount;
-      case 7:
-        return replacedRowsCount;
-      case 8:
-        return minSequenceNumber;
-      case 9:
-        return dv();
-      case 10:
-        return dvCardinality;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> addedFilesCount;
+      case 1 -> existingFilesCount;
+      case 2 -> deletedFilesCount;
+      case 3 -> replacedFilesCount;
+      case 4 -> addedRowsCount;
+      case 5 -> existingRowsCount;
+      case 6 -> deletedRowsCount;
+      case 7 -> replacedRowsCount;
+      case 8 -> minSequenceNumber;
+      case 9 -> dv();
+      case 10 -> dvCardinality;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.addedFilesCount = (Integer) value;
-        break;
-      case 1:
-        this.existingFilesCount = (Integer) value;
-        break;
-      case 2:
-        this.deletedFilesCount = (Integer) value;
-        break;
-      case 3:
-        this.replacedFilesCount = (Integer) value;
-        break;
-      case 4:
-        this.addedRowsCount = (Long) value;
-        break;
-      case 5:
-        this.existingRowsCount = (Long) value;
-        break;
-      case 6:
-        this.deletedRowsCount = (Long) value;
-        break;
-      case 7:
-        this.replacedRowsCount = (Long) value;
-        break;
-      case 8:
-        this.minSequenceNumber = (Long) value;
-        break;
-      case 9:
-        this.dv = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 10:
-        this.dvCardinality = (Long) value;
-        break;
-      default:
+      case 0 -> this.addedFilesCount = (Integer) value;
+      case 1 -> this.existingFilesCount = (Integer) value;
+      case 2 -> this.deletedFilesCount = (Integer) value;
+      case 3 -> this.replacedFilesCount = (Integer) value;
+      case 4 -> this.addedRowsCount = (Long) value;
+      case 5 -> this.existingRowsCount = (Long) value;
+      case 6 -> this.deletedRowsCount = (Long) value;
+      case 7 -> this.replacedRowsCount = (Long) value;
+      case 8 -> this.minSequenceNumber = (Long) value;
+      case 9 -> this.dv = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 10 -> this.dvCardinality = (Long) value;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -66,39 +66,37 @@ class ManifestLists {
       Long parentSnapshotId,
       long sequenceNumber,
       Long firstRowId) {
-    switch (formatVersion) {
+    return switch (formatVersion) {
       case 1 -> {
         Preconditions.checkArgument(
             sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,
             "Invalid sequence number for v1 manifest list: %s",
             sequenceNumber);
-        return new ManifestListWriter.V1Writer(
+        yield new ManifestListWriter.V1Writer(
             manifestListFile, encryptionManager, snapshotId, parentSnapshotId);
       }
-      case 2 -> {
-        return new ManifestListWriter.V2Writer(
-            manifestListFile, encryptionManager, snapshotId, parentSnapshotId, sequenceNumber);
-      }
-      case 3 -> {
-        return new ManifestListWriter.V3Writer(
-            manifestListFile,
-            encryptionManager,
-            snapshotId,
-            parentSnapshotId,
-            sequenceNumber,
-            firstRowId);
-      }
-      case 4 -> {
-        return new ManifestListWriter.V4Writer(
-            manifestListFile,
-            encryptionManager,
-            snapshotId,
-            parentSnapshotId,
-            sequenceNumber,
-            firstRowId);
-      }
-    }
-    throw new UnsupportedOperationException(
-        "Cannot write manifest list for table version: " + formatVersion);
+      case 2 ->
+          new ManifestListWriter.V2Writer(
+              manifestListFile, encryptionManager, snapshotId, parentSnapshotId, sequenceNumber);
+      case 3 ->
+          new ManifestListWriter.V3Writer(
+              manifestListFile,
+              encryptionManager,
+              snapshotId,
+              parentSnapshotId,
+              sequenceNumber,
+              firstRowId);
+      case 4 ->
+          new ManifestListWriter.V4Writer(
+              manifestListFile,
+              encryptionManager,
+              snapshotId,
+              parentSnapshotId,
+              sequenceNumber,
+              firstRowId);
+      default ->
+          throw new UnsupportedOperationException(
+              "Cannot write manifest list for table version: " + formatVersion);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -67,17 +67,19 @@ class ManifestLists {
       long sequenceNumber,
       Long firstRowId) {
     switch (formatVersion) {
-      case 1:
+      case 1 -> {
         Preconditions.checkArgument(
             sequenceNumber == TableMetadata.INITIAL_SEQUENCE_NUMBER,
             "Invalid sequence number for v1 manifest list: %s",
             sequenceNumber);
         return new ManifestListWriter.V1Writer(
             manifestListFile, encryptionManager, snapshotId, parentSnapshotId);
-      case 2:
+      }
+      case 2 -> {
         return new ManifestListWriter.V2Writer(
             manifestListFile, encryptionManager, snapshotId, parentSnapshotId, sequenceNumber);
-      case 3:
+      }
+      case 3 -> {
         return new ManifestListWriter.V3Writer(
             manifestListFile,
             encryptionManager,
@@ -85,7 +87,8 @@ class ManifestLists {
             parentSnapshotId,
             sequenceNumber,
             firstRowId);
-      case 4:
+      }
+      case 4 -> {
         return new ManifestListWriter.V4Writer(
             manifestListFile,
             encryptionManager,
@@ -93,6 +96,7 @@ class ManifestLists {
             parentSnapshotId,
             sequenceNumber,
             firstRowId);
+      }
     }
     throw new UnsupportedOperationException(
         "Cannot write manifest list for table version: " + formatVersion);

--- a/core/src/main/java/org/apache/iceberg/ManifestWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestWriter.java
@@ -110,18 +110,18 @@ public abstract class ManifestWriter<F extends ContentFile<F>> implements FileAp
 
   void addEntry(ManifestEntry<F> entry) {
     switch (entry.status()) {
-      case ADDED:
+      case ADDED -> {
         addedFiles += 1;
         addedRows += entry.file().recordCount();
-        break;
-      case EXISTING:
+      }
+      case EXISTING -> {
         existingFiles += 1;
         existingRows += entry.file().recordCount();
-        break;
-      case DELETED:
+      }
+      case DELETED -> {
         deletedFiles += 1;
         deletedRows += entry.file().recordCount();
-        break;
+      }
     }
 
     stats.update(entry.file().partition());

--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -294,24 +294,19 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
 
   private static void validateDeleteFileForVersion(DeleteFile file, int formatVersion) {
     switch (formatVersion) {
-      case 1:
-        throw new IllegalArgumentException("Deletes are supported in V2 and above");
-      case 2:
-        Preconditions.checkArgument(
-            file.content() == FileContent.EQUALITY_DELETES || !ContentFileUtil.isDV(file),
-            "Must not use DVs for position deletes in V2: %s",
-            ContentFileUtil.dvDesc(file));
-        break;
-      case 3:
-      case 4:
-        Preconditions.checkArgument(
-            file.content() == FileContent.EQUALITY_DELETES || ContentFileUtil.isDV(file),
-            "Must use DVs for position deletes in V%s: %s",
-            formatVersion,
-            file.location());
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported format version: " + formatVersion);
+      case 1 -> throw new IllegalArgumentException("Deletes are supported in V2 and above");
+      case 2 ->
+          Preconditions.checkArgument(
+              file.content() == FileContent.EQUALITY_DELETES || !ContentFileUtil.isDV(file),
+              "Must not use DVs for position deletes in V2: %s",
+              ContentFileUtil.dvDesc(file));
+      case 3, 4 ->
+          Preconditions.checkArgument(
+              file.content() == FileContent.EQUALITY_DELETES || ContentFileUtil.isDV(file),
+              "Must use DVs for position deletes in V%s: %s",
+              formatVersion,
+              file.location());
+      default -> throw new IllegalArgumentException("Unsupported format version: " + formatVersion);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -55,43 +55,27 @@ public class MetadataTableUtils {
 
   private static Table createMetadataTableInstance(
       Table baseTable, String metadataTableName, MetadataTableType type) {
-    switch (type) {
-      case ENTRIES:
-        return new ManifestEntriesTable(baseTable, metadataTableName);
-      case FILES:
-        return new FilesTable(baseTable, metadataTableName);
-      case DATA_FILES:
-        return new DataFilesTable(baseTable, metadataTableName);
-      case DELETE_FILES:
-        return new DeleteFilesTable(baseTable, metadataTableName);
-      case HISTORY:
-        return new HistoryTable(baseTable, metadataTableName);
-      case SNAPSHOTS:
-        return new SnapshotsTable(baseTable, metadataTableName);
-      case METADATA_LOG_ENTRIES:
-        return new MetadataLogEntriesTable(baseTable, metadataTableName);
-      case REFS:
-        return new RefsTable(baseTable, metadataTableName);
-      case MANIFESTS:
-        return new ManifestsTable(baseTable, metadataTableName);
-      case PARTITIONS:
-        return new PartitionsTable(baseTable, metadataTableName);
-      case ALL_DATA_FILES:
-        return new AllDataFilesTable(baseTable, metadataTableName);
-      case ALL_DELETE_FILES:
-        return new AllDeleteFilesTable(baseTable, metadataTableName);
-      case ALL_FILES:
-        return new AllFilesTable(baseTable, metadataTableName);
-      case ALL_MANIFESTS:
-        return new AllManifestsTable(baseTable, metadataTableName);
-      case ALL_ENTRIES:
-        return new AllEntriesTable(baseTable, metadataTableName);
-      case POSITION_DELETES:
-        return new PositionDeletesTable(baseTable, metadataTableName);
-      default:
-        throw new NoSuchTableException(
-            "Unknown metadata table type: %s for %s", type, metadataTableName);
-    }
+    return switch (type) {
+      case ENTRIES -> new ManifestEntriesTable(baseTable, metadataTableName);
+      case FILES -> new FilesTable(baseTable, metadataTableName);
+      case DATA_FILES -> new DataFilesTable(baseTable, metadataTableName);
+      case DELETE_FILES -> new DeleteFilesTable(baseTable, metadataTableName);
+      case HISTORY -> new HistoryTable(baseTable, metadataTableName);
+      case SNAPSHOTS -> new SnapshotsTable(baseTable, metadataTableName);
+      case METADATA_LOG_ENTRIES -> new MetadataLogEntriesTable(baseTable, metadataTableName);
+      case REFS -> new RefsTable(baseTable, metadataTableName);
+      case MANIFESTS -> new ManifestsTable(baseTable, metadataTableName);
+      case PARTITIONS -> new PartitionsTable(baseTable, metadataTableName);
+      case ALL_DATA_FILES -> new AllDataFilesTable(baseTable, metadataTableName);
+      case ALL_DELETE_FILES -> new AllDeleteFilesTable(baseTable, metadataTableName);
+      case ALL_FILES -> new AllFilesTable(baseTable, metadataTableName);
+      case ALL_MANIFESTS -> new AllManifestsTable(baseTable, metadataTableName);
+      case ALL_ENTRIES -> new AllEntriesTable(baseTable, metadataTableName);
+      case POSITION_DELETES -> new PositionDeletesTable(baseTable, metadataTableName);
+      default ->
+          throw new NoSuchTableException(
+              "Unknown metadata table type: %s for %s", type, metadataTableName);
+    };
   }
 
   public static Table createMetadataTableInstance(

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import java.util.Locale;
 import org.apache.iceberg.catalog.TableIdentifier;
-import org.apache.iceberg.exceptions.NoSuchTableException;
 
 public class MetadataTableUtils {
   private MetadataTableUtils() {}
@@ -72,9 +71,6 @@ public class MetadataTableUtils {
       case ALL_MANIFESTS -> new AllManifestsTable(baseTable, metadataTableName);
       case ALL_ENTRIES -> new AllEntriesTable(baseTable, metadataTableName);
       case POSITION_DELETES -> new PositionDeletesTable(baseTable, metadataTableName);
-      default ->
-          throw new NoSuchTableException(
-              "Unknown metadata table type: %s for %s", type, metadataTableName);
     };
   }
 

--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -192,89 +192,62 @@ public class MetadataUpdateParser {
     generator.writeStringField(ACTION, updateAction);
 
     switch (updateAction) {
-      case ASSIGN_UUID:
-        writeAssignUUID((MetadataUpdate.AssignUUID) metadataUpdate, generator);
-        break;
-      case UPGRADE_FORMAT_VERSION:
-        writeUpgradeFormatVersion((MetadataUpdate.UpgradeFormatVersion) metadataUpdate, generator);
-        break;
-      case ADD_SCHEMA:
-        writeAddSchema((MetadataUpdate.AddSchema) metadataUpdate, generator);
-        break;
-      case SET_CURRENT_SCHEMA:
-        writeSetCurrentSchema((MetadataUpdate.SetCurrentSchema) metadataUpdate, generator);
-        break;
-      case ADD_PARTITION_SPEC:
-        writeAddPartitionSpec((MetadataUpdate.AddPartitionSpec) metadataUpdate, generator);
-        break;
-      case SET_DEFAULT_PARTITION_SPEC:
-        writeSetDefaultPartitionSpec(
-            (MetadataUpdate.SetDefaultPartitionSpec) metadataUpdate, generator);
-        break;
-      case ADD_SORT_ORDER:
-        writeAddSortOrder((MetadataUpdate.AddSortOrder) metadataUpdate, generator);
-        break;
-      case SET_DEFAULT_SORT_ORDER:
-        writeSetDefaultSortOrder((MetadataUpdate.SetDefaultSortOrder) metadataUpdate, generator);
-        break;
-      case SET_STATISTICS:
-        writeSetStatistics((MetadataUpdate.SetStatistics) metadataUpdate, generator);
-        break;
-      case REMOVE_STATISTICS:
-        writeRemoveStatistics((MetadataUpdate.RemoveStatistics) metadataUpdate, generator);
-        break;
-      case SET_PARTITION_STATISTICS:
-        writeSetPartitionStatistics(
-            (MetadataUpdate.SetPartitionStatistics) metadataUpdate, generator);
-        break;
-      case REMOVE_PARTITION_STATISTICS:
-        writeRemovePartitionStatistics(
-            (MetadataUpdate.RemovePartitionStatistics) metadataUpdate, generator);
-        break;
-      case ADD_SNAPSHOT:
-        writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
-        break;
-      case REMOVE_SNAPSHOTS:
-        writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
-        break;
-      case REMOVE_SNAPSHOT_REF:
-        writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
-        break;
-      case SET_SNAPSHOT_REF:
-        writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
-        break;
-      case SET_PROPERTIES:
-        writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
-        break;
-      case REMOVE_PROPERTIES:
-        writeRemoveProperties((MetadataUpdate.RemoveProperties) metadataUpdate, generator);
-        break;
-      case SET_LOCATION:
-        writeSetLocation((MetadataUpdate.SetLocation) metadataUpdate, generator);
-        break;
-      case ADD_VIEW_VERSION:
-        writeAddViewVersion((MetadataUpdate.AddViewVersion) metadataUpdate, generator);
-        break;
-      case SET_CURRENT_VIEW_VERSION:
-        writeSetCurrentViewVersionId(
-            (MetadataUpdate.SetCurrentViewVersion) metadataUpdate, generator);
-        break;
-      case REMOVE_PARTITION_SPECS:
-        writeRemovePartitionSpecs((MetadataUpdate.RemovePartitionSpecs) metadataUpdate, generator);
-        break;
-      case REMOVE_SCHEMAS:
-        writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
-        break;
-      case ADD_ENCRYPTION_KEY:
-        writeAddEncryptionKey((MetadataUpdate.AddEncryptionKey) metadataUpdate, generator);
-        break;
-      case REMOVE_ENCRYPTION_KEY:
-        writeRemoveEncryptionKey((MetadataUpdate.RemoveEncryptionKey) metadataUpdate, generator);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot convert metadata update to json. Unrecognized action: %s", updateAction));
+      case ASSIGN_UUID -> writeAssignUUID((MetadataUpdate.AssignUUID) metadataUpdate, generator);
+      case UPGRADE_FORMAT_VERSION ->
+          writeUpgradeFormatVersion(
+              (MetadataUpdate.UpgradeFormatVersion) metadataUpdate, generator);
+      case ADD_SCHEMA -> writeAddSchema((MetadataUpdate.AddSchema) metadataUpdate, generator);
+      case SET_CURRENT_SCHEMA ->
+          writeSetCurrentSchema((MetadataUpdate.SetCurrentSchema) metadataUpdate, generator);
+      case ADD_PARTITION_SPEC ->
+          writeAddPartitionSpec((MetadataUpdate.AddPartitionSpec) metadataUpdate, generator);
+      case SET_DEFAULT_PARTITION_SPEC ->
+          writeSetDefaultPartitionSpec(
+              (MetadataUpdate.SetDefaultPartitionSpec) metadataUpdate, generator);
+      case ADD_SORT_ORDER ->
+          writeAddSortOrder((MetadataUpdate.AddSortOrder) metadataUpdate, generator);
+      case SET_DEFAULT_SORT_ORDER ->
+          writeSetDefaultSortOrder((MetadataUpdate.SetDefaultSortOrder) metadataUpdate, generator);
+      case SET_STATISTICS ->
+          writeSetStatistics((MetadataUpdate.SetStatistics) metadataUpdate, generator);
+      case REMOVE_STATISTICS ->
+          writeRemoveStatistics((MetadataUpdate.RemoveStatistics) metadataUpdate, generator);
+      case SET_PARTITION_STATISTICS ->
+          writeSetPartitionStatistics(
+              (MetadataUpdate.SetPartitionStatistics) metadataUpdate, generator);
+      case REMOVE_PARTITION_STATISTICS ->
+          writeRemovePartitionStatistics(
+              (MetadataUpdate.RemovePartitionStatistics) metadataUpdate, generator);
+      case ADD_SNAPSHOT -> writeAddSnapshot((MetadataUpdate.AddSnapshot) metadataUpdate, generator);
+      case REMOVE_SNAPSHOTS ->
+          writeRemoveSnapshots((MetadataUpdate.RemoveSnapshots) metadataUpdate, generator);
+      case REMOVE_SNAPSHOT_REF ->
+          writeRemoveSnapshotRef((MetadataUpdate.RemoveSnapshotRef) metadataUpdate, generator);
+      case SET_SNAPSHOT_REF ->
+          writeSetSnapshotRef((MetadataUpdate.SetSnapshotRef) metadataUpdate, generator);
+      case SET_PROPERTIES ->
+          writeSetProperties((MetadataUpdate.SetProperties) metadataUpdate, generator);
+      case REMOVE_PROPERTIES ->
+          writeRemoveProperties((MetadataUpdate.RemoveProperties) metadataUpdate, generator);
+      case SET_LOCATION -> writeSetLocation((MetadataUpdate.SetLocation) metadataUpdate, generator);
+      case ADD_VIEW_VERSION ->
+          writeAddViewVersion((MetadataUpdate.AddViewVersion) metadataUpdate, generator);
+      case SET_CURRENT_VIEW_VERSION ->
+          writeSetCurrentViewVersionId(
+              (MetadataUpdate.SetCurrentViewVersion) metadataUpdate, generator);
+      case REMOVE_PARTITION_SPECS ->
+          writeRemovePartitionSpecs(
+              (MetadataUpdate.RemovePartitionSpecs) metadataUpdate, generator);
+      case REMOVE_SCHEMAS ->
+          writeRemoveSchemas((MetadataUpdate.RemoveSchemas) metadataUpdate, generator);
+      case ADD_ENCRYPTION_KEY ->
+          writeAddEncryptionKey((MetadataUpdate.AddEncryptionKey) metadataUpdate, generator);
+      case REMOVE_ENCRYPTION_KEY ->
+          writeRemoveEncryptionKey((MetadataUpdate.RemoveEncryptionKey) metadataUpdate, generator);
+      default ->
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot convert metadata update to json. Unrecognized action: %s", updateAction));
     }
 
     generator.writeEndObject();
@@ -299,61 +272,36 @@ public class MetadataUpdateParser {
         jsonNode.hasNonNull(ACTION), "Cannot parse metadata update. Missing field: action");
     String action = JsonUtil.getString(ACTION, jsonNode).toLowerCase(Locale.ROOT);
 
-    switch (action) {
-      case ASSIGN_UUID:
-        return readAssignUUID(jsonNode);
-      case UPGRADE_FORMAT_VERSION:
-        return readUpgradeFormatVersion(jsonNode);
-      case ADD_SCHEMA:
-        return readAddSchema(jsonNode);
-      case SET_CURRENT_SCHEMA:
-        return readSetCurrentSchema(jsonNode);
-      case ADD_PARTITION_SPEC:
-        return readAddPartitionSpec(jsonNode);
-      case SET_DEFAULT_PARTITION_SPEC:
-        return readSetDefaultPartitionSpec(jsonNode);
-      case ADD_SORT_ORDER:
-        return readAddSortOrder(jsonNode);
-      case SET_DEFAULT_SORT_ORDER:
-        return readSetDefaultSortOrder(jsonNode);
-      case SET_STATISTICS:
-        return readSetStatistics(jsonNode);
-      case REMOVE_STATISTICS:
-        return readRemoveStatistics(jsonNode);
-      case SET_PARTITION_STATISTICS:
-        return readSetPartitionStatistics(jsonNode);
-      case REMOVE_PARTITION_STATISTICS:
-        return readRemovePartitionStatistics(jsonNode);
-      case ADD_SNAPSHOT:
-        return readAddSnapshot(jsonNode);
-      case REMOVE_SNAPSHOTS:
-        return readRemoveSnapshots(jsonNode);
-      case REMOVE_SNAPSHOT_REF:
-        return readRemoveSnapshotRef(jsonNode);
-      case SET_SNAPSHOT_REF:
-        return readSetSnapshotRef(jsonNode);
-      case SET_PROPERTIES:
-        return readSetProperties(jsonNode);
-      case REMOVE_PROPERTIES:
-        return readRemoveProperties(jsonNode);
-      case SET_LOCATION:
-        return readSetLocation(jsonNode);
-      case ADD_VIEW_VERSION:
-        return readAddViewVersion(jsonNode);
-      case SET_CURRENT_VIEW_VERSION:
-        return readCurrentViewVersionId(jsonNode);
-      case REMOVE_PARTITION_SPECS:
-        return readRemovePartitionSpecs(jsonNode);
-      case REMOVE_SCHEMAS:
-        return readRemoveSchemas(jsonNode);
-      case ADD_ENCRYPTION_KEY:
-        return readAddEncryptionKey(jsonNode);
-      case REMOVE_ENCRYPTION_KEY:
-        return readRemoveEncryptionKey(jsonNode);
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Cannot convert metadata update action to json: %s", action));
-    }
+    return switch (action) {
+      case ASSIGN_UUID -> readAssignUUID(jsonNode);
+      case UPGRADE_FORMAT_VERSION -> readUpgradeFormatVersion(jsonNode);
+      case ADD_SCHEMA -> readAddSchema(jsonNode);
+      case SET_CURRENT_SCHEMA -> readSetCurrentSchema(jsonNode);
+      case ADD_PARTITION_SPEC -> readAddPartitionSpec(jsonNode);
+      case SET_DEFAULT_PARTITION_SPEC -> readSetDefaultPartitionSpec(jsonNode);
+      case ADD_SORT_ORDER -> readAddSortOrder(jsonNode);
+      case SET_DEFAULT_SORT_ORDER -> readSetDefaultSortOrder(jsonNode);
+      case SET_STATISTICS -> readSetStatistics(jsonNode);
+      case REMOVE_STATISTICS -> readRemoveStatistics(jsonNode);
+      case SET_PARTITION_STATISTICS -> readSetPartitionStatistics(jsonNode);
+      case REMOVE_PARTITION_STATISTICS -> readRemovePartitionStatistics(jsonNode);
+      case ADD_SNAPSHOT -> readAddSnapshot(jsonNode);
+      case REMOVE_SNAPSHOTS -> readRemoveSnapshots(jsonNode);
+      case REMOVE_SNAPSHOT_REF -> readRemoveSnapshotRef(jsonNode);
+      case SET_SNAPSHOT_REF -> readSetSnapshotRef(jsonNode);
+      case SET_PROPERTIES -> readSetProperties(jsonNode);
+      case REMOVE_PROPERTIES -> readRemoveProperties(jsonNode);
+      case SET_LOCATION -> readSetLocation(jsonNode);
+      case ADD_VIEW_VERSION -> readAddViewVersion(jsonNode);
+      case SET_CURRENT_VIEW_VERSION -> readCurrentViewVersionId(jsonNode);
+      case REMOVE_PARTITION_SPECS -> readRemovePartitionSpecs(jsonNode);
+      case REMOVE_SCHEMAS -> readRemoveSchemas(jsonNode);
+      case ADD_ENCRYPTION_KEY -> readAddEncryptionKey(jsonNode);
+      case REMOVE_ENCRYPTION_KEY -> readRemoveEncryptionKey(jsonNode);
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Cannot convert metadata update action to json: %s", action));
+    };
   }
 
   private static void writeAssignUUID(MetadataUpdate.AssignUUID update, JsonGenerator gen)

--- a/core/src/main/java/org/apache/iceberg/PartitionData.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionData.java
@@ -203,21 +203,16 @@ public class PartitionData
       } else {
         Types.NestedField field = fields.get(i);
         switch (field.type().typeId()) {
-          case STRUCT:
-          case LIST:
-          case MAP:
-            throw new IllegalArgumentException("Unsupported type in partition data: " + type);
-          case BINARY:
-          case FIXED:
+          case STRUCT, LIST, MAP ->
+              throw new IllegalArgumentException("Unsupported type in partition data: " + type);
+          case BINARY, FIXED -> {
             byte[] buffer = (byte[]) data[i];
             copy[i] = Arrays.copyOf(buffer, buffer.length);
-            break;
-          case STRING:
-            copy[i] = data[i].toString();
-            break;
-          default:
-            // no need to copy the object
-            copy[i] = data[i];
+          }
+          case STRING -> copy[i] = data[i].toString();
+          default ->
+              // no need to copy the object
+              copy[i] = data[i];
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionStatsHandler.java
@@ -355,7 +355,7 @@ public class PartitionStatsHandler {
     Preconditions.checkArgument(stats.specId() == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         stats.set(
             PartitionStatistics.DATA_RECORD_COUNT_POSITION,
             stats.dataRecordCount() + file.recordCount());
@@ -363,8 +363,8 @@ public class PartitionStatsHandler {
         stats.set(
             PartitionStatistics.TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION,
             stats.totalDataFileSizeInBytes() + file.fileSizeInBytes());
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         stats.set(
             PartitionStatistics.POSITION_DELETE_RECORD_COUNT_POSITION,
             stats.positionDeleteRecordCount() + file.recordCount());
@@ -375,18 +375,18 @@ public class PartitionStatsHandler {
               PartitionStatistics.POSITION_DELETE_FILE_COUNT_POSITION,
               stats.positionDeleteFileCount() + 1);
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_RECORD_COUNT_POSITION,
             stats.equalityDeleteRecordCount() + file.recordCount());
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_FILE_COUNT_POSITION,
             stats.equalityDeleteFileCount() + 1);
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {
@@ -420,7 +420,7 @@ public class PartitionStatsHandler {
     Preconditions.checkArgument(stats.specId() == file.specId(), "Spec IDs must match");
 
     switch (file.content()) {
-      case DATA:
+      case DATA -> {
         stats.set(
             PartitionStatistics.DATA_RECORD_COUNT_POSITION,
             stats.dataRecordCount() - file.recordCount());
@@ -428,8 +428,8 @@ public class PartitionStatsHandler {
         stats.set(
             PartitionStatistics.TOTAL_DATA_FILE_SIZE_IN_BYTES_POSITION,
             stats.totalDataFileSizeInBytes() - file.fileSizeInBytes());
-        break;
-      case POSITION_DELETES:
+      }
+      case POSITION_DELETES -> {
         stats.set(
             PartitionStatistics.POSITION_DELETE_RECORD_COUNT_POSITION,
             stats.positionDeleteRecordCount() - file.recordCount());
@@ -440,18 +440,18 @@ public class PartitionStatsHandler {
               PartitionStatistics.POSITION_DELETE_FILE_COUNT_POSITION,
               stats.positionDeleteFileCount() - 1);
         }
-
-        break;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_RECORD_COUNT_POSITION,
             stats.equalityDeleteRecordCount() - file.recordCount());
         stats.set(
             PartitionStatistics.EQUALITY_DELETE_FILE_COUNT_POSITION,
             stats.equalityDeleteFileCount() - 1);
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported file content type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported file content type: " + file.content());
     }
 
     if (snapshot != null) {

--- a/core/src/main/java/org/apache/iceberg/PartitionsTable.java
+++ b/core/src/main/java/org/apache/iceberg/PartitionsTable.java
@@ -340,22 +340,22 @@ public class PartitionsTable extends BaseMetadataTable {
       }
 
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.dataRecordCount += file.recordCount();
           this.dataFileCount += 1;
           this.dataFileSizeInBytes += file.fileSizeInBytes();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           this.posDeleteRecordCount += file.recordCount();
           this.posDeleteFileCount += 1;
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.eqDeleteRecordCount += file.recordCount();
           this.eqDeleteFileCount += 1;
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -451,7 +451,7 @@ public class RewriteTablePathUtil {
     RewriteResult<DeleteFile> result = new RewriteResult<>();
 
     switch (file.content()) {
-      case POSITION_DELETES:
+      case POSITION_DELETES -> {
         DeleteFile posDeleteFile = newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, posDeleteFile);
         // keep the following entries in metadata but exclude them from copyPlan
@@ -467,7 +467,8 @@ public class RewriteTablePathUtil {
         }
         result.toRewrite().add(file.copy());
         return result;
-      case EQUALITY_DELETES:
+      }
+      case EQUALITY_DELETES -> {
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, eqDeleteFile);
         // keep the following entries in metadata but exclude them from copyPlan
@@ -478,9 +479,10 @@ public class RewriteTablePathUtil {
           result.copyPlan().add(Pair.of(file.location(), eqDeleteFile.location()));
         }
         return result;
-
-      default:
-        throw new UnsupportedOperationException("Unsupported delete file type: " + file.content());
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported delete file type: " + file.content());
     }
   }
 
@@ -488,16 +490,11 @@ public class RewriteTablePathUtil {
       ManifestEntry<F> entry, ManifestWriter<F> writer, F file) {
 
     switch (entry.status()) {
-      case ADDED:
-        writer.add(file);
-        break;
-      case EXISTING:
-        writer.existing(
-            file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
-        break;
-      case DELETED:
-        writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
-        break;
+      case ADDED -> writer.add(file);
+      case EXISTING ->
+          writer.existing(
+              file, entry.snapshotId(), entry.dataSequenceNumber(), entry.fileSequenceNumber());
+      case DELETED -> writer.delete(file, entry.dataSequenceNumber(), entry.fileSequenceNumber());
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/ScanSummary.java
+++ b/core/src/main/java/org/apache/iceberg/ScanSummary.java
@@ -388,37 +388,37 @@ public class ScanSummary {
     for (UnboundPredicate<Long> pred : timeFilters) {
       long value = pred.literal().value();
       switch (pred.op()) {
-        case LT:
+        case LT -> {
           if (value - 1 < maxTimestamp) {
             maxTimestamp = value - 1;
           }
-          break;
-        case LT_EQ:
+        }
+        case LT_EQ -> {
           if (value < maxTimestamp) {
             maxTimestamp = value;
           }
-          break;
-        case GT:
+        }
+        case GT -> {
           if (value + 1 > minTimestamp) {
             minTimestamp = value + 1;
           }
-          break;
-        case GT_EQ:
+        }
+        case GT_EQ -> {
           if (value > minTimestamp) {
             minTimestamp = value;
           }
-          break;
-        case EQ:
+        }
+        case EQ -> {
           if (value < maxTimestamp) {
             maxTimestamp = value;
           }
           if (value > minTimestamp) {
             minTimestamp = value;
           }
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot filter timestamps using predicate: " + pred);
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Cannot filter timestamps using predicate: " + pred);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
@@ -113,19 +113,14 @@ public class ScanTaskParser {
       taskType = TaskType.fromTypeName(taskTypeStr);
     }
 
-    switch (taskType) {
-      case FILE_SCAN_TASK:
-        return FileScanTaskParser.fromJson(jsonNode, caseSensitive);
-      case DATA_TASK:
-        return DataTaskParser.fromJson(jsonNode);
-      case FILES_TABLE_TASK:
-        return FilesTableTaskParser.fromJson(jsonNode);
-      case ALL_MANIFESTS_TABLE_TASK:
-        return AllManifestsTableTaskParser.fromJson(jsonNode);
-      case MANIFEST_ENTRIES_TABLE_TASK:
-        return ManifestEntriesTableTaskParser.fromJson(jsonNode);
-      default:
-        throw new UnsupportedOperationException("Unsupported task type: " + taskType.typeName());
-    }
+    return switch (taskType) {
+      case FILE_SCAN_TASK -> FileScanTaskParser.fromJson(jsonNode, caseSensitive);
+      case DATA_TASK -> DataTaskParser.fromJson(jsonNode);
+      case FILES_TABLE_TASK -> FilesTableTaskParser.fromJson(jsonNode);
+      case ALL_MANIFESTS_TABLE_TASK -> AllManifestsTableTaskParser.fromJson(jsonNode);
+      case MANIFEST_ENTRIES_TABLE_TASK -> ManifestEntriesTableTaskParser.fromJson(jsonNode);
+      default ->
+          throw new UnsupportedOperationException("Unsupported task type: " + taskType.typeName());
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/ScanTaskParser.java
@@ -119,8 +119,6 @@ public class ScanTaskParser {
       case FILES_TABLE_TASK -> FilesTableTaskParser.fromJson(jsonNode);
       case ALL_MANIFESTS_TABLE_TASK -> AllManifestsTableTaskParser.fromJson(jsonNode);
       case MANIFEST_ENTRIES_TABLE_TASK -> ManifestEntriesTableTaskParser.fromJson(jsonNode);
-      default ->
-          throw new UnsupportedOperationException("Unsupported task type: " + taskType.typeName());
     };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SchemaParser.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaParser.java
@@ -146,17 +146,10 @@ public class SchemaParser {
     } else {
       Type.NestedType nested = type.asNestedType();
       switch (type.typeId()) {
-        case STRUCT:
-          toJson(nested.asStructType(), generator);
-          break;
-        case LIST:
-          toJson(nested.asListType(), generator);
-          break;
-        case MAP:
-          toJson(nested.asMapType(), generator);
-          break;
-        default:
-          throw new IllegalArgumentException("Cannot write unknown type: " + type);
+        case STRUCT -> toJson(nested.asStructType(), generator);
+        case LIST -> toJson(nested.asListType(), generator);
+        case MAP -> toJson(nested.asMapType(), generator);
+        default -> throw new IllegalArgumentException("Cannot write unknown type: " + type);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -790,27 +790,21 @@ class SchemaUpdate implements UpdateSchema {
       reordered.remove(toMove);
 
       switch (move.type()) {
-        case FIRST:
-          reordered.addFirst(toMove);
-          break;
-
-        case BEFORE:
+        case FIRST -> reordered.addFirst(toMove);
+        case BEFORE -> {
           Types.NestedField before =
               Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
           int beforeIndex = reordered.indexOf(before);
           // insert the new node at the index of the existing node
           reordered.add(beforeIndex, toMove);
-          break;
-
-        case AFTER:
+        }
+        case AFTER -> {
           Types.NestedField after =
               Iterables.find(reordered, field -> field.fieldId() == move.referenceFieldId());
           int afterIndex = reordered.indexOf(after);
           reordered.add(afterIndex + 1, toMove);
-          break;
-
-        default:
-          throw new UnsupportedOperationException("Unknown move type: " + move.type());
+        }
+        default -> throw new UnsupportedOperationException("Unknown move type: " + move.type());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -52,11 +52,11 @@ public class SingleValueParser {
       return null;
     }
 
-    switch (type.typeId()) {
+    return switch (type.typeId()) {
       case BOOLEAN -> {
         Preconditions.checkArgument(
             defaultValue.isBoolean(), "Cannot parse default as a %s value: %s", type, defaultValue);
-        return defaultValue.booleanValue();
+        yield defaultValue.booleanValue();
       }
       case INTEGER -> {
         Preconditions.checkArgument(
@@ -64,7 +64,7 @@ public class SingleValueParser {
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
-        return defaultValue.intValue();
+        yield defaultValue.intValue();
       }
       case LONG -> {
         Preconditions.checkArgument(
@@ -72,7 +72,7 @@ public class SingleValueParser {
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
-        return defaultValue.longValue();
+        yield defaultValue.longValue();
       }
       case FLOAT -> {
         Preconditions.checkArgument(
@@ -80,7 +80,7 @@ public class SingleValueParser {
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
-        return defaultValue.floatValue();
+        yield defaultValue.floatValue();
       }
       case DOUBLE -> {
         Preconditions.checkArgument(
@@ -88,7 +88,7 @@ public class SingleValueParser {
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
-        return defaultValue.doubleValue();
+        yield defaultValue.doubleValue();
       }
       case DECIMAL -> {
         Preconditions.checkArgument(
@@ -105,12 +105,12 @@ public class SingleValueParser {
             "Cannot parse default as a %s value: %s, the scale doesn't match",
             type,
             defaultValue);
-        return retDecimal;
+        yield retDecimal;
       }
       case STRING -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
-        return defaultValue.textValue();
+        yield defaultValue.textValue();
       }
       case UUID -> {
         Preconditions.checkArgument(
@@ -125,17 +125,17 @@ public class SingleValueParser {
           throw new IllegalArgumentException(
               String.format("Cannot parse default as a %s value: %s", type, defaultValue), e);
         }
-        return uuid;
+        yield uuid;
       }
       case DATE -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
-        return DateTimeUtil.isoDateToDays(defaultValue.textValue());
+        yield DateTimeUtil.isoDateToDays(defaultValue.textValue());
       }
       case TIME -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
-        return DateTimeUtil.isoTimeToMicros(defaultValue.textValue());
+        yield DateTimeUtil.isoTimeToMicros(defaultValue.textValue());
       }
       case TIMESTAMP -> {
         Preconditions.checkArgument(
@@ -147,9 +147,9 @@ public class SingleValueParser {
               "Cannot parse default as a %s value: %s, offset must be +00:00",
               type,
               defaultValue);
-          return DateTimeUtil.isoTimestamptzToMicros(timestampTz);
+          yield DateTimeUtil.isoTimestamptzToMicros(timestampTz);
         } else {
-          return DateTimeUtil.isoTimestampToMicros(defaultValue.textValue());
+          yield DateTimeUtil.isoTimestampToMicros(defaultValue.textValue());
         }
       }
       case TIMESTAMP_NANO -> {
@@ -162,9 +162,9 @@ public class SingleValueParser {
               "Cannot parse default as a %s value: %s, offset must be +00:00",
               type,
               defaultValue);
-          return DateTimeUtil.isoTimestamptzToNanos(timestampTzNano);
+          yield DateTimeUtil.isoTimestamptzToNanos(timestampTzNano);
         } else {
-          return DateTimeUtil.isoTimestampToNanos(defaultValue.textValue());
+          yield DateTimeUtil.isoTimestampToNanos(defaultValue.textValue());
         }
       }
       case FIXED -> {
@@ -180,27 +180,21 @@ public class SingleValueParser {
             defaultLength);
         byte[] fixedBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
-        return ByteBuffer.wrap(fixedBytes);
+        yield ByteBuffer.wrap(fixedBytes);
       }
       case BINARY -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         byte[] binaryBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
-        return ByteBuffer.wrap(binaryBytes);
+        yield ByteBuffer.wrap(binaryBytes);
       }
-      case LIST -> {
-        return listFromJson(type, defaultValue);
-      }
-      case MAP -> {
-        return mapFromJson(type, defaultValue);
-      }
-      case STRUCT -> {
-        return structFromJson(type, defaultValue);
-      }
+      case LIST -> listFromJson(type, defaultValue);
+      case MAP -> mapFromJson(type, defaultValue);
+      case STRUCT -> structFromJson(type, defaultValue);
       default ->
           throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
-    }
+    };
   }
 
   private static StructLike structFromJson(Type type, JsonNode defaultValue) {

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -52,39 +52,44 @@ public class SingleValueParser {
     }
 
     switch (type.typeId()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         Preconditions.checkArgument(
             defaultValue.isBoolean(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return defaultValue.booleanValue();
-      case INTEGER:
+      }
+      case INTEGER -> {
         Preconditions.checkArgument(
             defaultValue.isIntegralNumber() && defaultValue.canConvertToInt(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.intValue();
-      case LONG:
+      }
+      case LONG -> {
         Preconditions.checkArgument(
             defaultValue.isIntegralNumber() && defaultValue.canConvertToLong(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.longValue();
-      case FLOAT:
+      }
+      case FLOAT -> {
         Preconditions.checkArgument(
             defaultValue.isFloatingPointNumber(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.floatValue();
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         Preconditions.checkArgument(
             defaultValue.isFloatingPointNumber(),
             "Cannot parse default as a %s value: %s",
             type,
             defaultValue);
         return defaultValue.doubleValue();
-      case DECIMAL:
+      }
+      case DECIMAL -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         BigDecimal retDecimal;
@@ -100,11 +105,13 @@ public class SingleValueParser {
             type,
             defaultValue);
         return retDecimal;
-      case STRING:
+      }
+      case STRING -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return defaultValue.textValue();
-      case UUID:
+      }
+      case UUID -> {
         Preconditions.checkArgument(
             defaultValue.isTextual() && defaultValue.textValue().length() == 36,
             "Cannot parse default as a %s value: %s",
@@ -118,15 +125,18 @@ public class SingleValueParser {
               String.format("Cannot parse default as a %s value: %s", type, defaultValue), e);
         }
         return uuid;
-      case DATE:
+      }
+      case DATE -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return DateTimeUtil.isoDateToDays(defaultValue.textValue());
-      case TIME:
+      }
+      case TIME -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         return DateTimeUtil.isoTimeToMicros(defaultValue.textValue());
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
@@ -140,7 +150,8 @@ public class SingleValueParser {
         } else {
           return DateTimeUtil.isoTimestampToMicros(defaultValue.textValue());
         }
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
@@ -154,7 +165,8 @@ public class SingleValueParser {
         } else {
           return DateTimeUtil.isoTimestampToNanos(defaultValue.textValue());
         }
-      case FIXED:
+      }
+      case FIXED -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         int defaultLength = defaultValue.textValue().length();
@@ -168,20 +180,25 @@ public class SingleValueParser {
         byte[] fixedBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
         return ByteBuffer.wrap(fixedBytes);
-      case BINARY:
+      }
+      case BINARY -> {
         Preconditions.checkArgument(
             defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
         byte[] binaryBytes =
             BaseEncoding.base16().decode(defaultValue.textValue().toUpperCase(Locale.ROOT));
         return ByteBuffer.wrap(binaryBytes);
-      case LIST:
+      }
+      case LIST -> {
         return listFromJson(type, defaultValue);
-      case MAP:
+      }
+      case MAP -> {
         return mapFromJson(type, defaultValue);
-      case STRUCT:
+      }
+      case STRUCT -> {
         return structFromJson(type, defaultValue);
-      default:
-        throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
+      }
+      default ->
+          throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
     }
   }
 
@@ -259,42 +276,42 @@ public class SingleValueParser {
     }
 
     switch (type.typeId()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         Preconditions.checkArgument(
             defaultValue instanceof Boolean, "Invalid default %s value: %s", type, defaultValue);
         generator.writeBoolean((Boolean) defaultValue);
-        break;
-      case INTEGER:
+      }
+      case INTEGER -> {
         Preconditions.checkArgument(
             defaultValue instanceof Integer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Integer) defaultValue);
-        break;
-      case LONG:
+      }
+      case LONG -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Long) defaultValue);
-        break;
-      case FLOAT:
+      }
+      case FLOAT -> {
         Preconditions.checkArgument(
             defaultValue instanceof Float, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Float) defaultValue);
-        break;
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         Preconditions.checkArgument(
             defaultValue instanceof Double, "Invalid default %s value: %s", type, defaultValue);
         generator.writeNumber((Double) defaultValue);
-        break;
-      case DATE:
+      }
+      case DATE -> {
         Preconditions.checkArgument(
             defaultValue instanceof Integer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(DateTimeUtil.daysToIsoDate((Integer) defaultValue));
-        break;
-      case TIME:
+      }
+      case TIME -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(DateTimeUtil.microsToIsoTime((Long) defaultValue));
-        break;
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
@@ -302,8 +319,8 @@ public class SingleValueParser {
         } else {
           generator.writeString(DateTimeUtil.microsToIsoTimestamp((Long) defaultValue));
         }
-        break;
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         Preconditions.checkArgument(
             defaultValue instanceof Long, "Invalid default %s value: %s", type, defaultValue);
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
@@ -311,21 +328,21 @@ public class SingleValueParser {
         } else {
           generator.writeString(DateTimeUtil.nanosToIsoTimestamp((Long) defaultValue));
         }
-        break;
-      case STRING:
+      }
+      case STRING -> {
         Preconditions.checkArgument(
             defaultValue instanceof CharSequence,
             "Invalid default %s value: %s",
             type,
             defaultValue);
         generator.writeString(((CharSequence) defaultValue).toString());
-        break;
-      case UUID:
+      }
+      case UUID -> {
         Preconditions.checkArgument(
             defaultValue instanceof UUID, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(defaultValue.toString());
-        break;
-      case FIXED:
+      }
+      case FIXED -> {
         Preconditions.checkArgument(
             defaultValue instanceof ByteBuffer, "Invalid default %s value: %s", type, defaultValue);
         ByteBuffer byteBufferValue = (ByteBuffer) defaultValue;
@@ -337,14 +354,14 @@ public class SingleValueParser {
             byteBufferValue.remaining());
         generator.writeString(
             BaseEncoding.base16().encode(ByteBuffers.toByteArray(byteBufferValue)));
-        break;
-      case BINARY:
+      }
+      case BINARY -> {
         Preconditions.checkArgument(
             defaultValue instanceof ByteBuffer, "Invalid default %s value: %s", type, defaultValue);
         generator.writeString(
             BaseEncoding.base16().encode(ByteBuffers.toByteArray((ByteBuffer) defaultValue)));
-        break;
-      case DECIMAL:
+      }
+      case DECIMAL -> {
         Preconditions.checkArgument(
             defaultValue instanceof BigDecimal
                 && ((BigDecimal) defaultValue).scale() == ((Types.DecimalType) type).scale(),
@@ -357,8 +374,8 @@ public class SingleValueParser {
         } else {
           generator.writeString(decimalValue.toString());
         }
-        break;
-      case LIST:
+      }
+      case LIST -> {
         Preconditions.checkArgument(
             defaultValue instanceof List, "Invalid default %s value: %s", type, defaultValue);
         List<Object> defaultList = (List<Object>) defaultValue;
@@ -368,8 +385,8 @@ public class SingleValueParser {
           toJson(elementType, element, generator);
         }
         generator.writeEndArray();
-        break;
-      case MAP:
+      }
+      case MAP -> {
         Preconditions.checkArgument(
             defaultValue instanceof Map, "Invalid default %s value: %s", type, defaultValue);
         Map<Object, Object> defaultMap = (Map<Object, Object>) defaultValue;
@@ -390,8 +407,8 @@ public class SingleValueParser {
         }
         generator.writeEndArray();
         generator.writeEndObject();
-        break;
-      case STRUCT:
+      }
+      case STRUCT -> {
         Preconditions.checkArgument(
             defaultValue instanceof StructLike, "Invalid default %s value: %s", type, defaultValue);
         Types.StructType structType = type.asStructType();
@@ -409,9 +426,9 @@ public class SingleValueParser {
           }
         }
         generator.writeEndObject();
-        break;
-      default:
-        throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
+      }
+      default ->
+          throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -46,6 +46,7 @@ public class SingleValueParser {
   private static final String KEYS = "keys";
   private static final String VALUES = "values";
 
+  @SuppressWarnings("MethodLength")
   public static Object fromJson(Type type, JsonNode defaultValue) {
     if (defaultValue == null || defaultValue.isNull()) {
       return null;

--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -139,12 +139,8 @@ public class SnapshotChanges {
         iterate(manifestReadTasks)) {
       for (Pair<ManifestEntry.Status, DataFile> pair : changedDataFiles) {
         switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
+          case ADDED -> adds.add(pair.second());
+          case DELETED -> deletes.add(pair.second());
         }
       }
     } catch (IOException e) {
@@ -190,12 +186,8 @@ public class SnapshotChanges {
         iterate(manifestReadTasks)) {
       for (Pair<ManifestEntry.Status, DeleteFile> pair : changedDeleteFiles) {
         switch (pair.first()) {
-          case ADDED:
-            adds.add(pair.second());
-            break;
-          case DELETED:
-            deletes.add(pair.second());
-            break;
+          case ADDED -> adds.add(pair.second());
+          case DELETED -> deletes.add(pair.second());
         }
       }
     } catch (IOException e) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -833,24 +833,24 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         }
 
         switch (entry.status()) {
-          case ADDED:
+          case ADDED -> {
             addedFiles += 1;
             addedRows += entry.file().recordCount();
             if (snapshotId == null) {
               snapshotId = entry.snapshotId();
             }
-            break;
-          case EXISTING:
+          }
+          case EXISTING -> {
             existingFiles += 1;
             existingRows += entry.file().recordCount();
-            break;
-          case DELETED:
+          }
+          case DELETED -> {
             deletedFiles += 1;
             deletedRows += entry.file().recordCount();
             if (snapshotId == null) {
               snapshotId = entry.snapshotId();
             }
-            break;
+          }
         }
 
         stats.update(entry.file().partition());

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -291,11 +291,11 @@ public class SnapshotSummary {
     void addedFile(ContentFile<?> file) {
       this.addedSize += ScanTaskUtil.contentSizeInBytes(file);
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.addedFiles += 1;
           this.addedRecords += file.recordCount();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           DeleteFile deleteFile = (DeleteFile) file;
           if (ContentFileUtil.isDV(deleteFile)) {
             this.addedDVs += 1;
@@ -304,26 +304,26 @@ public class SnapshotSummary {
           }
           this.addedDeleteFiles += 1;
           this.addedPosDeletes += file.recordCount();
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.addedDeleteFiles += 1;
           this.addedEqDeleteFiles += 1;
           this.addedEqDeletes += file.recordCount();
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 
     void removedFile(ContentFile<?> file) {
       this.removedSize += ScanTaskUtil.contentSizeInBytes(file);
       switch (file.content()) {
-        case DATA:
+        case DATA -> {
           this.removedFiles += 1;
           this.deletedRecords += file.recordCount();
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           DeleteFile deleteFile = (DeleteFile) file;
           if (ContentFileUtil.isDV(deleteFile)) {
             this.removedDVs += 1;
@@ -332,31 +332,31 @@ public class SnapshotSummary {
           }
           this.removedDeleteFiles += 1;
           this.removedPosDeletes += file.recordCount();
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           this.removedDeleteFiles += 1;
           this.removedEqDeleteFiles += 1;
           this.removedEqDeletes += file.recordCount();
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Unsupported file content type: " + file.content());
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported file content type: " + file.content());
       }
     }
 
     void addedManifest(ManifestFile manifest) {
       switch (manifest.content()) {
-        case DATA:
+        case DATA -> {
           this.addedFiles += manifest.addedFilesCount();
           this.addedRecords += manifest.addedRowsCount();
           this.removedFiles += manifest.deletedFilesCount();
           this.deletedRecords += manifest.deletedRowsCount();
-          break;
-        case DELETES:
+        }
+        case DELETES -> {
           this.addedDeleteFiles += manifest.addedFilesCount();
           this.removedDeleteFiles += manifest.deletedFilesCount();
           this.trustSizeAndDeleteCounts = false;
-          break;
+        }
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -168,13 +168,11 @@ public class SortOrderParser {
   }
 
   private static NullOrder toNullOrder(String nullOrderingAsString) {
-    switch (nullOrderingAsString.toLowerCase(Locale.ROOT)) {
-      case "nulls-first":
-        return NULLS_FIRST;
-      case "nulls-last":
-        return NULLS_LAST;
-      default:
-        throw new IllegalArgumentException("Unexpected null order: " + nullOrderingAsString);
-    }
+    return switch (nullOrderingAsString.toLowerCase(Locale.ROOT)) {
+      case "nulls-first" -> NULLS_FIRST;
+      case "nulls-last" -> NULLS_LAST;
+      default ->
+          throw new IllegalArgumentException("Unexpected null order: " + nullOrderingAsString);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -258,98 +258,51 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case 0:
-        return tracking;
-      case 1:
-        return contentType != null ? contentType.id() : null;
-      case 2:
-        return writerFormatVersion;
-      case 3:
-        return location;
-      case 4:
-        return fileFormat != null ? fileFormat.toString() : null;
-      case 5:
-        return recordCount;
-      case 6:
-        return fileSizeInBytes;
-      case 7:
-        return specId;
-      case 8:
-        return partitionData;
-      case 9:
-        return contentStats;
-      case 10:
-        return sortOrderId;
-      case 11:
-        return deletionVector;
-      case 12:
-        return manifestInfo;
-      case 13:
-        return keyMetadata();
-      case 14:
-        return splitOffsets();
-      case 15:
-        return equalityIds();
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> tracking;
+      case 1 -> contentType != null ? contentType.id() : null;
+      case 2 -> writerFormatVersion;
+      case 3 -> location;
+      case 4 -> fileFormat != null ? fileFormat.toString() : null;
+      case 5 -> recordCount;
+      case 6 -> fileSizeInBytes;
+      case 7 -> specId;
+      case 8 -> partitionData;
+      case 9 -> contentStats;
+      case 10 -> sortOrderId;
+      case 11 -> deletionVector;
+      case 12 -> manifestInfo;
+      case 13 -> keyMetadata();
+      case 14 -> splitOffsets();
+      case 15 -> equalityIds();
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.tracking = (Tracking) value;
-        break;
-      case 1:
-        this.contentType = FileContent.fromId((Integer) value);
-        break;
-      case 2:
-        this.writerFormatVersion = (int) value;
-        break;
-      case 3:
-        // always coerce to String for Serializable
-        this.location = value.toString();
-        break;
-      case 4:
-        this.fileFormat = FileFormat.fromString(value.toString());
-        break;
-      case 5:
-        this.recordCount = (long) value;
-        break;
-      case 6:
-        this.fileSizeInBytes = (long) value;
-        break;
-      case 7:
-        this.specId = (Integer) value;
-        break;
-      case 8:
-        this.partitionData = (PartitionData) value;
-        break;
-      case 9:
-        this.contentStats = (ContentStats) value;
-        break;
-      case 10:
-        this.sortOrderId = (Integer) value;
-        break;
-      case 11:
-        this.deletionVector = (DeletionVector) value;
-        break;
-      case 12:
-        this.manifestInfo = (ManifestInfo) value;
-        break;
-      case 13:
-        this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 14:
-        this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
-        break;
-      case 15:
-        this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
-        break;
-      default:
+      case 0 -> this.tracking = (Tracking) value;
+      case 1 -> this.contentType = FileContent.fromId((Integer) value);
+      case 2 -> this.writerFormatVersion = (int) value;
+      case 3 ->
+          // always coerce to String for Serializable
+          this.location = value.toString();
+      case 4 -> this.fileFormat = FileFormat.fromString(value.toString());
+      case 5 -> this.recordCount = (long) value;
+      case 6 -> this.fileSizeInBytes = (long) value;
+      case 7 -> this.specId = (Integer) value;
+      case 8 -> this.partitionData = (PartitionData) value;
+      case 9 -> this.contentStats = (ContentStats) value;
+      case 10 -> this.sortOrderId = (Integer) value;
+      case 11 -> this.deletionVector = (DeletionVector) value;
+      case 12 -> this.manifestInfo = (ManifestInfo) value;
+      case 13 -> this.keyMetadata = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 14 -> this.splitOffsets = ArrayUtil.toLongArray((List<Long>) value);
+      case 15 -> this.equalityIds = ArrayUtil.toIntArray((List<Integer>) value);
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TrackingStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackingStruct.java
@@ -195,62 +195,35 @@ class TrackingStruct extends SupportsIndexProjection implements Tracking, Serial
   }
 
   private Object getByPos(int pos) {
-    switch (pos) {
-      case 0:
-        return status != null ? status.id() : null;
-      case 1:
-        return snapshotId();
-      case 2:
-        return dataSequenceNumber();
-      case 3:
-        return fileSequenceNumber();
-      case 4:
-        return dvSnapshotId;
-      case 5:
-        return firstRowId;
-      case 6:
-        return deletedPositions();
-      case 7:
-        return replacedPositions();
-      case 8:
-        return manifestPos;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-    }
+    return switch (pos) {
+      case 0 -> status != null ? status.id() : null;
+      case 1 -> snapshotId();
+      case 2 -> dataSequenceNumber();
+      case 3 -> fileSequenceNumber();
+      case 4 -> dvSnapshotId;
+      case 5 -> firstRowId;
+      case 6 -> deletedPositions();
+      case 7 -> replacedPositions();
+      case 8 -> manifestPos;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+    };
   }
 
   @Override
   protected <T> void internalSet(int pos, T value) {
     switch (pos) {
-      case 0:
-        this.status = EntryStatus.fromId((Integer) value);
-        break;
-      case 1:
-        this.snapshotId = (Long) value;
-        break;
-      case 2:
-        this.dataSequenceNumber = (Long) value;
-        break;
-      case 3:
-        this.fileSequenceNumber = (Long) value;
-        break;
-      case 4:
-        this.dvSnapshotId = (Long) value;
-        break;
-      case 5:
-        this.firstRowId = (Long) value;
-        break;
-      case 6:
-        this.deletedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 7:
-        this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
-        break;
-      case 8:
-        this.manifestPos = (long) value;
-        break;
-      default:
+      case 0 -> this.status = EntryStatus.fromId((Integer) value);
+      case 1 -> this.snapshotId = (Long) value;
+      case 2 -> this.dataSequenceNumber = (Long) value;
+      case 3 -> this.fileSequenceNumber = (Long) value;
+      case 4 -> this.dvSnapshotId = (Long) value;
+      case 5 -> this.firstRowId = (Long) value;
+      case 6 -> this.deletedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 7 -> this.replacedPositions = ByteBuffers.toByteArray((ByteBuffer) value);
+      case 8 -> this.manifestPos = (long) value;
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/UpdateRequirementParser.java
+++ b/core/src/main/java/org/apache/iceberg/UpdateRequirementParser.java
@@ -97,44 +97,36 @@ public class UpdateRequirementParser {
     generator.writeStringField(TYPE, requirementType);
 
     switch (requirementType) {
-      case ASSERT_TABLE_DOES_NOT_EXIST:
+      case ASSERT_TABLE_DOES_NOT_EXIST -> {
         // No fields beyond the requirement itself
-        break;
-      case ASSERT_TABLE_UUID:
-        writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
-        break;
-      case ASSERT_VIEW_UUID:
-        writeAssertViewUUID((UpdateRequirement.AssertViewUUID) updateRequirement, generator);
-        break;
-      case ASSERT_REF_SNAPSHOT_ID:
-        writeAssertRefSnapshotId(
-            (UpdateRequirement.AssertRefSnapshotID) updateRequirement, generator);
-        break;
-      case ASSERT_LAST_ASSIGNED_FIELD_ID:
-        writeAssertLastAssignedFieldId(
-            (UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
-        break;
-      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        writeAssertLastAssignedPartitionId(
-            (UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
-        break;
-      case ASSERT_CURRENT_SCHEMA_ID:
-        writeAssertCurrentSchemaId(
-            (UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
-        break;
-      case ASSERT_DEFAULT_SPEC_ID:
-        writeAssertDefaultSpecId(
-            (UpdateRequirement.AssertDefaultSpecID) updateRequirement, generator);
-        break;
-      case ASSERT_DEFAULT_SORT_ORDER_ID:
-        writeAssertDefaultSortOrderId(
-            (UpdateRequirement.AssertDefaultSortOrderID) updateRequirement, generator);
-        break;
-      default:
-        throw new IllegalArgumentException(
-            String.format(
-                "Cannot convert update requirement to json. Unrecognized type: %s",
-                requirementType));
+      }
+      case ASSERT_TABLE_UUID ->
+          writeAssertTableUUID((UpdateRequirement.AssertTableUUID) updateRequirement, generator);
+      case ASSERT_VIEW_UUID ->
+          writeAssertViewUUID((UpdateRequirement.AssertViewUUID) updateRequirement, generator);
+      case ASSERT_REF_SNAPSHOT_ID ->
+          writeAssertRefSnapshotId(
+              (UpdateRequirement.AssertRefSnapshotID) updateRequirement, generator);
+      case ASSERT_LAST_ASSIGNED_FIELD_ID ->
+          writeAssertLastAssignedFieldId(
+              (UpdateRequirement.AssertLastAssignedFieldId) updateRequirement, generator);
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID ->
+          writeAssertLastAssignedPartitionId(
+              (UpdateRequirement.AssertLastAssignedPartitionId) updateRequirement, generator);
+      case ASSERT_CURRENT_SCHEMA_ID ->
+          writeAssertCurrentSchemaId(
+              (UpdateRequirement.AssertCurrentSchemaID) updateRequirement, generator);
+      case ASSERT_DEFAULT_SPEC_ID ->
+          writeAssertDefaultSpecId(
+              (UpdateRequirement.AssertDefaultSpecID) updateRequirement, generator);
+      case ASSERT_DEFAULT_SORT_ORDER_ID ->
+          writeAssertDefaultSortOrderId(
+              (UpdateRequirement.AssertDefaultSortOrderID) updateRequirement, generator);
+      default ->
+          throw new IllegalArgumentException(
+              String.format(
+                  "Cannot convert update requirement to json. Unrecognized type: %s",
+                  requirementType));
     }
 
     generator.writeEndObject();
@@ -159,29 +151,20 @@ public class UpdateRequirementParser {
         jsonNode.hasNonNull(TYPE), "Cannot parse update requirement. Missing field: type");
     String type = JsonUtil.getString(TYPE, jsonNode).toLowerCase(Locale.ROOT);
 
-    switch (type) {
-      case ASSERT_TABLE_DOES_NOT_EXIST:
-        return readAssertTableDoesNotExist(jsonNode);
-      case ASSERT_TABLE_UUID:
-        return readAssertTableUUID(jsonNode);
-      case ASSERT_VIEW_UUID:
-        return readAssertViewUUID(jsonNode);
-      case ASSERT_REF_SNAPSHOT_ID:
-        return readAssertRefSnapshotId(jsonNode);
-      case ASSERT_LAST_ASSIGNED_FIELD_ID:
-        return readAssertLastAssignedFieldId(jsonNode);
-      case ASSERT_LAST_ASSIGNED_PARTITION_ID:
-        return readAssertLastAssignedPartitionId(jsonNode);
-      case ASSERT_CURRENT_SCHEMA_ID:
-        return readAssertCurrentSchemaId(jsonNode);
-      case ASSERT_DEFAULT_SPEC_ID:
-        return readAssertDefaultSpecId(jsonNode);
-      case ASSERT_DEFAULT_SORT_ORDER_ID:
-        return readAssertDefaultSortOrderId(jsonNode);
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Unrecognized update requirement. Cannot convert to json: %s", type));
-    }
+    return switch (type) {
+      case ASSERT_TABLE_DOES_NOT_EXIST -> readAssertTableDoesNotExist(jsonNode);
+      case ASSERT_TABLE_UUID -> readAssertTableUUID(jsonNode);
+      case ASSERT_VIEW_UUID -> readAssertViewUUID(jsonNode);
+      case ASSERT_REF_SNAPSHOT_ID -> readAssertRefSnapshotId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_FIELD_ID -> readAssertLastAssignedFieldId(jsonNode);
+      case ASSERT_LAST_ASSIGNED_PARTITION_ID -> readAssertLastAssignedPartitionId(jsonNode);
+      case ASSERT_CURRENT_SCHEMA_ID -> readAssertCurrentSchemaId(jsonNode);
+      case ASSERT_DEFAULT_SPEC_ID -> readAssertDefaultSpecId(jsonNode);
+      case ASSERT_DEFAULT_SORT_ORDER_ID -> readAssertDefaultSortOrderId(jsonNode);
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Unrecognized update requirement. Cannot convert to json: %s", type));
+    };
   }
 
   private static void writeAssertTableUUID(

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -253,22 +253,18 @@ class V1Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.status().id();
-        }
-        case 1 -> {
-          return wrapped.snapshotId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
         case 2 -> {
           DataFile file = wrapped.file();
           if (file != null) {
-            return fileWrapper.wrap(file);
+            yield fileWrapper.wrap(file);
           }
-          return null;
+          yield null;
         }
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -353,54 +349,24 @@ class V1Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.location();
-        }
-        case 1 -> {
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        }
-        case 2 -> {
-          return wrapped.partition();
-        }
-        case 3 -> {
-          return wrapped.recordCount();
-        }
-        case 4 -> {
-          return wrapped.fileSizeInBytes();
-        }
-        case 5 -> {
-          return DEFAULT_BLOCK_SIZE;
-        }
-        case 6 -> {
-          return wrapped.columnSizes();
-        }
-        case 7 -> {
-          return wrapped.valueCounts();
-        }
-        case 8 -> {
-          return wrapped.nullValueCounts();
-        }
-        case 9 -> {
-          return wrapped.nanValueCounts();
-        }
-        case 10 -> {
-          return wrapped.lowerBounds();
-        }
-        case 11 -> {
-          return wrapped.upperBounds();
-        }
-        case 12 -> {
-          return wrapped.keyMetadata();
-        }
-        case 13 -> {
-          return wrapped.splitOffsets();
-        }
-        case 14 -> {
-          return wrapped.sortOrderId();
-        }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      return switch (pos) {
+        case 0 -> wrapped.location();
+        case 1 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 2 -> wrapped.partition();
+        case 3 -> wrapped.recordCount();
+        case 4 -> wrapped.fileSizeInBytes();
+        case 5 -> DEFAULT_BLOCK_SIZE;
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.sortOrderId();
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V1Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V1Metadata.java
@@ -74,34 +74,21 @@ class V1Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0:
-          return path();
-        case 1:
-          return length();
-        case 2:
-          return partitionSpecId();
-        case 3:
-          return snapshotId();
-        case 4:
-          return addedFilesCount();
-        case 5:
-          return existingFilesCount();
-        case 6:
-          return deletedFilesCount();
-        case 7:
-          return partitions();
-        case 8:
-          return addedRowsCount();
-        case 9:
-          return existingRowsCount();
-        case 10:
-          return deletedRowsCount();
-        case 11:
-          return keyMetadata();
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      return switch (pos) {
+        case 0 -> path();
+        case 1 -> length();
+        case 2 -> partitionSpecId();
+        case 3 -> snapshotId();
+        case 4 -> addedFilesCount();
+        case 5 -> existingFilesCount();
+        case 6 -> deletedFilesCount();
+        case 7 -> partitions();
+        case 8 -> addedRowsCount();
+        case 9 -> existingRowsCount();
+        case 10 -> deletedRowsCount();
+        case 11 -> keyMetadata();
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override
@@ -267,18 +254,20 @@ class V1Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           DataFile file = wrapped.file();
           if (file != null) {
             return fileWrapper.wrap(file);
           }
           return null;
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -365,36 +354,51 @@ class V1Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.location();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partition();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.recordCount();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.fileSizeInBytes();
-        case 5:
+        }
+        case 5 -> {
           return DEFAULT_BLOCK_SIZE;
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.sortOrderId();
+        }
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -85,19 +85,13 @@ class V2Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.path();
-        }
-        case 1 -> {
-          return wrapped.length();
-        }
-        case 2 -> {
-          return wrapped.partitionSpecId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.path();
+        case 1 -> wrapped.length();
+        case 2 -> wrapped.partitionSpecId();
         case 3 -> {
           checkContentType(wrapped.content());
-          return wrapped.content().id();
+          yield wrapped.content().id();
         }
         case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
@@ -108,9 +102,9 @@ class V2Metadata {
                 commitSnapshotId == wrapped.snapshotId(),
                 "Found unassigned sequence number for a manifest from snapshot: %s",
                 wrapped.snapshotId());
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.sequenceNumber();
+            yield wrapped.sequenceNumber();
           }
         }
         case 5 -> {
@@ -124,40 +118,22 @@ class V2Metadata {
             // number for any file
             // written to the wrapped manifest. replace the unassigned sequence number with the one
             // for this commit
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.minSequenceNumber();
+            yield wrapped.minSequenceNumber();
           }
         }
-        case 6 -> {
-          return wrapped.snapshotId();
-        }
-        case 7 -> {
-          return wrapped.addedFilesCount();
-        }
-        case 8 -> {
-          return wrapped.existingFilesCount();
-        }
-        case 9 -> {
-          return wrapped.deletedFilesCount();
-        }
-        case 10 -> {
-          return wrapped.addedRowsCount();
-        }
-        case 11 -> {
-          return wrapped.existingRowsCount();
-        }
-        case 12 -> {
-          return wrapped.deletedRowsCount();
-        }
-        case 13 -> {
-          return wrapped.partitions();
-        }
-        case 14 -> {
-          return wrapped.keyMetadata();
-        }
+        case 6 -> wrapped.snapshotId();
+        case 7 -> wrapped.addedFilesCount();
+        case 8 -> wrapped.existingFilesCount();
+        case 9 -> wrapped.deletedFilesCount();
+        case 10 -> wrapped.addedRowsCount();
+        case 11 -> wrapped.existingRowsCount();
+        case 12 -> wrapped.deletedRowsCount();
+        case 13 -> wrapped.partitions();
+        case 14 -> wrapped.keyMetadata();
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -326,13 +302,9 @@ class V2Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.status().id();
-        }
-        case 1 -> {
-          return wrapped.snapshotId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
         case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
@@ -349,18 +321,14 @@ class V2Metadata {
                 wrapped.status() == Status.ADDED,
                 "Only entries with status ADDED can have null sequence number");
 
-            return null;
+            yield null;
           }
-          return wrapped.dataSequenceNumber();
+          yield wrapped.dataSequenceNumber();
         }
-        case 3 -> {
-          return wrapped.fileSequenceNumber();
-        }
-        case 4 -> {
-          return fileWrapper.wrap(wrapped.file());
-        }
+        case 3 -> wrapped.fileSequenceNumber();
+        case 4 -> fileWrapper.wrap(wrapped.file());
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -445,65 +413,35 @@ class V2Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
+      return switch (pos) {
         case 0 -> {
           checkContentType(wrapped.content());
-          return wrapped.content().id();
+          yield wrapped.content().id();
         }
-        case 1 -> {
-          return wrapped.location();
-        }
-        case 2 -> {
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        }
-        case 3 -> {
-          return wrapped.partition();
-        }
-        case 4 -> {
-          return wrapped.recordCount();
-        }
-        case 5 -> {
-          return wrapped.fileSizeInBytes();
-        }
-        case 6 -> {
-          return wrapped.columnSizes();
-        }
-        case 7 -> {
-          return wrapped.valueCounts();
-        }
-        case 8 -> {
-          return wrapped.nullValueCounts();
-        }
-        case 9 -> {
-          return wrapped.nanValueCounts();
-        }
-        case 10 -> {
-          return wrapped.lowerBounds();
-        }
-        case 11 -> {
-          return wrapped.upperBounds();
-        }
-        case 12 -> {
-          return wrapped.keyMetadata();
-        }
-        case 13 -> {
-          return wrapped.splitOffsets();
-        }
-        case 14 -> {
-          return wrapped.equalityFieldIds();
-        }
-        case 15 -> {
-          return wrapped.sortOrderId();
-        }
+        case 1 -> wrapped.location();
+        case 2 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 3 -> wrapped.partition();
+        case 4 -> wrapped.recordCount();
+        case 5 -> wrapped.fileSizeInBytes();
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.equalityFieldIds();
+        case 15 -> wrapped.sortOrderId();
         case 16 -> {
           if (wrapped instanceof DeleteFile) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+            yield ((DeleteFile) wrapped).referencedDataFile();
           } else {
-            return null;
+            yield null;
           }
         }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V2Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V2Metadata.java
@@ -86,16 +86,20 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.path();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.length();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partitionSpecId();
-        case 3:
+        }
+        case 3 -> {
           checkContentType(wrapped.content());
           return wrapped.content().id();
-        case 4:
+        }
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -108,7 +112,8 @@ class V2Metadata {
           } else {
             return wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -123,26 +128,35 @@ class V2Metadata {
           } else {
             return wrapped.minSequenceNumber();
           }
-        case 6:
+        }
+        case 6 -> {
           return wrapped.snapshotId();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.addedFilesCount();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.existingFilesCount();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.deletedFilesCount();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.addedRowsCount();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.existingRowsCount();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.deletedRowsCount();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.partitions();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.keyMetadata();
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -313,11 +327,13 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -336,12 +352,14 @@ class V2Metadata {
             return null;
           }
           return wrapped.dataSequenceNumber();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.fileSequenceNumber();
-        case 4:
+        }
+        case 4 -> {
           return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -428,45 +446,62 @@ class V2Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           checkContentType(wrapped.content());
           return wrapped.content().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.location();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
+        }
+        case 3 -> {
           return wrapped.partition();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.recordCount();
-        case 5:
+        }
+        case 5 -> {
           return wrapped.fileSizeInBytes();
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.equalityFieldIds();
-        case 15:
+        }
+        case 15 -> {
           return wrapped.sortOrderId();
-        case 16:
+        }
+        case 16 -> {
           if (wrapped instanceof DeleteFile) {
             return ((DeleteFile) wrapped).referencedDataFile();
           } else {
             return null;
           }
+        }
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -87,16 +87,20 @@ class V3Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.path();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.length();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partitionSpecId();
-        case 3:
+        }
+        case 3 -> {
           checkContentType(wrapped.content());
           return wrapped.content().id();
-        case 4:
+        }
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -109,7 +113,8 @@ class V3Metadata {
           } else {
             return wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -124,25 +129,35 @@ class V3Metadata {
           } else {
             return wrapped.minSequenceNumber();
           }
-        case 6:
+        }
+        case 6 -> {
           return wrapped.snapshotId();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.addedFilesCount();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.existingFilesCount();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.deletedFilesCount();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.addedRowsCount();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.existingRowsCount();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.deletedRowsCount();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.partitions();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.keyMetadata();
-        case 15:
+        }
+        case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
             Preconditions.checkState(
@@ -158,8 +173,8 @@ class V3Metadata {
                 "Found unassigned first-row-id for file: " + wrapped.path());
             return wrapped.firstRowId();
           }
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -338,11 +353,13 @@ class V3Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -361,12 +378,14 @@ class V3Metadata {
             return null;
           }
           return wrapped.dataSequenceNumber();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.fileSequenceNumber();
-        case 4:
+        }
+        case 4 -> {
           return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -454,63 +473,83 @@ class V3Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           checkContentType(wrapped.content());
           return wrapped.content().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.location();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
+        }
+        case 3 -> {
           return wrapped.partition();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.recordCount();
-        case 5:
+        }
+        case 5 -> {
           return wrapped.fileSizeInBytes();
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.equalityFieldIds();
-        case 15:
+        }
+        case 15 -> {
           return wrapped.sortOrderId();
-        case 16:
+        }
+        case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
             return wrapped.firstRowId();
           } else {
             return null;
           }
-        case 17:
+        }
+        case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).referencedDataFile();
           } else {
             return null;
           }
-        case 18:
+        }
+        case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).contentOffset();
           } else {
             return null;
           }
-        case 19:
+        }
+        case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
             return null;
           }
+        }
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }

--- a/core/src/main/java/org/apache/iceberg/V3Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V3Metadata.java
@@ -86,19 +86,13 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.path();
-        }
-        case 1 -> {
-          return wrapped.length();
-        }
-        case 2 -> {
-          return wrapped.partitionSpecId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.path();
+        case 1 -> wrapped.length();
+        case 2 -> wrapped.partitionSpecId();
         case 3 -> {
           checkContentType(wrapped.content());
-          return wrapped.content().id();
+          yield wrapped.content().id();
         }
         case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
@@ -109,9 +103,9 @@ class V3Metadata {
                 commitSnapshotId == wrapped.snapshotId(),
                 "Found unassigned sequence number for a manifest from snapshot: %s",
                 wrapped.snapshotId());
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.sequenceNumber();
+            yield wrapped.sequenceNumber();
           }
         }
         case 5 -> {
@@ -125,38 +119,20 @@ class V3Metadata {
             // number for any file
             // written to the wrapped manifest. replace the unassigned sequence number with the one
             // for this commit
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.minSequenceNumber();
+            yield wrapped.minSequenceNumber();
           }
         }
-        case 6 -> {
-          return wrapped.snapshotId();
-        }
-        case 7 -> {
-          return wrapped.addedFilesCount();
-        }
-        case 8 -> {
-          return wrapped.existingFilesCount();
-        }
-        case 9 -> {
-          return wrapped.deletedFilesCount();
-        }
-        case 10 -> {
-          return wrapped.addedRowsCount();
-        }
-        case 11 -> {
-          return wrapped.existingRowsCount();
-        }
-        case 12 -> {
-          return wrapped.deletedRowsCount();
-        }
-        case 13 -> {
-          return wrapped.partitions();
-        }
-        case 14 -> {
-          return wrapped.keyMetadata();
-        }
+        case 6 -> wrapped.snapshotId();
+        case 7 -> wrapped.addedFilesCount();
+        case 8 -> wrapped.existingFilesCount();
+        case 9 -> wrapped.deletedFilesCount();
+        case 10 -> wrapped.addedRowsCount();
+        case 11 -> wrapped.existingRowsCount();
+        case 12 -> wrapped.deletedRowsCount();
+        case 13 -> wrapped.partitions();
+        case 14 -> wrapped.keyMetadata();
         case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
@@ -164,18 +140,18 @@ class V3Metadata {
                 wrapped.content() == ManifestContent.DATA && wrapped.firstRowId() == null,
                 "Found invalid first-row-id assignment: %s",
                 wrapped);
-            return wrappedFirstRowId;
+            yield wrappedFirstRowId;
           } else if (wrapped.content() != ManifestContent.DATA) {
-            return null;
+            yield null;
           } else {
             Preconditions.checkState(
                 wrapped.firstRowId() != null,
                 "Found unassigned first-row-id for file: " + wrapped.path());
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           }
         }
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -352,13 +328,9 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.status().id();
-        }
-        case 1 -> {
-          return wrapped.snapshotId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
         case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
@@ -375,18 +347,14 @@ class V3Metadata {
                 wrapped.status() == Status.ADDED,
                 "Only entries with status ADDED can have null sequence number");
 
-            return null;
+            yield null;
           }
-          return wrapped.dataSequenceNumber();
+          yield wrapped.dataSequenceNumber();
         }
-        case 3 -> {
-          return wrapped.fileSequenceNumber();
-        }
-        case 4 -> {
-          return fileWrapper.wrap(wrapped.file());
-        }
+        case 3 -> wrapped.fileSequenceNumber();
+        case 4 -> fileWrapper.wrap(wrapped.file());
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -472,86 +440,56 @@ class V3Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
+      return switch (pos) {
         case 0 -> {
           checkContentType(wrapped.content());
-          return wrapped.content().id();
+          yield wrapped.content().id();
         }
-        case 1 -> {
-          return wrapped.location();
-        }
-        case 2 -> {
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        }
-        case 3 -> {
-          return wrapped.partition();
-        }
-        case 4 -> {
-          return wrapped.recordCount();
-        }
-        case 5 -> {
-          return wrapped.fileSizeInBytes();
-        }
-        case 6 -> {
-          return wrapped.columnSizes();
-        }
-        case 7 -> {
-          return wrapped.valueCounts();
-        }
-        case 8 -> {
-          return wrapped.nullValueCounts();
-        }
-        case 9 -> {
-          return wrapped.nanValueCounts();
-        }
-        case 10 -> {
-          return wrapped.lowerBounds();
-        }
-        case 11 -> {
-          return wrapped.upperBounds();
-        }
-        case 12 -> {
-          return wrapped.keyMetadata();
-        }
-        case 13 -> {
-          return wrapped.splitOffsets();
-        }
-        case 14 -> {
-          return wrapped.equalityFieldIds();
-        }
-        case 15 -> {
-          return wrapped.sortOrderId();
-        }
+        case 1 -> wrapped.location();
+        case 2 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 3 -> wrapped.partition();
+        case 4 -> wrapped.recordCount();
+        case 5 -> wrapped.fileSizeInBytes();
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.equalityFieldIds();
+        case 15 -> wrapped.sortOrderId();
         case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           } else {
-            return null;
+            yield null;
           }
         }
         case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+            yield ((DeleteFile) wrapped).referencedDataFile();
           } else {
-            return null;
+            yield null;
           }
         }
         case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentOffset();
+            yield ((DeleteFile) wrapped).contentOffset();
           } else {
-            return null;
+            yield null;
           }
         }
         case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentSizeInBytes();
+            yield ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
-            return null;
+            yield null;
           }
         }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V4Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V4Metadata.java
@@ -87,19 +87,11 @@ class V4Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.path();
-        }
-        case 1 -> {
-          return wrapped.length();
-        }
-        case 2 -> {
-          return wrapped.partitionSpecId();
-        }
-        case 3 -> {
-          return wrapped.content().id();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.path();
+        case 1 -> wrapped.length();
+        case 2 -> wrapped.partitionSpecId();
+        case 3 -> wrapped.content().id();
         case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
@@ -109,9 +101,9 @@ class V4Metadata {
                 commitSnapshotId == wrapped.snapshotId(),
                 "Found unassigned sequence number for a manifest from snapshot: %s",
                 wrapped.snapshotId());
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.sequenceNumber();
+            yield wrapped.sequenceNumber();
           }
         }
         case 5 -> {
@@ -125,38 +117,20 @@ class V4Metadata {
             // number for any file
             // written to the wrapped manifest. replace the unassigned sequence number with the one
             // for this commit
-            return sequenceNumber;
+            yield sequenceNumber;
           } else {
-            return wrapped.minSequenceNumber();
+            yield wrapped.minSequenceNumber();
           }
         }
-        case 6 -> {
-          return wrapped.snapshotId();
-        }
-        case 7 -> {
-          return wrapped.addedFilesCount();
-        }
-        case 8 -> {
-          return wrapped.existingFilesCount();
-        }
-        case 9 -> {
-          return wrapped.deletedFilesCount();
-        }
-        case 10 -> {
-          return wrapped.addedRowsCount();
-        }
-        case 11 -> {
-          return wrapped.existingRowsCount();
-        }
-        case 12 -> {
-          return wrapped.deletedRowsCount();
-        }
-        case 13 -> {
-          return wrapped.partitions();
-        }
-        case 14 -> {
-          return wrapped.keyMetadata();
-        }
+        case 6 -> wrapped.snapshotId();
+        case 7 -> wrapped.addedFilesCount();
+        case 8 -> wrapped.existingFilesCount();
+        case 9 -> wrapped.deletedFilesCount();
+        case 10 -> wrapped.addedRowsCount();
+        case 11 -> wrapped.existingRowsCount();
+        case 12 -> wrapped.deletedRowsCount();
+        case 13 -> wrapped.partitions();
+        case 14 -> wrapped.keyMetadata();
         case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
@@ -164,18 +138,18 @@ class V4Metadata {
                 wrapped.content() == ManifestContent.DATA && wrapped.firstRowId() == null,
                 "Found invalid first-row-id assignment: %s",
                 wrapped);
-            return wrappedFirstRowId;
+            yield wrappedFirstRowId;
           } else if (wrapped.content() != ManifestContent.DATA) {
-            return null;
+            yield null;
           } else {
             Preconditions.checkState(
                 wrapped.firstRowId() != null,
                 "Found unassigned first-row-id for file: " + wrapped.path());
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           }
         }
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -362,13 +336,9 @@ class V4Metadata {
     }
 
     private Object get(int pos) {
-      switch (pos) {
-        case 0 -> {
-          return wrapped.status().id();
-        }
-        case 1 -> {
-          return wrapped.snapshotId();
-        }
+      return switch (pos) {
+        case 0 -> wrapped.status().id();
+        case 1 -> wrapped.snapshotId();
         case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
@@ -385,18 +355,14 @@ class V4Metadata {
                 wrapped.status() == Status.ADDED,
                 "Only entries with status ADDED can have null sequence number");
 
-            return null;
+            yield null;
           }
-          return wrapped.dataSequenceNumber();
+          yield wrapped.dataSequenceNumber();
         }
-        case 3 -> {
-          return wrapped.fileSequenceNumber();
-        }
-        case 4 -> {
-          return fileWrapper.wrap(wrapped.file());
-        }
+        case 3 -> wrapped.fileSequenceNumber();
+        case 4 -> fileWrapper.wrap(wrapped.file());
         default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
-      }
+      };
     }
 
     @Override
@@ -489,85 +455,53 @@ class V4Metadata {
       // when the partition field is omitted, positions at or after where it would appear
       // shift down by 1, so adjust back to the canonical field ordering
       int adjusted = hasPartition ? pos : (pos >= PARTITION_POSITION ? pos + 1 : pos);
-      switch (adjusted) {
-        case 0 -> {
-          return wrapped.content().id();
-        }
-        case 1 -> {
-          return wrapped.location();
-        }
-        case 2 -> {
-          return wrapped.format() != null ? wrapped.format().toString() : null;
-        }
-        case 3 -> {
-          return wrapped.partition();
-        }
-        case 4 -> {
-          return wrapped.recordCount();
-        }
-        case 5 -> {
-          return wrapped.fileSizeInBytes();
-        }
-        case 6 -> {
-          return wrapped.columnSizes();
-        }
-        case 7 -> {
-          return wrapped.valueCounts();
-        }
-        case 8 -> {
-          return wrapped.nullValueCounts();
-        }
-        case 9 -> {
-          return wrapped.nanValueCounts();
-        }
-        case 10 -> {
-          return wrapped.lowerBounds();
-        }
-        case 11 -> {
-          return wrapped.upperBounds();
-        }
-        case 12 -> {
-          return wrapped.keyMetadata();
-        }
-        case 13 -> {
-          return wrapped.splitOffsets();
-        }
-        case 14 -> {
-          return wrapped.equalityFieldIds();
-        }
-        case 15 -> {
-          return wrapped.sortOrderId();
-        }
+      return switch (adjusted) {
+        case 0 -> wrapped.content().id();
+        case 1 -> wrapped.location();
+        case 2 -> wrapped.format() != null ? wrapped.format().toString() : null;
+        case 3 -> wrapped.partition();
+        case 4 -> wrapped.recordCount();
+        case 5 -> wrapped.fileSizeInBytes();
+        case 6 -> wrapped.columnSizes();
+        case 7 -> wrapped.valueCounts();
+        case 8 -> wrapped.nullValueCounts();
+        case 9 -> wrapped.nanValueCounts();
+        case 10 -> wrapped.lowerBounds();
+        case 11 -> wrapped.upperBounds();
+        case 12 -> wrapped.keyMetadata();
+        case 13 -> wrapped.splitOffsets();
+        case 14 -> wrapped.equalityFieldIds();
+        case 15 -> wrapped.sortOrderId();
         case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
-            return wrapped.firstRowId();
+            yield wrapped.firstRowId();
           } else {
-            return null;
+            yield null;
           }
         }
         case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).referencedDataFile();
+            yield ((DeleteFile) wrapped).referencedDataFile();
           } else {
-            return null;
+            yield null;
           }
         }
         case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentOffset();
+            yield ((DeleteFile) wrapped).contentOffset();
           } else {
-            return null;
+            yield null;
           }
         }
         case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
-            return ((DeleteFile) wrapped).contentSizeInBytes();
+            yield ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
-            return null;
+            yield null;
           }
         }
-      }
-      throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+        default -> throw new IllegalArgumentException("Unknown field ordinal: " + pos);
+      };
     }
 
     @Override

--- a/core/src/main/java/org/apache/iceberg/V4Metadata.java
+++ b/core/src/main/java/org/apache/iceberg/V4Metadata.java
@@ -88,15 +88,19 @@ class V4Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.path();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.length();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.partitionSpecId();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.content().id();
-        case 4:
+        }
+        case 4 -> {
           if (wrapped.sequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // if the sequence number is being assigned here, then the manifest must be created by
             // the current
@@ -109,7 +113,8 @@ class V4Metadata {
           } else {
             return wrapped.sequenceNumber();
           }
-        case 5:
+        }
+        case 5 -> {
           if (wrapped.minSequenceNumber() == ManifestWriter.UNASSIGNED_SEQ) {
             // same sanity check as above
             Preconditions.checkState(
@@ -124,25 +129,35 @@ class V4Metadata {
           } else {
             return wrapped.minSequenceNumber();
           }
-        case 6:
+        }
+        case 6 -> {
           return wrapped.snapshotId();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.addedFilesCount();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.existingFilesCount();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.deletedFilesCount();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.addedRowsCount();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.existingRowsCount();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.deletedRowsCount();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.partitions();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.keyMetadata();
-        case 15:
+        }
+        case 15 -> {
           if (wrappedFirstRowId != null) {
             // if first-row-id is assigned, ensure that it is valid
             Preconditions.checkState(
@@ -158,8 +173,8 @@ class V4Metadata {
                 "Found unassigned first-row-id for file: " + wrapped.path());
             return wrapped.firstRowId();
           }
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -348,11 +363,13 @@ class V4Metadata {
 
     private Object get(int pos) {
       switch (pos) {
-        case 0:
+        case 0 -> {
           return wrapped.status().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.snapshotId();
-        case 2:
+        }
+        case 2 -> {
           if (wrapped.dataSequenceNumber() == null) {
             // if the entry's data sequence number is null,
             // then it will inherit the sequence number of the current commit.
@@ -371,12 +388,14 @@ class V4Metadata {
             return null;
           }
           return wrapped.dataSequenceNumber();
-        case 3:
+        }
+        case 3 -> {
           return wrapped.fileSequenceNumber();
-        case 4:
+        }
+        case 4 -> {
           return fileWrapper.wrap(wrapped.file());
-        default:
-          throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
+        }
+        default -> throw new UnsupportedOperationException("Unknown field ordinal: " + pos);
       }
     }
 
@@ -471,62 +490,82 @@ class V4Metadata {
       // shift down by 1, so adjust back to the canonical field ordering
       int adjusted = hasPartition ? pos : (pos >= PARTITION_POSITION ? pos + 1 : pos);
       switch (adjusted) {
-        case 0:
+        case 0 -> {
           return wrapped.content().id();
-        case 1:
+        }
+        case 1 -> {
           return wrapped.location();
-        case 2:
+        }
+        case 2 -> {
           return wrapped.format() != null ? wrapped.format().toString() : null;
-        case 3:
+        }
+        case 3 -> {
           return wrapped.partition();
-        case 4:
+        }
+        case 4 -> {
           return wrapped.recordCount();
-        case 5:
+        }
+        case 5 -> {
           return wrapped.fileSizeInBytes();
-        case 6:
+        }
+        case 6 -> {
           return wrapped.columnSizes();
-        case 7:
+        }
+        case 7 -> {
           return wrapped.valueCounts();
-        case 8:
+        }
+        case 8 -> {
           return wrapped.nullValueCounts();
-        case 9:
+        }
+        case 9 -> {
           return wrapped.nanValueCounts();
-        case 10:
+        }
+        case 10 -> {
           return wrapped.lowerBounds();
-        case 11:
+        }
+        case 11 -> {
           return wrapped.upperBounds();
-        case 12:
+        }
+        case 12 -> {
           return wrapped.keyMetadata();
-        case 13:
+        }
+        case 13 -> {
           return wrapped.splitOffsets();
-        case 14:
+        }
+        case 14 -> {
           return wrapped.equalityFieldIds();
-        case 15:
+        }
+        case 15 -> {
           return wrapped.sortOrderId();
-        case 16:
+        }
+        case 16 -> {
           if (wrapped.content() == FileContent.DATA) {
             return wrapped.firstRowId();
           } else {
             return null;
           }
-        case 17:
+        }
+        case 17 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).referencedDataFile();
           } else {
             return null;
           }
-        case 18:
+        }
+        case 18 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).contentOffset();
           } else {
             return null;
           }
-        case 19:
+        }
+        case 19 -> {
           if (wrapped.content() == FileContent.POSITION_DELETES) {
             return ((DeleteFile) wrapped).contentSizeInBytes();
           } else {
             return null;
           }
+        }
       }
       throw new IllegalArgumentException("Unknown field ordinal: " + pos);
     }

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteFileGroup.java
@@ -104,18 +104,14 @@ public class RewriteFileGroup extends RewriteGroupBase<FileGroupInfo, FileScanTa
   }
 
   public static Comparator<RewriteFileGroup> comparator(RewriteJobOrder rewriteJobOrder) {
-    switch (rewriteJobOrder) {
-      case BYTES_ASC:
-        return Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes);
-      case BYTES_DESC:
-        return Comparator.comparing(
-            RewriteFileGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
-      case FILES_ASC:
-        return Comparator.comparing(RewriteFileGroup::inputFileNum);
-      case FILES_DESC:
-        return Comparator.comparing(RewriteFileGroup::inputFileNum, Comparator.reverseOrder());
-      default:
-        return (unused, unused2) -> 0;
-    }
+    return switch (rewriteJobOrder) {
+      case BYTES_ASC -> Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes);
+      case BYTES_DESC ->
+          Comparator.comparing(RewriteFileGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
+      case FILES_ASC -> Comparator.comparing(RewriteFileGroup::inputFileNum);
+      case FILES_DESC ->
+          Comparator.comparing(RewriteFileGroup::inputFileNum, Comparator.reverseOrder());
+      default -> (unused, unused2) -> 0;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewritePositionDeletesGroup.java
@@ -108,19 +108,16 @@ public class RewritePositionDeletesGroup
   }
 
   public static Comparator<RewritePositionDeletesGroup> comparator(RewriteJobOrder order) {
-    switch (order) {
-      case BYTES_ASC:
-        return Comparator.comparing(RewritePositionDeletesGroup::inputFilesSizeInBytes);
-      case BYTES_DESC:
-        return Comparator.comparing(
-            RewritePositionDeletesGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
-      case FILES_ASC:
-        return Comparator.comparing(RewritePositionDeletesGroup::inputFileNum);
-      case FILES_DESC:
-        return Comparator.comparing(
-            RewritePositionDeletesGroup::inputFileNum, Comparator.reverseOrder());
-      default:
-        return (unused, unused2) -> 0;
-    }
+    return switch (order) {
+      case BYTES_ASC -> Comparator.comparing(RewritePositionDeletesGroup::inputFilesSizeInBytes);
+      case BYTES_DESC ->
+          Comparator.comparing(
+              RewritePositionDeletesGroup::inputFilesSizeInBytes, Comparator.reverseOrder());
+      case FILES_ASC -> Comparator.comparing(RewritePositionDeletesGroup::inputFileNum);
+      case FILES_DESC ->
+          Comparator.comparing(
+              RewritePositionDeletesGroup::inputFileNum, Comparator.reverseOrder());
+      default -> (unused, unused2) -> 0;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -248,26 +248,20 @@ public class Avro {
       private static CodecFactory toCodec(String codecAsString, String compressionLevel) {
         CodecFactory codecFactory;
         try {
-          switch (Codec.valueOf(codecAsString.toUpperCase(Locale.ENGLISH))) {
-            case UNCOMPRESSED:
-              codecFactory = CodecFactory.nullCodec();
-              break;
-            case SNAPPY:
-              codecFactory = CodecFactory.snappyCodec();
-              break;
-            case ZSTD:
-              codecFactory =
-                  CodecFactory.zstandardCodec(
-                      compressionLevelAsInt(compressionLevel, ZSTD_COMPRESSION_LEVEL_DEFAULT));
-              break;
-            case GZIP:
-              codecFactory =
-                  CodecFactory.deflateCodec(
-                      compressionLevelAsInt(compressionLevel, GZIP_COMPRESSION_LEVEL_DEFAULT));
-              break;
-            default:
-              throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
-          }
+          codecFactory =
+              switch (Codec.valueOf(codecAsString.toUpperCase(Locale.ENGLISH))) {
+                case UNCOMPRESSED -> CodecFactory.nullCodec();
+                case SNAPPY -> CodecFactory.snappyCodec();
+                case ZSTD ->
+                    CodecFactory.zstandardCodec(
+                        compressionLevelAsInt(compressionLevel, ZSTD_COMPRESSION_LEVEL_DEFAULT));
+                case GZIP ->
+                    CodecFactory.deflateCodec(
+                        compressionLevelAsInt(compressionLevel, GZIP_COMPRESSION_LEVEL_DEFAULT));
+                default ->
+                    throw new IllegalArgumentException(
+                        "Unsupported compression codec: " + codecAsString);
+              };
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
         }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -258,9 +258,6 @@ public class Avro {
                 case GZIP ->
                     CodecFactory.deflateCodec(
                         compressionLevelAsInt(compressionLevel, GZIP_COMPRESSION_LEVEL_DEFAULT));
-                default ->
-                    throw new IllegalArgumentException(
-                        "Unsupported compression codec: " + codecAsString);
               };
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);

--- a/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
@@ -31,7 +31,7 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
   private static final String VALUE = "value";
 
   public static <T, F> T visit(Schema schema, AvroCustomOrderSchemaVisitor<T, F> visitor) {
-    switch (schema.getType()) {
+    return switch (schema.getType()) {
       case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
@@ -42,7 +42,7 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
           Preconditions.checkArgument(
               AvroSchemaUtil.isVariantSchema(schema), "Invalid variant record: %s", schema);
 
-          return visitor.variant(
+          yield visitor.variant(
               schema,
               new VisitFuture<>(schema.getField(METADATA).schema(), visitor),
               new VisitFuture<>(schema.getField(VALUE).schema(), visitor));
@@ -58,7 +58,7 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
           }
 
           visitor.recordLevels.pop();
-          return visitor.record(schema, names, Iterables.transform(results, Supplier::get));
+          yield visitor.record(schema, names, Iterables.transform(results, Supplier::get));
         }
       }
       case UNION -> {
@@ -67,18 +67,12 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
         for (Schema type : types) {
           options.add(new VisitFuture<>(type, visitor));
         }
-        return visitor.union(schema, Iterables.transform(options, Supplier::get));
+        yield visitor.union(schema, Iterables.transform(options, Supplier::get));
       }
-      case ARRAY -> {
-        return visitor.array(schema, new VisitFuture<>(schema.getElementType(), visitor));
-      }
-      case MAP -> {
-        return visitor.map(schema, new VisitFuture<>(schema.getValueType(), visitor));
-      }
-      default -> {
-        return visitor.primitive(schema);
-      }
-    }
+      case ARRAY -> visitor.array(schema, new VisitFuture<>(schema.getElementType(), visitor));
+      case MAP -> visitor.map(schema, new VisitFuture<>(schema.getValueType(), visitor));
+      default -> visitor.primitive(schema);
+    };
   }
 
   private final Deque<String> recordLevels = Lists.newLinkedList();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroCustomOrderSchemaVisitor.java
@@ -32,7 +32,7 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
 
   public static <T, F> T visit(Schema schema, AvroCustomOrderSchemaVisitor<T, F> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
         Preconditions.checkState(
@@ -60,23 +60,24 @@ abstract class AvroCustomOrderSchemaVisitor<T, F> {
           visitor.recordLevels.pop();
           return visitor.record(schema, names, Iterables.transform(results, Supplier::get));
         }
-
-      case UNION:
+      }
+      case UNION -> {
         List<Schema> types = schema.getTypes();
         List<Supplier<T>> options = Lists.newArrayListWithExpectedSize(types.size());
         for (Schema type : types) {
           options.add(new VisitFuture<>(type, visitor));
         }
         return visitor.union(schema, Iterables.transform(options, Supplier::get));
-
-      case ARRAY:
+      }
+      case ARRAY -> {
         return visitor.array(schema, new VisitFuture<>(schema.getElementType(), visitor));
-
-      case MAP:
+      }
+      case MAP -> {
         return visitor.map(schema, new VisitFuture<>(schema.getValueType(), visitor));
-
-      default:
+      }
+      default -> {
         return visitor.primitive(schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFormatModel.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFormatModel.java
@@ -159,17 +159,17 @@ public class AvroFormatModel<D, S>
     @Override
     public FileAppender<D> build() throws IOException {
       switch (content) {
-        case DATA:
+        case DATA -> {
           internal.createContextFunc(Avro.WriteBuilder.Context::dataContext);
           internal.createWriterFunc(
               avroSchema -> writerFunction.write(schema, avroSchema, engineSchema));
-          break;
-        case EQUALITY_DELETES:
+        }
+        case EQUALITY_DELETES -> {
           internal.createContextFunc(Avro.WriteBuilder.Context::deleteContext);
           internal.createWriterFunc(
               avroSchema -> writerFunction.write(schema, avroSchema, engineSchema));
-          break;
-        case POSITION_DELETES:
+        }
+        case POSITION_DELETES -> {
           Preconditions.checkState(
               schema == null,
               "Invalid schema: %s. Position deletes with schema are not supported by the API.",
@@ -182,9 +182,8 @@ public class AvroFormatModel<D, S>
           internal.createContextFunc(Avro.WriteBuilder.Context::deleteContext);
           internal.createWriterFunc(unused -> new Avro.PositionDatumWriter());
           internal.schema(DeleteSchemaUtil.pathPosSchema());
-          break;
-        default:
-          throw new IllegalArgumentException("Unknown file content: " + content);
+        }
+        default -> throw new IllegalArgumentException("Unknown file content: " + content);
       }
 
       return internal.build();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -189,16 +189,15 @@ public class AvroSchemaUtil {
   }
 
   static Schema toOption(Schema schema) {
-    switch (schema.getType()) {
-      case UNION:
+    return switch (schema.getType()) {
+      case UNION -> {
         Preconditions.checkArgument(
             isOptionSchema(schema), "Union schemas are not supported: %s", schema);
-        return schema;
-      case NULL:
-        return schema;
-      default:
-        return Schema.createUnion(NULL, schema);
-    }
+        yield schema;
+      }
+      case NULL -> schema;
+      default -> Schema.createUnion(NULL, schema);
+    };
   }
 
   static Schema fromOption(Schema schema) {

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -29,7 +29,7 @@ public abstract class AvroSchemaVisitor<T> {
   private static final String VALUE = "value";
 
   public static <T> T visit(Schema schema, AvroSchemaVisitor<T> visitor) {
-    switch (schema.getType()) {
+    return switch (schema.getType()) {
       case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
@@ -40,7 +40,7 @@ public abstract class AvroSchemaVisitor<T> {
           Preconditions.checkArgument(
               AvroSchemaUtil.isVariantSchema(schema), "Invalid variant record: %s", schema);
 
-          return visitor.variant(
+          yield visitor.variant(
               schema,
               visit(schema.getField(METADATA).schema(), visitor),
               visit(schema.getField(VALUE).schema(), visitor));
@@ -57,7 +57,7 @@ public abstract class AvroSchemaVisitor<T> {
           }
 
           visitor.recordLevels.pop();
-          return visitor.record(schema, names, results);
+          yield visitor.record(schema, names, results);
         }
       }
       case UNION -> {
@@ -66,22 +66,18 @@ public abstract class AvroSchemaVisitor<T> {
         for (Schema type : types) {
           options.add(visit(type, visitor));
         }
-        return visitor.union(schema, options);
+        yield visitor.union(schema, options);
       }
       case ARRAY -> {
         if (schema.getLogicalType() instanceof LogicalMap) {
-          return visitor.array(schema, visit(schema.getElementType(), visitor));
+          yield visitor.array(schema, visit(schema.getElementType(), visitor));
         } else {
-          return visitor.array(schema, visitWithName("element", schema.getElementType(), visitor));
+          yield visitor.array(schema, visitWithName("element", schema.getElementType(), visitor));
         }
       }
-      case MAP -> {
-        return visitor.map(schema, visitWithName("value", schema.getValueType(), visitor));
-      }
-      default -> {
-        return visitor.primitive(schema);
-      }
-    }
+      case MAP -> visitor.map(schema, visitWithName("value", schema.getValueType(), visitor));
+      default -> visitor.primitive(schema);
+    };
   }
 
   private final Deque<String> recordLevels = Lists.newLinkedList();

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaVisitor.java
@@ -30,7 +30,7 @@ public abstract class AvroSchemaVisitor<T> {
 
   public static <T> T visit(Schema schema, AvroSchemaVisitor<T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         // check to make sure this hasn't been visited before
         String name = schema.getFullName();
         Preconditions.checkState(
@@ -59,27 +59,28 @@ public abstract class AvroSchemaVisitor<T> {
           visitor.recordLevels.pop();
           return visitor.record(schema, names, results);
         }
-
-      case UNION:
+      }
+      case UNION -> {
         List<Schema> types = schema.getTypes();
         List<T> options = Lists.newArrayListWithExpectedSize(types.size());
         for (Schema type : types) {
           options.add(visit(type, visitor));
         }
         return visitor.union(schema, options);
-
-      case ARRAY:
+      }
+      case ARRAY -> {
         if (schema.getLogicalType() instanceof LogicalMap) {
           return visitor.array(schema, visit(schema.getElementType(), visitor));
         } else {
           return visitor.array(schema, visitWithName("element", schema.getElementType(), visitor));
         }
-
-      case MAP:
+      }
+      case MAP -> {
         return visitor.map(schema, visitWithName("value", schema.getValueType(), visitor));
-
-      default:
+      }
+      default -> {
         return visitor.primitive(schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -34,24 +34,25 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
 
   public static <T> T visit(Type iType, Schema schema, AvroSchemaWithTypeVisitor<T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         return visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
-
-      case UNION:
+      }
+      case UNION -> {
         return visitUnion(iType, schema, visitor);
-
-      case ARRAY:
+      }
+      case ARRAY -> {
         return visitArray(iType, schema, visitor);
-
-      case MAP:
+      }
+      case MAP -> {
         Types.MapType map = iType != null ? iType.asMapType() : null;
         return visitor.map(
             map,
             schema,
             visit(map != null ? map.valueType() : null, schema.getValueType(), visitor));
-
-      default:
+      }
+      default -> {
         return visitor.primitive(iType != null ? iType.asPrimitiveType() : null, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaWithTypeVisitor.java
@@ -33,27 +33,19 @@ public abstract class AvroSchemaWithTypeVisitor<T> {
   }
 
   public static <T> T visit(Type iType, Schema schema, AvroSchemaWithTypeVisitor<T> visitor) {
-    switch (schema.getType()) {
-      case RECORD -> {
-        return visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
-      }
-      case UNION -> {
-        return visitUnion(iType, schema, visitor);
-      }
-      case ARRAY -> {
-        return visitArray(iType, schema, visitor);
-      }
+    return switch (schema.getType()) {
+      case RECORD -> visitRecord(iType != null ? iType.asStructType() : null, schema, visitor);
+      case UNION -> visitUnion(iType, schema, visitor);
+      case ARRAY -> visitArray(iType, schema, visitor);
       case MAP -> {
         Types.MapType map = iType != null ? iType.asMapType() : null;
-        return visitor.map(
+        yield visitor.map(
             map,
             schema,
             visit(map != null ? map.valueType() : null, schema.getValueType(), visitor));
       }
-      default -> {
-        return visitor.primitive(iType != null ? iType.asPrimitiveType() : null, schema);
-      }
-    }
+      default -> visitor.primitive(iType != null ? iType.asPrimitiveType() : null, schema);
+    };
   }
 
   private static <T> T visitRecord(

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
@@ -37,32 +37,26 @@ public abstract class AvroWithPartnerByStructureVisitor<P, T> {
 
   public static <P, T> T visit(
       P partner, Schema schema, AvroWithPartnerByStructureVisitor<P, T> visitor) {
-    switch (schema.getType()) {
+    return switch (schema.getType()) {
       case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType
             || visitor.isVariantType(partner)) {
-          return visitVariant(partner, schema, visitor);
+          yield visitVariant(partner, schema, visitor);
         } else {
-          return visitRecord(partner, schema, visitor);
+          yield visitRecord(partner, schema, visitor);
         }
       }
-      case UNION -> {
-        return visitUnion(partner, schema, visitor);
-      }
-      case ARRAY -> {
-        return visitArray(partner, schema, visitor);
-      }
+      case UNION -> visitUnion(partner, schema, visitor);
+      case ARRAY -> visitArray(partner, schema, visitor);
       case MAP -> {
         P keyType = visitor.mapKeyType(partner);
         Preconditions.checkArgument(
             visitor.isStringType(keyType), "Invalid map: %s is not a string", keyType);
-        return visitor.map(
+        yield visitor.map(
             partner, schema, visit(visitor.mapValueType(partner), schema.getValueType(), visitor));
       }
-      default -> {
-        return visitor.primitive(partner, schema);
-      }
-    }
+      default -> visitor.primitive(partner, schema);
+    };
   }
 
   // ---------------------------------- Static helpers ---------------------------------------------

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerByStructureVisitor.java
@@ -38,29 +38,30 @@ public abstract class AvroWithPartnerByStructureVisitor<P, T> {
   public static <P, T> T visit(
       P partner, Schema schema, AvroWithPartnerByStructureVisitor<P, T> visitor) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType
             || visitor.isVariantType(partner)) {
           return visitVariant(partner, schema, visitor);
         } else {
           return visitRecord(partner, schema, visitor);
         }
-
-      case UNION:
+      }
+      case UNION -> {
         return visitUnion(partner, schema, visitor);
-
-      case ARRAY:
+      }
+      case ARRAY -> {
         return visitArray(partner, schema, visitor);
-
-      case MAP:
+      }
+      case MAP -> {
         P keyType = visitor.mapKeyType(partner);
         Preconditions.checkArgument(
             visitor.isStringType(keyType), "Invalid map: %s is not a string", keyType);
         return visitor.map(
             partner, schema, visit(visitor.mapValueType(partner), schema.getValueType(), visitor));
-
-      default:
+      }
+      default -> {
         return visitor.primitive(partner, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
@@ -103,20 +103,20 @@ public class AvroWithPartnerVisitor<P, R> {
       AvroWithPartnerVisitor<P, R> visitor,
       PartnerAccessors<P> accessors) {
     switch (schema.getType()) {
-      case RECORD:
+      case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType) {
           return visitVariant(partner, schema, visitor, accessors);
         } else {
           return visitRecord(partner, schema, visitor, accessors);
         }
-
-      case UNION:
+      }
+      case UNION -> {
         return visitUnion(partner, schema, visitor, accessors);
-
-      case ARRAY:
+      }
+      case ARRAY -> {
         return visitArray(partner, schema, visitor, accessors);
-
-      case MAP:
+      }
+      case MAP -> {
         return visitor.map(
             partner,
             schema,
@@ -125,9 +125,10 @@ public class AvroWithPartnerVisitor<P, R> {
                 schema.getValueType(),
                 visitor,
                 accessors));
-
-      default:
+      }
+      default -> {
         return visitor.primitive(partner, schema);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroWithPartnerVisitor.java
@@ -102,34 +102,27 @@ public class AvroWithPartnerVisitor<P, R> {
       Schema schema,
       AvroWithPartnerVisitor<P, R> visitor,
       PartnerAccessors<P> accessors) {
-    switch (schema.getType()) {
+    return switch (schema.getType()) {
       case RECORD -> {
         if (schema.getLogicalType() instanceof VariantLogicalType) {
-          return visitVariant(partner, schema, visitor, accessors);
+          yield visitVariant(partner, schema, visitor, accessors);
         } else {
-          return visitRecord(partner, schema, visitor, accessors);
+          yield visitRecord(partner, schema, visitor, accessors);
         }
       }
-      case UNION -> {
-        return visitUnion(partner, schema, visitor, accessors);
-      }
-      case ARRAY -> {
-        return visitArray(partner, schema, visitor, accessors);
-      }
-      case MAP -> {
-        return visitor.map(
-            partner,
-            schema,
-            visit(
-                partner != null ? accessors.mapValuePartner(partner) : null,
-                schema.getValueType(),
-                visitor,
-                accessors));
-      }
-      default -> {
-        return visitor.primitive(partner, schema);
-      }
-    }
+      case UNION -> visitUnion(partner, schema, visitor, accessors);
+      case ARRAY -> visitArray(partner, schema, visitor, accessors);
+      case MAP ->
+          visitor.map(
+              partner,
+              schema,
+              visit(
+                  partner != null ? accessors.mapValuePartner(partner) : null,
+                  schema.getValueType(),
+                  visitor,
+                  accessors));
+      default -> visitor.primitive(partner, schema);
+    };
   }
 
   private static <P, R> R visitVariant(

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -75,51 +75,40 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
     LogicalType logicalType = primitive.getLogicalType();
     if (logicalType != null) {
       switch (logicalType.getName()) {
-        case "date":
+        case "date" -> {
           return ValueWriters.ints();
-
-        case "time-micros":
+        }
+        case "time-micros" -> {
           return ValueWriters.longs();
-
-        case "timestamp-micros":
+        }
+        case "timestamp-micros" -> {
           return ValueWriters.longs();
-
-        case "timestamp-nanos":
+        }
+        case "timestamp-nanos" -> {
           return ValueWriters.longs();
-
-        case "decimal":
+        }
+        case "decimal" -> {
           LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
           return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
-
-        case "uuid":
+        }
+        case "uuid" -> {
           return ValueWriters.uuids();
-
-        default:
-          throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
+        }
+        default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
       }
     }
 
-    switch (primitive.getType()) {
-      case NULL:
-        return ValueWriters.nulls();
-      case BOOLEAN:
-        return ValueWriters.booleans();
-      case INT:
-        return ValueWriters.ints();
-      case LONG:
-        return ValueWriters.longs();
-      case FLOAT:
-        return ValueWriters.floats();
-      case DOUBLE:
-        return ValueWriters.doubles();
-      case STRING:
-        return ValueWriters.strings();
-      case FIXED:
-        return fixedWriter(primitive.getFixedSize());
-      case BYTES:
-        return ValueWriters.byteBuffers();
-      default:
-        throw new IllegalArgumentException("Unsupported type: " + primitive);
-    }
+    return switch (primitive.getType()) {
+      case NULL -> ValueWriters.nulls();
+      case BOOLEAN -> ValueWriters.booleans();
+      case INT -> ValueWriters.ints();
+      case LONG -> ValueWriters.longs();
+      case FLOAT -> ValueWriters.floats();
+      case DOUBLE -> ValueWriters.doubles();
+      case STRING -> ValueWriters.strings();
+      case FIXED -> fixedWriter(primitive.getFixedSize());
+      case BYTES -> ValueWriters.byteBuffers();
+      default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BaseWriteBuilder.java
@@ -74,28 +74,18 @@ abstract class BaseWriteBuilder extends AvroSchemaVisitor<ValueWriter<?>> {
   public ValueWriter<?> primitive(Schema primitive) {
     LogicalType logicalType = primitive.getLogicalType();
     if (logicalType != null) {
-      switch (logicalType.getName()) {
-        case "date" -> {
-          return ValueWriters.ints();
-        }
-        case "time-micros" -> {
-          return ValueWriters.longs();
-        }
-        case "timestamp-micros" -> {
-          return ValueWriters.longs();
-        }
-        case "timestamp-nanos" -> {
-          return ValueWriters.longs();
-        }
+      return switch (logicalType.getName()) {
+        case "date" -> ValueWriters.ints();
+        case "time-micros" -> ValueWriters.longs();
+        case "timestamp-micros" -> ValueWriters.longs();
+        case "timestamp-nanos" -> ValueWriters.longs();
         case "decimal" -> {
           LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
-          return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
+          yield ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
         }
-        case "uuid" -> {
-          return ValueWriters.uuids();
-        }
+        case "uuid" -> ValueWriters.uuids();
         default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
-      }
+      };
     }
 
     return switch (primitive.getType()) {

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -273,22 +273,20 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   @Override
   public Schema primitive(Schema primitive) {
     // check for type promotion
-    switch (primitive.getType()) {
+    return switch (primitive.getType()) {
       case INT -> {
         if (current.typeId() == Type.TypeID.LONG) {
-          return Schema.create(Schema.Type.LONG);
+          yield Schema.create(Schema.Type.LONG);
         }
-        return primitive;
+        yield primitive;
       }
       case FLOAT -> {
         if (current.typeId() == Type.TypeID.DOUBLE) {
-          return Schema.create(Schema.Type.DOUBLE);
+          yield Schema.create(Schema.Type.DOUBLE);
         }
-        return primitive;
+        yield primitive;
       }
-      default -> {
-        return primitive;
-      }
-    }
+      default -> primitive;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
+++ b/core/src/main/java/org/apache/iceberg/avro/BuildAvroProjection.java
@@ -274,20 +274,21 @@ class BuildAvroProjection extends AvroCustomOrderSchemaVisitor<Schema, Schema.Fi
   public Schema primitive(Schema primitive) {
     // check for type promotion
     switch (primitive.getType()) {
-      case INT:
+      case INT -> {
         if (current.typeId() == Type.TypeID.LONG) {
           return Schema.create(Schema.Type.LONG);
         }
         return primitive;
-
-      case FLOAT:
+      }
+      case FLOAT -> {
         if (current.typeId() == Type.TypeID.DOUBLE) {
           return Schema.create(Schema.Type.DOUBLE);
         }
         return primitive;
-
-      default:
+      }
+      default -> {
         return primitive;
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -173,74 +173,50 @@ public class GenericAvroReader<T>
     public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
-        switch (logicalType.getName()) {
-          case "date" -> {
+        return switch (logicalType.getName()) {
             // Spark uses the same representation
-            return ValueReaders.ints();
-          }
-          case "time-micros" -> {
-            return ValueReaders.longs();
-          }
+          case "date" -> ValueReaders.ints();
+          case "time-micros" -> ValueReaders.longs();
           case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
-            return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
+            yield (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
           }
-          case "timestamp-micros", "timestamp-nanos" -> {
-            // both are handled in memory as long values, using the type to track units
-            return ValueReaders.longs();
-          }
-          case "decimal" -> {
-            return ValueReaders.decimal(
-                ValueReaders.decimalBytesReader(primitive),
-                ((LogicalTypes.Decimal) logicalType).getScale());
-          }
-          case "uuid" -> {
-            return ValueReaders.uuids();
-          }
+            // both timestamp-micros and timestamp-nanos are handled in memory as long values,
+            // using the type to track units
+          case "timestamp-micros", "timestamp-nanos" -> ValueReaders.longs();
+          case "decimal" ->
+              ValueReaders.decimal(
+                  ValueReaders.decimalBytesReader(primitive),
+                  ((LogicalTypes.Decimal) logicalType).getScale());
+          case "uuid" -> ValueReaders.uuids();
           default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
-        }
+        };
       }
 
-      switch (primitive.getType()) {
-        case NULL -> {
-          return ValueReaders.nulls();
-        }
-        case BOOLEAN -> {
-          return ValueReaders.booleans();
-        }
+      return switch (primitive.getType()) {
+        case NULL -> ValueReaders.nulls();
+        case BOOLEAN -> ValueReaders.booleans();
         case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
-            return ValueReaders.intsAsLongs();
+            yield ValueReaders.intsAsLongs();
           }
-          return ValueReaders.ints();
+          yield ValueReaders.ints();
         }
-        case LONG -> {
-          return ValueReaders.longs();
-        }
+        case LONG -> ValueReaders.longs();
         case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
-            return ValueReaders.floatsAsDoubles();
+            yield ValueReaders.floatsAsDoubles();
           }
-          return ValueReaders.floats();
+          yield ValueReaders.floats();
         }
-        case DOUBLE -> {
-          return ValueReaders.doubles();
-        }
-        case STRING -> {
-          return ValueReaders.utf8s();
-        }
-        case FIXED -> {
-          return ValueReaders.fixed(primitive);
-        }
-        case BYTES -> {
-          return ValueReaders.byteBuffers();
-        }
-        case ENUM -> {
-          return ValueReaders.enums(primitive.getEnumSymbols());
-        }
+        case DOUBLE -> ValueReaders.doubles();
+        case STRING -> ValueReaders.utf8s();
+        case FIXED -> ValueReaders.fixed(primitive);
+        case BYTES -> ValueReaders.byteBuffers();
+        case ENUM -> ValueReaders.enums(primitive.getEnumSymbols());
         default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
-      }
+      };
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -174,65 +174,72 @@ public class GenericAvroReader<T>
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             // Spark uses the same representation
             return ValueReaders.ints();
-
-          case "time-micros":
+          }
+          case "time-micros" -> {
             return ValueReaders.longs();
-
-          case "timestamp-millis":
+          }
+          case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
-
-          case "timestamp-micros":
-          case "timestamp-nanos":
+          }
+          case "timestamp-micros", "timestamp-nanos" -> {
             // both are handled in memory as long values, using the type to track units
             return ValueReaders.longs();
-
-          case "decimal":
+          }
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
-
-          case "uuid":
+          }
+          case "uuid" -> {
             return ValueReaders.uuids();
-
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          }
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+        case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
           return ValueReaders.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
+        case STRING -> {
           return ValueReaders.utf8s();
-        case FIXED:
+        }
+        case FIXED -> {
           return ValueReaders.fixed(primitive);
-        case BYTES:
+        }
+        case BYTES -> {
           return ValueReaders.byteBuffers();
-        case ENUM:
+        }
+        case ENUM -> {
           return ValueReaders.enums(primitive.getEnumSymbols());
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/GenericAvroReader.java
@@ -177,11 +177,8 @@ public class GenericAvroReader<T>
             // Spark uses the same representation
           case "date" -> ValueReaders.ints();
           case "time-micros" -> ValueReaders.longs();
-          case "timestamp-millis" -> {
-            // adjust to microseconds
-            ValueReader<Long> longs = ValueReaders.longs();
-            yield (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
-          }
+          case "timestamp-millis" -> // adjust to microseconds
+              (decoder, ignored) -> ValueReaders.longs().read(decoder, null) * 1000L;
             // both timestamp-micros and timestamp-nanos are handled in memory as long values,
             // using the type to track units
           case "timestamp-micros", "timestamp-nanos" -> ValueReaders.longs();

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -171,63 +171,68 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return ValueReaders.ints();
-
-          case "time-micros":
+          }
+          case "time-micros" -> {
             return ValueReaders.longs();
-
-          case "timestamp-millis":
+          }
+          case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
             return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
-
-          case "timestamp-micros":
-          case "timestamp-nanos":
+          }
+          case "timestamp-micros", "timestamp-nanos" -> {
             // both are handled in memory as long values, using the type to track units
             return ValueReaders.longs();
-
-          case "decimal":
+          }
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
-
-          case "uuid":
+          }
+          case "uuid" -> {
             return ValueReaders.uuids();
-
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          }
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+        case INT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
           return ValueReaders.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
+        case STRING -> {
           return ValueReaders.strings();
-        case FIXED:
-        case BYTES:
+        }
+        case FIXED, BYTES -> {
           return ValueReaders.byteBuffers();
-        case ENUM:
+        }
+        case ENUM -> {
           return ValueReaders.enums(primitive.getEnumSymbols());
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -173,11 +173,8 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
         return switch (logicalType.getName()) {
           case "date" -> ValueReaders.ints();
           case "time-micros" -> ValueReaders.longs();
-          case "timestamp-millis" -> {
-            // adjust to microseconds
-            ValueReader<Long> longs = ValueReaders.longs();
-            yield (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
-          }
+          case "timestamp-millis" -> // adjust to microseconds
+              (decoder, ignored) -> ValueReaders.longs().read(decoder, null) * 1000L;
             // both timestamp-micros and timestamp-nanos are handled in memory as long values,
             // using the type to track units
           case "timestamp-micros", "timestamp-nanos" -> ValueReaders.longs();

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -170,70 +170,48 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
     public ValueReader<?> primitive(Pair<Integer, Type> partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
-        switch (logicalType.getName()) {
-          case "date" -> {
-            return ValueReaders.ints();
-          }
-          case "time-micros" -> {
-            return ValueReaders.longs();
-          }
+        return switch (logicalType.getName()) {
+          case "date" -> ValueReaders.ints();
+          case "time-micros" -> ValueReaders.longs();
           case "timestamp-millis" -> {
             // adjust to microseconds
             ValueReader<Long> longs = ValueReaders.longs();
-            return (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
+            yield (ValueReader<Long>) (decoder, ignored) -> longs.read(decoder, null) * 1000L;
           }
-          case "timestamp-micros", "timestamp-nanos" -> {
-            // both are handled in memory as long values, using the type to track units
-            return ValueReaders.longs();
-          }
-          case "decimal" -> {
-            return ValueReaders.decimal(
-                ValueReaders.decimalBytesReader(primitive),
-                ((LogicalTypes.Decimal) logicalType).getScale());
-          }
-          case "uuid" -> {
-            return ValueReaders.uuids();
-          }
+            // both timestamp-micros and timestamp-nanos are handled in memory as long values,
+            // using the type to track units
+          case "timestamp-micros", "timestamp-nanos" -> ValueReaders.longs();
+          case "decimal" ->
+              ValueReaders.decimal(
+                  ValueReaders.decimalBytesReader(primitive),
+                  ((LogicalTypes.Decimal) logicalType).getScale());
+          case "uuid" -> ValueReaders.uuids();
           default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
-        }
+        };
       }
 
-      switch (primitive.getType()) {
-        case NULL -> {
-          return ValueReaders.nulls();
-        }
-        case BOOLEAN -> {
-          return ValueReaders.booleans();
-        }
+      return switch (primitive.getType()) {
+        case NULL -> ValueReaders.nulls();
+        case BOOLEAN -> ValueReaders.booleans();
         case INT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.LONG) {
-            return ValueReaders.intsAsLongs();
+            yield ValueReaders.intsAsLongs();
           }
-          return ValueReaders.ints();
+          yield ValueReaders.ints();
         }
-        case LONG -> {
-          return ValueReaders.longs();
-        }
+        case LONG -> ValueReaders.longs();
         case FLOAT -> {
           if (partner != null && partner.second().typeId() == Type.TypeID.DOUBLE) {
-            return ValueReaders.floatsAsDoubles();
+            yield ValueReaders.floatsAsDoubles();
           }
-          return ValueReaders.floats();
+          yield ValueReaders.floats();
         }
-        case DOUBLE -> {
-          return ValueReaders.doubles();
-        }
-        case STRING -> {
-          return ValueReaders.strings();
-        }
-        case FIXED, BYTES -> {
-          return ValueReaders.byteBuffers();
-        }
-        case ENUM -> {
-          return ValueReaders.enums(primitive.getEnumSymbols());
-        }
+        case DOUBLE -> ValueReaders.doubles();
+        case STRING -> ValueReaders.strings();
+        case FIXED, BYTES -> ValueReaders.byteBuffers();
+        case ENUM -> ValueReaders.enums(primitive.getEnumSymbols());
         default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
-      }
+      };
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -224,36 +224,18 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
       }
     }
 
-    switch (primitive.getType()) {
-      case BOOLEAN -> {
-        return Types.BooleanType.get();
-      }
-      case INT -> {
-        return Types.IntegerType.get();
-      }
-      case LONG -> {
-        return Types.LongType.get();
-      }
-      case FLOAT -> {
-        return Types.FloatType.get();
-      }
-      case DOUBLE -> {
-        return Types.DoubleType.get();
-      }
-      case STRING, ENUM -> {
-        return Types.StringType.get();
-      }
-      case FIXED -> {
-        return Types.FixedType.ofLength(primitive.getFixedSize());
-      }
-      case BYTES -> {
-        return Types.BinaryType.get();
-      }
-      case NULL -> {
-        return Types.UnknownType.get();
-      }
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + primitive);
+    return switch (primitive.getType()) {
+      case BOOLEAN -> Types.BooleanType.get();
+      case INT -> Types.IntegerType.get();
+      case LONG -> Types.LongType.get();
+      case FLOAT -> Types.FloatType.get();
+      case DOUBLE -> Types.DoubleType.get();
+      case STRING, ENUM -> Types.StringType.get();
+      case FIXED -> Types.FixedType.ofLength(primitive.getFixedSize());
+      case BYTES -> Types.BinaryType.get();
+      case NULL -> Types.UnknownType.get();
+      default ->
+          throw new UnsupportedOperationException("Unsupported primitive type: " + primitive);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -225,25 +225,33 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     }
 
     switch (primitive.getType()) {
-      case BOOLEAN:
+      case BOOLEAN -> {
         return Types.BooleanType.get();
-      case INT:
+      }
+      case INT -> {
         return Types.IntegerType.get();
-      case LONG:
+      }
+      case LONG -> {
         return Types.LongType.get();
-      case FLOAT:
+      }
+      case FLOAT -> {
         return Types.FloatType.get();
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         return Types.DoubleType.get();
-      case STRING:
-      case ENUM:
+      }
+      case STRING, ENUM -> {
         return Types.StringType.get();
-      case FIXED:
+      }
+      case FIXED -> {
         return Types.FixedType.ofLength(primitive.getFixedSize());
-      case BYTES:
+      }
+      case BYTES -> {
         return Types.BinaryType.get();
-      case NULL:
+      }
+      case NULL -> {
         return Types.UnknownType.get();
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported primitive type: " + primitive);

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -213,58 +213,36 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   public Schema primitive(Type.PrimitiveType primitive) {
     Schema primitiveSchema;
     switch (primitive.typeId()) {
-      case UNKNOWN:
-        primitiveSchema = NULL_SCHEMA;
-        break;
-      case BOOLEAN:
-        primitiveSchema = BOOLEAN_SCHEMA;
-        break;
-      case INTEGER:
-        primitiveSchema = INTEGER_SCHEMA;
-        break;
-      case LONG:
-        primitiveSchema = LONG_SCHEMA;
-        break;
-      case FLOAT:
-        primitiveSchema = FLOAT_SCHEMA;
-        break;
-      case DOUBLE:
-        primitiveSchema = DOUBLE_SCHEMA;
-        break;
-      case DATE:
-        primitiveSchema = DATE_SCHEMA;
-        break;
-      case TIME:
-        primitiveSchema = TIME_SCHEMA;
-        break;
-      case TIMESTAMP:
+      case UNKNOWN -> primitiveSchema = NULL_SCHEMA;
+      case BOOLEAN -> primitiveSchema = BOOLEAN_SCHEMA;
+      case INTEGER -> primitiveSchema = INTEGER_SCHEMA;
+      case LONG -> primitiveSchema = LONG_SCHEMA;
+      case FLOAT -> primitiveSchema = FLOAT_SCHEMA;
+      case DOUBLE -> primitiveSchema = DOUBLE_SCHEMA;
+      case DATE -> primitiveSchema = DATE_SCHEMA;
+      case TIME -> primitiveSchema = TIME_SCHEMA;
+      case TIMESTAMP -> {
         if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
           primitiveSchema = TIMESTAMPTZ_SCHEMA;
         } else {
           primitiveSchema = TIMESTAMP_SCHEMA;
         }
-        break;
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
           primitiveSchema = TIMESTAMPTZ_NANO_SCHEMA;
         } else {
           primitiveSchema = TIMESTAMP_NANO_SCHEMA;
         }
-        break;
-      case STRING:
-        primitiveSchema = STRING_SCHEMA;
-        break;
-      case UUID:
-        primitiveSchema = UUID_SCHEMA;
-        break;
-      case FIXED:
+      }
+      case STRING -> primitiveSchema = STRING_SCHEMA;
+      case UUID -> primitiveSchema = UUID_SCHEMA;
+      case FIXED -> {
         Types.FixedType fixed = (Types.FixedType) primitive;
         primitiveSchema = Schema.createFixed("fixed_" + fixed.length(), null, null, fixed.length());
-        break;
-      case BINARY:
-        primitiveSchema = BINARY_SCHEMA;
-        break;
-      case DECIMAL:
+      }
+      case BINARY -> primitiveSchema = BINARY_SCHEMA;
+      case DECIMAL -> {
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         primitiveSchema =
             LogicalTypes.decimal(decimal.precision(), decimal.scale())
@@ -274,9 +252,9 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
                         null,
                         null,
                         TypeUtil.decimalRequiredBytes(decimal.precision())));
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported type ID: " + primitive.typeId());
+      }
+      default ->
+          throw new UnsupportedOperationException("Unsupported type ID: " + primitive.typeId());
     }
 
     cacheSchema(primitive, primitiveSchema);

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -133,15 +133,13 @@ public class ValueReaders {
   }
 
   public static ValueReader<byte[]> decimalBytesReader(Schema schema) {
-    switch (schema.getType()) {
-      case FIXED:
-        return ValueReaders.fixed(schema.getFixedSize());
-      case BYTES:
-        return ValueReaders.bytes();
-      default:
-        throw new IllegalArgumentException(
-            "Invalid primitive type for decimal: " + schema.getType());
-    }
+    return switch (schema.getType()) {
+      case FIXED -> ValueReaders.fixed(schema.getFixedSize());
+      case BYTES -> ValueReaders.bytes();
+      default ->
+          throw new IllegalArgumentException(
+              "Invalid primitive type for decimal: " + schema.getType());
+    };
   }
 
   public static ValueReader<Variant> variants() {

--- a/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
+++ b/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
@@ -41,24 +41,29 @@ public class GenericDataUtil {
     }
 
     switch (type.typeId()) {
-      case DATE:
+      case DATE -> {
         return DateTimeUtil.dateFromDays((Integer) value);
-      case TIME:
+      }
+      case TIME -> {
         return DateTimeUtil.timeFromMicros((Long) value);
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
           return DateTimeUtil.timestampFromMicros((Long) value);
         }
-      case TIMESTAMP_NANO:
+      }
+      case TIMESTAMP_NANO -> {
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromNanos((Long) value);
         } else {
           return DateTimeUtil.timestampFromNanos((Long) value);
         }
-      case FIXED:
+      }
+      case FIXED -> {
         return ByteBuffers.toByteArray((ByteBuffer) value);
+      }
     }
 
     return value;

--- a/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
+++ b/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java
@@ -40,32 +40,25 @@ public class GenericDataUtil {
       return null;
     }
 
-    switch (type.typeId()) {
-      case DATE -> {
-        return DateTimeUtil.dateFromDays((Integer) value);
-      }
-      case TIME -> {
-        return DateTimeUtil.timeFromMicros((Long) value);
-      }
+    return switch (type.typeId()) {
+      case DATE -> DateTimeUtil.dateFromDays((Integer) value);
+      case TIME -> DateTimeUtil.timeFromMicros((Long) value);
       case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
-          return DateTimeUtil.timestamptzFromMicros((Long) value);
+          yield DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
-          return DateTimeUtil.timestampFromMicros((Long) value);
+          yield DateTimeUtil.timestampFromMicros((Long) value);
         }
       }
       case TIMESTAMP_NANO -> {
         if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
-          return DateTimeUtil.timestamptzFromNanos((Long) value);
+          yield DateTimeUtil.timestamptzFromNanos((Long) value);
         } else {
-          return DateTimeUtil.timestampFromNanos((Long) value);
+          yield DateTimeUtil.timestampFromNanos((Long) value);
         }
       }
-      case FIXED -> {
-        return ByteBuffers.toByteArray((ByteBuffer) value);
-      }
-    }
-
-    return value;
+      case FIXED -> ByteBuffers.toByteArray((ByteBuffer) value);
+      default -> value;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
+++ b/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
@@ -32,31 +32,24 @@ public class IdentityPartitionConverters {
       return null;
     }
 
-    switch (type.typeId()) {
-      case STRING -> {
-        return value.toString();
-      }
-      case TIME -> {
-        return DateTimeUtil.timeFromMicros((Long) value);
-      }
-      case DATE -> {
-        return DateTimeUtil.dateFromDays((Integer) value);
-      }
+    return switch (type.typeId()) {
+      case STRING -> value.toString();
+      case TIME -> DateTimeUtil.timeFromMicros((Long) value);
+      case DATE -> DateTimeUtil.dateFromDays((Integer) value);
       case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
-          return DateTimeUtil.timestamptzFromMicros((Long) value);
+          yield DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
-          return DateTimeUtil.timestampFromMicros((Long) value);
+          yield DateTimeUtil.timestampFromMicros((Long) value);
         }
       }
       case FIXED -> {
         if (value instanceof GenericData.Fixed) {
-          return ((GenericData.Fixed) value).bytes();
+          yield ((GenericData.Fixed) value).bytes();
         }
-        return value;
+        yield value;
       }
-      default -> {}
-    }
-    return value;
+      default -> value;
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
+++ b/core/src/main/java/org/apache/iceberg/data/IdentityPartitionConverters.java
@@ -33,24 +33,29 @@ public class IdentityPartitionConverters {
     }
 
     switch (type.typeId()) {
-      case STRING:
+      case STRING -> {
         return value.toString();
-      case TIME:
+      }
+      case TIME -> {
         return DateTimeUtil.timeFromMicros((Long) value);
-      case DATE:
+      }
+      case DATE -> {
         return DateTimeUtil.dateFromDays((Integer) value);
-      case TIMESTAMP:
+      }
+      case TIMESTAMP -> {
         if (((Types.TimestampType) type).shouldAdjustToUTC()) {
           return DateTimeUtil.timestamptzFromMicros((Long) value);
         } else {
           return DateTimeUtil.timestampFromMicros((Long) value);
         }
-      case FIXED:
+      }
+      case FIXED -> {
         if (value instanceof GenericData.Fixed) {
           return ((GenericData.Fixed) value).bytes();
         }
         return value;
-      default:
+      }
+      default -> {}
     }
     return value;
   }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -128,66 +128,56 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericReaders.dates();
-
-          case "time-micros":
+          }
+          case "time-micros" -> {
             return GenericReaders.times();
-
-          case "timestamp-micros":
+          }
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptz();
             }
             return GenericReaders.timestamps();
-
-          case "timestamp-nanos":
+          }
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
-
-          case "timestamp-millis":
+          }
+          case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
             return GenericReaders.timestampMillis();
-
-          case "decimal":
+          }
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
-
-          case "uuid":
+          }
+          case "uuid" -> {
             return ValueReaders.uuids();
-
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          }
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
-      switch (primitive.getType()) {
-        case NULL:
-          return ValueReaders.nulls();
-        case BOOLEAN:
-          return ValueReaders.booleans();
-        case INT:
-          return ValueReaders.ints();
-        case LONG:
-          return ValueReaders.longs();
-        case FLOAT:
-          return ValueReaders.floats();
-        case DOUBLE:
-          return ValueReaders.doubles();
-        case STRING:
-          // might want to use a binary-backed container like Utf8
-          return ValueReaders.strings();
-        case FIXED:
-          return ValueReaders.fixed(primitive.getFixedSize());
-        case BYTES:
-          return ValueReaders.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
-      }
+      return switch (primitive.getType()) {
+        case NULL -> ValueReaders.nulls();
+        case BOOLEAN -> ValueReaders.booleans();
+        case INT -> ValueReaders.ints();
+        case LONG -> ValueReaders.longs();
+        case FLOAT -> ValueReaders.floats();
+        case DOUBLE -> ValueReaders.doubles();
+        case STRING ->
+            // might want to use a binary-backed container like Utf8
+            ValueReaders.strings();
+        case FIXED -> ValueReaders.fixed(primitive.getFixedSize());
+        case BYTES -> ValueReaders.byteBuffers();
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
+      };
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataReader.java
@@ -127,41 +127,34 @@ public class DataReader<T> implements DatumReader<T>, SupportsRowPosition {
     public ValueReader<?> primitive(Type.PrimitiveType ignored, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
-        switch (logicalType.getName()) {
-          case "date" -> {
-            return GenericReaders.dates();
-          }
-          case "time-micros" -> {
-            return GenericReaders.times();
-          }
+        return switch (logicalType.getName()) {
+          case "date" -> GenericReaders.dates();
+          case "time-micros" -> GenericReaders.times();
           case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptz();
+              yield GenericReaders.timestamptz();
             }
-            return GenericReaders.timestamps();
+            yield GenericReaders.timestamps();
           }
           case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptzNanos();
+              yield GenericReaders.timestamptzNanos();
             }
-            return GenericReaders.timestampNanos();
+            yield GenericReaders.timestampNanos();
           }
           case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptzMillis();
+              yield GenericReaders.timestamptzMillis();
             }
-            return GenericReaders.timestampMillis();
+            yield GenericReaders.timestampMillis();
           }
-          case "decimal" -> {
-            return ValueReaders.decimal(
-                ValueReaders.decimalBytesReader(primitive),
-                ((LogicalTypes.Decimal) logicalType).getScale());
-          }
-          case "uuid" -> {
-            return ValueReaders.uuids();
-          }
+          case "decimal" ->
+              ValueReaders.decimal(
+                  ValueReaders.decimalBytesReader(primitive),
+                  ((LogicalTypes.Decimal) logicalType).getScale());
+          case "uuid" -> ValueReaders.uuids();
           default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
-        }
+        };
       }
 
       return switch (primitive.getType()) {

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -111,34 +111,28 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
     public ValueWriter<?> primitive(Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
-        switch (logicalType.getName()) {
-          case "date" -> {
-            return GenericWriters.dates();
-          }
-          case "time-micros" -> {
-            return GenericWriters.times();
-          }
+        return switch (logicalType.getName()) {
+          case "date" -> GenericWriters.dates();
+          case "time-micros" -> GenericWriters.times();
           case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericWriters.timestamptz();
+              yield GenericWriters.timestamptz();
             }
-            return GenericWriters.timestamps();
+            yield GenericWriters.timestamps();
           }
           case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericWriters.timestamptzNanos();
+              yield GenericWriters.timestamptzNanos();
             }
-            return GenericWriters.timestampNanos();
+            yield GenericWriters.timestampNanos();
           }
           case "decimal" -> {
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
-            return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
+            yield ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
           }
-          case "uuid" -> {
-            return ValueWriters.uuids();
-          }
+          case "uuid" -> ValueWriters.uuids();
           default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
-        }
+        };
       }
 
       return switch (primitive.getType()) {

--- a/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/DataWriter.java
@@ -112,58 +112,47 @@ public class DataWriter<T> implements MetricsAwareDatumWriter<T> {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericWriters.dates();
-
-          case "time-micros":
+          }
+          case "time-micros" -> {
             return GenericWriters.times();
-
-          case "timestamp-micros":
+          }
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericWriters.timestamptz();
             }
             return GenericWriters.timestamps();
-
-          case "timestamp-nanos":
+          }
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericWriters.timestamptzNanos();
             }
             return GenericWriters.timestampNanos();
-
-          case "decimal":
+          }
+          case "decimal" -> {
             LogicalTypes.Decimal decimal = (LogicalTypes.Decimal) logicalType;
             return ValueWriters.decimal(decimal.getPrecision(), decimal.getScale());
-
-          case "uuid":
+          }
+          case "uuid" -> {
             return ValueWriters.uuids();
-
-          default:
-            throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
+          }
+          default -> throw new IllegalArgumentException("Unsupported logical type: " + logicalType);
         }
       }
 
-      switch (primitive.getType()) {
-        case NULL:
-          return ValueWriters.nulls();
-        case BOOLEAN:
-          return ValueWriters.booleans();
-        case INT:
-          return ValueWriters.ints();
-        case LONG:
-          return ValueWriters.longs();
-        case FLOAT:
-          return ValueWriters.floats();
-        case DOUBLE:
-          return ValueWriters.doubles();
-        case STRING:
-          return ValueWriters.strings();
-        case FIXED:
-          return ValueWriters.fixed(primitive.getFixedSize());
-        case BYTES:
-          return ValueWriters.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
-      }
+      return switch (primitive.getType()) {
+        case NULL -> ValueWriters.nulls();
+        case BOOLEAN -> ValueWriters.booleans();
+        case INT -> ValueWriters.ints();
+        case LONG -> ValueWriters.longs();
+        case FLOAT -> ValueWriters.floats();
+        case DOUBLE -> ValueWriters.doubles();
+        case STRING -> ValueWriters.strings();
+        case FIXED -> ValueWriters.fixed(primitive.getFixedSize());
+        case BYTES -> ValueWriters.byteBuffers();
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
+      };
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -135,80 +135,60 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
     public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
-        switch (logicalType.getName()) {
-          case "date" -> {
-            return GenericReaders.dates();
-          }
-          case "time-micros" -> {
-            return GenericReaders.times();
-          }
+        return switch (logicalType.getName()) {
+          case "date" -> GenericReaders.dates();
+          case "time-micros" -> GenericReaders.times();
           case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptz();
+              yield GenericReaders.timestamptz();
             }
-            return GenericReaders.timestamps();
+            yield GenericReaders.timestamps();
           }
           case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptzNanos();
+              yield GenericReaders.timestamptzNanos();
             }
-            return GenericReaders.timestampNanos();
+            yield GenericReaders.timestampNanos();
           }
           case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
-              return GenericReaders.timestamptzMillis();
+              yield GenericReaders.timestamptzMillis();
             }
-            return GenericReaders.timestampMillis();
+            yield GenericReaders.timestampMillis();
           }
-          case "decimal" -> {
-            return ValueReaders.decimal(
-                ValueReaders.decimalBytesReader(primitive),
-                ((LogicalTypes.Decimal) logicalType).getScale());
-          }
-          case "uuid" -> {
-            return ValueReaders.uuids();
-          }
+          case "decimal" ->
+              ValueReaders.decimal(
+                  ValueReaders.decimalBytesReader(primitive),
+                  ((LogicalTypes.Decimal) logicalType).getScale());
+          case "uuid" -> ValueReaders.uuids();
           default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
-        }
+        };
       }
 
-      switch (primitive.getType()) {
-        case NULL -> {
-          return ValueReaders.nulls();
-        }
-        case BOOLEAN -> {
-          return ValueReaders.booleans();
-        }
+      return switch (primitive.getType()) {
+        case NULL -> ValueReaders.nulls();
+        case BOOLEAN -> ValueReaders.booleans();
         case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
-            return ValueReaders.intsAsLongs();
+            yield ValueReaders.intsAsLongs();
           }
-          return ValueReaders.ints();
+          yield ValueReaders.ints();
         }
-        case LONG -> {
-          return ValueReaders.longs();
-        }
+        case LONG -> ValueReaders.longs();
         case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
-            return ValueReaders.floatsAsDoubles();
+            yield ValueReaders.floatsAsDoubles();
           }
-          return ValueReaders.floats();
+          yield ValueReaders.floats();
         }
-        case DOUBLE -> {
-          return ValueReaders.doubles();
-        }
-        case STRING -> {
-          // might want to use a binary-backed container like Utf8
-          return ValueReaders.strings();
-        }
-        case FIXED -> {
-          return ValueReaders.fixed(primitive.getFixedSize());
-        }
-        case BYTES -> {
-          return ValueReaders.byteBuffers();
-        }
+        case DOUBLE -> ValueReaders.doubles();
+        case STRING ->
+            // might want to use a binary-backed container like Utf8
+            ValueReaders.strings();
+        case FIXED -> ValueReaders.fixed(primitive.getFixedSize());
+        case BYTES -> ValueReaders.byteBuffers();
         default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
-      }
+      };
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
+++ b/core/src/main/java/org/apache/iceberg/data/avro/PlannedDataReader.java
@@ -136,71 +136,78 @@ public class PlannedDataReader<T> implements DatumReader<T>, SupportsRowPosition
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {
         switch (logicalType.getName()) {
-          case "date":
+          case "date" -> {
             return GenericReaders.dates();
-
-          case "time-micros":
+          }
+          case "time-micros" -> {
             return GenericReaders.times();
-
-          case "timestamp-micros":
+          }
+          case "timestamp-micros" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptz();
             }
             return GenericReaders.timestamps();
-
-          case "timestamp-nanos":
+          }
+          case "timestamp-nanos" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzNanos();
             }
             return GenericReaders.timestampNanos();
-
-          case "timestamp-millis":
+          }
+          case "timestamp-millis" -> {
             if (AvroSchemaUtil.isTimestamptz(primitive)) {
               return GenericReaders.timestamptzMillis();
             }
             return GenericReaders.timestampMillis();
-
-          case "decimal":
+          }
+          case "decimal" -> {
             return ValueReaders.decimal(
                 ValueReaders.decimalBytesReader(primitive),
                 ((LogicalTypes.Decimal) logicalType).getScale());
-
-          case "uuid":
+          }
+          case "uuid" -> {
             return ValueReaders.uuids();
-
-          default:
-            throw new IllegalArgumentException("Unknown logical type: " + logicalType);
+          }
+          default -> throw new IllegalArgumentException("Unknown logical type: " + logicalType);
         }
       }
 
       switch (primitive.getType()) {
-        case NULL:
+        case NULL -> {
           return ValueReaders.nulls();
-        case BOOLEAN:
+        }
+        case BOOLEAN -> {
           return ValueReaders.booleans();
-        case INT:
+        }
+        case INT -> {
           if (partner != null && partner.typeId() == Type.TypeID.LONG) {
             return ValueReaders.intsAsLongs();
           }
           return ValueReaders.ints();
-        case LONG:
+        }
+        case LONG -> {
           return ValueReaders.longs();
-        case FLOAT:
+        }
+        case FLOAT -> {
           if (partner != null && partner.typeId() == Type.TypeID.DOUBLE) {
             return ValueReaders.floatsAsDoubles();
           }
           return ValueReaders.floats();
-        case DOUBLE:
+        }
+        case DOUBLE -> {
           return ValueReaders.doubles();
-        case STRING:
+        }
+        case STRING -> {
           // might want to use a binary-backed container like Utf8
           return ValueReaders.strings();
-        case FIXED:
+        }
+        case FIXED -> {
           return ValueReaders.fixed(primitive.getFixedSize());
-        case BYTES:
+        }
+        case BYTES -> {
           return ValueReaders.byteBuffers();
-        default:
-          throw new IllegalArgumentException("Unsupported type: " + primitive);
+        }
+        default -> throw new IllegalArgumentException("Unsupported type: " + primitive);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
@@ -48,14 +48,11 @@ public enum DeleteGranularity {
 
   @Override
   public String toString() {
-    switch (this) {
-      case FILE:
-        return "file";
-      case PARTITION:
-        return "partition";
-      default:
-        throw new IllegalArgumentException("Unknown delete granularity: " + this);
-    }
+    return switch (this) {
+      case FILE -> "file";
+      case PARTITION -> "partition";
+      default -> throw new IllegalArgumentException("Unknown delete granularity: " + this);
+    };
   }
 
   public static DeleteGranularity fromString(String valueAsString) {

--- a/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/DeleteGranularity.java
@@ -51,7 +51,6 @@ public enum DeleteGranularity {
     return switch (this) {
       case FILE -> "file";
       case PARTITION -> "partition";
-      default -> throw new IllegalArgumentException("Unknown delete granularity: " + this);
     };
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/PositionDelete.java
@@ -81,32 +81,21 @@ public class PositionDelete<R> implements StructLike {
   @Override
   @SuppressWarnings("unchecked")
   public <T> T get(int colPos, Class<T> javaClass) {
-    switch (colPos) {
-      case 0:
-        return (T) path;
-      case 1:
-        return (T) (Long) pos;
-      case 2:
-        return (T) row;
-      default:
-        throw new IllegalArgumentException("No column at position " + colPos);
-    }
+    return switch (colPos) {
+      case 0 -> (T) path;
+      case 1 -> (T) (Long) pos;
+      case 2 -> (T) row;
+      default -> throw new IllegalArgumentException("No column at position " + colPos);
+    };
   }
 
   @Override
   public <T> void set(int colPos, T value) {
     switch (colPos) {
-      case 0:
-        this.path = (CharSequence) value;
-        break;
-      case 1:
-        this.pos = (Long) value;
-        break;
-      case 2:
-        this.row = (R) value;
-        break;
-      default:
-        throw new IllegalArgumentException("No column at position " + colPos);
+      case 0 -> this.path = (CharSequence) value;
+      case 1 -> this.pos = (Long) value;
+      case 2 -> this.row = (R) value;
+      default -> throw new IllegalArgumentException("No column at position " + colPos);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
@@ -101,14 +101,17 @@ public class SortingPositionOnlyDeleteWriter<T>
   public void close() throws IOException {
     if (result == null) {
       switch (granularity) {
-        case FILE:
+        case FILE -> {
           this.result = writeFileDeletes();
           return;
-        case PARTITION:
+        }
+        case PARTITION -> {
           this.result = writePartitionDeletes();
           return;
-        default:
-          throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Unsupported delete granularity: " + granularity);
       }
     }
   }

--- a/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/SortingPositionOnlyDeleteWriter.java
@@ -101,14 +101,8 @@ public class SortingPositionOnlyDeleteWriter<T>
   public void close() throws IOException {
     if (result == null) {
       switch (granularity) {
-        case FILE -> {
-          this.result = writeFileDeletes();
-          return;
-        }
-        case PARTITION -> {
-          this.result = writePartitionDeletes();
-          return;
-        }
+        case FILE -> this.result = writeFileDeletes();
+        case PARTITION -> this.result = writePartitionDeletes();
         default ->
             throw new UnsupportedOperationException(
                 "Unsupported delete granularity: " + granularity);

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
@@ -144,32 +144,32 @@ class StandardKeyMetadata implements NativeEncryptionKeyMetadata, IndexedRecord 
   @Override
   public void put(int i, Object v) {
     switch (i) {
-      case 0:
+      case 0 -> {
         this.encryptionKey = (ByteBuffer) v;
         return;
-      case 1:
+      }
+      case 1 -> {
         this.aadPrefix = (ByteBuffer) v;
         return;
-      case 2:
+      }
+      case 2 -> {
         this.fileLength = (Long) v;
         return;
-      default:
+      }
+      default -> {
         // ignore the object, it must be from a newer version of the format
+      }
     }
   }
 
   @Override
   public Object get(int i) {
-    switch (i) {
-      case 0:
-        return encryptionKey;
-      case 1:
-        return aadPrefix;
-      case 2:
-        return fileLength;
-      default:
-        throw new UnsupportedOperationException("Unknown field ordinal: " + i);
-    }
+    return switch (i) {
+      case 0 -> encryptionKey;
+      case 1 -> aadPrefix;
+      case 2 -> fileLength;
+      default -> throw new UnsupportedOperationException("Unknown field ordinal: " + i);
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java
@@ -144,18 +144,9 @@ class StandardKeyMetadata implements NativeEncryptionKeyMetadata, IndexedRecord 
   @Override
   public void put(int i, Object v) {
     switch (i) {
-      case 0 -> {
-        this.encryptionKey = (ByteBuffer) v;
-        return;
-      }
-      case 1 -> {
-        this.aadPrefix = (ByteBuffer) v;
-        return;
-      }
-      case 2 -> {
-        this.fileLength = (Long) v;
-        return;
-      }
+      case 0 -> this.encryptionKey = (ByteBuffer) v;
+      case 1 -> this.aadPrefix = (ByteBuffer) v;
+      case 2 -> this.fileLength = (Long) v;
       default -> {
         // ignore the object, it must be from a newer version of the format
       }

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -296,16 +296,19 @@ public class ExpressionParser {
 
     Expression.Operation op = fromType(type);
     switch (op) {
-      case NOT:
+      case NOT -> {
         return Expressions.not(fromJson(JsonUtil.get(CHILD, json), schema));
-      case AND:
+      }
+      case AND -> {
         return Expressions.and(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
-      case OR:
+      }
+      case OR -> {
         return Expressions.or(
             fromJson(JsonUtil.get(LEFT, json), schema),
             fromJson(JsonUtil.get(RIGHT, json), schema));
+      }
     }
 
     return predicateFromJson(op, json, schema);
@@ -329,24 +332,15 @@ public class ExpressionParser {
     }
 
     switch (op) {
-      case IS_NULL:
-      case NOT_NULL:
-      case IS_NAN:
-      case NOT_NAN:
+      case IS_NULL, NOT_NULL, IS_NAN, NOT_NAN -> {
         // unary predicates
         Preconditions.checkArgument(
             !node.has(VALUE), "Cannot parse %s predicate: has invalid value field", op);
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
         return Expressions.predicate(op, term);
-      case LT:
-      case LT_EQ:
-      case GT:
-      case GT_EQ:
-      case EQ:
-      case NOT_EQ:
-      case STARTS_WITH:
-      case NOT_STARTS_WITH:
+      }
+      case LT, LT_EQ, GT, GT_EQ, EQ, NOT_EQ, STARTS_WITH, NOT_STARTS_WITH -> {
         // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);
@@ -354,8 +348,8 @@ public class ExpressionParser {
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
         T value = literal(JsonUtil.get(VALUE, node), convertValue);
         return Expressions.predicate(op, term, ImmutableList.of(value));
-      case IN:
-      case NOT_IN:
+      }
+      case IN, NOT_IN -> {
         // literal set predicates
         Preconditions.checkArgument(
             node.has(VALUES), "Cannot parse %s predicate: missing values", op);
@@ -369,8 +363,8 @@ public class ExpressionParser {
             term,
             Iterables.transform(
                 ((ArrayNode) valuesNode)::elements, valueNode -> literal(valueNode, convertValue)));
-      default:
-        throw new UnsupportedOperationException("Unsupported operation: " + op);
+      }
+      default -> throw new UnsupportedOperationException("Unsupported operation: " + op);
     }
   }
 
@@ -407,15 +401,16 @@ public class ExpressionParser {
     } else if (node.isObject()) {
       String type = JsonUtil.getString(TYPE, node);
       switch (type) {
-        case REFERENCE:
+        case REFERENCE -> {
           return Expressions.ref(JsonUtil.getString(TERM, node));
-        case TRANSFORM:
+        }
+        case TRANSFORM -> {
           UnboundTerm<T> child = term(JsonUtil.get(TERM, node));
           String transform = JsonUtil.getString(TRANSFORM, node);
           return (UnboundTerm<T>)
               Expressions.transform(child.ref().name(), Transforms.fromString(transform));
-        default:
-          throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
+        }
+        default -> throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -295,23 +295,18 @@ public class ExpressionParser {
     }
 
     Expression.Operation op = fromType(type);
-    switch (op) {
-      case NOT -> {
-        return Expressions.not(fromJson(JsonUtil.get(CHILD, json), schema));
-      }
-      case AND -> {
-        return Expressions.and(
-            fromJson(JsonUtil.get(LEFT, json), schema),
-            fromJson(JsonUtil.get(RIGHT, json), schema));
-      }
-      case OR -> {
-        return Expressions.or(
-            fromJson(JsonUtil.get(LEFT, json), schema),
-            fromJson(JsonUtil.get(RIGHT, json), schema));
-      }
-    }
-
-    return predicateFromJson(op, json, schema);
+    return switch (op) {
+      case NOT -> Expressions.not(fromJson(JsonUtil.get(CHILD, json), schema));
+      case AND ->
+          Expressions.and(
+              fromJson(JsonUtil.get(LEFT, json), schema),
+              fromJson(JsonUtil.get(RIGHT, json), schema));
+      case OR ->
+          Expressions.or(
+              fromJson(JsonUtil.get(LEFT, json), schema),
+              fromJson(JsonUtil.get(RIGHT, json), schema));
+      default -> predicateFromJson(op, json, schema);
+    };
   }
 
   private static Expression.Operation fromType(String type) {
@@ -331,14 +326,14 @@ public class ExpressionParser {
       convertValue = valueNode -> (T) ExpressionParser.asObject(valueNode);
     }
 
-    switch (op) {
+    return switch (op) {
       case IS_NULL, NOT_NULL, IS_NAN, NOT_NAN -> {
         // unary predicates
         Preconditions.checkArgument(
             !node.has(VALUE), "Cannot parse %s predicate: has invalid value field", op);
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
-        return Expressions.predicate(op, term);
+        yield Expressions.predicate(op, term);
       }
       case LT, LT_EQ, GT, GT_EQ, EQ, NOT_EQ, STARTS_WITH, NOT_STARTS_WITH -> {
         // literal predicates
@@ -347,7 +342,7 @@ public class ExpressionParser {
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
         T value = literal(JsonUtil.get(VALUE, node), convertValue);
-        return Expressions.predicate(op, term, ImmutableList.of(value));
+        yield Expressions.predicate(op, term, ImmutableList.of(value));
       }
       case IN, NOT_IN -> {
         // literal set predicates
@@ -358,14 +353,14 @@ public class ExpressionParser {
         JsonNode valuesNode = JsonUtil.get(VALUES, node);
         Preconditions.checkArgument(
             valuesNode.isArray(), "Cannot parse literals from non-array: %s", valuesNode);
-        return Expressions.predicate(
+        yield Expressions.predicate(
             op,
             term,
             Iterables.transform(
                 ((ArrayNode) valuesNode)::elements, valueNode -> literal(valueNode, convertValue)));
       }
       default -> throw new UnsupportedOperationException("Unsupported operation: " + op);
-    }
+    };
   }
 
   private static <T> T literal(JsonNode valueNode, Function<JsonNode, T> toValue) {
@@ -400,18 +395,16 @@ public class ExpressionParser {
       return Expressions.ref(node.asText());
     } else if (node.isObject()) {
       String type = JsonUtil.getString(TYPE, node);
-      switch (type) {
-        case REFERENCE -> {
-          return Expressions.ref(JsonUtil.getString(TERM, node));
-        }
+      return switch (type) {
+        case REFERENCE -> Expressions.ref(JsonUtil.getString(TERM, node));
         case TRANSFORM -> {
           UnboundTerm<T> child = term(JsonUtil.get(TERM, node));
           String transform = JsonUtil.getString(TRANSFORM, node);
-          return (UnboundTerm<T>)
+          yield (UnboundTerm<T>)
               Expressions.transform(child.ref().name(), Transforms.fromString(transform));
         }
         default -> throw new IllegalArgumentException("Cannot parse type as a reference: " + type);
-      }
+      };
     }
 
     throw new IllegalArgumentException(

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopMetricsContext.java
@@ -66,24 +66,28 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
   @Override
   @SuppressWarnings("unchecked")
   public <T extends Number> Counter<T> counter(String name, Class<T> type, Unit unit) {
-    switch (name) {
-      case READ_BYTES:
+    return switch (name) {
+      case READ_BYTES -> {
         ValidationException.check(type == Long.class, "'%s' requires Long type", READ_BYTES);
-        return (Counter<T>) longCounter(statistics()::incrementBytesRead);
-      case READ_OPERATIONS:
+        yield (Counter<T>) longCounter(statistics()::incrementBytesRead);
+      }
+      case READ_OPERATIONS -> {
         ValidationException.check(
             type == Integer.class, "'%s' requires Integer type", READ_OPERATIONS);
-        return (Counter<T>) integerCounter(statistics()::incrementReadOps);
-      case WRITE_BYTES:
+        yield (Counter<T>) integerCounter(statistics()::incrementReadOps);
+      }
+      case WRITE_BYTES -> {
         ValidationException.check(type == Long.class, "'%s' requires Long type", WRITE_BYTES);
-        return (Counter<T>) longCounter(statistics()::incrementBytesWritten);
-      case WRITE_OPERATIONS:
+        yield (Counter<T>) longCounter(statistics()::incrementBytesWritten);
+      }
+      case WRITE_OPERATIONS -> {
         ValidationException.check(
             type == Integer.class, "'%s' requires Integer type", WRITE_OPERATIONS);
-        return (Counter<T>) integerCounter(statistics()::incrementWriteOps);
-      default:
-        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
-    }
+        yield (Counter<T>) integerCounter(statistics()::incrementWriteOps);
+      }
+      default ->
+          throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
+    };
   }
 
   private Counter<Long> longCounter(Consumer<Long> consumer) {
@@ -125,19 +129,17 @@ public class HadoopMetricsContext implements FileIOMetricsContext {
    */
   @Override
   public org.apache.iceberg.metrics.Counter counter(String name, Unit unit) {
-    switch (name) {
-      case READ_BYTES:
-        return counter(statistics()::incrementBytesRead, statistics()::getBytesRead);
-      case READ_OPERATIONS:
-        return counter((long x) -> statistics.incrementReadOps((int) x), statistics()::getReadOps);
-      case WRITE_BYTES:
-        return counter(statistics()::incrementBytesWritten, statistics()::getBytesWritten);
-      case WRITE_OPERATIONS:
-        return counter(
-            (long x) -> statistics.incrementWriteOps((int) x), statistics()::getWriteOps);
-      default:
-        throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
-    }
+    return switch (name) {
+      case READ_BYTES -> counter(statistics()::incrementBytesRead, statistics()::getBytesRead);
+      case READ_OPERATIONS ->
+          counter((long x) -> statistics.incrementReadOps((int) x), statistics()::getReadOps);
+      case WRITE_BYTES ->
+          counter(statistics()::incrementBytesWritten, statistics()::getBytesWritten);
+      case WRITE_OPERATIONS ->
+          counter((long x) -> statistics.incrementWriteOps((int) x), statistics()::getWriteOps);
+      default ->
+          throw new IllegalArgumentException(String.format("Unsupported counter: '%s'", name));
+    };
   }
 
   private org.apache.iceberg.metrics.Counter counter(LongConsumer consumer, LongSupplier supplier) {

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
@@ -70,14 +70,12 @@ public class ClusteredPositionDeleteWriter<T>
   @Override
   protected FileWriter<PositionDelete<T>, DeleteWriteResult> newWriter(
       PartitionSpec spec, StructLike partition) {
-    switch (granularity) {
-      case FILE:
-        return new FileScopedPositionDeleteWriter<>(() -> newRollingWriter(spec, partition));
-      case PARTITION:
-        return newRollingWriter(spec, partition);
-      default:
-        throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
-    }
+    return switch (granularity) {
+      case FILE -> new FileScopedPositionDeleteWriter<>(() -> newRollingWriter(spec, partition));
+      case PARTITION -> newRollingWriter(spec, partition);
+      default ->
+          throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
+    };
   }
 
   private RollingPositionDeleteWriter<T> newRollingWriter(

--- a/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
+++ b/core/src/main/java/org/apache/iceberg/io/ClusteredPositionDeleteWriter.java
@@ -73,8 +73,6 @@ public class ClusteredPositionDeleteWriter<T>
     return switch (granularity) {
       case FILE -> new FileScopedPositionDeleteWriter<>(() -> newRollingWriter(spec, partition));
       case PARTITION -> newRollingWriter(spec, partition);
-      default ->
-          throw new UnsupportedOperationException("Unsupported delete granularity: " + granularity);
     };
   }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
@@ -119,23 +119,17 @@ class TimerResultParser {
   }
 
   private static ChronoUnit toChronoUnit(TimeUnit unit) {
-    switch (unit) {
-      case NANOSECONDS:
-        return ChronoUnit.NANOS;
-      case MICROSECONDS:
-        return ChronoUnit.MICROS;
-      case MILLISECONDS:
-        return ChronoUnit.MILLIS;
-      case SECONDS:
-        return ChronoUnit.SECONDS;
-      case MINUTES:
-        return ChronoUnit.MINUTES;
-      case HOURS:
-        return ChronoUnit.HOURS;
-      case DAYS:
-        return ChronoUnit.DAYS;
-      default:
-        throw new IllegalArgumentException("Cannot determine chrono unit from time unit: " + unit);
-    }
+    return switch (unit) {
+      case NANOSECONDS -> ChronoUnit.NANOS;
+      case MICROSECONDS -> ChronoUnit.MICROS;
+      case MILLISECONDS -> ChronoUnit.MILLIS;
+      case SECONDS -> ChronoUnit.SECONDS;
+      case MINUTES -> ChronoUnit.MINUTES;
+      case HOURS -> ChronoUnit.HOURS;
+      case DAYS -> ChronoUnit.DAYS;
+      default ->
+          throw new IllegalArgumentException(
+              "Cannot determine chrono unit from time unit: " + unit);
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
@@ -105,14 +105,16 @@ final class PuffinFormat {
 
   static ByteBuffer compress(PuffinCompressionCodec codec, ByteBuffer input) {
     switch (codec) {
-      case NONE:
+      case NONE -> {
         return input.duplicate();
-      case LZ4:
+      }
+      case LZ4 -> {
         // TODO requires LZ4 frame compressor, e.g.
         // https://github.com/airlift/aircompressor/pull/142
-        break;
-      case ZSTD:
+      }
+      case ZSTD -> {
         return compress(new ZstdCompressor(), input);
+      }
     }
     throw new UnsupportedOperationException("Unsupported codec: " + codec);
   }
@@ -126,16 +128,16 @@ final class PuffinFormat {
 
   static ByteBuffer decompress(PuffinCompressionCodec codec, ByteBuffer input) {
     switch (codec) {
-      case NONE:
+      case NONE -> {
         return input.duplicate();
-
-      case LZ4:
+      }
+      case LZ4 -> {
         // TODO requires LZ4 frame decompressor, e.g.
         // https://github.com/airlift/aircompressor/pull/142
-        break;
-
-      case ZSTD:
+      }
+      case ZSTD -> {
         return decompressZstd(input);
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported codec: " + codec);

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
@@ -104,19 +104,14 @@ final class PuffinFormat {
   }
 
   static ByteBuffer compress(PuffinCompressionCodec codec, ByteBuffer input) {
-    switch (codec) {
-      case NONE -> {
-        return input.duplicate();
-      }
-      case LZ4 -> {
-        // TODO requires LZ4 frame compressor, e.g.
-        // https://github.com/airlift/aircompressor/pull/142
-      }
-      case ZSTD -> {
-        return compress(new ZstdCompressor(), input);
-      }
-    }
-    throw new UnsupportedOperationException("Unsupported codec: " + codec);
+    return switch (codec) {
+      case NONE -> input.duplicate();
+      case LZ4 ->
+          // TODO requires LZ4 frame compressor, e.g.
+          // https://github.com/airlift/aircompressor/pull/142
+          throw new UnsupportedOperationException("Unsupported codec: " + codec);
+      case ZSTD -> compress(new ZstdCompressor(), input);
+    };
   }
 
   private static ByteBuffer compress(Compressor compressor, ByteBuffer input) {
@@ -127,20 +122,14 @@ final class PuffinFormat {
   }
 
   static ByteBuffer decompress(PuffinCompressionCodec codec, ByteBuffer input) {
-    switch (codec) {
-      case NONE -> {
-        return input.duplicate();
-      }
-      case LZ4 -> {
-        // TODO requires LZ4 frame decompressor, e.g.
-        // https://github.com/airlift/aircompressor/pull/142
-      }
-      case ZSTD -> {
-        return decompressZstd(input);
-      }
-    }
-
-    throw new UnsupportedOperationException("Unsupported codec: " + codec);
+    return switch (codec) {
+      case NONE -> input.duplicate();
+      case LZ4 ->
+          // TODO requires LZ4 frame decompressor, e.g.
+          // https://github.com/airlift/aircompressor/pull/142
+          throw new UnsupportedOperationException("Unsupported codec: " + codec);
+      case ZSTD -> decompressZstd(input);
+    };
   }
 
   private static ByteBuffer decompressZstd(ByteBuffer input) {

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -71,13 +71,11 @@ public class PuffinReader implements Closeable {
 
       PuffinCompressionCodec footerCompression = PuffinCompressionCodec.NONE;
       for (Flag flag : decodeFlags(footer, footerStructOffset)) {
-        switch (flag) {
-          case FOOTER_PAYLOAD_COMPRESSED:
-            footerCompression = PuffinFormat.FOOTER_COMPRESSION_CODEC;
-            break;
-          default:
-            throw new IllegalStateException("Unsupported flag: " + flag);
-        }
+        footerCompression =
+            switch (flag) {
+              case FOOTER_PAYLOAD_COMPRESSED -> PuffinFormat.FOOTER_COMPRESSION_CODEC;
+              default -> throw new IllegalStateException("Unsupported flag: " + flag);
+            };
       }
 
       int footerPayloadSize =

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -74,6 +74,7 @@ public class PuffinReader implements Closeable {
         footerCompression =
             switch (flag) {
               case FOOTER_PAYLOAD_COMPRESSED -> PuffinFormat.FOOTER_COMPRESSION_CODEC;
+              default -> throw new IllegalStateException("Unsupported flag: " + flag);
             };
       }
 

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -74,7 +74,6 @@ public class PuffinReader implements Closeable {
         footerCompression =
             switch (flag) {
               case FOOTER_PAYLOAD_COMPRESSED -> PuffinFormat.FOOTER_COMPRESSION_CODEC;
-              default -> throw new IllegalStateException("Unsupported flag: " + flag);
             };
       }
 

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -526,9 +526,6 @@ public class CatalogHandlers {
                     .withMetadataLocation(loadedMetadata.metadataFileLocation())
                     .suppressHistoricalSnapshots()
                     .build();
-            default ->
-                throw new IllegalArgumentException(
-                    String.format("Invalid snapshot mode: %s", mode));
           };
 
       return LoadTableResponse.builder().withTableMetadata(metadata).build();

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -526,6 +526,9 @@ public class CatalogHandlers {
                     .withMetadataLocation(loadedMetadata.metadataFileLocation())
                     .suppressHistoricalSnapshots()
                     .build();
+            default ->
+                throw new IllegalArgumentException(
+                    String.format("Invalid snapshot mode: %s", mode));
           };
 
       return LoadTableResponse.builder().withTableMetadata(metadata).build();

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -518,21 +518,18 @@ public class CatalogHandlers {
     if (table instanceof BaseTable) {
       TableMetadata loadedMetadata = ((BaseTable) table).operations().current();
 
-      TableMetadata metadata;
-      switch (mode) {
-        case ALL:
-          metadata = loadedMetadata;
-          break;
-        case REFS:
-          metadata =
-              TableMetadata.buildFrom(loadedMetadata)
-                  .withMetadataLocation(loadedMetadata.metadataFileLocation())
-                  .suppressHistoricalSnapshots()
-                  .build();
-          break;
-        default:
-          throw new IllegalArgumentException(String.format("Invalid snapshot mode: %s", mode));
-      }
+      TableMetadata metadata =
+          switch (mode) {
+            case ALL -> loadedMetadata;
+            case REFS ->
+                TableMetadata.buildFrom(loadedMetadata)
+                    .withMetadataLocation(loadedMetadata.metadataFileLocation())
+                    .suppressHistoricalSnapshots()
+                    .build();
+            default ->
+                throw new IllegalArgumentException(
+                    String.format("Invalid snapshot mode: %s", mode));
+          };
 
       return LoadTableResponse.builder().withTableMetadata(metadata).build();
     } else if (table instanceof BaseMetadataTable) {

--- a/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ErrorHandlers.java
@@ -122,16 +122,12 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchTableException("%s", error.message());
-        case 409:
-          throw new CommitFailedException("Commit failed: %s", error.message());
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new CommitStateUnknownException(
-              new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));
+        case 404 -> throw new NoSuchTableException("%s", error.message());
+        case 409 -> throw new CommitFailedException("Commit failed: %s", error.message());
+        case 500, 502, 503, 504 ->
+            throw new CommitStateUnknownException(
+                new ServiceFailureException(
+                    "Service failed: %s: %s", error.code(), error.message()));
       }
 
       super.accept(error);
@@ -145,7 +141,7 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
+        case 404 -> {
           if (NoSuchNamespaceException.class.getSimpleName().equals(error.type())) {
             throw new NoSuchNamespaceException("%s", error.message());
           } else if (NotFoundException.class.getSimpleName().equals(error.type())) {
@@ -153,8 +149,8 @@ public class ErrorHandlers {
           } else {
             throw new NoSuchTableException("%s", error.message());
           }
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        }
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
       }
 
       super.accept(error);
@@ -168,10 +164,8 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchNamespaceException("%s", error.message());
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        case 404 -> throw new NoSuchNamespaceException("%s", error.message());
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
       }
 
       super.accept(error);
@@ -225,16 +219,12 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
-          throw new NoSuchViewException("%s", error.message());
-        case 409:
-          throw new CommitFailedException("Commit failed: %s", error.message());
-        case 500:
-        case 502:
-        case 503:
-        case 504:
-          throw new CommitStateUnknownException(
-              new ServiceFailureException("Service failed: %s: %s", error.code(), error.message()));
+        case 404 -> throw new NoSuchViewException("%s", error.message());
+        case 409 -> throw new CommitFailedException("Commit failed: %s", error.message());
+        case 500, 502, 503, 504 ->
+            throw new CommitStateUnknownException(
+                new ServiceFailureException(
+                    "Service failed: %s: %s", error.code(), error.message()));
       }
 
       super.accept(error);
@@ -248,14 +238,14 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 404:
+        case 404 -> {
           if (NoSuchNamespaceException.class.getSimpleName().equals(error.type())) {
             throw new NoSuchNamespaceException("%s", error.message());
           } else {
             throw new NoSuchViewException("%s", error.message());
           }
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
+        }
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
       }
 
       super.accept(error);
@@ -269,17 +259,15 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 400:
+        case 400 -> {
           if (NamespaceNotEmptyException.class.getSimpleName().equals(error.type())) {
             throw new NamespaceNotEmptyException("%s", error.message());
           }
           throw new BadRequestException("Malformed request: %s", error.message());
-        case 404:
-          throw new NoSuchNamespaceException("%s", error.message());
-        case 409:
-          throw new AlreadyExistsException("%s", error.message());
-        case 422:
-          throw createRESTException(error);
+        }
+        case 404 -> throw new NoSuchNamespaceException("%s", error.message());
+        case 409 -> throw new AlreadyExistsException("%s", error.message());
+        case 422 -> throw createRESTException(error);
       }
 
       super.accept(error);
@@ -334,24 +322,21 @@ public class ErrorHandlers {
     @Override
     public void accept(ErrorResponse error) {
       switch (error.code()) {
-        case 400:
+        case 400 -> {
           if (IllegalArgumentException.class.getSimpleName().equals(error.type())) {
             throw new IllegalArgumentException(error.message());
           }
           throw new BadRequestException("Malformed request: %s", error.message());
-        case 401:
-          throw new NotAuthorizedException("Not authorized: %s", error.message());
-        case 403:
-          throw new ForbiddenException("Forbidden: %s", error.message());
-        case 405:
-        case 406:
-          break;
-        case 500:
-          throw new ServiceFailureException("Server error: %s: %s", error.type(), error.message());
-        case 501:
-          throw new UnsupportedOperationException(error.message());
-        case 503:
-          throw new ServiceUnavailableException("Service unavailable: %s", error.message());
+        }
+        case 401 -> throw new NotAuthorizedException("Not authorized: %s", error.message());
+        case 403 -> throw new ForbiddenException("Forbidden: %s", error.message());
+        case 405, 406 -> {}
+        case 500 ->
+            throw new ServiceFailureException(
+                "Server error: %s: %s", error.type(), error.message());
+        case 501 -> throw new UnsupportedOperationException(error.message());
+        case 503 ->
+            throw new ServiceUnavailableException("Service unavailable: %s", error.message());
       }
 
       throw createRESTException(error);
@@ -375,16 +360,16 @@ public class ErrorHandlers {
     public void accept(ErrorResponse error) {
       if (error.type() != null) {
         switch (error.type()) {
-          case OAuth2Properties.INVALID_CLIENT_ERROR:
-            throw new NotAuthorizedException(
-                "Not authorized: %s: %s", error.type(), error.message());
-          case OAuth2Properties.INVALID_REQUEST_ERROR:
-          case OAuth2Properties.INVALID_GRANT_ERROR:
-          case OAuth2Properties.UNAUTHORIZED_CLIENT_ERROR:
-          case OAuth2Properties.UNSUPPORTED_GRANT_TYPE_ERROR:
-          case OAuth2Properties.INVALID_SCOPE_ERROR:
-            throw new BadRequestException(
-                "Malformed request: %s: %s", error.type(), error.message());
+          case OAuth2Properties.INVALID_CLIENT_ERROR ->
+              throw new NotAuthorizedException(
+                  "Not authorized: %s: %s", error.type(), error.message());
+          case OAuth2Properties.INVALID_REQUEST_ERROR,
+                  OAuth2Properties.INVALID_GRANT_ERROR,
+                  OAuth2Properties.UNAUTHORIZED_CLIENT_ERROR,
+                  OAuth2Properties.UNSUPPORTED_GRANT_TYPE_ERROR,
+                  OAuth2Properties.INVALID_SCOPE_ERROR ->
+              throw new BadRequestException(
+                  "Malformed request: %s: %s", error.type(), error.message());
         }
       }
       throw createRESTException(error);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -160,7 +160,7 @@ class RESTTableOperations implements TableOperations {
     List<UpdateRequirement> requirements;
     List<MetadataUpdate> updates;
     switch (updateType) {
-      case CREATE:
+      case CREATE -> {
         Preconditions.checkState(
             base == null, "Invalid base metadata for create transaction, expected null: %s", base);
         updates =
@@ -170,9 +170,8 @@ class RESTTableOperations implements TableOperations {
                 .build();
         requirements = UpdateRequirements.forCreateTable(updates);
         errorHandler = ErrorHandlers.createTableErrorHandler();
-        break;
-
-      case REPLACE:
+      }
+      case REPLACE -> {
         Preconditions.checkState(base != null, "Invalid base metadata: null");
         updates =
             ImmutableList.<MetadataUpdate>builder()
@@ -182,18 +181,16 @@ class RESTTableOperations implements TableOperations {
         // use the original replace base metadata because the transaction will refresh
         requirements = UpdateRequirements.forReplaceTable(replaceBase, updates);
         errorHandler = ErrorHandlers.tableCommitHandler();
-        break;
-
-      case SIMPLE:
+      }
+      case SIMPLE -> {
         Preconditions.checkState(base != null, "Invalid base metadata: null");
         updates = metadata.changes();
         requirements = UpdateRequirements.forUpdateTable(base, updates);
         errorHandler = ErrorHandlers.tableCommitHandler();
-        break;
-
-      default:
-        throw new UnsupportedOperationException(
-            String.format("Update type %s is not supported", updateType));
+      }
+      default ->
+          throw new UnsupportedOperationException(
+              String.format("Update type %s is not supported", updateType));
     }
 
     UpdateTableRequest request = new UpdateTableRequest(requirements, updates);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableScan.java
@@ -212,18 +212,18 @@ class RESTTableScan extends DataTableScan {
     this.scanFileIO =
         !response.credentials().isEmpty() ? scanFileIO(response.credentials()) : table().io();
 
-    switch (planStatus) {
-      case COMPLETED:
-        return scanTasksIterable(response.planTasks(), response.fileScanTasks());
-      case SUBMITTED:
+    return switch (planStatus) {
+      case COMPLETED -> scanTasksIterable(response.planTasks(), response.fileScanTasks());
+      case SUBMITTED -> {
         Endpoint.check(supportedEndpoints, Endpoint.V1_FETCH_TABLE_SCAN_PLAN);
-        return fetchPlanningResult();
-      case FAILED:
-        throw new IllegalStateException(failureMessage(planId, response.errorResponse()));
-      default:
-        throw new IllegalStateException(
-            String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
-    }
+        yield fetchPlanningResult();
+      }
+      case FAILED ->
+          throw new IllegalStateException(failureMessage(planId, response.errorResponse()));
+      default ->
+          throw new IllegalStateException(
+              String.format("Invalid planStatus: %s for planId: %s", planStatus, planId));
+    };
   }
 
   private FileIO scanFileIO(List<Credential> storageCredentials) {
@@ -282,24 +282,21 @@ class RESTTableScan extends DataTableScan {
                         parserContext);
 
                 switch (response.planStatus()) {
-                  case COMPLETED:
-                    result.set(response);
-                    break;
-                  case SUBMITTED:
-                    throw new NotCompleteException();
-                  case FAILED:
-                    throw new IllegalStateException(failureMessage(id, response.errorResponse()));
-                  case CANCELLED:
-                    throw new IllegalStateException(
-                        String.format(
-                            Locale.ROOT, "Remote scan planning cancelled for planId: %s", id));
-                  default:
-                    throw new IllegalStateException(
-                        String.format(
-                            Locale.ROOT,
-                            "Invalid planStatus: %s for planId: %s",
-                            response.planStatus(),
-                            id));
+                  case COMPLETED -> result.set(response);
+                  case SUBMITTED -> throw new NotCompleteException();
+                  case FAILED ->
+                      throw new IllegalStateException(failureMessage(id, response.errorResponse()));
+                  case CANCELLED ->
+                      throw new IllegalStateException(
+                          String.format(
+                              Locale.ROOT, "Remote scan planning cancelled for planId: %s", id));
+                  default ->
+                      throw new IllegalStateException(
+                          String.format(
+                              Locale.ROOT,
+                              "Invalid planStatus: %s for planId: %s",
+                              response.planStatus(),
+                              id));
                 }
               });
     } catch (NotCompleteException e) {

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
@@ -84,26 +84,15 @@ public class AuthManagers {
       delegate = loadAuthManager(name, newProperties);
     }
 
-    String impl;
-    switch (authType.toLowerCase(Locale.ROOT)) {
-      case AuthProperties.AUTH_TYPE_NONE:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_NONE;
-        break;
-      case AuthProperties.AUTH_TYPE_BASIC:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_BASIC;
-        break;
-      case AuthProperties.AUTH_TYPE_SIGV4:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_SIGV4;
-        break;
-      case AuthProperties.AUTH_TYPE_GOOGLE:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_GOOGLE;
-        break;
-      case AuthProperties.AUTH_TYPE_OAUTH2:
-        impl = AuthProperties.AUTH_MANAGER_IMPL_OAUTH2;
-        break;
-      default:
-        impl = authType;
-    }
+    String impl =
+        switch (authType.toLowerCase(Locale.ROOT)) {
+          case AuthProperties.AUTH_TYPE_NONE -> AuthProperties.AUTH_MANAGER_IMPL_NONE;
+          case AuthProperties.AUTH_TYPE_BASIC -> AuthProperties.AUTH_MANAGER_IMPL_BASIC;
+          case AuthProperties.AUTH_TYPE_SIGV4 -> AuthProperties.AUTH_MANAGER_IMPL_SIGV4;
+          case AuthProperties.AUTH_TYPE_GOOGLE -> AuthProperties.AUTH_MANAGER_IMPL_GOOGLE;
+          case AuthProperties.AUTH_TYPE_OAUTH2 -> AuthProperties.AUTH_MANAGER_IMPL_OAUTH2;
+          default -> authType;
+        };
 
     LOG.info("Loading AuthManager implementation: {}", impl);
     DynConstructors.Ctor<AuthManager> ctor;

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -290,17 +290,17 @@ public class OAuth2Util {
   private static Pair<String, String> parseCredential(String credential) {
     Preconditions.checkNotNull(credential, "Invalid credential: null");
     List<String> parts = CREDENTIAL_SPLITTER.splitToList(credential);
-    switch (parts.size()) {
-      case 2:
-        // client ID and client secret
-        return Pair.of(parts.get(0), parts.get(1));
-      case 1:
-        // client secret
-        return Pair.of(null, parts.get(0));
-      default:
-        // this should never happen because the credential splitter is limited to 2
-        throw new IllegalArgumentException("Invalid credential: " + credential);
-    }
+    return switch (parts.size()) {
+      case 2 ->
+          // client ID and client secret
+          Pair.of(parts.get(0), parts.get(1));
+      case 1 ->
+          // client secret
+          Pair.of(null, parts.get(0));
+      default ->
+          // this should never happen because the credential splitter is limited to 2
+          throw new IllegalArgumentException("Invalid credential: " + credential);
+    };
   }
 
   private static Map<String, String> clientCredentialsRequest(

--- a/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
@@ -48,7 +48,7 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
   public static <P, T> T visit(
       Type type, P partner, SchemaWithPartnerVisitor<P, T> visitor, PartnerAccessors<P> accessors) {
     switch (type.typeId()) {
-      case STRUCT:
+      case STRUCT -> {
         Types.StructType struct = type.asNestedType().asStructType();
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
         for (Types.NestedField field : struct.fields()) {
@@ -66,8 +66,8 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
           results.add(visitor.field(field, fieldPartner, result));
         }
         return visitor.struct(struct, partner, results);
-
-      case LIST:
+      }
+      case LIST -> {
         Types.ListType list = type.asNestedType().asListType();
         T elementResult;
 
@@ -81,8 +81,8 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
         }
 
         return visitor.list(list, partner, elementResult);
-
-      case MAP:
+      }
+      case MAP -> {
         Types.MapType map = type.asNestedType().asMapType();
         T keyResult;
         T valueResult;
@@ -106,12 +106,13 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
         }
 
         return visitor.map(map, partner, keyResult, valueResult);
-
-      case VARIANT:
+      }
+      case VARIANT -> {
         return visitor.variant(type.asVariantType(), partner);
-
-      default:
+      }
+      default -> {
         return visitor.primitive(type.asPrimitiveType(), partner);
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/schema/SchemaWithPartnerVisitor.java
@@ -47,7 +47,7 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
 
   public static <P, T> T visit(
       Type type, P partner, SchemaWithPartnerVisitor<P, T> visitor, PartnerAccessors<P> accessors) {
-    switch (type.typeId()) {
+    return switch (type.typeId()) {
       case STRUCT -> {
         Types.StructType struct = type.asNestedType().asStructType();
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
@@ -65,7 +65,7 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
           }
           results.add(visitor.field(field, fieldPartner, result));
         }
-        return visitor.struct(struct, partner, results);
+        yield visitor.struct(struct, partner, results);
       }
       case LIST -> {
         Types.ListType list = type.asNestedType().asListType();
@@ -80,7 +80,7 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
           visitor.afterListElement(elementField, partnerElement);
         }
 
-        return visitor.list(list, partner, elementResult);
+        yield visitor.list(list, partner, elementResult);
       }
       case MAP -> {
         Types.MapType map = type.asNestedType().asMapType();
@@ -105,15 +105,11 @@ public abstract class SchemaWithPartnerVisitor<P, R> {
           visitor.afterMapValue(valueField, valuePartner);
         }
 
-        return visitor.map(map, partner, keyResult, valueResult);
+        yield visitor.map(map, partner, keyResult, valueResult);
       }
-      case VARIANT -> {
-        return visitor.variant(type.asVariantType(), partner);
-      }
-      default -> {
-        return visitor.primitive(type.asPrimitiveType(), partner);
-      }
-    }
+      case VARIANT -> visitor.variant(type.asVariantType(), partner);
+      default -> visitor.primitive(type.asPrimitiveType(), partner);
+    };
   }
 
   public void beforeField(Types.NestedField field, P partnerField) {}

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -82,132 +82,106 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
 
   @Override
   public int sizeInBytes() {
-    switch (type()) {
-      case NULL, BOOLEAN_TRUE, BOOLEAN_FALSE -> {
-        return 1; // 1 header only
-      }
-      case INT8 -> {
-        return 2; // 1 header + 1 value
-      }
-      case INT16 -> {
-        return 3; // 1 header + 2 value
-      }
-      case INT32, DATE, FLOAT -> {
-        return 5; // 1 header + 4 value
-      }
-      case INT64,
-          DOUBLE,
-          TIMESTAMPTZ,
-          TIMESTAMPNTZ,
-          TIMESTAMPTZ_NANOS,
-          TIMESTAMPNTZ_NANOS,
-          TIME -> {
-        return 9; // 1 header + 8 value
-      }
-      case DECIMAL4 -> {
-        return 6; // 1 header + 1 scale + 4 unscaled value
-      }
-      case DECIMAL8 -> {
-        return 10; // 1 header + 1 scale + 8 unscaled value
-      }
-      case DECIMAL16 -> {
-        return 18; // 1 header + 1 scale + 16 unscaled value
-      }
-      case BINARY -> {
-        return 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
-      }
+    return switch (type()) {
+      case NULL, BOOLEAN_TRUE, BOOLEAN_FALSE -> 1; // 1 header only
+      case INT8 -> 2; // 1 header + 1 value
+      case INT16 -> 3; // 1 header + 2 value
+      case INT32, DATE, FLOAT -> 5; // 1 header + 4 value
+      case INT64, DOUBLE, TIMESTAMPTZ, TIMESTAMPNTZ, TIMESTAMPTZ_NANOS, TIMESTAMPNTZ_NANOS, TIME ->
+          9; // 1 header + 8 value
+      case DECIMAL4 -> 6; // 1 header + 1 scale + 4 unscaled value
+      case DECIMAL8 -> 10; // 1 header + 1 scale + 8 unscaled value
+      case DECIMAL16 -> 18; // 1 header + 1 scale + 16 unscaled value
+      case BINARY -> 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
       case STRING -> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
         if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
-          return 1 + buffer.remaining(); // 1 header + value length
+          yield 1 + buffer.remaining(); // 1 header + value length
         }
-        return 5 + buffer.remaining(); // 1 header + 4 length + value length
+        yield 5 + buffer.remaining(); // 1 header + 4 length + value length
       }
-      case UUID -> {
-        return 1 + 16; // 1 header + 16 length
-      }
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+      case UUID -> 1 + 16; // 1 header + 16 length
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+    };
   }
 
   @Override
   public int writeTo(ByteBuffer outBuffer, int offset) {
     Preconditions.checkArgument(
         outBuffer.order() == ByteOrder.LITTLE_ENDIAN, "Invalid byte order: big endian");
-    switch (type()) {
+    return switch (type()) {
       case NULL -> {
         outBuffer.put(offset, NULL_HEADER);
-        return 1;
+        yield 1;
       }
       case BOOLEAN_TRUE -> {
         outBuffer.put(offset, TRUE_HEADER);
-        return 1;
+        yield 1;
       }
       case BOOLEAN_FALSE -> {
         outBuffer.put(offset, FALSE_HEADER);
-        return 1;
+        yield 1;
       }
       case INT8 -> {
         outBuffer.put(offset, INT8_HEADER);
         outBuffer.put(offset + 1, (Byte) value);
-        return 2;
+        yield 2;
       }
       case INT16 -> {
         outBuffer.put(offset, INT16_HEADER);
         outBuffer.putShort(offset + 1, (Short) value);
-        return 3;
+        yield 3;
       }
       case INT32 -> {
         outBuffer.put(offset, INT32_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
-        return 5;
+        yield 5;
       }
       case INT64 -> {
         outBuffer.put(offset, INT64_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case FLOAT -> {
         outBuffer.put(offset, FLOAT_HEADER);
         outBuffer.putFloat(offset + 1, (Float) value);
-        return 5;
+        yield 5;
       }
       case DOUBLE -> {
         outBuffer.put(offset, DOUBLE_HEADER);
         outBuffer.putDouble(offset + 1, (Double) value);
-        return 9;
+        yield 9;
       }
       case DATE -> {
         outBuffer.put(offset, DATE_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
-        return 5;
+        yield 5;
       }
       case TIMESTAMPTZ -> {
         outBuffer.put(offset, TIMESTAMPTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case TIMESTAMPNTZ -> {
         outBuffer.put(offset, TIMESTAMPNTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case DECIMAL4 -> {
         BigDecimal decimal4 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL4_HEADER);
         outBuffer.put(offset + 1, (byte) decimal4.scale());
         outBuffer.putInt(offset + 2, decimal4.unscaledValue().intValueExact());
-        return 6;
+        yield 6;
       }
       case DECIMAL8 -> {
         BigDecimal decimal8 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL8_HEADER);
         outBuffer.put(offset + 1, (byte) decimal8.scale());
         outBuffer.putLong(offset + 2, decimal8.unscaledValue().longValueExact());
-        return 10;
+        yield 10;
       }
       case DECIMAL16 -> {
         BigDecimal decimal16 = (BigDecimal) value;
@@ -224,14 +198,14 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
             outBuffer.put(offset + 2 + i, padding);
           }
         }
-        return 18;
+        yield 18;
       }
       case BINARY -> {
         ByteBuffer binary = (ByteBuffer) value;
         outBuffer.put(offset, BINARY_HEADER);
         outBuffer.putInt(offset + 1, binary.remaining());
         outBuffer.put(offset + 5, binary, binary.position(), binary.remaining());
-        return 5 + binary.remaining();
+        yield 5 + binary.remaining();
       }
       case STRING -> {
         if (null == buffer) {
@@ -240,38 +214,37 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
         if (buffer.remaining() <= MAX_SHORT_STRING_LENGTH) {
           outBuffer.put(offset, VariantUtil.shortStringHeader(buffer.remaining()));
           outBuffer.put(offset + 1, buffer, buffer.position(), buffer.remaining());
-          return 1 + buffer.remaining();
+          yield 1 + buffer.remaining();
         } else {
           outBuffer.put(offset, STRING_HEADER);
           outBuffer.putInt(offset + 1, buffer.remaining());
           outBuffer.put(offset + 5, buffer, buffer.position(), buffer.remaining());
-          return 5 + buffer.remaining();
+          yield 5 + buffer.remaining();
         }
       }
       case TIME -> {
         outBuffer.put(offset, TIME_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case TIMESTAMPTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case TIMESTAMPNTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPNTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
-        return 9;
+        yield 9;
       }
       case UUID -> {
         outBuffer.put(offset, UUID_HEADER);
         ByteBuffer uuidBuffer = UUIDUtil.convertToByteBuffer((UUID) value);
         outBuffer.put(offset + 1, uuidBuffer, uuidBuffer.position(), uuidBuffer.remaining());
-        return 17;
+        yield 17;
       }
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type());
+    };
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -83,35 +83,40 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   @Override
   public int sizeInBytes() {
     switch (type()) {
-      case NULL:
-      case BOOLEAN_TRUE:
-      case BOOLEAN_FALSE:
+      case NULL, BOOLEAN_TRUE, BOOLEAN_FALSE -> {
         return 1; // 1 header only
-      case INT8:
+      }
+      case INT8 -> {
         return 2; // 1 header + 1 value
-      case INT16:
+      }
+      case INT16 -> {
         return 3; // 1 header + 2 value
-      case INT32:
-      case DATE:
-      case FLOAT:
+      }
+      case INT32, DATE, FLOAT -> {
         return 5; // 1 header + 4 value
-      case INT64:
-      case DOUBLE:
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-      case TIME:
+      }
+      case INT64,
+          DOUBLE,
+          TIMESTAMPTZ,
+          TIMESTAMPNTZ,
+          TIMESTAMPTZ_NANOS,
+          TIMESTAMPNTZ_NANOS,
+          TIME -> {
         return 9; // 1 header + 8 value
-      case DECIMAL4:
+      }
+      case DECIMAL4 -> {
         return 6; // 1 header + 1 scale + 4 unscaled value
-      case DECIMAL8:
+      }
+      case DECIMAL8 -> {
         return 10; // 1 header + 1 scale + 8 unscaled value
-      case DECIMAL16:
+      }
+      case DECIMAL16 -> {
         return 18; // 1 header + 1 scale + 16 unscaled value
-      case BINARY:
+      }
+      case BINARY -> {
         return 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
-      case STRING:
+      }
+      case STRING -> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
@@ -119,8 +124,10 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
           return 1 + buffer.remaining(); // 1 header + value length
         }
         return 5 + buffer.remaining(); // 1 header + 4 length + value length
-      case UUID:
+      }
+      case UUID -> {
         return 1 + 16; // 1 header + 16 length
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported primitive type: " + type());
@@ -131,64 +138,78 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
     Preconditions.checkArgument(
         outBuffer.order() == ByteOrder.LITTLE_ENDIAN, "Invalid byte order: big endian");
     switch (type()) {
-      case NULL:
+      case NULL -> {
         outBuffer.put(offset, NULL_HEADER);
         return 1;
-      case BOOLEAN_TRUE:
+      }
+      case BOOLEAN_TRUE -> {
         outBuffer.put(offset, TRUE_HEADER);
         return 1;
-      case BOOLEAN_FALSE:
+      }
+      case BOOLEAN_FALSE -> {
         outBuffer.put(offset, FALSE_HEADER);
         return 1;
-      case INT8:
+      }
+      case INT8 -> {
         outBuffer.put(offset, INT8_HEADER);
         outBuffer.put(offset + 1, (Byte) value);
         return 2;
-      case INT16:
+      }
+      case INT16 -> {
         outBuffer.put(offset, INT16_HEADER);
         outBuffer.putShort(offset + 1, (Short) value);
         return 3;
-      case INT32:
+      }
+      case INT32 -> {
         outBuffer.put(offset, INT32_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
         return 5;
-      case INT64:
+      }
+      case INT64 -> {
         outBuffer.put(offset, INT64_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case FLOAT:
+      }
+      case FLOAT -> {
         outBuffer.put(offset, FLOAT_HEADER);
         outBuffer.putFloat(offset + 1, (Float) value);
         return 5;
-      case DOUBLE:
+      }
+      case DOUBLE -> {
         outBuffer.put(offset, DOUBLE_HEADER);
         outBuffer.putDouble(offset + 1, (Double) value);
         return 9;
-      case DATE:
+      }
+      case DATE -> {
         outBuffer.put(offset, DATE_HEADER);
         outBuffer.putInt(offset + 1, (Integer) value);
         return 5;
-      case TIMESTAMPTZ:
+      }
+      case TIMESTAMPTZ -> {
         outBuffer.put(offset, TIMESTAMPTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case TIMESTAMPNTZ:
+      }
+      case TIMESTAMPNTZ -> {
         outBuffer.put(offset, TIMESTAMPNTZ_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case DECIMAL4:
+      }
+      case DECIMAL4 -> {
         BigDecimal decimal4 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL4_HEADER);
         outBuffer.put(offset + 1, (byte) decimal4.scale());
         outBuffer.putInt(offset + 2, decimal4.unscaledValue().intValueExact());
         return 6;
-      case DECIMAL8:
+      }
+      case DECIMAL8 -> {
         BigDecimal decimal8 = (BigDecimal) value;
         outBuffer.put(offset, DECIMAL8_HEADER);
         outBuffer.put(offset + 1, (byte) decimal8.scale());
         outBuffer.putLong(offset + 2, decimal8.unscaledValue().longValueExact());
         return 10;
-      case DECIMAL16:
+      }
+      case DECIMAL16 -> {
         BigDecimal decimal16 = (BigDecimal) value;
         byte padding = (byte) (decimal16.signum() < 0 ? 0xFF : 0x00);
         byte[] bytes = decimal16.unscaledValue().toByteArray();
@@ -204,13 +225,15 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
           }
         }
         return 18;
-      case BINARY:
+      }
+      case BINARY -> {
         ByteBuffer binary = (ByteBuffer) value;
         outBuffer.put(offset, BINARY_HEADER);
         outBuffer.putInt(offset + 1, binary.remaining());
         outBuffer.put(offset + 5, binary, binary.position(), binary.remaining());
         return 5 + binary.remaining();
-      case STRING:
+      }
+      case STRING -> {
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
         }
@@ -224,23 +247,28 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
           outBuffer.put(offset + 5, buffer, buffer.position(), buffer.remaining());
           return 5 + buffer.remaining();
         }
-      case TIME:
+      }
+      case TIME -> {
         outBuffer.put(offset, TIME_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case TIMESTAMPTZ_NANOS:
+      }
+      case TIMESTAMPTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case TIMESTAMPNTZ_NANOS:
+      }
+      case TIMESTAMPNTZ_NANOS -> {
         outBuffer.put(offset, TIMESTAMPNTZ_NANOS_HEADER);
         outBuffer.putLong(offset + 1, (Long) value);
         return 9;
-      case UUID:
+      }
+      case UUID -> {
         outBuffer.put(offset, UUID_HEADER);
         ByteBuffer uuidBuffer = UUIDUtil.convertToByteBuffer((UUID) value);
         outBuffer.put(offset + 1, uuidBuffer, uuidBuffer.position(), uuidBuffer.remaining());
         return 17;
+      }
     }
 
     throw new UnsupportedOperationException("Unsupported primitive type: " + type());

--- a/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
@@ -47,7 +47,7 @@ public class VariantVisitor<R> {
   }
 
   public static <R> R visit(VariantValue value, VariantVisitor<R> visitor) {
-    switch (value.type()) {
+    return switch (value.type()) {
       case ARRAY -> {
         VariantArray array = value.asArray();
         List<R> elementResults = Lists.newArrayList();
@@ -60,7 +60,7 @@ public class VariantVisitor<R> {
           }
         }
 
-        return visitor.array(array, elementResults);
+        yield visitor.array(array, elementResults);
       }
       case OBJECT -> {
         VariantObject object = value.asObject();
@@ -76,11 +76,9 @@ public class VariantVisitor<R> {
           }
         }
 
-        return visitor.object(object, fieldNames, fieldResults);
+        yield visitor.object(object, fieldNames, fieldResults);
       }
-      default -> {
-        return visitor.primitive(value.asPrimitive());
-      }
-    }
+      default -> visitor.primitive(value.asPrimitive());
+    };
   }
 }

--- a/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
+++ b/core/src/main/java/org/apache/iceberg/variants/VariantVisitor.java
@@ -48,7 +48,7 @@ public class VariantVisitor<R> {
 
   public static <R> R visit(VariantValue value, VariantVisitor<R> visitor) {
     switch (value.type()) {
-      case ARRAY:
+      case ARRAY -> {
         VariantArray array = value.asArray();
         List<R> elementResults = Lists.newArrayList();
         for (int index = 0; index < array.numElements(); index += 1) {
@@ -61,8 +61,8 @@ public class VariantVisitor<R> {
         }
 
         return visitor.array(array, elementResults);
-
-      case OBJECT:
+      }
+      case OBJECT -> {
         VariantObject object = value.asObject();
         List<String> fieldNames = Lists.newArrayList();
         List<R> fieldResults = Lists.newArrayList();
@@ -77,9 +77,10 @@ public class VariantVisitor<R> {
         }
 
         return visitor.object(object, fieldNames, fieldResults);
-
-      default:
+      }
+      default -> {
         return visitor.primitive(value.asPrimitive());
+      }
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
@@ -34,14 +34,12 @@ class ViewRepresentationParser {
       throws IOException {
     Preconditions.checkArgument(representation != null, "Invalid view representation: null");
     switch (representation.type().toLowerCase(Locale.ENGLISH)) {
-      case ViewRepresentation.Type.SQL:
-        SQLViewRepresentationParser.toJson((SQLViewRepresentation) representation, generator);
-        break;
-
-      default:
-        throw new UnsupportedOperationException(
-            String.format(
-                "Cannot serialize unsupported view representation: %s", representation.type()));
+      case ViewRepresentation.Type.SQL ->
+          SQLViewRepresentationParser.toJson((SQLViewRepresentation) representation, generator);
+      default ->
+          throw new UnsupportedOperationException(
+              String.format(
+                  "Cannot serialize unsupported view representation: %s", representation.type()));
     }
   }
 
@@ -58,12 +56,9 @@ class ViewRepresentationParser {
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse view representation from non-object: %s", node);
     String type = JsonUtil.getString(TYPE, node).toLowerCase(Locale.ENGLISH);
-    switch (type) {
-      case ViewRepresentation.Type.SQL:
-        return SQLViewRepresentationParser.fromJson(node);
-
-      default:
-        return ImmutableUnknownViewRepresentation.builder().type(type).build();
-    }
+    return switch (type) {
+      case ViewRepresentation.Type.SQL -> SQLViewRepresentationParser.fromJson(node);
+      default -> ImmutableUnknownViewRepresentation.builder().type(type).build();
+    };
   }
 }


### PR DESCRIPTION
Continues [#15494](https://github.com/apache/iceberg/pull/15494) (@mxm) and [#15176](https://github.com/apache/iceberg/pull/15176) (@manuzhang)

## Summary

Converts statement-form `switch` blocks in `iceberg-core` to expression-form (arrow syntax). Eliminates `StatementSwitchToExpressionSwitch` ErrorProne warnings and removes the risk of accidental fall-through in the converted code.

## Rationale for the change

Per the [[DISCUSS] Switching to new switches](https://lists.apache.org/thread/k2cg9v6rxs8lb74qbok166k68h1r0f3k) dev list thread, consensus was option 2
(merge sweeping syntax changes shortly before the release). Targeting 1.12.

## Changes

- `iceberg-core` only. Pattern-matching for `instanceof` - I'll create a separate follow-up PR.
- The diff was generated by ErrorProne's auto-patcher (`-XepPatchChecks:StatementSwitchToExpressionSwitch -XepPatchLocation:IN_PLACE`), then `spotlessApply`, plus a small manual cleanup in `PrimitiveWrapper.sizeInBytes()` to keep trailing comments inline.
- `SingleValueParser.fromJson` was annotated `@SuppressWarnings("MethodLength")` because the arrow-form blocks push it past the 150-line checkstyle limit. Should be refactored later but out of scope for a mechanical syntax migration.

## Test 
- locally ran the core tests