### PR TITLE
Spark 4.1: Throw on unsupported complex types in SparkValueConverter

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -129,7 +129,7 @@ public class SparkValueConverter {
       case STRUCT:
       case LIST:
       case MAP:
-        return new UnsupportedOperationException("Complex types currently not supported");
+        throw new UnsupportedOperationException("Complex types currently not supported");
       case DATE:
         return DateTimeUtils.daysToLocalDate((int) object);
       case TIMESTAMP:

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
@@ -81,6 +82,26 @@ public class TestSparkValueConverter {
             Types.NestedField.required(0, "id", Types.LongType.get()),
             Types.NestedField.optional(5, "location", Types.StringType.get()));
     assertCorrectNullConversion(schema);
+  }
+
+  @Test
+  public void testConvertToSparkComplexTypesThrow() {
+    Types.StructType struct =
+        Types.StructType.of(Types.NestedField.required(1, "lat", Types.FloatType.get()));
+    Types.ListType list = Types.ListType.ofOptional(1, Types.StringType.get());
+    Types.MapType map =
+        Types.MapType.ofOptional(1, 2, Types.StringType.get(), Types.StringType.get());
+
+    for (Types.NestedField field :
+        new Types.NestedField[] {
+          Types.NestedField.required(0, "s", struct),
+          Types.NestedField.required(0, "l", list),
+          Types.NestedField.required(0, "m", map)
+        }) {
+      assertThatThrownBy(() -> SparkValueConverter.convertToSpark(field.type(), "unused"))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Complex types currently not supported");
+    }
   }
 
   private void assertCorrectNullConversion(Schema schema) {


### PR DESCRIPTION
Closes #16923

## Summary

- `SparkValueConverter.convertToSpark` returned a `new UnsupportedOperationException(...)` for `STRUCT`, `LIST`, and `MAP` instead of throwing it.
- The method returns `Object`, so the exception flows downstream as a value into `lit(...)` and fails in a confusing place.
- Throw it, matching the same method's `default` branch.
- Code: `spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java`.

## Testing done

- Added `TestSparkValueConverter#testConvertToSparkComplexTypesThrow` (STRUCT/LIST/MAP) — pure unit test, no SparkSession. Fails on the old `return`, passes with `throw`.
- `:iceberg-spark:iceberg-spark-4.1_2.13:test --tests ...TestSparkValueConverter` and `spotlessCheck` — passed.
- Skipped the full `:check` (heavy Spark integration suites); the one-keyword change on a static utility is covered by the unit test. 




---

**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
