### PR TITLE
Build: Align Jackson versions to fix CVE

### DIFF
--- a/.github/trivyignore/kafka-connect-runtime.trivyignore
+++ b/.github/trivyignore/kafka-connect-runtime.trivyignore
@@ -1,0 +1,29 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Trivy ignore file for the Kafka Connect runtime distribution.
+#
+# The Kafka Connect runtime's own jackson-databind is already aligned to the
+# project version (2.22.x). The remaining finding comes from parquet-jackson,
+# which ships its own shaded copy of jackson-databind (relocated under
+# shaded.parquet.*). That copy cannot be upgraded independently of Apache
+# Parquet, and 1.17.1 still bundles a vulnerable version.
+#
+# jackson-databind CVEs shaded into parquet-jackson, only fixed in jackson
+# >= 2.21.4 / 2.18.8.
+CVE-2026-54512
+CVE-2026-54513

--- a/.github/trivyignore/spark-runtime-3.5.trivyignore
+++ b/.github/trivyignore/spark-runtime-3.5.trivyignore
@@ -1,0 +1,27 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# Trivy ignore file for the Spark 3.5 runtime bundle.
+#
+# The Spark 3.5 runtime bundles the Jackson version provided by Spark 3.5
+# (jackson 2.15.x), which cannot be safely upgraded without breaking
+# compatibility with Spark 3.5. Newer Spark lines (4.0, 4.1) align Jackson to a
+# fixed version instead of ignoring the finding.
+#
+# jackson-databind CVEs that are only fixed in jackson >= 2.18.8.
+CVE-2026-54512
+CVE-2026-54513

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -31,6 +31,7 @@ on:
     - '**'
     - '!.github/**'
     - '.github/workflows/cve-scan.yml'
+    - '.github/trivyignore/**'
     - '!.baseline/**'
     - '!.palantir/**'
     - '!.gitignore'
@@ -54,6 +55,7 @@ on:
     - '**'
     - '!.github/**'
     - '.github/workflows/cve-scan.yml'
+    - '.github/trivyignore/**'
     - '!.baseline/**'
     - '!.palantir/**'
     - '!.gitignore'
@@ -113,6 +115,7 @@ jobs:
             :iceberg-kafka-connect:iceberg-kafka-connect-runtime:distZip
           scan-path: kafka-connect/kafka-connect-runtime/build/distributions
           unpack: true
+          trivyignores: .github/trivyignore/kafka-connect-runtime.trivyignore
         - distribution: aws-bundle
           build-task: :iceberg-aws-bundle:shadowJar
           scan-path: aws-bundle/build/libs
@@ -131,6 +134,7 @@ jobs:
             :iceberg-spark:iceberg-spark-runtime-3.5_2.12:shadowJar
           scan-path: spark/v3.5/spark-runtime/build/libs
           unpack: false
+          trivyignores: .github/trivyignore/spark-runtime-3.5.trivyignore
         - distribution: spark-runtime-4.0_2.13
           build-task: >-
             -DsparkVersions=4.0
@@ -214,6 +218,7 @@ jobs:
         scan-ref: '/tmp/cve-scan'
         scanners: 'vuln'
         severity: 'HIGH,CRITICAL'
+        trivyignores: ${{ matrix.trivyignores }}
         limit-severities-for-sarif: true
         # Block PRs on CVE findings; on main/release branches report without failing
         exit-code: ${{ github.event_name == 'pull_request' && '1' || '0' }}

--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -31,6 +31,9 @@ project(":iceberg-azure-bundle") {
 
   dependencies {
     implementation platform(libs.azuresdk.bom)
+    // Align the shaded Jackson to the project version; the Azure SDK BOM otherwise
+    // pulls in an older jackson-databind with known CVEs.
+    implementation platform(libs.jackson.bom)
     implementation "com.azure:azure-storage-file-datalake"
     implementation "com.azure:azure-security-keyvault-keys"
     implementation "com.azure:azure-identity"

--- a/azure-bundle/runtime-deps.txt
+++ b/azure-bundle/runtime-deps.txt
@@ -8,10 +8,10 @@ com.azure:azure-storage-common:12.33
 com.azure:azure-storage-file-datalake:12.27
 com.azure:azure-storage-internal-avro:12.19
 com.azure:azure-xml:1.2
-com.fasterxml.jackson.core:jackson-annotations:2.18
-com.fasterxml.jackson.core:jackson-core:2.18
-com.fasterxml.jackson.core:jackson-databind:2.18
-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18
+com.fasterxml.jackson.core:jackson-annotations:2.22
+com.fasterxml.jackson.core:jackson-core:2.22
+com.fasterxml.jackson.core:jackson-databind:2.22
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.microsoft.azure:msal4j-persistence-extension:1.3
 com.microsoft.azure:msal4j:1.23
 io.netty:netty-buffer:4.2

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -32,6 +32,9 @@ project(":iceberg-gcp-bundle") {
 
   dependencies {
     implementation platform(libs.google.libraries.bom)
+    // Align the shaded Jackson to the project version; the Google libraries BOM
+    // otherwise pulls in an older jackson-databind with known CVEs.
+    implementation platform(libs.jackson.bom)
     implementation "com.google.cloud:google-cloud-storage"
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-core"

--- a/gcp-bundle/runtime-deps.txt
+++ b/gcp-bundle/runtime-deps.txt
@@ -1,8 +1,8 @@
-com.fasterxml.jackson.core:jackson-annotations:2.18
-com.fasterxml.jackson.core:jackson-core:2.18
-com.fasterxml.jackson.core:jackson-databind:2.18
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18
-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18
+com.fasterxml.jackson.core:jackson-annotations:2.22
+com.fasterxml.jackson.core:jackson-core:2.22
+com.fasterxml.jackson.core:jackson-databind:2.22
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.fasterxml.woodstox:woodstox-core:7.0
 com.github.ben-manes.caffeine:caffeine:3.2
 com.google.android:annotations:4.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,8 +60,9 @@ hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 immutables-value = "2.12.2"
 jackson-annotations = "2.22"
 jackson-bom = "2.22.0"
-jackson214 = { strictly = "2.14.2"}
 jackson215 = { strictly = "2.15.2"} # see rich version usage explanation above
+jackson218 = { strictly = "2.18.8"}
+jackson221 = { strictly = "2.21.4"}
 jakarta-el-api = "3.0.3"
 jakarta-servlet-api = "6.1.0"
 jaxb-api = "2.3.1"
@@ -157,8 +158,6 @@ jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jac
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson-bom" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-bom" }
 jackson-annotations = { module = "com.fasterxml.jackson.core:jackson-annotations", version.ref = "jackson-annotations" }
-jackson214-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref =  "jackson214" }
-jackson215-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson215" }
 jaxb-api = { module = "javax.xml.bind:jaxb-api", version.ref = "jaxb-api" }
 jaxb-runtime = { module = "org.glassfish.jaxb:jaxb-runtime", version.ref = "jaxb-runtime" }
 kafka-clients = { module = "org.apache.kafka:kafka-clients", version.ref = "kafka" }

--- a/spark/v4.0/build.gradle
+++ b/spark/v4.0/build.gradle
@@ -30,9 +30,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson215.get()}"
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson218.get()}"
       }
     }
   }

--- a/spark/v4.0/spark-runtime/runtime-deps.txt
+++ b/spark/v4.0/spark-runtime/runtime-deps.txt
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.22
-com.fasterxml.jackson.core:jackson-core:2.15
-com.fasterxml.jackson.core:jackson-databind:2.15
+com.fasterxml.jackson.core:jackson-core:2.18
+com.fasterxml.jackson.core:jackson-databind:2.18
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.github.ben-manes.caffeine:caffeine:2.9
 com.google.errorprone:error_prone_annotations:2.10

--- a/spark/v4.1/build.gradle
+++ b/spark/v4.1/build.gradle
@@ -30,9 +30,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson215.get()}"
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson221.get()}"
+        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson221.get()}"
+        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson221.get()}"
       }
     }
   }

--- a/spark/v4.1/spark-runtime/runtime-deps.txt
+++ b/spark/v4.1/spark-runtime/runtime-deps.txt
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.22
-com.fasterxml.jackson.core:jackson-core:2.15
-com.fasterxml.jackson.core:jackson-databind:2.15
+com.fasterxml.jackson.core:jackson-core:2.21
+com.fasterxml.jackson.core:jackson-databind:2.21
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.github.ben-manes.caffeine:caffeine:2.9
 com.google.errorprone:error_prone_annotations:2.10


### PR DESCRIPTION
I did a quick check across Spark versions using Claude and this is what the result was:
Line | Latest release | FasterXML Jackson
-- | -- | --
3.5.x | v3.5.8 | 2.15.2
4.0.x | v4.0.3 | 2.18.6
4.1.x | v4.1.2 | 2.21.2

Also looks like Trivy scans are failing due to jackson versions that contain a CVE.

## Trivy CVE Scan Results — spark-runtime-4.0_2.12
- CVE-2026-54512: Package: com.fasterxml.jackson.core:jackson-databind
Installed Version: 2.18.6
Vulnerability CVE-2026-54512
Severity: HIGH
Fixed Version: 2.18.8, 3.1.4, 2.21.4
Link: [CVE-2026-54512](https://avd.aquasec.com/nvd/cve-2026-54512)


## Trivy CVE Scan Results — spark-runtime-3.5_2.12
- CVE-2026-54512: Package: com.fasterxml.jackson.core:jackson-databind
Installed Version: 2.15.2
Vulnerability CVE-2026-54512
Severity: HIGH
Fixed Version: 2.18.8, 3.1.4, 2.21.4
Link: [CVE-2026-54512](https://avd.aquasec.com/nvd/cve-2026-54512)
- CVE-2026-54513: Package: com.fasterxml.jackson.core:jackson-databind
Installed Version: 2.15.2
Vulnerability CVE-2026-54513
Severity: HIGH
Fixed Version: 2.18.8, 2.21.4, 3.1.4
Link: [CVE-2026-54513](https://avd.aquasec.com/nvd/cve-2026-54513)

I don't think we can safely upgrade the jackson version for Spark 3.5, so I've added a trivyignore for this

Most stuff was done manually with some help of Claude. 