### PR TITLE
Spark: Avoid real-time waits in streaming read timestamp tests

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -119,11 +119,19 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   protected long waitUntilAfter(long timestampMillis) {
-    long current = System.currentTimeMillis();
-    while (current <= timestampMillis) {
-      current = System.currentTimeMillis();
+    // Sleep once for the remaining time instead of busy-spinning on System.currentTimeMillis(),
+    // which pegs a core for the whole wait and starves other test forks/threads on a busy CI box.
+    // A past timestamp returns immediately.
+    long delta = timestampMillis - System.currentTimeMillis();
+    if (delta >= 0) {
+      try {
+        Thread.sleep(delta + 1);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting until after " + timestampMillis, e);
+      }
     }
-    return current;
+    return System.currentTimeMillis();
   }
 
   protected List<Object[]> sql(String query, Object... args) {

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -603,36 +603,33 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
   @TestTemplate
   public void testReadingStreamFromFutureTimetsamp() throws Exception {
-    long futureTimestamp = System.currentTimeMillis() + 10000;
-
-    StreamingQuery query =
-        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(futureTimestamp));
-
-    List<SimpleRecord> actual = rowsAvailable(query);
-    assertThat(actual).isEmpty();
-
     List<SimpleRecord> data =
         Lists.newArrayList(
             new SimpleRecord(-2, "minustwo"),
             new SimpleRecord(-1, "minusone"),
             new SimpleRecord(0, "zero"));
 
-    // Perform several inserts that should not show up because the fromTimestamp has not elapsed
-    IntStream.range(0, 3)
-        .forEach(
-            x -> {
-              appendData(data);
-              assertThat(rowsAvailable(query)).isEmpty();
-            });
+    // Snapshots committed before the stream's start timestamp must not show up.
+    IntStream.range(0, 3).forEach(x -> appendData(data));
+    table.refresh();
 
-    waitUntilAfter(futureTimestamp);
+    // Anchor the start timestamp just after the last pre-timestamp snapshot, then let the wall
+    // clock move past it so later snapshots are strictly newer. Keeps the "skip snapshots older
+    // than fromTimestamp" semantics without waiting out a synthetic future timestamp (was now +
+    // 10s, busy-spun on by waitUntilAfter).
+    long fromTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(fromTimestamp);
+
+    StreamingQuery query =
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(fromTimestamp));
+
+    assertThat(rowsAvailable(query)).isEmpty();
 
     // Data appended after the timestamp should appear
     appendData(data);
     // Allow async background thread to refresh, else test sometimes fails
     Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data);
   }
 
   @TestTemplate
@@ -641,17 +638,20 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         Lists.newArrayList(
             new SimpleRecord(1, "one"), new SimpleRecord(2, "two"), new SimpleRecord(3, "three"));
     appendData(dataBeforeTimestamp);
+    table.refresh();
 
-    long streamStartTimestamp = System.currentTimeMillis() + 2000;
+    // Anchor the start timestamp just after the existing snapshot instead of waiting out a
+    // synthetic future timestamp (was now + 2s); later snapshots are then strictly newer.
+    long streamStartTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(streamStartTimestamp);
 
-    // Start the stream with a future timestamp after the current snapshot
+    // Start the stream with a timestamp after the current snapshot
     StreamingQuery query =
         startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(streamStartTimestamp));
     List<SimpleRecord> actual = rowsAvailable(query);
     assertThat(actual).isEmpty();
 
-    // Stream should contain data added after the timestamp elapses
-    waitUntilAfter(streamStartTimestamp);
+    // Stream should contain data added after the timestamp
     List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
     appendDataAsMultipleSnapshots(expected);
     assertThat(rowsAvailable(query))

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -119,11 +119,19 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   protected long waitUntilAfter(long timestampMillis) {
-    long current = System.currentTimeMillis();
-    while (current <= timestampMillis) {
-      current = System.currentTimeMillis();
+    // Sleep once for the remaining time instead of busy-spinning on System.currentTimeMillis(),
+    // which pegs a core for the whole wait and starves other test forks/threads on a busy CI box.
+    // A past timestamp returns immediately.
+    long delta = timestampMillis - System.currentTimeMillis();
+    if (delta >= 0) {
+      try {
+        Thread.sleep(delta + 1);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting until after " + timestampMillis, e);
+      }
     }
-    return current;
+    return System.currentTimeMillis();
   }
 
   protected List<Object[]> sql(String query, Object... args) {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -610,36 +610,33 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
   @TestTemplate
   public void testReadingStreamFromFutureTimetsamp() throws Exception {
-    long futureTimestamp = System.currentTimeMillis() + 10000;
-
-    StreamingQuery query =
-        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(futureTimestamp));
-
-    List<SimpleRecord> actual = rowsAvailable(query);
-    assertThat(actual).isEmpty();
-
     List<SimpleRecord> data =
         Lists.newArrayList(
             new SimpleRecord(-2, "minustwo"),
             new SimpleRecord(-1, "minusone"),
             new SimpleRecord(0, "zero"));
 
-    // Perform several inserts that should not show up because the fromTimestamp has not elapsed
-    IntStream.range(0, 3)
-        .forEach(
-            x -> {
-              appendData(data);
-              assertThat(rowsAvailable(query)).isEmpty();
-            });
+    // Snapshots committed before the stream's start timestamp must not show up.
+    IntStream.range(0, 3).forEach(x -> appendData(data));
+    table.refresh();
 
-    waitUntilAfter(futureTimestamp);
+    // Anchor the start timestamp just after the last pre-timestamp snapshot, then let the wall
+    // clock move past it so later snapshots are strictly newer. Keeps the "skip snapshots older
+    // than fromTimestamp" semantics without waiting out a synthetic future timestamp (was now +
+    // 10s, busy-spun on by waitUntilAfter).
+    long fromTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(fromTimestamp);
+
+    StreamingQuery query =
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(fromTimestamp));
+
+    assertThat(rowsAvailable(query)).isEmpty();
 
     // Data appended after the timestamp should appear
     appendData(data);
     // Allow async background thread to refresh, else test sometimes fails
     Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data);
   }
 
   @TestTemplate
@@ -648,17 +645,20 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         Lists.newArrayList(
             new SimpleRecord(1, "one"), new SimpleRecord(2, "two"), new SimpleRecord(3, "three"));
     appendData(dataBeforeTimestamp);
+    table.refresh();
 
-    long streamStartTimestamp = System.currentTimeMillis() + 2000;
+    // Anchor the start timestamp just after the existing snapshot instead of waiting out a
+    // synthetic future timestamp (was now + 2s); later snapshots are then strictly newer.
+    long streamStartTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(streamStartTimestamp);
 
-    // Start the stream with a future timestamp after the current snapshot
+    // Start the stream with a timestamp after the current snapshot
     StreamingQuery query =
         startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(streamStartTimestamp));
     List<SimpleRecord> actual = rowsAvailable(query);
     assertThat(actual).isEmpty();
 
-    // Stream should contain data added after the timestamp elapses
-    waitUntilAfter(streamStartTimestamp);
+    // Stream should contain data added after the timestamp
     List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
     appendDataAsMultipleSnapshots(expected);
     assertThat(rowsAvailable(query))

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestBase.java
@@ -120,11 +120,19 @@ public abstract class TestBase extends SparkTestHelperBase {
   }
 
   protected long waitUntilAfter(long timestampMillis) {
-    long current = System.currentTimeMillis();
-    while (current <= timestampMillis) {
-      current = System.currentTimeMillis();
+    // Sleep once for the remaining time instead of busy-spinning on System.currentTimeMillis(),
+    // which pegs a core for the whole wait and starves other test forks/threads on a busy CI box.
+    // A past timestamp returns immediately.
+    long delta = timestampMillis - System.currentTimeMillis();
+    if (delta >= 0) {
+      try {
+        Thread.sleep(delta + 1);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException("Interrupted while waiting until after " + timestampMillis, e);
+      }
     }
-    return current;
+    return System.currentTimeMillis();
   }
 
   protected List<Object[]> sql(String query, Object... args) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -611,36 +611,33 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
   @TestTemplate
   public void testReadingStreamFromFutureTimetsamp() throws Exception {
-    long futureTimestamp = System.currentTimeMillis() + 10000;
-
-    StreamingQuery query =
-        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(futureTimestamp));
-
-    List<SimpleRecord> actual = rowsAvailable(query);
-    assertThat(actual).isEmpty();
-
     List<SimpleRecord> data =
         Lists.newArrayList(
             new SimpleRecord(-2, "minustwo"),
             new SimpleRecord(-1, "minusone"),
             new SimpleRecord(0, "zero"));
 
-    // Perform several inserts that should not show up because the fromTimestamp has not elapsed
-    IntStream.range(0, 3)
-        .forEach(
-            x -> {
-              appendData(data);
-              assertThat(rowsAvailable(query)).isEmpty();
-            });
+    // Snapshots committed before the stream's start timestamp must not show up.
+    IntStream.range(0, 3).forEach(x -> appendData(data));
+    table.refresh();
 
-    waitUntilAfter(futureTimestamp);
+    // Anchor the start timestamp just after the last pre-timestamp snapshot, then let the wall
+    // clock move past it so later snapshots are strictly newer. Keeps the "skip snapshots older
+    // than fromTimestamp" semantics without waiting out a synthetic future timestamp (was now +
+    // 10s, busy-spun on by waitUntilAfter).
+    long fromTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(fromTimestamp);
+
+    StreamingQuery query =
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(fromTimestamp));
+
+    assertThat(rowsAvailable(query)).isEmpty();
 
     // Data appended after the timestamp should appear
     appendData(data);
     // Allow async background thread to refresh, else test sometimes fails
     Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data);
   }
 
   @TestTemplate
@@ -649,17 +646,20 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
         Lists.newArrayList(
             new SimpleRecord(1, "one"), new SimpleRecord(2, "two"), new SimpleRecord(3, "three"));
     appendData(dataBeforeTimestamp);
+    table.refresh();
 
-    long streamStartTimestamp = System.currentTimeMillis() + 2000;
+    // Anchor the start timestamp just after the existing snapshot instead of waiting out a
+    // synthetic future timestamp (was now + 2s); later snapshots are then strictly newer.
+    long streamStartTimestamp = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(streamStartTimestamp);
 
-    // Start the stream with a future timestamp after the current snapshot
+    // Start the stream with a timestamp after the current snapshot
     StreamingQuery query =
         startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(streamStartTimestamp));
     List<SimpleRecord> actual = rowsAvailable(query);
     assertThat(actual).isEmpty();
 
-    // Stream should contain data added after the timestamp elapses
-    waitUntilAfter(streamStartTimestamp);
+    // Stream should contain data added after the timestamp
     List<List<SimpleRecord>> expected = TEST_DATA_MULTIPLE_SNAPSHOTS;
     appendDataAsMultipleSnapshots(expected);
     assertThat(rowsAvailable(query))


### PR DESCRIPTION
## Problem

`TestStructuredStreamingRead3` has two timestamp-based streaming read tests that pick a stream start timestamp in the *future* and then wait for the wall clock to reach it:

- `testReadingStreamFromFutureTimetsamp` uses `now + 10000` ms
- `testReadingStreamFromTimestampFutureWithExistingSnapshots` uses `now + 2000` ms

The wait goes through `TestBase.waitUntilAfter()`, which busy-spins on `System.currentTimeMillis()`. So the future-timestamp test idles for ~10s on every run (it averaged ~16s/run in CI), and because the wait is a spin it pegs a core for the whole duration, contending with the other parallel Gradle test forks.

## Change

Anchor the stream's start timestamp to the committed snapshot's `timestampMillis() + 1` instead of a synthetic future instant:

- snapshots committed before that point are still excluded;
- snapshots committed after `waitUntilAfter(startTimestamp)` returns are still included.

The read semantics are unchanged, but no real time has to elapse — `waitUntilAfter` is now handed a near-current timestamp and returns within ~1ms. This matches the existing `testReadingStreamFromTimestamp` / `testReadingStreamFromTimestampOfExistingSnapshot` idiom in the same class.

`waitUntilAfter()` is also changed to sleep once for the remaining time instead of busy-spinning, so any remaining future wait no longer burns a core.

Applied identically to spark v3.5, v4.0 and v4.1.

### Note on coverage

The original `testReadingStreamFromFutureTimetsamp` asserted emptiness after each insert *while the stream was running* (the inserts landed before the future timestamp elapsed). The rewrite commits those snapshots first and starts the stream from a timestamp just after them, so it exercises start-timestamp filtering rather than a running stream crossing the boundary. Verifying the latter deterministically would require controlling snapshot commit timestamps, which has no clean test hook; both paths hit the same start-timestamp boundary check.

## Testing

- The two methods pass on spark v3.5, v4.0 and v4.1 (HIVE/async + REST params).
- Stress-ran the two methods 20x on v3.5 with the Gradle build cache disabled: 0 failures.
