### PR TITLE
Flink: Backport: Add equality delete conversion planner (#16889)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -1,0 +1,762 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Planner for the equality delete conversion pipeline. For each trigger, it picks the oldest
+ * staging snapshot that hasn't been converted yet and emits {@link ReadCommand}s describing the
+ * files its downstream readers and workers must process.
+ *
+ * <p>Each trigger runs two steps in order:
+ *
+ * <ol>
+ *   <li>{@link #ensureIndexCurrent}: updates {@link #lastStagingSnapshotId} from main's history,
+ *       bootstraps the worker index from main on first run, and reindexes when external commits
+ *       (e.g. compaction) have advanced main past the currently-indexed snapshot.
+ *   <li>{@link #processStagingSnapshot}: resolve the chosen staging snapshot's eq deletes against
+ *       the (now-current) index, pass through any DV files, and index the snapshot's new data files
+ *       for the next cycle.
+ * </ol>
+ *
+ * Watermarks separate phases that gate the worker's keyed state. The contract is documented on
+ * {@link #advancePhase()}.
+ *
+ * <p>An {@link EqualityConvertPlan} with the current cycle's metadata is emitted via the {@link
+ * #METADATA_STREAM} side output after the read commands.
+ *
+ * <p>Assumes a single equality-field set supplied via the builder; staging eq-deletes with a
+ * different {@code equalityFieldIds} fail fast in {@link #retrieveStagingFiles}. Concurrent writes
+ * on the target branch are handled by {@link #ensureIndexCurrent} reindexing from the new main
+ * snapshot; commit-time conflicts are caught by {@code RowDelta.validateFromSnapshot}.
+ */
+@Internal
+public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
+    implements OneInputStreamOperator<Trigger, ReadCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPlanner.class);
+
+  public static final OutputTag<EqualityConvertPlan> METADATA_STREAM =
+      new OutputTag<>("metadata-stream") {};
+
+  public static final OutputTag<IndexCommand> CLEAR_BROADCAST_STREAM =
+      new OutputTag<>("clear-broadcast-stream") {};
+
+  private static final String PROCESSED_EQ_DELETE_FILE_NUM_METRIC = "processedEqDeleteFileNum";
+  private static final String PROCESSED_STAGING_SNAPSHOT_NUM_METRIC = "processedStagingSnapshotNum";
+  private static final String SKIPPED_NO_OP_CYCLES_METRIC = "skippedNoOpCycles";
+  private static final String REINDEX_COUNT_METRIC = "reindexCount";
+
+  private final String tableName;
+  private final String taskName;
+  private final TableLoader tableLoader;
+  private final String stagingBranch;
+  private final String targetBranch;
+  private final boolean stagingOnTargetBranch;
+  // Equality-field-id set the worker keys on. Supplied via the builder; every staging
+  // eq-delete's equalityFieldIds() must match exactly.
+  private final Set<Integer> eqFieldIds;
+
+  // Main snapshot id the worker's index reflects.
+  private transient ListState<Long> indexSnapshotState;
+  // Main sequence number the worker's index reflects.
+  private transient ListState<Long> indexedSequenceNumberState;
+  // Equality field IDs the index was built with, allows to detect reconfiguration.
+  private transient ListState<Integer> eqFieldIdsState;
+
+  private transient Table table;
+
+  private transient Long lastMainSnapshotId;
+  private transient Long lastStagingSnapshotId;
+  private transient Long indexSnapshotId;
+  private transient Long indexedSequenceNumber;
+
+  private transient long nextPhaseTs;
+
+  private transient Counter processedEqDeleteFileNumCounter;
+  private transient Counter processedStagingSnapshotNumCounter;
+  private transient Counter skippedNoOpCyclesCounter;
+  private transient Counter reindexCounter;
+  private transient Counter errorCounter;
+
+  public EqualityConvertPlanner(
+      String tableName,
+      String taskName,
+      TableLoader tableLoader,
+      String stagingBranch,
+      String targetBranch,
+      Set<Integer> eqFieldIds) {
+    this.tableName = tableName;
+    this.taskName = taskName;
+    this.tableLoader = tableLoader;
+    this.stagingBranch = stagingBranch;
+    this.targetBranch = targetBranch;
+    this.stagingOnTargetBranch = stagingBranch.equals(targetBranch);
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+
+    MetricGroup taskMetricGroup =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, 0);
+    this.processedEqDeleteFileNumCounter =
+        taskMetricGroup.counter(PROCESSED_EQ_DELETE_FILE_NUM_METRIC);
+    this.processedStagingSnapshotNumCounter =
+        taskMetricGroup.counter(PROCESSED_STAGING_SNAPSHOT_NUM_METRIC);
+    this.skippedNoOpCyclesCounter = taskMetricGroup.counter(SKIPPED_NO_OP_CYCLES_METRIC);
+    this.reindexCounter = taskMetricGroup.counter(REINDEX_COUNT_METRIC);
+    this.errorCounter = taskMetricGroup.counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    indexSnapshotState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexSnapshotId", Types.LONG));
+
+    indexSnapshotId = null;
+    for (Long stateValue : indexSnapshotState.get()) {
+      Preconditions.checkState(
+          indexSnapshotId == null, "indexSnapshotId state should hold at most one value");
+      indexSnapshotId = stateValue;
+    }
+
+    indexedSequenceNumberState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexedSequenceNumber", Types.LONG));
+
+    indexedSequenceNumber = null;
+    for (Long stateValue : indexedSequenceNumberState.get()) {
+      Preconditions.checkState(
+          indexedSequenceNumber == null,
+          "indexedSequenceNumber state should hold at most one value");
+      indexedSequenceNumber = stateValue;
+    }
+
+    eqFieldIdsState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("eqFieldIds", Types.INT));
+    Set<Integer> restoredEqFieldIds = Sets.newHashSet(eqFieldIdsState.get());
+    Preconditions.checkState(
+        restoredEqFieldIds.isEmpty() || restoredEqFieldIds.equals(eqFieldIds),
+        "Equality field IDs changed across restart: restored=%s, configured=%s. "
+            + "Reconfiguring equality-field columns is not supported; "
+            + "restart from a clean state (no savepoint).",
+        restoredEqFieldIds,
+        eqFieldIds);
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    indexSnapshotState.clear();
+    if (indexSnapshotId != null) {
+      indexSnapshotState.add(indexSnapshotId);
+    }
+
+    indexedSequenceNumberState.clear();
+    if (indexedSequenceNumber != null) {
+      indexedSequenceNumberState.add(indexedSequenceNumber);
+    }
+
+    eqFieldIdsState.clear();
+    for (int id : eqFieldIds) {
+      eqFieldIdsState.add(id);
+    }
+  }
+
+  @Override
+  public void processElement(StreamRecord<Trigger> element) throws Exception {
+    long triggerTs = element.getTimestamp();
+    nextPhaseTs = Math.max(triggerTs, nextPhaseTs + 1);
+
+    Long currentMainSnapshotId = lastMainSnapshotId;
+    try {
+      table.refresh();
+      Snapshot mainSnapshot = table.snapshot(targetBranch);
+      currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+      ensureIndexCurrent(mainSnapshot);
+
+      Snapshot nextToProcess =
+          nextUnprocessedStagingSnapshot(table.snapshot(stagingBranch), mainSnapshot);
+
+      if (nextToProcess == null) {
+        LOG.info("Nothing new to convert on staging branch '{}'.", stagingBranch);
+        emitNoOpResult(triggerTs, currentMainSnapshotId);
+        return;
+      }
+
+      processStagingSnapshot(nextToProcess, triggerTs, currentMainSnapshotId);
+    } catch (Exception e) {
+      LOG.error("Error processing equality deletes for table {} task {}", tableName, taskName, e);
+      output.collect(TaskResultAggregator.ERROR_STREAM, new StreamRecord<>(e));
+      errorCounter.inc();
+      emitDrainResult(triggerTs, currentMainSnapshotId);
+    }
+  }
+
+  /**
+   * Brings the worker's index up to date with the current state of the target branch:
+   *
+   * <ul>
+   *   <li>Updates {@link #lastStagingSnapshotId} from the most recent committer marker on main.
+   *   <li>Bootstraps the index from main on the first trigger with a non-null main snapshot.
+   *   <li>Reindexes from main when external commits (e.g. compaction or direct writes) have
+   *       advanced main past the currently-indexed snapshot.
+   * </ul>
+   *
+   * <p>No-op when main hasn't moved since the last trigger. Otherwise the history walk is bounded
+   * to commits added since {@link #lastMainSnapshotId}.
+   */
+  private void ensureIndexCurrent(Snapshot mainSnapshot) {
+    Long currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+    if (Objects.equals(lastMainSnapshotId, currentMainSnapshotId)) {
+      return;
+    }
+
+    LastCommittedWork info = discoverLastCommittedWork(mainSnapshot);
+    updateLastStagingSnapshotId(info);
+
+    boolean bootstrap = mainSnapshot != null && indexSnapshotId == null;
+    boolean reindex = indexSnapshotId != null && info.externalCommitCount() > 0;
+    if (bootstrap || reindex) {
+      LOG.info(
+          "{} worker index from main snapshot {} for field IDs {}.",
+          bootstrap ? "Bootstrapping" : "Reindexing",
+          currentMainSnapshotId,
+          eqFieldIds);
+      if (reindex) {
+        // Evict keyed entries the reindex will not re-add (e.g. data file removed by CoW).
+        output.collect(
+            CLEAR_BROADCAST_STREAM,
+            new StreamRecord<>(
+                IndexCommand.clearBeforeReindex(
+                    currentMainSnapshotId, mainSnapshot.sequenceNumber())));
+        reindexCounter.inc();
+      }
+
+      indexSnapshotId = currentMainSnapshotId;
+      indexedSequenceNumber = mainSnapshot.sequenceNumber();
+      emitMainDataReadCommands(mainSnapshot);
+    }
+
+    lastMainSnapshotId = currentMainSnapshotId;
+  }
+
+  private void updateLastStagingSnapshotId(LastCommittedWork info) {
+    if (info.lastCommittedStaging() != null) {
+      lastStagingSnapshotId = info.lastCommittedStaging();
+      return;
+    }
+
+    Preconditions.checkState(
+        lastMainSnapshotId == null || lastStagingSnapshotId == null || info.reachedLastInspected(),
+        "No COMMITTED_STAGING_SNAPSHOT marker reachable on target branch '%s' for table %s, "
+            + "but a prior marker was seen (lastStagingSnapshotId=%s). Target may have been "
+            + "rewritten (rollback, replace_main, or snapshot expiration). "
+            + "Manual intervention required.",
+        targetBranch,
+        tableName,
+        lastStagingSnapshotId);
+  }
+
+  /**
+   * Walks main back from head looking for the most recent snapshot tagged with {@link
+   * EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}. Returns the staging snapshot id
+   * recorded there (or {@code null} if not reached) and the count of intervening external commits.
+   *
+   * <p>The walk stops at whichever comes first:
+   *
+   * <ul>
+   *   <li>The first snapshot carrying the committer marker.
+   *   <li>{@link #lastMainSnapshotId} — anything older was inspected on a previous trigger.
+   * </ul>
+   */
+  private LastCommittedWork discoverLastCommittedWork(Snapshot mainSnapshot) {
+    Long lastCommittedStaging = null;
+    int externalCount = 0;
+    boolean reachedLastInspected = false;
+    Snapshot current = mainSnapshot;
+    while (current != null) {
+      if (lastMainSnapshotId != null && current.snapshotId() == lastMainSnapshotId) {
+        reachedLastInspected = true;
+        break;
+      }
+
+      String prop =
+          current.summary().get(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY);
+      if (prop != null) {
+        lastCommittedStaging = Long.parseLong(prop);
+        break;
+      }
+
+      externalCount++;
+      current = parentOf(current);
+    }
+
+    return new LastCommittedWork(lastCommittedStaging, externalCount, reachedLastInspected);
+  }
+
+  private record LastCommittedWork(
+      Long lastCommittedStaging, int externalCommitCount, boolean reachedLastInspected) {}
+
+  /**
+   * Walks staging history from head back to the stop point and returns the oldest unprocessed
+   * snapshot to convert this cycle, or {@code null} if there's nothing new.
+   *
+   * <p>The stop point is:
+   *
+   * <ul>
+   *   <li>the last-processed staging snapshot, if known;
+   *   <li>otherwise, on cold start with {@code stagingBranch != targetBranch}, the common ancestor
+   *       with target;
+   *   <li>otherwise, on cold start with {@code stagingBranch == targetBranch}, the root of history
+   *       ({@code null}). {@link #shouldSkip} filters already-converted snapshots in O(1) via the
+   *       {@code COMMITTED_STAGING_SNAPSHOT_PROPERTY} marker, and pure-insert snapshots via the
+   *       same-branch eq-delete predicate.
+   * </ul>
+   *
+   * <p>When {@code stagingBranch == targetBranch}, the writer commits eq-deletes and data files
+   * directly to target; the converter performs in-place eq-delete-to-DV compaction. On cold start
+   * we walk the full history so eq-deletes committed before the converter started are still picked
+   * up.
+   */
+  private Snapshot nextUnprocessedStagingSnapshot(Snapshot stagingHead, Snapshot mainSnapshot) {
+    if (stagingHead == null) {
+      return null;
+    }
+
+    Long stopAt;
+    if (lastStagingSnapshotId != null) {
+      stopAt = lastStagingSnapshotId;
+    } else if (stagingOnTargetBranch) {
+      stopAt = null;
+    } else {
+      stopAt = findCommonAncestor(stagingHead, mainSnapshot);
+    }
+
+    Snapshot current = stagingHead;
+    Snapshot oldestUnprocessed = null;
+    while (current != null) {
+      if (stopAt != null && current.snapshotId() == stopAt) {
+        break;
+      }
+
+      if (!shouldSkip(current)) {
+        oldestUnprocessed = current;
+      }
+
+      current = parentOf(current);
+    }
+
+    return oldestUnprocessed;
+  }
+
+  /**
+   * Resolves the eq deletes in {@code stagingSnapshot} against the current index and emits the
+   * cycle's metadata. Phase ordering (separated by watermarks):
+   *
+   * <ol>
+   *   <li>Eq delete read commands. Eq deletes resolve in the worker.
+   *   <li>Staging data files. Indexed for the NEXT cycle's eq-delete resolution.
+   * </ol>
+   *
+   * Cold-start bootstrap of the index from main data is handled separately in {@link
+   * #processElement}, which runs once before the first cycle.
+   */
+  private void processStagingSnapshot(
+      Snapshot stagingSnapshot, long triggerTs, Long currentMainSnapshotId) {
+
+    StagingInputs inputs = retrieveStagingFiles(stagingSnapshot);
+    Preconditions.checkState(
+        !inputs.isEmpty(),
+        "Staging snapshot %s has no convertible inputs; shouldSkip should have filtered it.",
+        stagingSnapshot.snapshotId());
+
+    emitDeletePhase(inputs.eqDeleteFiles());
+    emitSnapshotDataPhase(inputs.newDataFiles());
+
+    LOG.info(
+        "Emitted read commands for {} new data files from staging branch '{}'.",
+        inputs.newDataFiles().size(),
+        stagingBranch);
+
+    processedStagingSnapshotNumCounter.inc();
+
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            new EqualityConvertPlan(
+                inputs.newDataFiles(),
+                inputs.stagingDVFiles(),
+                stagingSnapshot.snapshotId(),
+                currentMainSnapshotId,
+                triggerTs,
+                nextPhaseTs)));
+
+    advancePhase();
+  }
+
+  /**
+   * Classifies the files added by {@code stagingSnapshot} into data files, eq delete files, and DV
+   * files. Throws if the snapshot:
+   *
+   * <ul>
+   *   <li>Removes data files (rewrites on the staging branch aren't supported).
+   *   <li>Contains V2 positional delete files (the converter expects a V3 staging branch written by
+   *       Flink, which produces only deletion vectors for deletes).
+   *   <li>Contains an eq-delete file whose {@code equalityFieldIds()} doesn't match the
+   *       builder-configured set (silent wrong-key serialization otherwise).
+   * </ul>
+   */
+  private StagingInputs retrieveStagingFiles(Snapshot stagingSnapshot) {
+    SnapshotChanges changes = SnapshotChanges.builderFor(table).snapshot(stagingSnapshot).build();
+
+    // Rewrites on the staging branch would require rewriting the corresponding DVs against new
+    // data files on target. Not implemented; fail fast instead of silently dropping work.
+    if (changes.removedDataFiles().iterator().hasNext()) {
+      throw new IllegalStateException(
+          String.format(
+              "Staging snapshot %s on branch '%s' removes data files; "
+                  + "equality delete conversion does not support rewrites on the staging branch. "
+                  + "Run compaction on the target branch instead.",
+              stagingSnapshot.snapshotId(), stagingBranch));
+    }
+
+    List<DataFile> newDataFiles = Lists.newArrayList();
+    List<DeleteFile> stagingDVFiles = Lists.newArrayList();
+    List<DeleteFile> eqDeleteFiles = Lists.newArrayList();
+
+    for (DataFile dataFile : changes.addedDataFiles()) {
+      newDataFiles.add(dataFile);
+    }
+
+    for (DeleteFile deleteFile : changes.addedDeleteFiles()) {
+      if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+        Set<Integer> deleteFieldIds = Sets.newHashSet(deleteFile.equalityFieldIds());
+        Preconditions.checkState(
+            deleteFieldIds.equals(eqFieldIds),
+            "Staging snapshot %s on branch '%s' contains an equality delete file %s with "
+                + "equalityFieldIds=%s, which does not match the configured eqFieldIds=%s. "
+                + "The writer must use the same equality field IDs as the converter.",
+            stagingSnapshot.snapshotId(),
+            stagingBranch,
+            deleteFile.location(),
+            deleteFieldIds,
+            eqFieldIds);
+        eqDeleteFiles.add(deleteFile);
+      } else if (ContentFileUtil.isDV(deleteFile)) {
+        stagingDVFiles.add(deleteFile);
+      } else {
+        throw new IllegalStateException(
+            String.format(
+                "Staging snapshot %s on branch '%s' contains a V2 positional delete file (%s); "
+                    + "equality delete conversion expects a V3 staging branch written by Flink, "
+                    + "which produces only deletion vectors for deletes.",
+                stagingSnapshot.snapshotId(), stagingBranch, deleteFile.location()));
+      }
+    }
+
+    return new StagingInputs(newDataFiles, stagingDVFiles, eqDeleteFiles);
+  }
+
+  /** Files added by one staging snapshot, classified for cycle emission. */
+  private record StagingInputs(
+      List<DataFile> newDataFiles,
+      List<DeleteFile> stagingDVFiles,
+      List<DeleteFile> eqDeleteFiles) {
+
+    boolean isEmpty() {
+      return newDataFiles.isEmpty() && eqDeleteFiles.isEmpty() && stagingDVFiles.isEmpty();
+    }
+  }
+
+  private void emitDeletePhase(List<DeleteFile> eqDeleteFiles) {
+    for (DeleteFile deleteFile : eqDeleteFiles) {
+      PartitionSpec spec = table.specs().get(deleteFile.specId());
+      output.collect(
+          new StreamRecord<>(
+              ReadCommand.eqDeleteFile(
+                  deleteFile,
+                  spec,
+                  indexSnapshotId,
+                  indexedSequenceNumber,
+                  dataSequenceNumber(deleteFile)),
+              nextPhaseTs));
+      processedEqDeleteFileNumCounter.inc();
+    }
+
+    advancePhase();
+  }
+
+  private void emitSnapshotDataPhase(List<DataFile> snapshotDataFiles) {
+    // Shared-branch skip: when stagingBranch == targetBranch, these files are already on target
+    // and were indexed by bootstrap/reindex. Re-emitting would duplicate entries in
+    // dataRowPositions.
+    if (!stagingOnTargetBranch) {
+      for (DataFile dataFile : snapshotDataFiles) {
+        PartitionSpec spec = table.specs().get(dataFile.specId());
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.stagingDataFile(
+                    new FlinkAddedRowsScanTask(dataFile, spec),
+                    indexSnapshotId,
+                    indexedSequenceNumber,
+                    dataSequenceNumber(dataFile)),
+                nextPhaseTs));
+      }
+    }
+
+    advancePhase();
+  }
+
+  private void emitNoOpResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    skippedNoOpCyclesCounter.inc();
+    emitDrainResult(triggerTimestamp, currentMainSnapshotId);
+  }
+
+  /** Emits an empty plan result and advances the phase so the pipeline drains. */
+  private void emitDrainResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            EqualityConvertPlan.noOp(currentMainSnapshotId, triggerTimestamp, nextPhaseTs)));
+    advancePhase();
+  }
+
+  /**
+   * Emits {@link ReadCommand}s for every data file on {@code mainSnapshot} so the worker indexes
+   * them for the configured equality-field set. Existing DVs attached to a data file are loaded by
+   * the reader and their positions are skipped. V2 positional deletes are not expected on main; the
+   * reader throws if it encounters one. Equality deletes attached to the scan task are skipped
+   * during indexing (they are processed via the planner's eq-delete read commands).
+   */
+  private void emitMainDataReadCommands(Snapshot mainSnapshot) {
+    long commitSnapshotId = mainSnapshot.snapshotId();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+      for (FileScanTask task : tasks) {
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.dataFile(
+                    task, indexSnapshotId, indexedSequenceNumber, dataSequenceNumber(task.file())),
+                nextPhaseTs));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to plan files for main index", e);
+    }
+
+    LOG.info(
+        "Emitted main data read commands for field IDs {} from snapshot {}.",
+        eqFieldIds,
+        commitSnapshotId);
+
+    advancePhase();
+  }
+
+  /**
+   * Emits a phase-end watermark and bumps the phase timestamp. Every phase-emitting method must
+   * call this exactly once after its records; the worker uses these watermarks to gate keyed-state
+   * transitions. Missing or extra calls silently break ordering.
+   */
+  private void advancePhase() {
+    output.emitWatermark(new Watermark(nextPhaseTs));
+    nextPhaseTs++;
+  }
+
+  /**
+   * Returns {@code true} if {@code snapshot} can be skipped:
+   *
+   * <ul>
+   *   <li>It was already committed by us (carries {@link
+   *       EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}), OR
+   *   <li>it adds no data or delete files (e.g. delete-file-only removals), OR
+   *   <li>{@code stagingBranch == targetBranch} and the snapshot adds no equality-delete files.
+   *       Pure-insert (and data-file-only) commits on the shared branch don't need a conversion
+   *       cycle: their data is already on target, and the worker's index stays fresh via {@link
+   *       #ensureIndexCurrent} when the next eq-delete arrives.
+   * </ul>
+   *
+   * <p>Filter checks read per-snapshot counts from {@link Snapshot#summary()}; we don't parse
+   * manifests here. Manifest parsing happens later in {@link #retrieveStagingFiles} only for the
+   * chosen snapshot.
+   */
+  private boolean shouldSkip(Snapshot snapshot) {
+    Map<String, String> summary = snapshot.summary();
+    if (summary.containsKey(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY)) {
+      return true;
+    }
+
+    long addedDataFiles = summaryCount(summary, SnapshotSummary.ADDED_FILES_PROP);
+    long addedDeleteFiles = summaryCount(summary, SnapshotSummary.ADDED_DELETE_FILES_PROP);
+    if (addedDataFiles == 0 && addedDeleteFiles == 0) {
+      LOG.info(
+          "Skipping staging snapshot {}: no added data or delete files.", snapshot.snapshotId());
+      return true;
+    }
+
+    if (stagingOnTargetBranch
+        && summaryCount(summary, SnapshotSummary.ADD_EQ_DELETE_FILES_PROP) == 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private static long summaryCount(Map<String, String> summary, String key) {
+    String value = summary.get(key);
+    return value == null ? 0L : Long.parseLong(value);
+  }
+
+  /**
+   * Returns the id of the newest snapshot that is reachable from both the staging and target branch
+   * heads (i.e. the most recent common ancestor where the two branches last matched), or {@code
+   * null} if they share no history. Used on cold start to know where staging diverged from target
+   * so we can skip converting snapshots that already exist on target.
+   */
+  private Long findCommonAncestor(Snapshot stagingHead, Snapshot mainHead) {
+    if (mainHead == null) {
+      return null;
+    }
+
+    Set<Long> stagingSeen = Sets.newHashSet();
+    Set<Long> mainSeen = Sets.newHashSet();
+    Snapshot stagingCurrent = stagingHead;
+    Snapshot mainCurrent = mainHead;
+
+    while (stagingCurrent != null || mainCurrent != null) {
+      if (stagingCurrent != null) {
+        long id = stagingCurrent.snapshotId();
+        if (mainSeen.contains(id)) {
+          return id;
+        }
+
+        stagingSeen.add(id);
+        stagingCurrent = parentOf(stagingCurrent);
+      }
+
+      if (mainCurrent != null) {
+        long id = mainCurrent.snapshotId();
+        if (stagingSeen.contains(id)) {
+          return id;
+        }
+
+        mainSeen.add(id);
+        mainCurrent = parentOf(mainCurrent);
+      }
+    }
+
+    return null;
+  }
+
+  /** Returns the parent snapshot, or {@code null} if {@code snapshot} has no parent. */
+  private Snapshot parentOf(Snapshot snapshot) {
+    Long parentId = snapshot.parentId();
+    return parentId != null ? table.snapshot(parentId) : null;
+  }
+
+  private static long dataSequenceNumber(ContentFile<?> file) {
+    Long sequenceNumber = file.dataSequenceNumber();
+    Preconditions.checkNotNull(
+        sequenceNumber, "Missing data sequence number for committed file %s", file.location());
+    return sequenceNumber;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  @VisibleForTesting
+  long reindexCount() {
+    return reindexCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long skippedNoOpCycles() {
+    return skippedNoOpCyclesCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long processedStagingSnapshotNum() {
+    return processedStagingSnapshotNumCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long processedEqDeleteFileNum() {
+    return processedEqDeleteFileNumCounter.getCount();
+  }
+}

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityDeleteFileScanTask.java
@@ -29,10 +29,30 @@ import org.apache.iceberg.expressions.Expressions;
  * {@link ContentScanTask} for reading a single equality delete file standalone. The {@link
  * DeleteFile#equalityFieldIds()} on {@link #file()} carries the PK field IDs the worker resolves
  * against.
+ *
+ * <p>A plain class rather than a record so it round-trips through Flink's Kryo fallback on Flink
+ * 1.20, whose bundled Kryo 2.x cannot build a serializer for record classes.
  */
 @Internal
-record EqualityDeleteFileScanTask(DeleteFile file, PartitionSpec spec)
-    implements ContentScanTask<DeleteFile> {
+class EqualityDeleteFileScanTask implements ContentScanTask<DeleteFile> {
+
+  private final DeleteFile file;
+  private final PartitionSpec spec;
+
+  EqualityDeleteFileScanTask(DeleteFile file, PartitionSpec spec) {
+    this.file = file;
+    this.spec = spec;
+  }
+
+  @Override
+  public DeleteFile file() {
+    return file;
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return spec;
+  }
 
   @Override
   public long start() {

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/FlinkAddedRowsScanTask.java
@@ -34,20 +34,43 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
  * staging data file from {@code SnapshotChanges#addedDataFiles}) and need to feed it into the
  * reader. For data files that already come from a planned scan, we pass the native {@link
  * FileScanTask} through directly.
+ *
+ * <p>A plain class rather than a record to please Kryo 2.x in Flink 1.20, both of which cannot
+ * build a serializer for record classes.
  */
 @Internal
-record FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec, List<DeleteFile> deletes)
-    implements FileScanTask {
+class FlinkAddedRowsScanTask implements FileScanTask {
 
-  FlinkAddedRowsScanTask {
+  private final DataFile file;
+  private final PartitionSpec spec;
+  private final List<DeleteFile> deletes;
+
+  FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec, List<DeleteFile> deletes) {
+    this.file = file;
+    this.spec = spec;
     // Iceberg's scan APIs return Guava ImmutableList (see BaseAddedRowsScanTask#deletes), which
-    // does not round-trip through Flink's Kryo fallback. Copy into a plain ArrayList so the record
+    // does not round-trip through Flink's Kryo fallback. Copy into a plain ArrayList so the task
     // serializes cleanly regardless of what the caller passes.
-    deletes = Lists.newArrayList(deletes);
+    this.deletes = Lists.newArrayList(deletes);
   }
 
   FlinkAddedRowsScanTask(DataFile file, PartitionSpec spec) {
     this(file, spec, Collections.emptyList());
+  }
+
+  @Override
+  public DataFile file() {
+    return file;
+  }
+
+  @Override
+  public PartitionSpec spec() {
+    return spec;
+  }
+
+  @Override
+  public List<DeleteFile> deletes() {
+    return deletes;
   }
 
   @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -1,0 +1,1115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertPlanner extends OperatorTestBase {
+
+  private static final String STAGING_BRANCH = "__flink_staging_test";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void bootstrapsIndexFromBuilderEqualityFieldIds() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Staging branch exists but contains no eq-delete files yet. The planner still populates the
+    // worker index from main using the builder-configured equality field set so the index is ready
+    // when the first delete arrives.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenStagingEqDeleteFieldIdsMismatchBuilder() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Builder configured for [1, 2], but writer produces an eq delete with [1] only.
+    DeleteFile mismatched = writeIdOnlyEqualityDelete(table, 1);
+    table.newRowDelta().addDeletes(mismatched).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void doesNotDuplicateNewDataFilesWhenStagingEqualsTarget() throws Exception {
+    // When stagingBranch == targetBranch, the writer commits new data files directly to main.
+    // Bootstrap scans the main snapshot (which already includes those files) and indexes them.
+    // The planner must NOT also emit the staging-data phase for the same files — that would
+    // duplicate ADD_DATA_ROW commands for the same (PK, file, position) in the worker's index.
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Writer commits (new-data id=3) + (eq-delete id=1) in one RowDelta directly to main.
+    DataFile newDataFile = writeDataFile(table, createRecord(3, "c"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(SnapshotRef.MAIN_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+
+      // Bootstrap from main emits one data-file command per file (id=1, id=2, id=3) = 3.
+      // Without the same-branch guard, emitSnapshotDataPhase would also emit newDataFile → 4.
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      long newDataFileCount =
+          commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .filter(c -> c.task().file().location().equals(newDataFile.location()))
+              .count();
+      assertThat(newDataFileCount).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void emitsReadCommandsForEqualityDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 3 DATA_FILE (from main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(1);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).isEmpty();
+    }
+  }
+
+  @Test
+  void emitsDataFileFromInsertOnlyStagingSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S1: eq delete targeting main data
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s1SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // S2: insert-only (no eq deletes), but its data must still be indexed for the configured
+    // equality fields
+    DataFile insertS2 = writeDataFile(table, createRecord(2, "b"));
+    table.newAppend().appendFile(insertS2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: processes S1 (eq delete)
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      // Record S1's conversion on main, so the planner walks past S1 before processing S2.
+      simulateConvertCommit(table, s1SnapshotId);
+
+      // Trigger 2: processes S2 (insert-only). Must emit its data file so the configured equality
+      // fields stay indexed.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+
+      Set<String> dataFilePaths =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .map(TestEqualityConvertPlanner::filePath)
+              .collect(Collectors.toSet());
+
+      assertThat(dataFilePaths).contains(insertS2.location());
+    }
+  }
+
+  @Test
+  void includesNewDataFilesFromStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 1 main data file + 1 eq delete + 1 staging data file
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).hasSize(1);
+    }
+  }
+
+  @Test
+  void findsIntersectionWhenMainAdvancedAfterStagingFork() throws Exception {
+    Table table = createTableWithDelete(3);
+    // Pre-fork main: two snapshots.
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Fork staging from current main head.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Main advances with two more snapshots after the fork. These are on main's
+    // lineage but not on staging's.
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    // Staging gets one new snapshot containing an equality delete.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Planner identifies the fork point and processes only the staging-only
+      // commit (the eq delete), and emits all four current main data files
+      // for the index refresh.
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+      assertThat(countDataFileTasks(commands)).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void skipsAlreadyProcessedStagingSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      assertThat(firstTriggerCount).isGreaterThan(0);
+      assertThat(planner(harness).skippedNoOpCycles()).isZero();
+
+      // Simulate the committer committing to main with the staging snapshot property
+      // (the planner promotes pending only after confirming the commit landed on main).
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(firstTriggerCount);
+      assertThat(planner(harness).skippedNoOpCycles()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void noOutputWhenStagingBranchEmpty() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Bootstrap from main for the configured field set: 1 main DATA_FILE; no-op metadata still
+      // emitted because there's nothing on staging to convert.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(1);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+      assertThat(planner(harness).skippedNoOpCycles()).isEqualTo(1);
+      assertThat(planner(harness).reindexCount()).isZero();
+    }
+  }
+
+  @Test
+  void propagatesStagingOnlyPositionalDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    DataFile mainData = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(mainData).commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot has only a DV (no eq deletes, no new data files). Without the
+    // planner forwarding stagingDVFiles in this case, the committer would never
+    // see the DV and it would be lost.
+    DeleteFile stagingDV = writeStagingDV(table, mainData.location(), 0L);
+    table.newRowDelta().addDeletes(stagingDV).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      EqualityConvertPlan result = metadata.get(0).getValue();
+      assertThat(result.dataFiles()).isEmpty();
+      assertThat(result.stagingDVFiles()).hasSize(1);
+      assertThat(result.stagingDVFiles().get(0).location()).isEqualTo(stagingDV.location());
+    }
+  }
+
+  @Test
+  void phaseTimestampsAreMonotonicallyIncreasing() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging: eq delete + new data file (triggers 3 phases: main data, eq delete, staging data)
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      long triggerTs = 100L;
+      sendTrigger(harness, triggerTs);
+
+      List<Object> output = Lists.newArrayList(harness.getOutput());
+      assertThat(((StreamRecord<ReadCommand>) output.get(0)).getValue().task())
+          .isInstanceOf(FileScanTask.class);
+      assertThat(output.get(1)).isEqualTo(new Watermark(triggerTs));
+
+      assertThat(((StreamRecord<ReadCommand>) output.get(2)).getValue().task())
+          .isInstanceOf(EqualityDeleteFileScanTask.class);
+      assertThat(output.get(3)).isEqualTo(new Watermark(triggerTs + 1));
+
+      assertThat(((StreamRecord<ReadCommand>) output.get(4)).getValue().task())
+          .isInstanceOf(FileScanTask.class);
+      assertThat(output.get(5)).isEqualTo(new Watermark(triggerTs + 2));
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    createTableWithDelete(3);
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      dropTable();
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsOnRemovedDataFilesOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    Set<DataFile> oldDataFiles = Sets.newHashSet();
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile df : reader) {
+          oldDataFiles.add(df.copy());
+        }
+      }
+    }
+
+    assertThat(oldDataFiles).hasSize(2);
+
+    // Rewrite on the staging branch (not main). Equality delete conversion does not support
+    // rewrites on staging; the planner must fail the cycle instead of silently dropping the
+    // removed files.
+    DataFile compactedFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    RewriteFiles rewrite = table.newRewrite();
+    for (DataFile old : oldDataFiles) {
+      rewrite.deleteFile(old);
+    }
+
+    rewrite.addFile(compactedFile);
+    rewrite.toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      // Bootstrap runs before processCycle's failure, so the main data commands are already on
+      // the wire. Only the cycle itself fails.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+    }
+  }
+
+  @Test
+  void reEmitsMainDataAfterCompaction() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+
+      // Compact data files on main: rewrite 2 files into 1
+      Set<DataFile> oldDataFiles = Sets.newHashSet();
+      for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+        try (ManifestReader<DataFile> reader =
+            ManifestFiles.read(manifest, table.io(), table.specs())) {
+          for (DataFile df : reader) {
+            oldDataFiles.add(df.copy());
+          }
+        }
+      }
+
+      assertThat(oldDataFiles).hasSize(2);
+
+      DataFile compactedFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+      RewriteFiles rewrite = table.newRewrite();
+      for (DataFile old : oldDataFiles) {
+        rewrite.deleteFile(old);
+      }
+
+      rewrite.addFile(compactedFile);
+      rewrite.commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // 1 DATA_FILE (compacted main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      // DATA_FILE should reference the compacted file
+      List<ReadCommand> dataCmds =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .collect(Collectors.toList());
+      for (ReadCommand cmd : dataCmds) {
+        assertThat(cmd.task().file().location()).isEqualTo(compactedFile.location());
+      }
+    }
+  }
+
+  @Test
+  void refreshesIndexBeforeFirstCycleProcessesEqDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Stage MULTIPLE eq-delete snapshots before the first trigger arrives. The first trigger
+    // bootstraps the index from main for the configured equality fields before processing any eq
+    // deletes, then processes one snapshot per trigger (oldest first).
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s2SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+
+      // First trigger processes the OLDER staging snapshot (eqDelete1). Bootstrap built the index
+      // from main once: 2 main DATA_FILE + 1 EQ_DELETE_FILE = 3 commands.
+      assertThat(afterFirst).isEqualTo(3);
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      simulateConvertCommit(table, table.snapshot(STAGING_BRANCH).parentId());
+
+      // Second trigger processes the newer staging snapshot. The index is already up-to-date.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isZero();
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      simulateConvertCommit(table, s2SnapshotId);
+    }
+  }
+
+  @Test
+  void noMainReEmitWhenUnchanged() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Only 1 EQ_DELETE_FILE, no main re-emission
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(2);
+    }
+  }
+
+  @Test
+  void noMainReEmitAfterOwnCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long indexedStagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+
+      // Record the converter's own commit (COMMITTED_STAGING_SNAPSHOT property) for the staging
+      // snapshot the first trigger processed. The next trigger reads the property off main and
+      // advances lastStagingSnapshotId. No reindex should be triggered.
+      simulateConvertCommit(table, indexedStagingSnapshotId);
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Own commits don't trigger index rebuild.
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void reIndexesAfterExternalCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 1 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(2);
+      assertThat(planner(harness).reindexCount()).isZero();
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(1);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(1);
+
+      // External commit: no COMMITTED_STAGING_SNAPSHOT_PROPERTY
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // External commit triggers re-index: main data files are re-emitted
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+      assertThat(planner(harness).reindexCount()).isEqualTo(1);
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(2);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void emitsClearIndexBroadcastOnReindex() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1 bootstraps the index. Bootstrap does not broadcast CLEAR_INDEX.
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM))
+          .isNullOrEmpty();
+
+      // External commit advances main. The next trigger reindexes and must broadcast CLEAR_INDEX
+      // so workers evict ghost keys (e.g. a PK whose data file was removed by external CoW).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+      long mainAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).snapshotId();
+      long mainSeqAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).sequenceNumber();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+
+      List<IndexCommand> clears =
+          harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM).stream()
+              .map(StreamRecord::getValue)
+              .collect(Collectors.toList());
+      assertThat(clears).hasSize(1);
+      assertThat(clears.get(0).type()).isEqualTo(IndexCommand.Type.CLEAR_INDEX);
+      assertThat(clears.get(0).mainSnapshotId()).isEqualTo(mainAfterExternal);
+      assertThat(clears.get(0).mainSequenceNumber()).isEqualTo(mainSeqAfterExternal);
+    }
+  }
+
+  @Test
+  void detectsMainBranchChangeWithoutNewStagingSnapshots() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: build the index and process the existing eq delete.
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(afterFirst).isGreaterThan(0);
+
+      // External commit on main (no COMMITTED_STAGING_SNAPSHOT_PROPERTY).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      // Trigger 2: nothing new on staging, but the planner must still notice the
+      // external main change and immediately re-emit main data for index rebuild.
+      sendTrigger(harness);
+      List<ReadCommand> allAfterTrigger2 = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allAfterTrigger2.subList(afterFirst, allAfterTrigger2.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+
+      // A subsequent staging eq delete should NOT re-emit main data because the index
+      // was already rebuilt in trigger 2.
+      int afterSecond = allAfterTrigger2.size();
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 10, "z");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> all = harness.extractOutputValues();
+      List<ReadCommand> trigger3 = all.subList(afterSecond, all.size());
+      assertThat(countDataFileTasks(trigger3)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger3)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void stateRestoredAfterCheckpoint() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // First trigger bootstraps the index and processes the staging snapshot.
+      sendTrigger(harness);
+      int commandCount = harness.extractOutputValues().size();
+      assertThat(commandCount).isGreaterThan(0);
+
+      // Record S1's conversion on main (committer marker) so the planner advances
+      // lastStagingSnapshotId on the second trigger.
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      // Second trigger reads the marker and advances lastStagingSnapshotId.
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(commandCount);
+
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // Restore from checkpoint: the restored index is not re-indexed because its state matches the
+    // snapshot COMMITTED_STAGING_SNAPSHOT_PROPERTY property.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void failsOnV2PosDeleteOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(2);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Flink-written staging branches are V3 and only produce DVs for deletes. A V2 positional
+    // delete on staging is a writer-side misconfiguration and should fail the cycle rather than
+    // be silently absorbed.
+    DataFile dataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile posDelete = writePosDeleteFile(table, dataFile.location(), 0);
+    table.newRowDelta().addRows(dataFile).addDeletes(posDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void skipsCommittedSnapshotAfterCommitLandsButCheckpointDoesNot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // Capture the planner's checkpoint before any cycle has run.
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // The staging commit landed on main but lastStagingSnapshotId was not checkpointed.
+    simulateConvertCommit(table, stagingSnapshotId);
+
+    // On restore, the planner walks main, finds the COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+    // advances lastStagingSnapshotId, and skips re-emitting the already-committed snapshot.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(0);
+      // Bootstrap from main creates the index from the main data files on the first trigger even
+      // though the staging snapshot itself is already committed and skipped. Main now has the
+      // original insert plus simulateConvertCommit's marker file = 2 data files.
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void failsWhenCommitMarkerDisappears() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    long startSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    simulateConvertCommit(table, stagingSnapshotId);
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      table.manageSnapshots().rollbackTo(startSnapshotId).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(
+              harness
+                  .getSideOutput(TaskResultAggregator.ERROR_STREAM)
+                  .poll()
+                  .getValue()
+                  .getMessage())
+          .contains("No COMMITTED_STAGING_SNAPSHOT marker reachable");
+    }
+  }
+
+  @Test
+  void failsOnEqFieldIdsChangeAcrossRestart() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1))) {
+      assertThatThrownBy(() -> harness.initializeState(state))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Equality field IDs changed across restart");
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch) throws Exception {
+    // Default matches the [1, 2] equality-field-id list produced by writeEqualityDelete.
+    return createHarness(stagingBranch, Lists.newArrayList(1, 2));
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch, List<Integer> eqFieldIds) throws Exception {
+    return new OneInputStreamOperatorTestHarness<>(
+        new EqualityConvertPlanner(
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            tableLoader(),
+            stagingBranch,
+            SnapshotRef.MAIN_BRANCH,
+            Sets.newHashSet(eqFieldIds)));
+  }
+
+  private static void sendTrigger(OneInputStreamOperatorTestHarness<Trigger, ?> harness)
+      throws Exception {
+    sendTrigger(harness, System.currentTimeMillis());
+  }
+
+  private static void sendTrigger(OneInputStreamOperatorTestHarness<Trigger, ?> harness, long time)
+      throws Exception {
+    harness.processElement(new StreamRecord<>(Trigger.create(time, 0), time));
+  }
+
+  private DataFile writeDataFile(Table table, Record record) throws IOException {
+    return new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .writeFile(Lists.newArrayList(record));
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private DeleteFile writeIdOnlyEqualityDelete(Table table, int id) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    Schema idOnly = table.schema().select("id");
+    Record record = GenericRecord.create(idOnly);
+    record.setField("id", id);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(record),
+        idOnly);
+  }
+
+  private DeleteFile writeStagingDV(Table table, String dataFilePath, long position)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PositionDelete<Record> delete = PositionDelete.create();
+    delete.set(dataFilePath, position, null);
+    return FileHelpers.writePosDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(delete),
+        3);
+  }
+
+  private static long countDataFileTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(c -> c.task() instanceof FileScanTask).count();
+  }
+
+  private static long countEqDeleteTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(TestEqualityConvertPlanner::isEqDelete).count();
+  }
+
+  private static EqualityConvertPlanner planner(
+      OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness) {
+    return (EqualityConvertPlanner) harness.getOperator();
+  }
+
+  private static boolean isEqDelete(ReadCommand cmd) {
+    return cmd.task() instanceof EqualityDeleteFileScanTask;
+  }
+
+  private static String filePath(ReadCommand cmd) {
+    return cmd.task().file().location();
+  }
+
+  private void simulateConvertCommit(Table table, long stagingSnapshotId) throws IOException {
+    DataFile dummy =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(-1, "marker" + stagingSnapshotId)));
+    table
+        .newRowDelta()
+        .addRows(dummy)
+        .set(
+            EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+            String.valueOf(stagingSnapshotId))
+        .commit();
+    table.refresh();
+  }
+}

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -1,0 +1,762 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.annotation.VisibleForTesting;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.MetricGroup;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
+import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.util.OutputTag;
+import org.apache.iceberg.ContentFile;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotChanges;
+import org.apache.iceberg.SnapshotSummary;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Planner for the equality delete conversion pipeline. For each trigger, it picks the oldest
+ * staging snapshot that hasn't been converted yet and emits {@link ReadCommand}s describing the
+ * files its downstream readers and workers must process.
+ *
+ * <p>Each trigger runs two steps in order:
+ *
+ * <ol>
+ *   <li>{@link #ensureIndexCurrent}: updates {@link #lastStagingSnapshotId} from main's history,
+ *       bootstraps the worker index from main on first run, and reindexes when external commits
+ *       (e.g. compaction) have advanced main past the currently-indexed snapshot.
+ *   <li>{@link #processStagingSnapshot}: resolve the chosen staging snapshot's eq deletes against
+ *       the (now-current) index, pass through any DV files, and index the snapshot's new data files
+ *       for the next cycle.
+ * </ol>
+ *
+ * Watermarks separate phases that gate the worker's keyed state. The contract is documented on
+ * {@link #advancePhase()}.
+ *
+ * <p>An {@link EqualityConvertPlan} with the current cycle's metadata is emitted via the {@link
+ * #METADATA_STREAM} side output after the read commands.
+ *
+ * <p>Assumes a single equality-field set supplied via the builder; staging eq-deletes with a
+ * different {@code equalityFieldIds} fail fast in {@link #retrieveStagingFiles}. Concurrent writes
+ * on the target branch are handled by {@link #ensureIndexCurrent} reindexing from the new main
+ * snapshot; commit-time conflicts are caught by {@code RowDelta.validateFromSnapshot}.
+ */
+@Internal
+public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
+    implements OneInputStreamOperator<Trigger, ReadCommand> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(EqualityConvertPlanner.class);
+
+  public static final OutputTag<EqualityConvertPlan> METADATA_STREAM =
+      new OutputTag<>("metadata-stream") {};
+
+  public static final OutputTag<IndexCommand> CLEAR_BROADCAST_STREAM =
+      new OutputTag<>("clear-broadcast-stream") {};
+
+  private static final String PROCESSED_EQ_DELETE_FILE_NUM_METRIC = "processedEqDeleteFileNum";
+  private static final String PROCESSED_STAGING_SNAPSHOT_NUM_METRIC = "processedStagingSnapshotNum";
+  private static final String SKIPPED_NO_OP_CYCLES_METRIC = "skippedNoOpCycles";
+  private static final String REINDEX_COUNT_METRIC = "reindexCount";
+
+  private final String tableName;
+  private final String taskName;
+  private final TableLoader tableLoader;
+  private final String stagingBranch;
+  private final String targetBranch;
+  private final boolean stagingOnTargetBranch;
+  // Equality-field-id set the worker keys on. Supplied via the builder; every staging
+  // eq-delete's equalityFieldIds() must match exactly.
+  private final Set<Integer> eqFieldIds;
+
+  // Main snapshot id the worker's index reflects.
+  private transient ListState<Long> indexSnapshotState;
+  // Main sequence number the worker's index reflects.
+  private transient ListState<Long> indexedSequenceNumberState;
+  // Equality field IDs the index was built with, allows to detect reconfiguration.
+  private transient ListState<Integer> eqFieldIdsState;
+
+  private transient Table table;
+
+  private transient Long lastMainSnapshotId;
+  private transient Long lastStagingSnapshotId;
+  private transient Long indexSnapshotId;
+  private transient Long indexedSequenceNumber;
+
+  private transient long nextPhaseTs;
+
+  private transient Counter processedEqDeleteFileNumCounter;
+  private transient Counter processedStagingSnapshotNumCounter;
+  private transient Counter skippedNoOpCyclesCounter;
+  private transient Counter reindexCounter;
+  private transient Counter errorCounter;
+
+  public EqualityConvertPlanner(
+      String tableName,
+      String taskName,
+      TableLoader tableLoader,
+      String stagingBranch,
+      String targetBranch,
+      Set<Integer> eqFieldIds) {
+    this.tableName = tableName;
+    this.taskName = taskName;
+    this.tableLoader = tableLoader;
+    this.stagingBranch = stagingBranch;
+    this.targetBranch = targetBranch;
+    this.stagingOnTargetBranch = stagingBranch.equals(targetBranch);
+    Preconditions.checkArgument(
+        eqFieldIds != null && !eqFieldIds.isEmpty(), "eqFieldIds must not be null or empty");
+    this.eqFieldIds = ImmutableSet.copyOf(eqFieldIds);
+  }
+
+  @Override
+  public void open() throws Exception {
+    super.open();
+    if (!tableLoader.isOpen()) {
+      tableLoader.open();
+    }
+
+    table = tableLoader.loadTable();
+
+    MetricGroup taskMetricGroup =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, 0);
+    this.processedEqDeleteFileNumCounter =
+        taskMetricGroup.counter(PROCESSED_EQ_DELETE_FILE_NUM_METRIC);
+    this.processedStagingSnapshotNumCounter =
+        taskMetricGroup.counter(PROCESSED_STAGING_SNAPSHOT_NUM_METRIC);
+    this.skippedNoOpCyclesCounter = taskMetricGroup.counter(SKIPPED_NO_OP_CYCLES_METRIC);
+    this.reindexCounter = taskMetricGroup.counter(REINDEX_COUNT_METRIC);
+    this.errorCounter = taskMetricGroup.counter(TableMaintenanceMetrics.ERROR_COUNTER);
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+    indexSnapshotState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexSnapshotId", Types.LONG));
+
+    indexSnapshotId = null;
+    for (Long stateValue : indexSnapshotState.get()) {
+      Preconditions.checkState(
+          indexSnapshotId == null, "indexSnapshotId state should hold at most one value");
+      indexSnapshotId = stateValue;
+    }
+
+    indexedSequenceNumberState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("indexedSequenceNumber", Types.LONG));
+
+    indexedSequenceNumber = null;
+    for (Long stateValue : indexedSequenceNumberState.get()) {
+      Preconditions.checkState(
+          indexedSequenceNumber == null,
+          "indexedSequenceNumber state should hold at most one value");
+      indexedSequenceNumber = stateValue;
+    }
+
+    eqFieldIdsState =
+        context
+            .getOperatorStateStore()
+            .getListState(new ListStateDescriptor<>("eqFieldIds", Types.INT));
+    Set<Integer> restoredEqFieldIds = Sets.newHashSet(eqFieldIdsState.get());
+    Preconditions.checkState(
+        restoredEqFieldIds.isEmpty() || restoredEqFieldIds.equals(eqFieldIds),
+        "Equality field IDs changed across restart: restored=%s, configured=%s. "
+            + "Reconfiguring equality-field columns is not supported; "
+            + "restart from a clean state (no savepoint).",
+        restoredEqFieldIds,
+        eqFieldIds);
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    indexSnapshotState.clear();
+    if (indexSnapshotId != null) {
+      indexSnapshotState.add(indexSnapshotId);
+    }
+
+    indexedSequenceNumberState.clear();
+    if (indexedSequenceNumber != null) {
+      indexedSequenceNumberState.add(indexedSequenceNumber);
+    }
+
+    eqFieldIdsState.clear();
+    for (int id : eqFieldIds) {
+      eqFieldIdsState.add(id);
+    }
+  }
+
+  @Override
+  public void processElement(StreamRecord<Trigger> element) throws Exception {
+    long triggerTs = element.getTimestamp();
+    nextPhaseTs = Math.max(triggerTs, nextPhaseTs + 1);
+
+    Long currentMainSnapshotId = lastMainSnapshotId;
+    try {
+      table.refresh();
+      Snapshot mainSnapshot = table.snapshot(targetBranch);
+      currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+      ensureIndexCurrent(mainSnapshot);
+
+      Snapshot nextToProcess =
+          nextUnprocessedStagingSnapshot(table.snapshot(stagingBranch), mainSnapshot);
+
+      if (nextToProcess == null) {
+        LOG.info("Nothing new to convert on staging branch '{}'.", stagingBranch);
+        emitNoOpResult(triggerTs, currentMainSnapshotId);
+        return;
+      }
+
+      processStagingSnapshot(nextToProcess, triggerTs, currentMainSnapshotId);
+    } catch (Exception e) {
+      LOG.error("Error processing equality deletes for table {} task {}", tableName, taskName, e);
+      output.collect(TaskResultAggregator.ERROR_STREAM, new StreamRecord<>(e));
+      errorCounter.inc();
+      emitDrainResult(triggerTs, currentMainSnapshotId);
+    }
+  }
+
+  /**
+   * Brings the worker's index up to date with the current state of the target branch:
+   *
+   * <ul>
+   *   <li>Updates {@link #lastStagingSnapshotId} from the most recent committer marker on main.
+   *   <li>Bootstraps the index from main on the first trigger with a non-null main snapshot.
+   *   <li>Reindexes from main when external commits (e.g. compaction or direct writes) have
+   *       advanced main past the currently-indexed snapshot.
+   * </ul>
+   *
+   * <p>No-op when main hasn't moved since the last trigger. Otherwise the history walk is bounded
+   * to commits added since {@link #lastMainSnapshotId}.
+   */
+  private void ensureIndexCurrent(Snapshot mainSnapshot) {
+    Long currentMainSnapshotId = mainSnapshot != null ? mainSnapshot.snapshotId() : null;
+
+    if (Objects.equals(lastMainSnapshotId, currentMainSnapshotId)) {
+      return;
+    }
+
+    LastCommittedWork info = discoverLastCommittedWork(mainSnapshot);
+    updateLastStagingSnapshotId(info);
+
+    boolean bootstrap = mainSnapshot != null && indexSnapshotId == null;
+    boolean reindex = indexSnapshotId != null && info.externalCommitCount() > 0;
+    if (bootstrap || reindex) {
+      LOG.info(
+          "{} worker index from main snapshot {} for field IDs {}.",
+          bootstrap ? "Bootstrapping" : "Reindexing",
+          currentMainSnapshotId,
+          eqFieldIds);
+      if (reindex) {
+        // Evict keyed entries the reindex will not re-add (e.g. data file removed by CoW).
+        output.collect(
+            CLEAR_BROADCAST_STREAM,
+            new StreamRecord<>(
+                IndexCommand.clearBeforeReindex(
+                    currentMainSnapshotId, mainSnapshot.sequenceNumber())));
+        reindexCounter.inc();
+      }
+
+      indexSnapshotId = currentMainSnapshotId;
+      indexedSequenceNumber = mainSnapshot.sequenceNumber();
+      emitMainDataReadCommands(mainSnapshot);
+    }
+
+    lastMainSnapshotId = currentMainSnapshotId;
+  }
+
+  private void updateLastStagingSnapshotId(LastCommittedWork info) {
+    if (info.lastCommittedStaging() != null) {
+      lastStagingSnapshotId = info.lastCommittedStaging();
+      return;
+    }
+
+    Preconditions.checkState(
+        lastMainSnapshotId == null || lastStagingSnapshotId == null || info.reachedLastInspected(),
+        "No COMMITTED_STAGING_SNAPSHOT marker reachable on target branch '%s' for table %s, "
+            + "but a prior marker was seen (lastStagingSnapshotId=%s). Target may have been "
+            + "rewritten (rollback, replace_main, or snapshot expiration). "
+            + "Manual intervention required.",
+        targetBranch,
+        tableName,
+        lastStagingSnapshotId);
+  }
+
+  /**
+   * Walks main back from head looking for the most recent snapshot tagged with {@link
+   * EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}. Returns the staging snapshot id
+   * recorded there (or {@code null} if not reached) and the count of intervening external commits.
+   *
+   * <p>The walk stops at whichever comes first:
+   *
+   * <ul>
+   *   <li>The first snapshot carrying the committer marker.
+   *   <li>{@link #lastMainSnapshotId} — anything older was inspected on a previous trigger.
+   * </ul>
+   */
+  private LastCommittedWork discoverLastCommittedWork(Snapshot mainSnapshot) {
+    Long lastCommittedStaging = null;
+    int externalCount = 0;
+    boolean reachedLastInspected = false;
+    Snapshot current = mainSnapshot;
+    while (current != null) {
+      if (lastMainSnapshotId != null && current.snapshotId() == lastMainSnapshotId) {
+        reachedLastInspected = true;
+        break;
+      }
+
+      String prop =
+          current.summary().get(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY);
+      if (prop != null) {
+        lastCommittedStaging = Long.parseLong(prop);
+        break;
+      }
+
+      externalCount++;
+      current = parentOf(current);
+    }
+
+    return new LastCommittedWork(lastCommittedStaging, externalCount, reachedLastInspected);
+  }
+
+  private record LastCommittedWork(
+      Long lastCommittedStaging, int externalCommitCount, boolean reachedLastInspected) {}
+
+  /**
+   * Walks staging history from head back to the stop point and returns the oldest unprocessed
+   * snapshot to convert this cycle, or {@code null} if there's nothing new.
+   *
+   * <p>The stop point is:
+   *
+   * <ul>
+   *   <li>the last-processed staging snapshot, if known;
+   *   <li>otherwise, on cold start with {@code stagingBranch != targetBranch}, the common ancestor
+   *       with target;
+   *   <li>otherwise, on cold start with {@code stagingBranch == targetBranch}, the root of history
+   *       ({@code null}). {@link #shouldSkip} filters already-converted snapshots in O(1) via the
+   *       {@code COMMITTED_STAGING_SNAPSHOT_PROPERTY} marker, and pure-insert snapshots via the
+   *       same-branch eq-delete predicate.
+   * </ul>
+   *
+   * <p>When {@code stagingBranch == targetBranch}, the writer commits eq-deletes and data files
+   * directly to target; the converter performs in-place eq-delete-to-DV compaction. On cold start
+   * we walk the full history so eq-deletes committed before the converter started are still picked
+   * up.
+   */
+  private Snapshot nextUnprocessedStagingSnapshot(Snapshot stagingHead, Snapshot mainSnapshot) {
+    if (stagingHead == null) {
+      return null;
+    }
+
+    Long stopAt;
+    if (lastStagingSnapshotId != null) {
+      stopAt = lastStagingSnapshotId;
+    } else if (stagingOnTargetBranch) {
+      stopAt = null;
+    } else {
+      stopAt = findCommonAncestor(stagingHead, mainSnapshot);
+    }
+
+    Snapshot current = stagingHead;
+    Snapshot oldestUnprocessed = null;
+    while (current != null) {
+      if (stopAt != null && current.snapshotId() == stopAt) {
+        break;
+      }
+
+      if (!shouldSkip(current)) {
+        oldestUnprocessed = current;
+      }
+
+      current = parentOf(current);
+    }
+
+    return oldestUnprocessed;
+  }
+
+  /**
+   * Resolves the eq deletes in {@code stagingSnapshot} against the current index and emits the
+   * cycle's metadata. Phase ordering (separated by watermarks):
+   *
+   * <ol>
+   *   <li>Eq delete read commands. Eq deletes resolve in the worker.
+   *   <li>Staging data files. Indexed for the NEXT cycle's eq-delete resolution.
+   * </ol>
+   *
+   * Cold-start bootstrap of the index from main data is handled separately in {@link
+   * #processElement}, which runs once before the first cycle.
+   */
+  private void processStagingSnapshot(
+      Snapshot stagingSnapshot, long triggerTs, Long currentMainSnapshotId) {
+
+    StagingInputs inputs = retrieveStagingFiles(stagingSnapshot);
+    Preconditions.checkState(
+        !inputs.isEmpty(),
+        "Staging snapshot %s has no convertible inputs; shouldSkip should have filtered it.",
+        stagingSnapshot.snapshotId());
+
+    emitDeletePhase(inputs.eqDeleteFiles());
+    emitSnapshotDataPhase(inputs.newDataFiles());
+
+    LOG.info(
+        "Emitted read commands for {} new data files from staging branch '{}'.",
+        inputs.newDataFiles().size(),
+        stagingBranch);
+
+    processedStagingSnapshotNumCounter.inc();
+
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            new EqualityConvertPlan(
+                inputs.newDataFiles(),
+                inputs.stagingDVFiles(),
+                stagingSnapshot.snapshotId(),
+                currentMainSnapshotId,
+                triggerTs,
+                nextPhaseTs)));
+
+    advancePhase();
+  }
+
+  /**
+   * Classifies the files added by {@code stagingSnapshot} into data files, eq delete files, and DV
+   * files. Throws if the snapshot:
+   *
+   * <ul>
+   *   <li>Removes data files (rewrites on the staging branch aren't supported).
+   *   <li>Contains V2 positional delete files (the converter expects a V3 staging branch written by
+   *       Flink, which produces only deletion vectors for deletes).
+   *   <li>Contains an eq-delete file whose {@code equalityFieldIds()} doesn't match the
+   *       builder-configured set (silent wrong-key serialization otherwise).
+   * </ul>
+   */
+  private StagingInputs retrieveStagingFiles(Snapshot stagingSnapshot) {
+    SnapshotChanges changes = SnapshotChanges.builderFor(table).snapshot(stagingSnapshot).build();
+
+    // Rewrites on the staging branch would require rewriting the corresponding DVs against new
+    // data files on target. Not implemented; fail fast instead of silently dropping work.
+    if (changes.removedDataFiles().iterator().hasNext()) {
+      throw new IllegalStateException(
+          String.format(
+              "Staging snapshot %s on branch '%s' removes data files; "
+                  + "equality delete conversion does not support rewrites on the staging branch. "
+                  + "Run compaction on the target branch instead.",
+              stagingSnapshot.snapshotId(), stagingBranch));
+    }
+
+    List<DataFile> newDataFiles = Lists.newArrayList();
+    List<DeleteFile> stagingDVFiles = Lists.newArrayList();
+    List<DeleteFile> eqDeleteFiles = Lists.newArrayList();
+
+    for (DataFile dataFile : changes.addedDataFiles()) {
+      newDataFiles.add(dataFile);
+    }
+
+    for (DeleteFile deleteFile : changes.addedDeleteFiles()) {
+      if (deleteFile.content() == FileContent.EQUALITY_DELETES) {
+        Set<Integer> deleteFieldIds = Sets.newHashSet(deleteFile.equalityFieldIds());
+        Preconditions.checkState(
+            deleteFieldIds.equals(eqFieldIds),
+            "Staging snapshot %s on branch '%s' contains an equality delete file %s with "
+                + "equalityFieldIds=%s, which does not match the configured eqFieldIds=%s. "
+                + "The writer must use the same equality field IDs as the converter.",
+            stagingSnapshot.snapshotId(),
+            stagingBranch,
+            deleteFile.location(),
+            deleteFieldIds,
+            eqFieldIds);
+        eqDeleteFiles.add(deleteFile);
+      } else if (ContentFileUtil.isDV(deleteFile)) {
+        stagingDVFiles.add(deleteFile);
+      } else {
+        throw new IllegalStateException(
+            String.format(
+                "Staging snapshot %s on branch '%s' contains a V2 positional delete file (%s); "
+                    + "equality delete conversion expects a V3 staging branch written by Flink, "
+                    + "which produces only deletion vectors for deletes.",
+                stagingSnapshot.snapshotId(), stagingBranch, deleteFile.location()));
+      }
+    }
+
+    return new StagingInputs(newDataFiles, stagingDVFiles, eqDeleteFiles);
+  }
+
+  /** Files added by one staging snapshot, classified for cycle emission. */
+  private record StagingInputs(
+      List<DataFile> newDataFiles,
+      List<DeleteFile> stagingDVFiles,
+      List<DeleteFile> eqDeleteFiles) {
+
+    boolean isEmpty() {
+      return newDataFiles.isEmpty() && eqDeleteFiles.isEmpty() && stagingDVFiles.isEmpty();
+    }
+  }
+
+  private void emitDeletePhase(List<DeleteFile> eqDeleteFiles) {
+    for (DeleteFile deleteFile : eqDeleteFiles) {
+      PartitionSpec spec = table.specs().get(deleteFile.specId());
+      output.collect(
+          new StreamRecord<>(
+              ReadCommand.eqDeleteFile(
+                  deleteFile,
+                  spec,
+                  indexSnapshotId,
+                  indexedSequenceNumber,
+                  dataSequenceNumber(deleteFile)),
+              nextPhaseTs));
+      processedEqDeleteFileNumCounter.inc();
+    }
+
+    advancePhase();
+  }
+
+  private void emitSnapshotDataPhase(List<DataFile> snapshotDataFiles) {
+    // Shared-branch skip: when stagingBranch == targetBranch, these files are already on target
+    // and were indexed by bootstrap/reindex. Re-emitting would duplicate entries in
+    // dataRowPositions.
+    if (!stagingOnTargetBranch) {
+      for (DataFile dataFile : snapshotDataFiles) {
+        PartitionSpec spec = table.specs().get(dataFile.specId());
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.stagingDataFile(
+                    new FlinkAddedRowsScanTask(dataFile, spec),
+                    indexSnapshotId,
+                    indexedSequenceNumber,
+                    dataSequenceNumber(dataFile)),
+                nextPhaseTs));
+      }
+    }
+
+    advancePhase();
+  }
+
+  private void emitNoOpResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    skippedNoOpCyclesCounter.inc();
+    emitDrainResult(triggerTimestamp, currentMainSnapshotId);
+  }
+
+  /** Emits an empty plan result and advances the phase so the pipeline drains. */
+  private void emitDrainResult(long triggerTimestamp, Long currentMainSnapshotId) {
+    output.collect(
+        METADATA_STREAM,
+        new StreamRecord<>(
+            EqualityConvertPlan.noOp(currentMainSnapshotId, triggerTimestamp, nextPhaseTs)));
+    advancePhase();
+  }
+
+  /**
+   * Emits {@link ReadCommand}s for every data file on {@code mainSnapshot} so the worker indexes
+   * them for the configured equality-field set. Existing DVs attached to a data file are loaded by
+   * the reader and their positions are skipped. V2 positional deletes are not expected on main; the
+   * reader throws if it encounters one. Equality deletes attached to the scan task are skipped
+   * during indexing (they are processed via the planner's eq-delete read commands).
+   */
+  private void emitMainDataReadCommands(Snapshot mainSnapshot) {
+    long commitSnapshotId = mainSnapshot.snapshotId();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table.newScan().useSnapshot(commitSnapshotId).planFiles()) {
+      for (FileScanTask task : tasks) {
+        output.collect(
+            new StreamRecord<>(
+                ReadCommand.dataFile(
+                    task, indexSnapshotId, indexedSequenceNumber, dataSequenceNumber(task.file())),
+                nextPhaseTs));
+      }
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to plan files for main index", e);
+    }
+
+    LOG.info(
+        "Emitted main data read commands for field IDs {} from snapshot {}.",
+        eqFieldIds,
+        commitSnapshotId);
+
+    advancePhase();
+  }
+
+  /**
+   * Emits a phase-end watermark and bumps the phase timestamp. Every phase-emitting method must
+   * call this exactly once after its records; the worker uses these watermarks to gate keyed-state
+   * transitions. Missing or extra calls silently break ordering.
+   */
+  private void advancePhase() {
+    output.emitWatermark(new Watermark(nextPhaseTs));
+    nextPhaseTs++;
+  }
+
+  /**
+   * Returns {@code true} if {@code snapshot} can be skipped:
+   *
+   * <ul>
+   *   <li>It was already committed by us (carries {@link
+   *       EqualityConvertCommitter#COMMITTED_STAGING_SNAPSHOT_PROPERTY}), OR
+   *   <li>it adds no data or delete files (e.g. delete-file-only removals), OR
+   *   <li>{@code stagingBranch == targetBranch} and the snapshot adds no equality-delete files.
+   *       Pure-insert (and data-file-only) commits on the shared branch don't need a conversion
+   *       cycle: their data is already on target, and the worker's index stays fresh via {@link
+   *       #ensureIndexCurrent} when the next eq-delete arrives.
+   * </ul>
+   *
+   * <p>Filter checks read per-snapshot counts from {@link Snapshot#summary()}; we don't parse
+   * manifests here. Manifest parsing happens later in {@link #retrieveStagingFiles} only for the
+   * chosen snapshot.
+   */
+  private boolean shouldSkip(Snapshot snapshot) {
+    Map<String, String> summary = snapshot.summary();
+    if (summary.containsKey(EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY)) {
+      return true;
+    }
+
+    long addedDataFiles = summaryCount(summary, SnapshotSummary.ADDED_FILES_PROP);
+    long addedDeleteFiles = summaryCount(summary, SnapshotSummary.ADDED_DELETE_FILES_PROP);
+    if (addedDataFiles == 0 && addedDeleteFiles == 0) {
+      LOG.info(
+          "Skipping staging snapshot {}: no added data or delete files.", snapshot.snapshotId());
+      return true;
+    }
+
+    if (stagingOnTargetBranch
+        && summaryCount(summary, SnapshotSummary.ADD_EQ_DELETE_FILES_PROP) == 0) {
+      return true;
+    }
+
+    return false;
+  }
+
+  private static long summaryCount(Map<String, String> summary, String key) {
+    String value = summary.get(key);
+    return value == null ? 0L : Long.parseLong(value);
+  }
+
+  /**
+   * Returns the id of the newest snapshot that is reachable from both the staging and target branch
+   * heads (i.e. the most recent common ancestor where the two branches last matched), or {@code
+   * null} if they share no history. Used on cold start to know where staging diverged from target
+   * so we can skip converting snapshots that already exist on target.
+   */
+  private Long findCommonAncestor(Snapshot stagingHead, Snapshot mainHead) {
+    if (mainHead == null) {
+      return null;
+    }
+
+    Set<Long> stagingSeen = Sets.newHashSet();
+    Set<Long> mainSeen = Sets.newHashSet();
+    Snapshot stagingCurrent = stagingHead;
+    Snapshot mainCurrent = mainHead;
+
+    while (stagingCurrent != null || mainCurrent != null) {
+      if (stagingCurrent != null) {
+        long id = stagingCurrent.snapshotId();
+        if (mainSeen.contains(id)) {
+          return id;
+        }
+
+        stagingSeen.add(id);
+        stagingCurrent = parentOf(stagingCurrent);
+      }
+
+      if (mainCurrent != null) {
+        long id = mainCurrent.snapshotId();
+        if (stagingSeen.contains(id)) {
+          return id;
+        }
+
+        mainSeen.add(id);
+        mainCurrent = parentOf(mainCurrent);
+      }
+    }
+
+    return null;
+  }
+
+  /** Returns the parent snapshot, or {@code null} if {@code snapshot} has no parent. */
+  private Snapshot parentOf(Snapshot snapshot) {
+    Long parentId = snapshot.parentId();
+    return parentId != null ? table.snapshot(parentId) : null;
+  }
+
+  private static long dataSequenceNumber(ContentFile<?> file) {
+    Long sequenceNumber = file.dataSequenceNumber();
+    Preconditions.checkNotNull(
+        sequenceNumber, "Missing data sequence number for committed file %s", file.location());
+    return sequenceNumber;
+  }
+
+  @Override
+  public void close() throws Exception {
+    super.close();
+    tableLoader.close();
+  }
+
+  @VisibleForTesting
+  long reindexCount() {
+    return reindexCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long skippedNoOpCycles() {
+    return skippedNoOpCyclesCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long processedStagingSnapshotNum() {
+    return processedStagingSnapshotNumCounter.getCount();
+  }
+
+  @VisibleForTesting
+  long processedEqDeleteFileNum() {
+    return processedEqDeleteFileNumCounter.getCount();
+  }
+}

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertPlanner.java
@@ -1,0 +1,1115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.operator;
+
+import static org.apache.iceberg.flink.SimpleDataUtil.createRecord;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.api.watermark.Watermark;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.OneInputStreamOperatorTestHarness;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.data.FileHelpers;
+import org.apache.iceberg.data.GenericAppenderHelper;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.deletes.PositionDelete;
+import org.apache.iceberg.flink.maintenance.api.Trigger;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class TestEqualityConvertPlanner extends OperatorTestBase {
+
+  private static final String STAGING_BRANCH = "__flink_staging_test";
+
+  @TempDir private Path tempDir;
+
+  @Test
+  void bootstrapsIndexFromBuilderEqualityFieldIds() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Staging branch exists but contains no eq-delete files yet. The planner still populates the
+    // worker index from main using the builder-configured equality field set so the index is ready
+    // when the first delete arrives.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsWhenStagingEqDeleteFieldIdsMismatchBuilder() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Builder configured for [1, 2], but writer produces an eq delete with [1] only.
+    DeleteFile mismatched = writeIdOnlyEqualityDelete(table, 1);
+    table.newRowDelta().addDeletes(mismatched).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void doesNotDuplicateNewDataFilesWhenStagingEqualsTarget() throws Exception {
+    // When stagingBranch == targetBranch, the writer commits new data files directly to main.
+    // Bootstrap scans the main snapshot (which already includes those files) and indexes them.
+    // The planner must NOT also emit the staging-data phase for the same files — that would
+    // duplicate ADD_DATA_ROW commands for the same (PK, file, position) in the worker's index.
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Writer commits (new-data id=3) + (eq-delete id=1) in one RowDelta directly to main.
+    DataFile newDataFile = writeDataFile(table, createRecord(3, "c"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(SnapshotRef.MAIN_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+
+      // Bootstrap from main emits one data-file command per file (id=1, id=2, id=3) = 3.
+      // Without the same-branch guard, emitSnapshotDataPhase would also emit newDataFile → 4.
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      long newDataFileCount =
+          commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .filter(c -> c.task().file().location().equals(newDataFile.location()))
+              .count();
+      assertThat(newDataFileCount).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void emitsReadCommandsForEqualityDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+    insert(table, 3, "c");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 3 DATA_FILE (from main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(commands)).isEqualTo(3);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(1);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).isEmpty();
+    }
+  }
+
+  @Test
+  void emitsDataFileFromInsertOnlyStagingSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // S1: eq delete targeting main data
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s1SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // S2: insert-only (no eq deletes), but its data must still be indexed for the configured
+    // equality fields
+    DataFile insertS2 = writeDataFile(table, createRecord(2, "b"));
+    table.newAppend().appendFile(insertS2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: processes S1 (eq delete)
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      // Record S1's conversion on main, so the planner walks past S1 before processing S2.
+      simulateConvertCommit(table, s1SnapshotId);
+
+      // Trigger 2: processes S2 (insert-only). Must emit its data file so the configured equality
+      // fields stay indexed.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+
+      Set<String> dataFilePaths =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .map(TestEqualityConvertPlanner::filePath)
+              .collect(Collectors.toSet());
+
+      assertThat(dataFilePaths).contains(insertS2.location());
+    }
+  }
+
+  @Test
+  void includesNewDataFilesFromStaging() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      // 1 main data file + 1 eq delete + 1 staging data file
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      assertThat(metadata.get(0).getValue().dataFiles()).hasSize(1);
+    }
+  }
+
+  @Test
+  void findsIntersectionWhenMainAdvancedAfterStagingFork() throws Exception {
+    Table table = createTableWithDelete(3);
+    // Pre-fork main: two snapshots.
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    // Fork staging from current main head.
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Main advances with two more snapshots after the fork. These are on main's
+    // lineage but not on staging's.
+    insert(table, 3, "c");
+    insert(table, 4, "d");
+
+    // Staging gets one new snapshot containing an equality delete.
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Planner identifies the fork point and processes only the staging-only
+      // commit (the eq delete), and emits all four current main data files
+      // for the index refresh.
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(1);
+      assertThat(countDataFileTasks(commands)).isEqualTo(4);
+    }
+  }
+
+  @Test
+  void skipsAlreadyProcessedStagingSnapshot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      assertThat(firstTriggerCount).isGreaterThan(0);
+      assertThat(planner(harness).skippedNoOpCycles()).isZero();
+
+      // Simulate the committer committing to main with the staging snapshot property
+      // (the planner promotes pending only after confirming the commit landed on main).
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(firstTriggerCount);
+      assertThat(planner(harness).skippedNoOpCycles()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void noOutputWhenStagingBranchEmpty() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      // Bootstrap from main for the configured field set: 1 main DATA_FILE; no-op metadata still
+      // emitted because there's nothing on staging to convert.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(1);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+      assertThat(planner(harness).skippedNoOpCycles()).isEqualTo(1);
+      assertThat(planner(harness).reindexCount()).isZero();
+    }
+  }
+
+  @Test
+  void propagatesStagingOnlyPositionalDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    DataFile mainData = writeDataFile(table, createRecord(1, "a"));
+    table.newAppend().appendFile(mainData).commit();
+    table.refresh();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging snapshot has only a DV (no eq deletes, no new data files). Without the
+    // planner forwarding stagingDVFiles in this case, the committer would never
+    // see the DV and it would be lost.
+    DeleteFile stagingDV = writeStagingDV(table, mainData.location(), 0L);
+    table.newRowDelta().addDeletes(stagingDV).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countDataFileTasks(commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(commands)).isZero();
+
+      List<StreamRecord<EqualityConvertPlan>> metadata =
+          Lists.newArrayList(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM));
+      assertThat(metadata).hasSize(1);
+      EqualityConvertPlan result = metadata.get(0).getValue();
+      assertThat(result.dataFiles()).isEmpty();
+      assertThat(result.stagingDVFiles()).hasSize(1);
+      assertThat(result.stagingDVFiles().get(0).location()).isEqualTo(stagingDV.location());
+    }
+  }
+
+  @Test
+  void phaseTimestampsAreMonotonicallyIncreasing() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Staging: eq delete + new data file (triggers 3 phases: main data, eq delete, staging data)
+    DataFile newDataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addRows(newDataFile).addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      long triggerTs = 100L;
+      sendTrigger(harness, triggerTs);
+
+      List<Object> output = Lists.newArrayList(harness.getOutput());
+      assertThat(((StreamRecord<ReadCommand>) output.get(0)).getValue().task())
+          .isInstanceOf(FileScanTask.class);
+      assertThat(output.get(1)).isEqualTo(new Watermark(triggerTs));
+
+      assertThat(((StreamRecord<ReadCommand>) output.get(2)).getValue().task())
+          .isInstanceOf(EqualityDeleteFileScanTask.class);
+      assertThat(output.get(3)).isEqualTo(new Watermark(triggerTs + 1));
+
+      assertThat(((StreamRecord<ReadCommand>) output.get(4)).getValue().task())
+          .isInstanceOf(FileScanTask.class);
+      assertThat(output.get(5)).isEqualTo(new Watermark(triggerTs + 2));
+    }
+  }
+
+  @Test
+  void routesExceptionToErrorStream() throws Exception {
+    createTableWithDelete(3);
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      dropTable();
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).isNull();
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void failsOnRemovedDataFilesOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    Set<DataFile> oldDataFiles = Sets.newHashSet();
+    for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+      try (ManifestReader<DataFile> reader =
+          ManifestFiles.read(manifest, table.io(), table.specs())) {
+        for (DataFile df : reader) {
+          oldDataFiles.add(df.copy());
+        }
+      }
+    }
+
+    assertThat(oldDataFiles).hasSize(2);
+
+    // Rewrite on the staging branch (not main). Equality delete conversion does not support
+    // rewrites on staging; the planner must fail the cycle instead of silently dropping the
+    // removed files.
+    DataFile compactedFile =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+    RewriteFiles rewrite = table.newRewrite();
+    for (DataFile old : oldDataFiles) {
+      rewrite.deleteFile(old);
+    }
+
+    rewrite.addFile(compactedFile);
+    rewrite.toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      // Bootstrap runs before processCycle's failure, so the main data commands are already on
+      // the wire. Only the cycle itself fails.
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isZero();
+    }
+  }
+
+  @Test
+  void reEmitsMainDataAfterCompaction() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+
+      // Compact data files on main: rewrite 2 files into 1
+      Set<DataFile> oldDataFiles = Sets.newHashSet();
+      for (ManifestFile manifest : table.currentSnapshot().dataManifests(table.io())) {
+        try (ManifestReader<DataFile> reader =
+            ManifestFiles.read(manifest, table.io(), table.specs())) {
+          for (DataFile df : reader) {
+            oldDataFiles.add(df.copy());
+          }
+        }
+      }
+
+      assertThat(oldDataFiles).hasSize(2);
+
+      DataFile compactedFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(1, "a"), createRecord(2, "b")));
+      RewriteFiles rewrite = table.newRewrite();
+      for (DataFile old : oldDataFiles) {
+        rewrite.deleteFile(old);
+      }
+
+      rewrite.addFile(compactedFile);
+      rewrite.commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // 1 DATA_FILE (compacted main) + 1 EQ_DELETE_FILE
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(1);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      // DATA_FILE should reference the compacted file
+      List<ReadCommand> dataCmds =
+          trigger2Commands.stream()
+              .filter(c -> c.task() instanceof FileScanTask)
+              .collect(Collectors.toList());
+      for (ReadCommand cmd : dataCmds) {
+        assertThat(cmd.task().file().location()).isEqualTo(compactedFile.location());
+      }
+    }
+  }
+
+  @Test
+  void refreshesIndexBeforeFirstCycleProcessesEqDeletes() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Stage MULTIPLE eq-delete snapshots before the first trigger arrives. The first trigger
+    // bootstraps the index from main for the configured equality fields before processing any eq
+    // deletes, then processes one snapshot per trigger (oldest first).
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+    table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long s2SnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+
+      // First trigger processes the OLDER staging snapshot (eqDelete1). Bootstrap built the index
+      // from main once: 2 main DATA_FILE + 1 EQ_DELETE_FILE = 3 commands.
+      assertThat(afterFirst).isEqualTo(3);
+      assertThat(countDataFileTasks(harness.extractOutputValues())).isEqualTo(2);
+      assertThat(countEqDeleteTasks(harness.extractOutputValues())).isEqualTo(1);
+
+      simulateConvertCommit(table, table.snapshot(STAGING_BRANCH).parentId());
+
+      // Second trigger processes the newer staging snapshot. The index is already up-to-date.
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands = allCommands.subList(afterFirst, allCommands.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isZero();
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      simulateConvertCommit(table, s2SnapshotId);
+    }
+  }
+
+  @Test
+  void noMainReEmitWhenUnchanged() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 2 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(3);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(1);
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Only 1 EQ_DELETE_FILE, no main re-emission
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.METADATA_STREAM)).hasSize(2);
+    }
+  }
+
+  @Test
+  void noMainReEmitAfterOwnCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    insert(table, 2, "b");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long indexedStagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+
+      // Record the converter's own commit (COMMITTED_STAGING_SNAPSHOT property) for the staging
+      // snapshot the first trigger processed. The next trigger reads the property off main and
+      // advances lastStagingSnapshotId. No reindex should be triggered.
+      simulateConvertCommit(table, indexedStagingSnapshotId);
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // Own commits don't trigger index rebuild.
+      assertThat(countDataFileTasks(trigger2Commands)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void reIndexesAfterExternalCommit() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      sendTrigger(harness);
+      int firstTriggerCount = harness.extractOutputValues().size();
+      // 1 DATA_FILE (main) + 1 EQ_DELETE_FILE
+      assertThat(firstTriggerCount).isEqualTo(2);
+      assertThat(planner(harness).reindexCount()).isZero();
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(1);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(1);
+
+      // External commit: no COMMITTED_STAGING_SNAPSHOT_PROPERTY
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> allCommands = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allCommands.subList(firstTriggerCount, allCommands.size());
+
+      // External commit triggers re-index: main data files are re-emitted
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+      assertThat(countEqDeleteTasks(trigger2Commands)).isEqualTo(1);
+      assertThat(planner(harness).reindexCount()).isEqualTo(1);
+      assertThat(planner(harness).processedStagingSnapshotNum()).isEqualTo(2);
+      assertThat(planner(harness).processedEqDeleteFileNum()).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void emitsClearIndexBroadcastOnReindex() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1 bootstraps the index. Bootstrap does not broadcast CLEAR_INDEX.
+      sendTrigger(harness);
+      assertThat(harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM))
+          .isNullOrEmpty();
+
+      // External commit advances main. The next trigger reindexes and must broadcast CLEAR_INDEX
+      // so workers evict ghost keys (e.g. a PK whose data file was removed by external CoW).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+      long mainAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).snapshotId();
+      long mainSeqAfterExternal = table.snapshot(SnapshotRef.MAIN_BRANCH).sequenceNumber();
+
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 2, "b");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+
+      List<IndexCommand> clears =
+          harness.getSideOutput(EqualityConvertPlanner.CLEAR_BROADCAST_STREAM).stream()
+              .map(StreamRecord::getValue)
+              .collect(Collectors.toList());
+      assertThat(clears).hasSize(1);
+      assertThat(clears.get(0).type()).isEqualTo(IndexCommand.Type.CLEAR_INDEX);
+      assertThat(clears.get(0).mainSnapshotId()).isEqualTo(mainAfterExternal);
+      assertThat(clears.get(0).mainSequenceNumber()).isEqualTo(mainSeqAfterExternal);
+    }
+  }
+
+  @Test
+  void detectsMainBranchChangeWithoutNewStagingSnapshots() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete1 = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete1).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // Trigger 1: build the index and process the existing eq delete.
+      sendTrigger(harness);
+      int afterFirst = harness.extractOutputValues().size();
+      assertThat(afterFirst).isGreaterThan(0);
+
+      // External commit on main (no COMMITTED_STAGING_SNAPSHOT_PROPERTY).
+      DataFile externalFile =
+          new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+              .writeFile(Lists.newArrayList(createRecord(10, "z")));
+      table.newAppend().appendFile(externalFile).commit();
+      table.refresh();
+
+      // Trigger 2: nothing new on staging, but the planner must still notice the
+      // external main change and immediately re-emit main data for index rebuild.
+      sendTrigger(harness);
+      List<ReadCommand> allAfterTrigger2 = harness.extractOutputValues();
+      List<ReadCommand> trigger2Commands =
+          allAfterTrigger2.subList(afterFirst, allAfterTrigger2.size());
+      assertThat(countDataFileTasks(trigger2Commands)).isGreaterThan(0);
+
+      // A subsequent staging eq delete should NOT re-emit main data because the index
+      // was already rebuilt in trigger 2.
+      int afterSecond = allAfterTrigger2.size();
+      DeleteFile eqDelete2 = writeEqualityDelete(table, 10, "z");
+      table.newRowDelta().addDeletes(eqDelete2).toBranch(STAGING_BRANCH).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+      List<ReadCommand> all = harness.extractOutputValues();
+      List<ReadCommand> trigger3 = all.subList(afterSecond, all.size());
+      assertThat(countDataFileTasks(trigger3)).isEqualTo(0);
+      assertThat(countEqDeleteTasks(trigger3)).isEqualTo(1);
+    }
+  }
+
+  @Test
+  void stateRestoredAfterCheckpoint() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+
+      // First trigger bootstraps the index and processes the staging snapshot.
+      sendTrigger(harness);
+      int commandCount = harness.extractOutputValues().size();
+      assertThat(commandCount).isGreaterThan(0);
+
+      // Record S1's conversion on main (committer marker) so the planner advances
+      // lastStagingSnapshotId on the second trigger.
+      simulateConvertCommit(table, stagingSnapshotId);
+
+      // Second trigger reads the marker and advances lastStagingSnapshotId.
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).hasSize(commandCount);
+
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // Restore from checkpoint: the restored index is not re-indexed because its state matches the
+    // snapshot COMMITTED_STAGING_SNAPSHOT_PROPERTY property.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+      assertThat(harness.extractOutputValues()).isEmpty();
+    }
+  }
+
+  @Test
+  void failsOnV2PosDeleteOnStagingBranch() throws Exception {
+    Table table = createTableWithDelete(2);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    // Flink-written staging branches are V3 and only produce DVs for deletes. A V2 positional
+    // delete on staging is a writer-side misconfiguration and should fail the cycle rather than
+    // be silently absorbed.
+    DataFile dataFile = writeDataFile(table, createRecord(2, "b"));
+    DeleteFile posDelete = writePosDeleteFile(table, dataFile.location(), 0);
+    table.newRowDelta().addRows(dataFile).addDeletes(posDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+    }
+  }
+
+  @Test
+  void skipsCommittedSnapshotAfterCommitLandsButCheckpointDoesNot() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    // Capture the planner's checkpoint before any cycle has run.
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    // The staging commit landed on main but lastStagingSnapshotId was not checkpointed.
+    simulateConvertCommit(table, stagingSnapshotId);
+
+    // On restore, the planner walks main, finds the COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+    // advances lastStagingSnapshotId, and skips re-emitting the already-committed snapshot.
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.initializeState(state);
+      harness.open();
+
+      sendTrigger(harness);
+
+      List<ReadCommand> commands = harness.extractOutputValues();
+      assertThat(countEqDeleteTasks(commands)).isEqualTo(0);
+      // Bootstrap from main creates the index from the main data files on the first trigger even
+      // though the staging snapshot itself is already committed and skipped. Main now has the
+      // original insert plus simulateConvertCommit's marker file = 2 data files.
+      assertThat(countDataFileTasks(commands)).isEqualTo(2);
+    }
+  }
+
+  @Test
+  void failsWhenCommitMarkerDisappears() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    long startSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).toBranch(STAGING_BRANCH).commit();
+    table.refresh();
+    long stagingSnapshotId = table.snapshot(STAGING_BRANCH).snapshotId();
+
+    simulateConvertCommit(table, stagingSnapshotId);
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH)) {
+      harness.open();
+      sendTrigger(harness);
+
+      table.manageSnapshots().rollbackTo(startSnapshotId).commit();
+      table.refresh();
+
+      sendTrigger(harness);
+
+      assertThat(harness.getSideOutput(TaskResultAggregator.ERROR_STREAM)).hasSize(1);
+      assertThat(
+              harness
+                  .getSideOutput(TaskResultAggregator.ERROR_STREAM)
+                  .poll()
+                  .getValue()
+                  .getMessage())
+          .contains("No COMMITTED_STAGING_SNAPSHOT marker reachable");
+    }
+  }
+
+  @Test
+  void failsOnEqFieldIdsChangeAcrossRestart() throws Exception {
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+    table.manageSnapshots().createBranch(STAGING_BRANCH).commit();
+    table.refresh();
+
+    OperatorSubtaskState state;
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1, 2))) {
+      harness.open();
+      state = harness.snapshot(1, System.currentTimeMillis());
+    }
+
+    try (OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness =
+        createHarness(STAGING_BRANCH, Lists.newArrayList(1))) {
+      assertThatThrownBy(() -> harness.initializeState(state))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Equality field IDs changed across restart");
+    }
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch) throws Exception {
+    // Default matches the [1, 2] equality-field-id list produced by writeEqualityDelete.
+    return createHarness(stagingBranch, Lists.newArrayList(1, 2));
+  }
+
+  private OneInputStreamOperatorTestHarness<Trigger, ReadCommand> createHarness(
+      String stagingBranch, List<Integer> eqFieldIds) throws Exception {
+    return new OneInputStreamOperatorTestHarness<>(
+        new EqualityConvertPlanner(
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            tableLoader(),
+            stagingBranch,
+            SnapshotRef.MAIN_BRANCH,
+            Sets.newHashSet(eqFieldIds)));
+  }
+
+  private static void sendTrigger(OneInputStreamOperatorTestHarness<Trigger, ?> harness)
+      throws Exception {
+    sendTrigger(harness, System.currentTimeMillis());
+  }
+
+  private static void sendTrigger(OneInputStreamOperatorTestHarness<Trigger, ?> harness, long time)
+      throws Exception {
+    harness.processElement(new StreamRecord<>(Trigger.create(time, 0), time));
+  }
+
+  private DataFile writeDataFile(Table table, Record record) throws IOException {
+    return new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .writeFile(Lists.newArrayList(record));
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(createRecord(id, data)),
+        table.schema());
+  }
+
+  private DeleteFile writeIdOnlyEqualityDelete(Table table, int id) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    Schema idOnly = table.schema().select("id");
+    Record record = GenericRecord.create(idOnly);
+    record.setField("id", id);
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(record),
+        idOnly);
+  }
+
+  private DeleteFile writeStagingDV(Table table, String dataFilePath, long position)
+      throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+
+    PositionDelete<Record> delete = PositionDelete.create();
+    delete.set(dataFilePath, position, null);
+    return FileHelpers.writePosDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(delete),
+        3);
+  }
+
+  private static long countDataFileTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(c -> c.task() instanceof FileScanTask).count();
+  }
+
+  private static long countEqDeleteTasks(List<ReadCommand> commands) {
+    return commands.stream().filter(TestEqualityConvertPlanner::isEqDelete).count();
+  }
+
+  private static EqualityConvertPlanner planner(
+      OneInputStreamOperatorTestHarness<Trigger, ReadCommand> harness) {
+    return (EqualityConvertPlanner) harness.getOperator();
+  }
+
+  private static boolean isEqDelete(ReadCommand cmd) {
+    return cmd.task() instanceof EqualityDeleteFileScanTask;
+  }
+
+  private static String filePath(ReadCommand cmd) {
+    return cmd.task().file().location();
+  }
+
+  private void simulateConvertCommit(Table table, long stagingSnapshotId) throws IOException {
+    DataFile dummy =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+            .writeFile(Lists.newArrayList(createRecord(-1, "marker" + stagingSnapshotId)));
+    table
+        .newRowDelta()
+        .addRows(dummy)
+        .set(
+            EqualityConvertCommitter.COMMITTED_STAGING_SNAPSHOT_PROPERTY,
+            String.valueOf(stagingSnapshotId))
+        .commit();
+    table.refresh();
+  }
+}


### PR DESCRIPTION
This is a clean backport of #16889 for Flink version 2.0, and mostly clean backport for Flink 1.20.

For Flink 1.20, https://github.com/apache/iceberg/pull/16944/commits/6a8c58d9941300caa251ff69a0175cb5702a0981 was required to work around the lack of serialization support for Java Record classes.