### PR TITLE
Core: stop serializing deprecated schema last column id

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataUpdateParser.java
@@ -70,7 +70,6 @@ public class MetadataUpdateParser {
 
   // AddSchema
   private static final String SCHEMA = "schema";
-  private static final String LAST_COLUMN_ID = "last-column-id";
 
   // SetCurrentSchema
   private static final String SCHEMA_ID = "schema-id";
@@ -370,7 +369,6 @@ public class MetadataUpdateParser {
       throws IOException {
     gen.writeFieldName(SCHEMA);
     SchemaParser.toJson(update.schema(), gen);
-    gen.writeNumberField(LAST_COLUMN_ID, update.lastColumnId());
   }
 
   private static void writeSetCurrentSchema(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataUpdateParser.java
@@ -125,13 +125,22 @@ public class TestMetadataUpdateParser {
   }
 
   @Test
+  public void testAddSchemaFromJsonWithDeprecatedLastColumnId() {
+    String action = MetadataUpdateParser.ADD_SCHEMA;
+    Schema schema = ID_DATA_SCHEMA;
+    String json =
+        String.format(
+            "{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":34}",
+            SchemaParser.toJson(schema));
+    MetadataUpdate actualUpdate = new MetadataUpdate.AddSchema(schema);
+    assertEquals(action, actualUpdate, MetadataUpdateParser.fromJson(json));
+  }
+
+  @Test
   public void testAddSchemaToJson() {
     Schema schema = ID_DATA_SCHEMA;
-    int lastColumnId = schema.highestFieldId();
     String expected =
-        String.format(
-            "{\"action\":\"add-schema\",\"schema\":%s,\"last-column-id\":%d}",
-            SchemaParser.toJson(schema), lastColumnId);
+        String.format("{\"action\":\"add-schema\",\"schema\":%s}", SchemaParser.toJson(schema));
     MetadataUpdate update = new MetadataUpdate.AddSchema(schema);
     String actual = MetadataUpdateParser.toJson(update);
     assertThat(actual)

--- a/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlers.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestCatalogHandlers.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TestTables;
+import org.apache.iceberg.UpdateRequirement;
+import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequestParser;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestCatalogHandlers {
+  private static final int LAST_ADDED = -1;
+
+  @TempDir private Path temp;
+
+  @AfterEach
+  public void clearTables() {
+    TestTables.clearTables();
+  }
+
+  @Test
+  public void commitAddSchemaWithoutDeprecatedLastColumnIdPreservesTableLastColumnId() {
+    Schema baseSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "dropme", Types.StringType.get()));
+    TestTables.TestTableOperations ops = new TestTables.TestTableOperations("test", temp.toFile());
+    TestTables.create(
+        temp.toFile(),
+        "test",
+        baseSchema,
+        PartitionSpec.unpartitioned(),
+        SortOrder.unsorted(),
+        2,
+        ops);
+    TableMetadata base = ops.current();
+    assertThat(base.lastColumnId()).isEqualTo(2);
+
+    Schema schemaAfterDroppingHighestId =
+        new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    List<MetadataUpdate> updates =
+        ImmutableList.of(
+            new MetadataUpdate.AddSchema(schemaAfterDroppingHighestId),
+            new MetadataUpdate.SetCurrentSchema(LAST_ADDED));
+    List<UpdateRequirement> requirements = UpdateRequirements.forUpdateTable(base, updates);
+    UpdateTableRequest request = new UpdateTableRequest(requirements, updates);
+
+    String json = UpdateTableRequestParser.toJson(request, true);
+    assertThat(json).doesNotContain("last-column-id");
+
+    TableMetadata updated = CatalogHandlers.commit(ops, UpdateTableRequestParser.fromJson(json));
+
+    assertThat(updated.schema().highestFieldId()).isEqualTo(1);
+    assertThat(updated.lastColumnId()).isEqualTo(2);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateTableRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestUpdateTableRequestParser.java
@@ -23,8 +23,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
 public class TestUpdateTableRequestParser {
@@ -193,6 +196,24 @@ public class TestUpdateTableRequestParser {
     // don't implement equals/hashcode
     assertThat(UpdateTableRequestParser.toJson(UpdateTableRequestParser.fromJson(json), true))
         .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void serializeAddSchemaWithoutDeprecatedLastColumnId() {
+    Schema schemaAfterDroppingHighestId =
+        new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    UpdateTableRequest request =
+        UpdateTableRequest.create(
+            TableIdentifier.of("ns1", "table1"),
+            ImmutableList.of(new UpdateRequirement.AssertLastAssignedFieldId(2)),
+            ImmutableList.of(new MetadataUpdate.AddSchema(schemaAfterDroppingHighestId)));
+
+    String json = UpdateTableRequestParser.toJson(request, true);
+
+    assertThat(json).contains("\"action\" : \"add-schema\"");
+    assertThat(json).contains("\"type\" : \"assert-last-assigned-field-id\"");
+    assertThat(json).contains("\"last-assigned-field-id\" : 2");
+    assertThat(json).doesNotContain("last-column-id");
   }
 
   @Test


### PR DESCRIPTION
## Why

`AddSchemaUpdate.last-column-id` is deprecated and optional in the REST OpenAPI spec. Java already ignores this field when parsing add-schema updates and computes the table-level last column ID internally.

However, Java still serializes the deprecated field using `schema.highestFieldId()`. After dropping the column with the highest field ID, this value can decrease even though table metadata `last-column-id` must not decrease. REST catalog implementations that validate the deprecated request field can reject otherwise valid schema evolution updates, as reported in #13850.

This does not remove table metadata `last-column-id`; it only stops sending the deprecated optional field in `AddSchemaUpdate`. Field-id conflict validation is still carried by `AssertLastAssignedFieldId` requirements.

## Compatibility notes

- The REST OpenAPI spec marks `AddSchemaUpdate.last-column-id` as deprecated and optional, and says that when it is omitted it will be computed on the server side: https://github.com/apache/iceberg/blob/main/open-api/rest-catalog-open-api.yaml#L3116-L3135
- Apache Iceberg's REST server path validates update requirements before applying metadata updates, and `TableMetadata.Builder.addSchema` preserves the table-level last column ID with `Math.max(lastColumnId, schema.highestFieldId())`: https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java#L613-L659 and https://github.com/apache/iceberg/blob/main/core/src/main/java/org/apache/iceberg/TableMetadata.java#L1136-L1138
- Nessie already models this field as optional (`OptionalInt`) and its changelog notes the AddSchema `lastColumnId` deprecation/optional change. When the value is omitted, Nessie computes from the schema max field ID and only increases the stored table-level value: https://github.com/projectnessie/nessie/blob/8f3a35c103ccf98fad9a95c22f2cf50993026a7f/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/rest/IcebergMetadataUpdate.java#L348-L371 and https://github.com/projectnessie/nessie/blob/8f3a35c103ccf98fad9a95c22f2cf50993026a7f/catalog/format/iceberg/src/main/java/org/projectnessie/catalog/formats/iceberg/nessie/NessieModelIceberg.java#L1198-L1250
- Polaris uses Iceberg's `UpdateTableRequest`/`MetadataUpdate` model for commits and applies updates via `MetadataUpdate.applyTo(...)`, so it follows the Iceberg parser/model behavior instead of requiring the deprecated request field. Its copied REST spec also marks the field deprecated and optional: https://github.com/apache/polaris/blob/e3f26cf69f6ee189328f1b7adb90ec83cbbb26d9/api/iceberg-service/src/main/java/org/apache/polaris/service/types/CommitTableRequest.java#L19-L23 and https://github.com/apache/polaris/blob/e3f26cf69f6ee189328f1b7adb90ec83cbbb26d9/runtime/service/src/main/java/org/apache/polaris/service/catalog/iceberg/CatalogHandlerUtils.java#L408-L522 and https://github.com/apache/polaris/blob/e3f26cf69f6ee189328f1b7adb90ec83cbbb26d9/spec/iceberg-rest-catalog-open-api.yaml#L2969-L2988
- The `tabulario/iceberg-rest` reference image is a thin wrapper around Apache Iceberg's `RESTCatalogAdapter`, so it does not add a separate `last-column-id` validator. Its exact behavior is tied to the bundled Iceberg version, which is why the fix belongs in Iceberg's REST metadata update serialization/model: https://github.com/databricks/iceberg-rest-image/blob/62a5078032e0675d34b377d2ead2eea814c1da48/src/main/java/org/apache/iceberg/rest/RESTServerCatalogAdapter.java#L28-L43

Catalogs that still send the deprecated field remain supported because parsing is unchanged. The omission path is part of the REST contract; server implementations that need the table-level last assigned field ID should use existing table metadata and/or `AssertLastAssignedFieldId` requirements rather than depending on the deprecated `AddSchemaUpdate` field.

## What changed

- Stop serializing deprecated `last-column-id` for `add-schema` metadata updates.
- Keep parsing legacy payloads that still include `last-column-id`.
- Add request serialization coverage for an add-schema update representing the schema after dropping the highest field ID.

## Testing

- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :iceberg-core:test --tests org.apache.iceberg.TestMetadataUpdateParser --tests org.apache.iceberg.rest.requests.TestUpdateTableRequestParser --tests org.apache.iceberg.rest.TestCatalogHandlers --console=plain --warning-mode=none`
- `JAVA_HOME=$(/usr/libexec/java_home -v 21) ./gradlew :iceberg-core:spotlessJavaCheck --console=plain --warning-mode=none`
