### PR TITLE
Flink 2.1: Fix file offset mismatch in DataIterator.seek() when files are skipped

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -86,6 +86,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
         combinedTask);
     for (long i = 0L; i < startingFileOffset; ++i) {
       tasks.next();
+      fileOffset += 1;
     }
 
     updateCurrentIterator();
@@ -103,9 +104,6 @@ public class DataIterator<T> implements CloseableIterator<T> {
                 combinedTask));
       }
     }
-
-    fileOffset = startingFileOffset;
-    recordOffset = startingRecordOffset;
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -57,6 +57,21 @@ public class ReaderUtil {
 
   public static FileScanTask createFileTask(
       List<Record> records, File file, FileFormat fileFormat, Schema schema) throws IOException {
+    return createFileTask(
+        records,
+        file,
+        fileFormat,
+        schema,
+        ResidualEvaluator.unpartitioned(Expressions.alwaysTrue()));
+  }
+
+  public static FileScanTask createFileTask(
+      List<Record> records,
+      File file,
+      FileFormat fileFormat,
+      Schema schema,
+      ResidualEvaluator residuals)
+      throws IOException {
     DataWriter<Record> writer =
         new GenericFileWriterFactory.Builder()
             .dataSchema(schema)
@@ -69,7 +84,6 @@ public class ReaderUtil {
 
     DataFile dataFile = writer.toDataFile();
 
-    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.alwaysTrue());
     return new BaseFileScanTask(
         dataFile,
         null,

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -32,13 +33,18 @@ import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -353,5 +359,99 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     batch21.recycle();
 
     assertThat(recordBatchIterator).isExhausted();
+  }
+
+  @Test
+  public void testDataIteratorWithResidualFilter() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "file-1");
+    record0.setField("id", 0L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "file-2");
+    record1.setField("id", 1L);
+    record1.setField("dt", "-");
+
+    List<Record> fileRecords0 = ImmutableList.of(record0);
+    List<Record> fileRecords1 = ImmutableList.of(record1);
+
+    validateFileOffsetWithResidualFilter(fileRecords0, fileRecords1, Expressions.alwaysTrue());
+
+    validateFileOffsetWithResidualFilter(
+        fileRecords0, fileRecords1, Expressions.greaterThan("id", 0));
+  }
+
+  private void validateFileOffsetWithResidualFilter(
+      List<Record> fileRecords0, List<Record> fileRecords1, Expression residualFilter)
+      throws IOException {
+    ResidualEvaluator residualEvaluator = ResidualEvaluator.unpartitioned(residualFilter);
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            fileRecords0,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            fileRecords1,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    while (dataIterator.hasNext()) {
+      assertThat(dataIterator.fileOffset()).isEqualTo(dataIterator.next().getLong(1));
+    }
+  }
+
+  @Test
+  public void testInitializationWithHeadFilesSkipped() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "a");
+    record0.setField("id", 1L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "a");
+    record1.setField("id", 10L);
+    record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    assertThat(dataIterator.fileOffset())
+        .as("File offset should be 1 because file 0 should be skipped")
+        .isEqualTo(1);
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -456,4 +456,86 @@ public class TestArrayPoolDataIteratorBatcherRowData {
 
     TestHelpers.assertRowData(TestFixtures.SCHEMA, record1, dataIterator.next());
   }
+
+  @Test
+  void testSeekResumesCorrectlyAfterHeadFilesSkipped() throws IOException {
+    // Setup: [F0(filtered), F1(1 record), F2(2 records)]
+    // F1 has only 1 record so that after reading F1, the checkpoint position (fileOffset=1,
+    // recordOffset=1) falls at a file boundary. Without the fix, fileOffset is incorrectly
+    // reported as 0 instead of 1 after seek(0,0) skips F0. This causes F2's first record to
+    // be reported at (fileOffset=1, recordOffset=1). On restore with seek(1, 1), the iterator
+    // skips only F0 + 1 record from F1, landing at the start of F2 instead of after F2 record0,
+    // resulting in F2 record0 being read again (duplicate).
+    GenericRecord filteredRecord = GenericRecord.create(TestFixtures.SCHEMA);
+    filteredRecord.setField("data", "a");
+    filteredRecord.setField("id", 1L);
+    filteredRecord.setField("dt", "-");
+
+    GenericRecord f1Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f1Record0.setField("data", "b");
+    f1Record0.setField("id", 10L);
+    f1Record0.setField("dt", "-");
+
+    GenericRecord f2Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record0.setField("data", "d");
+    f2Record0.setField("id", 20L);
+    f2Record0.setField("dt", "-");
+
+    GenericRecord f2Record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record1.setField("data", "e");
+    f2Record1.setField("id", 21L);
+    f2Record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(filteredRecord),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f1Record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask2 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f2Record0, f2Record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask =
+        new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
+
+    // First read: consume file 1's record and file 2's first record
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    dataIterator.seek(0, 0);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f1Record0, dataIterator.next());
+    // F1 exhausted, updateCurrentIterator moves to F2
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record0, dataIterator.next());
+
+    // Capture checkpoint position after reading F2 record0.
+    // With the fix: fileOffset=2, recordOffset=1 (correctly points into F2)
+    // Without fix: fileOffset=1, recordOffset=1 (incorrectly points to "F1 record 1")
+    int checkpointFileOffset = dataIterator.fileOffset();
+    long checkpointRecordOffset = dataIterator.recordOffset();
+
+    // Simulate restore: seek to the checkpoint position
+    DataIterator<RowData> restoredIterator = ReaderUtil.createDataIterator(combinedTask);
+    restoredIterator.seek(checkpointFileOffset, checkpointRecordOffset);
+
+    // After restore, should read only F2 record1 (the unread remainder)
+    assertThat(restoredIterator.hasNext()).isTrue();
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record1, restoredIterator.next());
+    assertThat(restoredIterator.hasNext()).isFalse();
+  }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -453,5 +453,7 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     assertThat(dataIterator.fileOffset())
         .as("File offset should be 1 because file 0 should be skipped")
         .isEqualTo(1);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, record1, dataIterator.next());
   }
 }


### PR DESCRIPTION
## Summary

`DataIterator.seek()` overwrites `fileOffset` after `updateCurrentIterator()` has correctly advanced it past files skipped by residual filters. This causes checkpoint to record a wrong file offset, leading to duplicate consumption or `IllegalStateException` on recovery.

This is a port of #10567 (Flink 1.19) to Flink 2.1.

## The Bug

In `seek(startingFileOffset, startingRecordOffset)`, the call to `updateCurrentIterator()` may advance `fileOffset` beyond `startingFileOffset` when head files are skipped (e.g., their row-group statistics allow the residual filter to eliminate all rows). However, `seek()` then unconditionally executes:

```java
fileOffset = startingFileOffset;
recordOffset = startingRecordOffset;
```

This overwrites the correct value with a stale one. For example, if `seek(0, 0)` is called and file 0 is skipped by the residual filter, `updateCurrentIterator()` correctly sets `fileOffset = 1` (pointing to file 1). But the assignment resets it to 0.

**Consequence:** Checkpoint records `fileOffset = 0` instead of `1`. On recovery:
- If file 1 has fewer records than `recordOffset`, throws `IllegalStateException: Invalid starting record offset`
- Otherwise, reads from the wrong file → duplicate data

## The Fix

1. Increment `fileOffset` in the skip-files loop (so it tracks position as files are skipped)
2. Remove the incorrect `fileOffset = startingFileOffset` / `recordOffset = startingRecordOffset` assignments at the end of `seek()` — these values are already correct through incremental updates

`recordOffset` is also naturally correct after the skip-records loop because `next()` increments it on each call, and the loop is guarded by `currentFileHasNext()` so no file-switch (which would reset `recordOffset`) can occur mid-skip.

## Tests

- `testDataIteratorWithResidualFilter`: validates that `fileOffset` matches the actual file being read when a residual filter is applied
- `testInitializationWithHeadFilesSkipped`: directly asserts that `fileOffset = 1` after `seek(0, 0)` when file 0 is skipped by residual filter — this fails without the fix

cc @pvary @stevenzwu Could you please review? This is a resubmission of #10567 ported to the latest Flink version (2.1), with an improved description. The underlying bug and fix are identical.