### PR TITLE
Spark: Fail fast when table metadata file location is null in BaseSparkAction

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -135,8 +135,13 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
+    String metadataFileLocation = metadata.metadataFileLocation();
+    ValidationException.check(
+        metadataFileLocation != null,
+        "Table metadata file location is null. This may indicate an invalid table metadata "
+            + "response, such as a missing metadata-location field from a REST catalog.");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
-    return new BaseTable(ops, metadata.metadataFileLocation());
+    return new BaseTable(ops, metadataFileLocation);
   }
 
   protected Table newStaticTable(String metadataFileLocation, FileIO io) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -135,8 +135,13 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
+    String metadataFileLocation = metadata.metadataFileLocation();
+    ValidationException.check(
+        metadataFileLocation != null,
+        "Table metadata file location is null. This may indicate an invalid table metadata "
+            + "response, such as a missing metadata-location field from a REST catalog.");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
-    return new BaseTable(ops, metadata.metadataFileLocation());
+    return new BaseTable(ops, metadataFileLocation);
   }
 
   protected Table newStaticTable(String metadataFileLocation, FileIO io) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/BaseSparkAction.java
@@ -135,8 +135,13 @@ abstract class BaseSparkAction<ThisT> {
   }
 
   protected Table newStaticTable(TableMetadata metadata, FileIO io) {
+    String metadataFileLocation = metadata.metadataFileLocation();
+    ValidationException.check(
+        metadataFileLocation != null,
+        "Table metadata file location is null. This may indicate an invalid table metadata "
+            + "response, such as a missing metadata-location field from a REST catalog.");
     StaticTableOperations ops = new StaticTableOperations(metadata, io);
-    return new BaseTable(ops, metadata.metadataFileLocation());
+    return new BaseTable(ops, metadataFileLocation);
   }
 
   protected Table newStaticTable(String metadataFileLocation, FileIO io) {


### PR DESCRIPTION
Fixes #16838

## Problem

`ExpireSnapshotsSparkAction` fails with an opaque `NullPointerException` when `TableMetadata.metadataFileLocation()` returns `null`. This can happen when a REST catalog returns an invalid or incomplete table metadata response (e.g. using `metadata_location` instead of the expected `metadata-location` field name). Normal table reads continue to work because Iceberg can discover the current metadata through the table location, but after a successful `remove-snapshots` commit, `ExpireSnapshotsSparkAction` reloads the table and constructs a static table via `BaseSparkAction.newStaticTable()`. Since `metadata.metadataFileLocation()` is `null`, the resulting `BaseTable` is created with a `null` metadata location, which later causes an unexpected `NullPointerException` deep inside the Spark job execution — making the root cause very difficult to identify.

## What changed

Added an explicit null check in `BaseSparkAction.newStaticTable(TableMetadata, FileIO)` that throws a descriptive `ValidationException` when `metadata.metadataFileLocation()` is `null`, instead of silently proceeding and failing later with an unrelated NPE. The change was applied consistently across all three Spark version modules (v3.5, v4.0, v4.1).

The error message clearly explains that a null metadata file location may indicate an invalid REST catalog response or a missing `metadata-location` field, helping users quickly diagnose the root cause.

## Validation

- Verified the fix compiles and the null check triggers a `ValidationException` with a descriptive message instead of an NPE.
- Existing `ExpireSnapshots` tests continue to pass since the null check only activates when `metadataFileLocation` is genuinely `null` (which does not occur in normal operation with a correctly configured catalog).