### PR TITLE
Hive: Add HiveCatalog(Configuration, Map) convenience constructor

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -102,6 +102,25 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
 
   public HiveCatalog() {}
 
+  /**
+   * Convenience constructor that uses the passed configuration and properties to initialize the
+   * catalog under the name {@code "hive"}, equivalent to calling {@link #setConf(Configuration)}
+   * followed by {@link #initialize(String, Map)}.
+   *
+   * @param conf The Hadoop configuration
+   * @param properties The catalog properties
+   */
+  public HiveCatalog(Configuration conf, Map<String, String> properties) {
+    setConf(conf);
+    initialize("hive", properties);
+  }
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines {@code setConf(...)} and this call.
+   */
   @Override
   public void initialize(String inputName, Map<String, String> properties) {
     this.catalogProperties = ImmutableMap.copyOf(properties);
@@ -824,6 +843,12 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
         .toString();
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * <p>When instantiating {@code HiveCatalog} directly, prefer {@link #HiveCatalog(Configuration,
+   * Map)}, which combines this call and {@code initialize(...)}.
+   */
   @Override
   public void setConf(Configuration conf) {
     this.conf = new Configuration(conf);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -287,6 +287,23 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
   }
 
   @Test
+  public void testConstructorWithConfAndProperties() {
+    Configuration conf = new Configuration();
+    conf.set("custom.caller.key", "custom-value");
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put("uri", "thrift://examplehost:9083");
+    properties.put("warehouse", "/user/hive/testwarehouse");
+
+    HiveCatalog hiveCatalog = new HiveCatalog(conf, properties);
+
+    assertThat(hiveCatalog.getConf().get("hive.metastore.uris")).isEqualTo(properties.get("uri"));
+    assertThat(hiveCatalog.getConf().get("hive.metastore.warehouse.dir"))
+        .isEqualTo(properties.get("warehouse"));
+    assertThat(hiveCatalog.getConf().get("custom.caller.key"))
+        .isEqualTo(conf.get("custom.caller.key"));
+  }
+
+  @Test
   public void testCreateTableTxnBuilder() throws Exception {
     Schema schema = getTestSchema();
     TableIdentifier tableIdent = TableIdentifier.of(DB_NAME, "tbl");


### PR DESCRIPTION
Closes #16134

## Summary

- Add `HiveCatalog(Configuration, Map)` that calls `setConf(conf)` then `initialize("hive", properties)`, so callers configure a catalog in one step instead of new + setConf + initialize.
- Mirrors the existing `HadoopCatalog(Configuration, String)` anchor in core.
- Adds constructor Javadoc, cross-referenced from `setConf`/`initialize`.
- Revives stale-bot-closed PR #16135 (committer-approved "LGTM +1" by deniskuzZ). Original author: 1fanwang.

## Testing done

- Added `TestHiveCatalog#testConstructorWithConfAndProperties`, asserting `getConf()` retains the URI, warehouse, and a custom caller key (expected values read from the inputs, not hardcoded).
- `./gradlew :iceberg-hive-metastore:check` passed on JDK 21 — 309 tests, 0 failures, including spotlessCheck, checkstyle, errorProne, and in-process HMS (Derby) tests.
- This module is not a REVAPI target, so no revapi run.

Note: this adds public API, so a committer waits 24h before merge for feedback.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
