### PR TITLE
Docs: Fix broken internal anchor links

### DIFF
--- a/docs/docs/branching.md
+++ b/docs/docs/branching.md
@@ -25,7 +25,7 @@ title: "Branching and Tagging"
 
 Iceberg table metadata maintains a snapshot log, which represents the changes applied to a table.
 Snapshots are fundamental in Iceberg as they are the basis for reader isolation and time travel queries.
-For controlling metadata size and storage costs, Iceberg provides snapshot lifecycle management procedures such as [`expire_snapshots`](spark-procedures.md#expire-snapshots) for removing unused snapshots and no longer necessary data files based on table snapshot retention properties.
+For controlling metadata size and storage costs, Iceberg provides snapshot lifecycle management procedures such as [`expire_snapshots`](spark-procedures.md#expire_snapshots) for removing unused snapshots and no longer necessary data files based on table snapshot retention properties.
 
 **For more sophisticated snapshot lifecycle management, Iceberg supports branches and tags which are named references to snapshots with their own independent lifecycles. This lifecycle is controlled by branch and tag level retention policies.**
 Branches are independent lineages of snapshots and point to the head of the lineage.
@@ -109,7 +109,7 @@ Creating, querying and writing to branches and tags are supported in the Iceberg
 
 - [Iceberg Java Library](java-api-quickstart.md#branching-and-tagging)
 - [Spark DDLs](spark-ddl.md#branching-and-tagging-ddl)
-- [Spark Reads](spark-queries.md#time-travel)
+- [Spark Reads](spark-queries.md#time-travel-queries-with-sql)
 - [Spark Branch Writes](spark-writes.md#writing-to-branches)
 - [Flink Reads](flink-queries.md#reading-branches-and-tags-with-SQL)
 - [Flink Branch Writes](flink-writes.md#branch-writes)

--- a/docs/docs/flink-ddl.md
+++ b/docs/docs/flink-ddl.md
@@ -186,7 +186,7 @@ Currently, it does not support computed column and watermark definition etc.
 #### `PRIMARY KEY`
 
 Primary key constraint can be declared for a column or a set of columns, which must be unique and do not contain null.
-It's required for [`UPSERT` mode](flink-writes.md/#upsert).
+It's required for [`UPSERT` mode](flink-writes.md#upsert).
 
 ```sql
 CREATE TABLE `hive_catalog`.`default`.`sample` (

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -69,7 +69,7 @@ Iceberg supports `UPSERT` based on the primary key when writing data into v2 tab
     ) with ('format-version'='2', 'write.upsert.enabled'='true');
     ```
 
-2. Enabling `UPSERT` mode using `upsert-enabled` in the [write options](#write-options) provides more flexibility than a table level config. Note that you still need to use v2 table format and specify the [primary key](flink-ddl.md/#primary-key) or [identifier fields](../../spec.md#identifier-field-ids) when creating the table.
+2. Enabling `UPSERT` mode using `upsert-enabled` in the [write options](#write-options) provides more flexibility than a table level config. Note that you still need to use v2 table format and specify the [primary key](flink-ddl.md#primary-key) or [identifier fields](../../spec.md#identifier-field-ids) when creating the table.
 
     ```sql
     INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -29,7 +29,7 @@ Iceberg avoids unpleasant surprises. Schema evolution works and won't inadverten
 * [Schema evolution](evolution.md#schema-evolution) supports add, drop, update, or rename, and has [no side-effects](evolution.md#correctness)
 * [Hidden partitioning](partitioning.md) prevents user mistakes that cause silently incorrect results or extremely slow queries
 * [Partition layout evolution](evolution.md#partition-evolution) can update the layout of a table as data volume or query patterns change
-* [Time travel](spark-queries.md#time-travel) enables reproducible queries that use exactly the same table snapshot, or lets users easily examine changes
+* [Time travel](spark-queries.md#time-travel-queries-with-sql) enables reproducible queries that use exactly the same table snapshot, or lets users easily examine changes
 * Version rollback allows users to quickly correct problems by resetting tables to a good state
 
 ### Reliability and performance

--- a/docs/docs/nessie.md
+++ b/docs/docs/nessie.md
@@ -80,7 +80,7 @@ conf.set("spark.sql.catalog.nessie.type", "nessie")
 conf.set("spark.sql.catalog.nessie", "org.apache.iceberg.spark.SparkCatalog")
 conf.set("spark.sql.extensions", "org.apache.iceberg.spark.extensions.IcebergSparkSessionExtensions,org.projectnessie.spark.extensions.NessieSparkSessionExtensions")
 ```
-This is how it looks in Flink via the Python API (additional details can be found [here](flink.md#preparation-when-using-flinks-python-api)):
+This is how it looks in Flink via the Python API (additional details can be found [here](flink.md#flinks-python-api)):
 ```python
 import os
 from pyflink.datastream import StreamExecutionEnvironment


### PR DESCRIPTION
<!-- No issue: minor docs fix, issue not required -->

## Summary

Several internal doc links pointed to anchors that do not exist on the target page, so clicking them loaded the page but did not scroll to the section.

- `branching.md`: `spark-procedures.md#expire-snapshots` → `#expire_snapshots` (header `### \`expire_snapshots\`` keeps the underscore).
- `branching.md`, `index.md`: `spark-queries.md#time-travel` had no such anchor → `#time-travel-queries-with-sql` (section `### Time travel Queries with SQL`).
- `nessie.md`: `flink.md#preparation-when-using-flinks-python-api` did not exist → `#flinks-python-api` (section `## Flink's Python API`).
- `flink-ddl.md`, `flink-writes.md`: dropped a stray slash in `*.md/#anchor` links to match every other cross-page link.

Sibling links already use the correct slugs (e.g. `spark-structured-streaming.md` links `spark-procedures.md#expire_snapshots`), confirming these are typos.

## Testing done

- Docs-only change, no behavior change — no test added.
- Verified each updated slug matches exactly one existing target header. The docs build sets no custom `slugify`, so the default toc slugify keeps underscores and turns spaces into hyphens.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
