### PR TITLE
Core: Improve error message for missing ManifestList

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -33,11 +33,6 @@ class ManifestLists {
   private ManifestLists() {}
 
   static List<ManifestFile> read(InputFile manifestList) {
-    if (!manifestList.exists()) {
-      throw new NotFoundException(
-          "Failed to read manifest list: file %s does not exist", manifestList.location());
-    }
-
     try (CloseableIterable<ManifestFile> files =
         InternalData.read(FileFormat.AVRO, manifestList)
             .setRootType(GenericManifestFile.class)
@@ -47,7 +42,8 @@ class ManifestLists {
             .build()) {
 
       return Lists.newArrayList(files);
-
+    } catch (NotFoundException e) {
+      throw new NotFoundException(e, "Failed to read manifest list file: %s", s);
     } catch (IOException e) {
       throw new RuntimeIOException(
           e, "Cannot read manifest list file: %s", manifestList.location());

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -32,6 +32,11 @@ class ManifestLists {
   private ManifestLists() {}
 
   static List<ManifestFile> read(InputFile manifestList) {
+    if (!manifestList.exists()) {
+      throw new RuntimeIOException(
+          "Failed to read manifest list: file %s does not exist", manifestList.location());
+    }
+
     try (CloseableIterable<ManifestFile> files =
         InternalData.read(FileFormat.AVRO, manifestList)
             .setRootType(GenericManifestFile.class)

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
@@ -33,7 +34,7 @@ class ManifestLists {
 
   static List<ManifestFile> read(InputFile manifestList) {
     if (!manifestList.exists()) {
-      throw new RuntimeIOException(
+      throw new NotFoundException(
           "Failed to read manifest list: file %s does not exist", manifestList.location());
     }
 


### PR DESCRIPTION
Tiny improvement to the error handling surrounding SnapshotScan. Sometimes I end up in a state where my filesystem's retention policy has been improperly set and the underlying manifest file has been removed; in that case my SnapshotScan fails with the somewhat cryptic error:

```
java.lang.NullPointerException: Cannot invoke "com.google.cloud.storage.Blob.getSize()" because the return value of "org.apache.iceberg.gcp.gcs.GCSInputFile.getBlob()" is null
	at org.apache.iceberg.gcp.gcs.GCSInputFile.getLength(GCSInputFile.java:67)
	at org.apache.iceberg.avro.AvroIterable.newFileReader(AvroIterable.java:103)
	at org.apache.iceberg.avro.AvroIterable.iterator(AvroIterable.java:78)
	at org.apache.iceberg.avro.AvroIterable.iterator(AvroIterable.java:38)
	at org.apache.iceberg.relocated.com.google.common.collect.Iterables.addAll(Iterables.java:333)
	at org.apache.iceberg.relocated.com.google.common.collect.Lists.newLinkedList(Lists.java:251)
	at org.apache.iceberg.ManifestLists.read(ManifestLists.java:43)
	at org.apache.iceberg.BaseSnapshot.cacheManifests(BaseSnapshot.java:186)
	at org.apache.iceberg.BaseSnapshot.dataManifests(BaseSnapshot.java:213)
	at org.apache.iceberg.DataTableScan.doPlanFiles(DataTableScan.java:68)
	at org.apache.iceberg.SnapshotScan.planFiles(SnapshotScan.java:162)
```

With this PR, the error message gains a bit more clarity:

```
org.apache.iceberg.exceptions.RuntimeIOException: java.io.IOException: Failed to read manifest list: file <fs://path/to/my/file> does not exist
	at org.apache.iceberg.ManifestLists.read(ManifestLists.java:37)
	at org.apache.iceberg.BaseSnapshot.cacheManifests(BaseSnapshot.java:186)
	at org.apache.iceberg.BaseSnapshot.dataManifests(BaseSnapshot.java:213)
	at org.apache.iceberg.DataTableScan.doPlanFiles(DataTableScan.java:68)
	at org.apache.iceberg.SnapshotScan.planFiles(SnapshotScan.java:162)

```