### PR TITLE
Core, Data, Spark: Build equality delete map once per task

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/BinPacking.java
+++ b/core/src/main/java/org/apache/iceberg/util/BinPacking.java
@@ -26,12 +26,54 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 public class BinPacking {
+
+  /**
+   * Computes the weight an item contributes to a bin, with awareness of the bin's current contents.
+   * A new instance is created for each bin, allowing stateful deduplication of shared resources
+   * (e.g. equality delete files that apply to multiple data files in the same bin).
+   */
+  public interface BinWeighter<T> {
+    /**
+     * Returns the weight this item would add to the bin given its current contents. Must not modify
+     * internal state — called speculatively during bin selection.
+     */
+    long tentativeWeight(T item);
+
+    /**
+     * Called after the item is confirmed to be placed in this bin. Implementations should update
+     * any internal state (e.g. record which shared resources are now present in the bin).
+     */
+    void commit(T item);
+  }
+
+  public static class StatelessBinWeighter<T> implements BinWeighter<T>, Supplier<BinWeighter<T>> {
+    private final Function<T, Long> weightFunc;
+
+    public StatelessBinWeighter(Function<T, Long> weightFunc) {
+      this.weightFunc = weightFunc;
+    }
+
+    @Override
+    public BinWeighter<T> get() {
+      return this;
+    }
+
+    @Override
+    public long tentativeWeight(T item) {
+      return weightFunc.apply(item);
+    }
+
+    @Override
+    public void commit(T item) {}
+  }
+
   public static class ListPacker<T> {
     private final long targetWeight;
     private final int lookback;
@@ -76,7 +118,7 @@ public class BinPacking {
     private final long targetWeight;
     private final int lookback;
     private final long maxSize;
-    private final Function<T, Long> weightFunc;
+    private final Supplier<BinWeighter<T>> weighterFactory;
     private final boolean largestBinFirst;
 
     public PackingIterable(
@@ -100,20 +142,45 @@ public class BinPacking {
         Function<T, Long> weightFunc,
         boolean largestBinFirst,
         long maxSize) {
+      this(
+          iterable,
+          targetWeight,
+          lookback,
+          new StatelessBinWeighter<>(weightFunc),
+          largestBinFirst,
+          maxSize);
+    }
+
+    public PackingIterable(
+        Iterable<T> iterable,
+        long targetWeight,
+        int lookback,
+        Supplier<BinWeighter<T>> weighterFactory,
+        boolean largestBinFirst) {
+      this(iterable, targetWeight, lookback, weighterFactory, largestBinFirst, Long.MAX_VALUE);
+    }
+
+    public PackingIterable(
+        Iterable<T> iterable,
+        long targetWeight,
+        int lookback,
+        Supplier<BinWeighter<T>> weighterFactory,
+        boolean largestBinFirst,
+        long maxSize) {
       Preconditions.checkArgument(
           lookback > 0, "Bin look-back size must be greater than 0: %s", lookback);
       this.iterable = iterable;
       this.targetWeight = targetWeight;
       this.lookback = lookback;
       this.maxSize = maxSize;
-      this.weightFunc = weightFunc;
+      this.weighterFactory = weighterFactory;
       this.largestBinFirst = largestBinFirst;
     }
 
     @Override
     public Iterator<List<T>> iterator() {
       return new PackingIterator<>(
-          iterable.iterator(), targetWeight, lookback, maxSize, weightFunc, largestBinFirst);
+          iterable.iterator(), targetWeight, lookback, maxSize, weighterFactory, largestBinFirst);
     }
   }
 
@@ -123,7 +190,7 @@ public class BinPacking {
     private final long targetWeight;
     private final int lookback;
     private final long maxSize;
-    private final Function<T, Long> weightFunc;
+    private final Supplier<BinWeighter<T>> weighterFactory;
     private final boolean largestBinFirst;
 
     private PackingIterator(
@@ -131,13 +198,13 @@ public class BinPacking {
         long targetWeight,
         int lookback,
         long maxSize,
-        Function<T, Long> weightFunc,
+        Supplier<BinWeighter<T>> weighterFactory,
         boolean largestBinFirst) {
       this.items = items;
       this.targetWeight = targetWeight;
       this.lookback = lookback;
       this.maxSize = maxSize;
-      this.weightFunc = weightFunc;
+      this.weighterFactory = weighterFactory;
       this.largestBinFirst = largestBinFirst;
     }
 
@@ -151,15 +218,14 @@ public class BinPacking {
       while (items.hasNext()) {
         T item = items.next();
 
-        long weight = weightFunc.apply(item);
-        Bin<T> bin = findBin(weight);
+        Bin<T> bin = findBin(item);
 
         if (bin != null) {
-          bin.add(item, weight);
+          bin.add(item);
 
         } else {
           bin = newBin();
-          bin.add(item, weight);
+          bin.add(item);
           bins.addLast(bin);
 
           if (bins.size() > lookback) {
@@ -181,9 +247,9 @@ public class BinPacking {
       return ImmutableList.copyOf(bins.removeFirst().items());
     }
 
-    private Bin<T> findBin(long weight) {
+    private Bin<T> findBin(T item) {
       for (Bin<T> bin : bins) {
-        if (bin.canAdd(weight)) {
+        if (bin.canAdd(item)) {
           return bin;
         }
       }
@@ -191,7 +257,7 @@ public class BinPacking {
     }
 
     private Bin<T> newBin() {
-      return new Bin<>(targetWeight, maxSize);
+      return new Bin<>(weighterFactory.get(), targetWeight, maxSize);
     }
 
     private static <T> Bin<T> removeLargestBin(Collection<Bin<T>> bins) {
@@ -211,10 +277,12 @@ public class BinPacking {
     private final long targetWeight;
     private final long maxSize;
     private final List<T> items = Lists.newArrayList();
+    private final BinWeighter<T> weighter;
     private long binWeight = 0L;
     private int binSize = 0;
 
-    Bin(long targetWeight, long maxSize) {
+    Bin(BinWeighter<T> weighter, long targetWeight, long maxSize) {
+      this.weighter = weighter;
       this.targetWeight = targetWeight;
       this.maxSize = maxSize;
     }
@@ -223,14 +291,15 @@ public class BinPacking {
       return items;
     }
 
-    boolean canAdd(long weight) {
-      return binWeight + weight <= targetWeight && binSize < maxSize;
+    boolean canAdd(T item) {
+      return binWeight + weighter.tentativeWeight(item) <= targetWeight && binSize < maxSize;
     }
 
-    void add(T item, long weight) {
-      this.binWeight += weight;
+    void add(T item) {
+      this.binWeight += weighter.tentativeWeight(item);
       this.binSize++;
       items.add(item);
+      weighter.commit(item);
     }
 
     long weight() {

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -21,10 +21,12 @@ package org.apache.iceberg.util;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.Set;
+import java.util.function.Supplier;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseScanTaskGroup;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MergeableScanTask;
@@ -42,6 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.LongMath;
 import org.apache.iceberg.types.Types;
 
@@ -50,6 +53,49 @@ public class TableScanUtil {
   private static final long MIN_SPLIT_SIZE = 16 * 1024 * 1024; // 16 MB
 
   private TableScanUtil() {}
+
+  public static class ScanTaskBinWeighter<T extends ScanTask> implements BinPacking.BinWeighter<T> {
+    private final Set<String> seenDeletePaths = Sets.newHashSet();
+    private final long openFileCost;
+
+    ScanTaskBinWeighter(long openFileCost) {
+      this.openFileCost = openFileCost;
+    }
+
+    @Override
+    public long tentativeWeight(ScanTask task) {
+      long sizeWeight;
+      int filesCount;
+      if (task instanceof FileScanTask fileScanTask) {
+        sizeWeight = fileScanTask.length();
+        filesCount = 1;
+        // Check the size of delete file as well to avoid unbalanced bin-packing
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          if (delete.location() == null || !seenDeletePaths.contains(delete.location())) {
+            sizeWeight += ScanTaskUtil.contentSizeInBytes(delete);
+            filesCount++;
+          } else if (ContentFileUtil.isDV(delete)) {
+            sizeWeight += ScanTaskUtil.contentSizeInBytes(delete);
+          }
+        }
+      } else {
+        sizeWeight = task.sizeBytes();
+        filesCount = task.filesCount();
+      }
+      return Math.max(sizeWeight, filesCount * openFileCost);
+    }
+
+    @Override
+    public void commit(ScanTask task) {
+      if (task instanceof FileScanTask fileScanTask) {
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          if (delete.location() != null) {
+            seenDeletePaths.add(delete.location());
+          }
+        }
+      }
+    }
+  }
 
   /**
    * @deprecated since 1.11.0 and will be removed in 1.12.0
@@ -94,16 +140,12 @@ public class TableScanUtil {
 
     validatePlanningArguments(splitSize, lookback, openFileCost);
 
-    // Check the size of delete file as well to avoid unbalanced bin-packing
-    Function<FileScanTask, Long> weightFunc =
-        file ->
-            Math.max(
-                file.length() + ScanTaskUtil.contentSizeInBytes(file.deletes()),
-                (1 + file.deletes().size()) * openFileCost);
+    Supplier<BinPacking.BinWeighter<FileScanTask>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     return CloseableIterable.transform(
         CloseableIterable.combine(
-            new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFunc, true),
+            new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFactory, true),
             splitFiles),
         BaseCombinedScanTask::new);
   }
@@ -134,12 +176,12 @@ public class TableScanUtil {
                     }),
             tasks);
 
-    Function<T, Long> weightFunc =
-        task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
+    Supplier<BinPacking.BinWeighter<T>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     return CloseableIterable.transform(
         CloseableIterable.combine(
-            new BinPacking.PackingIterable<>(splitTasks, splitSize, lookback, weightFunc, true),
+            new BinPacking.PackingIterable<>(splitTasks, splitSize, lookback, weightFactory, true),
             splitTasks),
         combinedTasks -> new BaseScanTaskGroup<>(mergeTasks(combinedTasks)));
   }
@@ -154,8 +196,8 @@ public class TableScanUtil {
 
     validatePlanningArguments(splitSize, lookback, openFileCost);
 
-    Function<T, Long> weightFunc =
-        task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
+    Supplier<BinPacking.BinWeighter<T>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     Map<Integer, StructProjection> groupingKeyProjectionsBySpec = Maps.newHashMap();
     PartitionData groupingKeyTemplate = new PartitionData(groupingKeyType);
@@ -188,7 +230,7 @@ public class TableScanUtil {
       List<T> groupingKeyTasks = entry.getValue();
       Iterables.addAll(
           taskGroups,
-          toTaskGroupIterable(groupingKey, groupingKeyTasks, splitSize, lookback, weightFunc));
+          toTaskGroupIterable(groupingKey, groupingKeyTasks, splitSize, lookback, weightFactory));
     }
 
     return taskGroups;
@@ -199,10 +241,10 @@ public class TableScanUtil {
       Iterable<T> tasks,
       long splitSize,
       int lookback,
-      Function<T, Long> weightFunc) {
+      Supplier<BinPacking.BinWeighter<T>> weightFactory) {
 
     return Iterables.transform(
-        new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFunc, true),
+        new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFactory, true),
         combinedTasks -> new BaseScanTaskGroup<>(groupingKey, mergeTasks(combinedTasks)));
   }
 

--- a/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/TableScanUtil.java
@@ -21,10 +21,12 @@ package org.apache.iceberg.util;
 import java.math.RoundingMode;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
+import java.util.Set;
+import java.util.function.Supplier;
 import org.apache.iceberg.BaseCombinedScanTask;
 import org.apache.iceberg.BaseScanTaskGroup;
 import org.apache.iceberg.CombinedScanTask;
+import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MergeableScanTask;
 import org.apache.iceberg.PartitionData;
@@ -41,6 +43,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.math.LongMath;
 import org.apache.iceberg.types.Types;
 
@@ -49,6 +52,49 @@ public class TableScanUtil {
   private static final long MIN_SPLIT_SIZE = 16 * 1024 * 1024; // 16 MB
 
   private TableScanUtil() {}
+
+  public static class ScanTaskBinWeighter<T extends ScanTask> implements BinPacking.BinWeighter<T> {
+    private final Set<String> seenDeletePaths = Sets.newHashSet();
+    private final long openFileCost;
+
+    ScanTaskBinWeighter(long openFileCost) {
+      this.openFileCost = openFileCost;
+    }
+
+    @Override
+    public long tentativeWeight(ScanTask task) {
+      long sizeWeight;
+      int filesCount;
+      if (task instanceof FileScanTask fileScanTask) {
+        sizeWeight = fileScanTask.length();
+        filesCount = 1;
+        // Check the size of delete file as well to avoid unbalanced bin-packing
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          if (delete.location() == null || !seenDeletePaths.contains(delete.location())) {
+            sizeWeight += ScanTaskUtil.contentSizeInBytes(delete);
+            filesCount++;
+          } else if (ContentFileUtil.isDV(delete)) {
+            sizeWeight += ScanTaskUtil.contentSizeInBytes(delete);
+          }
+        }
+      } else {
+        sizeWeight = task.sizeBytes();
+        filesCount = task.filesCount();
+      }
+      return Math.max(sizeWeight, filesCount * openFileCost);
+    }
+
+    @Override
+    public void commit(ScanTask task) {
+      if (task instanceof FileScanTask fileScanTask) {
+        for (DeleteFile delete : fileScanTask.deletes()) {
+          if (delete.location() != null) {
+            seenDeletePaths.add(delete.location());
+          }
+        }
+      }
+    }
+  }
 
   public static boolean hasDeletes(FileScanTask task) {
     return !task.deletes().isEmpty();
@@ -69,16 +115,12 @@ public class TableScanUtil {
 
     validatePlanningArguments(splitSize, lookback, openFileCost);
 
-    // Check the size of delete file as well to avoid unbalanced bin-packing
-    Function<FileScanTask, Long> weightFunc =
-        file ->
-            Math.max(
-                file.length() + ScanTaskUtil.contentSizeInBytes(file.deletes()),
-                (1 + file.deletes().size()) * openFileCost);
+    Supplier<BinPacking.BinWeighter<FileScanTask>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     return CloseableIterable.transform(
         CloseableIterable.combine(
-            new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFunc, true),
+            new BinPacking.PackingIterable<>(splitFiles, splitSize, lookback, weightFactory, true),
             splitFiles),
         BaseCombinedScanTask::new);
   }
@@ -109,12 +151,12 @@ public class TableScanUtil {
                     }),
             tasks);
 
-    Function<T, Long> weightFunc =
-        task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
+    Supplier<BinPacking.BinWeighter<T>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     return CloseableIterable.transform(
         CloseableIterable.combine(
-            new BinPacking.PackingIterable<>(splitTasks, splitSize, lookback, weightFunc, true),
+            new BinPacking.PackingIterable<>(splitTasks, splitSize, lookback, weightFactory, true),
             splitTasks),
         combinedTasks -> new BaseScanTaskGroup<>(mergeTasks(combinedTasks)));
   }
@@ -129,8 +171,8 @@ public class TableScanUtil {
 
     validatePlanningArguments(splitSize, lookback, openFileCost);
 
-    Function<T, Long> weightFunc =
-        task -> Math.max(task.sizeBytes(), task.filesCount() * openFileCost);
+    Supplier<BinPacking.BinWeighter<T>> weightFactory =
+        () -> new ScanTaskBinWeighter<>(openFileCost);
 
     Map<Integer, StructProjection> groupingKeyProjectionsBySpec = Maps.newHashMap();
     PartitionData groupingKeyTemplate = new PartitionData(groupingKeyType);
@@ -163,7 +205,7 @@ public class TableScanUtil {
       List<T> groupingKeyTasks = entry.getValue();
       Iterables.addAll(
           taskGroups,
-          toTaskGroupIterable(groupingKey, groupingKeyTasks, splitSize, lookback, weightFunc));
+          toTaskGroupIterable(groupingKey, groupingKeyTasks, splitSize, lookback, weightFactory));
     }
 
     return taskGroups;
@@ -174,10 +216,10 @@ public class TableScanUtil {
       Iterable<T> tasks,
       long splitSize,
       int lookback,
-      Function<T, Long> weightFunc) {
+      Supplier<BinPacking.BinWeighter<T>> weightFactory) {
 
     return Iterables.transform(
-        new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFunc, true),
+        new BinPacking.PackingIterable<>(tasks, splitSize, lookback, weightFactory, true),
         combinedTasks -> new BaseScanTaskGroup<>(groupingKey, mergeTasks(combinedTasks)));
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestTableScanUtil.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MergeableScanTask;
 import org.apache.iceberg.MockFileScanTask;
@@ -130,6 +131,47 @@ public class TestTableScanUtil {
           .as("Scan tasks detail in combined task check failed")
           .isEqualTo(expectedCombinedTasks.get(i).files());
     }
+  }
+
+  @Test
+  public void testPlanCountsSharedEqualityDeleteOnce() {
+    DeleteFile sharedDelete =
+        FileMetadata.deleteFileBuilder(SPEC1)
+            .ofEqualityDeletes()
+            .withPath("/path/to/shared-delete.parquet")
+            .withFileSizeInBytes(10L)
+            .withRecordCount(2)
+            .build();
+    DataFile data1 =
+        DataFiles.builder(SPEC1)
+            .withPath("/path/to/data-1.parquet")
+            .withFileSizeInBytes(250L)
+            .withRecordCount(1)
+            .build();
+    DataFile data2 =
+        DataFiles.builder(SPEC1)
+            .withPath("/path/to/data-2.parquet")
+            .withFileSizeInBytes(250L)
+            .withRecordCount(1)
+            .build();
+
+    List<FileScanTask> tasks =
+        ImmutableList.of(
+            new MockFileScanTask(data1, new DeleteFile[] {sharedDelete}, TEST_SCHEMA, SPEC1),
+            new MockFileScanTask(data2, new DeleteFile[] {sharedDelete}, TEST_SCHEMA, SPEC1));
+
+    // The shared equality delete (10 B) should be counted only once per bin.
+    // 2 data files x 250 B + 1 equality delete x 10 B = 510 B < 512 B -> 1 bin
+    // Bug: equality delete counted per task -> 260 B + 260 B = 520 B > 512 B -> 2 bins
+    assertThat(TableScanUtil.planTasks(CloseableIterable.withNoopClose(tasks), 512L, 1, 0L))
+        .as("Shared equality delete should be counted once per bin, not once per data file")
+        .hasSize(1);
+    assertThat(TableScanUtil.planTaskGroups(tasks, 512L, 1, 0L))
+        .as("Shared equality delete should be counted once per bin, not once per data file")
+        .hasSize(1);
+    assertThat(TableScanUtil.planTaskGroups(tasks, 512L, 1, 0L, SPEC1.partitionType()))
+        .as("Shared equality delete should be counted once per bin, not once per data file")
+        .hasSize(1);
   }
 
   @Test

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -47,6 +47,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.CharSequenceMap;
 import org.apache.iceberg.util.ContentFileUtil;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.Tasks;
 import org.apache.iceberg.util.ThreadPools;
@@ -103,6 +104,14 @@ public class BaseDeleteLoader implements DeleteLoader {
     StructLikeSet deleteSet = StructLikeSet.create(projection.asStruct());
     Iterables.addAll(deleteSet, Iterables.concat(deletes));
     return deleteSet;
+  }
+
+  @Override
+  public Iterable<Pair<DeleteFile, Iterable<StructLike>>> loadEqualityDeletes(
+      Iterable<Pair<DeleteFile, Schema>> deleteFiles) {
+    return execute(
+        deleteFiles,
+        pair -> Pair.of(pair.first(), getOrReadEqDeletes(pair.first(), pair.second())));
   }
 
   private Iterable<StructLike> getOrReadEqDeletes(DeleteFile deleteFile, Schema projection) {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -43,6 +43,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Multimaps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.StructLikeMap;
 import org.apache.iceberg.util.StructLikeSet;
 import org.apache.iceberg.util.StructProjection;
 import org.slf4j.Logger;
@@ -52,8 +54,10 @@ public abstract class DeleteFilter<T> {
   private static final Logger LOG = LoggerFactory.getLogger(DeleteFilter.class);
 
   private final String filePath;
+  private final long dataSequenceNumber;
   private final List<DeleteFile> posDeletes;
   private final List<DeleteFile> eqDeletes;
+  private final EqualityDeletes sharedEqDeletes;
   private final Schema requiredSchema;
   private final Schema expectedSchema;
   private final Accessor<StructLike> posAccessor;
@@ -83,9 +87,25 @@ public abstract class DeleteFilter<T> {
       Schema expectedSchema,
       DeleteCounter counter,
       boolean needRowPosCol) {
+    this(filePath, 0L, deletes, null, fieldLookup, expectedSchema, counter, needRowPosCol);
+  }
+
+  protected DeleteFilter(
+      String filePath,
+      Long dataSequenceNumber,
+      List<DeleteFile> deletes,
+      EqualityDeletes sharedEqDeletes,
+      Function<Integer, Types.NestedField> fieldLookup,
+      Schema expectedSchema,
+      DeleteCounter counter,
+      boolean needRowPosCol) {
     this.filePath = filePath;
-    this.counter = counter;
+    // dataSequenceNumber can be null, e.g. for synthetic data files backing metadata table scans,
+    // which never have applicable deletes; default to 0 so any real delete still applies
+    this.dataSequenceNumber = dataSequenceNumber == null ? 0L : dataSequenceNumber.longValue();
+    this.sharedEqDeletes = sharedEqDeletes;
     this.expectedSchema = expectedSchema;
+    this.counter = counter;
 
     ImmutableList.Builder<DeleteFile> posDeleteBuilder = ImmutableList.builder();
     ImmutableList.Builder<DeleteFile> eqDeleteBuilder = ImmutableList.builder();
@@ -199,6 +219,10 @@ public abstract class DeleteFilter<T> {
       return isInDeleteSets;
     }
 
+    if (sharedEqDeletes != null) {
+      return applySharedEqDeletes();
+    }
+
     Multimap<Set<Integer>, DeleteFile> filesByDeleteIds =
         Multimaps.newMultimap(Maps.newHashMap(), Lists::newArrayList);
     for (DeleteFile delete : eqDeletes) {
@@ -222,6 +246,55 @@ public abstract class DeleteFilter<T> {
     }
 
     return isInDeleteSets;
+  }
+
+  private List<Predicate<T>> applySharedEqDeletes() {
+    final Set<StructLikeMap<Long>> deleteMaps = Sets.newIdentityHashSet();
+    final Map<Set<Integer>, Schema> deleteSchemas = Maps.newHashMap();
+    final List<Pair<DeleteFile, Schema>> newEqDeletes = Lists.newArrayList();
+
+    for (DeleteFile delete : eqDeletes) {
+      Set<Integer> ids = Sets.newHashSet(delete.equalityFieldIds());
+      Schema deleteSchema =
+          deleteSchemas.computeIfAbsent(ids, key -> TypeUtil.selectInIdOrder(requiredSchema, key));
+
+      if (sharedEqDeletes.contains(delete)) {
+        StructLikeMap<Long> deleteMap = sharedEqDeletes.get(delete, ids);
+        if (deleteMaps.add(deleteMap)) {
+          isInDeleteSets.add(sharedEqDeleteFilter(deleteSchema, deleteMap));
+        }
+      } else {
+        newEqDeletes.add(Pair.of(delete, deleteSchema));
+      }
+    }
+
+    if (newEqDeletes.isEmpty()) {
+      return isInDeleteSets;
+    }
+
+    for (Pair<DeleteFile, Iterable<StructLike>> loaded :
+        deleteLoader().loadEqualityDeletes(newEqDeletes)) {
+      DeleteFile delete = loaded.first();
+      Set<Integer> ids = Sets.newHashSet(delete.equalityFieldIds());
+      Schema deleteSchema = deleteSchemas.get(ids);
+
+      StructLikeMap<Long> deleteMap =
+          sharedEqDeletes.merge(delete, ids, deleteSchema, loaded.second());
+      if (deleteMaps.add(deleteMap)) {
+        isInDeleteSets.add(sharedEqDeleteFilter(deleteSchema, deleteMap));
+      }
+    }
+
+    return isInDeleteSets;
+  }
+
+  private Predicate<T> sharedEqDeleteFilter(Schema deleteSchema, StructLikeMap<Long> deleteMap) {
+    // a projection to select and reorder fields of the file schema to match the delete rows
+    StructProjection projectRow = StructProjection.create(requiredSchema, deleteSchema);
+    return record -> {
+      Long deleteSequenceNumber = deleteMap.get(projectRow.wrap(asStructLike(record)));
+      return deleteSequenceNumber != null && deleteSequenceNumber > dataSequenceNumber;
+    };
   }
 
   public CloseableIterable<T> findEqualityDeleteRows(CloseableIterable<T> records) {

--- a/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteFilter.java
@@ -249,7 +249,8 @@ public abstract class DeleteFilter<T> {
   }
 
   private List<Predicate<T>> applySharedEqDeletes() {
-    final Set<StructLikeMap<Long>> deleteMaps = Sets.newIdentityHashSet();
+    final Multimap<Set<Integer>, StructLikeMap<Long>> deleteMaps =
+        Multimaps.newMultimap(Maps.newHashMap(), Sets::newIdentityHashSet);
     final Map<Set<Integer>, Schema> deleteSchemas = Maps.newHashMap();
     final List<Pair<DeleteFile, Schema>> newEqDeletes = Lists.newArrayList();
 
@@ -259,30 +260,29 @@ public abstract class DeleteFilter<T> {
           deleteSchemas.computeIfAbsent(ids, key -> TypeUtil.selectInIdOrder(requiredSchema, key));
 
       if (sharedEqDeletes.contains(delete)) {
-        StructLikeMap<Long> deleteMap = sharedEqDeletes.get(delete, ids);
-        if (deleteMaps.add(deleteMap)) {
-          isInDeleteSets.add(sharedEqDeleteFilter(deleteSchema, deleteMap));
-        }
+        deleteMaps.put(ids, sharedEqDeletes.get(delete, ids));
       } else {
         newEqDeletes.add(Pair.of(delete, deleteSchema));
       }
     }
 
-    if (newEqDeletes.isEmpty()) {
-      return isInDeleteSets;
+    if (!newEqDeletes.isEmpty()) {
+      for (Pair<DeleteFile, Iterable<StructLike>> loaded :
+          deleteLoader().loadEqualityDeletes(newEqDeletes)) {
+        DeleteFile delete = loaded.first();
+        Set<Integer> ids = Sets.newHashSet(delete.equalityFieldIds());
+        deleteMaps.put(
+            ids, sharedEqDeletes.merge(delete, ids, deleteSchemas.get(ids), loaded.second()));
+      }
     }
 
-    for (Pair<DeleteFile, Iterable<StructLike>> loaded :
-        deleteLoader().loadEqualityDeletes(newEqDeletes)) {
-      DeleteFile delete = loaded.first();
-      Set<Integer> ids = Sets.newHashSet(delete.equalityFieldIds());
-      Schema deleteSchema = deleteSchemas.get(ids);
-
-      StructLikeMap<Long> deleteMap =
-          sharedEqDeletes.merge(delete, ids, deleteSchema, loaded.second());
-      if (deleteMaps.add(deleteMap)) {
-        isInDeleteSets.add(sharedEqDeleteFilter(deleteSchema, deleteMap));
-      }
+    for (Map.Entry<Set<Integer>, Collection<StructLikeMap<Long>>> entry :
+        deleteMaps.asMap().entrySet()) {
+      Schema deleteSchema = deleteSchemas.get(entry.getKey());
+      isInDeleteSets.add(
+          entry.getValue().size() == 1
+              ? sharedEqDeleteFilter(deleteSchema, entry.getValue().iterator().next())
+              : sharedEqDeleteFilter(deleteSchema, entry.getValue()));
     }
 
     return isInDeleteSets;
@@ -294,6 +294,22 @@ public abstract class DeleteFilter<T> {
     return record -> {
       Long deleteSequenceNumber = deleteMap.get(projectRow.wrap(asStructLike(record)));
       return deleteSequenceNumber != null && deleteSequenceNumber > dataSequenceNumber;
+    };
+  }
+
+  private Predicate<T> sharedEqDeleteFilter(
+      Schema deleteSchema, Collection<StructLikeMap<Long>> deleteMaps) {
+    // a projection to select and reorder fields of the file schema to match the delete rows
+    StructProjection projectRow = StructProjection.create(requiredSchema, deleteSchema);
+    return record -> {
+      StructLike key = projectRow.wrap(asStructLike(record));
+      for (StructLikeMap<Long> deleteMap : deleteMaps) {
+        Long deleteSequenceNumber = deleteMap.get(key);
+        if (deleteSequenceNumber != null && deleteSequenceNumber > dataSequenceNumber) {
+          return true;
+        }
+      }
+      return false;
     };
   }
 

--- a/data/src/main/java/org/apache/iceberg/data/DeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/DeleteLoader.java
@@ -18,9 +18,14 @@
  */
 package org.apache.iceberg.data;
 
+import java.util.List;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.StructLikeSet;
 
 /** An API for loading delete file content into in-memory data structures. */
@@ -33,6 +38,28 @@ public interface DeleteLoader {
    * @return a set of equality deletes
    */
   StructLikeSet loadEqualityDeletes(Iterable<DeleteFile> deleteFiles, Schema projection);
+
+  /**
+   * Loads the content of multiple equality delete files at once, each with its own projection,
+   * keeping each delete file's content separate rather than merging it into a single set.
+   *
+   * <p>The default implementation calls {@link #loadEqualityDeletes(Iterable, Schema)} once per
+   * delete file. Override this method to provide a more efficient implementation, e.g. one that
+   * loads all delete files in a single batch.
+   *
+   * @param deleteFiles equality delete files, each paired with the projection to load it with
+   * @return each delete file paired with its own loaded content
+   */
+  default Iterable<Pair<DeleteFile, Iterable<StructLike>>> loadEqualityDeletes(
+      Iterable<Pair<DeleteFile, Schema>> deleteFiles) {
+    List<Pair<DeleteFile, Iterable<StructLike>>> loaded = Lists.newArrayList();
+    for (Pair<DeleteFile, Schema> pair : deleteFiles) {
+      Iterable<StructLike> deletes =
+          loadEqualityDeletes(ImmutableList.of(pair.first()), pair.second());
+      loaded.add(Pair.of(pair.first(), deletes));
+    }
+    return loaded;
+  }
 
   /**
    * Loads the content of a deletion vector or position delete files for a given data file path into

--- a/data/src/main/java/org/apache/iceberg/data/EqualityDeletes.java
+++ b/data/src/main/java/org/apache/iceberg/data/EqualityDeletes.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.data;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.PartitionMap;
+import org.apache.iceberg.util.StructLikeMap;
+
+public class EqualityDeletes {
+  private final Set<String> loadedEqDeletes;
+  private final PartitionMap<Map<Set<Integer>, StructLikeMap<Long>>> sharedEqDeletes;
+
+  public EqualityDeletes(Map<Integer, PartitionSpec> specs) {
+    this.loadedEqDeletes = Sets.newHashSet();
+    this.sharedEqDeletes = PartitionMap.create(specs);
+  }
+
+  public boolean contains(DeleteFile deleteFile) {
+    return deleteFile.location() != null && loadedEqDeletes.contains(deleteFile.location());
+  }
+
+  public StructLikeMap<Long> get(DeleteFile deleteFile, Set<Integer> ids) {
+    final Map<Set<Integer>, StructLikeMap<Long>> deleteMaps =
+        sharedEqDeletes.get(deleteFile.specId(), deleteFile.partition());
+    return deleteMaps == null ? null : deleteMaps.get(ids);
+  }
+
+  public StructLikeMap<Long> merge(
+      DeleteFile deleteFile,
+      Set<Integer> ids,
+      Schema deleteSchema,
+      Iterable<StructLike> deleteKeys) {
+    if (deleteFile.location() != null && !loadedEqDeletes.add(deleteFile.location())) {
+      return get(deleteFile, ids);
+    }
+    Preconditions.checkArgument(
+        deleteFile.dataSequenceNumber() != null,
+        "Equality delete file has no data sequence number: %s",
+        deleteFile.location());
+    long deleteSequenceNumber = deleteFile.dataSequenceNumber();
+    final StructLikeMap<Long> deleteMap =
+        sharedEqDeletes
+            .computeIfAbsent(deleteFile.specId(), deleteFile.partition(), Maps::newHashMap)
+            .computeIfAbsent(ids, key -> StructLikeMap.create(deleteSchema.asStruct()));
+    for (StructLike key : deleteKeys) {
+      deleteMap.merge(key, deleteSequenceNumber, Math::max);
+    }
+    return deleteMap;
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericDeleteFilter.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.data;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.StructLike;
+import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 
@@ -31,6 +32,25 @@ public class GenericDeleteFilter extends DeleteFilter<Record> {
   public GenericDeleteFilter(
       FileIO io, FileScanTask task, Schema tableSchema, Schema requestedSchema) {
     super(task.file().location(), task.deletes(), tableSchema, requestedSchema);
+    this.io = io;
+    this.asStructLike = new InternalRecordWrapper(requiredSchema().asStruct());
+  }
+
+  public GenericDeleteFilter(
+      FileIO io,
+      FileScanTask task,
+      EqualityDeletes sharedEqDeletes,
+      Schema tableSchema,
+      Schema requestedSchema) {
+    super(
+        task.file().location(),
+        task.file().dataSequenceNumber(),
+        task.deletes(),
+        sharedEqDeletes,
+        tableSchema::findField,
+        requestedSchema,
+        new DeleteCounter(),
+        true);
     this.io = io;
     this.asStructLike = new InternalRecordWrapper(requiredSchema().asStruct());
   }

--- a/data/src/main/java/org/apache/iceberg/data/GenericReader.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericReader.java
@@ -43,13 +43,15 @@ class GenericReader implements Serializable {
   private final Schema projection;
   private final boolean caseSensitive;
   private final boolean reuseContainers;
+  private final EqualityDeletes sharedEqDeletes;
 
-  GenericReader(TableScan scan, boolean reuseContainers) {
+  GenericReader(TableScan scan, boolean reuseContainers, boolean shareEqDeletes) {
     this.io = scan.table().io();
     this.tableSchema = scan.table().schema();
     this.projection = scan.schema();
     this.caseSensitive = scan.isCaseSensitive();
     this.reuseContainers = reuseContainers;
+    this.sharedEqDeletes = shareEqDeletes ? new EqualityDeletes(scan.table().specs()) : null;
   }
 
   CloseableIterator<Record> open(CloseableIterable<CombinedScanTask> tasks) {
@@ -63,7 +65,8 @@ class GenericReader implements Serializable {
   }
 
   public CloseableIterable<Record> open(FileScanTask task) {
-    DeleteFilter<Record> deletes = new GenericDeleteFilter(io, task, tableSchema, projection);
+    DeleteFilter<Record> deletes =
+        new GenericDeleteFilter(io, task, sharedEqDeletes, tableSchema, projection);
     Schema readSchema = deletes.requiredSchema();
 
     CloseableIterable<Record> records = openFile(task, readSchema);

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -103,7 +103,7 @@ public class IcebergGenerics {
     }
 
     public CloseableIterable<Record> build() {
-      return new TableScanIterable(tableScan, reuseContainers);
+      return new TableScanIterable(tableScan, reuseContainers, false);
     }
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
+++ b/data/src/main/java/org/apache/iceberg/data/IcebergGenerics.java
@@ -97,7 +97,7 @@ public class IcebergGenerics {
     }
 
     public CloseableIterable<Record> build() {
-      return new TableScanIterable(tableScan, reuseContainers);
+      return new TableScanIterable(tableScan, reuseContainers, false);
     }
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
+++ b/data/src/main/java/org/apache/iceberg/data/TableScanIterable.java
@@ -29,8 +29,8 @@ class TableScanIterable extends CloseableGroup implements CloseableIterable<Reco
   private final GenericReader reader;
   private final CloseableIterable<CombinedScanTask> tasks;
 
-  TableScanIterable(TableScan scan, boolean reuseContainers) {
-    this.reader = new GenericReader(scan, reuseContainers);
+  TableScanIterable(TableScan scan, boolean reuseContainers, boolean shareEqDeletes) {
+    this.reader = new GenericReader(scan, reuseContainers, shareEqDeletes);
     // start planning tasks in the background
     this.tasks = scan.planTasks();
   }

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericReaderDeletes.java
@@ -20,13 +20,18 @@ package org.apache.iceberg.data;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TestTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.StructLikeSet;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,6 +40,19 @@ import org.junit.jupiter.api.io.TempDir;
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestGenericReaderDeletes extends DeleteReadTests {
   @TempDir private File tableDir;
+
+  @Parameter(index = 2)
+  private boolean shareEqDeletes;
+
+  @Parameters(name = "fileFormat = {0}, formatVersion = {1}, shareEqDeletes = {2}")
+  public static Object[][] parameters() {
+    List<Object[]> parameters = Lists.newArrayList();
+    for (Object[] params : DeleteReadTests.parameters()) {
+      parameters.add(new Object[] {params[0], params[1], false});
+    }
+    parameters.add(new Object[] {FileFormat.PARQUET, 3, true});
+    return parameters.toArray(new Object[0][]);
+  }
 
   @Override
   protected Table createTable(String name, Schema schema, PartitionSpec spec) throws IOException {
@@ -50,7 +68,8 @@ public class TestGenericReaderDeletes extends DeleteReadTests {
   public StructLikeSet rowSet(String name, Table table, String... columns) throws IOException {
     Types.StructType schema = table.schema().select(columns).asStruct();
     StructLikeSet set = StructLikeSet.create(schema);
-    try (CloseableIterable<Record> reader = IcebergGenerics.read(table).select(columns).build()) {
+    try (CloseableIterable<Record> reader =
+        new TableScanIterable(table.newScan().select(columns), false, shareEqDeletes)) {
       Iterables.addAll(
           set,
           CloseableIterable.transform(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.BaseDeleteLoader;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.io.CloseableIterator;
@@ -206,6 +207,27 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     SparkDeleteFilter(
         String filePath, List<DeleteFile> deletes, DeleteCounter counter, boolean needRowPosCol) {
       super(filePath, deletes, tableSchema, expectedSchema, counter, needRowPosCol);
+      this.asStructLike =
+          new InternalRowWrapper(
+              SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+    }
+
+    SparkDeleteFilter(
+        String filePath,
+        Long dataSequenceNumber,
+        List<DeleteFile> deletes,
+        EqualityDeletes sharedEqDeletes,
+        DeleteCounter counter,
+        boolean needRowPosCol) {
+      super(
+          filePath,
+          dataSequenceNumber,
+          deletes,
+          sharedEqDeletes,
+          tableSchema::findField,
+          expectedSchema,
+          counter,
+          needRowPosCol);
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -47,6 +48,11 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
   private static final Logger LOG = LoggerFactory.getLogger(BatchDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   BatchDataReader(
       SparkInputPartition partition,
@@ -87,6 +93,8 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -112,8 +120,9 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
     InputFile inputFile = getInputFile(filePath);
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with FileScanTask");
 
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     Map<Integer, ?> idToConstant = constantsMap(task, deleteFilter.requiredSchema());
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -45,6 +46,11 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   private static final Logger LOG = LoggerFactory.getLogger(RowDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   RowDataReader(SparkInputPartition partition) {
     this(
@@ -77,6 +83,8 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -95,8 +103,9 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = deleteFilter.requiredSchema();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -526,12 +526,16 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
     sql(
         "CREATE TABLE %s (id INT, dep STRING) "
             + "USING iceberg "
-            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s')",
+            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s', '%s' '%s')",
         targetTableName,
         TableProperties.WRITE_METADATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
         TableProperties.WRITE_DATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
+        // Prevent deduplication of equality delete reads within a task
+        // by planning each data file into its own task.
+        TableProperties.SPLIT_SIZE,
+        "1",
         operation,
         mode.modeName());
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.BaseDeleteLoader;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.io.CloseableIterator;
@@ -206,6 +207,27 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     SparkDeleteFilter(
         String filePath, List<DeleteFile> deletes, DeleteCounter counter, boolean needRowPosCol) {
       super(filePath, deletes, tableSchema, expectedSchema, counter, needRowPosCol);
+      this.asStructLike =
+          new InternalRowWrapper(
+              SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+    }
+
+    SparkDeleteFilter(
+        String filePath,
+        Long dataSequenceNumber,
+        List<DeleteFile> deletes,
+        EqualityDeletes sharedEqDeletes,
+        DeleteCounter counter,
+        boolean needRowPosCol) {
+      super(
+          filePath,
+          dataSequenceNumber,
+          deletes,
+          sharedEqDeletes,
+          tableSchema::findField,
+          expectedSchema,
+          counter,
+          needRowPosCol);
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -47,6 +48,11 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
   private static final Logger LOG = LoggerFactory.getLogger(BatchDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   BatchDataReader(
       SparkInputPartition partition,
@@ -87,6 +93,8 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -112,8 +120,9 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
     InputFile inputFile = getInputFile(filePath);
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with FileScanTask");
 
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     Map<Integer, ?> idToConstant = constantsMap(task, deleteFilter.requiredSchema());
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -45,6 +46,11 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   private static final Logger LOG = LoggerFactory.getLogger(RowDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   RowDataReader(SparkInputPartition partition) {
     this(
@@ -77,6 +83,8 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -95,8 +103,9 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = deleteFilter.requiredSchema();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -526,12 +526,16 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
     sql(
         "CREATE TABLE %s (id INT, dep STRING) "
             + "USING iceberg "
-            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s')",
+            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s', '%s' '%s')",
         targetTableName,
         TableProperties.WRITE_METADATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
         TableProperties.WRITE_DATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
+        // Prevent deduplication of equality delete reads within a task
+        // by planning each data file into its own task.
+        TableProperties.SPLIT_SIZE,
+        "1",
         operation,
         mode.modeName());
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.BaseDeleteLoader;
 import org.apache.iceberg.data.DeleteFilter;
 import org.apache.iceberg.data.DeleteLoader;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.deletes.DeleteCounter;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.io.CloseableIterator;
@@ -205,6 +206,27 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     SparkDeleteFilter(
         String filePath, List<DeleteFile> deletes, DeleteCounter counter, boolean needRowPosCol) {
       super(filePath, deletes, new FieldLookup(table), expectedSchema, counter, needRowPosCol);
+      this.asStructLike =
+          new InternalRowWrapper(
+              SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());
+    }
+
+    SparkDeleteFilter(
+        String filePath,
+        Long dataSequenceNumber,
+        List<DeleteFile> deletes,
+        EqualityDeletes sharedEqDeletes,
+        DeleteCounter counter,
+        boolean needRowPosCol) {
+      super(
+          filePath,
+          dataSequenceNumber,
+          deletes,
+          sharedEqDeletes,
+          new FieldLookup(table),
+          expectedSchema,
+          counter,
+          needRowPosCol);
       this.asStructLike =
           new InternalRowWrapper(
               SparkSchemaUtil.convert(requiredSchema()), requiredSchema().asStruct());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
@@ -46,6 +47,11 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
   private static final Logger LOG = LoggerFactory.getLogger(BatchDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   BatchDataReader(
       SparkInputPartition partition,
@@ -83,6 +89,8 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -108,8 +116,9 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
     InputFile inputFile = getInputFile(filePath);
     Preconditions.checkNotNull(inputFile, "Could not find InputFile associated with FileScanTask");
 
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     Map<Integer, ?> idToConstant = constantsMap(task, deleteFilter.requiredSchema());
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -26,6 +26,7 @@ import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.data.EqualityDeletes;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
@@ -44,6 +45,11 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   private static final Logger LOG = LoggerFactory.getLogger(RowDataReader.class);
 
   private final long numSplits;
+
+  // Shared across every data file in this task group so an equality delete file referenced by
+  // more than one of them is read and materialized only once. Not thread-safe because open()
+  // is called sequentially by the single task thread, so these are mutated by one thread.
+  private final EqualityDeletes sharedEqDeletes;
 
   RowDataReader(SparkInputPartition partition) {
     this(
@@ -67,6 +73,8 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
 
     numSplits = taskGroup.tasks().size();
     LOG.debug("Reading {} file split(s) for table {}", numSplits, table.name());
+
+    sharedEqDeletes = new EqualityDeletes(table.specs());
   }
 
   @Override
@@ -85,8 +93,9 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   protected CloseableIterator<InternalRow> open(FileScanTask task) {
     String filePath = task.file().location();
     LOG.debug("Opening data file {}", filePath);
+    Long fileSeq = task.file().dataSequenceNumber();
     SparkDeleteFilter deleteFilter =
-        new SparkDeleteFilter(filePath, task.deletes(), counter(), true);
+        new SparkDeleteFilter(filePath, fileSeq, task.deletes(), sharedEqDeletes, counter(), true);
 
     // schema or rows returned by readers
     Schema requiredSchema = deleteFilter.requiredSchema();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkExecutorCache.java
@@ -526,12 +526,16 @@ public class TestSparkExecutorCache extends TestBaseWithCatalog {
     sql(
         "CREATE TABLE %s (id INT, dep STRING) "
             + "USING iceberg "
-            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s')",
+            + "TBLPROPERTIES ('%s' '%s', '%s' '%s', '%s' '%s', '%s' '%s')",
         targetTableName,
         TableProperties.WRITE_METADATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
         TableProperties.WRITE_DATA_LOCATION,
         temp.toString().replaceFirst("file:", ""),
+        // Prevent deduplication of equality delete reads within a task
+        // by planning each data file into its own task.
+        TableProperties.SPLIT_SIZE,
+        "1",
         operation,
         mode.modeName());
 


### PR DESCRIPTION
Equality delete files can be referenced by many data files. This PR allows to accumulate all equality deletes of a table snapshot in the structure `spec id -> partition -> equality field ids -> equality key -> max data sequence number` that can be reused for many data files. If passed to `DeleteFilter`, it fills the structure lazily.

I added shared equality deletes to Spark's `RowDataReader` and `BatchDataReader` by default, because the size of the shared structure is bounded by split size (multiplied by compression rate). To `GenericReader` I added a boolean parameter `shareEqDeletes` which is false by default, because the size is unbounded, and switching the parameter to true might cause OOMs. And I don't use Flink, so I hesitated to propose changing its behavior.

The non-shared `DeleteFilter` path is unchanged, so Flink and other engines are byte-for-byte identical. The shared path produces identical results (equivalence covered by tests).

Additionally, this PR changes task weight calculation algorithm - each delete file is accounted only once per bin even if it is referenced by several data files in that bin. This change can be moved into a separate PR if preferred.

In our case these changes reduced Spark memory consumption by 30-50% and, more important, prevented Spark from hanging for hours on building and evicting huge equality delete sets for each data file. For frequently updated tables (several thousands of equality delete files per day) ingested with [Debezium Iceberg Sink](https://github.com/memiiso/debezium-server-iceberg) `rewrite_data_files` execution time is reduced from several hours to several minutes.

Btw, I found that Trino uses a similar technique: [EqualityDeleteFilter](https://github.com/trinodb/trino/blob/481/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/EqualityDeleteFilter.java), [DeleteManager](https://github.com/trinodb/trino/blob/481/plugin/trino-iceberg/src/main/java/io/trino/plugin/iceberg/delete/DeleteManager.java).