### PR TITLE
BigQuery: Make BigQueryMetastoreCatalog.initialize() with client argument public

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
@@ -44,7 +44,6 @@ import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
-import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -113,8 +112,7 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
     initialize(name, properties, projectId, projectLocation, client);
   }
 
-  @VisibleForTesting
-  void initialize(
+  public void initialize(
       String name,
       Map<String, String> properties,
       String initialProjectId,


### PR DESCRIPTION
## Summary

The 5-argument `BigQueryMetastoreCatalog.initialize()` overload that accepts a pre-built `BigQueryMetastoreClient` was `@VisibleForTesting` and package-private. External callers who need to inject a custom-credentialed client (e.g. service-account impersonation, OAuth tokens) had to resort to reflection. Making this overload public provides a stable, supported API for that use case.

A related issue https://github.com/apache/iceberg/issues/13036 was rasied before but closed due to inactivity.

## Testing

Relying on existing tests and they should all pass as before.