### PR TITLE
Flink: Backport improved createTable error message to 1.20 and 2.0

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -427,7 +427,12 @@ public class FlinkCatalog extends AbstractCatalog {
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
 
-    Preconditions.checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
+    Preconditions.checkArgument(
+        table instanceof ResolvedCatalogTable,
+        "Expected a ResolvedCatalogTable but got: %s. "
+            + "Iceberg Flink catalog only supports resolved catalog tables "
+            + "(Materialized tables and other table kinds are not supported).",
+        table == null ? "null" : table.getClass().getName());
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -33,7 +33,9 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.BaseTable;
@@ -741,6 +743,31 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
             .map(ContentFile::location)
             .collect(Collectors.toSet());
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
+  }
+
+  @TestTemplate
+  public void testCreateMaterializedTableIsUnsupported() {
+    CatalogMaterializedTable materializedTable =
+        CatalogMaterializedTable.newBuilder()
+            .schema(
+                org.apache.flink.table.api.Schema.newBuilder()
+                    .column("id", DataTypes.BIGINT())
+                    .build())
+            .definitionQuery("SELECT id FROM tl")
+            .freshness(IntervalFreshness.ofMinute("5"))
+            .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC)
+            .refreshMode(CatalogMaterializedTable.RefreshMode.CONTINUOUS)
+            .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                getTableEnv()
+                    .getCatalog(catalogName)
+                    .get()
+                    .createTable(new ObjectPath(DATABASE, "mt_table"), materializedTable, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Materialized tables and other table kinds are not supported");
   }
 
   private Table table(String name) {

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalog.java
@@ -427,7 +427,12 @@ public class FlinkCatalog extends AbstractCatalog {
               + "create table without 'connector'='iceberg' related properties in an iceberg table.");
     }
 
-    Preconditions.checkArgument(table instanceof ResolvedCatalogTable, "table should be resolved");
+    Preconditions.checkArgument(
+        table instanceof ResolvedCatalogTable,
+        "Expected a ResolvedCatalogTable but got: %s. "
+            + "Iceberg Flink catalog only supports resolved catalog tables "
+            + "(Materialized tables and other table kinds are not supported).",
+        table == null ? "null" : table.getClass().getName());
     createIcebergTable(tablePath, (ResolvedCatalogTable) table, ignoreIfExists);
   }
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkCatalogTable.java
@@ -33,8 +33,10 @@ import org.apache.flink.table.api.DataTypes;
 import org.apache.flink.table.api.Schema.UnresolvedPrimaryKey;
 import org.apache.flink.table.api.TableException;
 import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.catalog.CatalogMaterializedTable;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.CommonCatalogOptions;
+import org.apache.flink.table.catalog.IntervalFreshness;
 import org.apache.flink.table.catalog.ObjectPath;
 import org.apache.flink.table.catalog.exceptions.TableNotExistException;
 import org.apache.iceberg.BaseTable;
@@ -748,6 +750,31 @@ public class TestFlinkCatalogTable extends CatalogTestBase {
             .map(ContentFile::location)
             .collect(Collectors.toSet());
     assertThat(actualFilePaths).as("Files should match").isEqualTo(expectedFilePaths);
+  }
+
+  @TestTemplate
+  public void testCreateMaterializedTableIsUnsupported() {
+    CatalogMaterializedTable materializedTable =
+        CatalogMaterializedTable.newBuilder()
+            .schema(
+                org.apache.flink.table.api.Schema.newBuilder()
+                    .column("id", DataTypes.BIGINT())
+                    .build())
+            .definitionQuery("SELECT id FROM tl")
+            .freshness(IntervalFreshness.ofMinute("5"))
+            .logicalRefreshMode(CatalogMaterializedTable.LogicalRefreshMode.AUTOMATIC)
+            .refreshMode(CatalogMaterializedTable.RefreshMode.CONTINUOUS)
+            .refreshStatus(CatalogMaterializedTable.RefreshStatus.INITIALIZING)
+            .build();
+
+    assertThatThrownBy(
+            () ->
+                getTableEnv()
+                    .getCatalog(catalogName)
+                    .get()
+                    .createTable(new ObjectPath(DATABASE, "mt_table"), materializedTable, false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Materialized tables and other table kinds are not supported");
   }
 
   private Table table(String name) {


### PR DESCRIPTION
Backports #16079 to the Flink 1.20 and 2.0 modules, as requested by @pvary on that PR.

`FlinkCatalog#createTable` previously failed with a terse `IllegalArgumentException: table should be resolved` when given a table kind it cannot handle (e.g. a `CatalogMaterializedTable`, see #15318). The improved `Preconditions.checkArgument` message now reports the actual table class and explains that the Iceberg Flink catalog only supports resolved catalog tables.

This applies the exact same change merged for Flink 2.1 in #16079 to the 1.20 and 2.0 modules (the `createTable` method is identical across all three).
