### PR TITLE
Delta: Fix invalid @Returns Javadoc tag in SnapshotDeltaLakeTable

### DIFF
--- a/delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java
@@ -62,7 +62,8 @@ public interface SnapshotDeltaLakeTable
    * Sets the identifier of the newly created Iceberg table. This is required to be set before
    * execute the action.
    *
-   * @param identifier a table identifier (namespace, name) @Returns this for method chaining
+   * @param identifier a table identifier (namespace, name)
+   * @return this for method chaining
    */
   SnapshotDeltaLakeTable as(TableIdentifier identifier);
 
@@ -70,7 +71,8 @@ public interface SnapshotDeltaLakeTable
    * Sets the catalog of the newly created Iceberg table. This is required to be set before execute
    * the action
    *
-   * @param catalog a catalog @Returns this for method chaining
+   * @param catalog a catalog
+   * @return this for method chaining
    */
   SnapshotDeltaLakeTable icebergCatalog(Catalog catalog);
 
@@ -78,7 +80,8 @@ public interface SnapshotDeltaLakeTable
    * Sets the Hadoop configuration used to access delta lake table's logs and datafiles. This is
    * required to be set before execute the action.
    *
-   * @param conf a Hadoop configuration @Returns this for method chaining
+   * @param conf a Hadoop configuration
+   * @return this for method chaining
    */
   SnapshotDeltaLakeTable deltaLakeConfiguration(Configuration conf);
 


### PR DESCRIPTION
<!-- No issue: minor docs fix, issue not required -->

## Summary

- The `as`, `icebergCatalog`, and `deltaLakeConfiguration` builder methods appended `@Returns this for method chaining` to their `@param` line.
- `@Returns` is not a valid Javadoc tag, so the return value was never documented.
- Replaced it with a `@return this for method chaining` line, matching the sibling methods `tableProperties`, `tableProperty`, and `tableLocation` in the same interface (lines 38, 48, 57), which already use `@return` on its own line.
- File: `delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java`.

## Testing done

- Docs/comment-only change, no behavior change — no test added. `./gradlew :iceberg-delta-lake:spotlessCheck` passed.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Correct the invalid `@Returns` Javadoc tag in `SnapshotDeltaLakeTable`.
