### PR TITLE
Core, Spark: Fix stale manifest_length in rewrite_table_path manifest lists

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -519,6 +519,12 @@ acceptedBreaks:
       justification: "Removing deprecated code for 1.11.0"
   "1.11.0":
     org.apache.iceberg:iceberg-core:
+    - code: "java.class.defaultSerializationChanged"
+      old: "class org.apache.iceberg.RewriteTablePathUtil.RewriteResult<T extends\
+        \ java.lang.Object>"
+      new: "class org.apache.iceberg.RewriteTablePathUtil.RewriteResult<T extends\
+        \ java.lang.Object>"
+      justification: "Serialization across versions is not guaranteed"
     - code: "java.class.removed"
       old: "class org.apache.iceberg.PartitionStats"
       justification: "Removed deprecated functionality for partition stats"
@@ -609,6 +615,18 @@ acceptedBreaks:
       justification: "These interfaces were package-private in 1.11.0 and could not\
         \ be implemented outside the project. Promoting them to public reads as an\
         \ existing type gaining methods, not as a new type appearing."
+    - code: "java.method.numberOfParametersChanged"
+      old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
+        \ org.apache.iceberg.RewriteTablePathUtil::rewriteManifestList(org.apache.iceberg.Snapshot,\
+        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, java.util.Set<java.lang.String>,\
+        \ java.lang.String, java.lang.String, java.lang.String, java.lang.String)"
+      new: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
+        \ org.apache.iceberg.RewriteTablePathUtil::rewriteManifestList(org.apache.iceberg.Snapshot,\
+        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, java.util.Set<java.lang.String>,\
+        \ java.lang.String, java.lang.String, java.lang.String, java.lang.String,\
+        \ java.util.Map<java.lang.String, java.lang.Long>)"
+      justification: "Manifest lengths are known only after the manifests are rewritten,\
+        \ which the previous signature cannot record"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::forPositionDelete(org.apache.iceberg.Table)"
       justification: "Deprecated for removal in 1.12.0"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -615,18 +615,18 @@ acceptedBreaks:
       justification: "These interfaces were package-private in 1.11.0 and could not\
         \ be implemented outside the project. Promoting them to public reads as an\
         \ existing type gaining methods, not as a new type appearing."
-    - code: "java.method.numberOfParametersChanged"
-      old: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
+    - code: "java.method.parameterTypeChanged"
+      old: "parameter org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
         \ org.apache.iceberg.RewriteTablePathUtil::rewriteManifestList(org.apache.iceberg.Snapshot,\
-        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, java.util.Set<java.lang.String>,\
+        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, ===java.util.Set<java.lang.String>===,\
         \ java.lang.String, java.lang.String, java.lang.String, java.lang.String)"
-      new: "method org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
+      new: "parameter org.apache.iceberg.RewriteTablePathUtil.RewriteResult<org.apache.iceberg.ManifestFile>\
         \ org.apache.iceberg.RewriteTablePathUtil::rewriteManifestList(org.apache.iceberg.Snapshot,\
-        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, java.util.Set<java.lang.String>,\
-        \ java.lang.String, java.lang.String, java.lang.String, java.lang.String,\
-        \ java.util.Map<java.lang.String, java.lang.Long>)"
-      justification: "Manifest lengths are known only after the manifests are rewritten,\
-        \ which the previous signature cannot record"
+        \ org.apache.iceberg.io.FileIO, org.apache.iceberg.TableMetadata, ===java.util.Map<java.lang.String,\
+        \ java.lang.Long>===, java.lang.String, java.lang.String, java.lang.String,\
+        \ java.lang.String)"
+      justification: "A manifest can only be rewritten together with its measured\
+        \ length, which the set of manifest paths cannot carry"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::forPositionDelete(org.apache.iceberg.Table)"
       justification: "Deprecated for removal in 1.12.0"

--- a/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RewriteTablePath.java
@@ -62,6 +62,11 @@ public interface RewriteTablePath extends Action<RewriteTablePath, RewriteTableP
    * metadata log. It is optional, if provided then this action will only rewrite metadata files
    * added after this version.
    *
+   * <p>Manifests added before this version are not rewritten, so snapshots that still reference
+   * them keep the {@code manifest_length} recorded in the source table. That length does not match
+   * the manifest at the target when the source and target prefixes differ in length, and readers
+   * that validate the field will reject those manifest lists.
+   *
    * @param startVersion name of a metadata.json file. For example,
    *     "00001-8893aa9e-f92e-4443-80e7-cfa42238a654.metadata.json".
    * @return this for method chaining

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -251,6 +251,36 @@ public class RewriteTablePathUtil {
   /**
    * Rewrite a manifest list representing a snapshot, replacing path references.
    *
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link #rewriteManifestList(Snapshot,
+   *     FileIO, TableMetadata, Set, String, String, String, String, Map)}, which records the
+   *     rewritten manifest length so that manifest_length stays consistent with the rewritten
+   *     manifest file on disk.
+   */
+  @Deprecated
+  public static RewriteResult<ManifestFile> rewriteManifestList(
+      Snapshot snapshot,
+      FileIO io,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingDir,
+      String outputPath) {
+    return rewriteManifestList(
+        snapshot,
+        io,
+        tableMetadata,
+        manifestsToRewrite,
+        sourcePrefix,
+        targetPrefix,
+        stagingDir,
+        outputPath,
+        ImmutableMap.of());
+  }
+
+  /**
+   * Rewrite a manifest list representing a snapshot, replacing path references.
+   *
    * @param snapshot snapshot represented by the manifest list
    * @param io file io
    * @param tableMetadata metadata of table
@@ -259,6 +289,8 @@ public class RewriteTablePathUtil {
    * @param targetPrefix target prefix that will replace it
    * @param stagingDir staging directory
    * @param outputPath location to write the manifest list
+   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
+   *     rewritten manifest; entries absent from the map keep their original length
    * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
    *     list
    */
@@ -270,7 +302,8 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix,
       String stagingDir,
-      String outputPath) {
+      String outputPath,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
 
@@ -301,6 +334,8 @@ public class RewriteTablePathUtil {
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        ((StructLike) newFile)
+            .set(1, rewrittenManifestLengths.getOrDefault(file.path(), file.length()));
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {
@@ -329,6 +364,25 @@ public class RewriteTablePathUtil {
   }
 
   /**
+   * Identify the manifest files in a snapshot's manifest list that are selected for rewrite.
+   *
+   * <p>Reads the snapshot's manifest list and filters it by {@code manifestsToRewrite} without
+   * writing anything, so callers can enumerate the manifests to rewrite before producing the
+   * rewritten manifest list (which needs the rewritten manifest lengths).
+   *
+   * @param snapshot snapshot whose manifest list is read
+   * @param io file io
+   * @param manifestsToRewrite paths of manifests selected for rewrite
+   * @return the manifest files in the snapshot that are selected for rewrite
+   */
+  public static Set<ManifestFile> manifestsToRewriteForSnapshot(
+      Snapshot snapshot, FileIO io, Set<String> manifestsToRewrite) {
+    return manifestFilesInSnapshot(io, snapshot).stream()
+        .filter(manifestFile -> manifestsToRewrite.contains(manifestFile.path()))
+        .collect(Collectors.toSet());
+  }
+
+  /**
    * Rewrite a data manifest, replacing path references.
    *
    * @param manifestFile source manifest file to rewrite
@@ -340,7 +394,11 @@ public class RewriteTablePathUtil {
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @return a copy plan of content files in the manifest that was rewritten
+   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
+   *     #rewriteDataManifestWithLength}, which also returns the rewritten manifest length so that
+   *     manifest_length can be recorded accurately in the manifest list.
    */
+  @Deprecated
   public static RewriteResult<DataFile> rewriteDataManifest(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
@@ -351,17 +409,64 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
+    return rewriteDataManifestWithLength(
+            manifestFile,
+            snapshotIds,
+            outputFile,
+            io,
+            format,
+            specsById,
+            sourcePrefix,
+            targetPrefix)
+        .first();
+  }
+
+  /**
+   * Rewrite a data manifest, replacing path references, and return the rewritten manifest's byte
+   * length.
+   *
+   * <p>The length is measured from the manifest writer after it is closed (rather than via a
+   * separate {@code getLength()}/HEAD call) so it is accurate even on file systems where the length
+   * of an in-progress write underreports. Callers record this length as the {@code manifest_length}
+   * of the rewritten manifest in the manifest list.
+   *
+   * @param manifestFile source manifest file to rewrite
+   * @param snapshotIds snapshot ids for filtering returned data manifest entries
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
+   *     manifest's byte length
+   */
+  public static Pair<RewriteResult<DataFile>, Long> rewriteDataManifestWithLength(
+      ManifestFile manifestFile,
+      Set<Long> snapshotIds,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
     PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
-    try (ManifestWriter<DataFile> writer =
-            ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+    RewriteResult<DataFile> result;
+    try (writer;
         ManifestReader<DataFile> reader =
             ManifestFiles.read(manifestFile, io, specsById).select(Arrays.asList("*"))) {
-      return StreamSupport.stream(reader.entries().spliterator(), false)
-          .map(
-              entry ->
-                  writeDataFileEntry(entry, snapshotIds, spec, sourcePrefix, targetPrefix, writer))
-          .reduce(new RewriteResult<>(), RewriteResult::append);
+      result =
+          StreamSupport.stream(reader.entries().spliterator(), false)
+              .map(
+                  entry ->
+                      writeDataFileEntry(
+                          entry, snapshotIds, spec, sourcePrefix, targetPrefix, writer))
+              .reduce(new RewriteResult<>(), RewriteResult::append);
     }
+    return Pair.of(result, writer.length());
   }
 
   /**
@@ -378,10 +483,10 @@ public class RewriteTablePathUtil {
    * @param stagingLocation staging location for rewritten files (referred delete file will be
    *     rewritten here)
    * @return a copy plan of content files in the manifest that was rewritten
-   * @deprecated since 1.12.0, will be removed in 1.13.0; use the overload that accepts the map of
-   *     rewritten position delete file sizes. This overload records the original {@code
-   *     file_size_in_bytes}, which can be inconsistent with the rewritten file size on disk once
-   *     embedded data file paths change length.
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+   *     #rewriteDeleteManifestWithLength}, which accepts the map of rewritten position delete file
+   *     sizes and also returns the rewritten manifest length so that {@code file_size_in_bytes}
+   *     and {@code manifest_length} stay consistent with the rewritten files on disk.
    */
   @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(
@@ -428,7 +533,11 @@ public class RewriteTablePathUtil {
    * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
    *     the rewritten file; entries absent from the map keep their original size
    * @return a copy plan of content files in the manifest that was rewritten
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
+   *     #rewriteDeleteManifestWithLength}, which also returns the rewritten manifest length so that
+   *     manifest_length can be recorded accurately in the manifest list.
    */
+  @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
@@ -441,26 +550,84 @@ public class RewriteTablePathUtil {
       String stagingLocation,
       Map<String, Long> rewrittenDeleteFileSizes)
       throws IOException {
+    return rewriteDeleteManifestWithLength(
+            manifestFile,
+            snapshotIds,
+            outputFile,
+            io,
+            format,
+            specsById,
+            sourcePrefix,
+            targetPrefix,
+            stagingLocation,
+            rewrittenDeleteFileSizes)
+        .first();
+  }
+
+  /**
+   * Rewrite a delete manifest, replacing path references, and return the rewritten manifest's byte
+   * length.
+   *
+   * <p>This is a metadata-only operation: position delete file content is rewritten separately (see
+   * {@link #rewritePositionDelete}). The actual sizes of those rewritten files are supplied via
+   * {@code rewrittenDeleteFileSizes} and recorded in the manifest so that {@code
+   * file_size_in_bytes} stays consistent with the rewritten file on disk.
+   *
+   * <p>The manifest length is measured from the manifest writer after it is closed (rather than via
+   * a separate {@code getLength()}/HEAD call) so it is accurate even on file systems where the
+   * length of an in-progress write underreports. Callers record this length as the {@code
+   * manifest_length} of the rewritten manifest in the manifest list.
+   *
+   * @param manifestFile source delete manifest to rewrite
+   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @param stagingLocation staging location for rewritten position delete files
+   * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
+   *     the rewritten file; entries absent from the map keep their original size
+   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
+   *     manifest's byte length
+   */
+  public static Pair<RewriteResult<DeleteFile>, Long> rewriteDeleteManifestWithLength(
+      ManifestFile manifestFile,
+      Set<Long> snapshotIds,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingLocation,
+      Map<String, Long> rewrittenDeleteFileSizes)
+      throws IOException {
     PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
-    try (ManifestWriter<DeleteFile> writer =
-            ManifestFiles.writeDeleteManifest(format, spec, outputFile, manifestFile.snapshotId());
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(format, spec, outputFile, manifestFile.snapshotId());
+    RewriteResult<DeleteFile> result;
+    try (writer;
         ManifestReader<DeleteFile> reader =
             ManifestFiles.readDeleteManifest(manifestFile, io, specsById)
                 .select(Arrays.asList("*"))) {
-      return StreamSupport.stream(reader.entries().spliterator(), false)
-          .map(
-              entry ->
-                  writeDeleteFileEntry(
-                      entry,
-                      snapshotIds,
-                      spec,
-                      sourcePrefix,
-                      targetPrefix,
-                      stagingLocation,
-                      writer,
-                      rewrittenDeleteFileSizes))
-          .reduce(new RewriteResult<>(), RewriteResult::append);
+      result =
+          StreamSupport.stream(reader.entries().spliterator(), false)
+              .map(
+                  entry ->
+                      writeDeleteFileEntry(
+                          entry,
+                          snapshotIds,
+                          spec,
+                          sourcePrefix,
+                          targetPrefix,
+                          stagingLocation,
+                          writer,
+                          rewrittenDeleteFileSizes))
+              .reduce(new RewriteResult<>(), RewriteResult::append);
     }
+    return Pair.of(result, writer.length());
   }
 
   private static RewriteResult<DataFile> writeDataFileEntry(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -251,7 +251,7 @@ public class RewriteTablePathUtil {
   /**
    * Rewrite a manifest list representing a snapshot, replacing path references.
    *
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link #rewriteManifestList(Snapshot,
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link #rewriteManifestList(Snapshot,
    *     FileIO, TableMetadata, Set, String, String, String, String, Map)}, which records the
    *     rewritten manifest length so that manifest_length stays consistent with the rewritten
    *     manifest file on disk.
@@ -394,7 +394,7 @@ public class RewriteTablePathUtil {
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @return a copy plan of content files in the manifest that was rewritten
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
    *     #rewriteDataManifestWithLength}, which also returns the rewritten manifest length so that
    *     manifest_length can be recorded accurately in the manifest list.
    */

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -485,8 +485,8 @@ public class RewriteTablePathUtil {
    * @return a copy plan of content files in the manifest that was rewritten
    * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
    *     #rewriteDeleteManifestWithLength}, which accepts the map of rewritten position delete file
-   *     sizes and also returns the rewritten manifest length so that {@code file_size_in_bytes}
-   *     and {@code manifest_length} stay consistent with the rewritten files on disk.
+   *     sizes and also returns the rewritten manifest length so that {@code file_size_in_bytes} and
+   *     {@code manifest_length} stay consistent with the rewritten files on disk.
    */
   @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -265,7 +265,9 @@ public class RewriteTablePathUtil {
       String targetPrefix,
       String stagingDir,
       String outputPath) {
-    return rewriteManifestList(
+    // no lengths are known to this overload, so every entry keeping its source length is expected
+    // and is not reported
+    return writeManifestList(
         snapshot,
         io,
         tableMetadata,
@@ -319,6 +321,40 @@ public class RewriteTablePathUtil {
       String stagingDir,
       String outputPath,
       Map<String, Long> rewrittenManifestLengths) {
+    manifestFiles.stream()
+        .filter(file -> rewrittenManifestLengths.get(file.path()) == null)
+        .forEach(
+            file ->
+                LOG.warn(
+                    "No measured length for manifest {}; recording its source length {}, which "
+                        + "will not match the rewritten file at the target",
+                    file.path(),
+                    file.length()));
+
+    return writeManifestList(
+        snapshot,
+        io,
+        tableMetadata,
+        manifestFiles,
+        manifestsToRewrite,
+        sourcePrefix,
+        targetPrefix,
+        stagingDir,
+        outputPath,
+        rewrittenManifestLengths);
+  }
+
+  private static RewriteResult<ManifestFile> writeManifestList(
+      Snapshot snapshot,
+      FileIO io,
+      TableMetadata tableMetadata,
+      List<ManifestFile> manifestFiles,
+      Set<String> manifestsToRewrite,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingDir,
+      String outputPath,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
 
@@ -341,13 +377,6 @@ public class RewriteTablePathUtil {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
         Long rewrittenLength = rewrittenManifestLengths.get(file.path());
-        if (rewrittenLength == null && !rewrittenManifestLengths.isEmpty()) {
-          LOG.warn(
-              "No measured length for manifest {}; recording its source length {}, which will not "
-                  + "match the rewritten file at the target",
-              file.path(),
-              file.length());
-        }
         ((StructLike) newFile).set(1, rewrittenLength != null ? rewrittenLength : file.length());
         writer.add(newFile);
 
@@ -363,17 +392,6 @@ public class RewriteTablePathUtil {
       throw new UncheckedIOException(
           "Failed to rewrite the manifest list file " + snapshot.manifestListLocation(), e);
     }
-  }
-
-  private static List<ManifestFile> manifestFilesInSnapshot(FileIO io, Snapshot snapshot) {
-    String path = snapshot.manifestListLocation();
-    List<ManifestFile> manifestFiles = Lists.newArrayList();
-    try {
-      manifestFiles = ManifestLists.read(io.newInputFile(path));
-    } catch (RuntimeIOException e) {
-      LOG.warn("Failed to read manifest list {}", path, e);
-    }
-    return manifestFiles;
   }
 
   /**
@@ -395,7 +413,14 @@ public class RewriteTablePathUtil {
    */
   public static List<ManifestFile> manifestsInSnapshot(
       Snapshot snapshot, FileIO io, String sourcePrefix) {
-    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(io, snapshot);
+    String path = snapshot.manifestListLocation();
+    List<ManifestFile> manifestFiles = Lists.newArrayList();
+    try {
+      manifestFiles = ManifestLists.read(io.newInputFile(path));
+    } catch (RuntimeIOException e) {
+      LOG.warn("Failed to read manifest list {}", path, e);
+    }
+
     manifestFiles.forEach(
         manifestFile ->
             Preconditions.checkArgument(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -47,6 +48,7 @@ import org.apache.iceberg.puffin.PuffinCompressionCodec;
 import org.apache.iceberg.puffin.PuffinReader;
 import org.apache.iceberg.puffin.PuffinWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -74,12 +76,14 @@ public class RewriteTablePathUtil {
   public static class RewriteResult<T> implements Serializable {
     private final Set<T> toRewrite = Sets.newHashSet();
     private final Set<Pair<String, String>> copyPlan = Sets.newHashSet();
+    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
 
     public RewriteResult() {}
 
     public RewriteResult<T> append(RewriteResult<T> r1) {
       toRewrite.addAll(r1.toRewrite);
       copyPlan.addAll(r1.copyPlan);
+      rewrittenManifestLengths.putAll(r1.rewrittenManifestLengths);
       return this;
     }
 
@@ -94,6 +98,16 @@ public class RewriteTablePathUtil {
      */
     public Set<Pair<String, String>> copyPlan() {
       return copyPlan;
+    }
+
+    /** Records the byte length of the manifest rewritten from the given source manifest path */
+    public void addRewrittenManifestLength(String sourceManifestPath, long length) {
+      rewrittenManifestLengths.put(sourceManifestPath, length);
+    }
+
+    /** Returns the byte length of each rewritten manifest, keyed by source manifest path */
+    public Map<String, Long> rewrittenManifestLengths() {
+      return Collections.unmodifiableMap(rewrittenManifestLengths);
     }
   }
 
@@ -251,62 +265,17 @@ public class RewriteTablePathUtil {
   /**
    * Rewrite a manifest list representing a snapshot, replacing path references.
    *
-   * <p>Every entry keeps its source {@code manifest_length}, which does not match the rewritten
-   * manifest when the target prefix differs in length from the source. Callers that rewrite to a
-   * different-length prefix should use {@link #rewriteManifestList(Snapshot, FileIO, TableMetadata,
-   * List, Set, String, String, String, String, Map)} and pass the measured lengths.
-   */
-  public static RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      FileIO io,
-      TableMetadata tableMetadata,
-      Set<String> manifestsToRewrite,
-      String sourcePrefix,
-      String targetPrefix,
-      String stagingDir,
-      String outputPath) {
-    // no lengths are known to this overload, so every entry keeping its source length is expected
-    // and is not reported
-    return writeManifestList(
-        snapshot,
-        io,
-        tableMetadata,
-        manifestsInSnapshot(snapshot, io, sourcePrefix),
-        manifestsToRewrite,
-        sourcePrefix,
-        targetPrefix,
-        stagingDir,
-        outputPath,
-        ImmutableMap.of());
-  }
-
-  /**
-   * Rewrite a manifest list representing a snapshot, replacing path references.
-   *
-   * <p>Each entry's {@code manifest_length} is taken from {@code rewrittenManifestLengths}, because
-   * replacing the path prefix changes the byte length of the rewritten manifest.
-   *
-   * <p>Known gap: an entry whose manifest is absent from the map keeps its source length, which
-   * does not match the rewritten file. This is reachable in an incremental run, where a manifest
-   * carried over from an earlier run is still referenced by the new snapshot's manifest list but is
-   * not rewritten again. Re-measuring it here does not help, because the length of the file the
-   * earlier run produced depends on the table metadata as it was then: the manifest header embeds
-   * the current schema, so re-measuring after schema evolution yields a different length. Closing
-   * the gap needs either read access to the target, which this action deliberately does not have,
-   * or state carried between runs.
-   *
    * @param snapshot snapshot represented by the manifest list
    * @param io file io
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
-   *     {@link #manifestsInSnapshot(Snapshot, FileIO, String)}
    * @param manifestsToRewrite a list of manifest files to filter for rewrite
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @param stagingDir staging directory
    * @param outputPath location to write the manifest list
-   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
-   *     rewritten manifest
+   * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source
+   *     manifest path. Every manifest in {@code manifestsToRewrite} must be present; any other
+   *     manifest missing from the map keeps its source length.
    * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
    *     list
    */
@@ -314,41 +283,6 @@ public class RewriteTablePathUtil {
       Snapshot snapshot,
       FileIO io,
       TableMetadata tableMetadata,
-      List<ManifestFile> manifestFiles,
-      Set<String> manifestsToRewrite,
-      String sourcePrefix,
-      String targetPrefix,
-      String stagingDir,
-      String outputPath,
-      Map<String, Long> rewrittenManifestLengths) {
-    manifestFiles.stream()
-        .filter(file -> rewrittenManifestLengths.get(file.path()) == null)
-        .forEach(
-            file ->
-                LOG.warn(
-                    "No measured length for manifest {}; recording its source length {}, which "
-                        + "will not match the rewritten file at the target",
-                    file.path(),
-                    file.length()));
-
-    return writeManifestList(
-        snapshot,
-        io,
-        tableMetadata,
-        manifestFiles,
-        manifestsToRewrite,
-        sourcePrefix,
-        targetPrefix,
-        stagingDir,
-        outputPath,
-        rewrittenManifestLengths);
-  }
-
-  private static RewriteResult<ManifestFile> writeManifestList(
-      Snapshot snapshot,
-      FileIO io,
-      TableMetadata tableMetadata,
-      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       String sourcePrefix,
       String targetPrefix,
@@ -357,6 +291,28 @@ public class RewriteTablePathUtil {
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
+
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(io, snapshot);
+    manifestFiles.forEach(
+        mf ->
+            Preconditions.checkArgument(
+                mf.path().startsWith(sourcePrefix),
+                "Encountered manifest file %s not under the source prefix %s",
+                mf.path(),
+                sourcePrefix));
+
+    long unmeasured =
+        manifestFiles.stream()
+            .filter(mf -> !rewrittenManifestLengths.containsKey(mf.path()))
+            .count();
+    if (unmeasured > 0) {
+      LOG.warn(
+          "{} of {} manifests in {} keep their source length, which does not match the rewritten "
+              + "manifest at the target",
+          unmeasured,
+          manifestFiles.size(),
+          snapshot.manifestListLocation());
+    }
 
     EncryptionManager encryptionManager =
         (io instanceof EncryptingFileIO)
@@ -377,6 +333,10 @@ public class RewriteTablePathUtil {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
         Long rewrittenLength = rewrittenManifestLengths.get(file.path());
+        Preconditions.checkArgument(
+            rewrittenLength != null || !manifestsToRewrite.contains(file.path()),
+            "Missing rewritten length for manifest %s",
+            file.path());
         ((StructLike) newFile).set(1, rewrittenLength != null ? rewrittenLength : file.length());
         writer.add(newFile);
 
@@ -394,41 +354,13 @@ public class RewriteTablePathUtil {
     }
   }
 
-  /**
-   * Read the manifests referenced by a snapshot's manifest list, without writing anything.
-   *
-   * <p>Callers need this before producing the rewritten manifest list, which records each
-   * referenced manifest's rewritten length. Reading once here and passing the result to {@link
-   * #rewriteManifestList(Snapshot, FileIO, TableMetadata, List, Set, String, String, String,
-   * String, Map)} also avoids reading the manifest list twice.
-   *
-   * <p>An unreadable manifest list is logged and treated as empty, matching the behaviour this
-   * method was extracted from.
-   *
-   * @param snapshot snapshot whose manifest list is read
-   * @param io file io
-   * @param sourcePrefix source prefix every referenced manifest must live under
-   * @return the manifests referenced by the snapshot's manifest list, or an empty list if the
-   *     manifest list could not be read
-   */
-  public static List<ManifestFile> manifestsInSnapshot(
-      Snapshot snapshot, FileIO io, String sourcePrefix) {
-    String path = snapshot.manifestListLocation();
-    List<ManifestFile> manifestFiles = Lists.newArrayList();
+  private static List<ManifestFile> manifestFilesInSnapshot(FileIO io, Snapshot snapshot) {
     try {
-      manifestFiles = ManifestLists.read(io.newInputFile(path));
+      return snapshot.allManifests(io);
     } catch (RuntimeIOException e) {
-      LOG.warn("Failed to read manifest list {}", path, e);
+      LOG.warn("Failed to read manifest list {}", snapshot.manifestListLocation(), e);
+      return ImmutableList.of();
     }
-
-    manifestFiles.forEach(
-        manifestFile ->
-            Preconditions.checkArgument(
-                manifestFile.path().startsWith(sourcePrefix),
-                "Encountered manifest file %s not under the source prefix %s",
-                manifestFile.path(),
-                sourcePrefix));
-    return manifestFiles;
   }
 
   /**
@@ -442,53 +374,10 @@ public class RewriteTablePathUtil {
    * @param specsById map of partition specs by id
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
-   * @return a copy plan of content files in the manifest that was rewritten
-   * @see #rewriteDataManifestAndMeasureLength which also returns the rewritten manifest length, for
-   *     callers that need to record manifest_length in the manifest list
+   * @return a copy plan of content files in the manifest that was rewritten, recording the
+   *     rewritten manifest's byte length
    */
   public static RewriteResult<DataFile> rewriteDataManifest(
-      ManifestFile manifestFile,
-      Set<Long> snapshotIds,
-      OutputFile outputFile,
-      FileIO io,
-      int format,
-      Map<Integer, PartitionSpec> specsById,
-      String sourcePrefix,
-      String targetPrefix)
-      throws IOException {
-    return rewriteDataManifestAndMeasureLength(
-            manifestFile,
-            snapshotIds,
-            outputFile,
-            io,
-            format,
-            specsById,
-            sourcePrefix,
-            targetPrefix)
-        .first();
-  }
-
-  /**
-   * Rewrite a data manifest, replacing path references, and return the rewritten manifest's byte
-   * length.
-   *
-   * <p>The length is read from the closed manifest writer rather than via a separate {@code
-   * getLength()} call, which would cost a stat request per manifest against object storage. Callers
-   * record this length as the {@code manifest_length} of the rewritten manifest in the manifest
-   * list.
-   *
-   * @param manifestFile source manifest file to rewrite
-   * @param snapshotIds snapshot ids for filtering returned data manifest entries
-   * @param outputFile output file to rewrite manifest file to
-   * @param io file io
-   * @param format format of the manifest file
-   * @param specsById map of partition specs by id
-   * @param sourcePrefix source prefix that will be replaced
-   * @param targetPrefix target prefix that will replace it
-   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
-   *     manifest's byte length
-   */
-  public static Pair<RewriteResult<DataFile>, Long> rewriteDataManifestAndMeasureLength(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
       OutputFile outputFile,
@@ -513,7 +402,9 @@ public class RewriteTablePathUtil {
                           entry, snapshotIds, spec, sourcePrefix, targetPrefix, writer))
               .reduce(new RewriteResult<>(), RewriteResult::append);
     }
-    return Pair.of(result, writer.length());
+
+    result.addRewrittenManifestLength(manifestFile.path(), writer.length());
+    return result;
   }
 
   /**
@@ -530,11 +421,10 @@ public class RewriteTablePathUtil {
    * @param stagingLocation staging location for rewritten files (referred delete file will be
    *     rewritten here)
    * @return a copy plan of content files in the manifest that was rewritten
-   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
-   *     #rewriteDeleteManifestAndMeasureLength}, which accepts the map of rewritten position delete
-   *     file sizes and also returns the rewritten manifest length so that {@code
-   *     file_size_in_bytes} and {@code manifest_length} stay consistent with the rewritten files on
-   *     disk.
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use the overload that accepts the map of
+   *     rewritten position delete file sizes. This overload records the original {@code
+   *     file_size_in_bytes}, which can be inconsistent with the rewritten file size on disk once
+   *     embedded data file paths change length.
    */
   @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(
@@ -548,78 +438,27 @@ public class RewriteTablePathUtil {
       String targetPrefix,
       String stagingLocation)
       throws IOException {
-    return rewriteDeleteManifestAndMeasureLength(
-            manifestFile,
-            snapshotIds,
-            outputFile,
-            io,
-            format,
-            specsById,
-            sourcePrefix,
-            targetPrefix,
-            stagingLocation,
-            ImmutableMap.of())
-        .first();
+    return rewriteDeleteManifest(
+        manifestFile,
+        snapshotIds,
+        outputFile,
+        io,
+        format,
+        specsById,
+        sourcePrefix,
+        targetPrefix,
+        stagingLocation,
+        ImmutableMap.of());
   }
 
   /**
    * Rewrite a delete manifest, replacing path references.
-   *
-   * @param manifestFile source delete manifest to rewrite
-   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
-   * @param outputFile output file to rewrite manifest file to
-   * @param io file io
-   * @param format format of the manifest file
-   * @param specsById map of partition specs by id
-   * @param sourcePrefix source prefix that will be replaced
-   * @param targetPrefix target prefix that will replace it
-   * @param stagingLocation staging location for rewritten position delete files
-   * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
-   *     the rewritten file; entries absent from the map keep their original size
-   * @return a copy plan of content files in the manifest that was rewritten
-   * @see #rewriteDeleteManifestAndMeasureLength which also returns the rewritten manifest length,
-   *     for callers that need to record manifest_length in the manifest list
-   */
-  public static RewriteResult<DeleteFile> rewriteDeleteManifest(
-      ManifestFile manifestFile,
-      Set<Long> snapshotIds,
-      OutputFile outputFile,
-      FileIO io,
-      int format,
-      Map<Integer, PartitionSpec> specsById,
-      String sourcePrefix,
-      String targetPrefix,
-      String stagingLocation,
-      Map<String, Long> rewrittenDeleteFileSizes)
-      throws IOException {
-    return rewriteDeleteManifestAndMeasureLength(
-            manifestFile,
-            snapshotIds,
-            outputFile,
-            io,
-            format,
-            specsById,
-            sourcePrefix,
-            targetPrefix,
-            stagingLocation,
-            rewrittenDeleteFileSizes)
-        .first();
-  }
-
-  /**
-   * Rewrite a delete manifest, replacing path references, and return the rewritten manifest's byte
-   * length.
    *
    * <p>This is a metadata-only operation: position delete file content is rewritten separately (see
    * {@link #rewritePositionDelete}). The actual sizes of those rewritten files are supplied via
    * {@code rewrittenDeleteFileSizes} and recorded in the manifest so that {@code
    * file_size_in_bytes} stays consistent with the rewritten file on disk.
    *
-   * <p>The manifest length is read from the closed manifest writer rather than via a separate
-   * {@code getLength()} call, which would cost a stat request per manifest against object storage.
-   * Callers record this length as the {@code manifest_length} of the rewritten manifest in the
-   * manifest list.
-   *
    * @param manifestFile source delete manifest to rewrite
    * @param snapshotIds snapshot ids for filtering returned delete manifest entries
    * @param outputFile output file to rewrite manifest file to
@@ -631,10 +470,10 @@ public class RewriteTablePathUtil {
    * @param stagingLocation staging location for rewritten position delete files
    * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
    *     the rewritten file; entries absent from the map keep their original size
-   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
-   *     manifest's byte length
+   * @return a copy plan of content files in the manifest that was rewritten, recording the
+   *     rewritten manifest's byte length
    */
-  public static Pair<RewriteResult<DeleteFile>, Long> rewriteDeleteManifestAndMeasureLength(
+  public static RewriteResult<DeleteFile> rewriteDeleteManifest(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
       OutputFile outputFile,
@@ -669,7 +508,9 @@ public class RewriteTablePathUtil {
                           rewrittenDeleteFileSizes))
               .reduce(new RewriteResult<>(), RewriteResult::append);
     }
-    return Pair.of(result, writer.length());
+
+    result.addRewrittenManifestLength(manifestFile.path(), writer.length());
+    return result;
   }
 
   private static RewriteResult<DataFile> writeDataFileEntry(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -301,15 +301,19 @@ public class RewriteTablePathUtil {
                 mf.path(),
                 sourcePrefix));
 
-    long unmeasured =
+    Preconditions.checkArgument(
+        rewrittenManifestLengths.keySet().containsAll(manifestsToRewrite),
+        "Missing rewritten length for manifests: %s",
+        Sets.difference(manifestsToRewrite, rewrittenManifestLengths.keySet()));
+
+    long carriedOver =
         manifestFiles.stream()
             .filter(mf -> !rewrittenManifestLengths.containsKey(mf.path()))
             .count();
-    if (unmeasured > 0) {
-      LOG.warn(
-          "{} of {} manifests in {} keep their source length, which does not match the rewritten "
-              + "manifest at the target",
-          unmeasured,
+    if (carriedOver > 0) {
+      LOG.info(
+          "{} of {} manifests in {} were not rewritten in this run and keep their source length",
+          carriedOver,
           manifestFiles.size(),
           snapshot.manifestListLocation());
     }
@@ -332,12 +336,8 @@ public class RewriteTablePathUtil {
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
-        Long rewrittenLength = rewrittenManifestLengths.get(file.path());
-        Preconditions.checkArgument(
-            rewrittenLength != null || !manifestsToRewrite.contains(file.path()),
-            "Missing rewritten length for manifest %s",
-            file.path());
-        ((StructLike) newFile).set(1, rewrittenLength != null ? rewrittenLength : file.length());
+        ((StructLike) newFile)
+            .set(1, rewrittenManifestLengths.getOrDefault(file.path(), file.length()));
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -268,14 +268,13 @@ public class RewriteTablePathUtil {
    * @param snapshot snapshot represented by the manifest list
    * @param io file io
    * @param tableMetadata metadata of table
-   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param rewrittenManifestLengths byte length of each manifest rewritten by this run, keyed by
+   *     source manifest path. Only these manifests are rewritten; any other manifest in the
+   *     snapshot keeps the length recorded in the source table.
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @param stagingDir staging directory
    * @param outputPath location to write the manifest list
-   * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source
-   *     manifest path. Every manifest in {@code manifestsToRewrite} must be present; any other
-   *     manifest missing from the map keeps its source length.
    * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
    *     list
    */
@@ -283,12 +282,11 @@ public class RewriteTablePathUtil {
       Snapshot snapshot,
       FileIO io,
       TableMetadata tableMetadata,
-      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths,
       String sourcePrefix,
       String targetPrefix,
       String stagingDir,
-      String outputPath,
-      Map<String, Long> rewrittenManifestLengths) {
+      String outputPath) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
 
@@ -300,11 +298,6 @@ public class RewriteTablePathUtil {
                 "Encountered manifest file %s not under the source prefix %s",
                 mf.path(),
                 sourcePrefix));
-
-    Preconditions.checkArgument(
-        rewrittenManifestLengths.keySet().containsAll(manifestsToRewrite),
-        "Missing rewritten length for manifests: %s",
-        Sets.difference(manifestsToRewrite, rewrittenManifestLengths.keySet()));
 
     long carriedOver =
         manifestFiles.stream()
@@ -340,7 +333,7 @@ public class RewriteTablePathUtil {
             .set(1, rewrittenManifestLengths.getOrDefault(file.path(), file.length()));
         writer.add(newFile);
 
-        if (manifestsToRewrite.contains(file.path())) {
+        if (rewrittenManifestLengths.containsKey(file.path())) {
           result.toRewrite().add(file);
           result
               .copyPlan()

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -251,12 +251,11 @@ public class RewriteTablePathUtil {
   /**
    * Rewrite a manifest list representing a snapshot, replacing path references.
    *
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link #rewriteManifestList(Snapshot,
-   *     FileIO, TableMetadata, Set, String, String, String, String, Map)}, which records the
-   *     rewritten manifest length so that manifest_length stays consistent with the rewritten
-   *     manifest file on disk.
+   * <p>Every entry keeps its source {@code manifest_length}, which does not match the rewritten
+   * manifest when the target prefix differs in length from the source. Callers that rewrite to a
+   * different-length prefix should use {@link #rewriteManifestList(Snapshot, FileIO, TableMetadata,
+   * List, Set, String, String, String, String, Map)} and pass the measured lengths.
    */
-  @Deprecated
   public static RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,
       FileIO io,
@@ -270,6 +269,7 @@ public class RewriteTablePathUtil {
         snapshot,
         io,
         tableMetadata,
+        manifestsInSnapshot(snapshot, io, sourcePrefix),
         manifestsToRewrite,
         sourcePrefix,
         targetPrefix,
@@ -281,16 +281,30 @@ public class RewriteTablePathUtil {
   /**
    * Rewrite a manifest list representing a snapshot, replacing path references.
    *
+   * <p>Each entry's {@code manifest_length} is taken from {@code rewrittenManifestLengths}, because
+   * replacing the path prefix changes the byte length of the rewritten manifest.
+   *
+   * <p>Known gap: an entry whose manifest is absent from the map keeps its source length, which
+   * does not match the rewritten file. This is reachable in an incremental run, where a manifest
+   * carried over from an earlier run is still referenced by the new snapshot's manifest list but is
+   * not rewritten again. Re-measuring it here does not help, because the length of the file the
+   * earlier run produced depends on the table metadata as it was then: the manifest header embeds
+   * the current schema, so re-measuring after schema evolution yields a different length. Closing
+   * the gap needs either read access to the target, which this action deliberately does not have,
+   * or state carried between runs.
+   *
    * @param snapshot snapshot represented by the manifest list
    * @param io file io
    * @param tableMetadata metadata of table
+   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
+   *     {@link #manifestsInSnapshot(Snapshot, FileIO, String)}
    * @param manifestsToRewrite a list of manifest files to filter for rewrite
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @param stagingDir staging directory
    * @param outputPath location to write the manifest list
    * @param rewrittenManifestLengths map from source manifest path to the byte length of its
-   *     rewritten manifest; entries absent from the map keep their original length
+   *     rewritten manifest
    * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
    *     list
    */
@@ -298,6 +312,7 @@ public class RewriteTablePathUtil {
       Snapshot snapshot,
       FileIO io,
       TableMetadata tableMetadata,
+      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       String sourcePrefix,
       String targetPrefix,
@@ -306,15 +321,6 @@ public class RewriteTablePathUtil {
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
-
-    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(io, snapshot);
-    manifestFiles.forEach(
-        mf ->
-            Preconditions.checkArgument(
-                mf.path().startsWith(sourcePrefix),
-                "Encountered manifest file %s not under the source prefix %s",
-                mf.path(),
-                sourcePrefix));
 
     EncryptionManager encryptionManager =
         (io instanceof EncryptingFileIO)
@@ -334,8 +340,15 @@ public class RewriteTablePathUtil {
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
-        ((StructLike) newFile)
-            .set(1, rewrittenManifestLengths.getOrDefault(file.path(), file.length()));
+        Long rewrittenLength = rewrittenManifestLengths.get(file.path());
+        if (rewrittenLength == null && !rewrittenManifestLengths.isEmpty()) {
+          LOG.warn(
+              "No measured length for manifest {}; recording its source length {}, which will not "
+                  + "match the rewritten file at the target",
+              file.path(),
+              file.length());
+        }
+        ((StructLike) newFile).set(1, rewrittenLength != null ? rewrittenLength : file.length());
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {
@@ -364,22 +377,33 @@ public class RewriteTablePathUtil {
   }
 
   /**
-   * Identify the manifest files in a snapshot's manifest list that are selected for rewrite.
+   * Read the manifests referenced by a snapshot's manifest list, without writing anything.
    *
-   * <p>Reads the snapshot's manifest list and filters it by {@code manifestsToRewrite} without
-   * writing anything, so callers can enumerate the manifests to rewrite before producing the
-   * rewritten manifest list (which needs the rewritten manifest lengths).
+   * <p>Callers need this before producing the rewritten manifest list, which records each
+   * referenced manifest's rewritten length. Reading once here and passing the result to {@link
+   * #rewriteManifestList(Snapshot, FileIO, TableMetadata, List, Set, String, String, String,
+   * String, Map)} also avoids reading the manifest list twice.
+   *
+   * <p>An unreadable manifest list is logged and treated as empty, matching the behaviour this
+   * method was extracted from.
    *
    * @param snapshot snapshot whose manifest list is read
    * @param io file io
-   * @param manifestsToRewrite paths of manifests selected for rewrite
-   * @return the manifest files in the snapshot that are selected for rewrite
+   * @param sourcePrefix source prefix every referenced manifest must live under
+   * @return the manifests referenced by the snapshot's manifest list, or an empty list if the
+   *     manifest list could not be read
    */
-  public static Set<ManifestFile> manifestsToRewriteForSnapshot(
-      Snapshot snapshot, FileIO io, Set<String> manifestsToRewrite) {
-    return manifestFilesInSnapshot(io, snapshot).stream()
-        .filter(manifestFile -> manifestsToRewrite.contains(manifestFile.path()))
-        .collect(Collectors.toSet());
+  public static List<ManifestFile> manifestsInSnapshot(
+      Snapshot snapshot, FileIO io, String sourcePrefix) {
+    List<ManifestFile> manifestFiles = manifestFilesInSnapshot(io, snapshot);
+    manifestFiles.forEach(
+        manifestFile ->
+            Preconditions.checkArgument(
+                manifestFile.path().startsWith(sourcePrefix),
+                "Encountered manifest file %s not under the source prefix %s",
+                manifestFile.path(),
+                sourcePrefix));
+    return manifestFiles;
   }
 
   /**
@@ -394,11 +418,9 @@ public class RewriteTablePathUtil {
    * @param sourcePrefix source prefix that will be replaced
    * @param targetPrefix target prefix that will replace it
    * @return a copy plan of content files in the manifest that was rewritten
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     #rewriteDataManifestWithLength}, which also returns the rewritten manifest length so that
-   *     manifest_length can be recorded accurately in the manifest list.
+   * @see #rewriteDataManifestAndMeasureLength which also returns the rewritten manifest length, for
+   *     callers that need to record manifest_length in the manifest list
    */
-  @Deprecated
   public static RewriteResult<DataFile> rewriteDataManifest(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
@@ -409,7 +431,7 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
-    return rewriteDataManifestWithLength(
+    return rewriteDataManifestAndMeasureLength(
             manifestFile,
             snapshotIds,
             outputFile,
@@ -425,10 +447,10 @@ public class RewriteTablePathUtil {
    * Rewrite a data manifest, replacing path references, and return the rewritten manifest's byte
    * length.
    *
-   * <p>The length is measured from the manifest writer after it is closed (rather than via a
-   * separate {@code getLength()}/HEAD call) so it is accurate even on file systems where the length
-   * of an in-progress write underreports. Callers record this length as the {@code manifest_length}
-   * of the rewritten manifest in the manifest list.
+   * <p>The length is read from the closed manifest writer rather than via a separate {@code
+   * getLength()} call, which would cost a stat request per manifest against object storage. Callers
+   * record this length as the {@code manifest_length} of the rewritten manifest in the manifest
+   * list.
    *
    * @param manifestFile source manifest file to rewrite
    * @param snapshotIds snapshot ids for filtering returned data manifest entries
@@ -441,7 +463,7 @@ public class RewriteTablePathUtil {
    * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
    *     manifest's byte length
    */
-  public static Pair<RewriteResult<DataFile>, Long> rewriteDataManifestWithLength(
+  public static Pair<RewriteResult<DataFile>, Long> rewriteDataManifestAndMeasureLength(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
       OutputFile outputFile,
@@ -484,9 +506,10 @@ public class RewriteTablePathUtil {
    *     rewritten here)
    * @return a copy plan of content files in the manifest that was rewritten
    * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
-   *     #rewriteDeleteManifestWithLength}, which accepts the map of rewritten position delete file
-   *     sizes and also returns the rewritten manifest length so that {@code file_size_in_bytes} and
-   *     {@code manifest_length} stay consistent with the rewritten files on disk.
+   *     #rewriteDeleteManifestAndMeasureLength}, which accepts the map of rewritten position delete
+   *     file sizes and also returns the rewritten manifest length so that {@code
+   *     file_size_in_bytes} and {@code manifest_length} stay consistent with the rewritten files on
+   *     disk.
    */
   @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(
@@ -500,26 +523,22 @@ public class RewriteTablePathUtil {
       String targetPrefix,
       String stagingLocation)
       throws IOException {
-    return rewriteDeleteManifest(
-        manifestFile,
-        snapshotIds,
-        outputFile,
-        io,
-        format,
-        specsById,
-        sourcePrefix,
-        targetPrefix,
-        stagingLocation,
-        ImmutableMap.of());
+    return rewriteDeleteManifestAndMeasureLength(
+            manifestFile,
+            snapshotIds,
+            outputFile,
+            io,
+            format,
+            specsById,
+            sourcePrefix,
+            targetPrefix,
+            stagingLocation,
+            ImmutableMap.of())
+        .first();
   }
 
   /**
    * Rewrite a delete manifest, replacing path references.
-   *
-   * <p>This is a metadata-only operation: position delete file content is rewritten separately (see
-   * {@link #rewritePositionDelete}). The actual sizes of those rewritten files are supplied via
-   * {@code rewrittenDeleteFileSizes} and recorded in the manifest so that {@code
-   * file_size_in_bytes} stays consistent with the rewritten file on disk.
    *
    * @param manifestFile source delete manifest to rewrite
    * @param snapshotIds snapshot ids for filtering returned delete manifest entries
@@ -533,11 +552,9 @@ public class RewriteTablePathUtil {
    * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
    *     the rewritten file; entries absent from the map keep their original size
    * @return a copy plan of content files in the manifest that was rewritten
-   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link
-   *     #rewriteDeleteManifestWithLength}, which also returns the rewritten manifest length so that
-   *     manifest_length can be recorded accurately in the manifest list.
+   * @see #rewriteDeleteManifestAndMeasureLength which also returns the rewritten manifest length,
+   *     for callers that need to record manifest_length in the manifest list
    */
-  @Deprecated
   public static RewriteResult<DeleteFile> rewriteDeleteManifest(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
@@ -550,7 +567,7 @@ public class RewriteTablePathUtil {
       String stagingLocation,
       Map<String, Long> rewrittenDeleteFileSizes)
       throws IOException {
-    return rewriteDeleteManifestWithLength(
+    return rewriteDeleteManifestAndMeasureLength(
             manifestFile,
             snapshotIds,
             outputFile,
@@ -573,10 +590,10 @@ public class RewriteTablePathUtil {
    * {@code rewrittenDeleteFileSizes} and recorded in the manifest so that {@code
    * file_size_in_bytes} stays consistent with the rewritten file on disk.
    *
-   * <p>The manifest length is measured from the manifest writer after it is closed (rather than via
-   * a separate {@code getLength()}/HEAD call) so it is accurate even on file systems where the
-   * length of an in-progress write underreports. Callers record this length as the {@code
-   * manifest_length} of the rewritten manifest in the manifest list.
+   * <p>The manifest length is read from the closed manifest writer rather than via a separate
+   * {@code getLength()} call, which would cost a stat request per manifest against object storage.
+   * Callers record this length as the {@code manifest_length} of the rewritten manifest in the
+   * manifest list.
    *
    * @param manifestFile source delete manifest to rewrite
    * @param snapshotIds snapshot ids for filtering returned delete manifest entries
@@ -592,7 +609,7 @@ public class RewriteTablePathUtil {
    * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
    *     manifest's byte length
    */
-  public static Pair<RewriteResult<DeleteFile>, Long> rewriteDeleteManifestWithLength(
+  public static Pair<RewriteResult<DeleteFile>, Long> rewriteDeleteManifestAndMeasureLength(
       ManifestFile manifestFile,
       Set<Long> snapshotIds,
       OutputFile outputFile,

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -375,5 +377,71 @@ public class TestRewriteTablePathUtil extends TestBase {
     }
 
     return writer.toManifestFile();
+  }
+
+  @TestTemplate
+  public void testRewriteManifestListStampsRewrittenManifestLength() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    Snapshot snapshot = table.currentSnapshot();
+    List<ManifestFile> manifests = snapshot.allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+    ManifestFile sourceManifest = manifests.get(0);
+
+    String manifestPath = sourceManifest.path();
+    String sourcePrefix = manifestPath.substring(0, manifestPath.indexOf("/metadata/"));
+    String targetPrefix = sourcePrefix + "/relocated";
+    String stagingDir = temp.resolve("staging").toString();
+    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
+
+    // a value distinct from the source length so we can tell it was applied
+    long rewrittenLength = sourceManifest.length() + 4242L;
+
+    RewriteTablePathUtil.rewriteManifestList(
+        snapshot,
+        table.io(),
+        table.ops().current(),
+        Set.of(sourceManifest.path()),
+        sourcePrefix,
+        targetPrefix,
+        stagingDir,
+        outputPath,
+        Map.of(sourceManifest.path(), rewrittenLength));
+
+    List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
+    assertThat(rewritten).hasSize(1);
+    assertThat(rewritten.get(0).length())
+        .as("manifest_length should be stamped from the rewritten length map")
+        .isEqualTo(rewrittenLength);
+    assertThat(rewritten.get(0).path()).startsWith(targetPrefix);
+  }
+
+  @TestTemplate
+  public void testRewriteManifestListFallsBackToSourceLengthWhenAbsent() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snapshot = table.currentSnapshot();
+    ManifestFile sourceManifest = snapshot.allManifests(table.io()).get(0);
+
+    String manifestPath = sourceManifest.path();
+    String sourcePrefix = manifestPath.substring(0, manifestPath.indexOf("/metadata/"));
+    String targetPrefix = sourcePrefix + "/relocated";
+    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
+
+    // empty map: manifests not rewritten in this run must keep their original length
+    RewriteTablePathUtil.rewriteManifestList(
+        snapshot,
+        table.io(),
+        table.ops().current(),
+        Set.of(sourceManifest.path()),
+        sourcePrefix,
+        targetPrefix,
+        temp.resolve("staging-fallback").toString(),
+        outputPath,
+        Map.of());
+
+    List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
+    assertThat(rewritten).hasSize(1);
+    assertThat(rewritten.get(0).length())
+        .as("manifest_length should fall back to the source length when absent from the map")
+        .isEqualTo(sourceManifest.length());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -453,7 +453,42 @@ public class TestRewriteTablePathUtil extends TestBase {
                     outputPath,
                     ImmutableMap.of()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing rewritten length for manifest");
+        .hasMessageContaining("Missing rewritten length for manifests")
+        .hasMessageContaining(manifest.path());
+  }
+
+  @TestTemplate
+  public void testRewriteManifestListRejectsUnmeasuredManifestFromAnotherSnapshot() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot firstSnapshot = table.currentSnapshot();
+    ManifestFile firstManifest = firstSnapshot.allManifests(table.io()).get(0);
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    ManifestFile laterManifest =
+        table.currentSnapshot().allManifests(table.io()).stream()
+            .filter(manifest -> !manifest.path().equals(firstManifest.path()))
+            .findFirst()
+            .orElseThrow();
+
+    String sourcePrefix =
+        firstManifest.path().substring(0, firstManifest.path().lastIndexOf("/metadata/"));
+    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
+
+    assertThatThrownBy(
+            () ->
+                RewriteTablePathUtil.rewriteManifestList(
+                    firstSnapshot,
+                    table.io(),
+                    table.ops().current(),
+                    Set.of(firstManifest.path(), laterManifest.path()),
+                    sourcePrefix,
+                    sourcePrefix + "/relocated",
+                    temp.resolve("staging").toString(),
+                    outputPath,
+                    ImmutableMap.of(firstManifest.path(), firstManifest.length() + 4242L)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing rewritten length for manifests")
+        .hasMessageContaining(laterManifest.path());
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -404,16 +405,16 @@ public class TestRewriteTablePathUtil extends TestBase {
 
     long rewrittenLength = measured.length() + 4242L;
 
-    RewriteTablePathUtil.rewriteManifestList(
-        snapshot,
-        table.io(),
-        table.ops().current(),
-        Set.of(measured.path()),
-        sourcePrefix,
-        targetPrefix,
-        stagingDir,
-        outputPath,
-        ImmutableMap.of(measured.path(), rewrittenLength));
+    RewriteTablePathUtil.RewriteResult<ManifestFile> result =
+        RewriteTablePathUtil.rewriteManifestList(
+            snapshot,
+            table.io(),
+            table.ops().current(),
+            ImmutableMap.of(measured.path(), rewrittenLength),
+            sourcePrefix,
+            targetPrefix,
+            stagingDir,
+            outputPath);
 
     List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
     assertThat(rewritten).hasSize(2);
@@ -430,65 +431,17 @@ public class TestRewriteTablePathUtil extends TestBase {
     assertThat(lengthByPath)
         .as("unmeasured manifest should keep its source length")
         .containsEntry(unmeasuredTargetPath, unmeasured.length());
-  }
 
-  @TestTemplate
-  public void testRewriteManifestListRejectsRewrittenManifestWithoutLength() {
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snapshot = table.currentSnapshot();
-    ManifestFile manifest = snapshot.allManifests(table.io()).get(0);
-    String sourcePrefix = manifest.path().substring(0, manifest.path().lastIndexOf("/metadata/"));
-    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
-
-    assertThatThrownBy(
-            () ->
-                RewriteTablePathUtil.rewriteManifestList(
-                    snapshot,
-                    table.io(),
-                    table.ops().current(),
-                    Set.of(manifest.path()),
-                    sourcePrefix,
-                    sourcePrefix + "/relocated",
-                    temp.resolve("staging").toString(),
-                    outputPath,
-                    ImmutableMap.of()))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing rewritten length for manifests")
-        .hasMessageContaining(manifest.path());
-  }
-
-  @TestTemplate
-  public void testRewriteManifestListRejectsUnmeasuredManifestFromAnotherSnapshot() {
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot firstSnapshot = table.currentSnapshot();
-    ManifestFile firstManifest = firstSnapshot.allManifests(table.io()).get(0);
-
-    table.newFastAppend().appendFile(FILE_B).commit();
-    ManifestFile laterManifest =
-        table.currentSnapshot().allManifests(table.io()).stream()
-            .filter(manifest -> !manifest.path().equals(firstManifest.path()))
-            .findFirst()
-            .orElseThrow();
-
-    String sourcePrefix =
-        firstManifest.path().substring(0, firstManifest.path().lastIndexOf("/metadata/"));
-    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
-
-    assertThatThrownBy(
-            () ->
-                RewriteTablePathUtil.rewriteManifestList(
-                    firstSnapshot,
-                    table.io(),
-                    table.ops().current(),
-                    Set.of(firstManifest.path(), laterManifest.path()),
-                    sourcePrefix,
-                    sourcePrefix + "/relocated",
-                    temp.resolve("staging").toString(),
-                    outputPath,
-                    ImmutableMap.of(firstManifest.path(), firstManifest.length() + 4242L)))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing rewritten length for manifests")
-        .hasMessageContaining(laterManifest.path());
+    assertThat(result.toRewrite())
+        .as("only manifests with a measured length should be rewritten")
+        .extracting(ManifestFile::path)
+        .containsExactly(measured.path());
+    assertThat(result.copyPlan())
+        .as("the copy plan should cover the staged copy of that manifest only")
+        .containsExactly(
+            Pair.of(
+                RewriteTablePathUtil.stagingPath(measured.path(), sourcePrefix, stagingDir),
+                measuredTargetPath));
   }
 
   @TestTemplate
@@ -503,12 +456,11 @@ public class TestRewriteTablePathUtil extends TestBase {
                     snapshot,
                     table.io(),
                     table.ops().current(),
-                    Set.of(),
+                    ImmutableMap.of(),
                     "/some/unrelated/prefix/",
                     "/target/prefix/",
                     temp.resolve("staging").toString(),
-                    outputPath,
-                    ImmutableMap.of()))
+                    outputPath))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("not under the source prefix");
   }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -445,27 +445,6 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestListRejectsManifestOutsideSourcePrefix() {
-    table.newFastAppend().appendFile(FILE_A).commit();
-    Snapshot snapshot = table.currentSnapshot();
-    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
-
-    assertThatThrownBy(
-            () ->
-                RewriteTablePathUtil.rewriteManifestList(
-                    snapshot,
-                    table.io(),
-                    table.ops().current(),
-                    ImmutableMap.of(),
-                    "/some/unrelated/prefix/",
-                    "/target/prefix/",
-                    temp.resolve("staging").toString(),
-                    outputPath))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("not under the source prefix");
-  }
-
-  @TestTemplate
   public void testRewriteDataManifestRecordsRewrittenLength() throws IOException {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
     ManifestFile manifest = table.currentSnapshot().allManifests(table.io()).get(0);

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -26,9 +26,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -270,13 +272,15 @@ public class TestRewriteTablePathUtil extends TestBase {
     ManifestFile manifest =
         writeDeleteManifest(formatVersion, 1000L, FILE_A_DELETES, FILE_B_DELETES);
 
-    RewriteTablePathUtil.RewriteResult<DeleteFile> deleteFileRewriteResult =
-        RewriteTablePathUtil.rewriteDeleteManifest(
+    OutputFile output =
+        Files.localOutput(
+            FileFormat.AVRO.addExtension(
+                temp.resolve("junit" + System.nanoTime()).toFile().toString()));
+    Pair<RewriteTablePathUtil.RewriteResult<DeleteFile>, Long> deleteFileRewriteResult =
+        RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
             manifest,
             Set.of(1000L),
-            Files.localOutput(
-                FileFormat.AVRO.addExtension(
-                    temp.resolve("junit" + System.nanoTime()).toFile().toString())),
+            output,
             table.io(),
             formatVersion,
             table.specs(),
@@ -285,7 +289,10 @@ public class TestRewriteTablePathUtil extends TestBase {
             stagingDir,
             ImmutableMap.of());
 
-    assertThat(deleteFileRewriteResult.toRewrite()).hasSize(2);
+    assertThat(deleteFileRewriteResult.first().toRewrite()).hasSize(2);
+    assertThat(deleteFileRewriteResult.second())
+        .as("measured length should match the rewritten delete manifest on disk")
+        .isEqualTo(output.toInputFile().getLength());
   }
 
   // A position delete entry that is not rewritten (e.g. a DELETED entry not copied to the target)
@@ -310,7 +317,7 @@ public class TestRewriteTablePathUtil extends TestBase {
         Files.localOutput(
             FileFormat.AVRO.addExtension(
                 temp.resolve("junit" + System.nanoTime()).toFile().toString()));
-    RewriteTablePathUtil.rewriteDeleteManifest(
+    RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
         manifest,
         Set.of(1000L),
         output,
@@ -379,69 +386,69 @@ public class TestRewriteTablePathUtil extends TestBase {
     return writer.toManifestFile();
   }
 
+  /**
+   * One manifest is measured and one is not, in a single manifest list. The measured one must take
+   * the mapped length and the unmeasured one must keep its source length, which pins both the
+   * stamping and the fact that the map is keyed by the source path, not the rewritten one.
+   */
   @TestTemplate
-  public void testRewriteManifestListStampsRewrittenManifestLength() throws IOException {
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+  public void testRewriteManifestListStampsMeasuredManifestLengths() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newFastAppend().appendFile(FILE_B).commit();
     Snapshot snapshot = table.currentSnapshot();
     List<ManifestFile> manifests = snapshot.allManifests(table.io());
-    assertThat(manifests).hasSize(1);
-    ManifestFile sourceManifest = manifests.get(0);
+    assertThat(manifests).hasSize(2);
+    ManifestFile measured = manifests.get(0);
+    ManifestFile unmeasured = manifests.get(1);
 
-    String manifestPath = sourceManifest.path();
+    String manifestPath = measured.path();
     String sourcePrefix = manifestPath.substring(0, manifestPath.indexOf("/metadata/"));
     String targetPrefix = sourcePrefix + "/relocated";
     String stagingDir = temp.resolve("staging").toString();
     String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
 
     // a value distinct from the source length so we can tell it was applied
-    long rewrittenLength = sourceManifest.length() + 4242L;
+    long rewrittenLength = measured.length() + 4242L;
 
     RewriteTablePathUtil.rewriteManifestList(
         snapshot,
         table.io(),
         table.ops().current(),
-        Set.of(sourceManifest.path()),
+        manifests,
+        Set.of(measured.path(), unmeasured.path()),
         sourcePrefix,
         targetPrefix,
         stagingDir,
         outputPath,
-        Map.of(sourceManifest.path(), rewrittenLength));
+        Map.of(measured.path(), rewrittenLength));
 
     List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
-    assertThat(rewritten).hasSize(1);
-    assertThat(rewritten.get(0).length())
-        .as("manifest_length should be stamped from the rewritten length map")
-        .isEqualTo(rewrittenLength);
-    assertThat(rewritten.get(0).path()).startsWith(targetPrefix);
+    assertThat(rewritten).hasSize(2);
+    Map<String, Long> lengthByPath =
+        rewritten.stream().collect(Collectors.toMap(ManifestFile::path, ManifestFile::length));
+
+    String measuredTargetPath =
+        RewriteTablePathUtil.newPath(measured.path(), sourcePrefix, targetPrefix);
+    String unmeasuredTargetPath =
+        RewriteTablePathUtil.newPath(unmeasured.path(), sourcePrefix, targetPrefix);
+    assertThat(lengthByPath)
+        .as("measured manifest should take the mapped length, keyed by its source path")
+        .containsEntry(measuredTargetPath, rewrittenLength);
+    assertThat(lengthByPath)
+        .as("unmeasured manifest should keep its source length")
+        .containsEntry(unmeasuredTargetPath, unmeasured.length());
   }
 
   @TestTemplate
-  public void testRewriteManifestListFallsBackToSourceLengthWhenAbsent() throws IOException {
+  public void testManifestsInSnapshotRejectsManifestOutsideSourcePrefix() {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snapshot = table.currentSnapshot();
-    ManifestFile sourceManifest = snapshot.allManifests(table.io()).get(0);
 
-    String manifestPath = sourceManifest.path();
-    String sourcePrefix = manifestPath.substring(0, manifestPath.indexOf("/metadata/"));
-    String targetPrefix = sourcePrefix + "/relocated";
-    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
-
-    // empty map: manifests not rewritten in this run must keep their original length
-    RewriteTablePathUtil.rewriteManifestList(
-        snapshot,
-        table.io(),
-        table.ops().current(),
-        Set.of(sourceManifest.path()),
-        sourcePrefix,
-        targetPrefix,
-        temp.resolve("staging-fallback").toString(),
-        outputPath,
-        Map.of());
-
-    List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
-    assertThat(rewritten).hasSize(1);
-    assertThat(rewritten.get(0).length())
-        .as("manifest_length should fall back to the source length when absent from the map")
-        .isEqualTo(sourceManifest.length());
+    assertThatThrownBy(
+            () ->
+                RewriteTablePathUtil.manifestsInSnapshot(
+                    snapshot, table.io(), "/some/unrelated/prefix/"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("not under the source prefix");
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
@@ -30,7 +31,6 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -276,8 +276,8 @@ public class TestRewriteTablePathUtil extends TestBase {
         Files.localOutput(
             FileFormat.AVRO.addExtension(
                 temp.resolve("junit" + System.nanoTime()).toFile().toString()));
-    Pair<RewriteTablePathUtil.RewriteResult<DeleteFile>, Long> deleteFileRewriteResult =
-        RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
+    RewriteTablePathUtil.RewriteResult<DeleteFile> deleteFileRewriteResult =
+        RewriteTablePathUtil.rewriteDeleteManifest(
             manifest,
             Set.of(1000L),
             output,
@@ -289,10 +289,10 @@ public class TestRewriteTablePathUtil extends TestBase {
             stagingDir,
             ImmutableMap.of());
 
-    assertThat(deleteFileRewriteResult.first().toRewrite()).hasSize(2);
-    assertThat(deleteFileRewriteResult.second())
-        .as("measured length should match the rewritten delete manifest on disk")
-        .isEqualTo(output.toInputFile().getLength());
+    assertThat(deleteFileRewriteResult.toRewrite()).hasSize(2);
+    assertThat(deleteFileRewriteResult.rewrittenManifestLengths())
+        .as("recorded length should be keyed by source path and match the rewritten manifest")
+        .containsExactly(entry(manifest.path(), output.toInputFile().getLength()));
   }
 
   // A position delete entry that is not rewritten (e.g. a DELETED entry not copied to the target)
@@ -317,7 +317,7 @@ public class TestRewriteTablePathUtil extends TestBase {
         Files.localOutput(
             FileFormat.AVRO.addExtension(
                 temp.resolve("junit" + System.nanoTime()).toFile().toString()));
-    RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
+    RewriteTablePathUtil.rewriteDeleteManifest(
         manifest,
         Set.of(1000L),
         output,
@@ -386,11 +386,6 @@ public class TestRewriteTablePathUtil extends TestBase {
     return writer.toManifestFile();
   }
 
-  /**
-   * One manifest is measured and one is not, in a single manifest list. The measured one must take
-   * the mapped length and the unmeasured one must keep its source length, which pins both the
-   * stamping and the fact that the map is keyed by the source path, not the rewritten one.
-   */
   @TestTemplate
   public void testRewriteManifestListStampsMeasuredManifestLengths() throws IOException {
     table.newFastAppend().appendFile(FILE_A).commit();
@@ -407,15 +402,13 @@ public class TestRewriteTablePathUtil extends TestBase {
     String stagingDir = temp.resolve("staging").toString();
     String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
 
-    // a value distinct from the source length so we can tell it was applied
     long rewrittenLength = measured.length() + 4242L;
 
     RewriteTablePathUtil.rewriteManifestList(
         snapshot,
         table.io(),
         table.ops().current(),
-        manifests,
-        Set.of(measured.path(), unmeasured.path()),
+        Set.of(measured.path()),
         sourcePrefix,
         targetPrefix,
         stagingDir,
@@ -440,15 +433,87 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestsInSnapshotRejectsManifestOutsideSourcePrefix() {
+  public void testRewriteManifestListRejectsRewrittenManifestWithoutLength() {
     table.newFastAppend().appendFile(FILE_A).commit();
     Snapshot snapshot = table.currentSnapshot();
+    ManifestFile manifest = snapshot.allManifests(table.io()).get(0);
+    String sourcePrefix = manifest.path().substring(0, manifest.path().lastIndexOf("/metadata/"));
+    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
 
     assertThatThrownBy(
             () ->
-                RewriteTablePathUtil.manifestsInSnapshot(
-                    snapshot, table.io(), "/some/unrelated/prefix/"))
+                RewriteTablePathUtil.rewriteManifestList(
+                    snapshot,
+                    table.io(),
+                    table.ops().current(),
+                    Set.of(manifest.path()),
+                    sourcePrefix,
+                    sourcePrefix + "/relocated",
+                    temp.resolve("staging").toString(),
+                    outputPath,
+                    ImmutableMap.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Missing rewritten length for manifest");
+  }
+
+  @TestTemplate
+  public void testRewriteManifestListRejectsManifestOutsideSourcePrefix() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snapshot = table.currentSnapshot();
+    String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
+
+    assertThatThrownBy(
+            () ->
+                RewriteTablePathUtil.rewriteManifestList(
+                    snapshot,
+                    table.io(),
+                    table.ops().current(),
+                    Set.of(),
+                    "/some/unrelated/prefix/",
+                    "/target/prefix/",
+                    temp.resolve("staging").toString(),
+                    outputPath,
+                    ImmutableMap.of()))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("not under the source prefix");
+  }
+
+  @TestTemplate
+  public void testRewriteDataManifestRecordsRewrittenLength() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    ManifestFile manifest = table.currentSnapshot().allManifests(table.io()).get(0);
+
+    OutputFile output =
+        Files.localOutput(
+            FileFormat.AVRO.addExtension(
+                temp.resolve("junit" + System.nanoTime()).toFile().toString()));
+    RewriteTablePathUtil.RewriteResult<DataFile> result =
+        RewriteTablePathUtil.rewriteDataManifest(
+            manifest,
+            Set.of(table.currentSnapshot().snapshotId()),
+            output,
+            table.io(),
+            formatVersion,
+            table.specs(),
+            "/path/to/",
+            "/path/new/");
+
+    assertThat(result.rewrittenManifestLengths())
+        .as("recorded length should be keyed by source path and match the rewritten manifest")
+        .containsExactly(entry(manifest.path(), output.toInputFile().getLength()));
+  }
+
+  @Test
+  public void testRewriteResultAppendMergesManifestLengths() {
+    RewriteTablePathUtil.RewriteResult<DataFile> first = new RewriteTablePathUtil.RewriteResult<>();
+    first.addRewrittenManifestLength("/path/to/m1.avro", 10L);
+    RewriteTablePathUtil.RewriteResult<DataFile> second =
+        new RewriteTablePathUtil.RewriteResult<>();
+    second.addRewrittenManifestLength("/path/to/m2.avro", 20L);
+
+    assertThat(first.append(second).rewrittenManifestLengths())
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of("/path/to/m1.avro", 10L, "/path/to/m2.avro", 20L));
+    assertThat(first.rewrittenManifestLengths()).isUnmodifiable();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -402,7 +402,7 @@ public class TestRewriteTablePathUtil extends TestBase {
     ManifestFile unmeasured = manifests.get(1);
 
     String manifestPath = measured.path();
-    String sourcePrefix = manifestPath.substring(0, manifestPath.indexOf("/metadata/"));
+    String sourcePrefix = manifestPath.substring(0, manifestPath.lastIndexOf("/metadata/"));
     String targetPrefix = sourcePrefix + "/relocated";
     String stagingDir = temp.resolve("staging").toString();
     String outputPath = temp.resolve("rewritten-list-" + System.nanoTime() + ".avro").toString();
@@ -420,7 +420,7 @@ public class TestRewriteTablePathUtil extends TestBase {
         targetPrefix,
         stagingDir,
         outputPath,
-        Map.of(measured.path(), rewrittenLength));
+        ImmutableMap.of(measured.path(), rewrittenLength));
 
     List<ManifestFile> rewritten = ManifestLists.read(table.io().newInputFile(outputPath));
     assertThat(rewritten).hasSize(2);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,21 +302,19 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
+    // manifest list must record each rewritten manifest's length (manifest_length), which is only
+    // known after the manifests are rewritten below.
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+                manifestFiles.addAll(
+                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
+                        snapshot, table.io(), manifestsToRewrite)));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +331,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot,
+                        endMetadata,
+                        manifestsToRewrite,
+                        rewriteManifestResult.rewrittenManifestLengths())));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -495,11 +511,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
    * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +533,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestLengths);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -552,10 +573,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
+    // Map from source manifest path to the byte length of its rewritten manifest, used by the
+    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
+    // survives the map/reduce because Spark's EliminateSerialization collapses the
+    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
+
+    public Map<String, Long> rewrittenManifestLengths() {
+      return rewrittenManifestLengths;
+    }
+
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      if (r1 instanceof RewriteContentFileResult) {
+        this.rewrittenManifestLengths.putAll(
+            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
+      }
       return this;
     }
 
@@ -618,28 +653,36 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          result.appendDataFile(
-              writeDataManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix));
-          break;
+          {
+            Pair<RewriteResult<DataFile>, Long> dataManifest =
+                writeDataManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix);
+            result.appendDataFile(dataManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
+            break;
+          }
         case DELETES:
-          result.appendDeleteFile(
-              writeDeleteManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix,
-                  rewrittenDeleteFileSizes));
-          break;
+          {
+            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
+                writeDeleteManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix,
+                    rewrittenDeleteFileSizes);
+            result.appendDeleteFile(deleteManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
+            break;
+          }
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -648,7 +691,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static RewriteResult<DataFile> writeDataManifest(
+  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -663,7 +706,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifest(
+      return RewriteTablePathUtil.rewriteDataManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -677,7 +720,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static RewriteResult<DeleteFile> writeDeleteManifest(
+  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -693,7 +736,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifest(
+      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,10 +278,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Read the manifest lists of all valid snapshots
+   *   <li>Rebuild manifest list files to staging
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
-   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -303,27 +302,21 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // read every valid snapshot's manifest list
-    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
+    // rebuild manifest-list files
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestsBySnapshot.put(
-                    snapshot,
-                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
+                manifestListResults.add(
+                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
 
-    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
-    Set<ManifestFile> manifestFiles = Sets.newHashSet();
-    manifestsBySnapshot
-        .values()
-        .forEach(
-            manifests ->
-                manifests.stream()
-                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
-                    .forEach(manifestFiles::add));
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
+
+    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -340,25 +333,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
-
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
-    Tasks.foreach(validSnapshots)
-        .noRetry()
-        .throwFailureWhenFinished()
-        .executeWith(executorService)
-        .run(
-            snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(
-                        snapshot,
-                        endMetadata,
-                        manifestsBySnapshot.get(snapshot),
-                        manifestsToRewrite,
-                        rewriteManifestResult.rewrittenManifestLengths())));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -520,20 +494,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
-   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
-   * @param manifestsToRewrite a list of manifest files to filter for rewrite
-   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
-   *     rewritten manifest
+   * @param manifestsToRewrite filter of manifests to rewrite.
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      TableMetadata tableMetadata,
-      List<ManifestFile> manifestFiles,
-      Set<String> manifestsToRewrite,
-      Map<String, Long> rewrittenManifestLengths) {
+      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -543,13 +509,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath,
-            rewrittenManifestLengths);
+            outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -588,22 +552,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
-    // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length.
-    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
-
-    public Map<String, Long> rewrittenManifestLengths() {
-      return rewrittenManifestLengths;
-    }
-
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
-      if (r1 instanceof RewriteContentFileResult) {
-        this.rewrittenManifestLengths.putAll(
-            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
-      }
       return this;
     }
 
@@ -647,13 +599,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
-            // this class (none of its accessors are JavaBean getters), so the copy plan and the
-            // measured manifest lengths survive only because the optimizer collapses the
-            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
-            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
-            // serializes through neither encoder.
-            Encoders.javaSerialization(RewriteContentFileResult.class))
+            Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);
@@ -672,36 +618,28 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          {
-            Pair<RewriteResult<DataFile>, Long> dataManifest =
-                writeDataManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix);
-            result.appendDataFile(dataManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
-            break;
-          }
+          result.appendDataFile(
+              writeDataManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix));
+          break;
         case DELETES:
-          {
-            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
-                writeDeleteManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix,
-                    rewrittenDeleteFileSizes);
-            result.appendDeleteFile(deleteManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
-            break;
-          }
+          result.appendDeleteFile(
+              writeDeleteManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix,
+                  rewrittenDeleteFileSizes));
+          break;
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -710,7 +648,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
+  private static RewriteResult<DataFile> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -725,7 +663,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDataManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -739,7 +677,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
+  private static RewriteResult<DeleteFile> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -755,7 +693,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDeleteManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,19 +302,31 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
-    // manifest list must record each rewritten manifest's length (manifest_length), which is only
-    // known after the manifests are rewritten below.
-    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
+    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
+    // manifest list must record each referenced manifest's rewritten length (manifest_length),
+    // which is only known after the manifests are rewritten below.
+    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestFiles.addAll(
-                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
-                        snapshot, table.io(), manifestsToRewrite)));
+                manifestsBySnapshot.put(
+                    snapshot,
+                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
+
+    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
+    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
+    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    Set<ManifestFile> manifestFiles = Sets.newHashSet();
+    manifestsBySnapshot
+        .values()
+        .forEach(
+            manifests ->
+                manifests.stream()
+                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
+                    .forEach(manifestFiles::add));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -344,6 +356,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     rewriteManifestList(
                         snapshot,
                         endMetadata,
+                        manifestsBySnapshot.get(snapshot),
                         manifestsToRewrite,
                         rewriteManifestResult.rewrittenManifestLengths())));
 
@@ -510,6 +523,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
+   * @param manifestFiles the manifests the snapshot's manifest list references
    * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
@@ -518,6 +532,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,
       TableMetadata tableMetadata,
+      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
@@ -529,6 +544,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
+            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
@@ -574,9 +590,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
     // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
-    // survives the map/reduce because Spark's EliminateSerialization collapses the
-    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    // manifest-list rewrite to record an accurate manifest_length.
     private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
 
     public Map<String, Long> rewrittenManifestLengths() {
@@ -634,7 +648,13 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            Encoders.bean(RewriteContentFileResult.class))
+            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
+            // this class (none of its accessors are JavaBean getters), so the copy plan and the
+            // measured manifest lengths survive only because the optimizer collapses the
+            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
+            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
+            // serializes through neither encoder.
+            Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);
@@ -706,7 +726,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestWithLength(
+      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -736,7 +756,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
+      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -341,10 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot ->
                 manifestListResults.add(
                     rewriteManifestList(
-                        snapshot,
-                        endMetadata,
-                        manifestsToRewrite,
-                        rewriteManifestResult.rewrittenManifestLengths())));
+                        snapshot, endMetadata, rewriteManifestResult.rewrittenManifestLengths())));
 
     RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
     manifestListResults.forEach(rewriteManifestListResult::append);
@@ -509,16 +506,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      TableMetadata tableMetadata,
-      Set<String> manifestsToRewrite,
-      Map<String, Long> rewrittenManifestLengths) {
+      Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -528,12 +521,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestsToRewrite,
+            rewrittenManifestLengths,
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath,
-            rewrittenManifestLengths);
+            outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,9 +278,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Rebuild manifest list files to staging
+   *   <li>Read the manifest lists of all valid snapshots
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
+   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -302,21 +303,17 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    // read the manifest lists of all valid snapshots
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+                snapshot.allManifests(table.io()).stream()
+                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
+                    .forEach(manifestFiles::add));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +330,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // rebuild manifest-list files
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot,
+                        endMetadata,
+                        manifestsToRewrite,
+                        rewriteManifestResult.rewrittenManifestLengths())));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -495,11 +510,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
    * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +532,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestLengths);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -556,18 +576,21 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDataFile(RewriteResult<DataFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDeleteFile(RewriteResult<DeleteFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
   }
@@ -599,7 +622,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            Encoders.bean(RewriteContentFileResult.class))
+            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
+            Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,9 +278,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Rebuild manifest list files to staging
+   *   <li>Read the manifest lists of all valid snapshots
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
+   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -302,9 +303,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
-    // manifest list must record each referenced manifest's rewritten length (manifest_length),
-    // which is only known after the manifests are rewritten below.
+    // read every valid snapshot's manifest list
     Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -316,9 +315,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     snapshot,
                     RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
 
-    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
-    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
-    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
     Set<ManifestFile> manifestFiles = Sets.newHashSet();
     manifestsBySnapshot
         .values()
@@ -344,7 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
 
-    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    // rebuild manifest-list files
     Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -523,9 +520,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests the snapshot's manifest list references
-   * @param manifestsToRewrite filter of manifests to rewrite.
-   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
+   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
+   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
+   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
+   *     rewritten manifest
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -614,8 +614,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
-            Encoders.javaSerialization(RewriteContentFileResult.class))
+            Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -366,12 +366,11 @@ public class TestRewriteTablePathsAction extends TestBase {
   @TestTemplate
   public void testManifestLengthAfterRewrite() throws Exception {
     // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. The rewritten manifest list must record that new size
-    // in
-    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
-    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
-    // change from the prefix is dominated by the data block (not the constant Avro schema header),
-    // making the difference unambiguous.
+    // differs in byte size from the source. Every rewritten manifest list - for the current and all
+    // historical snapshots - must record that new size in manifest_length; otherwise readers that
+    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
+    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
+    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
     String sourceLocation = newTableLocation();
     Table sourceTable =
         TABLES.create(
@@ -380,19 +379,24 @@ public class TestRewriteTablePathsAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             sourceLocation);
 
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 50; i++) {
-      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
+    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
+      List<ThreeColumnRecord> records = Lists.newArrayList();
+      for (int i = 0; i < 30; i++) {
+        int id = snapshotNo * 100 + i;
+        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+      }
+      spark
+          .createDataFrame(records, ThreeColumnRecord.class)
+          .repartition(30)
+          .select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(sourceLocation);
     }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(50)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(sourceLocation);
     sourceTable.refresh();
+    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -407,15 +411,21 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     Table targetTable = TABLES.load(targetLocation);
     FileIO io = targetTable.io();
-    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
-    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
-    for (ManifestFile manifest : manifests) {
-      assertThat(manifest.length())
-          .as(
-              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
-              manifest.path())
-          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    int checkedManifests = 0;
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+        checkedManifests++;
+      }
     }
+    assertThat(checkedManifests)
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isGreaterThan(1);
   }
 
   @TestTemplate

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,6 +364,61 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testManifestLengthAfterRewrite() throws Exception {
+    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
+    // differs in byte size from the source. The rewritten manifest list must record that new size
+    // in
+    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
+    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
+    // change from the prefix is dominated by the data block (not the constant Avro schema header),
+    // making the difference unambiguous.
+    String sourceLocation = newTableLocation();
+    Table sourceTable =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            sourceLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 50; i++) {
+      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(50)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceLocation);
+    sourceTable.refresh();
+
+    String targetLocation =
+        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
+            .execute();
+    copyTableFiles(result);
+
+    Table targetTable = TABLES.load(targetLocation);
+    FileIO io = targetTable.io();
+    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
+    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
+    for (ManifestFile manifest : manifests) {
+      assertThat(manifest.length())
+          .as(
+              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
+              manifest.path())
+          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    }
+  }
+
+  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -380,23 +380,10 @@ public class TestRewriteTablePathsAction extends TestBase {
             sourceLocation);
 
     // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
-    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
-      List<ThreeColumnRecord> records = Lists.newArrayList();
-      for (int i = 0; i < 30; i++) {
-        int id = snapshotNo * 100 + i;
-        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-      }
-      spark
-          .createDataFrame(records, ThreeColumnRecord.class)
-          .repartition(30)
-          .select("c1", "c2", "c3")
-          .write()
-          .format("iceberg")
-          .mode("append")
-          .save(sourceLocation);
-    }
+    appendManifestLengthRecords(sourceLocation, 0);
+    appendManifestLengthRecords(sourceLocation, 1);
     sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
+    assertThat(sourceTable.snapshots()).hasSize(2);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -410,6 +397,34 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetLocation);
+    // snapshot 1 references its own manifest, snapshot 2 references both
+    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isEqualTo(3);
+    assertRewriteChangedManifestLength(sourceTable, targetTable);
+  }
+
+  private void appendManifestLengthRecords(String location, int batch) {
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 30; i++) {
+      int id = batch * 100 + i;
+      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(30)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+  }
+
+  /**
+   * Assert that every manifest referenced by any snapshot of the target table records a
+   * manifest_length matching the file on disk, and return how many entries were checked.
+   */
+  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
     FileIO io = targetTable.io();
     int checkedManifests = 0;
     for (Snapshot snapshot : targetTable.snapshots()) {
@@ -423,9 +438,34 @@ public class TestRewriteTablePathsAction extends TestBase {
         checkedManifests++;
       }
     }
-    assertThat(checkedManifests)
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isGreaterThan(1);
+    return checkedManifests;
+  }
+
+  /**
+   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
+   * move the byte size of any manifest, they would hold even without stamping the measured length.
+   */
+  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
+    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
+    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
+    // compare like with like: a target manifest missing from the source map would otherwise satisfy
+    // the check below for the wrong reason, since Long.equals(null) is false
+    assertThat(targetLengths.keySet())
+        .as("target manifests should be the source manifests under a new prefix")
+        .isEqualTo(sourceLengths.keySet());
+    assertThat(targetLengths.entrySet())
+        .as("rewriting to a longer prefix must change at least one manifest's byte size")
+        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
+  }
+
+  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
+    Map<String, Long> lengths = Maps.newHashMap();
+    for (Snapshot snapshot : tbl.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
+        lengths.put(fileName(manifest.path()), manifest.length());
+      }
+    }
+    return lengths;
   }
 
   @TestTemplate
@@ -905,7 +945,14 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
-    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
+    List<ManifestFile> deleteManifests =
+        targetTable.currentSnapshot().deleteManifests(targetTable.io());
+    assertThat(deleteManifests).isNotEmpty();
+    for (ManifestFile manifest : deleteManifests) {
+      // the delete manifest itself is rewritten, so its manifest_length must be measured too
+      assertThat(manifest.length())
+          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
+          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,111 +364,6 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestLengthAfterRewrite() throws Exception {
-    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. Every rewritten manifest list - for the current and all
-    // historical snapshots - must record that new size in manifest_length; otherwise readers that
-    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
-    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
-    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
-    String sourceLocation = newTableLocation();
-    Table sourceTable =
-        TABLES.create(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
-            sourceLocation);
-
-    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
-    appendManifestLengthRecords(sourceLocation, 0);
-    appendManifestLengthRecords(sourceLocation, 1);
-    sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSize(2);
-
-    String targetLocation =
-        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
-
-    RewriteTablePath.Result result =
-        actions()
-            .rewriteTablePath(sourceTable)
-            .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
-            .execute();
-    copyTableFiles(result);
-
-    Table targetTable = TABLES.load(targetLocation);
-    // snapshot 1 references its own manifest, snapshot 2 references both
-    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isEqualTo(3);
-    assertRewriteChangedManifestLength(sourceTable, targetTable);
-  }
-
-  private void appendManifestLengthRecords(String location, int batch) {
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 30; i++) {
-      int id = batch * 100 + i;
-      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-    }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(30)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(location);
-  }
-
-  /**
-   * Assert that every manifest referenced by any snapshot of the target table records a
-   * manifest_length matching the file on disk, and return how many entries were checked.
-   */
-  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
-    FileIO io = targetTable.io();
-    int checkedManifests = 0;
-    for (Snapshot snapshot : targetTable.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(io)) {
-        assertThat(manifest.length())
-            .as(
-                "manifest_length in the rewritten manifest list of snapshot %s must match the"
-                    + " on-disk size of %s",
-                snapshot.snapshotId(), manifest.path())
-            .isEqualTo(io.newInputFile(manifest.path()).getLength());
-        checkedManifests++;
-      }
-    }
-    return checkedManifests;
-  }
-
-  /**
-   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
-   * move the byte size of any manifest, they would hold even without stamping the measured length.
-   */
-  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
-    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
-    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // compare like with like: a target manifest missing from the source map would otherwise satisfy
-    // the check below for the wrong reason, since Long.equals(null) is false
-    assertThat(targetLengths.keySet())
-        .as("target manifests should be the source manifests under a new prefix")
-        .isEqualTo(sourceLengths.keySet());
-    assertThat(targetLengths.entrySet())
-        .as("rewriting to a longer prefix must change at least one manifest's byte size")
-        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
-  }
-
-  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
-    Map<String, Long> lengths = Maps.newHashMap();
-    for (Snapshot snapshot : tbl.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
-        lengths.put(fileName(manifest.path()), manifest.length());
-      }
-    }
-    return lengths;
-  }
-
-  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -945,14 +840,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
-    List<ManifestFile> deleteManifests =
-        targetTable.currentSnapshot().deleteManifests(targetTable.io());
-    assertThat(deleteManifests).isNotEmpty();
-    for (ManifestFile manifest : deleteManifests) {
-      // the delete manifest itself is rewritten, so its manifest_length must be measured too
-      assertThat(manifest.length())
-          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
-          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
+    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,6 +364,96 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testManifestLengthAfterRewrite() throws Exception {
+    String sourceLocation = newTableLocation();
+    Table sourceTable =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            sourceLocation);
+
+    appendManifestLengthRecords(sourceLocation, 0);
+    appendManifestLengthRecords(sourceLocation, 1);
+    sourceTable.refresh();
+    assertThat(sourceTable.snapshots()).hasSize(2);
+
+    String targetLocation =
+        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
+            .execute();
+    copyTableFiles(result);
+
+    Table targetTable = TABLES.load(targetLocation);
+    // snapshot 1 references its own manifest, snapshot 2 references both
+    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isEqualTo(3);
+    assertRewriteChangedManifestLength(sourceTable, targetTable);
+  }
+
+  private void appendManifestLengthRecords(String location, int batch) {
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 30; i++) {
+      int id = batch * 100 + i;
+      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(30)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+  }
+
+  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
+    FileIO io = targetTable.io();
+    int checkedManifests = 0;
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+        checkedManifests++;
+      }
+    }
+    return checkedManifests;
+  }
+
+  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
+  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
+    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
+    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
+    // a target manifest missing from the source map would pass anyMatch for the wrong reason
+    assertThat(targetLengths.keySet())
+        .as("target manifests should be the source manifests under a new prefix")
+        .isEqualTo(sourceLengths.keySet());
+    assertThat(targetLengths.entrySet())
+        .as("rewriting to a longer prefix must change at least one manifest's byte size")
+        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
+  }
+
+  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
+    Map<String, Long> lengths = Maps.newHashMap();
+    for (Snapshot snapshot : tbl.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
+        lengths.put(fileName(manifest.path()), manifest.length());
+      }
+    }
+    return lengths;
+  }
+
+  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -831,16 +921,26 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
+    // a longer target prefix so the rewritten manifests change byte size
+    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
+
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetTableLocation())
+            .rewriteLocationPrefix(table.location(), targetLocation)
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetTableLocation());
-    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
+    Table targetTable = TABLES.load(targetLocation);
+    assertRewriteChangedManifestLength(table, targetTable);
+    List<ManifestFile> deleteManifests =
+        targetTable.currentSnapshot().deleteManifests(targetTable.io());
+    assertThat(deleteManifests).isNotEmpty();
+    for (ManifestFile manifest : deleteManifests) {
+      assertThat(manifest.length())
+          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
+          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -223,6 +223,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation));
 
     // verify the data file path after the rebuild
     List<String> validDataFilesAfterRebuilt =
@@ -364,96 +365,6 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestLengthAfterRewrite() throws Exception {
-    String sourceLocation = newTableLocation();
-    Table sourceTable =
-        TABLES.create(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
-            sourceLocation);
-
-    appendManifestLengthRecords(sourceLocation, 0);
-    appendManifestLengthRecords(sourceLocation, 1);
-    sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSize(2);
-
-    String targetLocation =
-        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
-
-    RewriteTablePath.Result result =
-        actions()
-            .rewriteTablePath(sourceTable)
-            .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
-            .execute();
-    copyTableFiles(result);
-
-    Table targetTable = TABLES.load(targetLocation);
-    // snapshot 1 references its own manifest, snapshot 2 references both
-    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isEqualTo(3);
-    assertRewriteChangedManifestLength(sourceTable, targetTable);
-  }
-
-  private void appendManifestLengthRecords(String location, int batch) {
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 30; i++) {
-      int id = batch * 100 + i;
-      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-    }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(30)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(location);
-  }
-
-  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
-    FileIO io = targetTable.io();
-    int checkedManifests = 0;
-    for (Snapshot snapshot : targetTable.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(io)) {
-        assertThat(manifest.length())
-            .as(
-                "manifest_length in the rewritten manifest list of snapshot %s must match the"
-                    + " on-disk size of %s",
-                snapshot.snapshotId(), manifest.path())
-            .isEqualTo(io.newInputFile(manifest.path()).getLength());
-        checkedManifests++;
-      }
-    }
-    return checkedManifests;
-  }
-
-  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
-  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
-    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
-    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // a target manifest missing from the source map would pass anyMatch for the wrong reason
-    assertThat(targetLengths.keySet())
-        .as("target manifests should be the source manifests under a new prefix")
-        .isEqualTo(sourceLengths.keySet());
-    assertThat(targetLengths.entrySet())
-        .as("rewriting to a longer prefix must change at least one manifest's byte size")
-        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
-  }
-
-  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
-    Map<String, Long> lengths = Maps.newHashMap();
-    for (Snapshot snapshot : tbl.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
-        lengths.put(fileName(manifest.path()), manifest.length());
-      }
-    }
-    return lengths;
-  }
-
-  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -504,6 +415,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // verify data rows
     Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation());
@@ -575,6 +487,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Positional delete affects a single row, so only one row must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -613,6 +526,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // check copied position delete row - only v2 stores row data with position deletes
     // v3+ uses Deletion Vectors (DV) which only store position information
@@ -672,6 +586,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
         .isEmpty();
@@ -790,6 +705,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<ManifestFile> deleteManifests =
         targetTable.currentSnapshot().deleteManifests(targetTable.io());
     assertThat(deleteManifests)
@@ -873,6 +789,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<Long> rewrittenSizes = Lists.newArrayList();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -921,26 +838,17 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
-    // a longer target prefix so the rewritten manifests change byte size
-    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
-
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetLocation)
+            .rewriteLocationPrefix(table.location(), targetTableLocation())
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetLocation);
-    assertRewriteChangedManifestLength(table, targetTable);
-    List<ManifestFile> deleteManifests =
-        targetTable.currentSnapshot().deleteManifests(targetTable.io());
-    assertThat(deleteManifests).isNotEmpty();
-    for (ManifestFile manifest : deleteManifests) {
-      assertThat(manifest.length())
-          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
-          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
+    Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
+    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {
@@ -1003,6 +911,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     Set<String> rewrittenLocations = Sets.newHashSet();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -1086,6 +995,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Equality deletes affect three rows, so just two rows must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -1209,6 +1119,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // expect deleted data file is excluded from rewrite and copy
     List<String> copiedDataFiles =
@@ -1668,6 +1579,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     String targetTableName = String.format("copiedV%sTable", formatVersion);
     TableIdentifier tableIdentifier = TableIdentifier.of("default", targetTableName);
     catalog.registerTable(tableIdentifier, targetTableLocation() + "/metadata/" + versionFile);
+    assertManifestLengthsMatchOnDisk(catalog.loadTable(tableIdentifier));
 
     List<Object[]> copiedData =
         rowsToJava(
@@ -1747,6 +1659,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // Copy the files and verify structure is preserved
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Read the file paths from the rewritten result to verify directory structure
     List<Tuple2<String, String>> filePaths = readPathPairList(result.fileListLocation());
@@ -1893,6 +1806,20 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   protected String toAbsolute(Path relative) {
     return relative.toFile().toURI().toString();
+  }
+
+  private void assertManifestLengthsMatchOnDisk(Table targetTable) {
+    FileIO io = targetTable.io();
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+      }
+    }
   }
 
   private void copyTableFiles(RewriteTablePath.Result result) throws Exception {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,21 +302,19 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
+    // manifest list must record each rewritten manifest's length (manifest_length), which is only
+    // known after the manifests are rewritten below.
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+                manifestFiles.addAll(
+                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
+                        snapshot, table.io(), manifestsToRewrite)));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +331,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot,
+                        endMetadata,
+                        manifestsToRewrite,
+                        rewriteManifestResult.rewrittenManifestLengths())));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -495,11 +511,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
    * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +533,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestLengths);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -552,10 +573,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
+    // Map from source manifest path to the byte length of its rewritten manifest, used by the
+    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
+    // survives the map/reduce because Spark's EliminateSerialization collapses the
+    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
+
+    public Map<String, Long> rewrittenManifestLengths() {
+      return rewrittenManifestLengths;
+    }
+
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      if (r1 instanceof RewriteContentFileResult) {
+        this.rewrittenManifestLengths.putAll(
+            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
+      }
       return this;
     }
 
@@ -618,28 +653,36 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          result.appendDataFile(
-              writeDataManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix));
-          break;
+          {
+            Pair<RewriteResult<DataFile>, Long> dataManifest =
+                writeDataManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix);
+            result.appendDataFile(dataManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
+            break;
+          }
         case DELETES:
-          result.appendDeleteFile(
-              writeDeleteManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix,
-                  rewrittenDeleteFileSizes));
-          break;
+          {
+            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
+                writeDeleteManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix,
+                    rewrittenDeleteFileSizes);
+            result.appendDeleteFile(deleteManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
+            break;
+          }
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -648,7 +691,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static RewriteResult<DataFile> writeDataManifest(
+  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -663,7 +706,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifest(
+      return RewriteTablePathUtil.rewriteDataManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -677,7 +720,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static RewriteResult<DeleteFile> writeDeleteManifest(
+  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -693,7 +736,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifest(
+      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,10 +278,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Read the manifest lists of all valid snapshots
+   *   <li>Rebuild manifest list files to staging
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
-   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -303,27 +302,21 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // read every valid snapshot's manifest list
-    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
+    // rebuild manifest-list files
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestsBySnapshot.put(
-                    snapshot,
-                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
+                manifestListResults.add(
+                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
 
-    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
-    Set<ManifestFile> manifestFiles = Sets.newHashSet();
-    manifestsBySnapshot
-        .values()
-        .forEach(
-            manifests ->
-                manifests.stream()
-                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
-                    .forEach(manifestFiles::add));
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
+
+    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -340,25 +333,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
-
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
-    Tasks.foreach(validSnapshots)
-        .noRetry()
-        .throwFailureWhenFinished()
-        .executeWith(executorService)
-        .run(
-            snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(
-                        snapshot,
-                        endMetadata,
-                        manifestsBySnapshot.get(snapshot),
-                        manifestsToRewrite,
-                        rewriteManifestResult.rewrittenManifestLengths())));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -520,20 +494,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
-   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
-   * @param manifestsToRewrite a list of manifest files to filter for rewrite
-   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
-   *     rewritten manifest
+   * @param manifestsToRewrite filter of manifests to rewrite.
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      TableMetadata tableMetadata,
-      List<ManifestFile> manifestFiles,
-      Set<String> manifestsToRewrite,
-      Map<String, Long> rewrittenManifestLengths) {
+      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -543,13 +509,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath,
-            rewrittenManifestLengths);
+            outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -588,22 +552,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
-    // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length.
-    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
-
-    public Map<String, Long> rewrittenManifestLengths() {
-      return rewrittenManifestLengths;
-    }
-
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
-      if (r1 instanceof RewriteContentFileResult) {
-        this.rewrittenManifestLengths.putAll(
-            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
-      }
       return this;
     }
 
@@ -647,13 +599,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
-            // this class (none of its accessors are JavaBean getters), so the copy plan and the
-            // measured manifest lengths survive only because the optimizer collapses the
-            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
-            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
-            // serializes through neither encoder.
-            Encoders.javaSerialization(RewriteContentFileResult.class))
+            Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);
@@ -672,36 +618,28 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          {
-            Pair<RewriteResult<DataFile>, Long> dataManifest =
-                writeDataManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix);
-            result.appendDataFile(dataManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
-            break;
-          }
+          result.appendDataFile(
+              writeDataManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix));
+          break;
         case DELETES:
-          {
-            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
-                writeDeleteManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix,
-                    rewrittenDeleteFileSizes);
-            result.appendDeleteFile(deleteManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
-            break;
-          }
+          result.appendDeleteFile(
+              writeDeleteManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix,
+                  rewrittenDeleteFileSizes));
+          break;
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -710,7 +648,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
+  private static RewriteResult<DataFile> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -725,7 +663,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDataManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -739,7 +677,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
+  private static RewriteResult<DeleteFile> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -755,7 +693,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDeleteManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,19 +302,31 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
-    // manifest list must record each rewritten manifest's length (manifest_length), which is only
-    // known after the manifests are rewritten below.
-    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
+    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
+    // manifest list must record each referenced manifest's rewritten length (manifest_length),
+    // which is only known after the manifests are rewritten below.
+    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestFiles.addAll(
-                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
-                        snapshot, table.io(), manifestsToRewrite)));
+                manifestsBySnapshot.put(
+                    snapshot,
+                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
+
+    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
+    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
+    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    Set<ManifestFile> manifestFiles = Sets.newHashSet();
+    manifestsBySnapshot
+        .values()
+        .forEach(
+            manifests ->
+                manifests.stream()
+                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
+                    .forEach(manifestFiles::add));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -344,6 +356,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     rewriteManifestList(
                         snapshot,
                         endMetadata,
+                        manifestsBySnapshot.get(snapshot),
                         manifestsToRewrite,
                         rewriteManifestResult.rewrittenManifestLengths())));
 
@@ -510,6 +523,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
+   * @param manifestFiles the manifests the snapshot's manifest list references
    * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
@@ -518,6 +532,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,
       TableMetadata tableMetadata,
+      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
@@ -529,6 +544,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
+            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
@@ -574,9 +590,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
     // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
-    // survives the map/reduce because Spark's EliminateSerialization collapses the
-    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    // manifest-list rewrite to record an accurate manifest_length.
     private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
 
     public Map<String, Long> rewrittenManifestLengths() {
@@ -634,7 +648,13 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            Encoders.bean(RewriteContentFileResult.class))
+            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
+            // this class (none of its accessors are JavaBean getters), so the copy plan and the
+            // measured manifest lengths survive only because the optimizer collapses the
+            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
+            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
+            // serializes through neither encoder.
+            Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);
@@ -706,7 +726,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestWithLength(
+      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -736,7 +756,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
+      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -341,10 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot ->
                 manifestListResults.add(
                     rewriteManifestList(
-                        snapshot,
-                        endMetadata,
-                        manifestsToRewrite,
-                        rewriteManifestResult.rewrittenManifestLengths())));
+                        snapshot, endMetadata, rewriteManifestResult.rewrittenManifestLengths())));
 
     RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
     manifestListResults.forEach(rewriteManifestListResult::append);
@@ -509,16 +506,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      TableMetadata tableMetadata,
-      Set<String> manifestsToRewrite,
-      Map<String, Long> rewrittenManifestLengths) {
+      Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -528,12 +521,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestsToRewrite,
+            rewrittenManifestLengths,
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath,
-            rewrittenManifestLengths);
+            outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,9 +278,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Rebuild manifest list files to staging
+   *   <li>Read the manifest lists of all valid snapshots
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
+   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -302,21 +303,17 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    // read the manifest lists of all valid snapshots
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+                snapshot.allManifests(table.io()).stream()
+                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
+                    .forEach(manifestFiles::add));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +330,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // rebuild manifest-list files
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot,
+                        endMetadata,
+                        manifestsToRewrite,
+                        rewriteManifestResult.rewrittenManifestLengths())));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -495,11 +510,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
    * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +532,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestLengths);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -556,18 +576,21 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDataFile(RewriteResult<DataFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDeleteFile(RewriteResult<DeleteFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
   }
@@ -599,7 +622,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            Encoders.bean(RewriteContentFileResult.class))
+            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
+            Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,9 +278,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Rebuild manifest list files to staging
+   *   <li>Read the manifest lists of all valid snapshots
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
+   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -302,9 +303,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
-    // manifest list must record each referenced manifest's rewritten length (manifest_length),
-    // which is only known after the manifests are rewritten below.
+    // read every valid snapshot's manifest list
     Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -316,9 +315,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     snapshot,
                     RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
 
-    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
-    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
-    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
     Set<ManifestFile> manifestFiles = Sets.newHashSet();
     manifestsBySnapshot
         .values()
@@ -344,7 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
 
-    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    // rebuild manifest-list files
     Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -523,9 +520,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests the snapshot's manifest list references
-   * @param manifestsToRewrite filter of manifests to rewrite.
-   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
+   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
+   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
+   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
+   *     rewritten manifest
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -614,8 +614,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
-            Encoders.javaSerialization(RewriteContentFileResult.class))
+            Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -366,12 +366,11 @@ public class TestRewriteTablePathsAction extends TestBase {
   @TestTemplate
   public void testManifestLengthAfterRewrite() throws Exception {
     // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. The rewritten manifest list must record that new size
-    // in
-    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
-    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
-    // change from the prefix is dominated by the data block (not the constant Avro schema header),
-    // making the difference unambiguous.
+    // differs in byte size from the source. Every rewritten manifest list - for the current and all
+    // historical snapshots - must record that new size in manifest_length; otherwise readers that
+    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
+    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
+    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
     String sourceLocation = newTableLocation();
     Table sourceTable =
         TABLES.create(
@@ -380,19 +379,24 @@ public class TestRewriteTablePathsAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             sourceLocation);
 
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 50; i++) {
-      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
+    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
+      List<ThreeColumnRecord> records = Lists.newArrayList();
+      for (int i = 0; i < 30; i++) {
+        int id = snapshotNo * 100 + i;
+        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+      }
+      spark
+          .createDataFrame(records, ThreeColumnRecord.class)
+          .repartition(30)
+          .select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(sourceLocation);
     }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(50)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(sourceLocation);
     sourceTable.refresh();
+    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -407,15 +411,21 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     Table targetTable = TABLES.load(targetLocation);
     FileIO io = targetTable.io();
-    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
-    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
-    for (ManifestFile manifest : manifests) {
-      assertThat(manifest.length())
-          .as(
-              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
-              manifest.path())
-          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    int checkedManifests = 0;
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+        checkedManifests++;
+      }
     }
+    assertThat(checkedManifests)
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isGreaterThan(1);
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,6 +364,61 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testManifestLengthAfterRewrite() throws Exception {
+    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
+    // differs in byte size from the source. The rewritten manifest list must record that new size
+    // in
+    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
+    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
+    // change from the prefix is dominated by the data block (not the constant Avro schema header),
+    // making the difference unambiguous.
+    String sourceLocation = newTableLocation();
+    Table sourceTable =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            sourceLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 50; i++) {
+      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(50)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceLocation);
+    sourceTable.refresh();
+
+    String targetLocation =
+        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
+            .execute();
+    copyTableFiles(result);
+
+    Table targetTable = TABLES.load(targetLocation);
+    FileIO io = targetTable.io();
+    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
+    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
+    for (ManifestFile manifest : manifests) {
+      assertThat(manifest.length())
+          .as(
+              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
+              manifest.path())
+          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    }
+  }
+
+  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -380,23 +380,10 @@ public class TestRewriteTablePathsAction extends TestBase {
             sourceLocation);
 
     // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
-    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
-      List<ThreeColumnRecord> records = Lists.newArrayList();
-      for (int i = 0; i < 30; i++) {
-        int id = snapshotNo * 100 + i;
-        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-      }
-      spark
-          .createDataFrame(records, ThreeColumnRecord.class)
-          .repartition(30)
-          .select("c1", "c2", "c3")
-          .write()
-          .format("iceberg")
-          .mode("append")
-          .save(sourceLocation);
-    }
+    appendManifestLengthRecords(sourceLocation, 0);
+    appendManifestLengthRecords(sourceLocation, 1);
     sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
+    assertThat(sourceTable.snapshots()).hasSize(2);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -410,6 +397,34 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetLocation);
+    // snapshot 1 references its own manifest, snapshot 2 references both
+    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isEqualTo(3);
+    assertRewriteChangedManifestLength(sourceTable, targetTable);
+  }
+
+  private void appendManifestLengthRecords(String location, int batch) {
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 30; i++) {
+      int id = batch * 100 + i;
+      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(30)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+  }
+
+  /**
+   * Assert that every manifest referenced by any snapshot of the target table records a
+   * manifest_length matching the file on disk, and return how many entries were checked.
+   */
+  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
     FileIO io = targetTable.io();
     int checkedManifests = 0;
     for (Snapshot snapshot : targetTable.snapshots()) {
@@ -423,9 +438,34 @@ public class TestRewriteTablePathsAction extends TestBase {
         checkedManifests++;
       }
     }
-    assertThat(checkedManifests)
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isGreaterThan(1);
+    return checkedManifests;
+  }
+
+  /**
+   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
+   * move the byte size of any manifest, they would hold even without stamping the measured length.
+   */
+  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
+    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
+    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
+    // compare like with like: a target manifest missing from the source map would otherwise satisfy
+    // the check below for the wrong reason, since Long.equals(null) is false
+    assertThat(targetLengths.keySet())
+        .as("target manifests should be the source manifests under a new prefix")
+        .isEqualTo(sourceLengths.keySet());
+    assertThat(targetLengths.entrySet())
+        .as("rewriting to a longer prefix must change at least one manifest's byte size")
+        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
+  }
+
+  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
+    Map<String, Long> lengths = Maps.newHashMap();
+    for (Snapshot snapshot : tbl.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
+        lengths.put(fileName(manifest.path()), manifest.length());
+      }
+    }
+    return lengths;
   }
 
   @TestTemplate
@@ -905,7 +945,14 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
-    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
+    List<ManifestFile> deleteManifests =
+        targetTable.currentSnapshot().deleteManifests(targetTable.io());
+    assertThat(deleteManifests).isNotEmpty();
+    for (ManifestFile manifest : deleteManifests) {
+      // the delete manifest itself is rewritten, so its manifest_length must be measured too
+      assertThat(manifest.length())
+          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
+          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,111 +364,6 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestLengthAfterRewrite() throws Exception {
-    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. Every rewritten manifest list - for the current and all
-    // historical snapshots - must record that new size in manifest_length; otherwise readers that
-    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
-    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
-    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
-    String sourceLocation = newTableLocation();
-    Table sourceTable =
-        TABLES.create(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
-            sourceLocation);
-
-    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
-    appendManifestLengthRecords(sourceLocation, 0);
-    appendManifestLengthRecords(sourceLocation, 1);
-    sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSize(2);
-
-    String targetLocation =
-        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
-
-    RewriteTablePath.Result result =
-        actions()
-            .rewriteTablePath(sourceTable)
-            .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
-            .execute();
-    copyTableFiles(result);
-
-    Table targetTable = TABLES.load(targetLocation);
-    // snapshot 1 references its own manifest, snapshot 2 references both
-    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isEqualTo(3);
-    assertRewriteChangedManifestLength(sourceTable, targetTable);
-  }
-
-  private void appendManifestLengthRecords(String location, int batch) {
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 30; i++) {
-      int id = batch * 100 + i;
-      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-    }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(30)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(location);
-  }
-
-  /**
-   * Assert that every manifest referenced by any snapshot of the target table records a
-   * manifest_length matching the file on disk, and return how many entries were checked.
-   */
-  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
-    FileIO io = targetTable.io();
-    int checkedManifests = 0;
-    for (Snapshot snapshot : targetTable.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(io)) {
-        assertThat(manifest.length())
-            .as(
-                "manifest_length in the rewritten manifest list of snapshot %s must match the"
-                    + " on-disk size of %s",
-                snapshot.snapshotId(), manifest.path())
-            .isEqualTo(io.newInputFile(manifest.path()).getLength());
-        checkedManifests++;
-      }
-    }
-    return checkedManifests;
-  }
-
-  /**
-   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
-   * move the byte size of any manifest, they would hold even without stamping the measured length.
-   */
-  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
-    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
-    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // compare like with like: a target manifest missing from the source map would otherwise satisfy
-    // the check below for the wrong reason, since Long.equals(null) is false
-    assertThat(targetLengths.keySet())
-        .as("target manifests should be the source manifests under a new prefix")
-        .isEqualTo(sourceLengths.keySet());
-    assertThat(targetLengths.entrySet())
-        .as("rewriting to a longer prefix must change at least one manifest's byte size")
-        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
-  }
-
-  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
-    Map<String, Long> lengths = Maps.newHashMap();
-    for (Snapshot snapshot : tbl.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
-        lengths.put(fileName(manifest.path()), manifest.length());
-      }
-    }
-    return lengths;
-  }
-
-  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -945,14 +840,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
-    List<ManifestFile> deleteManifests =
-        targetTable.currentSnapshot().deleteManifests(targetTable.io());
-    assertThat(deleteManifests).isNotEmpty();
-    for (ManifestFile manifest : deleteManifests) {
-      // the delete manifest itself is rewritten, so its manifest_length must be measured too
-      assertThat(manifest.length())
-          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
-          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
+    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,6 +364,96 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testManifestLengthAfterRewrite() throws Exception {
+    String sourceLocation = newTableLocation();
+    Table sourceTable =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            sourceLocation);
+
+    appendManifestLengthRecords(sourceLocation, 0);
+    appendManifestLengthRecords(sourceLocation, 1);
+    sourceTable.refresh();
+    assertThat(sourceTable.snapshots()).hasSize(2);
+
+    String targetLocation =
+        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
+            .execute();
+    copyTableFiles(result);
+
+    Table targetTable = TABLES.load(targetLocation);
+    // snapshot 1 references its own manifest, snapshot 2 references both
+    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isEqualTo(3);
+    assertRewriteChangedManifestLength(sourceTable, targetTable);
+  }
+
+  private void appendManifestLengthRecords(String location, int batch) {
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 30; i++) {
+      int id = batch * 100 + i;
+      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(30)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+  }
+
+  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
+    FileIO io = targetTable.io();
+    int checkedManifests = 0;
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+        checkedManifests++;
+      }
+    }
+    return checkedManifests;
+  }
+
+  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
+  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
+    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
+    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
+    // a target manifest missing from the source map would pass anyMatch for the wrong reason
+    assertThat(targetLengths.keySet())
+        .as("target manifests should be the source manifests under a new prefix")
+        .isEqualTo(sourceLengths.keySet());
+    assertThat(targetLengths.entrySet())
+        .as("rewriting to a longer prefix must change at least one manifest's byte size")
+        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
+  }
+
+  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
+    Map<String, Long> lengths = Maps.newHashMap();
+    for (Snapshot snapshot : tbl.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
+        lengths.put(fileName(manifest.path()), manifest.length());
+      }
+    }
+    return lengths;
+  }
+
+  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -831,16 +921,26 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
+    // a longer target prefix so the rewritten manifests change byte size
+    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
+
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetTableLocation())
+            .rewriteLocationPrefix(table.location(), targetLocation)
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetTableLocation());
-    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
+    Table targetTable = TABLES.load(targetLocation);
+    assertRewriteChangedManifestLength(table, targetTable);
+    List<ManifestFile> deleteManifests =
+        targetTable.currentSnapshot().deleteManifests(targetTable.io());
+    assertThat(deleteManifests).isNotEmpty();
+    for (ManifestFile manifest : deleteManifests) {
+      assertThat(manifest.length())
+          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
+          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -223,6 +223,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation));
 
     // verify the data file path after the rebuild
     List<String> validDataFilesAfterRebuilt =
@@ -364,96 +365,6 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestLengthAfterRewrite() throws Exception {
-    String sourceLocation = newTableLocation();
-    Table sourceTable =
-        TABLES.create(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
-            sourceLocation);
-
-    appendManifestLengthRecords(sourceLocation, 0);
-    appendManifestLengthRecords(sourceLocation, 1);
-    sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSize(2);
-
-    String targetLocation =
-        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
-
-    RewriteTablePath.Result result =
-        actions()
-            .rewriteTablePath(sourceTable)
-            .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
-            .execute();
-    copyTableFiles(result);
-
-    Table targetTable = TABLES.load(targetLocation);
-    // snapshot 1 references its own manifest, snapshot 2 references both
-    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isEqualTo(3);
-    assertRewriteChangedManifestLength(sourceTable, targetTable);
-  }
-
-  private void appendManifestLengthRecords(String location, int batch) {
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 30; i++) {
-      int id = batch * 100 + i;
-      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-    }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(30)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(location);
-  }
-
-  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
-    FileIO io = targetTable.io();
-    int checkedManifests = 0;
-    for (Snapshot snapshot : targetTable.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(io)) {
-        assertThat(manifest.length())
-            .as(
-                "manifest_length in the rewritten manifest list of snapshot %s must match the"
-                    + " on-disk size of %s",
-                snapshot.snapshotId(), manifest.path())
-            .isEqualTo(io.newInputFile(manifest.path()).getLength());
-        checkedManifests++;
-      }
-    }
-    return checkedManifests;
-  }
-
-  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
-  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
-    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
-    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // a target manifest missing from the source map would pass anyMatch for the wrong reason
-    assertThat(targetLengths.keySet())
-        .as("target manifests should be the source manifests under a new prefix")
-        .isEqualTo(sourceLengths.keySet());
-    assertThat(targetLengths.entrySet())
-        .as("rewriting to a longer prefix must change at least one manifest's byte size")
-        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
-  }
-
-  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
-    Map<String, Long> lengths = Maps.newHashMap();
-    for (Snapshot snapshot : tbl.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
-        lengths.put(fileName(manifest.path()), manifest.length());
-      }
-    }
-    return lengths;
-  }
-
-  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -504,6 +415,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // verify data rows
     Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation());
@@ -575,6 +487,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Positional delete affects a single row, so only one row must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -613,6 +526,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // check copied position delete row - only v2 stores row data with position deletes
     // v3+ uses Deletion Vectors (DV) which only store position information
@@ -672,6 +586,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
         .isEmpty();
@@ -790,6 +705,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<ManifestFile> deleteManifests =
         targetTable.currentSnapshot().deleteManifests(targetTable.io());
     assertThat(deleteManifests)
@@ -873,6 +789,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<Long> rewrittenSizes = Lists.newArrayList();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -921,26 +838,17 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
-    // a longer target prefix so the rewritten manifests change byte size
-    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
-
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetLocation)
+            .rewriteLocationPrefix(table.location(), targetTableLocation())
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetLocation);
-    assertRewriteChangedManifestLength(table, targetTable);
-    List<ManifestFile> deleteManifests =
-        targetTable.currentSnapshot().deleteManifests(targetTable.io());
-    assertThat(deleteManifests).isNotEmpty();
-    for (ManifestFile manifest : deleteManifests) {
-      assertThat(manifest.length())
-          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
-          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
+    Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
+    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {
@@ -1003,6 +911,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     Set<String> rewrittenLocations = Sets.newHashSet();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -1086,6 +995,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Equality deletes affect three rows, so just two rows must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -1209,6 +1119,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // expect deleted data file is excluded from rewrite and copy
     List<String> copiedDataFiles =
@@ -1668,6 +1579,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     String targetTableName = String.format("copiedV%sTable", formatVersion);
     TableIdentifier tableIdentifier = TableIdentifier.of("default", targetTableName);
     catalog.registerTable(tableIdentifier, targetTableLocation() + "/metadata/" + versionFile);
+    assertManifestLengthsMatchOnDisk(catalog.loadTable(tableIdentifier));
 
     List<Object[]> copiedData =
         rowsToJava(
@@ -1747,6 +1659,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // Copy the files and verify structure is preserved
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Read the file paths from the rewritten result to verify directory structure
     List<Tuple2<String, String>> filePaths = readPathPairList(result.fileListLocation());
@@ -1893,6 +1806,20 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   protected String toAbsolute(Path relative) {
     return relative.toFile().toURI().toString();
+  }
+
+  private void assertManifestLengthsMatchOnDisk(Table targetTable) {
+    FileIO io = targetTable.io();
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+      }
+    }
   }
 
   private void copyTableFiles(RewriteTablePath.Result result) throws Exception {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,21 +302,19 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
+    // manifest list must record each rewritten manifest's length (manifest_length), which is only
+    // known after the manifests are rewritten below.
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+                manifestFiles.addAll(
+                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
+                        snapshot, table.io(), manifestsToRewrite)));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +331,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot,
+                        endMetadata,
+                        manifestsToRewrite,
+                        rewriteManifestResult.rewrittenManifestLengths())));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -495,11 +511,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
    * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +533,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestLengths);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -552,10 +573,24 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
+    // Map from source manifest path to the byte length of its rewritten manifest, used by the
+    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
+    // survives the map/reduce because Spark's EliminateSerialization collapses the
+    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
+
+    public Map<String, Long> rewrittenManifestLengths() {
+      return rewrittenManifestLengths;
+    }
+
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      if (r1 instanceof RewriteContentFileResult) {
+        this.rewrittenManifestLengths.putAll(
+            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
+      }
       return this;
     }
 
@@ -618,28 +653,36 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          result.appendDataFile(
-              writeDataManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix));
-          break;
+          {
+            Pair<RewriteResult<DataFile>, Long> dataManifest =
+                writeDataManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix);
+            result.appendDataFile(dataManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
+            break;
+          }
         case DELETES:
-          result.appendDeleteFile(
-              writeDeleteManifest(
-                  manifestFile,
-                  table,
-                  deltaSnapshotIds,
-                  stagingLocation,
-                  format,
-                  sourcePrefix,
-                  targetPrefix,
-                  rewrittenDeleteFileSizes));
-          break;
+          {
+            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
+                writeDeleteManifest(
+                    manifestFile,
+                    table,
+                    deltaSnapshotIds,
+                    stagingLocation,
+                    format,
+                    sourcePrefix,
+                    targetPrefix,
+                    rewrittenDeleteFileSizes);
+            result.appendDeleteFile(deleteManifest.first());
+            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
+            break;
+          }
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -648,7 +691,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static RewriteResult<DataFile> writeDataManifest(
+  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -663,7 +706,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifest(
+      return RewriteTablePathUtil.rewriteDataManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -677,7 +720,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static RewriteResult<DeleteFile> writeDeleteManifest(
+  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -693,7 +736,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifest(
+      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,19 +302,31 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Discover the manifests to rewrite without writing the manifest list yet. The rewritten
-    // manifest list must record each rewritten manifest's length (manifest_length), which is only
-    // known after the manifests are rewritten below.
-    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
+    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
+    // manifest list must record each referenced manifest's rewritten length (manifest_length),
+    // which is only known after the manifests are rewritten below.
+    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestFiles.addAll(
-                    RewriteTablePathUtil.manifestsToRewriteForSnapshot(
-                        snapshot, table.io(), manifestsToRewrite)));
+                manifestsBySnapshot.put(
+                    snapshot,
+                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
+
+    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
+    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
+    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    Set<ManifestFile> manifestFiles = Sets.newHashSet();
+    manifestsBySnapshot
+        .values()
+        .forEach(
+            manifests ->
+                manifests.stream()
+                    .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
+                    .forEach(manifestFiles::add));
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -344,6 +356,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     rewriteManifestList(
                         snapshot,
                         endMetadata,
+                        manifestsBySnapshot.get(snapshot),
                         manifestsToRewrite,
                         rewriteManifestResult.rewrittenManifestLengths())));
 
@@ -510,6 +523,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
+   * @param manifestFiles the manifests the snapshot's manifest list references
    * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
    * @return a result including a copy plan for the manifests contained in the manifest list, as
@@ -518,6 +532,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   private RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,
       TableMetadata tableMetadata,
+      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
@@ -529,6 +544,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
+            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
@@ -574,9 +590,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
     // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length. Like copyPlan/toRewrite, this
-    // survives the map/reduce because Spark's EliminateSerialization collapses the
-    // serialize/deserialize boundary (this class has no JavaBean accessors for the bean encoder).
+    // manifest-list rewrite to record an accurate manifest_length.
     private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
 
     public Map<String, Long> rewrittenManifestLengths() {
@@ -634,7 +648,13 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            Encoders.bean(RewriteContentFileResult.class))
+            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
+            // this class (none of its accessors are JavaBean getters), so the copy plan and the
+            // measured manifest lengths survive only because the optimizer collapses the
+            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
+            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
+            // serializes through neither encoder.
+            Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);
@@ -706,7 +726,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestWithLength(
+      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -736,7 +756,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestWithLength(
+      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -341,10 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot ->
                 manifestListResults.add(
                     rewriteManifestList(
-                        snapshot,
-                        endMetadata,
-                        manifestsToRewrite,
-                        rewriteManifestResult.rewrittenManifestLengths())));
+                        snapshot, endMetadata, rewriteManifestResult.rewrittenManifestLengths())));
 
     RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
     manifestListResults.forEach(rewriteManifestListResult::append);
@@ -509,16 +506,12 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestsToRewrite filter of manifests to rewrite.
    * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot,
-      TableMetadata tableMetadata,
-      Set<String> manifestsToRewrite,
-      Map<String, Long> rewrittenManifestLengths) {
+      Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -528,12 +521,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestsToRewrite,
+            rewrittenManifestLengths,
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath,
-            rewrittenManifestLengths);
+            outputPath);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -303,25 +303,15 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // read every valid snapshot's manifest list
-    Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
+    // read the manifest lists of all valid snapshots
+    Set<ManifestFile> manifestFiles = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
         .throwFailureWhenFinished()
         .executeWith(executorService)
         .run(
             snapshot ->
-                manifestsBySnapshot.put(
-                    snapshot,
-                    RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
-
-    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
-    Set<ManifestFile> manifestFiles = Sets.newHashSet();
-    manifestsBySnapshot
-        .values()
-        .forEach(
-            manifests ->
-                manifests.stream()
+                snapshot.allManifests(table.io()).stream()
                     .filter(manifest -> manifestsToRewrite.contains(manifest.path()))
                     .forEach(manifestFiles::add));
 
@@ -353,7 +343,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     rewriteManifestList(
                         snapshot,
                         endMetadata,
-                        manifestsBySnapshot.get(snapshot),
                         manifestsToRewrite,
                         rewriteManifestResult.rewrittenManifestLengths())));
 
@@ -520,18 +509,14 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
-   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
-   * @param manifestsToRewrite a list of manifest files to filter for rewrite
-   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
-   *     rewritten manifest
+   * @param manifestsToRewrite filter of manifests to rewrite.
+   * @param rewrittenManifestLengths byte length of each rewritten manifest, keyed by source path
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,
       TableMetadata tableMetadata,
-      List<ManifestFile> manifestFiles,
       Set<String> manifestsToRewrite,
       Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
@@ -543,7 +528,6 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             snapshot,
             table.io(),
             tableMetadata,
-            manifestFiles,
             manifestsToRewrite,
             sourcePrefix,
             targetPrefix,
@@ -588,34 +572,25 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {
-    // Map from source manifest path to the byte length of its rewritten manifest, used by the
-    // manifest-list rewrite to record an accurate manifest_length.
-    private final Map<String, Long> rewrittenManifestLengths = Maps.newHashMap();
-
-    public Map<String, Long> rewrittenManifestLengths() {
-      return rewrittenManifestLengths;
-    }
-
     @Override
     public RewriteContentFileResult append(RewriteResult<ContentFile<?>> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
-      if (r1 instanceof RewriteContentFileResult) {
-        this.rewrittenManifestLengths.putAll(
-            ((RewriteContentFileResult) r1).rewrittenManifestLengths());
-      }
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDataFile(RewriteResult<DataFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
 
     public RewriteContentFileResult appendDeleteFile(RewriteResult<DeleteFile> r1) {
       this.copyPlan().addAll(r1.copyPlan());
       this.toRewrite().addAll(r1.toRewrite());
+      r1.rewrittenManifestLengths().forEach(this::addRewrittenManifestLength);
       return this;
     }
   }
@@ -647,12 +622,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Java serialization, not Encoders.bean: the bean encoder derives an empty schema for
-            // this class (none of its accessors are JavaBean getters), so the copy plan and the
-            // measured manifest lengths survive only because the optimizer collapses the
-            // serialize/deserialize pair in this plan shape. Caching or shuffling the mapped
-            // Dataset would silently drop both. Costs nothing here, since the collapsed plan
-            // serializes through neither encoder.
+            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
             Encoders.javaSerialization(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
@@ -672,36 +642,28 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       RewriteContentFileResult result = new RewriteContentFileResult();
       switch (manifestFile.content()) {
         case DATA:
-          {
-            Pair<RewriteResult<DataFile>, Long> dataManifest =
-                writeDataManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix);
-            result.appendDataFile(dataManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), dataManifest.second());
-            break;
-          }
+          result.appendDataFile(
+              writeDataManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix));
+          break;
         case DELETES:
-          {
-            Pair<RewriteResult<DeleteFile>, Long> deleteManifest =
-                writeDeleteManifest(
-                    manifestFile,
-                    table,
-                    deltaSnapshotIds,
-                    stagingLocation,
-                    format,
-                    sourcePrefix,
-                    targetPrefix,
-                    rewrittenDeleteFileSizes);
-            result.appendDeleteFile(deleteManifest.first());
-            result.rewrittenManifestLengths().put(manifestFile.path(), deleteManifest.second());
-            break;
-          }
+          result.appendDeleteFile(
+              writeDeleteManifest(
+                  manifestFile,
+                  table,
+                  deltaSnapshotIds,
+                  stagingLocation,
+                  format,
+                  sourcePrefix,
+                  targetPrefix,
+                  rewrittenDeleteFileSizes));
+          break;
         default:
           throw new UnsupportedOperationException(
               "Unsupported manifest type: " + manifestFile.content());
@@ -710,7 +672,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     };
   }
 
-  private static Pair<RewriteResult<DataFile>, Long> writeDataManifest(
+  private static RewriteResult<DataFile> writeDataManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -725,7 +687,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDataManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDataManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,
@@ -739,7 +701,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     }
   }
 
-  private static Pair<RewriteResult<DeleteFile>, Long> writeDeleteManifest(
+  private static RewriteResult<DeleteFile> writeDeleteManifest(
       ManifestFile manifestFile,
       Broadcast<Table> table,
       Broadcast<Set<Long>> snapshotIds,
@@ -755,7 +717,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       OutputFile outputFile = io.newOutputFile(stagingPath);
       Map<Integer, PartitionSpec> specsById = table.getValue().specs();
       Set<Long> deltaSnapshotIds = snapshotIds.value();
-      return RewriteTablePathUtil.rewriteDeleteManifestAndMeasureLength(
+      return RewriteTablePathUtil.rewriteDeleteManifest(
           manifestFile,
           deltaSnapshotIds,
           outputFile,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -278,9 +278,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * <ul>
    *   <li>Rebuild version files to staging
-   *   <li>Rebuild manifest list files to staging
+   *   <li>Read the manifest lists of all valid snapshots
    *   <li>Rewrite referenced position delete files to staging
    *   <li>Rebuild manifests to staging
+   *   <li>Rebuild manifest list files to staging, recording each rewritten manifest's length
    *   <li>Get all files needed to move
    * </ul>
    */
@@ -302,9 +303,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // Read every valid snapshot's manifest list once, before writing anything. The rewritten
-    // manifest list must record each referenced manifest's rewritten length (manifest_length),
-    // which is only known after the manifests are rewritten below.
+    // read every valid snapshot's manifest list
     Map<Snapshot, List<ManifestFile>> manifestsBySnapshot = Maps.newConcurrentMap();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -316,9 +315,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                     snapshot,
                     RewriteTablePathUtil.manifestsInSnapshot(snapshot, table.io(), sourcePrefix)));
 
-    // Manifests selected for rewrite. In an incremental run this is only the manifests added by the
-    // delta snapshots, so a manifest carried over from an earlier run is not rewritten here and
-    // keeps its source length in the manifest list. See the note on rewriteManifestList.
+    // manifests selected for rewrite; see rewriteManifestList for the incremental gap
     Set<ManifestFile> manifestFiles = Sets.newHashSet();
     manifestsBySnapshot
         .values()
@@ -344,7 +341,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
 
-    // rebuild manifest-list files last, stamping manifest_length with the rewritten manifest sizes
+    // rebuild manifest-list files
     Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
     Tasks.foreach(validSnapshots)
         .noRetry()
@@ -523,9 +520,11 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *
    * @param snapshot snapshot represented by the manifest list
    * @param tableMetadata metadata of table
-   * @param manifestFiles the manifests the snapshot's manifest list references
-   * @param manifestsToRewrite filter of manifests to rewrite.
-   * @param rewrittenManifestLengths map from source manifest path to its rewritten byte length
+   * @param manifestFiles the manifests referenced by the snapshot's manifest list, as returned by
+   *     {@link RewriteTablePathUtil#manifestsInSnapshot(Snapshot, FileIO, String)}
+   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param rewrittenManifestLengths map from source manifest path to the byte length of its
+   *     rewritten manifest
    * @return a result including a copy plan for the manifests contained in the manifest list, as
    *     well as for the manifest list itself
    */

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -614,8 +614,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
                 sourcePrefix,
                 targetPrefix,
                 rewrittenDeleteFileSizes),
-            // Encoders.bean derives an empty schema here and would drop the copy plan and lengths
-            Encoders.javaSerialization(RewriteContentFileResult.class))
+            Encoders.bean(RewriteContentFileResult.class))
         // duplicates are expected here as the same data file can have different statuses
         // (e.g. added and deleted)
         .reduce((ReduceFunction<RewriteContentFileResult>) RewriteContentFileResult::append);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -366,12 +366,11 @@ public class TestRewriteTablePathsAction extends TestBase {
   @TestTemplate
   public void testManifestLengthAfterRewrite() throws Exception {
     // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. The rewritten manifest list must record that new size
-    // in
-    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
-    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
-    // change from the prefix is dominated by the data block (not the constant Avro schema header),
-    // making the difference unambiguous.
+    // differs in byte size from the source. Every rewritten manifest list - for the current and all
+    // historical snapshots - must record that new size in manifest_length; otherwise readers that
+    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
+    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
+    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
     String sourceLocation = newTableLocation();
     Table sourceTable =
         TABLES.create(
@@ -380,19 +379,24 @@ public class TestRewriteTablePathsAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             sourceLocation);
 
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 50; i++) {
-      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
+    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
+      List<ThreeColumnRecord> records = Lists.newArrayList();
+      for (int i = 0; i < 30; i++) {
+        int id = snapshotNo * 100 + i;
+        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+      }
+      spark
+          .createDataFrame(records, ThreeColumnRecord.class)
+          .repartition(30)
+          .select("c1", "c2", "c3")
+          .write()
+          .format("iceberg")
+          .mode("append")
+          .save(sourceLocation);
     }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(50)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(sourceLocation);
     sourceTable.refresh();
+    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -407,15 +411,21 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     Table targetTable = TABLES.load(targetLocation);
     FileIO io = targetTable.io();
-    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
-    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
-    for (ManifestFile manifest : manifests) {
-      assertThat(manifest.length())
-          .as(
-              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
-              manifest.path())
-          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    int checkedManifests = 0;
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+        checkedManifests++;
+      }
     }
+    assertThat(checkedManifests)
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isGreaterThan(1);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -364,6 +364,61 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  public void testManifestLengthAfterRewrite() throws Exception {
+    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
+    // differs in byte size from the source. The rewritten manifest list must record that new size
+    // in
+    // manifest_length; otherwise readers that validate the field (e.g. Trino) fail with "Incorrect
+    // file size (end of stream not reached)". The manifest holds many data files so the byte-size
+    // change from the prefix is dominated by the data block (not the constant Avro schema header),
+    // making the difference unambiguous.
+    String sourceLocation = newTableLocation();
+    Table sourceTable =
+        TABLES.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
+            sourceLocation);
+
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 50; i++) {
+      records.add(new ThreeColumnRecord(i, "row-" + i, "data-" + i));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(50)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(sourceLocation);
+    sourceTable.refresh();
+
+    String targetLocation =
+        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
+
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
+            .execute();
+    copyTableFiles(result);
+
+    Table targetTable = TABLES.load(targetLocation);
+    FileIO io = targetTable.io();
+    List<ManifestFile> manifests = targetTable.currentSnapshot().allManifests(io);
+    assertThat(manifests).as("Rewritten snapshot should have manifests").isNotEmpty();
+    for (ManifestFile manifest : manifests) {
+      assertThat(manifest.length())
+          .as(
+              "manifest_length in the rewritten manifest list must match the on-disk size of %s",
+              manifest.path())
+          .isEqualTo(io.newInputFile(manifest.path()).getLength());
+    }
+  }
+
+  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -380,23 +380,10 @@ public class TestRewriteTablePathsAction extends TestBase {
             sourceLocation);
 
     // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
-    for (int snapshotNo = 0; snapshotNo < 2; snapshotNo++) {
-      List<ThreeColumnRecord> records = Lists.newArrayList();
-      for (int i = 0; i < 30; i++) {
-        int id = snapshotNo * 100 + i;
-        records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-      }
-      spark
-          .createDataFrame(records, ThreeColumnRecord.class)
-          .repartition(30)
-          .select("c1", "c2", "c3")
-          .write()
-          .format("iceberg")
-          .mode("append")
-          .save(sourceLocation);
-    }
+    appendManifestLengthRecords(sourceLocation, 0);
+    appendManifestLengthRecords(sourceLocation, 1);
     sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSizeGreaterThan(1);
+    assertThat(sourceTable.snapshots()).hasSize(2);
 
     String targetLocation =
         targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
@@ -410,6 +397,34 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetLocation);
+    // snapshot 1 references its own manifest, snapshot 2 references both
+    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
+        .as("should validate manifests across all (current and historical) snapshots")
+        .isEqualTo(3);
+    assertRewriteChangedManifestLength(sourceTable, targetTable);
+  }
+
+  private void appendManifestLengthRecords(String location, int batch) {
+    List<ThreeColumnRecord> records = Lists.newArrayList();
+    for (int i = 0; i < 30; i++) {
+      int id = batch * 100 + i;
+      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
+    }
+    spark
+        .createDataFrame(records, ThreeColumnRecord.class)
+        .repartition(30)
+        .select("c1", "c2", "c3")
+        .write()
+        .format("iceberg")
+        .mode("append")
+        .save(location);
+  }
+
+  /**
+   * Assert that every manifest referenced by any snapshot of the target table records a
+   * manifest_length matching the file on disk, and return how many entries were checked.
+   */
+  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
     FileIO io = targetTable.io();
     int checkedManifests = 0;
     for (Snapshot snapshot : targetTable.snapshots()) {
@@ -423,9 +438,34 @@ public class TestRewriteTablePathsAction extends TestBase {
         checkedManifests++;
       }
     }
-    assertThat(checkedManifests)
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isGreaterThan(1);
+    return checkedManifests;
+  }
+
+  /**
+   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
+   * move the byte size of any manifest, they would hold even without stamping the measured length.
+   */
+  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
+    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
+    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
+    // compare like with like: a target manifest missing from the source map would otherwise satisfy
+    // the check below for the wrong reason, since Long.equals(null) is false
+    assertThat(targetLengths.keySet())
+        .as("target manifests should be the source manifests under a new prefix")
+        .isEqualTo(sourceLengths.keySet());
+    assertThat(targetLengths.entrySet())
+        .as("rewriting to a longer prefix must change at least one manifest's byte size")
+        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
+  }
+
+  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
+    Map<String, Long> lengths = Maps.newHashMap();
+    for (Snapshot snapshot : tbl.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
+        lengths.put(fileName(manifest.path()), manifest.length());
+      }
+    }
+    return lengths;
   }
 
   @TestTemplate
@@ -905,7 +945,14 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
-    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
+    List<ManifestFile> deleteManifests =
+        targetTable.currentSnapshot().deleteManifests(targetTable.io());
+    assertThat(deleteManifests).isNotEmpty();
+    for (ManifestFile manifest : deleteManifests) {
+      // the delete manifest itself is rewritten, so its manifest_length must be measured too
+      assertThat(manifest.length())
+          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
+          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -365,12 +365,6 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   @TestTemplate
   public void testManifestLengthAfterRewrite() throws Exception {
-    // Rewriting a manifest embeds the new (here, longer) data-file paths, so the rewritten manifest
-    // differs in byte size from the source. Every rewritten manifest list - for the current and all
-    // historical snapshots - must record that new size in manifest_length; otherwise readers that
-    // validate the field (e.g. Trino) fail with "Incorrect file size (end of stream not reached)".
-    // Each snapshot's manifest holds many data files so the byte-size change from the prefix is
-    // dominated by the data block (not the constant Avro schema header), making it unambiguous.
     String sourceLocation = newTableLocation();
     Table sourceTable =
         TABLES.create(
@@ -379,7 +373,6 @@ public class TestRewriteTablePathsAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             sourceLocation);
 
-    // Two appends produce two snapshots so the older snapshot is exercised as a historical one.
     appendManifestLengthRecords(sourceLocation, 0);
     appendManifestLengthRecords(sourceLocation, 1);
     sourceTable.refresh();
@@ -420,10 +413,6 @@ public class TestRewriteTablePathsAction extends TestBase {
         .save(location);
   }
 
-  /**
-   * Assert that every manifest referenced by any snapshot of the target table records a
-   * manifest_length matching the file on disk, and return how many entries were checked.
-   */
   private int assertManifestLengthsMatchOnDisk(Table targetTable) {
     FileIO io = targetTable.io();
     int checkedManifests = 0;
@@ -441,15 +430,11 @@ public class TestRewriteTablePathsAction extends TestBase {
     return checkedManifests;
   }
 
-  /**
-   * Guard against the length assertions degenerating into a tautology: if the prefix change did not
-   * move the byte size of any manifest, they would hold even without stamping the measured length.
-   */
+  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
   private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
     Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
     Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // compare like with like: a target manifest missing from the source map would otherwise satisfy
-    // the check below for the wrong reason, since Long.equals(null) is false
+    // a target manifest missing from the source map would pass anyMatch for the wrong reason
     assertThat(targetLengths.keySet())
         .as("target manifests should be the source manifests under a new prefix")
         .isEqualTo(sourceLengths.keySet());
@@ -936,20 +921,23 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
+    // a longer target prefix so the rewritten manifests change byte size
+    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
+
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetTableLocation())
+            .rewriteLocationPrefix(table.location(), targetLocation)
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetTableLocation());
+    Table targetTable = TABLES.load(targetLocation);
+    assertRewriteChangedManifestLength(table, targetTable);
     List<ManifestFile> deleteManifests =
         targetTable.currentSnapshot().deleteManifests(targetTable.io());
     assertThat(deleteManifests).isNotEmpty();
     for (ManifestFile manifest : deleteManifests) {
-      // the delete manifest itself is rewritten, so its manifest_length must be measured too
       assertThat(manifest.length())
           .as("manifest_length of the rewritten delete manifest %s", manifest.path())
           .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -223,6 +223,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation));
 
     // verify the data file path after the rebuild
     List<String> validDataFilesAfterRebuilt =
@@ -364,96 +365,6 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
-  public void testManifestLengthAfterRewrite() throws Exception {
-    String sourceLocation = newTableLocation();
-    Table sourceTable =
-        TABLES.create(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
-            sourceLocation);
-
-    appendManifestLengthRecords(sourceLocation, 0);
-    appendManifestLengthRecords(sourceLocation, 1);
-    sourceTable.refresh();
-    assertThat(sourceTable.snapshots()).hasSize(2);
-
-    String targetLocation =
-        targetTableLocation() + "this/is/a/much/longer/nested/target/prefix/than/the/source";
-
-    RewriteTablePath.Result result =
-        actions()
-            .rewriteTablePath(sourceTable)
-            .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(sourceTable.location(), targetLocation)
-            .execute();
-    copyTableFiles(result);
-
-    Table targetTable = TABLES.load(targetLocation);
-    // snapshot 1 references its own manifest, snapshot 2 references both
-    assertThat(assertManifestLengthsMatchOnDisk(targetTable))
-        .as("should validate manifests across all (current and historical) snapshots")
-        .isEqualTo(3);
-    assertRewriteChangedManifestLength(sourceTable, targetTable);
-  }
-
-  private void appendManifestLengthRecords(String location, int batch) {
-    List<ThreeColumnRecord> records = Lists.newArrayList();
-    for (int i = 0; i < 30; i++) {
-      int id = batch * 100 + i;
-      records.add(new ThreeColumnRecord(id, "row-" + id, "data-" + id));
-    }
-    spark
-        .createDataFrame(records, ThreeColumnRecord.class)
-        .repartition(30)
-        .select("c1", "c2", "c3")
-        .write()
-        .format("iceberg")
-        .mode("append")
-        .save(location);
-  }
-
-  private int assertManifestLengthsMatchOnDisk(Table targetTable) {
-    FileIO io = targetTable.io();
-    int checkedManifests = 0;
-    for (Snapshot snapshot : targetTable.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(io)) {
-        assertThat(manifest.length())
-            .as(
-                "manifest_length in the rewritten manifest list of snapshot %s must match the"
-                    + " on-disk size of %s",
-                snapshot.snapshotId(), manifest.path())
-            .isEqualTo(io.newInputFile(manifest.path()).getLength());
-        checkedManifests++;
-      }
-    }
-    return checkedManifests;
-  }
-
-  /** Guards the length assertions against a prefix change that moved no manifest's byte size. */
-  private void assertRewriteChangedManifestLength(Table sourceTable, Table targetTable) {
-    Map<String, Long> sourceLengths = manifestLengthsByFileName(sourceTable);
-    Map<String, Long> targetLengths = manifestLengthsByFileName(targetTable);
-    // a target manifest missing from the source map would pass anyMatch for the wrong reason
-    assertThat(targetLengths.keySet())
-        .as("target manifests should be the source manifests under a new prefix")
-        .isEqualTo(sourceLengths.keySet());
-    assertThat(targetLengths.entrySet())
-        .as("rewriting to a longer prefix must change at least one manifest's byte size")
-        .anyMatch(entry -> !entry.getValue().equals(sourceLengths.get(entry.getKey())));
-  }
-
-  private Map<String, Long> manifestLengthsByFileName(Table tbl) {
-    Map<String, Long> lengths = Maps.newHashMap();
-    for (Snapshot snapshot : tbl.snapshots()) {
-      for (ManifestFile manifest : snapshot.allManifests(tbl.io())) {
-        lengths.put(fileName(manifest.path()), manifest.length());
-      }
-    }
-    return lengths;
-  }
-
-  @TestTemplate
   public void testManifestRewriteAndIncrementalCopy() throws Exception {
     RewriteTablePath.Result initialResult =
         actions()
@@ -504,6 +415,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // verify data rows
     Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation());
@@ -575,6 +487,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Positional delete affects a single row, so only one row must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -613,6 +526,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // check copied position delete row - only v2 stores row data with position deletes
     // v3+ uses Deletion Vectors (DV) which only store position information
@@ -672,6 +586,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
         .isEmpty();
@@ -790,6 +705,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<ManifestFile> deleteManifests =
         targetTable.currentSnapshot().deleteManifests(targetTable.io());
     assertThat(deleteManifests)
@@ -873,6 +789,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     List<Long> rewrittenSizes = Lists.newArrayList();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -921,26 +838,17 @@ public class TestRewriteTablePathsAction extends TestBase {
             .first();
     table.newRowDelta().addDeletes(positionDeletes).commit();
 
-    // a longer target prefix so the rewritten manifests change byte size
-    String targetLocation = targetTableLocation() + "a/much/longer/nested/target/prefix";
-
     RewriteTablePath.Result result =
         actions()
             .rewriteTablePath(table)
             .stagingLocation(stagingLocation())
-            .rewriteLocationPrefix(table.location(), targetLocation)
+            .rewriteLocationPrefix(table.location(), targetTableLocation())
             .execute();
     copyTableFiles(result);
 
-    Table targetTable = TABLES.load(targetLocation);
-    assertRewriteChangedManifestLength(table, targetTable);
-    List<ManifestFile> deleteManifests =
-        targetTable.currentSnapshot().deleteManifests(targetTable.io());
-    assertThat(deleteManifests).isNotEmpty();
-    for (ManifestFile manifest : deleteManifests) {
-      assertThat(manifest.length())
-          .as("manifest_length of the rewritten delete manifest %s", manifest.path())
-          .isEqualTo(targetTable.io().newInputFile(manifest.path()).getLength());
+    Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
+    for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
           ManifestFiles.readDeleteManifest(manifest, targetTable.io(), targetTable.specs())) {
         for (DeleteFile df : reader) {
@@ -1003,6 +911,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     copyTableFiles(result);
 
     Table targetTable = TABLES.load(targetTableLocation());
+    assertManifestLengthsMatchOnDisk(targetTable);
     Set<String> rewrittenLocations = Sets.newHashSet();
     for (ManifestFile manifest : targetTable.currentSnapshot().deleteManifests(targetTable.io())) {
       try (ManifestReader<DeleteFile> reader =
@@ -1086,6 +995,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Equality deletes affect three rows, so just two rows must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -1209,6 +1119,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // expect deleted data file is excluded from rewrite and copy
     List<String> copiedDataFiles =
@@ -1668,6 +1579,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     String targetTableName = String.format("copiedV%sTable", formatVersion);
     TableIdentifier tableIdentifier = TableIdentifier.of("default", targetTableName);
     catalog.registerTable(tableIdentifier, targetTableLocation() + "/metadata/" + versionFile);
+    assertManifestLengthsMatchOnDisk(catalog.loadTable(tableIdentifier));
 
     List<Object[]> copiedData =
         rowsToJava(
@@ -1747,6 +1659,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // Copy the files and verify structure is preserved
     copyTableFiles(result);
+    assertManifestLengthsMatchOnDisk(TABLES.load(targetTableLocation()));
 
     // Read the file paths from the rewritten result to verify directory structure
     List<Tuple2<String, String>> filePaths = readPathPairList(result.fileListLocation());
@@ -1893,6 +1806,20 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   protected String toAbsolute(Path relative) {
     return relative.toFile().toURI().toString();
+  }
+
+  private void assertManifestLengthsMatchOnDisk(Table targetTable) {
+    FileIO io = targetTable.io();
+    for (Snapshot snapshot : targetTable.snapshots()) {
+      for (ManifestFile manifest : snapshot.allManifests(io)) {
+        assertThat(manifest.length())
+            .as(
+                "manifest_length in the rewritten manifest list of snapshot %s must match the"
+                    + " on-disk size of %s",
+                snapshot.snapshotId(), manifest.path())
+            .isEqualTo(io.newInputFile(manifest.path()).getLength());
+      }
+    }
   }
 
   private void copyTableFiles(RewriteTablePath.Result result) throws Exception {


### PR DESCRIPTION
Closes #16905

## Problem

`rewriteManifestList` updated only the manifest path in each manifest-list entry and left `manifest_length` (field 501) at the source value. A target prefix of a different length changes the rewritten manifest's byte size, so readers that validate the field (Trino, Impala, iceberg-rust, and Iceberg itself on V4) fail with `Incorrect file size`.

## Fix

The length is only known after the manifests are rewritten, but the action wrote the manifest lists first. `rebuildMetadata` now finds the manifests to rewrite through `Snapshot#allManifests`, rewrites them while `ManifestWriter.length()` records each byte length, and writes the manifest lists last.

`RewriteResult` carries those lengths and merges them in `append`, so `rewriteDataManifest` and `rewriteDeleteManifest` keep their signatures. `rewriteManifestList` is the only changed signature: the set of manifests to rewrite is replaced by a map from source manifest path to rewritten length, so a manifest cannot be selected for a rewrite that has no measured length. The released signature is changed in place rather than kept as a deprecated overload, since it cannot record a correct length. Two accepted breaks are recorded in `.palantir/revapi.yml`.

The changed signature had callers in every Spark tree, so the fix lands in 3.5, 4.0 and 4.1 together and no backport follows.

## Known gap: incremental runs

A manifest carried over from an earlier increment is not rewritten again, so it keeps its source length, and each manifest list logs one info line when that happens. Closing the gap means rewriting and re-copying carried-over manifests, which is what #13720 proposed for #13719 and where its cost discussion stalled, so this PR is scoped to the complete-copy path.

## Tests

`assertManifestLengthsMatchOnDisk` runs after `copyTableFiles` in every non-incremental test in `TestRewriteTablePathsAction`, asserting `manifest_length` against the on-disk size for every entry across current and historical snapshots (v2-v4). `TestRewriteTablePathUtil` pins the stamping, the source-path keying, the manifests the map selects for rewrite, and the `append` merge.

Thanks @vaultah for the incremental-mode catch.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix rewrite_table_path leaving the source manifest_length in the rewritten manifest lists.

