### PR TITLE
Flink 1.20, 2.0: Fix file offset mismatch in DataIterator.seek() when files are skipped

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -86,6 +86,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
         combinedTask);
     for (long i = 0L; i < startingFileOffset; ++i) {
       tasks.next();
+      fileOffset += 1;
     }
 
     updateCurrentIterator();
@@ -103,9 +104,6 @@ public class DataIterator<T> implements CloseableIterator<T> {
                 combinedTask));
       }
     }
-
-    fileOffset = startingFileOffset;
-    recordOffset = startingRecordOffset;
   }
 
   @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -57,6 +57,21 @@ public class ReaderUtil {
 
   public static FileScanTask createFileTask(
       List<Record> records, File file, FileFormat fileFormat, Schema schema) throws IOException {
+    return createFileTask(
+        records,
+        file,
+        fileFormat,
+        schema,
+        ResidualEvaluator.unpartitioned(Expressions.alwaysTrue()));
+  }
+
+  public static FileScanTask createFileTask(
+      List<Record> records,
+      File file,
+      FileFormat fileFormat,
+      Schema schema,
+      ResidualEvaluator residuals)
+      throws IOException {
     DataWriter<Record> writer =
         new GenericFileWriterFactory.Builder()
             .dataSchema(schema)
@@ -69,7 +84,6 @@ public class ReaderUtil {
 
     DataFile dataFile = writer.toDataFile();
 
-    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.alwaysTrue());
     return new BaseFileScanTask(
         dataFile,
         null,

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -32,13 +33,18 @@ import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -353,5 +359,169 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     batch21.recycle();
 
     assertThat(recordBatchIterator).isExhausted();
+  }
+
+  @Test
+  public void testDataIteratorWithResidualFilter() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "file-1");
+    record0.setField("id", 0L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "file-2");
+    record1.setField("id", 1L);
+    record1.setField("dt", "-");
+
+    List<Record> fileRecords0 = ImmutableList.of(record0);
+    List<Record> fileRecords1 = ImmutableList.of(record1);
+
+    validateFileOffsetWithResidualFilter(fileRecords0, fileRecords1, Expressions.alwaysTrue());
+
+    validateFileOffsetWithResidualFilter(
+        fileRecords0, fileRecords1, Expressions.greaterThan("id", 0));
+  }
+
+  private void validateFileOffsetWithResidualFilter(
+      List<Record> fileRecords0, List<Record> fileRecords1, Expression residualFilter)
+      throws IOException {
+    ResidualEvaluator residualEvaluator = ResidualEvaluator.unpartitioned(residualFilter);
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            fileRecords0,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            fileRecords1,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    while (dataIterator.hasNext()) {
+      assertThat(dataIterator.fileOffset()).isEqualTo(dataIterator.next().getLong(1));
+    }
+  }
+
+  @Test
+  public void testInitializationWithHeadFilesSkipped() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "a");
+    record0.setField("id", 1L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "a");
+    record1.setField("id", 10L);
+    record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    assertThat(dataIterator.fileOffset())
+        .as("File offset should be 1 because file 0 should be skipped")
+        .isEqualTo(1);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, record1, dataIterator.next());
+  }
+
+  @Test
+  void testSeekResumesCorrectlyAfterHeadFilesSkipped() throws IOException {
+    GenericRecord filteredRecord = GenericRecord.create(TestFixtures.SCHEMA);
+    filteredRecord.setField("data", "a");
+    filteredRecord.setField("id", 1L);
+    filteredRecord.setField("dt", "-");
+
+    GenericRecord f1Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f1Record0.setField("data", "b");
+    f1Record0.setField("id", 10L);
+    f1Record0.setField("dt", "-");
+
+    GenericRecord f2Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record0.setField("data", "d");
+    f2Record0.setField("id", 20L);
+    f2Record0.setField("dt", "-");
+
+    GenericRecord f2Record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record1.setField("data", "e");
+    f2Record1.setField("id", 21L);
+    f2Record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(filteredRecord),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f1Record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask2 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f2Record0, f2Record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask =
+        new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    dataIterator.seek(0, 0);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f1Record0, dataIterator.next());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record0, dataIterator.next());
+
+    int checkpointFileOffset = dataIterator.fileOffset();
+    long checkpointRecordOffset = dataIterator.recordOffset();
+
+    DataIterator<RowData> restoredIterator = ReaderUtil.createDataIterator(combinedTask);
+    restoredIterator.seek(checkpointFileOffset, checkpointRecordOffset);
+
+    assertThat(restoredIterator.hasNext()).isTrue();
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record1, restoredIterator.next());
+    assertThat(restoredIterator.hasNext()).isFalse();
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/DataIterator.java
@@ -86,6 +86,7 @@ public class DataIterator<T> implements CloseableIterator<T> {
         combinedTask);
     for (long i = 0L; i < startingFileOffset; ++i) {
       tasks.next();
+      fileOffset += 1;
     }
 
     updateCurrentIterator();
@@ -103,9 +104,6 @@ public class DataIterator<T> implements CloseableIterator<T> {
                 combinedTask));
       }
     }
-
-    fileOffset = startingFileOffset;
-    recordOffset = startingRecordOffset;
   }
 
   @Override

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/ReaderUtil.java
@@ -57,6 +57,21 @@ public class ReaderUtil {
 
   public static FileScanTask createFileTask(
       List<Record> records, File file, FileFormat fileFormat, Schema schema) throws IOException {
+    return createFileTask(
+        records,
+        file,
+        fileFormat,
+        schema,
+        ResidualEvaluator.unpartitioned(Expressions.alwaysTrue()));
+  }
+
+  public static FileScanTask createFileTask(
+      List<Record> records,
+      File file,
+      FileFormat fileFormat,
+      Schema schema,
+      ResidualEvaluator residuals)
+      throws IOException {
     DataWriter<Record> writer =
         new GenericFileWriterFactory.Builder()
             .dataSchema(schema)
@@ -69,7 +84,6 @@ public class ReaderUtil {
 
     DataFile dataFile = writer.toDataFile();
 
-    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.alwaysTrue());
     return new BaseFileScanTask(
         dataFile,
         null,

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestArrayPoolDataIteratorBatcherRowData.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.flink.source.reader;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -32,13 +33,18 @@ import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.CombinedScanTask;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.TestFixtures;
 import org.apache.iceberg.flink.TestHelpers;
 import org.apache.iceberg.flink.source.DataIterator;
 import org.apache.iceberg.io.CloseableIterator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -353,5 +359,169 @@ public class TestArrayPoolDataIteratorBatcherRowData {
     batch21.recycle();
 
     assertThat(recordBatchIterator).isExhausted();
+  }
+
+  @Test
+  public void testDataIteratorWithResidualFilter() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "file-1");
+    record0.setField("id", 0L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "file-2");
+    record1.setField("id", 1L);
+    record1.setField("dt", "-");
+
+    List<Record> fileRecords0 = ImmutableList.of(record0);
+    List<Record> fileRecords1 = ImmutableList.of(record1);
+
+    validateFileOffsetWithResidualFilter(fileRecords0, fileRecords1, Expressions.alwaysTrue());
+
+    validateFileOffsetWithResidualFilter(
+        fileRecords0, fileRecords1, Expressions.greaterThan("id", 0));
+  }
+
+  private void validateFileOffsetWithResidualFilter(
+      List<Record> fileRecords0, List<Record> fileRecords1, Expression residualFilter)
+      throws IOException {
+    ResidualEvaluator residualEvaluator = ResidualEvaluator.unpartitioned(residualFilter);
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            fileRecords0,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            fileRecords1,
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residualEvaluator);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    while (dataIterator.hasNext()) {
+      assertThat(dataIterator.fileOffset()).isEqualTo(dataIterator.next().getLong(1));
+    }
+  }
+
+  @Test
+  public void testInitializationWithHeadFilesSkipped() throws IOException {
+    GenericRecord record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    record0.setField("data", "a");
+    record0.setField("id", 1L);
+    record0.setField("dt", "-");
+
+    GenericRecord record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    record1.setField("data", "a");
+    record1.setField("id", 10L);
+    record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask = new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+
+    dataIterator.seek(0, 0);
+
+    assertThat(dataIterator.fileOffset())
+        .as("File offset should be 1 because file 0 should be skipped")
+        .isEqualTo(1);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, record1, dataIterator.next());
+  }
+
+  @Test
+  void testSeekResumesCorrectlyAfterHeadFilesSkipped() throws IOException {
+    GenericRecord filteredRecord = GenericRecord.create(TestFixtures.SCHEMA);
+    filteredRecord.setField("data", "a");
+    filteredRecord.setField("id", 1L);
+    filteredRecord.setField("dt", "-");
+
+    GenericRecord f1Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f1Record0.setField("data", "b");
+    f1Record0.setField("id", 10L);
+    f1Record0.setField("dt", "-");
+
+    GenericRecord f2Record0 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record0.setField("data", "d");
+    f2Record0.setField("id", 20L);
+    f2Record0.setField("dt", "-");
+
+    GenericRecord f2Record1 = GenericRecord.create(TestFixtures.SCHEMA);
+    f2Record1.setField("data", "e");
+    f2Record1.setField("id", 21L);
+    f2Record1.setField("dt", "-");
+
+    ResidualEvaluator residuals = ResidualEvaluator.unpartitioned(Expressions.greaterThan("id", 5));
+
+    FileScanTask fileTask0 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(filteredRecord),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask1 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f1Record0),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    FileScanTask fileTask2 =
+        ReaderUtil.createFileTask(
+            ImmutableList.of(f2Record0, f2Record1),
+            File.createTempFile("junit", null, temporaryFolder.toFile()),
+            FILE_FORMAT,
+            TestFixtures.SCHEMA,
+            residuals);
+
+    CombinedScanTask combinedTask =
+        new BaseCombinedScanTask(Arrays.asList(fileTask0, fileTask1, fileTask2));
+
+    DataIterator<RowData> dataIterator = ReaderUtil.createDataIterator(combinedTask);
+    dataIterator.seek(0, 0);
+
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f1Record0, dataIterator.next());
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record0, dataIterator.next());
+
+    int checkpointFileOffset = dataIterator.fileOffset();
+    long checkpointRecordOffset = dataIterator.recordOffset();
+
+    DataIterator<RowData> restoredIterator = ReaderUtil.createDataIterator(combinedTask);
+    restoredIterator.seek(checkpointFileOffset, checkpointRecordOffset);
+
+    assertThat(restoredIterator.hasNext()).isTrue();
+    TestHelpers.assertRowData(TestFixtures.SCHEMA, f2Record1, restoredIterator.next());
+    assertThat(restoredIterator.hasNext()).isFalse();
   }
 }


### PR DESCRIPTION
Cherry-pick of #16929 to Flink 1.20 and Flink 2.0.

cc @pvary Could you please review?