### PR TITLE
CI: Reduce Java 21 Spark matrix on pull requests

### DIFF
--- a/.github/workflows/spark-ci.yml
+++ b/.github/workflows/spark-ci.yml
@@ -88,12 +88,18 @@ jobs:
         # so they run as concurrent jobs rather than serially in one job.
         tests: [core, extensions]
         exclude:
-          # Spark 3.5 is the first version not failing on Java 21 (https://issues.apache.org/jira/browse/SPARK-42369)
-          # Full Java 21 support is coming in Spark 4 (https://issues.apache.org/jira/browse/SPARK-43831)
+          # Spark 4.x dropped Scala 2.12, so these combinations never exist.
           - spark: '4.0'
             scala: '2.12'
           - spark: '4.1'
             scala: '2.12'
+          # On PRs (unless labeled `full-ci`), drop Java 21 on older Spark and keep
+          # only the latest (4.1 / 2.13) as the canary. main/tags keep the full matrix;
+          # the guard is a non-matching value off PRs, so it excludes nothing there.
+          - jvm: 21
+            spark: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full-ci')) && '3.5' || '' }}
+          - jvm: 21
+            spark: ${{ (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'full-ci')) && '4.0' || '' }}
     env:
       SPARK_LOCAL_IP: localhost
     steps:


### PR DESCRIPTION
## Motivation

ASF Infra flagged Iceberg as a top-5 consumer of the shared GitHub-hosted runner pool ([dev list thread](https://lists.apache.org/thread/36vxlql61gojbg639c86mnz78n57kvgm)). One of the optimizations raised there is JVM coverage: run a primary JVM for PRs and reserve the full JVM matrix for `main`, release branches, tags, and `full-ci`-labeled PRs. This PR implements exactly that JVM-axis slice for Spark CI, and nothing else.

## Change

On pull requests (unless labeled `full-ci`), Java 21 runs only on the latest Spark (4.1 / Scala 2.13) as a canary. Java 17 still runs the full matrix. `main`, release branches, tags, and `full-ci` PRs keep the full Java 17 + Java 21 matrix, so coverage at the integration points is unchanged.

| Trigger | Spark jobs | Java 21 jobs |
|---|---|---|
| Pull request (default) | 10 | 2 (4.1/2.13 core + extensions) |
| `main` / release / tag / `full-ci` PR | 16 | 8 |

Implementation is two guarded `exclude` entries; the guard resolves to a non-matching value off PRs, so it excludes nothing on `main`.

## Scope

This is intentionally the JVM-axis reduction only, and is complementary to:

- #16566 (path/version-based PR matrix selection)
- #16945 (single Java version for PR checks)

It deliberately keeps a Java 21 canary on the latest Spark rather than dropping Java 21 from PRs entirely, to catch Java 21-specific regressions before merge at a cost of just 2 jobs.

## Notes

- Uses a `full-ci` label as the manual override, consistent with the dev list proposal. The label must exist in the repo to be used.
  
  