### PR TITLE
Azure: Fix ADLSInputStream.readTail for length over file size

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
@@ -189,7 +189,7 @@ class ADLSInputStream extends SeekableInputStream implements RangeReadable {
     if (this.fileSize == null) {
       this.fileSize = fileClient.getProperties().getFileSize();
     }
-    long readStart = fileSize - length;
+    long readStart = Math.max(0, fileSize - length);
 
     try (InputStream inputStream = openRange(new FileRange(readStart)).getInputStream()) {
       return IOUtil.readRemaining(inputStream, buffer, offset, length);

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
@@ -123,4 +123,27 @@ class TestADLSInputStream {
 
     verify(inputStream).close();
   }
+
+  @Test
+  void testReadTailLengthLargerThanFileSize() throws IOException {
+    byte[] data = new byte[] {1, 2, 3};
+    InputStream byteStream = new ByteArrayInputStream(data);
+    InternalDataLakeFileOpenInputStreamResult openInputStreamResult =
+        new InternalDataLakeFileOpenInputStreamResult(byteStream, mock());
+    when(fileClient.openInputStream(any())).thenReturn(openInputStreamResult);
+
+    try (ADLSInputStream in =
+        new ADLSInputStream(
+            "abfs://container@account.dfs.core.windows.net/path/to/file",
+            fileClient,
+            3L,
+            mock(),
+            MetricsContext.nullMetrics())) {
+
+      byte[] actual = new byte[10];
+      int bytesRead = in.readTail(actual, 0, 10);
+      assertThat(bytesRead).isEqualTo(3);
+      assertThat(Arrays.copyOfRange(actual, 0, bytesRead)).isEqualTo(data);
+    }
+  }
 }


### PR DESCRIPTION
<!-- No issue: minor parity bug fix, issue not required -->

## Summary

- `ADLSInputStream.readTail(buffer, offset, length)` computes the read start as `fileSize - length`. When the requested tail `length` exceeds the file size, that start goes negative and Azure SDK `FileRange` rejects it with `IllegalArgumentException`, so reading the tail of a small file fails.
- Clamp the start to `0` with `Math.max(0, fileSize - length)`, so the whole file is read and the actual number of bytes read is returned, per the `RangeReadable.readTail` contract.
- This matches the sibling `GCSInputStream.readTail`, which already clamps the same way (`gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java`). `S3InputStream` is unaffected because it uses an HTTP suffix range (`bytes=-{length}`).
- Reached in practice through `ParquetIO`, which delegates `readTail` to the cloud stream when prefetching the Parquet footer of a small file.

## Testing done

- Added `TestADLSInputStream#testReadTailLengthLargerThanFileSize`, asserting a `readTail` with `length` greater than the file size reads the whole file and returns its size (fails before the fix).
- `./gradlew :iceberg-azure:test --tests "org.apache.iceberg.azure.adlsv2.TestADLSInputStream"` — 5 tests passed.
- `./gradlew :iceberg-azure:spotlessCheck :iceberg-azure:checkstyleMain :iceberg-azure:checkstyleTest` — passed.
- Full `:iceberg-azure:check` not run locally: it pulls Azurite/Docker integration tests. Unit tests, spotless, and checkstyle were run separately.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
