### PR TITLE
Build: Align bundled Jackson to project version in azure/gcp bundles

### DIFF
--- a/azure-bundle/build.gradle
+++ b/azure-bundle/build.gradle
@@ -31,6 +31,9 @@ project(":iceberg-azure-bundle") {
 
   dependencies {
     implementation platform(libs.azuresdk.bom)
+    // Align the shaded Jackson to the project version; the Azure SDK BOM otherwise
+    // pulls in an older jackson-databind with known CVEs.
+    implementation platform(libs.jackson.bom)
     implementation "com.azure:azure-storage-file-datalake"
     implementation "com.azure:azure-security-keyvault-keys"
     implementation "com.azure:azure-identity"

--- a/azure-bundle/runtime-deps.txt
+++ b/azure-bundle/runtime-deps.txt
@@ -8,10 +8,10 @@ com.azure:azure-storage-common:12.33
 com.azure:azure-storage-file-datalake:12.27
 com.azure:azure-storage-internal-avro:12.19
 com.azure:azure-xml:1.2
-com.fasterxml.jackson.core:jackson-annotations:2.18
-com.fasterxml.jackson.core:jackson-core:2.18
-com.fasterxml.jackson.core:jackson-databind:2.18
-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18
+com.fasterxml.jackson.core:jackson-annotations:2.22
+com.fasterxml.jackson.core:jackson-core:2.22
+com.fasterxml.jackson.core:jackson-databind:2.22
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.microsoft.azure:msal4j-persistence-extension:1.3
 com.microsoft.azure:msal4j:1.23
 io.netty:netty-buffer:4.2

--- a/gcp-bundle/build.gradle
+++ b/gcp-bundle/build.gradle
@@ -32,6 +32,9 @@ project(":iceberg-gcp-bundle") {
 
   dependencies {
     implementation platform(libs.google.libraries.bom)
+    // Align the shaded Jackson to the project version; the Google libraries BOM
+    // otherwise pulls in an older jackson-databind with known CVEs.
+    implementation platform(libs.jackson.bom)
     implementation "com.google.cloud:google-cloud-storage"
     implementation "com.google.cloud:google-cloud-bigquery"
     implementation "com.google.cloud:google-cloud-core"

--- a/gcp-bundle/runtime-deps.txt
+++ b/gcp-bundle/runtime-deps.txt
@@ -1,8 +1,8 @@
-com.fasterxml.jackson.core:jackson-annotations:2.18
-com.fasterxml.jackson.core:jackson-core:2.18
-com.fasterxml.jackson.core:jackson-databind:2.18
-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.18
-com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.18
+com.fasterxml.jackson.core:jackson-annotations:2.22
+com.fasterxml.jackson.core:jackson-core:2.22
+com.fasterxml.jackson.core:jackson-databind:2.22
+com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.22
+com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.fasterxml.woodstox:woodstox-core:7.0
 com.github.ben-manes.caffeine:caffeine:3.2
 com.google.android:annotations:4.1


### PR DESCRIPTION
## Problem

Trivy (the `CVE Scan` workflow) flags two HIGH severity vulnerabilities in `com.fasterxml.jackson.core:jackson-databind`:

- [CVE-2026-54512](https://avd.aquasec.com/nvd/cve-2026-54512) — PolymorphicTypeValidator bypass via generic type parameters
- [CVE-2026-54513](https://avd.aquasec.com/nvd/cve-2026-54513) — incomplete allow-list check for array subtypes

Affected ranges: `>=2.10.0 <2.18.8`, `>=2.19.0 <2.21.4`, `>=3.0.0 <3.1.4`. Fixed in 2.18.8 / 2.21.4 / 3.1.4.

The `azure-bundle` and `gcp-bundle` distributions shade `jackson-databind` **2.18.x**, pulled in transitively from the Azure SDK BOM / Google libraries BOM. `open-api-test-fixtures-runtime` re-bundles those shadow jars, so it inherits the same vulnerable version.

## Change

Apply the project's Jackson BOM (`libs.jackson.bom` = 2.22.0, already used project-wide and outside all affected ranges) in `azure-bundle` and `gcp-bundle`, so the shaded Jackson family (databind + core + annotations + dataformat/datatype modules) aligns to a non-vulnerable version. The `runtime-deps.txt` baselines are regenerated to match (jackson `2.18` → `2.22`, no other dependencies added or removed; LICENSE/NOTICE are unaffected since no licenses change).

Fixing the two bundles also resolves `open-api-test-fixtures-runtime`, which re-bundles their shadow jars.

## Scope / not covered here

The same CVE also affects other distributions through **different** Jackson sources, which need separate, more involved fixes and are intentionally out of scope for this PR:

- `kafka-connect-runtime` — bundles `jackson-databind` **2.21.3** via Hive/Hadoop (its own runtime classpath is already 2.22).
- `spark-runtime-3.5/4.0/4.1` — bundle the Spark-aligned Jackson (e.g. **2.15.2** for 3.5), which has no fix in its release line; bumping risks Spark compatibility.

These are pre-existing, repo-wide failures (triggered by a Trivy DB update) that show up on every PR and on `main`, independent of this change.
