### PR TITLE
Core: Stream DV Puffin rewrite in RewriteTablePathUtil

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -807,7 +807,7 @@ public class RewriteTablePathUtil {
                 properties));
       }
 
-      writer.close();
+      writer.finish();
       return writer.length();
     }
   }

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -42,6 +42,7 @@ import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
+import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinCompressionCodec;
 import org.apache.iceberg.puffin.PuffinReader;
@@ -780,15 +781,14 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
-    List<Blob> rewrittenBlobs = Lists.newArrayList();
-    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build()) {
-      // Read all blobs and rewrite them with updated referenced data file paths
-      for (Pair<org.apache.iceberg.puffin.BlobMetadata, ByteBuffer> blobPair :
+    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build();
+        PuffinWriter writer =
+            Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
+      for (Pair<BlobMetadata, ByteBuffer> blobPair :
           reader.readAll(reader.fileMetadata().blobs())) {
-        org.apache.iceberg.puffin.BlobMetadata blobMetadata = blobPair.first();
+        BlobMetadata blobMetadata = blobPair.first();
         ByteBuffer blobData = blobPair.second();
 
-        // Get the original properties and update the referenced data file path
         Map<String, String> properties = Maps.newHashMap(blobMetadata.properties());
         String referencedDataFile = properties.get("referenced-data-file");
         if (referencedDataFile != null && referencedDataFile.startsWith(sourcePrefix)) {
@@ -796,8 +796,7 @@ public class RewriteTablePathUtil {
           properties.put("referenced-data-file", newReferencedDataFile);
         }
 
-        // Create a new blob with updated properties
-        rewrittenBlobs.add(
+        writer.write(
             new Blob(
                 blobMetadata.type(),
                 blobMetadata.inputFields(),
@@ -807,11 +806,7 @@ public class RewriteTablePathUtil {
                 PuffinCompressionCodec.forName(blobMetadata.compressionCodec()),
                 properties));
       }
-    }
 
-    try (PuffinWriter writer =
-        Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
-      rewrittenBlobs.forEach(writer::write);
       writer.close();
       return writer.length();
     }

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -783,10 +783,7 @@ public class RewriteTablePathUtil {
       throws IOException {
     try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build();
         PuffinWriter writer =
-            Puffin.write(outputFile)
-                .createdBy(IcebergBuild.fullVersion())
-                .overwrite()
-                .build()) {
+            Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).overwrite().build()) {
       for (Pair<BlobMetadata, ByteBuffer> blobPair :
           reader.readAll(reader.fileMetadata().blobs())) {
         BlobMetadata blobMetadata = blobPair.first();

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -783,9 +783,12 @@ public class RewriteTablePathUtil {
       throws IOException {
     try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build()) {
       List<BlobMetadata> blobs = reader.fileMetadata().blobs();
+      boolean writerCreated = false;
 
       try (PuffinWriter writer =
           Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
+        writerCreated = true;
+
         for (Pair<BlobMetadata, ByteBuffer> blobPair : reader.readAll(blobs)) {
           BlobMetadata blobMetadata = blobPair.first();
           ByteBuffer blobData = blobPair.second();
@@ -810,7 +813,21 @@ public class RewriteTablePathUtil {
 
         writer.finish();
         return writer.length();
+      } catch (IOException | RuntimeException e) {
+        if (writerCreated) {
+          cleanUpOutputFile(io, outputFile, e);
+        }
+
+        throw e;
       }
+    }
+  }
+
+  private static void cleanUpOutputFile(FileIO io, OutputFile outputFile, Exception failure) {
+    try {
+      io.deleteFile(outputFile.location());
+    } catch (RuntimeException deleteFailure) {
+      failure.addSuppressed(deleteFailure);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -781,47 +781,37 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
-    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build()) {
-      List<BlobMetadata> blobs = reader.fileMetadata().blobs();
-      PuffinWriter writer = Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build();
+    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build();
+        PuffinWriter writer =
+            Puffin.write(outputFile)
+                .createdBy(IcebergBuild.fullVersion())
+                .overwrite()
+                .build()) {
+      for (Pair<BlobMetadata, ByteBuffer> blobPair :
+          reader.readAll(reader.fileMetadata().blobs())) {
+        BlobMetadata blobMetadata = blobPair.first();
+        ByteBuffer blobData = blobPair.second();
 
-      try (writer) {
-        for (Pair<BlobMetadata, ByteBuffer> blobPair : reader.readAll(blobs)) {
-          BlobMetadata blobMetadata = blobPair.first();
-          ByteBuffer blobData = blobPair.second();
-
-          Map<String, String> properties = Maps.newHashMap(blobMetadata.properties());
-          String referencedDataFile = properties.get("referenced-data-file");
-          if (referencedDataFile != null && referencedDataFile.startsWith(sourcePrefix)) {
-            String newReferencedDataFile = newPath(referencedDataFile, sourcePrefix, targetPrefix);
-            properties.put("referenced-data-file", newReferencedDataFile);
-          }
-
-          writer.write(
-              new Blob(
-                  blobMetadata.type(),
-                  blobMetadata.inputFields(),
-                  blobMetadata.snapshotId(),
-                  blobMetadata.sequenceNumber(),
-                  blobData,
-                  PuffinCompressionCodec.forName(blobMetadata.compressionCodec()),
-                  properties));
+        Map<String, String> properties = Maps.newHashMap(blobMetadata.properties());
+        String referencedDataFile = properties.get("referenced-data-file");
+        if (referencedDataFile != null && referencedDataFile.startsWith(sourcePrefix)) {
+          String newReferencedDataFile = newPath(referencedDataFile, sourcePrefix, targetPrefix);
+          properties.put("referenced-data-file", newReferencedDataFile);
         }
 
-        writer.finish();
-        return writer.length();
-      } catch (IOException | RuntimeException e) {
-        cleanUpOutputFile(io, outputFile, e);
-        throw e;
+        writer.write(
+            new Blob(
+                blobMetadata.type(),
+                blobMetadata.inputFields(),
+                blobMetadata.snapshotId(),
+                blobMetadata.sequenceNumber(),
+                blobData,
+                PuffinCompressionCodec.forName(blobMetadata.compressionCodec()),
+                properties));
       }
-    }
-  }
 
-  private static void cleanUpOutputFile(FileIO io, OutputFile outputFile, Exception failure) {
-    try {
-      io.deleteFile(outputFile.location());
-    } catch (RuntimeException deleteFailure) {
-      failure.addSuppressed(deleteFailure);
+      writer.finish();
+      return writer.length();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -781,34 +781,36 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
-    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build();
-        PuffinWriter writer =
-            Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
-      for (Pair<BlobMetadata, ByteBuffer> blobPair :
-          reader.readAll(reader.fileMetadata().blobs())) {
-        BlobMetadata blobMetadata = blobPair.first();
-        ByteBuffer blobData = blobPair.second();
+    try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build()) {
+      List<BlobMetadata> blobs = reader.fileMetadata().blobs();
 
-        Map<String, String> properties = Maps.newHashMap(blobMetadata.properties());
-        String referencedDataFile = properties.get("referenced-data-file");
-        if (referencedDataFile != null && referencedDataFile.startsWith(sourcePrefix)) {
-          String newReferencedDataFile = newPath(referencedDataFile, sourcePrefix, targetPrefix);
-          properties.put("referenced-data-file", newReferencedDataFile);
+      try (PuffinWriter writer =
+          Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
+        for (Pair<BlobMetadata, ByteBuffer> blobPair : reader.readAll(blobs)) {
+          BlobMetadata blobMetadata = blobPair.first();
+          ByteBuffer blobData = blobPair.second();
+
+          Map<String, String> properties = Maps.newHashMap(blobMetadata.properties());
+          String referencedDataFile = properties.get("referenced-data-file");
+          if (referencedDataFile != null && referencedDataFile.startsWith(sourcePrefix)) {
+            String newReferencedDataFile = newPath(referencedDataFile, sourcePrefix, targetPrefix);
+            properties.put("referenced-data-file", newReferencedDataFile);
+          }
+
+          writer.write(
+              new Blob(
+                  blobMetadata.type(),
+                  blobMetadata.inputFields(),
+                  blobMetadata.snapshotId(),
+                  blobMetadata.sequenceNumber(),
+                  blobData,
+                  PuffinCompressionCodec.forName(blobMetadata.compressionCodec()),
+                  properties));
         }
 
-        writer.write(
-            new Blob(
-                blobMetadata.type(),
-                blobMetadata.inputFields(),
-                blobMetadata.snapshotId(),
-                blobMetadata.sequenceNumber(),
-                blobData,
-                PuffinCompressionCodec.forName(blobMetadata.compressionCodec()),
-                properties));
+        writer.finish();
+        return writer.length();
       }
-
-      writer.finish();
-      return writer.length();
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -783,12 +783,9 @@ public class RewriteTablePathUtil {
       throws IOException {
     try (PuffinReader reader = Puffin.read(io.newInputFile(deleteFile.location())).build()) {
       List<BlobMetadata> blobs = reader.fileMetadata().blobs();
-      boolean writerCreated = false;
+      PuffinWriter writer = Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build();
 
-      try (PuffinWriter writer =
-          Puffin.write(outputFile).createdBy(IcebergBuild.fullVersion()).build()) {
-        writerCreated = true;
-
+      try (writer) {
         for (Pair<BlobMetadata, ByteBuffer> blobPair : reader.readAll(blobs)) {
           BlobMetadata blobMetadata = blobPair.first();
           ByteBuffer blobData = blobPair.second();
@@ -814,10 +811,7 @@ public class RewriteTablePathUtil {
         writer.finish();
         return writer.length();
       } catch (IOException | RuntimeException e) {
-        if (writerCreated) {
-          cleanUpOutputFile(io, outputFile, e);
-        }
-
+        cleanUpOutputFile(io, outputFile, e);
         throw e;
       }
     }

--- a/core/src/main/java/org/apache/iceberg/puffin/Puffin.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/Puffin.java
@@ -72,12 +72,12 @@ public final class Puffin {
       return this;
     }
 
-    /** Configures the writer to overwrite existing output files. */
+    /** Configures the writer to replace an existing output file. */
     public WriteBuilder overwrite() {
       return overwrite(true);
     }
 
-    /** Configures whether the writer overwrites existing output files. */
+    /** Configures whether the writer replaces an existing output file. Disabled by default. */
     public WriteBuilder overwrite(boolean enabled) {
       this.overwrite = enabled;
       return this;

--- a/core/src/main/java/org/apache/iceberg/puffin/Puffin.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/Puffin.java
@@ -41,6 +41,7 @@ public final class Puffin {
     private final OutputFile outputFile;
     private final Map<String, String> properties = Maps.newLinkedHashMap();
     private boolean compressFooter = false;
+    private boolean overwrite = false;
     private PuffinCompressionCodec defaultBlobCompression = PuffinCompressionCodec.NONE;
 
     private WriteBuilder(OutputFile outputFile) {
@@ -71,6 +72,17 @@ public final class Puffin {
       return this;
     }
 
+    /** Configures the writer to overwrite existing output files. */
+    public WriteBuilder overwrite() {
+      return overwrite(true);
+    }
+
+    /** Configures whether the writer overwrites existing output files. */
+    public WriteBuilder overwrite(boolean enabled) {
+      this.overwrite = enabled;
+      return this;
+    }
+
     /**
      * Configures the writer to compress the blobs. Can be overwritten by {@link Blob} attribute.
      */
@@ -80,7 +92,8 @@ public final class Puffin {
     }
 
     public PuffinWriter build() {
-      return new PuffinWriter(outputFile, properties, compressFooter, defaultBlobCompression);
+      return new PuffinWriter(
+          outputFile, properties, compressFooter, defaultBlobCompression, overwrite);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -127,9 +127,11 @@ public class PuffinReader implements Closeable {
 
     // TODO inspect blob offsets and coalesce read regions close to each other
 
+    List<BlobMetadata> sortedBlobs =
+        ImmutableList.sortedCopyOf(Comparator.comparingLong(BlobMetadata::offset), blobs);
+
     return () ->
-        blobs.stream()
-            .sorted(Comparator.comparingLong(BlobMetadata::offset))
+        sortedBlobs.stream()
             .map(
                 (BlobMetadata blobMetadata) -> {
                   try {

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinWriter.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinWriter.java
@@ -60,12 +60,13 @@ public class PuffinWriter implements FileAppender<Blob> {
       OutputFile outputFile,
       Map<String, String> properties,
       boolean compressFooter,
-      PuffinCompressionCodec defaultBlobCompression) {
+      PuffinCompressionCodec defaultBlobCompression,
+      boolean overwrite) {
     Preconditions.checkNotNull(outputFile, "outputFile is null");
     Preconditions.checkNotNull(properties, "properties is null");
     Preconditions.checkNotNull(defaultBlobCompression, "defaultBlobCompression is null");
     this.outputFile = outputFile;
-    this.outputStream = outputFile.create();
+    this.outputStream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
     this.properties = ImmutableMap.copyOf(properties);
     this.footerCompression =
         compressFooter ? PuffinFormat.FOOTER_COMPRESSION_CODEC : PuffinCompressionCodec.NONE;

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -23,16 +23,32 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Set;
+import org.apache.iceberg.deletes.Deletes;
+import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.puffin.Blob;
+import org.apache.iceberg.puffin.BlobMetadata;
+import org.apache.iceberg.puffin.Puffin;
+import org.apache.iceberg.puffin.PuffinReader;
+import org.apache.iceberg.puffin.PuffinWriter;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.util.ByteBuffers;
+import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestRewriteTablePathUtil extends TestBase {
+  private static final String REFERENCED_DATA_FILE = "referenced-data-file";
+  private static final String CARDINALITY = "cardinality";
 
   @Test
   public void testStagingPathPreservesDirectoryStructure() {
@@ -375,5 +391,137 @@ public class TestRewriteTablePathUtil extends TestBase {
     }
 
     return writer.toManifestFile();
+  }
+
+  @TestTemplate
+  void rewriteDVFileRewritesReferencedDataFileInBlobMetadata() throws IOException {
+    assumeThat(formatVersion).as("DVs require format version 3+").isGreaterThanOrEqualTo(3);
+
+    String sourcePrefix = temp.resolve("source").toString();
+    String targetPrefix = temp.resolve("target").toString();
+    String sourceDataFile = sourcePrefix + "/data/file-a.parquet";
+    String externalDataFile = temp.resolve("external/data/file-b.parquet").toString();
+
+    PositionDeleteIndex sourceDeletes = positionDeleteIndex(1L, 4L);
+    PositionDeleteIndex externalDeletes = positionDeleteIndex(2L, 5L, 8L);
+    byte[] sourcePayload = serializedDV(sourceDeletes);
+    byte[] externalPayload = serializedDV(externalDeletes);
+
+    OutputFile sourceDVFile =
+        Files.localOutput(
+            temp.resolve("source/metadata/dv-" + System.nanoTime() + ".puffin").toString());
+    try (PuffinWriter writer = Puffin.write(sourceDVFile).createdBy("test").build()) {
+      writer.write(newDVBlob(sourceDeletes, sourcePayload, sourceDataFile));
+      writer.write(newDVBlob(externalDeletes, externalPayload, externalDataFile));
+    }
+
+    List<BlobMetadata> sourceBlobMetadata;
+    try (PuffinReader reader = Puffin.read(sourceDVFile.toInputFile()).build()) {
+      sourceBlobMetadata = reader.fileMetadata().blobs();
+    }
+    assertThat(sourceBlobMetadata).hasSize(2);
+
+    DeleteFile dvDeleteFile =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withFormat(FileFormat.PUFFIN)
+            .withPath(sourceDVFile.location())
+            .withFileSizeInBytes(sourceDVFile.toInputFile().getLength())
+            .withPartition(FILE_A.partition())
+            .withRecordCount(sourceDeletes.cardinality())
+            .withReferencedDataFile(sourceDataFile)
+            .withContentOffset(sourceBlobMetadata.get(0).offset())
+            .withContentSizeInBytes(sourceBlobMetadata.get(0).length())
+            .build();
+
+    OutputFile rewrittenDVFile =
+        Files.localOutput(
+            temp.resolve("target/metadata/dv-rewritten-" + System.nanoTime() + ".puffin")
+                .toString());
+    RewriteTablePathUtil.rewritePositionDeleteFile(
+        dvDeleteFile, rewrittenDVFile, table.io(), table.spec(), sourcePrefix, targetPrefix, null);
+
+    try (PuffinReader reader = Puffin.read(rewrittenDVFile.toInputFile()).build()) {
+      List<BlobMetadata> rewrittenBlobMetadata = reader.fileMetadata().blobs();
+      assertThat(rewrittenBlobMetadata).hasSize(2);
+
+      BlobMetadata rewrittenSourceBlob = rewrittenBlobMetadata.get(0);
+      BlobMetadata rewrittenExternalBlob = rewrittenBlobMetadata.get(1);
+      assertDVBlobMetadata(
+          rewrittenSourceBlob, targetPrefix + "/data/file-a.parquet", sourceDeletes.cardinality());
+      assertDVBlobMetadata(rewrittenExternalBlob, externalDataFile, externalDeletes.cardinality());
+
+      assertThat(rewrittenSourceBlob.offset()).isEqualTo(dvDeleteFile.contentOffset());
+      assertThat(rewrittenSourceBlob.length()).isEqualTo(dvDeleteFile.contentSizeInBytes());
+      assertThat(rewrittenExternalBlob.offset())
+          .isEqualTo(rewrittenSourceBlob.offset() + rewrittenSourceBlob.length());
+
+      List<Pair<BlobMetadata, ByteBuffer>> blobs =
+          ImmutableList.copyOf(reader.readAll(rewrittenBlobMetadata));
+      assertThat(ByteBuffers.toByteArray(blobs.get(0).second())).isEqualTo(sourcePayload);
+      assertThat(ByteBuffers.toByteArray(blobs.get(1).second())).isEqualTo(externalPayload);
+    }
+
+    DeleteFile rewrittenDVDeleteFile =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .copy(dvDeleteFile)
+            .withPath(rewrittenDVFile.location())
+            .withFileSizeInBytes(rewrittenDVFile.toInputFile().getLength())
+            .withReferencedDataFile(targetPrefix + "/data/file-a.parquet")
+            .build();
+    assertDeletedPositions(DVUtil.readDV(rewrittenDVDeleteFile, table.io()), 1L, 4L);
+  }
+
+  private static Blob newDVBlob(
+      PositionDeleteIndex deletes, byte[] payload, String referencedDataFile) {
+    return new Blob(
+        StandardBlobTypes.DV_V1,
+        ImmutableList.of(MetadataColumns.ROW_POSITION.fieldId()),
+        -1L,
+        -1L,
+        ByteBuffer.wrap(payload),
+        null,
+        ImmutableMap.of(
+            REFERENCED_DATA_FILE,
+            referencedDataFile,
+            CARDINALITY,
+            String.valueOf(deletes.cardinality())));
+  }
+
+  private static PositionDeleteIndex positionDeleteIndex(long... positions) {
+    ImmutableList.Builder<Long> builder = ImmutableList.builder();
+    for (long position : positions) {
+      builder.add(position);
+    }
+
+    return Deletes.toPositionIndex(CloseableIterable.withNoopClose(builder.build()));
+  }
+
+  private static byte[] serializedDV(PositionDeleteIndex deletes) {
+    return ByteBuffers.toByteArray(deletes.serialize());
+  }
+
+  private static void assertDVBlobMetadata(
+      BlobMetadata blobMetadata, String referencedDataFile, long cardinality) {
+    assertThat(blobMetadata.type()).isEqualTo(StandardBlobTypes.DV_V1);
+    assertThat(blobMetadata.inputFields()).containsExactly(MetadataColumns.ROW_POSITION.fieldId());
+    assertThat(blobMetadata.snapshotId()).isEqualTo(-1L);
+    assertThat(blobMetadata.sequenceNumber()).isEqualTo(-1L);
+    assertThat(blobMetadata.compressionCodec()).isNull();
+    assertThat(blobMetadata.offset()).isPositive();
+    assertThat(blobMetadata.length()).isPositive();
+    assertThat(blobMetadata.properties())
+        .containsExactlyInAnyOrderEntriesOf(
+            ImmutableMap.of(
+                REFERENCED_DATA_FILE,
+                referencedDataFile,
+                CARDINALITY,
+                String.valueOf(cardinality)));
+  }
+
+  private static void assertDeletedPositions(PositionDeleteIndex deletes, long... positions) {
+    for (long position : positions) {
+      assertThat(deletes.isDeleted(position)).isTrue();
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -520,6 +520,7 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   private static void assertDeletedPositions(PositionDeleteIndex deletes, long... positions) {
+    assertThat(deletes.cardinality()).isEqualTo(positions.length);
     for (long position : positions) {
       assertThat(deletes.isDeleted(position)).isTrue();
     }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -23,14 +23,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;
@@ -472,6 +475,98 @@ public class TestRewriteTablePathUtil extends TestBase {
     assertDeletedPositions(DVUtil.readDV(rewrittenDVDeleteFile, table.io()), 1L, 4L);
   }
 
+  @TestTemplate
+  void rewriteDVFileCleansUpOutputOnBlobReadFailure() throws IOException {
+    assumeThat(formatVersion).as("DVs require format version 3+").isGreaterThanOrEqualTo(3);
+
+    String sourcePrefix = temp.resolve("source").toString();
+    String targetPrefix = temp.resolve("target").toString();
+    String sourceDataFile = sourcePrefix + "/data/file-a.parquet";
+
+    PositionDeleteIndex sourceDeletes = positionDeleteIndex(1L, 4L);
+    byte[] sourcePayload = serializedDV(sourceDeletes);
+
+    OutputFile sourceDVFile =
+        Files.localOutput(
+            temp.resolve("source/metadata/dv-" + System.nanoTime() + ".puffin").toString());
+    try (PuffinWriter writer = Puffin.write(sourceDVFile).createdBy("test").build()) {
+      writer.write(newDVBlob(sourceDeletes, sourcePayload, sourceDataFile));
+    }
+
+    List<BlobMetadata> sourceBlobMetadata;
+    try (PuffinReader reader = Puffin.read(sourceDVFile.toInputFile()).build()) {
+      sourceBlobMetadata = reader.fileMetadata().blobs();
+    }
+    assertThat(sourceBlobMetadata).hasSize(1);
+
+    DeleteFile dvDeleteFile =
+        FileMetadata.deleteFileBuilder(table.spec())
+            .ofPositionDeletes()
+            .withFormat(FileFormat.PUFFIN)
+            .withPath(sourceDVFile.location())
+            .withFileSizeInBytes(sourceDVFile.toInputFile().getLength())
+            .withPartition(FILE_A.partition())
+            .withRecordCount(sourceDeletes.cardinality())
+            .withReferencedDataFile(sourceDataFile)
+            .withContentOffset(sourceBlobMetadata.get(0).offset())
+            .withContentSizeInBytes(sourceBlobMetadata.get(0).length())
+            .build();
+
+    OutputFile rewrittenDVFile =
+        Files.localOutput(
+            temp.resolve("target/metadata/dv-rewritten-" + System.nanoTime() + ".puffin")
+                .toString());
+    InputFile sourceInputFile = sourceDVFile.toInputFile();
+    FileIO failingReadIO =
+        new TestTables.LocalFileIO() {
+          @Override
+          public InputFile newInputFile(String path) {
+            if (!path.equals(sourceDVFile.location())) {
+              return super.newInputFile(path);
+            }
+
+            return new InputFile() {
+              @Override
+              public long getLength() {
+                return sourceInputFile.getLength();
+              }
+
+              @Override
+              public SeekableInputStream newStream() {
+                return new FailingReadInputStream(
+                    sourceInputFile.newStream(), sourceBlobMetadata.get(0).offset());
+              }
+
+              @Override
+              public String location() {
+                return sourceInputFile.location();
+              }
+
+              @Override
+              public boolean exists() {
+                return sourceInputFile.exists();
+              }
+            };
+          }
+        };
+
+    assertThatThrownBy(
+            () ->
+                RewriteTablePathUtil.rewritePositionDelete(
+                    dvDeleteFile,
+                    rewrittenDVFile,
+                    failingReadIO,
+                    table.spec(),
+                    sourcePrefix,
+                    targetPrefix,
+                    null))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasCauseInstanceOf(IOException.class)
+        .hasMessageContaining("Injected failure reading blob");
+
+    assertThat(rewrittenDVFile.toInputFile().exists()).isFalse();
+  }
+
   private static Blob newDVBlob(
       PositionDeleteIndex deletes, byte[] payload, String referencedDataFile) {
     return new Blob(
@@ -523,6 +618,55 @@ public class TestRewriteTablePathUtil extends TestBase {
     assertThat(deletes.cardinality()).isEqualTo(positions.length);
     for (long position : positions) {
       assertThat(deletes.isDeleted(position)).isTrue();
+    }
+  }
+
+  private static class FailingReadInputStream extends SeekableInputStream {
+    private final SeekableInputStream delegate;
+    private final long failOffset;
+
+    private FailingReadInputStream(SeekableInputStream delegate, long failOffset) {
+      this.delegate = delegate;
+      this.failOffset = failOffset;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return delegate.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      delegate.seek(newPos);
+    }
+
+    @Override
+    public int read() throws IOException {
+      failIfReadingBlob();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] bytes) throws IOException {
+      failIfReadingBlob();
+      return delegate.read(bytes);
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      failIfReadingBlob();
+      return delegate.read(bytes, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    private void failIfReadingBlob() throws IOException {
+      if (delegate.getPos() == failOffset) {
+        throw new IOException("Injected failure reading blob");
+      }
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -23,17 +23,14 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.io.CloseableIterable;
-import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
-import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;
@@ -441,6 +438,8 @@ public class TestRewriteTablePathUtil extends TestBase {
         Files.localOutput(
             temp.resolve("target/metadata/dv-rewritten-" + System.nanoTime() + ".puffin")
                 .toString());
+    try (PuffinWriter ignored = Puffin.write(rewrittenDVFile).createdBy("stale").build()) {}
+
     RewriteTablePathUtil.rewritePositionDeleteFile(
         dvDeleteFile, rewrittenDVFile, table.io(), table.spec(), sourcePrefix, targetPrefix, null);
 
@@ -473,98 +472,6 @@ public class TestRewriteTablePathUtil extends TestBase {
             .withReferencedDataFile(targetPrefix + "/data/file-a.parquet")
             .build();
     assertDeletedPositions(DVUtil.readDV(rewrittenDVDeleteFile, table.io()), 1L, 4L);
-  }
-
-  @TestTemplate
-  void rewriteDVFileCleansUpOutputOnBlobReadFailure() throws IOException {
-    assumeThat(formatVersion).as("DVs require format version 3+").isGreaterThanOrEqualTo(3);
-
-    String sourcePrefix = temp.resolve("source").toString();
-    String targetPrefix = temp.resolve("target").toString();
-    String sourceDataFile = sourcePrefix + "/data/file-a.parquet";
-
-    PositionDeleteIndex sourceDeletes = positionDeleteIndex(1L, 4L);
-    byte[] sourcePayload = serializedDV(sourceDeletes);
-
-    OutputFile sourceDVFile =
-        Files.localOutput(
-            temp.resolve("source/metadata/dv-" + System.nanoTime() + ".puffin").toString());
-    try (PuffinWriter writer = Puffin.write(sourceDVFile).createdBy("test").build()) {
-      writer.write(newDVBlob(sourceDeletes, sourcePayload, sourceDataFile));
-    }
-
-    List<BlobMetadata> sourceBlobMetadata;
-    try (PuffinReader reader = Puffin.read(sourceDVFile.toInputFile()).build()) {
-      sourceBlobMetadata = reader.fileMetadata().blobs();
-    }
-    assertThat(sourceBlobMetadata).hasSize(1);
-
-    DeleteFile dvDeleteFile =
-        FileMetadata.deleteFileBuilder(table.spec())
-            .ofPositionDeletes()
-            .withFormat(FileFormat.PUFFIN)
-            .withPath(sourceDVFile.location())
-            .withFileSizeInBytes(sourceDVFile.toInputFile().getLength())
-            .withPartition(FILE_A.partition())
-            .withRecordCount(sourceDeletes.cardinality())
-            .withReferencedDataFile(sourceDataFile)
-            .withContentOffset(sourceBlobMetadata.get(0).offset())
-            .withContentSizeInBytes(sourceBlobMetadata.get(0).length())
-            .build();
-
-    OutputFile rewrittenDVFile =
-        Files.localOutput(
-            temp.resolve("target/metadata/dv-rewritten-" + System.nanoTime() + ".puffin")
-                .toString());
-    InputFile sourceInputFile = sourceDVFile.toInputFile();
-    FileIO failingReadIO =
-        new TestTables.LocalFileIO() {
-          @Override
-          public InputFile newInputFile(String path) {
-            if (!path.equals(sourceDVFile.location())) {
-              return super.newInputFile(path);
-            }
-
-            return new InputFile() {
-              @Override
-              public long getLength() {
-                return sourceInputFile.getLength();
-              }
-
-              @Override
-              public SeekableInputStream newStream() {
-                return new FailingReadInputStream(
-                    sourceInputFile.newStream(), sourceBlobMetadata.get(0).offset());
-              }
-
-              @Override
-              public String location() {
-                return sourceInputFile.location();
-              }
-
-              @Override
-              public boolean exists() {
-                return sourceInputFile.exists();
-              }
-            };
-          }
-        };
-
-    assertThatThrownBy(
-            () ->
-                RewriteTablePathUtil.rewritePositionDelete(
-                    dvDeleteFile,
-                    rewrittenDVFile,
-                    failingReadIO,
-                    table.spec(),
-                    sourcePrefix,
-                    targetPrefix,
-                    null))
-        .isInstanceOf(UncheckedIOException.class)
-        .hasCauseInstanceOf(IOException.class)
-        .hasMessageContaining("Injected failure reading blob");
-
-    assertThat(rewrittenDVFile.toInputFile().exists()).isFalse();
   }
 
   private static Blob newDVBlob(
@@ -621,52 +528,4 @@ public class TestRewriteTablePathUtil extends TestBase {
     }
   }
 
-  private static class FailingReadInputStream extends SeekableInputStream {
-    private final SeekableInputStream delegate;
-    private final long failOffset;
-
-    private FailingReadInputStream(SeekableInputStream delegate, long failOffset) {
-      this.delegate = delegate;
-      this.failOffset = failOffset;
-    }
-
-    @Override
-    public long getPos() throws IOException {
-      return delegate.getPos();
-    }
-
-    @Override
-    public void seek(long newPos) throws IOException {
-      delegate.seek(newPos);
-    }
-
-    @Override
-    public int read() throws IOException {
-      failIfReadingBlob();
-      return delegate.read();
-    }
-
-    @Override
-    public int read(byte[] bytes) throws IOException {
-      failIfReadingBlob();
-      return delegate.read(bytes);
-    }
-
-    @Override
-    public int read(byte[] bytes, int offset, int length) throws IOException {
-      failIfReadingBlob();
-      return delegate.read(bytes, offset, length);
-    }
-
-    @Override
-    public void close() throws IOException {
-      delegate.close();
-    }
-
-    private void failIfReadingBlob() throws IOException {
-      if (delegate.getPos() == failOffset) {
-        throw new IOException("Injected failure reading blob");
-      }
-    }
-  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -23,14 +23,17 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.deletes.Deletes;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.BlobMetadata;
 import org.apache.iceberg.puffin.Puffin;
@@ -394,7 +397,7 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   @TestTemplate
-  void rewriteDVFileRewritesReferencedDataFileInBlobMetadata() throws IOException {
+  void rewriteDVFileCanRetryAfterReadFailure() throws IOException {
     assumeThat(formatVersion).as("DVs require format version 3+").isGreaterThanOrEqualTo(3);
 
     String sourcePrefix = temp.resolve("source").toString();
@@ -438,10 +441,47 @@ public class TestRewriteTablePathUtil extends TestBase {
         Files.localOutput(
             temp.resolve("target/metadata/dv-rewritten-" + System.nanoTime() + ".puffin")
                 .toString());
-    try (PuffinWriter ignored = Puffin.write(rewrittenDVFile).createdBy("stale").build()) {}
 
-    RewriteTablePathUtil.rewritePositionDeleteFile(
-        dvDeleteFile, rewrittenDVFile, table.io(), table.spec(), sourcePrefix, targetPrefix, null);
+    long firstBlobOffset = sourceBlobMetadata.get(0).offset();
+    long failingBlobOffset = sourceBlobMetadata.get(1).offset();
+    FileIO failingFileIO =
+        new TestTables.LocalFileIO() {
+          @Override
+          public InputFile newInputFile(String path) {
+            InputFile inputFile = super.newInputFile(path);
+            return path.equals(sourceDVFile.location())
+                ? new FailingInputFile(inputFile, firstBlobOffset, failingBlobOffset)
+                : inputFile;
+          }
+        };
+
+    assertThatThrownBy(
+            () ->
+                RewriteTablePathUtil.rewritePositionDelete(
+                    dvDeleteFile,
+                    rewrittenDVFile,
+                    failingFileIO,
+                    table.spec(),
+                    sourcePrefix,
+                    targetPrefix,
+                    null))
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("Injected read failure");
+
+    try (PuffinReader reader = Puffin.read(rewrittenDVFile.toInputFile()).build()) {
+      assertThat(reader.fileMetadata().blobs()).hasSize(1);
+    }
+
+    long rewrittenLength =
+        RewriteTablePathUtil.rewritePositionDelete(
+            dvDeleteFile,
+            rewrittenDVFile,
+            table.io(),
+            table.spec(),
+            sourcePrefix,
+            targetPrefix,
+            null);
+    assertThat(rewrittenLength).isEqualTo(rewrittenDVFile.toInputFile().getLength());
 
     try (PuffinReader reader = Puffin.read(rewrittenDVFile.toInputFile()).build()) {
       List<BlobMetadata> rewrittenBlobMetadata = reader.fileMetadata().blobs();
@@ -528,4 +568,96 @@ public class TestRewriteTablePathUtil extends TestBase {
     }
   }
 
+  private static class FailingInputFile implements InputFile {
+    private final InputFile delegate;
+    private final long firstBlobPosition;
+    private final long failingPosition;
+
+    private FailingInputFile(InputFile delegate, long firstBlobPosition, long failingPosition) {
+      this.delegate = delegate;
+      this.firstBlobPosition = firstBlobPosition;
+      this.failingPosition = failingPosition;
+    }
+
+    @Override
+    public long getLength() {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new FailingSeekableInputStream(
+          delegate.newStream(), firstBlobPosition, failingPosition);
+    }
+
+    @Override
+    public String location() {
+      return delegate.location();
+    }
+
+    @Override
+    public boolean exists() {
+      return delegate.exists();
+    }
+  }
+
+  private static class FailingSeekableInputStream extends SeekableInputStream {
+    private final SeekableInputStream delegate;
+    private final long firstBlobPosition;
+    private final long failingPosition;
+    private boolean readingBlobs;
+    private boolean failReads;
+
+    private FailingSeekableInputStream(
+        SeekableInputStream delegate, long firstBlobPosition, long failingPosition) {
+      this.delegate = delegate;
+      this.firstBlobPosition = firstBlobPosition;
+      this.failingPosition = failingPosition;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return delegate.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      delegate.seek(newPos);
+      if (newPos == firstBlobPosition) {
+        this.readingBlobs = true;
+        this.failReads = false;
+      } else {
+        this.failReads = readingBlobs && newPos == failingPosition;
+      }
+    }
+
+    @Override
+    public int read() throws IOException {
+      checkRead();
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] bytes) throws IOException {
+      checkRead();
+      return delegate.read(bytes);
+    }
+
+    @Override
+    public int read(byte[] bytes, int offset, int length) throws IOException {
+      checkRead();
+      return delegate.read(bytes, offset, length);
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+
+    private void checkRead() throws IOException {
+      if (failReads) {
+        throw new IOException("Injected read failure at position: " + failingPosition);
+      }
+    }
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/puffin/TestPuffinWriter.java
+++ b/core/src/test/java/org/apache/iceberg/puffin/TestPuffinWriter.java
@@ -32,6 +32,7 @@ import java.nio.file.Path;
 import java.util.Random;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.encryption.AesGcmOutputFile;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -86,6 +87,36 @@ public class TestPuffinWriter {
     assertThat(outputFile.toByteArray())
         .isEqualTo(readTestResource("v1/empty-puffin-uncompressed.bin"));
     assertThat(writer.footerSize()).isEqualTo(EMPTY_PUFFIN_UNCOMPRESSED_FOOTER_SIZE);
+  }
+
+  @Test
+  public void overwriteExistingFile() throws Exception {
+    InMemoryOutputFile outputFile = new InMemoryOutputFile();
+    try (PuffinWriter writer = Puffin.write(outputFile).createdBy("original").build()) {
+      writer.add(
+          new Blob(
+              "some-blob",
+              ImmutableList.of(1),
+              2,
+              1,
+              ByteBuffer.wrap("abcdefghi".getBytes(UTF_8)),
+              null,
+              ImmutableMap.of()));
+    }
+
+    assertThatThrownBy(() -> Puffin.write(outputFile).build())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Already exists");
+    assertThatThrownBy(() -> Puffin.write(outputFile).overwrite(false).build())
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessage("Already exists");
+
+    try (PuffinWriter writer = Puffin.write(outputFile).overwrite().build()) {
+      assertThat(writer.writtenBlobsMetadata()).isEmpty();
+    }
+
+    assertThat(outputFile.toByteArray())
+        .isEqualTo(readTestResource("v1/empty-puffin-uncompressed.bin"));
   }
 
   @Test


### PR DESCRIPTION
`rewriteDVFile` collected all rewritten blobs into an in-memory list before writing them out, creating unnecessary memory pressure for large DV files. This change opens the `PuffinReader` and `PuffinWriter` together in the same try-with-resources and streams each blob directly to the writer as it is read, keeping memory bounded to a single blob instead of the full file contents.

Added a test that creates real serialized deletion vectors, rewrites the Puffin file, and round-trips through `DVUtil.readDV()` to verify the output is valid.

Closes #15924