### PR TITLE
Core: Fail scans when position deletes/DVs don't match data file partition

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -75,6 +75,7 @@ class DeleteFileIndex {
   private final PartitionMap<PositionDeletes> posDeletesByPartition;
   private final Map<String, PositionDeletes> posDeletesByPath;
   private final Map<String, DeleteFile> dvByPath;
+  private final LoadingCache<Integer, Comparator<StructLike>> partitionComparatorsBySpecId;
   private final boolean hasEqDeletes;
   private final boolean hasPosDeletes;
   private final boolean isEmpty;
@@ -84,12 +85,18 @@ class DeleteFileIndex {
       PartitionMap<EqualityDeletes> eqDeletesByPartition,
       PartitionMap<PositionDeletes> posDeletesByPartition,
       Map<String, PositionDeletes> posDeletesByPath,
-      Map<String, DeleteFile> dvByPath) {
+      Map<String, DeleteFile> dvByPath,
+      Map<Integer, PartitionSpec> specsById) {
     this.globalDeletes = globalDeletes;
     this.eqDeletesByPartition = eqDeletesByPartition;
     this.posDeletesByPartition = posDeletesByPartition;
     this.posDeletesByPath = posDeletesByPath;
     this.dvByPath = dvByPath;
+    this.partitionComparatorsBySpecId =
+        specsById == null
+            ? null
+            : Caffeine.newBuilder()
+                .build(specId -> Comparators.forType(specsById.get(specId).partitionType()));
     this.hasEqDeletes = globalDeletes != null || eqDeletesByPartition != null;
     this.hasPosDeletes =
         posDeletesByPartition != null || posDeletesByPath != null || dvByPath != null;
@@ -196,7 +203,15 @@ class DeleteFileIndex {
     }
 
     PositionDeletes deletes = posDeletesByPath.get(dataFile.location());
-    return deletes == null ? EMPTY_DELETES : deletes.filter(seq);
+    if (deletes == null) {
+      return EMPTY_DELETES;
+    }
+
+    DeleteFile[] matchingDeletes = deletes.filter(seq);
+    for (DeleteFile deleteFile : matchingDeletes) {
+      validatePartitionMatch(deleteFile, dataFile);
+    }
+    return matchingDeletes;
   }
 
   private DeleteFile findDV(long seq, DataFile dataFile) {
@@ -211,8 +226,32 @@ class DeleteFileIndex {
           "DV data sequence number (%s) must be greater than or equal to data file sequence number (%s)",
           dv.dataSequenceNumber(),
           seq);
+      validatePartitionMatch(dv, dataFile);
     }
     return dv;
+  }
+
+  private void validatePartitionMatch(DeleteFile deleteFile, DataFile dataFile) {
+    ValidationException.check(
+        deleteFile.specId() == dataFile.specId(),
+        "Mismatched partition specs (%s, %s) for delete file %s and data file %s:"
+            + " metadata is corrupted",
+        deleteFile.specId(),
+        dataFile.specId(),
+        deleteFile.location(),
+        dataFile.location());
+    if (partitionComparatorsBySpecId != null) {
+      Comparator<StructLike> partitionComparator =
+          partitionComparatorsBySpecId.get(deleteFile.specId());
+      ValidationException.check(
+          partitionComparator.compare(deleteFile.partition(), dataFile.partition()) == 0,
+          "Mismatched partition tuples (%s, %s) for delete file %s and data file %s:"
+              + " metadata is corrupted",
+          deleteFile.partition(),
+          dataFile.partition(),
+          deleteFile.location(),
+          dataFile.location());
+    }
   }
 
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
@@ -522,7 +561,8 @@ class DeleteFileIndex {
           eqDeletesByPartition.isEmpty() ? null : eqDeletesByPartition,
           posDeletesByPartition.isEmpty() ? null : posDeletesByPartition,
           posDeletesByPath.isEmpty() ? null : posDeletesByPath,
-          dvByPath.isEmpty() ? null : dvByPath);
+          dvByPath.isEmpty() ? null : dvByPath,
+          specsById.isEmpty() ? null : specsById);
     }
 
     private void add(Map<String, DeleteFile> dvByPath, DeleteFile dv) {

--- a/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DataTableScanTestBase.java
@@ -27,6 +27,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -309,5 +310,123 @@ public abstract class DataTableScanTestBase<
             .collect(Collectors.toList())
             .get(0);
     assertThat(deletes.get(0).manifestLocation()).isEqualTo(deleteManifest.path());
+  }
+
+  @TestTemplate
+  public void testPlanFilesPositionDeletePathReferenceWithPartitionMismatchFails() {
+    assumeThat(formatVersion).as("Requires V2 position deletes").isEqualTo(2);
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    // Position delete whose metadata partition (data_bucket=1) does not match FILE_A's
+    // partition (data_bucket=0), but whose path reference points to FILE_A.
+    DeleteFile posDeleteWrongPartition =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-delete-wrong-partition-" + UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_A.location())
+            .build();
+
+    table.newRowDelta().addDeletes(posDeleteWrongPartition).commit();
+
+    assertThatThrownBy(() -> Lists.newArrayList(newScan().planFiles()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+            "Mismatched partition tuples (PartitionData{data_bucket=1},"
+                + " PartitionData{data_bucket=0})")
+        .hasMessageContaining(FILE_A.location())
+        .hasMessageContaining("metadata is corrupted");
+  }
+
+  @TestTemplate
+  public void testPlanFilesDeletionVectorPathReferenceWithPartitionMismatchFails() {
+    assumeThat(formatVersion).as("Requires V3 deletion vectors").isGreaterThanOrEqualTo(3);
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    // DV whose metadata partition (data_bucket=1) does not match FILE_A's partition
+    // (data_bucket=0), but whose path reference points to FILE_A.
+    DeleteFile dvWrongPartition =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/dv-wrong-partition-" + UUID.randomUUID() + ".puffin")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_A.location())
+            .withContentOffset(4)
+            .withContentSizeInBytes(6)
+            .build();
+
+    table.newRowDelta().addDeletes(dvWrongPartition).commit();
+
+    assertThatThrownBy(() -> Lists.newArrayList(newScan().planFiles()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining(
+            "Mismatched partition tuples (PartitionData{data_bucket=1},"
+                + " PartitionData{data_bucket=0})")
+        .hasMessageContaining(FILE_A.location())
+        .hasMessageContaining("metadata is corrupted");
+  }
+
+  @TestTemplate
+  public void testPlanFilesPositionDeletePathReferenceWithSpecMismatchFails() {
+    assumeThat(formatVersion).as("Requires V2 position deletes").isEqualTo(2);
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    table.updateSpec().addField("id").commit();
+
+    // Position delete (spec ID 1) whose path reference points to FILE_A (spec ID 0).
+    DeleteFile positionDeleteWrongSpec =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-delete-wrong-spec-" + UUID.randomUUID() + ".parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0/id=1")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_A.location())
+            .build();
+
+    table.newRowDelta().addDeletes(positionDeleteWrongSpec).commit();
+
+    assertThatThrownBy(() -> Lists.newArrayList(newScan().planFiles()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Mismatched partition specs (1, 0)")
+        .hasMessageContaining(FILE_A.location())
+        .hasMessageContaining("metadata is corrupted");
+  }
+
+  @TestTemplate
+  public void testPlanFilesDeletionVectorPathReferenceWithSpecMismatchFails() {
+    assumeThat(formatVersion).as("Requires V3 deletion vectors").isGreaterThanOrEqualTo(3);
+
+    table.newAppend().appendFile(FILE_A).commit();
+
+    table.updateSpec().addField("id").commit();
+
+    // DV (spec ID 1) whose path reference points to FILE_A (spec ID 0).
+    DeleteFile dvWrongSpec =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withPath("/path/to/dv-wrong-spec-" + UUID.randomUUID() + ".puffin")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0/id=1")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_A.location())
+            .withContentOffset(4)
+            .withContentSizeInBytes(6)
+            .build();
+
+    table.newRowDelta().addDeletes(dvWrongSpec).commit();
+
+    assertThatThrownBy(() -> Lists.newArrayList(newScan().planFiles()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Mismatched partition specs (1, 0)")
+        .hasMessageContaining(FILE_A.location())
+        .hasMessageContaining("metadata is corrupted");
   }
 }


### PR DESCRIPTION
Position deletes/DVs with partition values that differ from referenced data files are invalid and corrupt per iceberg spec:
https://iceberg.apache.org/spec/#scan-planning

> A position delete file must be applied to a data file when all of the following are true:
**The data file's file_path is equal to the delete file's referenced_data_file if it is non-null**
**The data file's partition (both spec and partition values) is equal to the delete file's partition**

This PR fails table scans when corrupt metadata is detected. 

See linked PR for discussion: https://github.com/apache/iceberg/pull/16939