### PR TITLE
Common: Preserve original exception in DynConstructors.Ctor.newInstance

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -64,7 +64,7 @@ public class DynConstructors {
         return newInstanceChecked(args);
       } catch (Exception e) {
         Throwables.throwIfInstanceOf(e, RuntimeException.class);
-        throw new RuntimeException(e.getCause());
+        throw new RuntimeException(e);
       }
     }
 

--- a/common/src/test/java/org/apache/iceberg/common/TestDynConstructors.java
+++ b/common/src/test/java/org/apache/iceberg/common/TestDynConstructors.java
@@ -77,9 +77,22 @@ public class TestDynConstructors {
     assertThat(ctor.newInstance()).isInstanceOf(MyClass.class);
   }
 
+  @Test
+  public void testNewInstancePreservesInstantiationException() throws Exception {
+    DynConstructors.Ctor<MyAbstractClass> ctor =
+        DynConstructors.builder().hiddenImpl(MyAbstractClass.class).buildChecked();
+    assertThatThrownBy(ctor::newInstance)
+        .isInstanceOf(RuntimeException.class)
+        .hasMessageContaining("InstantiationException")
+        .cause()
+        .isInstanceOf(InstantiationException.class);
+  }
+
   public interface MyInterface {}
 
   public static class MyClass implements MyInterface {}
 
   public static class MyUnrelatedClass {}
+
+  public abstract static class MyAbstractClass {}
 }


### PR DESCRIPTION
## Summary

- `Ctor.newInstance` wrapped `e.getCause()` in a `RuntimeException`, but `newInstanceChecked` rethrows `InstantiationException`/`IllegalAccessException` with no cause (`throw e`), so the wrapper got a null cause and the original exception was lost as `RuntimeException: null`.
- Wrap the caught exception `e` directly, preserving the original as the cause — matching the sibling `DynMethods.UnboundMethod.invoke`, which wraps `e` via `Throwables.propagate(e)`.
- Regression from PR #10542 (commit c469edf6c), which replaced `Throwables.propagate(e)` with `new RuntimeException(e.getCause())`.
- The `InvocationTargetException` branch in `newInstanceChecked` intentionally uses `e.getCause()` and is left unchanged.

## Testing done

- Added `TestDynConstructors#testNewInstancePreservesInstantiationException`: builds a `Ctor` for an abstract class and asserts the thrown `RuntimeException` carries the `InstantiationException` as its cause. Fails before the fix (null cause), passes after.
- `./gradlew :iceberg-common:check` — green, 6 tests in TestDynConstructors.
- `./gradlew :iceberg-common:revapi` — passed (no signature change).

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
