### PR TITLE
Aliyun: Improve OSS write performance with concurrent multipart upload (#16863)

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.aliyun;
 
 import java.io.Serializable;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.PropertyUtil;
 
@@ -76,11 +77,31 @@ public class AliyunProperties implements Serializable {
    */
   public static final String OSS_STAGING_DIRECTORY = "oss.staging-dir";
 
+  /** The size of each part for multipart upload. Minimum is 5MB. */
+  public static final String OSS_MULTIPART_SIZE = "oss.multipart.part-size-bytes";
+
+  public static final int OSS_MULTIPART_SIZE_DEFAULT = 8 * 1024 * 1024;
+  public static final int OSS_MULTIPART_SIZE_MIN = 5 * 1024 * 1024;
+
+  /**
+   * The threshold factor to switch from single putObject to multipart upload. Multipart upload is
+   * initiated when total bytes written >= partSize * thresholdFactor.
+   */
+  public static final String OSS_MULTIPART_THRESHOLD_FACTOR = "oss.multipart.threshold";
+
+  public static final double OSS_MULTIPART_THRESHOLD_FACTOR_DEFAULT = 1.5;
+
+  /** The number of threads used for uploading parts to OSS. */
+  public static final String OSS_MULTIPART_UPLOAD_THREADS = "oss.multipart.num-threads";
+
   private final String ossEndpoint;
   private final String accessKeyId;
   private final String accessKeySecret;
   private final String securityToken;
   private final String ossStagingDirectory;
+  private final int ossMultipartSize;
+  private final double ossMultipartThresholdFactor;
+  private final int ossMultipartUploadThreads;
 
   public AliyunProperties() {
     this(ImmutableMap.of());
@@ -96,6 +117,24 @@ public class AliyunProperties implements Serializable {
     this.ossStagingDirectory =
         PropertyUtil.propertyAsString(
             properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+
+    this.ossMultipartSize =
+        PropertyUtil.propertyAsInt(properties, OSS_MULTIPART_SIZE, OSS_MULTIPART_SIZE_DEFAULT);
+    Preconditions.checkArgument(
+        ossMultipartSize >= OSS_MULTIPART_SIZE_MIN,
+        "Minimum multipart upload size is %s bytes: configured %s",
+        OSS_MULTIPART_SIZE_MIN,
+        ossMultipartSize);
+
+    this.ossMultipartThresholdFactor =
+        PropertyUtil.propertyAsDouble(
+            properties, OSS_MULTIPART_THRESHOLD_FACTOR, OSS_MULTIPART_THRESHOLD_FACTOR_DEFAULT);
+    Preconditions.checkArgument(
+        ossMultipartThresholdFactor >= 1.0, "Multipart threshold factor must be >= 1.0");
+
+    this.ossMultipartUploadThreads =
+        PropertyUtil.propertyAsInt(
+            properties, OSS_MULTIPART_UPLOAD_THREADS, Runtime.getRuntime().availableProcessors());
   }
 
   public String ossEndpoint() {
@@ -116,5 +155,17 @@ public class AliyunProperties implements Serializable {
 
   public String ossStagingDirectory() {
     return ossStagingDirectory;
+  }
+
+  public int ossMultipartSize() {
+    return ossMultipartSize;
+  }
+
+  public double ossMultipartThresholdFactor() {
+    return ossMultipartThresholdFactor;
+  }
+
+  public int ossMultipartUploadThreads() {
+    return ossMultipartUploadThreads;
   }
 }

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputFile.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputFile.java
@@ -19,6 +19,8 @@
 package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import org.apache.iceberg.aliyun.AliyunProperties;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.io.InputFile;
@@ -49,7 +51,11 @@ class OSSOutputFile extends BaseOSSFile implements OutputFile {
 
   @Override
   public PositionOutputStream createOrOverwrite() {
-    return new OSSOutputStream(client(), uri(), aliyunProperties(), metrics());
+    try {
+      return new OSSOutputStream(client(), uri(), aliyunProperties(), metrics());
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to create output stream for " + uri(), e);
+    }
   }
 
   @Override

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/oss/OSSOutputStream.java
@@ -19,20 +19,35 @@
 package org.apache.iceberg.aliyun.oss;
 
 import com.aliyun.oss.OSS;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
 import com.aliyun.oss.model.ObjectMetadata;
+import com.aliyun.oss.model.PartETag;
 import com.aliyun.oss.model.PutObjectRequest;
+import com.aliyun.oss.model.UploadPartRequest;
+import com.aliyun.oss.model.UploadPartResult;
 import java.io.BufferedOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.SequenceInputStream;
 import java.io.UncheckedIOException;
+import java.nio.file.Files;
 import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.iceberg.aliyun.AliyunProperties;
-import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.io.FileIOMetricsContext;
 import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.metrics.Counter;
@@ -40,50 +55,295 @@ import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsContext.Unit;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.io.CountingOutputStream;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.MoreExecutors;
+import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class OSSOutputStream extends PositionOutputStream {
   private static final Logger LOG = LoggerFactory.getLogger(OSSOutputStream.class);
-  private final StackTraceElement[] createStack;
 
+  private static volatile ExecutorService executorService;
+
+  private final StackTraceElement[] createStack;
   private final OSS client;
   private final OSSURI uri;
 
-  private final File currentStagingFile;
-  private final OutputStream stream;
+  private final File stagingDirectory;
+  private final int multiPartSize;
+  private final int multiPartThresholdSize;
+
+  private final List<File> stagingFiles = Lists.newArrayList();
+  private final Map<File, CompletableFuture<PartETag>> parts = Maps.newLinkedHashMap();
+  private CountingOutputStream stream;
+  private File currentStagingFile;
+  private String multipartUploadId;
+
   private long pos = 0;
   private boolean closed = false;
 
   private final Counter writeBytes;
   private final Counter writeOperations;
 
-  OSSOutputStream(
-      OSS client, OSSURI uri, AliyunProperties aliyunProperties, MetricsContext metrics) {
+  @SuppressWarnings("StaticAssignmentInConstructor")
+  OSSOutputStream(OSS client, OSSURI uri, AliyunProperties aliyunProperties, MetricsContext metrics)
+      throws IOException {
+    if (executorService == null) {
+      synchronized (OSSOutputStream.class) {
+        if (executorService == null) {
+          executorService =
+              MoreExecutors.getExitingExecutorService(
+                  (ThreadPoolExecutor)
+                      Executors.newFixedThreadPool(
+                          aliyunProperties.ossMultipartUploadThreads(),
+                          new ThreadFactoryBuilder()
+                              .setDaemon(true)
+                              .setNameFormat("iceberg-ossfileio-upload-%d")
+                              .build()));
+        }
+      }
+    }
+
     this.client = client;
     this.uri = uri;
     this.createStack = Thread.currentThread().getStackTrace();
 
-    this.currentStagingFile = newStagingFile(aliyunProperties.ossStagingDirectory());
-    this.stream = newStream(currentStagingFile);
+    this.multiPartSize = aliyunProperties.ossMultipartSize();
+    this.multiPartThresholdSize =
+        (int) (multiPartSize * aliyunProperties.ossMultipartThresholdFactor());
+    this.stagingDirectory = new File(aliyunProperties.ossStagingDirectory());
+
     this.writeBytes = metrics.counter(FileIOMetricsContext.WRITE_BYTES, Unit.BYTES);
     this.writeOperations = metrics.counter(FileIOMetricsContext.WRITE_OPERATIONS);
+
+    newStream();
   }
 
-  private static File newStagingFile(String ossStagingDirectory) {
-    try {
-      File stagingFile = File.createTempFile("oss-file-io-", ".tmp", new File(ossStagingDirectory));
-      return stagingFile;
-    } catch (IOException e) {
-      throw new UncheckedIOException(e);
+  @Override
+  public long getPos() {
+    return pos;
+  }
+
+  @Override
+  public void flush() throws IOException {
+    stream.flush();
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    if (stream.getCount() >= multiPartSize) {
+      newStream();
+      uploadParts();
+    }
+
+    stream.write(b);
+    pos += 1;
+    writeBytes.increment();
+    writeOperations.increment();
+
+    if (multipartUploadId == null && pos >= multiPartThresholdSize) {
+      initializeMultiPartUpload();
+      uploadParts();
     }
   }
 
-  private static OutputStream newStream(File currentStagingFile) {
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    int remaining = len;
+    int relativeOffset = off;
+
+    while (stream.getCount() + remaining > multiPartSize) {
+      int writeSize = multiPartSize - (int) stream.getCount();
+      stream.write(b, relativeOffset, writeSize);
+      remaining -= writeSize;
+      relativeOffset += writeSize;
+      newStream();
+      uploadParts();
+    }
+
+    stream.write(b, relativeOffset, remaining);
+    pos += len;
+    writeBytes.increment(len);
+    writeOperations.increment();
+
+    if (multipartUploadId == null && pos >= multiPartThresholdSize) {
+      initializeMultiPartUpload();
+      uploadParts();
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    close(true);
+  }
+
+  private void close(boolean completeUploads) throws IOException {
+    if (closed) {
+      return;
+    }
+
+    super.close();
+    closed = true;
+
     try {
-      return new BufferedOutputStream(new FileOutputStream(currentStagingFile));
-    } catch (FileNotFoundException e) {
-      throw new NotFoundException(e, "Failed to create file: %s", currentStagingFile);
+      stream.close();
+      if (completeUploads) {
+        completeUploads();
+      }
+    } finally {
+      cleanUpStagingFiles();
+    }
+  }
+
+  private void newStream() throws IOException {
+    if (stream != null) {
+      stream.close();
+    }
+
+    createStagingDirectoryIfNotExists();
+    currentStagingFile = File.createTempFile("oss-file-io-", ".tmp", stagingDirectory);
+    stagingFiles.add(currentStagingFile);
+    stream =
+        new CountingOutputStream(
+            new BufferedOutputStream(Files.newOutputStream(currentStagingFile.toPath())));
+  }
+
+  private void initializeMultiPartUpload() {
+    multipartUploadId =
+        client
+            .initiateMultipartUpload(new InitiateMultipartUploadRequest(uri.bucket(), uri.key()))
+            .getUploadId();
+  }
+
+  private void uploadParts() {
+    if (multipartUploadId == null) {
+      return;
+    }
+
+    IntStream.range(0, stagingFiles.size())
+        .filter(i -> closed || !stagingFiles.get(i).equals(currentStagingFile))
+        .filter(i -> !parts.containsKey(stagingFiles.get(i)))
+        .forEach(
+            i -> {
+              File stagingFile = stagingFiles.get(i);
+              int partNumber = i + 1;
+              UploadPartRequest request = new UploadPartRequest();
+              request.setBucketName(uri.bucket());
+              request.setKey(uri.key());
+              request.setUploadId(multipartUploadId);
+              request.setPartNumber(partNumber);
+              request.setInputStream(uncheckedInputStream(stagingFile));
+              request.setPartSize(stagingFile.length());
+
+              CompletableFuture<PartETag> future =
+                  CompletableFuture.supplyAsync(
+                          () -> {
+                            UploadPartResult result = client.uploadPart(request);
+                            return result.getPartETag();
+                          },
+                          executorService)
+                      .whenComplete(
+                          (result, thrown) -> {
+                            try {
+                              Files.deleteIfExists(stagingFile.toPath());
+                            } catch (IOException e) {
+                              LOG.warn("Failed to delete staging file: {}", stagingFile, e);
+                            }
+
+                            if (thrown != null) {
+                              LOG.error("Failed to upload part: {}", partNumber, thrown);
+                            }
+                          });
+
+              parts.put(stagingFile, future);
+            });
+  }
+
+  private void completeMultiPartUpload() {
+    Preconditions.checkState(closed, "Complete upload called on open stream: %s", uri);
+
+    List<PartETag> partETags;
+    try {
+      partETags =
+          parts.values().stream()
+              .map(CompletableFuture::join)
+              .sorted(Comparator.comparing(PartETag::getPartNumber))
+              .collect(Collectors.toList());
+    } catch (CompletionException ce) {
+      parts.values().forEach(c -> c.cancel(true));
+      try {
+        abortUpload();
+      } catch (Exception e) {
+        LOG.warn("Failed to abort multipart upload: {}", multipartUploadId, e);
+      }
+      throw ce;
+    }
+
+    client.completeMultipartUpload(
+        new CompleteMultipartUploadRequest(uri.bucket(), uri.key(), multipartUploadId, partETags));
+  }
+
+  private void completeUploads() {
+    if (multipartUploadId == null) {
+      long contentLength = stagingFiles.stream().mapToLong(File::length).sum();
+      if (contentLength == 0) {
+        LOG.debug("Skipping empty upload to OSS");
+        return;
+      }
+
+      LOG.debug("Uploading {} staged bytes to OSS via putObject", contentLength);
+      ObjectMetadata metadata = new ObjectMetadata();
+      metadata.setContentLength(contentLength);
+
+      InputStream inputStream =
+          stagingFiles.stream()
+              .map(OSSOutputStream::uncheckedInputStream)
+              .reduce(SequenceInputStream::new)
+              .orElseGet(() -> new ByteArrayInputStream(new byte[0]));
+
+      client.putObject(new PutObjectRequest(uri.bucket(), uri.key(), inputStream, metadata));
+    } else {
+      uploadParts();
+      completeMultiPartUpload();
+    }
+  }
+
+  private void abortUpload() {
+    if (multipartUploadId != null) {
+      try {
+        client.abortMultipartUpload(
+            new AbortMultipartUploadRequest(uri.bucket(), uri.key(), multipartUploadId));
+      } finally {
+        cleanUpStagingFiles();
+      }
+    }
+  }
+
+  private void cleanUpStagingFiles() {
+    for (File file : stagingFiles) {
+      try {
+        Files.deleteIfExists(file.toPath());
+      } catch (IOException e) {
+        LOG.warn("Failed to delete staging file: {}", file, e);
+      }
+    }
+  }
+
+  private void createStagingDirectoryIfNotExists() throws IOException {
+    if (!stagingDirectory.exists()) {
+      LOG.info(
+          "Staging directory does not exist, trying to create one: {}",
+          stagingDirectory.getAbsolutePath());
+      boolean created = stagingDirectory.mkdirs();
+      if (created) {
+        LOG.info("Successfully created staging directory: {}", stagingDirectory.getAbsolutePath());
+      } else if (!stagingDirectory.exists()) {
+        throw new IOException(
+            "Failed to create staging directory: " + stagingDirectory.getAbsolutePath());
+      }
     }
   }
 
@@ -95,81 +355,12 @@ public class OSSOutputStream extends PositionOutputStream {
     }
   }
 
-  @Override
-  public long getPos() {
-    return pos;
-  }
-
-  @Override
-  public void flush() throws IOException {
-    Preconditions.checkState(!closed, "Already closed.");
-    stream.flush();
-  }
-
-  @Override
-  public void write(int b) throws IOException {
-    Preconditions.checkState(!closed, "Already closed.");
-    stream.write(b);
-    pos += 1;
-    writeBytes.increment();
-    writeOperations.increment();
-  }
-
-  @Override
-  public void write(byte[] b, int off, int len) throws IOException {
-    Preconditions.checkState(!closed, "Already closed.");
-    stream.write(b, off, len);
-    pos += len;
-    writeBytes.increment(len);
-    writeOperations.increment();
-  }
-
-  @Override
-  public void close() throws IOException {
-    if (closed) {
-      return;
-    }
-
-    super.close();
-    closed = true;
-
-    try {
-      stream.close();
-      completeUploads();
-    } finally {
-      cleanUpStagingFiles();
-    }
-  }
-
-  private void completeUploads() {
-    long contentLength = currentStagingFile.length();
-    if (contentLength == 0) {
-      LOG.debug("Skipping empty upload to OSS");
-      return;
-    }
-
-    LOG.debug("Uploading {} staged bytes to OSS", contentLength);
-    InputStream contentStream = uncheckedInputStream(currentStagingFile);
-    ObjectMetadata metadata = new ObjectMetadata();
-    metadata.setContentLength(contentLength);
-
-    PutObjectRequest request =
-        new PutObjectRequest(uri.bucket(), uri.key(), contentStream, metadata);
-    client.putObject(request);
-  }
-
-  private void cleanUpStagingFiles() {
-    if (!currentStagingFile.delete()) {
-      LOG.warn("Failed to delete staging file: {}", currentStagingFile);
-    }
-  }
-
   @SuppressWarnings({"checkstyle:NoFinalizer", "Finalize", "deprecation"})
   @Override
   protected void finalize() throws Throwable {
     super.finalize();
     if (!closed) {
-      close(); // releasing resources is more important than printing the warning.
+      close(false); // releasing resources is more important than printing the warning
       String trace = Joiner.on("\n\t").join(Arrays.copyOfRange(createStack, 1, createStack.length));
       LOG.warn("Unclosed output stream created by:\n\t{}", trace);
     }

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputStream.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/oss/TestOSSOutputStream.java
@@ -19,44 +19,64 @@
 package org.apache.iceberg.aliyun.oss;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalAnswers.delegatesTo;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.aliyun.oss.OSS;
+import com.aliyun.oss.OSSException;
+import com.aliyun.oss.model.AbortMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadRequest;
+import com.aliyun.oss.model.CompleteMultipartUploadResult;
+import com.aliyun.oss.model.InitiateMultipartUploadRequest;
+import com.aliyun.oss.model.InitiateMultipartUploadResult;
+import com.aliyun.oss.model.PutObjectRequest;
+import com.aliyun.oss.model.PutObjectResult;
+import com.aliyun.oss.model.UploadPartRequest;
+import com.aliyun.oss.model.UploadPartResult;
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.aliyun.AliyunProperties;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class TestOSSOutputStream extends AliyunOSSTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestOSSOutputStream.class);
+  private static final int PART_SIZE = 5 * 1024 * 1024;
+  private static final Random RANDOM = ThreadLocalRandom.current();
 
   private final OSS ossClient = ossClient().get();
   private final OSS ossMock = mock(OSS.class, delegatesTo(ossClient));
-
   private final Path tmpDir = Files.createTempDirectory("oss-file-io-test-");
-  private static final Random RANDOM = ThreadLocalRandom.current();
 
   private final AliyunProperties props =
       new AliyunProperties(
           ImmutableMap.of(AliyunProperties.OSS_STAGING_DIRECTORY, tmpDir.toString()));
 
   public TestOSSOutputStream() throws IOException {}
+
+  // --- Small file tests using mock HTTP server ---
 
   @Test
   public void testWrite() throws IOException {
@@ -113,6 +133,428 @@ public class TestOSSOutputStream extends AliyunOSSTestBase {
         .isEqualTo(0);
   }
 
+  // --- Multipart upload tests using pure Mockito (no HTTP server) ---
+
+  @Test
+  public void testSmallFileUsesPutObject() throws IOException {
+    OSS client = multipartMockClient();
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(new byte[1024]);
+    }
+
+    verify(client).putObject(any(PutObjectRequest.class));
+    verify(client, never()).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+  }
+
+  @Test
+  public void testEmptyFileSkipsUpload() throws IOException {
+    OSS client = multipartMockClient();
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      // write nothing
+    }
+
+    verify(client, never()).putObject(any(PutObjectRequest.class));
+    verify(client, never()).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+  }
+
+  @Test
+  public void testMultipartUpload() throws IOException {
+    OSS client = multipartMockClient();
+    // threshold = 5MB * 1.5 = 7.5MB, write 8MB to trigger multipart
+    byte[] data = new byte[8 * 1024 * 1024];
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+    verify(client, times(2)).uploadPart(any(UploadPartRequest.class));
+
+    ArgumentCaptor<CompleteMultipartUploadRequest> captor =
+        ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+    verify(client).completeMultipartUpload(captor.capture());
+    assertThat(captor.getValue().getPartETags()).hasSize(2);
+    verify(client, never()).putObject(any(PutObjectRequest.class));
+  }
+
+  @Test
+  public void testWriteAcrossPartBoundary() throws IOException {
+    OSS client = multipartMockClient();
+    // Write 2.5 parts worth of data in one call
+    byte[] data = new byte[PART_SIZE * 2 + PART_SIZE / 2];
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      out.write(data);
+    }
+
+    verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+    verify(client, times(3)).uploadPart(any(UploadPartRequest.class));
+    verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+  }
+
+  @Test
+  public void testMultipartAbortOnFailure() {
+    OSS client = multipartMockClient();
+    when(client.uploadPart(any(UploadPartRequest.class)))
+        .thenThrow(new OSSException("upload failed"));
+
+    byte[] data = new byte[PART_SIZE + 1];
+    assertThatThrownBy(
+            () -> {
+              try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+                out.write(data);
+              }
+            })
+        .hasCauseInstanceOf(OSSException.class);
+
+    verify(client).abortMultipartUpload(any(AbortMultipartUploadRequest.class));
+  }
+
+  @Test
+  public void testAbortFailurePreservesOriginalException() {
+    OSS client = multipartMockClient();
+    when(client.uploadPart(any(UploadPartRequest.class)))
+        .thenThrow(new OSSException("upload failed"));
+    when(client.abortMultipartUpload(any(AbortMultipartUploadRequest.class)))
+        .thenThrow(new OSSException("abort failed"));
+
+    byte[] data = new byte[PART_SIZE + 1];
+    assertThatThrownBy(
+            () -> {
+              try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+                out.write(data);
+              }
+            })
+        .hasCauseInstanceOf(OSSException.class)
+        .hasMessageContaining("upload failed");
+  }
+
+  @Test
+  public void testPositionTracking() throws IOException {
+    OSS client = multipartMockClient();
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      assertThat(out.getPos()).isEqualTo(0);
+
+      out.write(42);
+      assertThat(out.getPos()).isEqualTo(1);
+
+      out.write(new byte[99]);
+      assertThat(out.getPos()).isEqualTo(100);
+
+      out.write(new byte[200], 10, 50);
+      assertThat(out.getPos()).isEqualTo(150);
+    }
+  }
+
+  @Test
+  public void testSingleByteWriteTriggersMultipart() throws IOException {
+    OSS client = multipartMockClient();
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      for (int i = 0; i < PART_SIZE + 1; i++) {
+        out.write(0);
+      }
+    }
+
+    verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+    verify(client).completeMultipartUpload(any(CompleteMultipartUploadRequest.class));
+  }
+
+  @Test
+  public void testMultipleCloseIsIdempotent() throws IOException {
+    OSS client = multipartMockClient();
+
+    OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5);
+    out.write(new byte[100]);
+    out.close();
+    out.close();
+
+    verify(client, times(1)).putObject(any(PutObjectRequest.class));
+  }
+
+  @Test
+  public void testPartNumbersAreSequential() throws IOException {
+    OSS client = multipartMockClient();
+    byte[] data = new byte[PART_SIZE * 3];
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      out.write(data);
+    }
+
+    ArgumentCaptor<UploadPartRequest> captor = ArgumentCaptor.forClass(UploadPartRequest.class);
+    verify(client, times(3)).uploadPart(captor.capture());
+
+    assertThat(captor.getAllValues())
+        .extracting(UploadPartRequest::getPartNumber)
+        .containsExactlyInAnyOrder(1, 2, 3);
+  }
+
+  @Test
+  public void testUploadIdPassedCorrectly() throws IOException {
+    OSS client = multipartMockClient();
+    byte[] data = new byte[PART_SIZE + 1];
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      out.write(data);
+    }
+
+    ArgumentCaptor<UploadPartRequest> partCaptor = ArgumentCaptor.forClass(UploadPartRequest.class);
+    verify(client, times(2)).uploadPart(partCaptor.capture());
+    assertThat(partCaptor.getAllValues()).allMatch(r -> "test-upload-id".equals(r.getUploadId()));
+
+    ArgumentCaptor<CompleteMultipartUploadRequest> completeCaptor =
+        ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+    verify(client).completeMultipartUpload(completeCaptor.capture());
+    assertThat(completeCaptor.getValue().getUploadId()).isEqualTo("test-upload-id");
+  }
+
+  @Test
+  public void testBucketAndKeyPassedCorrectly() throws IOException {
+    OSS client = multipartMockClient();
+    OSSURI uri = randomURI();
+
+    try (OSSOutputStream out =
+        new OSSOutputStream(
+            client, uri, multipartProps(PART_SIZE, 1.5), MetricsContext.nullMetrics())) {
+      out.write(new byte[100]);
+    }
+
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(client).putObject(captor.capture());
+    assertThat(captor.getValue().getBucketName()).isEqualTo(uri.bucket());
+    assertThat(captor.getValue().getKey()).isEqualTo(uri.key());
+  }
+
+  // --- Data integrity tests ---
+
+  @Test
+  public void testSmallFileDataIntegrity() throws IOException {
+    OSS client = multipartMockClient();
+    byte[] data = randomData(1024);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    assertPutObjectDataEquals(client, data);
+  }
+
+  @Test
+  public void testFileBetweenPartSizeAndThresholdDataIntegrity() throws IOException {
+    // partSize=5MB, threshold=5MB*1.5=7.5MB, write 6MB → 2 staging files, putObject path
+    OSS client = multipartMockClient();
+    int dataSize = PART_SIZE + PART_SIZE / 5;
+    byte[] data = randomData(dataSize);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    verify(client, never()).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+
+    assertPutObjectDataEquals(client, data);
+  }
+
+  @Test
+  public void testMultipartDataIntegrity() throws IOException {
+    // partSize=5MB, threshold=5MB*1.5=7.5MB, write 8MB → multipart
+    OSS client = multipartMockClient();
+    byte[] data = randomData(8 * 1024 * 1024);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+    assertMultipartDataEquals(client, 2, data);
+  }
+
+  @Test
+  public void testExactPartSizeBoundaryDataIntegrity() throws IOException {
+    // Write exactly 2 * partSize → 2 full parts via multipart (threshold=1.0)
+    OSS client = multipartMockClient();
+    byte[] data = randomData(PART_SIZE * 2);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      out.write(data);
+    }
+
+    assertMultipartDataEquals(client, 2, data);
+  }
+
+  @Test
+  public void testSingleByteWriteDataIntegrity() throws IOException {
+    // Write byte-by-byte across part boundary, verify data still intact
+    OSS client = multipartMockClient();
+    int dataSize = PART_SIZE + 100;
+    byte[] data = randomData(dataSize);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      for (byte b : data) {
+        out.write(b);
+      }
+    }
+
+    assertMultipartDataEquals(client, 2, data);
+  }
+
+  // --- Boundary tests ---
+
+  @Test
+  public void testExactPartSizeUsesPutObject() throws IOException {
+    // partSize=5MB, threshold=5MB*1.5=7.5MB, write exactly 5MB → 1 staging file, putObject
+    OSS client = multipartMockClient();
+    byte[] data = randomData(PART_SIZE);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    verify(client, never()).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+
+    assertPutObjectDataEquals(client, data);
+  }
+
+  @Test
+  public void testExactThresholdTriggersMultipart() throws IOException {
+    // partSize=5MB, threshold=5MB*1.5=7.5MB, write exactly 7.5MB → multipart
+    OSS client = multipartMockClient();
+    int thresholdSize = (int) (PART_SIZE * 1.5);
+    byte[] data = randomData(thresholdSize);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(data);
+    }
+
+    verify(client).initiateMultipartUpload(any(InitiateMultipartUploadRequest.class));
+    assertMultipartDataEquals(client, 2, data);
+  }
+
+  @Test
+  public void testManyPartsDataIntegrity() throws IOException {
+    // Write 5 parts worth of data, verify all parts have correct content
+    OSS client = multipartMockClient();
+    byte[] data = randomData(PART_SIZE * 5);
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      out.write(data);
+    }
+
+    assertMultipartDataEquals(client, 5, data);
+  }
+
+  // --- Write method tests ---
+
+  @Test
+  public void testWriteWithOffsetDataIntegrity() throws IOException {
+    // write(byte[], off, len) with non-zero offset
+    OSS client = multipartMockClient();
+    byte[] buffer = randomData(2048);
+    int offset = 100;
+    int length = 1024;
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.5)) {
+      out.write(buffer, offset, length);
+      assertThat(out.getPos()).isEqualTo(length);
+    }
+
+    byte[] expected = new byte[length];
+    System.arraycopy(buffer, offset, expected, 0, length);
+    assertPutObjectDataEquals(client, expected);
+  }
+
+  @Test
+  public void testMixedWriteDataIntegrity() throws IOException {
+    // Mix array writes and single-byte writes across part boundary
+    OSS client = multipartMockClient();
+    ByteArrayOutputStream expectedStream = new ByteArrayOutputStream();
+
+    try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+      // Array write: first half of partSize
+      byte[] chunk1 = randomData(PART_SIZE / 2);
+      out.write(chunk1);
+      expectedStream.write(chunk1);
+
+      // Single-byte writes: fill the rest of first part + overflow into second
+      byte[] chunk2 = randomData(PART_SIZE / 2 + 200);
+      for (byte b : chunk2) {
+        out.write(b);
+      }
+      expectedStream.write(chunk2);
+
+      // Array write with offset: add more data
+      byte[] chunk3 = randomData(500);
+      out.write(chunk3, 50, 300);
+      expectedStream.write(chunk3, 50, 300);
+    }
+
+    byte[] expected = expectedStream.toByteArray();
+
+    assertMultipartDataEquals(client, 2, expected);
+  }
+
+  // --- Staging directory and cleanup tests ---
+
+  @Test
+  public void testStagingDirectoryAutoCreated() throws IOException {
+    OSS client = multipartMockClient();
+    Path nestedDir = tmpDir.resolve("sub1").resolve("sub2");
+
+    AliyunProperties nestedProps =
+        new AliyunProperties(
+            ImmutableMap.of(
+                AliyunProperties.OSS_STAGING_DIRECTORY,
+                nestedDir.toString(),
+                AliyunProperties.OSS_MULTIPART_SIZE,
+                Integer.toString(PART_SIZE),
+                AliyunProperties.OSS_MULTIPART_THRESHOLD_FACTOR,
+                "1.5",
+                AliyunProperties.OSS_MULTIPART_UPLOAD_THREADS,
+                "2"));
+
+    assertThat(Files.exists(nestedDir)).isFalse();
+
+    try (OSSOutputStream out =
+        new OSSOutputStream(
+            client,
+            new OSSURI("oss://test-bucket/test-key"),
+            nestedProps,
+            MetricsContext.nullMetrics())) {
+      out.write(new byte[100]);
+    }
+
+    assertThat(Files.exists(nestedDir)).isTrue();
+    // cleanup
+    Files.delete(nestedDir);
+    Files.delete(nestedDir.getParent());
+  }
+
+  @Test
+  public void testStagingFilesCleanedUpAfterFailure() throws IOException {
+    OSS client = multipartMockClient();
+    when(client.uploadPart(any(UploadPartRequest.class)))
+        .thenThrow(new OSSException("upload failed"));
+
+    byte[] data = new byte[PART_SIZE + 1];
+
+    try {
+      try (OSSOutputStream out = newOutputStream(client, PART_SIZE, 1.0)) {
+        out.write(data);
+      }
+    } catch (Exception e) {
+      // expected
+    }
+
+    assertThat(Files.list(tmpDir).filter(p -> p.toString().contains("oss-file-io-")).count())
+        .as("Staging files should be cleaned up after failure")
+        .isEqualTo(0);
+  }
+
+  // --- Helpers ---
+
   private OSSURI randomURI() {
     return new OSSURI(location(String.format("%s.dat", UUID.randomUUID())));
   }
@@ -137,5 +579,82 @@ public class TestOSSOutputStream extends AliyunOSSTestBase {
       ByteStreams.readFully(is, actual);
       return actual;
     }
+  }
+
+  private static void assertPutObjectDataEquals(OSS client, byte[] expected) throws IOException {
+    ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(client).putObject(captor.capture());
+    byte[] uploaded = readAllBytes(captor.getValue().getInputStream());
+    assertThat(uploaded).hasSize(expected.length).isEqualTo(expected);
+  }
+
+  private static void assertMultipartDataEquals(OSS client, int expectedParts, byte[] expected)
+      throws IOException {
+    ArgumentCaptor<UploadPartRequest> captor = ArgumentCaptor.forClass(UploadPartRequest.class);
+    verify(client, times(expectedParts)).uploadPart(captor.capture());
+
+    List<UploadPartRequest> parts = captor.getAllValues();
+    parts.sort(Comparator.comparingInt(UploadPartRequest::getPartNumber));
+    ByteArrayOutputStream combined = new ByteArrayOutputStream();
+    for (UploadPartRequest req : parts) {
+      combined.write(readAllBytes(req.getInputStream()));
+    }
+
+    assertThat(combined.size()).isEqualTo(expected.length);
+    assertThat(combined.toByteArray()).isEqualTo(expected);
+  }
+
+  private static byte[] readAllBytes(InputStream in) throws IOException {
+    try (in) {
+      return ByteStreams.toByteArray(in);
+    }
+  }
+
+  private AliyunProperties multipartProps(int partSize, double thresholdFactor) {
+    return new AliyunProperties(
+        ImmutableMap.of(
+            AliyunProperties.OSS_STAGING_DIRECTORY,
+            tmpDir.toString(),
+            AliyunProperties.OSS_MULTIPART_SIZE,
+            Integer.toString(partSize),
+            AliyunProperties.OSS_MULTIPART_THRESHOLD_FACTOR,
+            Double.toString(thresholdFactor),
+            AliyunProperties.OSS_MULTIPART_UPLOAD_THREADS,
+            "2"));
+  }
+
+  private OSSOutputStream newOutputStream(OSS client, int partSize, double thresholdFactor)
+      throws IOException {
+    return new OSSOutputStream(
+        client,
+        new OSSURI("oss://test-bucket/test-key"),
+        multipartProps(partSize, thresholdFactor),
+        MetricsContext.nullMetrics());
+  }
+
+  private static OSS multipartMockClient() {
+    OSS client = mock(OSS.class);
+
+    InitiateMultipartUploadResult initResult = new InitiateMultipartUploadResult();
+    initResult.setUploadId("test-upload-id");
+    when(client.initiateMultipartUpload(any(InitiateMultipartUploadRequest.class)))
+        .thenReturn(initResult);
+
+    AtomicInteger partCounter = new AtomicInteger(0);
+    when(client.uploadPart(any(UploadPartRequest.class)))
+        .thenAnswer(
+            invocation -> {
+              UploadPartRequest req = invocation.getArgument(0);
+              UploadPartResult result = new UploadPartResult();
+              result.setPartNumber(req.getPartNumber());
+              result.setETag("etag-" + partCounter.incrementAndGet());
+              return result;
+            });
+
+    when(client.completeMultipartUpload(any(CompleteMultipartUploadRequest.class)))
+        .thenReturn(new CompleteMultipartUploadResult());
+    when(client.putObject(any(PutObjectRequest.class))).thenReturn(new PutObjectResult());
+
+    return client;
   }
 }


### PR DESCRIPTION
see step 3 in #16863 

# code change summary
1. Use concurrent multipart uploads rather than whole-file serial putObject. `OSSOutputStream.java`
2. Add relative properties. `OSSOutputStream.java`
3. Add unit tests for `OSSOutputStream`. Code coverage of `OSSOutputStream` is 92% now.

# performance compare
## BEFORE
```
Benchmark                          (bufferSizeKB)                            (fileIOClass)  (fileSizeKB)  Mode  Cnt     Score       Error  Units
FileIOBenchmark.sequentialWrite              1024  org.apache.iceberg.aliyun.oss.OSSFileIO       1048576  avgt    5  4162.820 ±   162.809  ms/op
FileIOBenchmark.sequentialWrite              1024       org.apache.iceberg.aws.s3.S3FileIO       1048576  avgt    4  1615.085 ±    73.897  ms/op
```

## AFTER
```
Benchmark                          (bufferSizeKB)                            (fileIOClass)  (fileSizeKB)  Mode  Cnt     Score       Error  Units
FileIOBenchmark.sequentialWrite            1024  org.apache.iceberg.aliyun.oss.OSSFileIO       1048576  avgt    5  1103.280 ± 43.540  ms/op
FileIOBenchmark.sequentialWrite              1024       org.apache.iceberg.aws.s3.S3FileIO       1048576  avgt    4  1615.085 ±    73.897  ms/op
```

OSSFileIO is about 31% faster than S3FileIO when sequentialWrite now. The reason is that 8MB default part size can provide higher concurrency. 