### PR TITLE
Dell: Fix EcsURI null-location check that never triggers

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsURI.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsURI.java
@@ -35,7 +35,7 @@ class EcsURI {
   private final String name;
 
   EcsURI(String location) {
-    Preconditions.checkNotNull(location == null, "Location %s can not be null", location);
+    Preconditions.checkNotNull(location, "Location %s can not be null", location);
 
     this.location = location;
 

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsURI.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsURI.java
@@ -35,7 +35,7 @@ class EcsURI {
   private final String name;
 
   EcsURI(String location) {
-    Preconditions.checkNotNull(location, "Location %s can not be null", location);
+    Preconditions.checkNotNull(location, "Location can not be null");
 
     this.location = location;
 

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
@@ -59,4 +59,11 @@ public class TestEcsURI {
         .isInstanceOf(ValidationException.class)
         .hasMessage("Invalid ecs location: http://bucket/a");
   }
+
+  @Test
+  public void testNullLocation() {
+    assertThatThrownBy(() -> new EcsURI((String) null))
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("can not be null");
+  }
 }

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsURI.java
@@ -62,8 +62,8 @@ public class TestEcsURI {
 
   @Test
   public void testNullLocation() {
-    assertThatThrownBy(() -> new EcsURI((String) null))
+    assertThatThrownBy(() -> new EcsURI(null))
         .isInstanceOf(NullPointerException.class)
-        .hasMessageContaining("can not be null");
+        .hasMessage("Location can not be null");
   }
 }


### PR DESCRIPTION
<!-- No issue: minor bug fix, issue not required -->

## Summary

- `EcsURI(String location)` passed the boolean `location == null` to `Preconditions.checkNotNull`, whose first argument is the reference to null-check — so the autoboxed `Boolean` was always non-null and the guard never fired.
- When `location` was null the check passed and `URI.create(location)` threw a `NullPointerException` with no message.
- Fix: pass `location` itself so the intended null check runs and yields the "Location ... can not be null" message.
- The sibling `S3URI` constructor in the AWS module already validates its location up front: https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/s3/S3URI.java

## Testing done

- Added `TestEcsURI#testNullLocation` covering a null location input.
- Verified the regression: before the fix this test fails (the unguarded NPE from `URI.create(null)` has no "can not be null" message); after the fix it passes.
- `./gradlew :iceberg-dell:check` — passed, TestEcsURI runs 4 tests (test + spotlessCheck + checkstyle + errorProne).

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix the `EcsURI` null-location check that could never trigger, with a test.
