### PR TITLE
CI: Select Flink PR matrix by changed version

### DIFF
--- a/.github/scripts/ci-plan-common.sh
+++ b/.github/scripts/ci-plan-common.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+gradle_property() {
+  local name="$1"
+  sed -n "s/^systemProp\.${name}=//p" gradle.properties | head -n 1
+}
+
+changed_files=()
+read_changed_files() {
+  local file
+  changed_files=()
+
+  if [[ -n "${CHANGED_FILES_FILE:-}" ]]; then
+    while IFS= read -r file; do
+      if [[ -n "${file}" ]]; then
+        changed_files+=("${file}")
+      fi
+    done < "${CHANGED_FILES_FILE}"
+  elif [[ -n "${BASE_SHA:-}" ]]; then
+    git fetch --no-tags --depth=1 origin "${BASE_SHA}"
+    while IFS= read -r file; do
+      if [[ -n "${file}" ]]; then
+        changed_files+=("${file}")
+      fi
+    done < <(git diff --name-only "${BASE_SHA}" HEAD)
+  fi
+}
+
+value_in_list() {
+  local value="$1"
+  shift
+  local candidate
+  for candidate in "$@"; do
+    if [[ "${candidate}" == "${value}" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}

--- a/.github/scripts/plan-flink-ci.sh
+++ b/.github/scripts/plan-flink-ci.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -euo pipefail
+
+source .github/scripts/ci-plan-common.sh
+
+known_flink_versions="$(gradle_property knownFlinkVersions)"
+IFS=',' read -r -a all_flink_versions <<< "${known_flink_versions}"
+
+add_selected_flink_version() {
+  local value="$1"
+  if ! value_in_list "${value}" "${selected_flink_versions[@]:-}"; then
+    selected_flink_versions+=("${value}")
+  fi
+}
+
+select_flink_versions() {
+  local file
+  local flink_version
+  full_flink_matrix=false
+  selected_flink_versions=()
+
+  if [[ "${GITHUB_EVENT_NAME:-}" != "pull_request" ]]; then
+    full_flink_matrix=true
+    selected_flink_versions=("${all_flink_versions[@]}")
+    return
+  fi
+
+  read_changed_files
+  if [[ ${#changed_files[@]} -eq 0 ]]; then
+    full_flink_matrix=true
+    selected_flink_versions=("${all_flink_versions[@]}")
+    return
+  fi
+
+  for file in "${changed_files[@]}"; do
+    if [[ "${file}" =~ ^flink/v([^/]+)/ ]]; then
+      flink_version="${BASH_REMATCH[1]}"
+      if value_in_list "${flink_version}" "${all_flink_versions[@]}"; then
+        add_selected_flink_version "${flink_version}"
+      else
+        full_flink_matrix=true
+        selected_flink_versions=("${all_flink_versions[@]}")
+        return
+      fi
+    else
+      full_flink_matrix=true
+      selected_flink_versions=("${all_flink_versions[@]}")
+      return
+    fi
+  done
+}
+
+flink_versions() {
+  local flink_version
+  local -a rows=()
+
+  select_flink_versions
+
+  for flink_version in "${selected_flink_versions[@]}"; do
+    rows+=("${flink_version}")
+  done
+
+  printf '%s\n' "${rows[@]}" \
+    | jq -R '.' \
+    | jq -s -c '.'
+}
+
+echo "flink_versions=$(flink_versions)" >> "${GITHUB_OUTPUT}"

--- a/.github/workflows/flink-ci.yml
+++ b/.github/workflows/flink-ci.yml
@@ -73,9 +73,22 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  plan:
+    runs-on: ubuntu-24.04
+    outputs:
+      flink_versions: ${{ steps.plan.outputs.flink_versions }}
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
+    - id: plan
+      env:
+        BASE_SHA: ${{ github.event.pull_request.base.sha }}
+      run: bash .github/scripts/plan-flink-ci.sh
 
   # Test all flink versions with scala 2.12 for general validation.
   flink-scala-2-12-tests:
+    needs: plan
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     strategy:
@@ -87,7 +100,7 @@ jobs:
           # Pull requests run the baseline JDK only.
           - event_name: pull_request
             jvm: 21
-        flink: ['1.20', '2.0', '2.1']
+        flink: ${{ fromJson(needs.plan.outputs.flink_versions) }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:
@@ -103,7 +116,9 @@ jobs:
         # Read-only: java-ci's build-checks (17) is the global canonical writer.
         cache-read-only: true
     - run: echo -e "$(ip addr show eth0 | grep "inet\b" | awk '{print $2}' | cut -d/ -f1)\t$(hostname -f) $(hostname -s)" | sudo tee -a /etc/hosts
-    - run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions=${{ matrix.flink }} :iceberg-flink:iceberg-flink-${{ matrix.flink }}:check :iceberg-flink:iceberg-flink-runtime-${{ matrix.flink }}:check -Pquick=true -x javadoc -DtestParallelism=auto
+    - env:
+        FLINK_VERSION: ${{ matrix.flink }}
+      run: ./gradlew -DsparkVersions= -DkafkaVersions= -DflinkVersions="${FLINK_VERSION}" ":iceberg-flink:iceberg-flink-${FLINK_VERSION}:check" ":iceberg-flink:iceberg-flink-runtime-${FLINK_VERSION}:check" -Pquick=true -x javadoc -DtestParallelism=auto
     - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       if: failure()
       with:


### PR DESCRIPTION
### Summary

This updates Flink CI to build an incremental PR matrix based on the changed Flink version path.

For pull requests, Flink CI uses the baseline PR JDK from the merged workflow matrix and narrows the Flink version matrix only when all changed files are scoped to known Flink version paths:

- `flink/v1.20/**` runs Flink 1.20 only
- `flink/v2.0/**` runs Flink 2.0 only
- `flink/v2.1/**` runs Flink 2.1 only
- unknown Flink version paths, non-version Flink paths, workflow/script/build changes, and missing changed-file detection fall back to the full Flink version matrix

For non-PR runs, including pushes to the configured main/release branches and Iceberg release tags, Flink CI still runs the full Flink version matrix. This PR does not add a `full-ci` label or any other manual full-CI override.

Known Flink versions are read from `knownFlinkVersions` in `gradle.properties`, so adding/removing Flink versions does not require hard-coding the version list in the planner.

The planner selects Flink versions only. JVM selection stays in the workflow matrix using the existing `matrix.flink` and `matrix.jvm` names. Dynamic matrix values are passed through step environment variables before shell use, which keeps the Actions security check clean.

This keeps the PR path conservative: stale or unknown planner inputs run more Flink CI, not less. For this PR itself, because workflow/scripts changed, the planner falls back to the full Flink version matrix.

### Testing

- `zizmor --min-severity medium --min-confidence medium --no-progress .github/workflows/flink-ci.yml`
- `bash -n .github/scripts/ci-plan-common.sh .github/scripts/plan-flink-ci.sh`
- `git diff --check origin/main`
- `git diff --check`
- Local planner checks:
  - `flink/v2.0/**` -> Flink 2.0 only; workflow JVM matrix keeps PR jobs on the baseline JDK
  - unknown Flink version/path -> all known Flink versions; workflow JVM matrix keeps PR jobs on the baseline JDK
  - non-PR run -> all known Flink versions; workflow JVM matrix expands to JDK 17 and JDK 21
- GitHub PR builder checks are expected to validate the workflow end-to-end.

---
**AI Disclosure**
- Model: GPT-5 Codex
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Update Flink CI to select the PR matrix incrementally by changed Flink version path.
