### PR TITLE
GCP: Fix GCSInputStream.readTail partial read returning short count

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -179,7 +179,16 @@ class GCSInputStream extends SeekableInputStream implements RangeReadable {
     long startPosition = Math.max(0, blobSize - length);
     try (ReadChannel readChannel = openChannel()) {
       readChannel.seek(startPosition);
-      return read(readChannel, ByteBuffer.wrap(buffer), offset, length);
+      ByteBuffer wrapped = ByteBuffer.wrap(buffer);
+      int totalRead = 0;
+      while (totalRead < length) {
+        int bytesRead = read(readChannel, wrapped, offset + totalRead, length - totalRead);
+        if (bytesRead < 0) {
+          break;
+        }
+        totalRead += bytesRead;
+      }
+      return totalRead;
     }
   }
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSInputStream.java
@@ -20,13 +20,19 @@ package org.apache.iceberg.gcp.gcs;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.cloud.ReadChannel;
 import com.google.cloud.storage.BlobId;
 import com.google.cloud.storage.BlobInfo;
 import com.google.cloud.storage.Storage;
+import com.google.cloud.storage.Storage.BlobSourceOption;
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Arrays;
 import java.util.Random;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -179,6 +185,39 @@ public class TestGCSInputStream {
 
     assertThat(Arrays.copyOfRange(buffer, offset, offset + length))
         .isEqualTo(Arrays.copyOfRange(original, offset, offset + length));
+  }
+
+  @Test
+  public void testReadTailPartialRead() throws Exception {
+    BlobId blobId = BlobId.fromGsUtilUri("gs://bucket/path/to/tail.dat");
+    byte[] data = randomData(16);
+
+    Storage mockStorage = mock(Storage.class);
+    ReadChannel mockChannel = mock(ReadChannel.class);
+    when(mockStorage.reader(any(BlobId.class), any(BlobSourceOption[].class)))
+        .thenReturn(mockChannel);
+
+    // First read returns half of the requested bytes, the second read returns the rest.
+    when(mockChannel.read(any(ByteBuffer.class)))
+        .thenAnswer(invocation -> fill(invocation.getArgument(0), data, 0, data.length / 2))
+        .thenAnswer(
+            invocation -> fill(invocation.getArgument(0), data, data.length / 2, data.length / 2))
+        .thenReturn(-1);
+
+    byte[] buffer = new byte[data.length];
+    try (RangeReadable in =
+        new GCSInputStream(
+            mockStorage, blobId, (long) data.length, gcpProperties, MetricsContext.nullMetrics())) {
+      int totalRead = in.readTail(buffer, 0, data.length);
+
+      assertThat(totalRead).isEqualTo(data.length);
+      assertThat(buffer).isEqualTo(data);
+    }
+  }
+
+  private static int fill(ByteBuffer buffer, byte[] source, int sourceOffset, int count) {
+    buffer.put(source, sourceOffset, count);
+    return count;
   }
 
   @Test


### PR DESCRIPTION
<!-- No issue: minor parity bug fix, issue not required -->

## Summary

- `GCSInputStream.readTail` calls the private `read()` helper once, which does a single `readChannel.read(buffer)`. A GCS NIO `ReadChannel` may return fewer bytes than requested even when more data remains, so `readTail` can return a short count — violating the `RangeReadable.readTail` contract to return the actual number of bytes read.
- Fix: loop the channel read until the requested length is filled or EOF. `S3InputStream.readTail` and `ADLSInputStream.readTail` already loop via `IOUtil.readRemaining`; GCS uses a `ReadChannel` rather than an `InputStream`, so it needs a channel-based loop instead.
- Only `readTail` changes (`readFully` is a separate concern).

## Testing done

- Added `TestGCSInputStream#testReadTailPartialRead`: a Mockito mock `ReadChannel` fills the buffer in two partial reads; asserts `readTail` returns the full length with the expected bytes.
- The test fails against the pre-fix single-read code and passes after the fix.
- `./gradlew :iceberg-gcp:check` passed (test, spotlessCheck, checkstyle, errorProne). GCP is not a revapi module.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
