### PR TITLE
MR: Normalize default catalog name in Catalogs.hiveCatalog

### DIFF
--- a/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
+++ b/mr/src/main/java/org/apache/iceberg/mr/Catalogs.java
@@ -225,7 +225,8 @@ public final class Catalogs {
     if (catalogType != null) {
       return CatalogUtil.ICEBERG_CATALOG_TYPE_HIVE.equalsIgnoreCase(catalogType);
     }
-    return getCatalogProperties(conf, catalogName).get(CatalogProperties.CATALOG_IMPL) == null;
+    String name = catalogName == null ? ICEBERG_DEFAULT_CATALOG_NAME : catalogName;
+    return getCatalogProperties(conf, name).get(CatalogProperties.CATALOG_IMPL) == null;
   }
 
   @VisibleForTesting

--- a/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
+++ b/mr/src/test/java/org/apache/iceberg/mr/TestCatalogs.java
@@ -259,6 +259,22 @@ public class TestCatalogs {
   }
 
   @Test
+  public void testLoadCatalogDefaultWithCustomImpl() {
+    conf.set(
+        InputFormatConfig.catalogPropertyConfigKey(
+            Catalogs.ICEBERG_DEFAULT_CATALOG_NAME, CatalogProperties.CATALOG_IMPL),
+        CustomHadoopCatalog.class.getName());
+    conf.set(
+        InputFormatConfig.catalogPropertyConfigKey(
+            Catalogs.ICEBERG_DEFAULT_CATALOG_NAME, CatalogProperties.WAREHOUSE_LOCATION),
+        "/tmp/mylocation");
+    Optional<Catalog> customHadoopCatalog = Catalogs.loadCatalog(conf, null);
+    assertThat(customHadoopCatalog).isPresent();
+    assertThat(customHadoopCatalog.get()).isInstanceOf(CustomHadoopCatalog.class);
+    assertThat(Catalogs.hiveCatalog(conf, new Properties())).isFalse();
+  }
+
+  @Test
   public void testLoadCatalogLocation() {
     assertThat(Catalogs.loadCatalog(conf, Catalogs.ICEBERG_HADOOP_TABLE_NAME)).isNotPresent();
   }


### PR DESCRIPTION
## Summary

- When no catalog name is set, `Catalogs.hiveCatalog` passed null to `getCatalogProperties`, producing the prefix `iceberg.catalog.null` instead of `iceberg.catalog.default_iceberg`.
- A default catalog configured with a custom `catalog-impl` was then not found, so the method reported it as Hive — while `loadCatalog` loads the custom catalog from the same config.
- Fix normalizes a null catalog name to `ICEBERG_DEFAULT_CATALOG_NAME` before the lookup, matching sibling `loadCatalog` (`Catalogs.java:238`) and the earlier `getCatalogType` call on `ICEBERG_DEFAULT_CATALOG_NAME` in the same method.

## Testing done

- Added `TestCatalogs#testLoadCatalogDefaultWithCustomImpl`: a default (unnamed) catalog with a custom `catalog-impl` now makes `hiveCatalog` return `false`, consistent with `loadCatalog`. Fails before the fix (`Expecting value to be false but was true`), passes after.
- `./gradlew :iceberg-mr:check` — passed (test + spotlessCheck + checkstyle + errorProne), JDK 21.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
