### PR TITLE
Spark 3.5, 4.0: Throw on unsupported complex types in SparkValueConverter

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -129,7 +129,7 @@ public class SparkValueConverter {
       case STRUCT:
       case LIST:
       case MAP:
-        return new UnsupportedOperationException("Complex types currently not supported");
+        throw new UnsupportedOperationException("Complex types currently not supported");
       case DATE:
         return DateTimeUtils.daysToLocalDate((int) object);
       case TIMESTAMP:

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -81,6 +84,21 @@ public class TestSparkValueConverter {
             Types.NestedField.required(0, "id", Types.LongType.get()),
             Types.NestedField.optional(5, "location", Types.StringType.get()));
     assertCorrectNullConversion(schema);
+  }
+
+  @Test
+  public void testConvertToSparkComplexTypesThrow() {
+    Types.StructType struct =
+        Types.StructType.of(Types.NestedField.required(1, "lat", Types.FloatType.get()));
+    Types.ListType list = Types.ListType.ofOptional(1, Types.StringType.get());
+    Types.MapType map =
+        Types.MapType.ofOptional(1, 2, Types.StringType.get(), Types.StringType.get());
+
+    for (Type type : List.of(struct, list, map)) {
+      assertThatThrownBy(() -> SparkValueConverter.convertToSpark(type, "unused"))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Complex types currently not supported");
+    }
   }
 
   private void assertCorrectNullConversion(Schema schema) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
@@ -129,7 +129,7 @@ public class SparkValueConverter {
       case STRUCT:
       case LIST:
       case MAP:
-        return new UnsupportedOperationException("Complex types currently not supported");
+        throw new UnsupportedOperationException("Complex types currently not supported");
       case DATE:
         return DateTimeUtils.daysToLocalDate((int) object);
       case TIMESTAMP:

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.spark;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -81,6 +84,21 @@ public class TestSparkValueConverter {
             Types.NestedField.required(0, "id", Types.LongType.get()),
             Types.NestedField.optional(5, "location", Types.StringType.get()));
     assertCorrectNullConversion(schema);
+  }
+
+  @Test
+  public void testConvertToSparkComplexTypesThrow() {
+    Types.StructType struct =
+        Types.StructType.of(Types.NestedField.required(1, "lat", Types.FloatType.get()));
+    Types.ListType list = Types.ListType.ofOptional(1, Types.StringType.get());
+    Types.MapType map =
+        Types.MapType.ofOptional(1, 2, Types.StringType.get(), Types.StringType.get());
+
+    for (Type type : List.of(struct, list, map)) {
+      assertThatThrownBy(() -> SparkValueConverter.convertToSpark(type, "unused"))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessageContaining("Complex types currently not supported");
+    }
   }
 
   private void assertCorrectNullConversion(Schema schema) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.spark;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
@@ -92,13 +94,8 @@ public class TestSparkValueConverter {
     Types.MapType map =
         Types.MapType.ofOptional(1, 2, Types.StringType.get(), Types.StringType.get());
 
-    for (Types.NestedField field :
-        new Types.NestedField[] {
-          Types.NestedField.required(0, "s", struct),
-          Types.NestedField.required(0, "l", list),
-          Types.NestedField.required(0, "m", map)
-        }) {
-      assertThatThrownBy(() -> SparkValueConverter.convertToSpark(field.type(), "unused"))
+    for (Type type : List.of(struct, list, map)) {
+      assertThatThrownBy(() -> SparkValueConverter.convertToSpark(type, "unused"))
           .isInstanceOf(UnsupportedOperationException.class)
           .hasMessageContaining("Complex types currently not supported");
     }


### PR DESCRIPTION
SparkValueConverter and TestSparkValueConverter in 4.1, 4.0, and 3.5 are exactly the same:
```
diff spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
diff spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkValueConverter.java
-> both commands return empty

diff spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
diff spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkValueConverter.java
-> both commands return empty
```

- Backport https://github.com/apache/iceberg/pull/16924