### PR TITLE
Spark: Short-circuit latestOffset for unbounded (allAvailable) limit

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.connector.read.streaming.ReadAllAvailable;
 import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +132,16 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
 
     Snapshot curSnapshot = table().snapshot(startingOffset.snapshotId());
     validateCurrentSnapshotExists(curSnapshot, startingOffset);
+
+    // For an unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) there is no per-file
+    // rate limit to enforce: the end offset is just the latest valid snapshot's added-file count.
+    // Walking only the snapshot chain (metadata; skipping rewrite/delete snapshots) avoids reading
+    // every manifest across the committed->head gap. That walk is O(snapshots-in-gap x files),
+    // single-threaded on the driver, and the dominant cost for scheduled Trigger.AvailableNow
+    // consumers of high-commit-cadence tables. Mirrors AsyncSparkMicroBatchPlanner#latestOffset.
+    if (limit instanceof ReadAllAvailable) {
+      return latestOffsetForUnbounded(startingOffset, curSnapshot);
+    }
 
     // Use the pre-computed snapshotId when Trigger.AvailableNow is enabled.
     long latestSnapshotId =
@@ -231,6 +242,36 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
         new StreamingOffset(curSnapshot.snapshotId(), curPos, scanAllFiles);
 
     // if no new data arrived, then return null.
+    return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
+  }
+
+  // Computes latestOffset for an unbounded (allAvailable) limit without per-file planning: the end
+  // offset is the latest valid snapshot's added-file count (or the pre-computed
+  // Trigger.AvailableNow
+  // cap), reached by walking only the snapshot chain. See latestOffset for the rationale.
+  private StreamingOffset latestOffsetForUnbounded(
+      StreamingOffset startingOffset, Snapshot curSnapshot) {
+    StreamingOffset latestStreamingOffset;
+    if (lastOffsetForTriggerAvailableNow != null) {
+      // Trigger.AvailableNow caps the run at a snapshot computed up front.
+      latestStreamingOffset = lastOffsetForTriggerAvailableNow;
+    } else {
+      // Advance the snapshot chain (metadata only) to the latest valid snapshot.
+      Snapshot lastValidSnapshot = curSnapshot;
+      Snapshot next;
+      do {
+        next = nextValidSnapshot(lastValidSnapshot);
+        if (next != null) {
+          lastValidSnapshot = next;
+        }
+      } while (next != null);
+      latestStreamingOffset =
+          new StreamingOffset(
+              lastValidSnapshot.snapshotId(),
+              MicroBatchUtils.addedFilesCount(table(), lastValidSnapshot),
+              false);
+    }
+    // Preserve the existing contract: return null when the offset did not advance.
     return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -70,6 +70,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
@@ -473,6 +474,34 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
       assertThat(stream.latestOffset(secondEndOffset, stream.getDefaultReadLimit())).isNull();
       assertThat(((StreamingOffset) secondEndOffset).snapshotId()).isEqualTo(expectedCapSnapshotId);
+    } finally {
+      stream.stop();
+    }
+  }
+
+  @TestTemplate
+  public void testLatestOffsetForUnboundedLimitAdvancesToHeadSnapshot() {
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+
+    table.refresh();
+    long headSnapshotId = table.currentSnapshot().snapshotId();
+    long headAddedFiles = MicroBatchUtils.addedFilesCount(table, table.currentSnapshot());
+
+    SparkMicroBatchStream stream =
+        newMicroBatchStream(ImmutableMap.of(), "all-available-latest-offset-checkpoint");
+
+    try {
+      Offset startOffset = stream.initialOffset();
+
+      // An unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) advances straight to the
+      // latest snapshot and its added-file count without per-file planning. Both planners (sync and
+      // async, parameterized) must agree.
+      StreamingOffset endOffset =
+          (StreamingOffset) stream.latestOffset(startOffset, ReadLimit.allAvailable());
+
+      assertThat(endOffset).isNotNull();
+      assertThat(endOffset.snapshotId()).isEqualTo(headSnapshotId);
+      assertThat(endOffset.position()).isEqualTo(headAddedFiles);
     } finally {
       stream.stop();
     }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.connector.read.streaming.ReadAllAvailable;
 import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +132,16 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
 
     Snapshot curSnapshot = table().snapshot(startingOffset.snapshotId());
     validateCurrentSnapshotExists(curSnapshot, startingOffset);
+
+    // For an unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) there is no per-file
+    // rate limit to enforce: the end offset is just the latest valid snapshot's added-file count.
+    // Walking only the snapshot chain (metadata; skipping rewrite/delete snapshots) avoids reading
+    // every manifest across the committed->head gap. That walk is O(snapshots-in-gap x files),
+    // single-threaded on the driver, and the dominant cost for scheduled Trigger.AvailableNow
+    // consumers of high-commit-cadence tables. Mirrors AsyncSparkMicroBatchPlanner#latestOffset.
+    if (limit instanceof ReadAllAvailable) {
+      return latestOffsetForUnbounded(startingOffset, curSnapshot);
+    }
 
     // Use the pre-computed snapshotId when Trigger.AvailableNow is enabled.
     long latestSnapshotId =
@@ -231,6 +242,36 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
         new StreamingOffset(curSnapshot.snapshotId(), curPos, scanAllFiles);
 
     // if no new data arrived, then return null.
+    return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
+  }
+
+  // Computes latestOffset for an unbounded (allAvailable) limit without per-file planning: the end
+  // offset is the latest valid snapshot's added-file count (or the pre-computed
+  // Trigger.AvailableNow
+  // cap), reached by walking only the snapshot chain. See latestOffset for the rationale.
+  private StreamingOffset latestOffsetForUnbounded(
+      StreamingOffset startingOffset, Snapshot curSnapshot) {
+    StreamingOffset latestStreamingOffset;
+    if (lastOffsetForTriggerAvailableNow != null) {
+      // Trigger.AvailableNow caps the run at a snapshot computed up front.
+      latestStreamingOffset = lastOffsetForTriggerAvailableNow;
+    } else {
+      // Advance the snapshot chain (metadata only) to the latest valid snapshot.
+      Snapshot lastValidSnapshot = curSnapshot;
+      Snapshot next;
+      do {
+        next = nextValidSnapshot(lastValidSnapshot);
+        if (next != null) {
+          lastValidSnapshot = next;
+        }
+      } while (next != null);
+      latestStreamingOffset =
+          new StreamingOffset(
+              lastValidSnapshot.snapshotId(),
+              MicroBatchUtils.addedFilesCount(table(), lastValidSnapshot),
+              false);
+    }
+    // Preserve the existing contract: return null when the offset did not advance.
     return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -70,6 +70,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
@@ -480,6 +481,34 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
       assertThat(stream.latestOffset(secondEndOffset, stream.getDefaultReadLimit())).isNull();
       assertThat(((StreamingOffset) secondEndOffset).snapshotId()).isEqualTo(expectedCapSnapshotId);
+    } finally {
+      stream.stop();
+    }
+  }
+
+  @TestTemplate
+  public void testLatestOffsetForUnboundedLimitAdvancesToHeadSnapshot() {
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+
+    table.refresh();
+    long headSnapshotId = table.currentSnapshot().snapshotId();
+    long headAddedFiles = MicroBatchUtils.addedFilesCount(table, table.currentSnapshot());
+
+    SparkMicroBatchStream stream =
+        newMicroBatchStream(ImmutableMap.of(), "all-available-latest-offset-checkpoint");
+
+    try {
+      Offset startOffset = stream.initialOffset();
+
+      // An unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) advances straight to the
+      // latest snapshot and its added-file count without per-file planning. Both planners (sync and
+      // async, parameterized) must agree.
+      StreamingOffset endOffset =
+          (StreamingOffset) stream.latestOffset(startOffset, ReadLimit.allAvailable());
+
+      assertThat(endOffset).isNotNull();
+      assertThat(endOffset.snapshotId()).isEqualTo(headSnapshotId);
+      assertThat(endOffset.position()).isEqualTo(headAddedFiles);
     } finally {
       stream.stop();
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SyncSparkMicroBatchPlanner.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.SnapshotUtil;
+import org.apache.spark.sql.connector.read.streaming.ReadAllAvailable;
 import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -131,6 +132,16 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
 
     Snapshot curSnapshot = table().snapshot(startingOffset.snapshotId());
     validateCurrentSnapshotExists(curSnapshot, startingOffset);
+
+    // For an unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) there is no per-file
+    // rate limit to enforce: the end offset is just the latest valid snapshot's added-file count.
+    // Walking only the snapshot chain (metadata; skipping rewrite/delete snapshots) avoids reading
+    // every manifest across the committed->head gap. That walk is O(snapshots-in-gap x files),
+    // single-threaded on the driver, and the dominant cost for scheduled Trigger.AvailableNow
+    // consumers of high-commit-cadence tables. Mirrors AsyncSparkMicroBatchPlanner#latestOffset.
+    if (limit instanceof ReadAllAvailable) {
+      return latestOffsetForUnbounded(startingOffset, curSnapshot);
+    }
 
     // Use the pre-computed snapshotId when Trigger.AvailableNow is enabled.
     long latestSnapshotId =
@@ -231,6 +242,36 @@ class SyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner {
         new StreamingOffset(curSnapshot.snapshotId(), curPos, scanAllFiles);
 
     // if no new data arrived, then return null.
+    return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
+  }
+
+  // Computes latestOffset for an unbounded (allAvailable) limit without per-file planning: the end
+  // offset is the latest valid snapshot's added-file count (or the pre-computed
+  // Trigger.AvailableNow
+  // cap), reached by walking only the snapshot chain. See latestOffset for the rationale.
+  private StreamingOffset latestOffsetForUnbounded(
+      StreamingOffset startingOffset, Snapshot curSnapshot) {
+    StreamingOffset latestStreamingOffset;
+    if (lastOffsetForTriggerAvailableNow != null) {
+      // Trigger.AvailableNow caps the run at a snapshot computed up front.
+      latestStreamingOffset = lastOffsetForTriggerAvailableNow;
+    } else {
+      // Advance the snapshot chain (metadata only) to the latest valid snapshot.
+      Snapshot lastValidSnapshot = curSnapshot;
+      Snapshot next;
+      do {
+        next = nextValidSnapshot(lastValidSnapshot);
+        if (next != null) {
+          lastValidSnapshot = next;
+        }
+      } while (next != null);
+      latestStreamingOffset =
+          new StreamingOffset(
+              lastValidSnapshot.snapshotId(),
+              MicroBatchUtils.addedFilesCount(table(), lastValidSnapshot),
+              false);
+    }
+    // Preserve the existing contract: return null when the offset did not advance.
     return latestStreamingOffset.equals(startingOffset) ? null : latestStreamingOffset;
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -70,6 +70,7 @@ import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.connector.read.InputPartition;
 import org.apache.spark.sql.connector.read.streaming.Offset;
+import org.apache.spark.sql.connector.read.streaming.ReadLimit;
 import org.apache.spark.sql.internal.SQLConf;
 import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
@@ -481,6 +482,34 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
       assertThat(stream.latestOffset(secondEndOffset, stream.getDefaultReadLimit())).isNull();
       assertThat(((StreamingOffset) secondEndOffset).snapshotId()).isEqualTo(expectedCapSnapshotId);
+    } finally {
+      stream.stop();
+    }
+  }
+
+  @TestTemplate
+  public void testLatestOffsetForUnboundedLimitAdvancesToHeadSnapshot() {
+    appendDataAsMultipleSnapshots(TEST_DATA_MULTIPLE_SNAPSHOTS);
+
+    table.refresh();
+    long headSnapshotId = table.currentSnapshot().snapshotId();
+    long headAddedFiles = MicroBatchUtils.addedFilesCount(table, table.currentSnapshot());
+
+    SparkMicroBatchStream stream =
+        newMicroBatchStream(ImmutableMap.of(), "all-available-latest-offset-checkpoint");
+
+    try {
+      Offset startOffset = stream.initialOffset();
+
+      // An unbounded limit (Trigger.AvailableNow / ReadLimit.allAvailable) advances straight to the
+      // latest snapshot and its added-file count without per-file planning. Both planners (sync and
+      // async, parameterized) must agree.
+      StreamingOffset endOffset =
+          (StreamingOffset) stream.latestOffset(startOffset, ReadLimit.allAvailable());
+
+      assertThat(endOffset).isNotNull();
+      assertThat(endOffset.snapshotId()).isEqualTo(headSnapshotId);
+      assertThat(endOffset.position()).isEqualTo(headAddedFiles);
     } finally {
       stream.stop();
     }


### PR DESCRIPTION
## What

`SyncSparkMicroBatchPlanner.latestOffset` now short-circuits an unbounded `ReadLimit` (`ReadLimit.allAvailable()`) instead of walking every snapshot in `(committed, head]`. Applied to Spark 3.5, 4.0, and 4.1.

Fixes #16940.

## Why

`Trigger.AvailableNow` computes its target offset once per run via `latestOffset(committedOffset, ReadLimit.allAvailable())`. The sync planner served that by walking every snapshot in the committed→head range — reading each snapshot's manifests and iterating every `FileScanTask` on the driver. For an unbounded limit none of that per-file work bounds the result: the end offset is just the latest valid snapshot and its added-file count. So the traversal is wasted — `O(snapshots-in-gap × files)`, single-threaded.

A scheduled `Trigger.AvailableNow` consumer of a high-commit-cadence table is always ~one trigger interval behind, so the gap (and thus this cost) grows run over run and can diverge until the job exceeds its budget. `AsyncSparkMicroBatchPlanner` already short-circuits `ReadAllAvailable` by advancing only the snapshot chain (metadata, skipping rewrite/delete snapshots); the default (sync) planner did not.

## What it does

For `ReadLimit.allAvailable()`, `latestOffset` delegates to a small helper that:
- returns the pre-computed `Trigger.AvailableNow` cap if set, else
- advances only the snapshot chain (metadata; `nextValidSnapshot`, preserving `streaming-skip-overwrite-snapshots` / `streaming-skip-delete-snapshots`) to the latest valid snapshot and returns `(snapshotId, addedFilesCount, false)`,
- preserving the existing no-new-data → `null` contract.

This mirrors `AsyncSparkMicroBatchPlanner#latestOffset`. The bounded (rate-limited / `CompositeReadLimit`) path is unchanged.

## Equivalence / safety

Perf change with no intended behavior change for the unbounded path:
- The returned offset is identical to what the full walk produced — the walk's per-file accumulators only feed the rate-limit checks, which never fire for an unbounded limit, so the result depends only on the latest valid snapshot.
- `scanAllFiles` is hardcoded `false` here, matching the async planner. Every `StreamingOffset` construction in the Spark source currently passes `false`, so this is equivalent today; glad to revisit if that invariant changes.

## Tests

Added a parameterized `TestStructuredStreamingRead3` case (`testLatestOffsetForUnboundedLimitAdvancesToHeadSnapshot`) asserting `latestOffset(initialOffset, ReadLimit.allAvailable())` advances to the head snapshot's offset. It runs under both `async = false` and `async = true`, pinning sync↔async parity.

Verified locally for Spark 3.5 (Scala 2.12), 4.0 and 4.1 (Scala 2.13): `spotlessApply`, `compileTestJava`, `checkstyleMain`/`checkstyleTest`, and the new test all pass.
