### PR TITLE
Spark 4.1: Implement listTableSummaries

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -79,6 +79,7 @@ import org.apache.spark.sql.connector.catalog.TableChange;
 import org.apache.spark.sql.connector.catalog.TableChange.ColumnChange;
 import org.apache.spark.sql.connector.catalog.TableChange.RemoveProperty;
 import org.apache.spark.sql.connector.catalog.TableChange.SetProperty;
+import org.apache.spark.sql.connector.catalog.TableSummary;
 import org.apache.spark.sql.connector.catalog.View;
 import org.apache.spark.sql.connector.catalog.ViewChange;
 import org.apache.spark.sql.connector.catalog.ViewInfo;
@@ -366,6 +367,31 @@ public class SparkCatalog extends BaseCatalog {
     return icebergCatalog.listTables(Namespace.of(namespace)).stream()
         .map(ident -> Identifier.of(ident.namespace().levels(), ident.name()))
         .toArray(Identifier[]::new);
+  }
+
+  @Override
+  public TableSummary[] listTableSummaries(String[] namespace) {
+    // Build summaries directly from the catalog listings to avoid loading every table, which the
+    // default TableCatalog.listTableSummaries implementation would do. Iceberg tables are always
+    // reported as EXTERNAL (see SparkTable#properties), and views are reported as VIEW.
+    List<TableSummary> summaries = Lists.newArrayList();
+
+    // Collect views first. Most catalogs return only tables from listTables, but HiveCatalog with
+    // list-all-tables=true returns every metastore entry, including views. De-duplicate against the
+    // view identifiers so a view is never also reported as a table.
+    Set<Identifier> viewIdents = Sets.newHashSet(listViews(namespace));
+
+    for (Identifier ident : listTables(namespace)) {
+      if (!viewIdents.contains(ident)) {
+        summaries.add(TableSummary.of(ident, TableSummary.EXTERNAL_TABLE_TYPE));
+      }
+    }
+
+    for (Identifier ident : viewIdents) {
+      summaries.add(TableSummary.of(ident, TableSummary.VIEW_TABLE_TYPE));
+    }
+
+    return summaries.toArray(new TableSummary[0]);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -373,7 +373,7 @@ public class SparkCatalog extends BaseCatalog {
   public TableSummary[] listTableSummaries(String[] namespace) {
     // Build summaries directly from the catalog listings to avoid loading every table, which the
     // default TableCatalog.listTableSummaries implementation would do. Iceberg tables are always
-    // reported as EXTERNAL (see SparkTable#properties), and views are reported as VIEW.
+    // reported as EXTERNAL (see BaseSparkTable#properties), and views are reported as VIEW.
     List<TableSummary> summaries = Lists.newArrayList();
 
     // Collect views first. Most catalogs return only tables from listTables, but HiveCatalog with

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseSparkTable.java
@@ -40,6 +40,8 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.catalog.MetadataColumn;
 import org.apache.spark.sql.connector.catalog.SupportsMetadataColumns;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.connector.catalog.TableSummary;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 
@@ -59,7 +61,8 @@ abstract class BaseSparkTable
           LOCATION,
           FORMAT_VERSION,
           SORT_ORDER,
-          IDENTIFIER_FIELDS);
+          IDENTIFIER_FIELDS,
+          TableCatalog.PROP_TABLE_TYPE);
 
   private final Table table;
   private final Schema schema;
@@ -109,6 +112,11 @@ abstract class BaseSparkTable
     propsBuilder.put(PROVIDER, "iceberg");
     propsBuilder.put(LOCATION, table.location());
     propsBuilder.put(CURRENT_SNAPSHOT_ID, currentSnapshotId());
+
+    // Iceberg tables always have an explicit storage location and dropping a table through the
+    // catalog removes only the catalog entry unless purge is requested, which matches Spark's
+    // notion of an EXTERNAL table.
+    propsBuilder.put(TableCatalog.PROP_TABLE_TYPE, TableSummary.EXTERNAL_TABLE_TYPE);
 
     if (table instanceof BaseTable) {
       TableOperations ops = ((BaseTable) table).operations();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -20,9 +20,7 @@ package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -87,6 +85,17 @@ public class TestSparkCatalogOperations extends CatalogTestBase {
             "false", // Spark will delete tables using v1, leaving the cache out of sync
             "use-nullable-query-schema",
             Boolean.toString(USE_NULLABLE_QUERY_SCHEMA)),
+      },
+      {
+        // HiveCatalog with list-all-tables=true returns views from listTables, exercising the
+        // de-duplication guard in SparkCatalog.listTableSummaries.
+        "testhive_list_all",
+        SparkCatalog.class.getName(),
+        ImmutableMap.of(
+            "type", "hive",
+            "default-namespace", "default",
+            "list-all-tables", "true",
+            "use-nullable-query-schema", Boolean.toString(USE_NULLABLE_QUERY_SCHEMA))
       }
     };
   }
@@ -143,46 +152,27 @@ public class TestSparkCatalogOperations extends CatalogTestBase {
   @TestTemplate
   public void testListTableSummaries() throws NoSuchNamespaceException, NoSuchTableException {
     BaseCatalog catalog = (BaseCatalog) spark.sessionState().catalogManager().catalog(catalogName);
-    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+    String[] namespace = tableIdent.namespace().levels();
+    Identifier tableIdentifier = Identifier.of(namespace, tableIdent.name());
 
-    TableSummary[] summaries = catalog.listTableSummaries(tableIdent.namespace().levels());
-
-    assertThat(Arrays.stream(summaries))
-        .as("Listed table summary should report the table as EXTERNAL")
-        .anySatisfy(
-            summary -> {
-              assertThat(summary.identifier()).isEqualTo(identifier);
-              assertThat(summary.tableType()).isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
-            });
-  }
-
-  @TestTemplate
-  public void testListTableSummariesIncludesViews()
-      throws NoSuchNamespaceException, NoSuchTableException {
-    BaseCatalog catalog = (BaseCatalog) spark.sessionState().catalogManager().catalog(catalogName);
-    // Only SparkCatalog overrides listTableSummaries, and views require a view-capable catalog
-    // (e.g. Hive). Hadoop catalogs and the session catalog are skipped.
-    assumeThat(catalog).isInstanceOf(SparkCatalog.class);
-    assumeThat(validationCatalog)
-        .as("Requires a catalog that supports views")
-        .isInstanceOf(ViewCatalog.class);
-
-    // Create the view directly through the Iceberg ViewCatalog API. SQL CREATE VIEW against a v2
-    // catalog requires the Iceberg Spark extensions, which this module's tests do not load.
-    ViewCatalog viewCatalog = (ViewCatalog) validationCatalog;
+    // Views require a view-capable catalog (e.g. Hive), and only SparkCatalog overrides
+    // listTableSummaries to report them. Where that holds, create a view so the view-specific
+    // assertions exercise it; otherwise only the EXTERNAL-table assertion runs.
+    boolean supportsViews =
+        catalog instanceof SparkCatalog && validationCatalog instanceof ViewCatalog;
     TableIdentifier viewIdent = TableIdentifier.of(tableIdent.namespace(), "summary_view");
-    viewCatalog
-        .buildView(viewIdent)
-        .withSchema(new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())))
-        .withDefaultNamespace(tableIdent.namespace())
-        .withQuery("spark", "SELECT id FROM " + tableIdent.name())
-        .create();
+    if (supportsViews) {
+      // Create the view directly through the Iceberg ViewCatalog API. SQL CREATE VIEW against a v2
+      // catalog requires the Iceberg Spark extensions, which this module's tests do not load.
+      ((ViewCatalog) validationCatalog)
+          .buildView(viewIdent)
+          .withSchema(new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())))
+          .withDefaultNamespace(tableIdent.namespace())
+          .withQuery("spark", "SELECT id FROM " + tableIdent.name())
+          .create();
+    }
 
     try {
-      String[] namespace = tableIdent.namespace().levels();
-      Identifier tableIdentifier = Identifier.of(namespace, tableIdent.name());
-      Identifier viewIdentifier = Identifier.of(namespace, "summary_view");
-
       TableSummary[] summaries = catalog.listTableSummaries(namespace);
 
       assertThat(summaries)
@@ -192,14 +182,19 @@ public class TestSparkCatalogOperations extends CatalogTestBase {
           .extracting(TableSummary::tableType)
           .isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
 
-      assertThat(summaries)
-          .as("View should be reported exactly once as VIEW, never as a table")
-          .filteredOn(summary -> summary.identifier().equals(viewIdentifier))
-          .singleElement()
-          .extracting(TableSummary::tableType)
-          .isEqualTo(TableSummary.VIEW_TABLE_TYPE);
+      if (supportsViews) {
+        Identifier viewIdentifier = Identifier.of(namespace, "summary_view");
+        assertThat(summaries)
+            .as("View should be reported exactly once as VIEW, never as a table")
+            .filteredOn(summary -> summary.identifier().equals(viewIdentifier))
+            .singleElement()
+            .extracting(TableSummary::tableType)
+            .isEqualTo(TableSummary.VIEW_TABLE_TYPE);
+      }
     } finally {
-      viewCatalog.dropView(viewIdent);
+      if (supportsViews) {
+        ((ViewCatalog) validationCatalog).dropView(viewIdent);
+      }
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkCatalogOperations.java
@@ -20,20 +20,26 @@ package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.atIndex;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
+import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.catalog.ViewCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.analysis.NoSuchNamespaceException;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.connector.catalog.Column;
 import org.apache.spark.sql.connector.catalog.Identifier;
 import org.apache.spark.sql.connector.catalog.Table;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
 import org.apache.spark.sql.connector.catalog.TableChange;
+import org.apache.spark.sql.connector.catalog.TableSummary;
 import org.apache.spark.sql.types.DataTypes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -120,6 +126,81 @@ public class TestSparkCatalogOperations extends CatalogTestBase {
         .as(
             "Adding a property to a table should return the updated table with the new property with the new correct value")
         .containsEntry(propsKey, propsValue);
+  }
+
+  @TestTemplate
+  public void testTableTypeIsExternal() throws NoSuchTableException {
+    BaseCatalog catalog = (BaseCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+
+    Table table = catalog.loadTable(identifier);
+
+    assertThat(table.properties())
+        .as("Iceberg tables should report an EXTERNAL table type")
+        .containsEntry(TableCatalog.PROP_TABLE_TYPE, TableSummary.EXTERNAL_TABLE_TYPE);
+  }
+
+  @TestTemplate
+  public void testListTableSummaries() throws NoSuchNamespaceException, NoSuchTableException {
+    BaseCatalog catalog = (BaseCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    Identifier identifier = Identifier.of(tableIdent.namespace().levels(), tableIdent.name());
+
+    TableSummary[] summaries = catalog.listTableSummaries(tableIdent.namespace().levels());
+
+    assertThat(Arrays.stream(summaries))
+        .as("Listed table summary should report the table as EXTERNAL")
+        .anySatisfy(
+            summary -> {
+              assertThat(summary.identifier()).isEqualTo(identifier);
+              assertThat(summary.tableType()).isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
+            });
+  }
+
+  @TestTemplate
+  public void testListTableSummariesIncludesViews()
+      throws NoSuchNamespaceException, NoSuchTableException {
+    BaseCatalog catalog = (BaseCatalog) spark.sessionState().catalogManager().catalog(catalogName);
+    // Only SparkCatalog overrides listTableSummaries, and views require a view-capable catalog
+    // (e.g. Hive). Hadoop catalogs and the session catalog are skipped.
+    assumeThat(catalog).isInstanceOf(SparkCatalog.class);
+    assumeThat(validationCatalog)
+        .as("Requires a catalog that supports views")
+        .isInstanceOf(ViewCatalog.class);
+
+    // Create the view directly through the Iceberg ViewCatalog API. SQL CREATE VIEW against a v2
+    // catalog requires the Iceberg Spark extensions, which this module's tests do not load.
+    ViewCatalog viewCatalog = (ViewCatalog) validationCatalog;
+    TableIdentifier viewIdent = TableIdentifier.of(tableIdent.namespace(), "summary_view");
+    viewCatalog
+        .buildView(viewIdent)
+        .withSchema(new Schema(Types.NestedField.optional(1, "id", Types.LongType.get())))
+        .withDefaultNamespace(tableIdent.namespace())
+        .withQuery("spark", "SELECT id FROM " + tableIdent.name())
+        .create();
+
+    try {
+      String[] namespace = tableIdent.namespace().levels();
+      Identifier tableIdentifier = Identifier.of(namespace, tableIdent.name());
+      Identifier viewIdentifier = Identifier.of(namespace, "summary_view");
+
+      TableSummary[] summaries = catalog.listTableSummaries(namespace);
+
+      assertThat(summaries)
+          .as("Base table should be reported exactly once as EXTERNAL")
+          .filteredOn(summary -> summary.identifier().equals(tableIdentifier))
+          .singleElement()
+          .extracting(TableSummary::tableType)
+          .isEqualTo(TableSummary.EXTERNAL_TABLE_TYPE);
+
+      assertThat(summaries)
+          .as("View should be reported exactly once as VIEW, never as a table")
+          .filteredOn(summary -> summary.identifier().equals(viewIdentifier))
+          .singleElement()
+          .extracting(TableSummary::tableType)
+          .isEqualTo(TableSummary.VIEW_TABLE_TYPE);
+    } finally {
+      viewCatalog.dropView(viewIdent);
+    }
   }
 
   @TestTemplate


### PR DESCRIPTION
Implement `SparkCatalog.listTableSummaries` to report Iceberg tables as `EXTERNAL` and views as `VIEW` directly from catalog listings, avoiding the default implementation's per-table loads.
