### PR TITLE
BigQuery: Only load table metadata when dropping with purge

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.catalog.SupportsNamespaces;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
@@ -183,7 +184,17 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
   public boolean dropTable(TableIdentifier identifier, boolean purge) {
     try {
       TableOperations ops = newTableOps(identifier);
-      TableMetadata lastMetadata = ops.current();
+      TableMetadata lastMetadata = null;
+      if (purge) {
+        try {
+          lastMetadata = ops.current();
+        } catch (NotFoundException e) {
+          LOG.warn(
+              "Failed to load table metadata for table: {}, continuing drop without purge",
+              identifier,
+              e);
+        }
+      }
 
       client.delete(toTableReference(identifier));
 

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryTableOperations.java
@@ -26,6 +26,7 @@ import static org.assertj.core.api.Assertions.assertThatNoException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -242,6 +243,29 @@ public class TestBigQueryTableOperations {
     assertThat(loadedTable).isNotNull();
     assertThat(loadedTable.name()).isEqualTo(catalog.name() + "." + IDENTIFIER);
     assertThat(loadedTable.schema().asStruct()).isEqualTo(SCHEMA.asStruct());
+  }
+
+  @Test
+  public void dropTableWithoutPurgeDoesNotLoadMetadata() {
+    catalog.dropTable(IDENTIFIER, false);
+
+    // A plain drop must not trigger a tables.get on BigQuery, since the metadata is only needed for
+    // purge.
+    verify(client, never()).load(TABLE_REFERENCE);
+    verify(client, times(1)).delete(TABLE_REFERENCE);
+  }
+
+  @Test
+  public void dropTableWithPurgeLoadsMetadata() throws Exception {
+    Table createdTable = createTestTable();
+    reset(client);
+    when(client.load(TABLE_REFERENCE)).thenReturn(createdTable);
+
+    catalog.dropTable(IDENTIFIER, true);
+
+    // Purge needs the current metadata to delete the table's data files, so it must load it.
+    verify(client, times(1)).load(TABLE_REFERENCE);
+    verify(client, times(1)).delete(TABLE_REFERENCE);
   }
 
   /** Creates a test table to have Iceberg metadata files in place. */


### PR DESCRIPTION
<!-- No issue: minor bug fix / parity, issue not required (PR-only) -->

## Summary

- `BigQueryMetastoreCatalog.dropTable` always called `ops.current()` before checking `purge`.
- The first `ops.current()` triggers `doRefresh()` -> `client.load()` (a BigQuery `tables.get` call) plus a metadata file read.
- For a plain drop (`purge=false`) that load is wasted, since `lastMetadata` is only used when purging data.
- Load the metadata only when `purge` is true, tolerating a `NotFoundException` by continuing the drop without purge.
- This matches `GlueCatalog.dropTable` and `HiveCatalog.dropTable`, which already guard the load behind `purge`.

## Testing done

- Added `TestBigQueryTableOperations#dropTableWithoutPurgeDoesNotLoadMetadata` asserting `verify(client, never()).load(...)` for a plain drop.
- Added `TestBigQueryTableOperations#dropTableWithPurgeLoadsMetadata` asserting the metadata is still loaded when `purge=true`.
- `./gradlew :iceberg-bigquery:check` — passed, 125 tests (0 failures, 23 pre-existing `@Disabled` skips); `TestBigQueryTableOperations` now has 10 tests.
- REVAPI not applicable: `iceberg-bigquery` is not a REVAPI-published module.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
