### PR TITLE
CI: Check ASF action allowlist on every PR

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -25,13 +25,9 @@ name: "ASF Allowlist Check"
 
 on:
   pull_request:
-    paths:
-      - ".github/**"
   push:
     branches:
       - main
-    paths:
-      - ".github/**"
 
 permissions:
   contents: read


### PR DESCRIPTION
Fixes #16914

- Run the ASF allowlist check for every PR and main push so upstream approved-pattern drift is surfaced as a visible failing check.

---

Co-authored-by: Codex