### PR TITLE
ORC: Fix lower/upper bounds for timestamp_ns columns in OrcMetrics

### DIFF
--- a/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/orc/TestOrcMetrics.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.FileFormat;
@@ -31,6 +33,7 @@ import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.TestMetrics;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.orc.GenericOrcWriter;
 import org.apache.iceberg.io.FileAppender;
@@ -39,7 +42,10 @@ import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 /** Test Metrics for ORC. */
@@ -105,6 +111,35 @@ public class TestOrcMetrics extends TestMetrics {
 
   private boolean isBinaryType(Type type) {
     return BINARY_TYPES.contains(type.typeId());
+  }
+
+  @TestTemplate
+  public void timestampNanoBoundsKeepNanoPrecision() throws IOException {
+    Types.TimestampNanoType nanoType = Types.TimestampNanoType.withoutZone();
+    Schema schema = new Schema(Types.NestedField.optional(1, "tsNano", nanoType));
+
+    // sub-microsecond nanos that would change if truncated to micros
+    LocalDateTime lower = LocalDateTime.parse("1970-01-01T00:00:00.000001500");
+    LocalDateTime upper = LocalDateTime.parse("2024-01-02T03:04:05.123456789");
+
+    GenericRecord lowerRecord = GenericRecord.create(schema);
+    lowerRecord.set(0, lower);
+    GenericRecord upperRecord = GenericRecord.create(schema);
+    upperRecord.set(0, upper);
+
+    Metrics metrics = getMetrics(schema, lowerRecord, upperRecord);
+
+    LocalDateTime epoch = LocalDateTime.parse("1970-01-01T00:00:00");
+    long expectedLower = ChronoUnit.NANOS.between(epoch, lower);
+    long expectedUpper = ChronoUnit.NANOS.between(epoch, upper);
+
+    long actualLower = Conversions.fromByteBuffer(nanoType, metrics.lowerBounds().get(1));
+    long actualUpper = Conversions.fromByteBuffer(nanoType, metrics.upperBounds().get(1));
+
+    assertThat(actualLower).isEqualTo(expectedLower);
+    assertThat(actualUpper).isEqualTo(expectedUpper);
+    // guard against the micros regression: the bound must not be ~1000x smaller
+    assertThat(actualLower).isEqualTo(1500L);
   }
 
   @Override

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcMetrics.java
@@ -21,6 +21,9 @@ package org.apache.iceberg.orc;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -267,9 +270,7 @@ public class OrcMetrics {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp minValue = tColStats.getMinimumUTC();
       min =
-          Optional.ofNullable(minValue)
-              .map(v -> DateTimeUtil.microsFromInstant(v.toInstant()))
-              .orElse(null);
+          Optional.ofNullable(minValue).map(v -> timestampBound(type, v.toInstant())).orElse(null);
     } else if (columnStats instanceof BooleanColumnStatistics) {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;
       min = booleanStats.getFalseCount() <= 0;
@@ -322,15 +323,22 @@ public class OrcMetrics {
       TimestampColumnStatistics tColStats = (TimestampColumnStatistics) columnStats;
       Timestamp maxValue = tColStats.getMaximumUTC();
       max =
-          Optional.ofNullable(maxValue)
-              .map(v -> DateTimeUtil.microsFromInstant(v.toInstant()))
-              .orElse(null);
+          Optional.ofNullable(maxValue).map(v -> timestampBound(type, v.toInstant())).orElse(null);
     } else if (columnStats instanceof BooleanColumnStatistics) {
       BooleanColumnStatistics booleanStats = (BooleanColumnStatistics) columnStats;
       max = booleanStats.getTrueCount() > 0;
     }
     return Optional.ofNullable(
         Conversions.toByteBuffer(type, truncateIfNeeded(Bound.UPPER, type, max, metricsMode)));
+  }
+
+  private static long timestampBound(Type type, Instant instant) {
+    // timestamp_ns columns store bounds as nanoseconds from epoch, while timestamp columns store
+    // microseconds (see Conversions for TIMESTAMP and TIMESTAMP_NANO).
+    if (type.typeId() == Type.TypeID.TIMESTAMP_NANO) {
+      return ChronoUnit.NANOS.between(DateTimeUtil.EPOCH, instant.atOffset(ZoneOffset.UTC));
+    }
+    return DateTimeUtil.microsFromInstant(instant);
   }
 
   private static Object replaceNaN(double value, double replacement) {


### PR DESCRIPTION
## Summary

- `OrcMetrics.fromOrcMin/fromOrcMax` always converted ORC `TimestampColumnStatistics` to microseconds.
- But `Conversions` reads/writes `timestamp_ns` (`TIMESTAMP_NANO`) bounds as raw nanoseconds (`api/.../types/Conversions.java`, TIMESTAMP_NANO cases).
- The mismatch made `timestamp_ns` file bounds ~1000x too small, so file pruning could skip files that hold matching rows.
- Fix: convert the bound to nanoseconds for `TIMESTAMP_NANO`; keep microseconds for `TIMESTAMP` (backward compatible).
- Related work on this type: predicate pushdown #16609 (did not touch OrcMetrics).

## Testing done

- Added `TestOrcMetrics#timestampNanoBoundsKeepNanoPrecision`: writes a `timestamp_ns` column with sub-microsecond nanos and asserts the decoded lower/upper bounds equal the nanosecond value (not the truncated micros). Fails before the fix (lower bound `1` instead of `1500`), passes after.
- `./gradlew :iceberg-orc:check` and `:iceberg-data:test --tests "org.apache.iceberg.orc.TestOrcMetrics"` pass (84 tests, 0 failures). Both changed methods are private, so revapi stays backward compatible. Integration tests not run.

---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
