### PR TITLE
Spark: Write TestRewriteDataFilesAction inputs natively

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -166,6 +166,12 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
+  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
+  // currentData() returns. Lets tests that only compact (which preserves row content) assert
+  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
+  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  private final List<Object[]> writtenRecords = Lists.newArrayList();
+
   @BeforeAll
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
@@ -175,6 +181,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   @BeforeEach
   public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
+    this.writtenRecords.clear();
   }
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
@@ -202,7 +209,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackUnpartitionedTable() {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -222,7 +229,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackPartitionedTable() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -242,7 +249,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackWithFilter() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -268,7 +275,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
 
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -298,7 +305,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -828,7 +835,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -863,7 +870,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Map<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "1");
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -943,7 +950,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(1);
     shouldHaveFiles(table, 1);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long targetSize = testDataSize(table) / 2;
 
     long dataSizeBefore = testDataSize(table);
@@ -1017,7 +1024,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     int targetSize = ((int) testDataSize(table) / 3);
     // The test is to see if we can combine parts of files to make files of the correct size
 
@@ -1053,7 +1060,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1080,7 +1087,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1106,7 +1113,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1133,7 +1140,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1165,7 +1172,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1197,7 +1204,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1229,7 +1236,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1262,7 +1269,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1302,7 +1309,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1343,7 +1350,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1386,7 +1393,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1426,7 +1433,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
@@ -1503,7 +1510,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1532,7 +1539,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1565,7 +1572,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1598,7 +1605,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1636,7 +1643,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").apply();
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1671,7 +1678,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.replaceSortOrder().asc("c2").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1697,7 +1704,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1735,7 +1742,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction action = basicRewrite(table);
     RewriteDataFilesSparkAction spyAction = spy(action);
@@ -1789,7 +1796,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, originalFiles);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     double originalFilesC2 = percentFilesRequired(table, "c2", "foo23");
     double originalFilesC3 = percentFilesRequired(table, "c3", "bar21");
     double originalFilesC2C3 =
@@ -1942,7 +1949,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.truncate("c2", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1965,7 +1972,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2004,7 +2011,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2027,7 +2034,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2136,6 +2143,22 @@ public class TestRewriteDataFilesAction extends TestBase {
             .coalesce(1)
             .sort("c1", "c2", "c3")
             .collectAsList());
+  }
+
+  /**
+   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
+   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
+   * compact can assert against this instead of re-reading the table via Spark just to recover the
+   * data they already wrote. Only valid for tables populated exclusively through the native
+   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   */
+  private List<Object[]> expectedData() {
+    List<Object[]> rows = Lists.newArrayList(writtenRecords);
+    rows.sort(
+        Comparator.<Object[], Integer>comparing(row -> (Integer) row[0])
+            .thenComparing(row -> (String) row[1])
+            .thenComparing(row -> (String) row[2]));
+    return rows;
   }
 
   protected List<Object[]> currentDataWithLineage() {
@@ -2463,6 +2486,11 @@ public class TestRewriteDataFilesAction extends TestBase {
    * shuffle, sort, and DataFrame conversion per write.
    */
   private void appendRecords(List<Record> records, int files) {
+    for (Record record : records) {
+      writtenRecords.add(
+          new Object[] {record.getField("c1"), record.getField("c2"), record.getField("c3")});
+    }
+
     Table table = TABLES.load(tableLocation);
     PartitionSpec spec = table.spec();
     AppendFiles append = table.newAppend();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -53,6 +53,7 @@ import java.util.stream.IntStream;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -84,6 +85,7 @@ import org.apache.iceberg.actions.RewriteDataFiles.Result;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericFileWriterFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -106,6 +108,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -721,8 +724,10 @@ public class TestRewriteDataFilesAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             tableLocation);
 
-    // data seq = 1, write 4 files in 2 partitions
-    writeRecords(2, 2, 2);
+    // data seq = 1, write 4 files in 2 partitions. Uses the Spark writer because this test depends
+    // on the exact data-file ordering (dataFilesBefore.get(3)) and the row position the position
+    // delete below targets.
+    writeRecordsViaSpark(2, 2, 2);
     List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, null);
     shouldHaveFiles(table, 4);
 
@@ -740,7 +745,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 3, write 1 new data files in c1=1 for evolved spec
-    writeRecords(1, 1, 1);
+    writeRecordsViaSpark(1, 1, 1);
     shouldHaveFiles(table, 5);
     List<Object[]> expectedRecords = currentData();
 
@@ -962,12 +967,17 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TestTemplate
   public void testBinPackCombineMixedFiles() {
-    Table table = createTable(1); // 400000
+    // Uses the Spark writer: this test is calibrated to the exact on-disk byte sizes that Spark
+    // produces (see the format-version-specific MAX_FILE_SIZE_BYTES tuning below), so the input
+    // files must be written the same way.
+    Table table = createTable();
+    writeRecordsViaSpark(1, SCALE, 0); // 400000
+    table.refresh();
     shouldHaveFiles(table, 1);
 
     // Add one more small file, and one large file
-    writeRecords(1, SCALE);
-    writeRecords(1, SCALE * 3);
+    writeRecordsViaSpark(1, SCALE, 0);
+    writeRecordsViaSpark(1, SCALE * 3, 0);
     table.refresh();
     shouldHaveFiles(table, 3);
 
@@ -2393,6 +2403,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   private void writeRecords(int files, int numRecords, int partitions) {
+    appendRecords(generateRecords(numRecords, partitions), files);
+  }
+
+  /**
+   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
+   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
+   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
+   * int, int)} path instead.
+   */
+  private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
     int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
     List<Pair<Integer, Integer>> data =
@@ -2414,6 +2434,96 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
+  }
+
+  private List<Record> generateRecords(int numRecords, int partitions) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
+    for (Pair<Integer, Integer> pair : data) {
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", partitions > 0 ? pair.first() % partitions : pair.first());
+      record.setField("c2", "foo" + pair.first());
+      record.setField("c3", "bar" + pair.second());
+      records.add(record);
+    }
+    return records;
+  }
+
+  /**
+   * Append records as Iceberg data files without going through Spark, writing {@code files} data
+   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
+   * would produce: the suite asserts on file counts and row content, not on the row-to-file
+   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
+   * shuffle, sort, and DataFrame conversion per write.
+   */
+  private void appendRecords(List<Record> records, int files) {
+    Table table = TABLES.load(tableLocation);
+    PartitionSpec spec = table.spec();
+    AppendFiles append = table.newAppend();
+
+    if (spec.isUnpartitioned()) {
+      for (List<Record> chunk : split(records, files)) {
+        append.appendFile(writeDataFileNative(table, null, chunk));
+      }
+    } else {
+      Map<String, PartitionKey> keys = Maps.newLinkedHashMap();
+      Map<String, List<Record>> groups = Maps.newLinkedHashMap();
+      PartitionKey key = new PartitionKey(spec, table.schema());
+      for (Record record : records) {
+        key.partition(record);
+        String path = key.toPath();
+        keys.computeIfAbsent(path, p -> key.copy());
+        groups.computeIfAbsent(path, p -> Lists.newArrayList()).add(record);
+      }
+      groups.forEach(
+          (path, groupRecords) -> {
+            for (List<Record> chunk : split(groupRecords, files)) {
+              append.appendFile(writeDataFileNative(table, keys.get(path), chunk));
+            }
+          });
+    }
+
+    append.commit();
+  }
+
+  private DataFile writeDataFileNative(Table table, StructLike partition, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, partition, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
+  private static List<List<Record>> split(List<Record> records, int parts) {
+    int n = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
+    if (n <= 0) {
+      return chunks;
+    }
+    int base = records.size() / n;
+    int remainder = records.size() % n;
+    int start = 0;
+    for (int i = 0; i < n; i++) {
+      int size = base + (i < remainder ? 1 : 0);
+      chunks.add(records.subList(start, start + size));
+      start += size;
+    }
+    return chunks;
   }
 
   private void writeDF(Dataset<Row> df) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2510,15 +2510,15 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
-    int n = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
-    if (n <= 0) {
+    int count = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    if (count <= 0) {
       return chunks;
     }
-    int base = records.size() / n;
-    int remainder = records.size() % n;
+    int base = records.size() / count;
+    int remainder = records.size() % count;
     int start = 0;
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < count; i++) {
       int size = base + (i < remainder ? 1 : 0);
       chunks.add(records.subList(start, start + size));
       start += size;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -166,10 +166,8 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
-  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
-  // currentData() returns. Lets tests that only compact (which preserves row content) assert
-  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
-  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  // Rows written natively so far; lets compaction-only tests assert via expectedData() instead of a
+  // second Spark read to recover what they just wrote. Reset per test in setupTableLocation().
   private final List<Object[]> writtenRecords = Lists.newArrayList();
 
   @BeforeAll
@@ -2146,11 +2144,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
-   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
-   * compact can assert against this instead of re-reading the table via Spark just to recover the
-   * data they already wrote. Only valid for tables populated exclusively through the native
-   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   * In-memory equivalent of {@link #currentData()} for compaction-only tests, avoiding a second
+   * Spark read. Only valid for tables populated solely via the native writeRecords/createTable path
+   * (no row-level deletes, Spark writes, or lineage projections).
    */
   private List<Object[]> expectedData() {
     List<Object[]> rows = Lists.newArrayList(writtenRecords);
@@ -2430,43 +2426,22 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
-   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
-   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
-   * int, int)} path instead.
+   * Spark-based write, kept for the few tests that need the exact row-to-file placement {@code
+   * df.repartition(files)} produces (e.g. position deletes targeting a specific file/position).
+   * Most writes use the cheaper native {@link #writeRecords(int, int, int)} path.
    */
   private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
-    if (partitions > 0) {
-      data.forEach(
-          i ->
-              records.add(
-                  new ThreeColumnRecord(
-                      i.first() % partitions, "foo" + i.first(), "bar" + i.second())));
-    } else {
-      data.forEach(
-          i ->
-              records.add(new ThreeColumnRecord(i.first(), "foo" + i.first(), "bar" + i.second())));
+    for (Pair<Integer, Integer> pair : generateShuffledGrid(numRecords)) {
+      int c1 = partitions > 0 ? pair.first() % partitions : pair.first();
+      records.add(new ThreeColumnRecord(c1, "foo" + pair.first(), "bar" + pair.second()));
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
   }
 
   private List<Record> generateRecords(int numRecords, int partitions) {
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
+    List<Pair<Integer, Integer>> data = generateShuffledGrid(numRecords);
     List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
     for (Pair<Integer, Integer> pair : data) {
       GenericRecord record = GenericRecord.create(SCHEMA);
@@ -2479,11 +2454,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Append records as Iceberg data files without going through Spark, writing {@code files} data
-   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
-   * would produce: the suite asserts on file counts and row content, not on the row-to-file
-   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
-   * shuffle, sort, and DataFrame conversion per write.
+   * Deterministic seed-42 shuffled grid of (first, second) pairs, shared by the native {@link
+   * #generateRecords} and Spark {@link #writeRecordsViaSpark} writers so both produce the same
+   * rows.
+   */
+  private static List<Pair<Integer, Integer>> generateShuffledGrid(int numRecords) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    return data;
+  }
+
+  /**
+   * Append {@code records} as Iceberg data files without Spark, in {@code files} files per
+   * partition. The suite asserts on file counts and row content (not row-to-file placement), so a
+   * deterministic contiguous split matches {@code df.repartition(files)} while skipping a Spark
+   * job.
    */
   private void appendRecords(List<Record> records, int files) {
     for (Record record : records) {
@@ -2539,7 +2529,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
     int count = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(count);
     if (count <= 0) {
       return chunks;
     }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -26,10 +26,12 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
@@ -41,6 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -162,16 +165,49 @@ public class TestRewriteTablePathsAction extends TestBase {
                 .build(),
             location);
 
-    List<ThreeColumnRecord> records =
-        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    if ("append".equals(mode)) {
+      // Append snapshots natively: each snapshot is a single one-row data file, avoiding a Spark
+      // write job per snapshot. This fixture is built for every test (and some tests create up to
+      // 50 snapshots), so the per-job Spark overhead dominates the suite. Commit through a
+      // separate table instance so the returned handle stays unrefreshed, matching the old Spark
+      // path where writes happened outside this object.
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", 1);
+      record.setField("c2", "AAAAAAAAAA");
+      record.setField("c3", "AAAA");
+      List<Record> records = Lists.newArrayList(record);
+      Table writeTable = TABLES.load(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        writeTable.newAppend().appendFile(writeDataFileNative(writeTable, records)).commit();
+      }
+    } else {
+      List<ThreeColumnRecord> records =
+          Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
-    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+      Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    for (int i = 0; i < snapshotNumber; i++) {
-      df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      }
     }
 
     return newTable;
+  }
+
+  private DataFile writeDataFileNative(Table table, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private void createNameSpaces() {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2560,15 +2560,15 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
-    int n = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
-    if (n <= 0) {
+    int count = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    if (count <= 0) {
       return chunks;
     }
-    int base = records.size() / n;
-    int remainder = records.size() % n;
+    int base = records.size() / count;
+    int remainder = records.size() % count;
     int start = 0;
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < count; i++) {
       int size = base + (i < remainder ? 1 : 0);
       chunks.add(records.subList(start, start + size));
       start += size;

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -54,6 +54,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -85,6 +86,7 @@ import org.apache.iceberg.actions.RewriteDataFiles.Result;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericFileWriterFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -107,6 +109,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -722,8 +725,10 @@ public class TestRewriteDataFilesAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             tableLocation);
 
-    // data seq = 1, write 4 files in 2 partitions
-    writeRecords(2, 2, 2);
+    // data seq = 1, write 4 files in 2 partitions. Uses the Spark writer because this test depends
+    // on the exact data-file ordering (dataFilesBefore.get(3)) and the row position the position
+    // delete below targets.
+    writeRecordsViaSpark(2, 2, 2);
     List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, null);
     shouldHaveFiles(table, 4);
 
@@ -741,7 +746,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 3, write 1 new data files in c1=1 for evolved spec
-    writeRecords(1, 1, 1);
+    writeRecordsViaSpark(1, 1, 1);
     shouldHaveFiles(table, 5);
     List<Object[]> expectedRecords = currentData();
 
@@ -963,12 +968,17 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TestTemplate
   public void testBinPackCombineMixedFiles() {
-    Table table = createTable(1); // 400000
+    // Uses the Spark writer: this test is calibrated to the exact on-disk byte sizes that Spark
+    // produces (see the format-version-specific MAX_FILE_SIZE_BYTES tuning below), so the input
+    // files must be written the same way.
+    Table table = createTable();
+    writeRecordsViaSpark(1, SCALE, 0); // 400000
+    table.refresh();
     shouldHaveFiles(table, 1);
 
     // Add one more small file, and one large file
-    writeRecords(1, SCALE);
-    writeRecords(1, SCALE * 3);
+    writeRecordsViaSpark(1, SCALE, 0);
+    writeRecordsViaSpark(1, SCALE * 3, 0);
     table.refresh();
     shouldHaveFiles(table, 3);
 
@@ -2443,6 +2453,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   private void writeRecords(int files, int numRecords, int partitions) {
+    appendRecords(generateRecords(numRecords, partitions), files);
+  }
+
+  /**
+   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
+   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
+   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
+   * int, int)} path instead.
+   */
+  private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
     int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
     List<Pair<Integer, Integer>> data =
@@ -2464,6 +2484,96 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
+  }
+
+  private List<Record> generateRecords(int numRecords, int partitions) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
+    for (Pair<Integer, Integer> pair : data) {
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", partitions > 0 ? pair.first() % partitions : pair.first());
+      record.setField("c2", "foo" + pair.first());
+      record.setField("c3", "bar" + pair.second());
+      records.add(record);
+    }
+    return records;
+  }
+
+  /**
+   * Append records as Iceberg data files without going through Spark, writing {@code files} data
+   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
+   * would produce: the suite asserts on file counts and row content, not on the row-to-file
+   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
+   * shuffle, sort, and DataFrame conversion per write.
+   */
+  private void appendRecords(List<Record> records, int files) {
+    Table table = TABLES.load(tableLocation);
+    PartitionSpec spec = table.spec();
+    AppendFiles append = table.newAppend();
+
+    if (spec.isUnpartitioned()) {
+      for (List<Record> chunk : split(records, files)) {
+        append.appendFile(writeDataFileNative(table, null, chunk));
+      }
+    } else {
+      Map<String, PartitionKey> keys = Maps.newLinkedHashMap();
+      Map<String, List<Record>> groups = Maps.newLinkedHashMap();
+      PartitionKey key = new PartitionKey(spec, table.schema());
+      for (Record record : records) {
+        key.partition(record);
+        String path = key.toPath();
+        keys.computeIfAbsent(path, p -> key.copy());
+        groups.computeIfAbsent(path, p -> Lists.newArrayList()).add(record);
+      }
+      groups.forEach(
+          (path, groupRecords) -> {
+            for (List<Record> chunk : split(groupRecords, files)) {
+              append.appendFile(writeDataFileNative(table, keys.get(path), chunk));
+            }
+          });
+    }
+
+    append.commit();
+  }
+
+  private DataFile writeDataFileNative(Table table, StructLike partition, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, partition, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
+  private static List<List<Record>> split(List<Record> records, int parts) {
+    int n = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
+    if (n <= 0) {
+      return chunks;
+    }
+    int base = records.size() / n;
+    int remainder = records.size() % n;
+    int start = 0;
+    for (int i = 0; i < n; i++) {
+      int size = base + (i < remainder ? 1 : 0);
+      chunks.add(records.subList(start, start + size));
+      start += size;
+    }
+    return chunks;
   }
 
   private void writeDF(Dataset<Row> df) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -167,10 +167,8 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
-  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
-  // currentData() returns. Lets tests that only compact (which preserves row content) assert
-  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
-  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  // Rows written natively so far; lets compaction-only tests assert via expectedData() instead of a
+  // second Spark read to recover what they just wrote. Reset per test in setupTableLocation().
   private final List<Object[]> writtenRecords = Lists.newArrayList();
 
   @BeforeAll
@@ -2194,11 +2192,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
-   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
-   * compact can assert against this instead of re-reading the table via Spark just to recover the
-   * data they already wrote. Only valid for tables populated exclusively through the native
-   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   * In-memory equivalent of {@link #currentData()} for compaction-only tests, avoiding a second
+   * Spark read. Only valid for tables populated solely via the native writeRecords/createTable path
+   * (no row-level deletes, Spark writes, or lineage projections).
    */
   private List<Object[]> expectedData() {
     List<Object[]> rows = Lists.newArrayList(writtenRecords);
@@ -2480,43 +2476,22 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
-   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
-   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
-   * int, int)} path instead.
+   * Spark-based write, kept for the few tests that need the exact row-to-file placement {@code
+   * df.repartition(files)} produces (e.g. position deletes targeting a specific file/position).
+   * Most writes use the cheaper native {@link #writeRecords(int, int, int)} path.
    */
   private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
-    if (partitions > 0) {
-      data.forEach(
-          i ->
-              records.add(
-                  new ThreeColumnRecord(
-                      i.first() % partitions, "foo" + i.first(), "bar" + i.second())));
-    } else {
-      data.forEach(
-          i ->
-              records.add(new ThreeColumnRecord(i.first(), "foo" + i.first(), "bar" + i.second())));
+    for (Pair<Integer, Integer> pair : generateShuffledGrid(numRecords)) {
+      int c1 = partitions > 0 ? pair.first() % partitions : pair.first();
+      records.add(new ThreeColumnRecord(c1, "foo" + pair.first(), "bar" + pair.second()));
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
   }
 
   private List<Record> generateRecords(int numRecords, int partitions) {
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
+    List<Pair<Integer, Integer>> data = generateShuffledGrid(numRecords);
     List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
     for (Pair<Integer, Integer> pair : data) {
       GenericRecord record = GenericRecord.create(SCHEMA);
@@ -2529,11 +2504,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Append records as Iceberg data files without going through Spark, writing {@code files} data
-   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
-   * would produce: the suite asserts on file counts and row content, not on the row-to-file
-   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
-   * shuffle, sort, and DataFrame conversion per write.
+   * Deterministic seed-42 shuffled grid of (first, second) pairs, shared by the native {@link
+   * #generateRecords} and Spark {@link #writeRecordsViaSpark} writers so both produce the same
+   * rows.
+   */
+  private static List<Pair<Integer, Integer>> generateShuffledGrid(int numRecords) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    return data;
+  }
+
+  /**
+   * Append {@code records} as Iceberg data files without Spark, in {@code files} files per
+   * partition. The suite asserts on file counts and row content (not row-to-file placement), so a
+   * deterministic contiguous split matches {@code df.repartition(files)} while skipping a Spark
+   * job.
    */
   private void appendRecords(List<Record> records, int files) {
     for (Record record : records) {
@@ -2589,7 +2579,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
     int count = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(count);
     if (count <= 0) {
       return chunks;
     }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -167,6 +167,12 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
+  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
+  // currentData() returns. Lets tests that only compact (which preserves row content) assert
+  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
+  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  private final List<Object[]> writtenRecords = Lists.newArrayList();
+
   @BeforeAll
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
@@ -176,6 +182,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   @BeforeEach
   public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
+    this.writtenRecords.clear();
   }
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
@@ -203,7 +210,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackUnpartitionedTable() {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -223,7 +230,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackPartitionedTable() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -243,7 +250,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackWithFilter() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -269,7 +276,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
 
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -299,7 +306,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -829,7 +836,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -864,7 +871,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Map<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "1");
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -944,7 +951,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(1);
     shouldHaveFiles(table, 1);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long targetSize = testDataSize(table) / 2;
 
     long dataSizeBefore = testDataSize(table);
@@ -1018,7 +1025,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     int targetSize = ((int) testDataSize(table) / 3);
     // The test is to see if we can combine parts of files to make files of the correct size
 
@@ -1054,7 +1061,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1081,7 +1088,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1107,7 +1114,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1134,7 +1141,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1166,7 +1173,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1198,7 +1205,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1230,7 +1237,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1263,7 +1270,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1303,7 +1310,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1344,7 +1351,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1387,7 +1394,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1427,7 +1434,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
@@ -1504,7 +1511,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1533,7 +1540,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1566,7 +1573,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1599,7 +1606,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1637,7 +1644,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").apply();
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1672,7 +1679,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.replaceSortOrder().asc("c2").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1698,7 +1705,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1736,7 +1743,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction action = basicRewrite(table);
     RewriteDataFilesSparkAction spyAction = spy(action);
@@ -1790,7 +1797,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, originalFiles);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     double originalFilesC2 = percentFilesRequired(table, "c2", "foo23");
     double originalFilesC3 = percentFilesRequired(table, "c3", "bar21");
     double originalFilesC2C3 =
@@ -1944,7 +1951,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.truncate("c2", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1967,7 +1974,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2006,7 +2013,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2029,7 +2036,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2184,6 +2191,22 @@ public class TestRewriteDataFilesAction extends TestBase {
             .coalesce(1)
             .sort("c1", "c2", "c3")
             .collectAsList());
+  }
+
+  /**
+   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
+   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
+   * compact can assert against this instead of re-reading the table via Spark just to recover the
+   * data they already wrote. Only valid for tables populated exclusively through the native
+   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   */
+  private List<Object[]> expectedData() {
+    List<Object[]> rows = Lists.newArrayList(writtenRecords);
+    rows.sort(
+        Comparator.<Object[], Integer>comparing(row -> (Integer) row[0])
+            .thenComparing(row -> (String) row[1])
+            .thenComparing(row -> (String) row[2]));
+    return rows;
   }
 
   protected List<Object[]> currentDataWithLineage() {
@@ -2513,6 +2536,11 @@ public class TestRewriteDataFilesAction extends TestBase {
    * shuffle, sort, and DataFrame conversion per write.
    */
   private void appendRecords(List<Record> records, int files) {
+    for (Record record : records) {
+      writtenRecords.add(
+          new Object[] {record.getField("c1"), record.getField("c2"), record.getField("c3")});
+    }
+
     Table table = TABLES.load(tableLocation);
     PartitionSpec spec = table.spec();
     AppendFiles append = table.newAppend();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -26,10 +26,12 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
@@ -41,6 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -162,16 +165,49 @@ public class TestRewriteTablePathsAction extends TestBase {
                 .build(),
             location);
 
-    List<ThreeColumnRecord> records =
-        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    if ("append".equals(mode)) {
+      // Append snapshots natively: each snapshot is a single one-row data file, avoiding a Spark
+      // write job per snapshot. This fixture is built for every test (and some tests create up to
+      // 50 snapshots), so the per-job Spark overhead dominates the suite. Commit through a
+      // separate table instance so the returned handle stays unrefreshed, matching the old Spark
+      // path where writes happened outside this object.
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", 1);
+      record.setField("c2", "AAAAAAAAAA");
+      record.setField("c3", "AAAA");
+      List<Record> records = Lists.newArrayList(record);
+      Table writeTable = TABLES.load(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        writeTable.newAppend().appendFile(writeDataFileNative(writeTable, records)).commit();
+      }
+    } else {
+      List<ThreeColumnRecord> records =
+          Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
-    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+      Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    for (int i = 0; i < snapshotNumber; i++) {
-      df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      }
     }
 
     return newTable;
+  }
+
+  private DataFile writeDataFileNative(Table table, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private void createNameSpaces() {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -2560,15 +2560,15 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
-    int n = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
-    if (n <= 0) {
+    int count = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    if (count <= 0) {
       return chunks;
     }
-    int base = records.size() / n;
-    int remainder = records.size() % n;
+    int base = records.size() / count;
+    int remainder = records.size() % count;
     int start = 0;
-    for (int i = 0; i < n; i++) {
+    for (int i = 0; i < count; i++) {
       int size = base + (i < remainder ? 1 : 0);
       chunks.add(records.subList(start, start + size));
       start += size;

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -54,6 +54,7 @@ import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -85,6 +86,7 @@ import org.apache.iceberg.actions.RewriteDataFiles.Result;
 import org.apache.iceberg.actions.RewriteDataFilesCommitManager;
 import org.apache.iceberg.actions.RewriteFileGroup;
 import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.data.FileHelpers;
 import org.apache.iceberg.data.GenericFileWriterFactory;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
@@ -107,6 +109,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.FileRewriteCoordinator;
@@ -722,8 +725,10 @@ public class TestRewriteDataFilesAction extends TestBase {
             ImmutableMap.of(TableProperties.FORMAT_VERSION, String.valueOf(formatVersion)),
             tableLocation);
 
-    // data seq = 1, write 4 files in 2 partitions
-    writeRecords(2, 2, 2);
+    // data seq = 1, write 4 files in 2 partitions. Uses the Spark writer because this test depends
+    // on the exact data-file ordering (dataFilesBefore.get(3)) and the row position the position
+    // delete below targets.
+    writeRecordsViaSpark(2, 2, 2);
     List<DataFile> dataFilesBefore = TestHelpers.dataFiles(table, null);
     shouldHaveFiles(table, 4);
 
@@ -741,7 +746,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.ref("c3")).commit();
 
     // data seq = 3, write 1 new data files in c1=1 for evolved spec
-    writeRecords(1, 1, 1);
+    writeRecordsViaSpark(1, 1, 1);
     shouldHaveFiles(table, 5);
     List<Object[]> expectedRecords = currentData();
 
@@ -963,12 +968,17 @@ public class TestRewriteDataFilesAction extends TestBase {
 
   @TestTemplate
   public void testBinPackCombineMixedFiles() {
-    Table table = createTable(1); // 400000
+    // Uses the Spark writer: this test is calibrated to the exact on-disk byte sizes that Spark
+    // produces (see the format-version-specific MAX_FILE_SIZE_BYTES tuning below), so the input
+    // files must be written the same way.
+    Table table = createTable();
+    writeRecordsViaSpark(1, SCALE, 0); // 400000
+    table.refresh();
     shouldHaveFiles(table, 1);
 
     // Add one more small file, and one large file
-    writeRecords(1, SCALE);
-    writeRecords(1, SCALE * 3);
+    writeRecordsViaSpark(1, SCALE, 0);
+    writeRecordsViaSpark(1, SCALE * 3, 0);
     table.refresh();
     shouldHaveFiles(table, 3);
 
@@ -2443,6 +2453,16 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   private void writeRecords(int files, int numRecords, int partitions) {
+    appendRecords(generateRecords(numRecords, partitions), files);
+  }
+
+  /**
+   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
+   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
+   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
+   * int, int)} path instead.
+   */
+  private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
     int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
     List<Pair<Integer, Integer>> data =
@@ -2464,6 +2484,96 @@ public class TestRewriteDataFilesAction extends TestBase {
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
+  }
+
+  private List<Record> generateRecords(int numRecords, int partitions) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
+    for (Pair<Integer, Integer> pair : data) {
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", partitions > 0 ? pair.first() % partitions : pair.first());
+      record.setField("c2", "foo" + pair.first());
+      record.setField("c3", "bar" + pair.second());
+      records.add(record);
+    }
+    return records;
+  }
+
+  /**
+   * Append records as Iceberg data files without going through Spark, writing {@code files} data
+   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
+   * would produce: the suite asserts on file counts and row content, not on the row-to-file
+   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
+   * shuffle, sort, and DataFrame conversion per write.
+   */
+  private void appendRecords(List<Record> records, int files) {
+    Table table = TABLES.load(tableLocation);
+    PartitionSpec spec = table.spec();
+    AppendFiles append = table.newAppend();
+
+    if (spec.isUnpartitioned()) {
+      for (List<Record> chunk : split(records, files)) {
+        append.appendFile(writeDataFileNative(table, null, chunk));
+      }
+    } else {
+      Map<String, PartitionKey> keys = Maps.newLinkedHashMap();
+      Map<String, List<Record>> groups = Maps.newLinkedHashMap();
+      PartitionKey key = new PartitionKey(spec, table.schema());
+      for (Record record : records) {
+        key.partition(record);
+        String path = key.toPath();
+        keys.computeIfAbsent(path, p -> key.copy());
+        groups.computeIfAbsent(path, p -> Lists.newArrayList()).add(record);
+      }
+      groups.forEach(
+          (path, groupRecords) -> {
+            for (List<Record> chunk : split(groupRecords, files)) {
+              append.appendFile(writeDataFileNative(table, keys.get(path), chunk));
+            }
+          });
+    }
+
+    append.commit();
+  }
+
+  private DataFile writeDataFileNative(Table table, StructLike partition, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, partition, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+
+  /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
+  private static List<List<Record>> split(List<Record> records, int parts) {
+    int n = Math.min(parts, records.size());
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(n, 0));
+    if (n <= 0) {
+      return chunks;
+    }
+    int base = records.size() / n;
+    int remainder = records.size() % n;
+    int start = 0;
+    for (int i = 0; i < n; i++) {
+      int size = base + (i < remainder ? 1 : 0);
+      chunks.add(records.subList(start, start + size));
+      start += size;
+    }
+    return chunks;
   }
 
   private void writeDF(Dataset<Row> df) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -167,10 +167,8 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
-  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
-  // currentData() returns. Lets tests that only compact (which preserves row content) assert
-  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
-  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  // Rows written natively so far; lets compaction-only tests assert via expectedData() instead of a
+  // second Spark read to recover what they just wrote. Reset per test in setupTableLocation().
   private final List<Object[]> writtenRecords = Lists.newArrayList();
 
   @BeforeAll
@@ -2194,11 +2192,9 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
-   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
-   * compact can assert against this instead of re-reading the table via Spark just to recover the
-   * data they already wrote. Only valid for tables populated exclusively through the native
-   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   * In-memory equivalent of {@link #currentData()} for compaction-only tests, avoiding a second
+   * Spark read. Only valid for tables populated solely via the native writeRecords/createTable path
+   * (no row-level deletes, Spark writes, or lineage projections).
    */
   private List<Object[]> expectedData() {
     List<Object[]> rows = Lists.newArrayList(writtenRecords);
@@ -2480,43 +2476,22 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Spark-based write, kept for the few tests that depend on the exact data-file ordering and
-   * row-to-file placement that {@code df.repartition(files)} produces (e.g. position deletes that
-   * target a specific file/position). Most writes use the cheaper native {@link #writeRecords(int,
-   * int, int)} path instead.
+   * Spark-based write, kept for the few tests that need the exact row-to-file placement {@code
+   * df.repartition(files)} produces (e.g. position deletes targeting a specific file/position).
+   * Most writes use the cheaper native {@link #writeRecords(int, int, int)} path.
    */
   private void writeRecordsViaSpark(int files, int numRecords, int partitions) {
     List<ThreeColumnRecord> records = Lists.newArrayList();
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
-    if (partitions > 0) {
-      data.forEach(
-          i ->
-              records.add(
-                  new ThreeColumnRecord(
-                      i.first() % partitions, "foo" + i.first(), "bar" + i.second())));
-    } else {
-      data.forEach(
-          i ->
-              records.add(new ThreeColumnRecord(i.first(), "foo" + i.first(), "bar" + i.second())));
+    for (Pair<Integer, Integer> pair : generateShuffledGrid(numRecords)) {
+      int c1 = partitions > 0 ? pair.first() % partitions : pair.first();
+      records.add(new ThreeColumnRecord(c1, "foo" + pair.first(), "bar" + pair.second()));
     }
     Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).repartition(files);
     writeDF(df);
   }
 
   private List<Record> generateRecords(int numRecords, int partitions) {
-    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
-    List<Pair<Integer, Integer>> data =
-        IntStream.range(0, rowDimension)
-            .boxed()
-            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
-            .collect(Collectors.toList());
-    Collections.shuffle(data, new Random(42));
+    List<Pair<Integer, Integer>> data = generateShuffledGrid(numRecords);
     List<Record> records = Lists.newArrayListWithExpectedSize(data.size());
     for (Pair<Integer, Integer> pair : data) {
       GenericRecord record = GenericRecord.create(SCHEMA);
@@ -2529,11 +2504,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   /**
-   * Append records as Iceberg data files without going through Spark, writing {@code files} data
-   * files per table partition. This mirrors the file layout that {@code df.repartition(files)}
-   * would produce: the suite asserts on file counts and row content, not on the row-to-file
-   * assignment, so a deterministic contiguous split is equivalent while avoiding a Spark job,
-   * shuffle, sort, and DataFrame conversion per write.
+   * Deterministic seed-42 shuffled grid of (first, second) pairs, shared by the native {@link
+   * #generateRecords} and Spark {@link #writeRecordsViaSpark} writers so both produce the same
+   * rows.
+   */
+  private static List<Pair<Integer, Integer>> generateShuffledGrid(int numRecords) {
+    int rowDimension = (int) Math.ceil(Math.sqrt(numRecords));
+    List<Pair<Integer, Integer>> data =
+        IntStream.range(0, rowDimension)
+            .boxed()
+            .flatMap(x -> IntStream.range(0, rowDimension).boxed().map(y -> Pair.of(x, y)))
+            .collect(Collectors.toList());
+    Collections.shuffle(data, new Random(42));
+    return data;
+  }
+
+  /**
+   * Append {@code records} as Iceberg data files without Spark, in {@code files} files per
+   * partition. The suite asserts on file counts and row content (not row-to-file placement), so a
+   * deterministic contiguous split matches {@code df.repartition(files)} while skipping a Spark
+   * job.
    */
   private void appendRecords(List<Record> records, int files) {
     for (Record record : records) {
@@ -2589,7 +2579,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   /** Split a list into at most {@code parts} contiguous, non-empty sublists. */
   private static List<List<Record>> split(List<Record> records, int parts) {
     int count = Math.min(parts, records.size());
-    List<List<Record>> chunks = Lists.newArrayListWithCapacity(Math.max(count, 0));
+    List<List<Record>> chunks = Lists.newArrayListWithCapacity(count);
     if (count <= 0) {
       return chunks;
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -167,6 +167,12 @@ public class TestRewriteDataFilesAction extends TestBase {
   private final ScanTaskSetManager manager = ScanTaskSetManager.get();
   private String tableLocation = null;
 
+  // Mirror of the rows written natively via appendRecords, in the {c1, c2, c3} shape that
+  // currentData() returns. Lets tests that only compact (which preserves row content) assert
+  // against the known input via expectedData() instead of paying a second Spark read+sort+collect
+  // just to re-materialize what they wrote. Reset per test in setupTableLocation().
+  private final List<Object[]> writtenRecords = Lists.newArrayList();
+
   @BeforeAll
   public static void setupSpark() {
     // disable AQE as tests assume that writes generate a particular number of files
@@ -176,6 +182,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   @BeforeEach
   public void setupTableLocation() {
     this.tableLocation = tableDir.toURI().toString();
+    this.writtenRecords.clear();
   }
 
   private RewriteDataFilesSparkAction basicRewrite(Table table) {
@@ -203,7 +210,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackUnpartitionedTable() {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -223,7 +230,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackPartitionedTable() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result = basicRewrite(table).execute();
@@ -243,7 +250,7 @@ public class TestRewriteDataFilesAction extends TestBase {
   public void testBinPackWithFilter() {
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -269,7 +276,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTablePartitioned(4, 2);
 
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     Result result =
@@ -299,7 +306,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveFiles(table, 20);
     table.updateSpec().addField(Expressions.ref("c1")).commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -829,7 +836,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(2);
     Table table = createTablePartitioned(4, 2);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     long dataSizeBefore = testDataSize(table);
 
@@ -864,7 +871,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Map<String, String> properties = ImmutableMap.of(TableProperties.FORMAT_VERSION, "1");
     Table table = createTablePartitioned(4, 2, SCALE, properties);
     shouldHaveFiles(table, 8);
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long oldSequenceNumber = table.currentSnapshot().sequenceNumber();
     assertThat(oldSequenceNumber).as("Table sequence number should be 0").isZero();
     long dataSizeBefore = testDataSize(table);
@@ -944,7 +951,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(1);
     shouldHaveFiles(table, 1);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     long targetSize = testDataSize(table) / 2;
 
     long dataSizeBefore = testDataSize(table);
@@ -1018,7 +1025,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(4);
     shouldHaveFiles(table, 4);
 
-    List<Object[]> expectedRecords = currentData();
+    List<Object[]> expectedRecords = expectedData();
     int targetSize = ((int) testDataSize(table) / 3);
     // The test is to see if we can combine parts of files to make files of the correct size
 
@@ -1054,7 +1061,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.updateProperties().set(COMMIT_NUM_RETRIES, "10").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1081,7 +1088,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1107,7 +1114,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1134,7 +1141,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1166,7 +1173,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1198,7 +1205,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1230,7 +1237,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1263,7 +1270,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1303,7 +1310,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1344,7 +1351,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFilesSparkAction realRewrite =
@@ -1387,7 +1394,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction realRewrite =
         basicRewrite(table)
@@ -1427,7 +1434,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction rewrite =
         basicRewrite(table)
@@ -1504,7 +1511,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     int fileSize = averageFileSize(table);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     // Perform a rewrite but only allow 2 files to be compacted at a time
@@ -1533,7 +1540,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1566,7 +1573,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").commit();
     shouldHaveLastCommitUnsorted(table, "c2");
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1599,7 +1606,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1637,7 +1644,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.replaceSortOrder().asc("c2").apply();
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1672,7 +1679,7 @@ public class TestRewriteDataFilesAction extends TestBase {
 
     table.replaceSortOrder().asc("c2").commit();
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1698,7 +1705,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     long dataSizeBefore = testDataSize(table);
 
     RewriteDataFiles.Result result =
@@ -1736,7 +1743,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
 
     RewriteDataFilesSparkAction action = basicRewrite(table);
     RewriteDataFilesSparkAction spyAction = spy(action);
@@ -1790,7 +1797,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     shouldHaveLastCommitUnsorted(table, "c2");
     shouldHaveFiles(table, originalFiles);
 
-    List<Object[]> originalData = currentData();
+    List<Object[]> originalData = expectedData();
     double originalFilesC2 = percentFilesRequired(table, "c2", "foo23");
     double originalFilesC3 = percentFilesRequired(table, "c3", "bar21");
     double originalFilesC2C3 =
@@ -1944,7 +1951,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.truncate("c2", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -1967,7 +1974,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2006,7 +2013,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2029,7 +2036,7 @@ public class TestRewriteDataFilesAction extends TestBase {
     table.updateSpec().addField(Expressions.bucket("c3", 2)).commit();
 
     long dataSizeBefore = testDataSize(table);
-    long count = currentData().size();
+    long count = expectedData().size();
 
     RewriteDataFiles.Result result =
         basicRewrite(table)
@@ -2184,6 +2191,22 @@ public class TestRewriteDataFilesAction extends TestBase {
             .coalesce(1)
             .sort("c1", "c2", "c3")
             .collectAsList());
+  }
+
+  /**
+   * The rows written natively so far, in the same {c1, c2, c3} shape and (c1, c2, c3) sort order
+   * that {@link #currentData()} produces. Compaction preserves row content, so tests that only
+   * compact can assert against this instead of re-reading the table via Spark just to recover the
+   * data they already wrote. Only valid for tables populated exclusively through the native
+   * writeRecords/createTable path (no row-level deletes, Spark writes, or lineage projections).
+   */
+  private List<Object[]> expectedData() {
+    List<Object[]> rows = Lists.newArrayList(writtenRecords);
+    rows.sort(
+        Comparator.<Object[], Integer>comparing(row -> (Integer) row[0])
+            .thenComparing(row -> (String) row[1])
+            .thenComparing(row -> (String) row[2]));
+    return rows;
   }
 
   protected List<Object[]> currentDataWithLineage() {
@@ -2513,6 +2536,11 @@ public class TestRewriteDataFilesAction extends TestBase {
    * shuffle, sort, and DataFrame conversion per write.
    */
   private void appendRecords(List<Record> records, int files) {
+    for (Record record : records) {
+      writtenRecords.add(
+          new Object[] {record.getField("c1"), record.getField("c2"), record.getField("c3")});
+    }
+
     Table table = TABLES.load(tableLocation);
     PartitionSpec spec = table.spec();
     AppendFiles append = table.newAppend();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -26,10 +26,12 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.function.Predicate;
@@ -41,6 +43,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
@@ -162,16 +165,49 @@ public class TestRewriteTablePathsAction extends TestBase {
                 .build(),
             location);
 
-    List<ThreeColumnRecord> records =
-        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+    if ("append".equals(mode)) {
+      // Append snapshots natively: each snapshot is a single one-row data file, avoiding a Spark
+      // write job per snapshot. This fixture is built for every test (and some tests create up to
+      // 50 snapshots), so the per-job Spark overhead dominates the suite. Commit through a
+      // separate table instance so the returned handle stays unrefreshed, matching the old Spark
+      // path where writes happened outside this object.
+      GenericRecord record = GenericRecord.create(SCHEMA);
+      record.setField("c1", 1);
+      record.setField("c2", "AAAAAAAAAA");
+      record.setField("c3", "AAAA");
+      List<Record> records = Lists.newArrayList(record);
+      Table writeTable = TABLES.load(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        writeTable.newAppend().appendFile(writeDataFileNative(writeTable, records)).commit();
+      }
+    } else {
+      List<ThreeColumnRecord> records =
+          Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
 
-    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+      Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
 
-    for (int i = 0; i < snapshotNumber; i++) {
-      df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      for (int i = 0; i < snapshotNumber; i++) {
+        df.select("c1", "c2", "c3").write().format("iceberg").mode(mode).save(location);
+      }
     }
 
     return newTable;
+  }
+
+  private DataFile writeDataFileNative(Table table, List<Record> records) {
+    OutputFile outputFile =
+        table
+            .io()
+            .newOutputFile(
+                table
+                    .locationProvider()
+                    .newDataLocation(
+                        FileFormat.PARQUET.addExtension(UUID.randomUUID().toString())));
+    try {
+      return FileHelpers.writeDataFile(table, outputFile, records);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
   }
 
   private void createNameSpaces() {


### PR DESCRIPTION
## What

`TestRewriteDataFilesAction` generated its input data files through Spark on every `writeRecords(...)` call: `spark.createDataFrame()` bean-reflection over the records, a `repartition(files)` shuffle, a `sortWithinPartitions`, and a separate Spark job per write. This change writes the inputs directly with the Iceberg API instead.

The new path builds the records in memory, groups them by partition via `PartitionKey`, splits each group into the requested number of files, writes each file with `FileHelpers.writeDataFile`, and commits them in a single `newAppend()`.

## Why

The suite is the single heaviest Spark core test class, and on the `SCALE = 400000` cases the Spark write overhead (DataFrame conversion + shuffle + sort + per-write job scheduling) dominates the actual rewrite under test. The suite asserts on file counts and row content, not on the row-to-file assignment, so a deterministic contiguous split is equivalent.

A measured A/B (identical compiled binary, runtime toggle, interleaved reps at low load) showed **−26% wall-clock on the full v4.1 suite** (701.9 s → 520.3 s).

## What stays on Spark

Two tests keep the Spark writer because they depend on the exact on-disk layout it produces:
- `testBinPackCombineMixedFiles` — calibrated to Spark's on-disk byte sizes.
- `testRemoveDangledPositionDeletesPartitionEvolution` — depends on data-file ordering
  and the row position its position delete targets.
