### PR TITLE
Snowflake: Include underlying SQL error in fallback exception message

### DIFF
--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/JdbcSnowflakeClient.java
@@ -384,6 +384,7 @@ class JdbcSnowflakeClient implements SnowflakeClient {
           ex.getMessage());
     }
     // Unchecked SQL Exception in all other cases as fall back
-    return new UncheckedSQLException(ex, "Exception Message: %s", defaultExceptionMessage);
+    return new UncheckedSQLException(
+        ex, "%s. Underlying exception: '%s'", defaultExceptionMessage, ex.getMessage());
   }
 }

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/TestJdbcSnowflakeClient.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/TestJdbcSnowflakeClient.java
@@ -277,6 +277,7 @@ public class TestJdbcSnowflakeClient {
     assertThatExceptionOfType(UncheckedSQLException.class)
         .isThrownBy(() -> snowflakeClient.listDatabases())
         .withMessageContaining("Failed to list databases")
+        .withMessageContaining("SQL exception with Error Code 0")
         .withCause(injectedException);
   }
 
@@ -294,6 +295,7 @@ public class TestJdbcSnowflakeClient {
     assertThatExceptionOfType(UncheckedSQLException.class)
         .isThrownBy(() -> snowflakeClient.listDatabases())
         .withMessageContaining("Failed to list databases")
+        .withMessageContaining("Fake SQL exception")
         .withCause(injectedException);
   }
 


### PR DESCRIPTION
## Summary

- `JdbcSnowflakeClient.snowflakeExceptionToIcebergException` builds the fallback `UncheckedSQLException` from `"Exception Message: %s"` and only the static `defaultExceptionMessage`, leaving the SQL driver message (`ex.getMessage()`) out of the top-level message.
- The sibling branches in the same method (`NoSuchNamespaceException`, `NoSuchTableException`) already append `"Underlying exception: '%s'"` with `ex.getMessage()`. This aligns the fallback with them.
- The cause (`ex`) is still passed through, so exception type and cause behavior are unchanged — only the message text changes. The fallback is reached by `listDatabases`/`listSchemas`/`listIcebergTables`/`loadTableMetadata` on any non-not-found `SQLException`.

## Testing done

- Extended `TestJdbcSnowflakeClient#testListDatabasesSQLExceptionAtRootLevel` and `#testListDatabasesSQLExceptionWithoutErrorCode` to assert the SQL message now appears in the thrown message; both fail on the old message and pass after the change.
- `./gradlew :iceberg-snowflake:check` — passed (no Docker required).

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
