### PR TITLE
Spark: Fix ColumnVectorWithFilter child vectors

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -18,7 +18,10 @@
  */
 package org.apache.iceberg.spark.data.vectorized;
 
+import org.apache.spark.sql.types.ArrayType;
+import org.apache.spark.sql.types.CalendarIntervalType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
@@ -35,6 +38,8 @@ import org.apache.spark.unsafe.types.UTF8String;
  * modifying the underlying data.
  */
 public class ColumnVectorWithFilter extends ColumnVector {
+  private static final int NUM_INTERVAL_CHILDREN = 3;
+
   private final ColumnVector delegate;
   private final int[] rowIdMapping;
   private volatile ColumnVectorWithFilter[] children = null;
@@ -134,18 +139,30 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
+      return delegate.getChild(ordinal);
+    }
+
     if (children == null) {
       synchronized (this) {
         if (children == null) {
+          int numChildren;
           if (dataType() instanceof StructType) {
             StructType structType = (StructType) dataType();
-            this.children = new ColumnVectorWithFilter[structType.length()];
-            for (int index = 0; index < structType.length(); index++) {
-              children[index] = new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
-            }
+            numChildren = structType.length();
+          } else if (dataType() instanceof CalendarIntervalType) {
+            numChildren = NUM_INTERVAL_CHILDREN;
           } else {
             throw new UnsupportedOperationException("Unsupported nested type: " + dataType());
           }
+
+          ColumnVectorWithFilter[] remappedChildren = new ColumnVectorWithFilter[numChildren];
+          for (int index = 0; index < numChildren; index++) {
+            remappedChildren[index] =
+                new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
+          }
+
+          this.children = remappedChildren;
         }
       }
     }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -139,6 +139,7 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    // Array and map children use absolute element offsets after the parent row is remapped.
     if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
       return delegate.getChild(ordinal);
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.junit.jupiter.api.Test;
+
+class TestColumnVectorWithFilter {
+
+  @Test
+  void unsupportedChildTypeFails() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(1, DataTypes.IntegerType)) {
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0});
+
+      assertThatThrownBy(() -> filtered.getChild(0))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Unsupported nested type:");
+    }
+  }
+
+  @Test
+  void intervalColumnVectorRemapsRows() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(5, DataTypes.CalendarIntervalType)) {
+      for (int rowId = 0; rowId < 5; rowId++) {
+        delegate.putInterval(rowId, new CalendarInterval(rowId, rowId * 10, rowId * 100L));
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+      assertInterval(filtered.getInterval(0), 1, 10, 100L);
+      assertInterval(filtered.getInterval(1), 3, 30, 300L);
+    }
+  }
+
+  @Test
+  void arrayChildVectorIsNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(6, DataTypes.createArrayType(DataTypes.IntegerType))) {
+      WritableColumnVector elements = (WritableColumnVector) delegate.getChild(0);
+      for (int elementId = 0; elementId < 6; elementId++) {
+        elements.putInt(elementId, (elementId + 1) * 10);
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getInt(1)).isEqualTo(20);
+    }
+  }
+
+  @Test
+  void mapChildVectorsAreNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(
+            3, DataTypes.createMapType(DataTypes.StringType, DataTypes.IntegerType))) {
+      WritableColumnVector keys = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector values = (WritableColumnVector) delegate.getChild(1);
+      keys.putByteArray(0, bytes("a"));
+      keys.putByteArray(1, bytes("b"));
+      keys.putByteArray(2, bytes("c"));
+      values.putInt(0, 1);
+      values.putInt(1, 2);
+      values.putInt(2, 3);
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getUTF8String(1).toString()).isEqualTo("b");
+      assertThat(filtered.getChild(1).getInt(1)).isEqualTo(2);
+    }
+  }
+
+  private static void assertInterval(
+      CalendarInterval interval, int months, int days, long microseconds) {
+    assertThat(interval.months).isEqualTo(months);
+    assertThat(interval.days).isEqualTo(days);
+    assertThat(interval.microseconds).isEqualTo(microseconds);
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -18,12 +18,15 @@
  */
 package org.apache.iceberg.spark.data.vectorized;
 
+import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -36,6 +39,8 @@ import org.apache.spark.unsafe.types.UTF8String;
  * modifying the underlying data.
  */
 public class ColumnVectorWithFilter extends ColumnVector {
+  private static final int NUM_VARIANT_CHILDREN = 2;
+
   private final ColumnVector delegate;
   private final int[] rowIdMapping;
   private volatile ColumnVectorWithFilter[] children = null;
@@ -109,6 +114,11 @@ public class ColumnVectorWithFilter extends ColumnVector {
   }
 
   @Override
+  public CalendarInterval getInterval(int rowId) {
+    return delegate.getInterval(rowIdMapping[rowId]);
+  }
+
+  @Override
   public ColumnarArray getArray(int rowId) {
     return delegate.getArray(rowIdMapping[rowId]);
   }
@@ -135,24 +145,30 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
+      return delegate.getChild(ordinal);
+    }
+
     if (children == null) {
       synchronized (this) {
         if (children == null) {
+          int numChildren;
           if (dataType() instanceof StructType) {
             StructType structType = (StructType) dataType();
-            this.children = new ColumnVectorWithFilter[structType.length()];
-            for (int index = 0; index < structType.length(); index++) {
-              children[index] = new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
-            }
+            numChildren = structType.length();
           } else if (dataType() instanceof VariantType) {
-            this.children =
-                new ColumnVectorWithFilter[] {
-                  new ColumnVectorWithFilter(delegate.getChild(0), rowIdMapping),
-                  new ColumnVectorWithFilter(delegate.getChild(1), rowIdMapping)
-                };
+            numChildren = NUM_VARIANT_CHILDREN;
           } else {
             throw new UnsupportedOperationException("Unsupported nested type: " + dataType());
           }
+
+          ColumnVectorWithFilter[] remappedChildren = new ColumnVectorWithFilter[numChildren];
+          for (int index = 0; index < numChildren; index++) {
+            remappedChildren[index] =
+                new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
+          }
+
+          this.children = remappedChildren;
         }
       }
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -145,6 +145,7 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    // Array and map children use absolute element offsets after the parent row is remapped.
     if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
       return delegate.getChild(ordinal);
     }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.VariantType$;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.VariantVal;
+import org.junit.jupiter.api.Test;
+
+class TestColumnVectorWithFilter {
+
+  @Test
+  void unsupportedChildTypeFails() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(1, DataTypes.IntegerType)) {
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0});
+
+      assertThatThrownBy(() -> filtered.getChild(0))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Unsupported nested type:");
+    }
+  }
+
+  @Test
+  void intervalColumnVectorRemapsRows() {
+    ColumnVector delegate = mock(ColumnVector.class);
+    CalendarInterval expected = new CalendarInterval(3, 30, 300L);
+    when(delegate.getInterval(3)).thenReturn(expected);
+
+    ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+    assertThat(filtered.getInterval(1)).isSameAs(expected);
+  }
+
+  @Test
+  void variantColumnVectorRemapsRows() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(5, VariantType$.MODULE$)) {
+      WritableColumnVector values = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector metadata = (WritableColumnVector) delegate.getChild(1);
+      for (int rowId = 0; rowId < 5; rowId++) {
+        values.putByteArray(rowId, bytes("value-" + rowId));
+        metadata.putByteArray(rowId, bytes("metadata-" + rowId));
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+      assertVariant(filtered.getVariant(0), "value-1", "metadata-1");
+      assertVariant(filtered.getVariant(1), "value-3", "metadata-3");
+    }
+  }
+
+  @Test
+  void arrayChildVectorIsNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(6, DataTypes.createArrayType(DataTypes.IntegerType))) {
+      WritableColumnVector elements = (WritableColumnVector) delegate.getChild(0);
+      for (int elementId = 0; elementId < 6; elementId++) {
+        elements.putInt(elementId, (elementId + 1) * 10);
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getInt(1)).isEqualTo(20);
+    }
+  }
+
+  @Test
+  void mapChildVectorsAreNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(
+            3, DataTypes.createMapType(DataTypes.StringType, DataTypes.IntegerType))) {
+      WritableColumnVector keys = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector values = (WritableColumnVector) delegate.getChild(1);
+      keys.putByteArray(0, bytes("a"));
+      keys.putByteArray(1, bytes("b"));
+      keys.putByteArray(2, bytes("c"));
+      values.putInt(0, 1);
+      values.putInt(1, 2);
+      values.putInt(2, 3);
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getUTF8String(1).toString()).isEqualTo("b");
+      assertThat(filtered.getChild(1).getInt(1)).isEqualTo(2);
+    }
+  }
+
+  private static void assertVariant(VariantVal variant, String value, String metadata) {
+    assertThat(variant.getValue()).isEqualTo(bytes(value));
+    assertThat(variant.getMetadata()).isEqualTo(bytes(metadata));
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -18,12 +18,15 @@
  */
 package org.apache.iceberg.spark.data.vectorized;
 
+import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.MapType;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -36,6 +39,8 @@ import org.apache.spark.unsafe.types.UTF8String;
  * modifying the underlying data.
  */
 public class ColumnVectorWithFilter extends ColumnVector {
+  private static final int NUM_VARIANT_CHILDREN = 2;
+
   private final ColumnVector delegate;
   private final int[] rowIdMapping;
   private volatile ColumnVectorWithFilter[] children = null;
@@ -109,6 +114,11 @@ public class ColumnVectorWithFilter extends ColumnVector {
   }
 
   @Override
+  public CalendarInterval getInterval(int rowId) {
+    return delegate.getInterval(rowIdMapping[rowId]);
+  }
+
+  @Override
   public ColumnarArray getArray(int rowId) {
     return delegate.getArray(rowIdMapping[rowId]);
   }
@@ -135,24 +145,30 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
+      return delegate.getChild(ordinal);
+    }
+
     if (children == null) {
       synchronized (this) {
         if (children == null) {
+          int numChildren;
           if (dataType() instanceof StructType) {
             StructType structType = (StructType) dataType();
-            this.children = new ColumnVectorWithFilter[structType.length()];
-            for (int index = 0; index < structType.length(); index++) {
-              children[index] = new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
-            }
+            numChildren = structType.length();
           } else if (dataType() instanceof VariantType) {
-            this.children =
-                new ColumnVectorWithFilter[] {
-                  new ColumnVectorWithFilter(delegate.getChild(0), rowIdMapping),
-                  new ColumnVectorWithFilter(delegate.getChild(1), rowIdMapping)
-                };
+            numChildren = NUM_VARIANT_CHILDREN;
           } else {
             throw new UnsupportedOperationException("Unsupported nested type: " + dataType());
           }
+
+          ColumnVectorWithFilter[] remappedChildren = new ColumnVectorWithFilter[numChildren];
+          for (int index = 0; index < numChildren; index++) {
+            remappedChildren[index] =
+                new ColumnVectorWithFilter(delegate.getChild(index), rowIdMapping);
+          }
+
+          this.children = remappedChildren;
         }
       }
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -145,6 +145,7 @@ public class ColumnVectorWithFilter extends ColumnVector {
 
   @Override
   public ColumnVector getChild(int ordinal) {
+    // Array and map children use absolute element offsets after the parent row is remapped.
     if (dataType() instanceof ArrayType || dataType() instanceof MapType) {
       return delegate.getChild(ordinal);
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
@@ -1,0 +1,121 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.spark.sql.execution.vectorized.OnHeapColumnVector;
+import org.apache.spark.sql.execution.vectorized.WritableColumnVector;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.VariantType$;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.unsafe.types.CalendarInterval;
+import org.apache.spark.unsafe.types.VariantVal;
+import org.junit.jupiter.api.Test;
+
+class TestColumnVectorWithFilter {
+
+  @Test
+  void unsupportedChildTypeFails() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(1, DataTypes.IntegerType)) {
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0});
+
+      assertThatThrownBy(() -> filtered.getChild(0))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Unsupported nested type:");
+    }
+  }
+
+  @Test
+  void intervalColumnVectorRemapsRows() {
+    ColumnVector delegate = mock(ColumnVector.class);
+    CalendarInterval expected = new CalendarInterval(3, 30, 300L);
+    when(delegate.getInterval(3)).thenReturn(expected);
+
+    ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+    assertThat(filtered.getInterval(1)).isSameAs(expected);
+  }
+
+  @Test
+  void variantColumnVectorRemapsRows() {
+    try (WritableColumnVector delegate = new OnHeapColumnVector(5, VariantType$.MODULE$)) {
+      WritableColumnVector values = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector metadata = (WritableColumnVector) delegate.getChild(1);
+      for (int rowId = 0; rowId < 5; rowId++) {
+        values.putByteArray(rowId, bytes("value-" + rowId));
+        metadata.putByteArray(rowId, bytes("metadata-" + rowId));
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {1, 3});
+
+      assertVariant(filtered.getVariant(0), "value-1", "metadata-1");
+      assertVariant(filtered.getVariant(1), "value-3", "metadata-3");
+    }
+  }
+
+  @Test
+  void arrayChildVectorIsNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(6, DataTypes.createArrayType(DataTypes.IntegerType))) {
+      WritableColumnVector elements = (WritableColumnVector) delegate.getChild(0);
+      for (int elementId = 0; elementId < 6; elementId++) {
+        elements.putInt(elementId, (elementId + 1) * 10);
+      }
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getInt(1)).isEqualTo(20);
+    }
+  }
+
+  @Test
+  void mapChildVectorsAreNotRemapped() {
+    try (WritableColumnVector delegate =
+        new OnHeapColumnVector(
+            3, DataTypes.createMapType(DataTypes.StringType, DataTypes.IntegerType))) {
+      WritableColumnVector keys = (WritableColumnVector) delegate.getChild(0);
+      WritableColumnVector values = (WritableColumnVector) delegate.getChild(1);
+      keys.putByteArray(0, bytes("a"));
+      keys.putByteArray(1, bytes("b"));
+      keys.putByteArray(2, bytes("c"));
+      values.putInt(0, 1);
+      values.putInt(1, 2);
+      values.putInt(2, 3);
+
+      ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {0, 2});
+
+      assertThat(filtered.getChild(0).getUTF8String(1).toString()).isEqualTo("b");
+      assertThat(filtered.getChild(1).getInt(1)).isEqualTo(2);
+    }
+  }
+
+  private static void assertVariant(VariantVal variant, String value, String metadata) {
+    assertThat(variant.getValue()).isEqualTo(bytes(value));
+    assertThat(variant.getMetadata()).isEqualTo(bytes(metadata));
+  }
+
+  private static byte[] bytes(String value) {
+    return value.getBytes(StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
This PR fixes `ColumnVectorWithFilter` for Spark column vectors with nested public accessors.

Spark 3.5's final `getInterval` accessor reads row-indexed child vectors, so those children receive the row ID mapping. Spark 4.0 and 4.1 allow delegate-specific interval representations, so `getInterval` remaps the row and delegates directly. Variant children remain row-mapped.

Array and map children are addressed by element offset, so this PR returns their delegate child vectors without applying the parent row mapping. Unknown child layouts continue to fail fast.

The first commit adds coverage for interval, array, map, unsupported child layouts, and Spark 4.0/4.1 variant vectors. The second commit applies the fix across Spark 3.5, Spark 4.0, and Spark 4.1.

Tests:

```
./gradlew --no-daemon -DsparkVersions=3.5 :iceberg-spark:iceberg-spark-3.5_2.12:test --tests org.apache.iceberg.spark.data.vectorized.TestColumnVectorWithFilter
./gradlew --no-daemon -DsparkVersions=4.0 -DscalaVersion=2.13 :iceberg-spark:iceberg-spark-4.0_2.13:test --tests org.apache.iceberg.spark.data.vectorized.TestColumnVectorWithFilter
./gradlew --no-daemon :iceberg-spark:iceberg-spark-4.1_2.13:test --tests org.apache.iceberg.spark.data.vectorized.TestColumnVectorWithFilter
./gradlew --no-daemon spotlessCheck
```