### PR TITLE
Kafka Connect: Fix case-insensitive field lookup with name mapping

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -276,22 +276,29 @@ class RecordConverter {
           : schema.field(fieldName);
     }
 
-    return structNameMap
-        .computeIfAbsent(structFieldId, notUsed -> createStructNameMap(schema))
-        .get(fieldName);
+    Map<String, NestedField> nameMap =
+        structNameMap.computeIfAbsent(structFieldId, notUsed -> createStructNameMap(schema));
+    String lookupKey =
+        config.schemaCaseInsensitive() ? fieldName.toLowerCase(Locale.ROOT) : fieldName;
+    return nameMap.get(lookupKey);
   }
 
   private Map<String, NestedField> createStructNameMap(StructType schema) {
     Map<String, NestedField> map = Maps.newHashMap();
+    boolean caseInsensitive = config.schemaCaseInsensitive();
     schema
         .fields()
         .forEach(
             col -> {
               MappedField mappedField = nameMapping.find(col.fieldId());
               if (mappedField != null && !mappedField.names().isEmpty()) {
-                mappedField.names().forEach(name -> map.put(name, col));
+                mappedField
+                    .names()
+                    .forEach(
+                        name ->
+                            map.put(caseInsensitive ? name.toLowerCase(Locale.ROOT) : name, col));
               } else {
-                map.put(col.name(), col);
+                map.put(caseInsensitive ? col.name().toLowerCase(Locale.ROOT) : col.name(), col);
               }
             });
     return map;

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -412,6 +412,33 @@ public class TestRecordConverter {
 
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
+  public void testNameMappingWithDifferentCaseAlias(boolean caseInsensitive) {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+
+    NameMapping nameMapping = NameMapping.of(MappedField.of(1, ImmutableList.of("II")));
+    when(table.properties())
+        .thenReturn(
+            ImmutableMap.of(
+                TableProperties.DEFAULT_NAME_MAPPING, NameMappingParser.toJson(nameMapping)));
+    when(config.schemaCaseInsensitive()).thenReturn(caseInsensitive);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    // exact-case alias always matches
+    assertThat(converter.convert(ImmutableMap.of("II", 100)).getField("ii")).isEqualTo(100);
+
+    // different-case input matches only when case-insensitive
+    Object actual = converter.convert(ImmutableMap.of("ii", 200)).getField("ii");
+    if (caseInsensitive) {
+      assertThat(actual).isEqualTo(200);
+    } else {
+      assertThat(actual).isNull();
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
   public void testCaseSensitivity(boolean caseInsensitive) {
     Table table = mock(Table.class);
     when(table.schema()).thenReturn(SIMPLE_SCHEMA);


### PR DESCRIPTION
Closes #15392

## Summary

- With a name mapping configured, `RecordConverter.lookupStructField` ignored `iceberg.tables.schema-case-insensitive`: fields differing only in case failed to match, and schema evolution then created duplicate columns.
- The `nameMapping == null` branch already handles this via `schema.caseInsensitiveField`; the name-mapping path did not.
- Fix: normalize the name map keys on both `put` (`createStructNameMap`) and `get` (`lookupStructField`) to lower case with `Locale.ROOT` when case-insensitive.
- Revives the approach from the stale-closed #15393 (credit to @annurahar).

## Testing done

- Added `TestRecordConverter#testNameMappingWithDifferentCaseAlias`, parameterized over case-insensitive true/false: an exact-case alias always matches; a different-case input matches only when case-insensitive.
- Regression: with the test in place but the fix reverted, the `caseInsensitive = true` case fails (expected 200, got null); with the fix it passes.
- `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:check` passed; `TestRecordConverter` runs 51 tests, 0 failures.
- Module is not a REVAPI target, so no revapi run.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
