### PR TITLE
Core: Preserve concurrent snapshots on replace transaction retry

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreCatalog.java
@@ -21,6 +21,7 @@ package org.apache.iceberg;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
@@ -237,12 +238,19 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
         throw new NoSuchTableException("Table does not exist: %s", identifier);
       }
 
-      TableMetadata metadata;
       tableProperties.putAll(tableOverrideProperties());
+      UnaryOperator<TableMetadata> replacement =
+          base ->
+              base.buildReplacement(
+                  schema,
+                  spec,
+                  sortOrder,
+                  location != null ? location : base.location(),
+                  tableProperties);
+
+      TableMetadata metadata;
       if (ops.current() != null) {
-        String baseLocation = location != null ? location : ops.current().location();
-        metadata =
-            ops.current().buildReplacement(schema, spec, sortOrder, baseLocation, tableProperties);
+        metadata = replacement.apply(ops.current());
       } else {
         String baseLocation = location != null ? location : defaultWarehouseLocation(identifier);
         metadata =
@@ -251,10 +259,10 @@ public abstract class BaseMetastoreCatalog implements Catalog, Closeable {
 
       if (orCreate) {
         return Transactions.createOrReplaceTableTransaction(
-            identifier.toString(), ops, metadata, metricsReporter());
+            identifier.toString(), ops, metadata, replacement, metricsReporter());
       } else {
         return Transactions.replaceTableTransaction(
-            identifier.toString(), ops, metadata, metricsReporter());
+            identifier.toString(), ops, metadata, replacement, metricsReporter());
       }
     }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -72,6 +73,9 @@ public class BaseTransaction implements Transaction {
       Sets.newHashSet(); // keep track of files deleted in the most recent commit
   private final Consumer<String> enqueueDelete = deletedFiles::add;
   private final TransactionType type;
+  // for replace transactions, rebuilds the replacement metadata from the latest table metadata so a
+  // concurrent writer's snapshots are preserved when the commit is retried; null otherwise
+  private final UnaryOperator<TableMetadata> replacement;
   private TableMetadata base;
   private TableMetadata current;
   private boolean hasLastOpCommitted;
@@ -79,7 +83,7 @@ public class BaseTransaction implements Transaction {
 
   BaseTransaction(
       String tableName, TableOperations ops, TransactionType type, TableMetadata start) {
-    this(tableName, ops, type, start, LoggingMetricsReporter.instance());
+    this(tableName, ops, type, start, null, LoggingMetricsReporter.instance());
   }
 
   BaseTransaction(
@@ -87,6 +91,25 @@ public class BaseTransaction implements Transaction {
       TableOperations ops,
       TransactionType type,
       TableMetadata start,
+      MetricsReporter reporter) {
+    this(tableName, ops, type, start, null, reporter);
+  }
+
+  BaseTransaction(
+      String tableName,
+      TableOperations ops,
+      TransactionType type,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement) {
+    this(tableName, ops, type, start, replacement, LoggingMetricsReporter.instance());
+  }
+
+  BaseTransaction(
+      String tableName,
+      TableOperations ops,
+      TransactionType type,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement,
       MetricsReporter reporter) {
     this.tableName = tableName;
     this.ops = ops;
@@ -96,6 +119,7 @@ public class BaseTransaction implements Transaction {
     this.updates = Lists.newArrayList();
     this.base = ops.current();
     this.type = type;
+    this.replacement = replacement;
     this.hasLastOpCommitted = true;
     this.reporter = reporter;
   }
@@ -312,20 +336,7 @@ public class BaseTransaction implements Transaction {
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {
-                try {
-                  underlyingOps.refresh();
-                } catch (NoSuchTableException e) {
-                  if (!orCreate) {
-                    throw e;
-                  }
-                }
-
-                // because this is a replace table, it will always completely replace the table
-                // metadata. even if it was just updated.
-                if (base != underlyingOps.current()) {
-                  this.base = underlyingOps.current(); // just refreshed
-                }
-
+                refreshReplacement(underlyingOps, orCreate);
                 underlyingOps.commit(base, current);
               });
 
@@ -345,6 +356,42 @@ public class BaseTransaction implements Transaction {
       // retries are not
       // a concern, it is safe to delete all the deleted files from individual operations
       deleteUncommittedFiles(deletedFiles);
+    }
+  }
+
+  // refreshes the underlying table before a replace commit. if a concurrent writer changed the
+  // table, rebuilds the replacement metadata on top of the refreshed table so the concurrent
+  // writer's snapshots are preserved in history (the replacement still becomes the current state),
+  // then re-applies the pending updates to recreate this transaction's snapshot on top. catalogs
+  // that merge changes server-side (e.g. REST) pass no replacement builder and keep their existing
+  // behavior of completely replacing the table metadata.
+  private void refreshReplacement(TableOperations underlyingOps, boolean orCreate) {
+    try {
+      underlyingOps.refresh();
+    } catch (NoSuchTableException e) {
+      if (!orCreate) {
+        throw e;
+      }
+    }
+
+    if (base == underlyingOps.current()) {
+      return;
+    }
+
+    this.base = underlyingOps.current(); // just refreshed
+    if (replacement == null || base == null) {
+      return;
+    }
+
+    TableMetadata rebuilt = replacement.apply(base);
+    // only rebuild when the concurrent change preserves this replacement's schema and spec.
+    // otherwise rebuilding would reassign field ids and break data this transaction already wrote,
+    // so fall back to replacing the table outright (last writer wins).
+    if (rebuilt.schema().sameSchema(current.schema()) && rebuilt.spec().equals(current.spec())) {
+      this.current = rebuilt;
+      for (PendingUpdate update : updates) {
+        update.commit();
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
+import java.util.function.UnaryOperator;
 import java.util.stream.Collectors;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -71,6 +72,9 @@ public class BaseTransaction implements Transaction {
       Sets.newHashSet(); // keep track of files deleted in the most recent commit
   private final Consumer<String> enqueueDelete = deletedFiles::add;
   private final TransactionType type;
+  // for replace transactions, rebuilds the replacement metadata from the latest table metadata so a
+  // concurrent writer's snapshots are preserved when the commit is retried; null otherwise
+  private final UnaryOperator<TableMetadata> replacement;
   private TableMetadata base;
   private TableMetadata current;
   private boolean hasLastOpCommitted;
@@ -78,7 +82,7 @@ public class BaseTransaction implements Transaction {
 
   BaseTransaction(
       String tableName, TableOperations ops, TransactionType type, TableMetadata start) {
-    this(tableName, ops, type, start, LoggingMetricsReporter.instance());
+    this(tableName, ops, type, start, null, LoggingMetricsReporter.instance());
   }
 
   BaseTransaction(
@@ -86,6 +90,25 @@ public class BaseTransaction implements Transaction {
       TableOperations ops,
       TransactionType type,
       TableMetadata start,
+      MetricsReporter reporter) {
+    this(tableName, ops, type, start, null, reporter);
+  }
+
+  BaseTransaction(
+      String tableName,
+      TableOperations ops,
+      TransactionType type,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement) {
+    this(tableName, ops, type, start, replacement, LoggingMetricsReporter.instance());
+  }
+
+  BaseTransaction(
+      String tableName,
+      TableOperations ops,
+      TransactionType type,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement,
       MetricsReporter reporter) {
     this.tableName = tableName;
     this.ops = ops;
@@ -95,6 +118,7 @@ public class BaseTransaction implements Transaction {
     this.updates = Lists.newArrayList();
     this.base = ops.current();
     this.type = type;
+    this.replacement = replacement;
     this.hasLastOpCommitted = true;
     this.reporter = reporter;
   }
@@ -311,20 +335,7 @@ public class BaseTransaction implements Transaction {
           .onlyRetryOn(CommitFailedException.class)
           .run(
               underlyingOps -> {
-                try {
-                  underlyingOps.refresh();
-                } catch (NoSuchTableException e) {
-                  if (!orCreate) {
-                    throw e;
-                  }
-                }
-
-                // because this is a replace table, it will always completely replace the table
-                // metadata. even if it was just updated.
-                if (base != underlyingOps.current()) {
-                  this.base = underlyingOps.current(); // just refreshed
-                }
-
+                refreshReplacement(underlyingOps, orCreate);
                 underlyingOps.commit(base, current);
               });
 
@@ -344,6 +355,42 @@ public class BaseTransaction implements Transaction {
       // retries are not
       // a concern, it is safe to delete all the deleted files from individual operations
       deleteUncommittedFiles(deletedFiles);
+    }
+  }
+
+  // refreshes the underlying table before a replace commit. if a concurrent writer changed the
+  // table, rebuilds the replacement metadata on top of the refreshed table so the concurrent
+  // writer's snapshots are preserved in history (the replacement still becomes the current state),
+  // then re-applies the pending updates to recreate this transaction's snapshot on top. catalogs
+  // that merge changes server-side (e.g. REST) pass no replacement builder and keep their existing
+  // behavior of completely replacing the table metadata.
+  private void refreshReplacement(TableOperations underlyingOps, boolean orCreate) {
+    try {
+      underlyingOps.refresh();
+    } catch (NoSuchTableException e) {
+      if (!orCreate) {
+        throw e;
+      }
+    }
+
+    if (base == underlyingOps.current()) {
+      return;
+    }
+
+    this.base = underlyingOps.current(); // just refreshed
+    if (replacement == null || base == null) {
+      return;
+    }
+
+    TableMetadata rebuilt = replacement.apply(base);
+    // only rebuild when the concurrent change preserves this replacement's schema and spec.
+    // otherwise rebuilding would reassign field ids and break data this transaction already wrote,
+    // so fall back to replacing the table outright (last writer wins).
+    if (rebuilt.schema().sameSchema(current.schema()) && rebuilt.spec().equals(current.spec())) {
+      this.current = rebuilt;
+      for (PendingUpdate update : updates) {
+        update.commit();
+      }
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/Transactions.java
+++ b/core/src/main/java/org/apache/iceberg/Transactions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import java.util.function.UnaryOperator;
 import org.apache.iceberg.BaseTransaction.TransactionType;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -36,6 +37,32 @@ public final class Transactions {
         tableName, ops, TransactionType.CREATE_OR_REPLACE_TABLE, start, reporter);
   }
 
+  /**
+   * Start a create-or-replace transaction that rebuilds its replacement metadata if a concurrent
+   * writer changes the table before the transaction commits.
+   *
+   * @param replacement builds the replacement metadata from the latest table metadata; used to
+   *     rebuild the transaction's metadata on commit retry so concurrent snapshots are preserved
+   */
+  public static Transaction createOrReplaceTableTransaction(
+      String tableName,
+      TableOperations ops,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement) {
+    return new BaseTransaction(
+        tableName, ops, TransactionType.CREATE_OR_REPLACE_TABLE, start, replacement);
+  }
+
+  public static Transaction createOrReplaceTableTransaction(
+      String tableName,
+      TableOperations ops,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement,
+      MetricsReporter reporter) {
+    return new BaseTransaction(
+        tableName, ops, TransactionType.CREATE_OR_REPLACE_TABLE, start, replacement, reporter);
+  }
+
   public static Transaction replaceTableTransaction(
       String tableName, TableOperations ops, TableMetadata start) {
     return new BaseTransaction(tableName, ops, TransactionType.REPLACE_TABLE, start);
@@ -44,6 +71,31 @@ public final class Transactions {
   public static Transaction replaceTableTransaction(
       String tableName, TableOperations ops, TableMetadata start, MetricsReporter reporter) {
     return new BaseTransaction(tableName, ops, TransactionType.REPLACE_TABLE, start, reporter);
+  }
+
+  /**
+   * Start a replace transaction that rebuilds its replacement metadata if a concurrent writer
+   * changes the table before the transaction commits.
+   *
+   * @param replacement builds the replacement metadata from the latest table metadata; used to
+   *     rebuild the transaction's metadata on commit retry so concurrent snapshots are preserved
+   */
+  public static Transaction replaceTableTransaction(
+      String tableName,
+      TableOperations ops,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement) {
+    return new BaseTransaction(tableName, ops, TransactionType.REPLACE_TABLE, start, replacement);
+  }
+
+  public static Transaction replaceTableTransaction(
+      String tableName,
+      TableOperations ops,
+      TableMetadata start,
+      UnaryOperator<TableMetadata> replacement,
+      MetricsReporter reporter) {
+    return new BaseTransaction(
+        tableName, ops, TransactionType.REPLACE_TABLE, start, replacement, reporter);
   }
 
   public static Transaction createTableTransaction(

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTables.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.hadoop;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -369,17 +370,19 @@ public class HadoopTables implements Tables, Configurable {
       }
 
       Map<String, String> properties = propertiesBuilder.build();
+      UnaryOperator<TableMetadata> replacement =
+          base -> base.buildReplacement(schema, spec, sortOrder, location, properties);
       TableMetadata metadata;
       if (ops.current() != null) {
-        metadata = ops.current().buildReplacement(schema, spec, sortOrder, location, properties);
+        metadata = replacement.apply(ops.current());
       } else {
         metadata = tableMetadata(schema, spec, sortOrder, properties, location);
       }
 
       if (orCreate) {
-        return Transactions.createOrReplaceTableTransaction(location, ops, metadata);
+        return Transactions.createOrReplaceTableTransaction(location, ops, metadata, replacement);
       } else {
-        return Transactions.replaceTableTransaction(location, ops, metadata);
+        return Transactions.replaceTableTransaction(location, ops, metadata, replacement);
       }
     }
   }

--- a/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
+++ b/core/src/test/java/org/apache/iceberg/TestReplaceTransaction.java
@@ -316,6 +316,44 @@ public class TestReplaceTransaction extends TestBase {
   }
 
   @TestTemplate
+  public void testReplaceTransactionConcurrentCommitRetainsHistory() {
+    // use random snapshot ids (like real catalogs) so the replace's snapshot and the concurrent
+    // writer's snapshot do not collide on the sequential ids that TestTables assigns by default
+    table.updateProperties().set("random-snapshot-ids", "true").commit();
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    validateSnapshot(null, table.currentSnapshot(), FILE_A);
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+
+    // start a replace that will make FILE_B the new current data
+    Transaction replace = TestTables.beginReplace(tableDir, "test", table.schema(), table.spec());
+    replace.newAppend().appendFile(FILE_B).commit();
+
+    // a concurrent writer commits FILE_C out-of-band, forcing the replace commit to retry
+    table.newAppend().appendFile(FILE_C).commit();
+    long concurrentSnapshotId = table.currentSnapshot().snapshotId();
+
+    replace.commitTransaction();
+
+    table.refresh();
+
+    // the replace wins for the current state
+    assertThat(table.currentSnapshot()).isNotNull();
+    validateSnapshot(null, table.currentSnapshot(), FILE_B);
+
+    // regression for #16942: a concurrent writer's snapshot committed during the replace must
+    // remain in the table history rather than being silently dropped on commit retry
+    assertThat(table.snapshot(concurrentSnapshotId))
+        .as("Concurrent writer's snapshot should be preserved in history")
+        .isNotNull();
+    assertThat(table.snapshot(firstSnapshotId))
+        .as("Original snapshot should be preserved in history")
+        .isNotNull();
+    assertThat(table.snapshots()).hasSize(3);
+  }
+
+  @TestTemplate
   public void testReplaceToCreateAndAppend() throws IOException {
     // this table doesn't exist.
     Transaction replace = TestTables.beginReplace(tableDir, "test_append", SCHEMA, unpartitioned());

--- a/core/src/test/java/org/apache/iceberg/TestTables.java
+++ b/core/src/test/java/org/apache/iceberg/TestTables.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.TableMetadata.newTableMetadata;
 
 import java.io.File;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -204,8 +205,10 @@ public class TestTables {
     TableMetadata current = ops.current();
     TableMetadata metadata;
     if (current != null) {
-      metadata = current.buildReplacement(schema, spec, sortOrder, current.location(), properties);
-      return Transactions.replaceTableTransaction(name, ops, metadata);
+      UnaryOperator<TableMetadata> replacement =
+          base -> base.buildReplacement(schema, spec, sortOrder, base.location(), properties);
+      metadata = replacement.apply(current);
+      return Transactions.replaceTableTransaction(name, ops, metadata, replacement);
     } else {
       metadata = newTableMetadata(schema, spec, sortOrder, temp.toURI().toString(), properties);
       return Transactions.createTableTransaction(name, ops, metadata);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCreateReplaceTable.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCreateReplaceTable.java
@@ -235,11 +235,13 @@ public class TestHiveCreateReplaceTable {
     txn.updateProperties().set("prop", "value").commit();
     txn.commitTransaction();
 
-    // the replace should still succeed
+    // the replace should still succeed, and the property the concurrent writer committed during
+    // the replace transaction must be preserved on retry. this is the same rebuild that preserves
+    // concurrent snapshots and matches REST delta semantics - see #16942
     table = catalog.loadTable(TABLE_IDENTIFIER);
     assertThat(table.properties())
-        .as("Table props should be updated")
-        .doesNotContainKey("another-prop")
+        .as("Replace retry should preserve concurrent property updates")
+        .containsEntry("another-prop", "another-value")
         .containsEntry("prop", "value");
   }
 


### PR DESCRIPTION
Closes #16942

## Problem

`createOrReplace` and `replace` build their replacement metadata from the table state captured when the transaction starts, and `TableMetadata.buildReplacement` keeps the existing snapshot history. When two such transactions run concurrently, the one that loses the optimistic-lock race retries in `BaseTransaction.commitReplaceTransaction`, but the retry advanced `base` to the refreshed metadata while re-committing the stale replacement built from the original base. As a result, any snapshot the concurrent writer committed in between was silently dropped from history. This contradicts the documented behavior that replacing a table keeps its history (`docs/docs/spark-ddl.md`) and is inconsistent with sequential replace, which preserves all snapshots. It affects full-metadata-rewrite catalogs (Hadoop, Hive, Glue, JDBC, Nessie, in-memory); REST already merges these changes server-side.

See #16942 for the minimal reproduction.

## Fix

On a replace commit retry, when a concurrent change is detected, the replacement metadata is rebuilt on top of the refreshed table and the transaction's pending updates are re-applied. The concurrent writer's snapshots stay in history while the replacement still becomes the current state, mirroring how the simple-transaction path re-applies its updates after a refresh. The rebuild is skipped when the concurrent change altered the schema or partition spec, since re-running `buildReplacement` would reassign field ids and break data this transaction already wrote; in that case the existing last-writer-wins behavior is retained. Catalogs that merge changes server-side (REST) pass no rebuild function and are unaffected.

Because the replacement is now rebuilt on the refreshed base, a concurrent writer's property updates committed during a replace transaction are also preserved on retry, where the metadata-rewrite catalogs (Hadoop, Hive) previously clobbered them. `buildReplacement` overlays the replace's properties on top of the base it is built from, so a concurrently-set property that is already on the refreshed base is carried forward. This brings those catalogs in line with REST, which applies the replace as a delta and never removes a concurrently-set property server-side.

## Tests

Added `TestReplaceTransaction.testReplaceTransactionConcurrentCommitRetainsHistory`, which forces a concurrent commit during a replace and asserts the concurrent writer's snapshot stays in history while the replacement wins the current state. It fails without the fix and passes with it across all format versions. The existing concurrent-replace coverage in `CatalogTests` (including the schema and partition-spec variants) continues to pass for in-memory, JDBC, and REST catalogs. `TestHiveCreateReplaceTable.testReplaceTableTxnTableModifiedConcurrently` was updated to assert that the concurrent property update is now preserved, reflecting the REST-consistent behavior described above.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Fix createOrReplace and replace transactions dropping concurrently committed snapshots by rebuilding the replacement metadata on the refreshed base.
