### PR TITLE
Docs: Fix broken anchor links in Spark and Hive quickstarts

### DIFF
--- a/site/docs/hive-quickstart.md
+++ b/site/docs/hive-quickstart.md
@@ -105,7 +105,7 @@ SELECT * FROM nyc.taxis;
 
 #### Adding Iceberg to Hive
 
-If you already have a Hive 4.0.0 or later environment, it comes with the Iceberg included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [Enabling Iceberg support in Hive](docs/latest/hive.md#hive-23x-hive-31x).
+If you already have a Hive 4.0.0 or later environment, it comes with the Iceberg included. No additional downloads or jars are needed. If you have a Hive 2.3.x or Hive 3.1.x environment see [Enabling Iceberg support in Hive](docs/latest/hive.md#enabling-iceberg-support-in-hive).
 
 #### Learn More
 

--- a/site/docs/spark-quickstart.md
+++ b/site/docs/spark-quickstart.md
@@ -217,7 +217,7 @@ Then create the table:
 Iceberg catalogs support the full range of SQL DDL commands, including:
 
 * [`CREATE TABLE ... PARTITIONED BY`](docs/latest/spark-ddl.md#create-table)
-* [`CREATE TABLE ... AS SELECT`](docs/latest/spark-ddl.md#create-table--as-select)
+* [`CREATE TABLE ... AS SELECT`](docs/latest/spark-ddl.md#create-table-as-select)
 * [`ALTER TABLE`](docs/latest/spark-ddl.md#alter-table)
 * [`DROP TABLE`](docs/latest/spark-ddl.md#drop-table)
 


### PR DESCRIPTION


## Summary

- `site/docs/spark-quickstart.md` linked `spark-ddl.md#create-table--as-select` (double hyphen), but the `## CREATE TABLE ... AS SELECT` header's slug is `create-table-as-select`, so the anchor matched nothing.
- Sibling pages `docs/docs/spark-getting-started.md` and `docs/docs/table-migration.md` already use the correct `spark-ddl.md#create-table-as-select`.
- `site/docs/hive-quickstart.md` linked `hive.md#hive-23x-hive-31x`, which matches no header. The correct target is the `## Enabling Iceberg support in Hive` section (slug `enabling-iceberg-support-in-hive`), named by the link text; it covers Hive 2.x/3.x, so the sentence is unchanged.
- `site/mkdocs.yml` sets no custom `toc` slugify, so default python-markdown slug rules apply.

## Testing done

- Docs-only change (two anchor fragments), no behavior change — no test added. Verified each broken anchor appears only on the edited line and each target header slug exists via grep.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
