### PR TITLE
Kafka Connect: Fix CommitToTable payload Javadoc

### DIFF
--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/CommitToTable.java
@@ -30,9 +30,10 @@ import org.apache.iceberg.types.Types.UUIDType;
 import org.apache.iceberg.util.DateTimeUtil;
 
 /**
- * A control event payload for events sent by a coordinator that indicates it has completed a commit
- * cycle. Events with this payload are not consumed by the sink, they are informational and can be
- * used by consumers to trigger downstream processes.
+ * A control event payload for events sent by a coordinator that indicates it has committed data to
+ * a table during a commit cycle. One event is sent per committed table and carries the table
+ * reference and resulting snapshot ID. Events with this payload are not consumed by the sink, they
+ * are informational and can be used by consumers to trigger downstream processes.
  */
 public class CommitToTable implements Payload {
 


### PR DESCRIPTION
## Summary

- `CommitToTable`'s class Javadoc was copy-pasted from `CommitComplete` and says the payload "indicates it has completed a commit cycle", which is wrong.
- `CommitToTable` is a per-table event carrying `tableReference` and `snapshotId`; the coordinator sends one per committed table (`Coordinator.commitToTable`), while `CommitComplete` is sent once at the end of the cycle (`Coordinator.doCommit`).
- Updated the Javadoc to match the per-table semantics.

## Testing done

- Docs/comment-only change, no behavior change — no test added. `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect-events:spotlessCheck` passed.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
