### PR TITLE
Add Flink GEOGRAPHY mapping for Iceberg

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
@@ -45,6 +46,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private static final String GEOGRAPHY_TYPE_ROOT = "GEOGRAPHY";
 
   private final RowType root;
   private int nextId;
@@ -149,6 +152,15 @@ class FlinkTypeToType extends FlinkTypeVisitor<Type> {
       return Types.TimestampNanoType.withZone();
     }
     return Types.TimestampType.withZone();
+  }
+
+  @Override
+  public Type visit(LogicalType other) {
+    if (GEOGRAPHY_TYPE_ROOT.equals(other.getTypeRoot().name())) {
+      return Types.GeographyType.crs84();
+    }
+
+    return super.visit(other);
   }
 
   @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -39,11 +39,15 @@ import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
 class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  private static final String FLINK_GEOGRAPHY_TYPE =
+      "org.apache.flink.table.types.logical.GeographyType";
+
   TypeToFlinkType() {}
 
   @Override
@@ -138,9 +142,34 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return new DecimalType(decimal.precision(), decimal.scale());
+      case GEOGRAPHY:
+        return geographyType((Types.GeographyType) primitive);
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+
+  private static LogicalType geographyType(Types.GeographyType geography) {
+    if (!Types.GeographyType.DEFAULT_CRS.equalsIgnoreCase(geography.crs())
+        || geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot convert Iceberg geography type %s to Flink: only OGC:CRS84 with spherical"
+                  + " edges is supported",
+              geography));
+    }
+
+    try {
+      Class<?> geographyType = Class.forName(FLINK_GEOGRAPHY_TYPE);
+      return (LogicalType) geographyType.getConstructor(boolean.class).newInstance(true);
+    } catch (ClassNotFoundException e) {
+      throw new UnsupportedOperationException(
+          "Cannot convert Iceberg geography to Flink: current Flink runtime does not provide"
+              + " GeographyType",
+          e);
+    } catch (ReflectiveOperationException e) {
+      throw new UnsupportedOperationException("Cannot instantiate Flink GeographyType", e);
     }
   }
 }

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -38,6 +40,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -326,6 +329,42 @@ public class TestFlinkSchemaUtil {
     checkSchema(flinkSchema, icebergSchema);
   }
 
+  @TestTemplate
+  public void testGeographyField() {
+    LogicalType geographyType = geographyType();
+    assumeThat(geographyType)
+        .as("Flink GeographyType is not available in this Flink version")
+        .isNotNull();
+
+    DataType geographyDataType = TypeConversions.fromLogicalToDataType(geographyType);
+    DataType requiredGeographyDataType =
+        TypeConversions.fromLogicalToDataType(geographyType.copy(false));
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("location", geographyDataType),
+            Column.physical("required_location", requiredGeographyDataType),
+            Column.physical("locations", DataTypes.ARRAY(geographyDataType)),
+            Column.physical(
+                "nested",
+                DataTypes.ROW(DataTypes.FIELD("location", geographyDataType, "location field"))));
+
+    Schema icebergSchema =
+        new Schema(
+            Types.NestedField.optional(0, "location", Types.GeographyType.crs84()),
+            Types.NestedField.required(1, "required_location", Types.GeographyType.crs84()),
+            Types.NestedField.optional(
+                2, "locations", Types.ListType.ofOptional(4, Types.GeographyType.crs84())),
+            Types.NestedField.optional(
+                3,
+                "nested",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        5, "location", Types.GeographyType.crs84(), "location field"))));
+
+    checkSchema(flinkSchema, icebergSchema);
+  }
+
   private void checkSchema(ResolvedSchema flinkSchema, Schema icebergSchema) {
     if (isTableSchema) {
       assertThat(FlinkSchemaUtil.convert(TableSchema.fromResolvedSchema(flinkSchema)).asStruct())
@@ -345,6 +384,17 @@ public class TestFlinkSchemaUtil {
                       FlinkSchemaUtil.toResolvedSchema(FlinkSchemaUtil.convert(icebergSchema)))
                   .asStruct())
           .isEqualTo(icebergSchema.asStruct());
+    }
+  }
+
+  private static LogicalType geographyType() {
+    try {
+      Class<?> geographyType = Class.forName("org.apache.flink.table.types.logical.GeographyType");
+      return (LogicalType) geographyType.getConstructor().newInstance();
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate Flink GeographyType", e);
     }
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
@@ -45,6 +46,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private static final String GEOGRAPHY_TYPE_ROOT = "GEOGRAPHY";
 
   private final RowType root;
   private int nextId;
@@ -149,6 +152,15 @@ class FlinkTypeToType extends FlinkTypeVisitor<Type> {
       return Types.TimestampNanoType.withZone();
     }
     return Types.TimestampType.withZone();
+  }
+
+  @Override
+  public Type visit(LogicalType other) {
+    if (GEOGRAPHY_TYPE_ROOT.equals(other.getTypeRoot().name())) {
+      return Types.GeographyType.crs84();
+    }
+
+    return super.visit(other);
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -39,11 +39,15 @@ import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
 class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  private static final String FLINK_GEOGRAPHY_TYPE =
+      "org.apache.flink.table.types.logical.GeographyType";
+
   TypeToFlinkType() {}
 
   @Override
@@ -138,9 +142,34 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return new DecimalType(decimal.precision(), decimal.scale());
+      case GEOGRAPHY:
+        return geographyType((Types.GeographyType) primitive);
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+
+  private static LogicalType geographyType(Types.GeographyType geography) {
+    if (!Types.GeographyType.DEFAULT_CRS.equalsIgnoreCase(geography.crs())
+        || geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot convert Iceberg geography type %s to Flink: only OGC:CRS84 with spherical"
+                  + " edges is supported",
+              geography));
+    }
+
+    try {
+      Class<?> geographyType = Class.forName(FLINK_GEOGRAPHY_TYPE);
+      return (LogicalType) geographyType.getConstructor(boolean.class).newInstance(true);
+    } catch (ClassNotFoundException e) {
+      throw new UnsupportedOperationException(
+          "Cannot convert Iceberg geography to Flink: current Flink runtime does not provide"
+              + " GeographyType",
+          e);
+    } catch (ReflectiveOperationException e) {
+      throw new UnsupportedOperationException("Cannot instantiate Flink GeographyType", e);
     }
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.legacy.api.TableSchema;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -38,6 +40,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -326,6 +329,42 @@ public class TestFlinkSchemaUtil {
     checkSchema(flinkSchema, icebergSchema);
   }
 
+  @TestTemplate
+  public void testGeographyField() {
+    LogicalType geographyType = geographyType();
+    assumeThat(geographyType)
+        .as("Flink GeographyType is not available in this Flink version")
+        .isNotNull();
+
+    DataType geographyDataType = TypeConversions.fromLogicalToDataType(geographyType);
+    DataType requiredGeographyDataType =
+        TypeConversions.fromLogicalToDataType(geographyType.copy(false));
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("location", geographyDataType),
+            Column.physical("required_location", requiredGeographyDataType),
+            Column.physical("locations", DataTypes.ARRAY(geographyDataType)),
+            Column.physical(
+                "nested",
+                DataTypes.ROW(DataTypes.FIELD("location", geographyDataType, "location field"))));
+
+    Schema icebergSchema =
+        new Schema(
+            Types.NestedField.optional(0, "location", Types.GeographyType.crs84()),
+            Types.NestedField.required(1, "required_location", Types.GeographyType.crs84()),
+            Types.NestedField.optional(
+                2, "locations", Types.ListType.ofOptional(4, Types.GeographyType.crs84())),
+            Types.NestedField.optional(
+                3,
+                "nested",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        5, "location", Types.GeographyType.crs84(), "location field"))));
+
+    checkSchema(flinkSchema, icebergSchema);
+  }
+
   private void checkSchema(ResolvedSchema flinkSchema, Schema icebergSchema) {
     if (isTableSchema) {
       assertThat(FlinkSchemaUtil.convert(TableSchema.fromResolvedSchema(flinkSchema)).asStruct())
@@ -345,6 +384,17 @@ public class TestFlinkSchemaUtil {
                       FlinkSchemaUtil.toResolvedSchema(FlinkSchemaUtil.convert(icebergSchema)))
                   .asStruct())
           .isEqualTo(icebergSchema.asStruct());
+    }
+  }
+
+  private static LogicalType geographyType() {
+    try {
+      Class<?> geographyType = Class.forName("org.apache.flink.table.types.logical.GeographyType");
+      return (LogicalType) geographyType.getConstructor().newInstance();
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate Flink GeographyType", e);
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java
@@ -31,6 +31,7 @@ import org.apache.flink.table.types.logical.DoubleType;
 import org.apache.flink.table.types.logical.FloatType;
 import org.apache.flink.table.types.logical.IntType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
+import org.apache.flink.table.types.logical.LogicalType;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.MultisetType;
 import org.apache.flink.table.types.logical.RowType;
@@ -46,6 +47,8 @@ import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 
 class FlinkTypeToType extends FlinkTypeVisitor<Type> {
+
+  private static final String GEOGRAPHY_TYPE_ROOT = "GEOGRAPHY";
 
   private final RowType root;
   private int nextId;
@@ -150,6 +153,15 @@ class FlinkTypeToType extends FlinkTypeVisitor<Type> {
       return Types.TimestampNanoType.withZone();
     }
     return Types.TimestampType.withZone();
+  }
+
+  @Override
+  public Type visit(LogicalType other) {
+    if (GEOGRAPHY_TYPE_ROOT.equals(other.getTypeRoot().name())) {
+      return Types.GeographyType.crs84();
+    }
+
+    return super.visit(other);
   }
 
   @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/TypeToFlinkType.java
@@ -40,11 +40,15 @@ import org.apache.flink.table.types.logical.VarCharType;
 import org.apache.flink.table.types.logical.VariantType;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 
 class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
+  private static final String FLINK_GEOGRAPHY_TYPE =
+      "org.apache.flink.table.types.logical.GeographyType";
+
   TypeToFlinkType() {}
 
   @Override
@@ -144,9 +148,34 @@ class TypeToFlinkType extends TypeUtil.SchemaVisitor<LogicalType> {
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         return new DecimalType(decimal.precision(), decimal.scale());
+      case GEOGRAPHY:
+        return geographyType((Types.GeographyType) primitive);
       default:
         throw new UnsupportedOperationException(
             "Cannot convert unknown type to Flink: " + primitive);
+    }
+  }
+
+  private static LogicalType geographyType(Types.GeographyType geography) {
+    if (!Types.GeographyType.DEFAULT_CRS.equalsIgnoreCase(geography.crs())
+        || geography.algorithm() != EdgeAlgorithm.SPHERICAL) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot convert Iceberg geography type %s to Flink: only OGC:CRS84 with spherical"
+                  + " edges is supported",
+              geography));
+    }
+
+    try {
+      Class<?> geographyType = Class.forName(FLINK_GEOGRAPHY_TYPE);
+      return (LogicalType) geographyType.getConstructor(boolean.class).newInstance(true);
+    } catch (ClassNotFoundException e) {
+      throw new UnsupportedOperationException(
+          "Cannot convert Iceberg geography to Flink: current Flink runtime does not provide"
+              + " GeographyType",
+          e);
+    } catch (ReflectiveOperationException e) {
+      throw new UnsupportedOperationException("Cannot instantiate Flink GeographyType", e);
     }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.data;
 
+import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -314,6 +315,12 @@ public class FlinkParquetReaders {
 
       @Override
       public Optional<ParquetValueReader<?>> visit(
+          LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+        return Optional.of(new GeographyDataReader(desc));
+      }
+
+      @Override
+      public Optional<ParquetValueReader<?>> visit(
           LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
         return Optional.of(new ParquetValueReaders.ByteArrayReader(desc));
       }
@@ -471,6 +478,41 @@ public class FlinkParquetReaders {
             buffer.array(), buffer.arrayOffset() + buffer.position(), buffer.remaining());
       } else {
         return StringData.fromBytes(binary.getBytes());
+      }
+    }
+  }
+
+  private static class GeographyDataReader extends ParquetValueReaders.PrimitiveReader<Object> {
+    GeographyDataReader(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public Object read(Object ignored) {
+      return GeographyDataUtil.fromBytes(column.nextBinary().getBytes());
+    }
+  }
+
+  private static class GeographyDataUtil {
+    private static final String GEOGRAPHY_DATA_CLASS = "org.apache.flink.table.data.GeographyData";
+    private static final Method FROM_BYTES = loadFromBytesMethod();
+
+    private GeographyDataUtil() {}
+
+    private static Object fromBytes(byte[] bytes) {
+      try {
+        return FROM_BYTES.invoke(null, bytes);
+      } catch (ReflectiveOperationException e) {
+        throw new UnsupportedOperationException(
+            "Cannot deserialize Parquet WKB to Flink GeographyData", e);
+      }
+    }
+
+    private static Method loadFromBytesMethod() {
+      try {
+        return Class.forName(GEOGRAPHY_DATA_CLASS).getMethod("fromBytes", byte[].class);
+      } catch (ReflectiveOperationException e) {
+        throw new UnsupportedOperationException("Flink GeographyData is not available", e);
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetWriters.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.data;
 
+import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Arrays;
@@ -312,6 +313,12 @@ public class FlinkParquetWriters {
     }
 
     @Override
+    public Optional<ParquetValueWriter<?>> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation ignored) {
+      return Optional.of(geographies(desc));
+    }
+
+    @Override
     public Optional<ParquetValueWriter<?>> visit(UUIDLogicalTypeAnnotation uuid) {
       return Optional.of(byteArrays(desc));
     }
@@ -369,6 +376,10 @@ public class FlinkParquetWriters {
 
   private static ParquetValueWriter<byte[]> byteArrays(ColumnDescriptor desc) {
     return new ByteArrayWriter(desc);
+  }
+
+  private static ParquetValueWriter<Object> geographies(ColumnDescriptor desc) {
+    return new GeographyDataWriter(desc);
   }
 
   private static class StringDataWriter extends ParquetValueWriters.PrimitiveWriter<StringData> {
@@ -508,6 +519,46 @@ public class FlinkParquetWriters {
     @Override
     public void write(int repetitionLevel, byte[] bytes) {
       column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(bytes));
+    }
+  }
+
+  private static class GeographyDataWriter extends ParquetValueWriters.PrimitiveWriter<Object> {
+    private GeographyDataWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, Object value) {
+      column.writeBinary(
+          repetitionLevel, Binary.fromReusedByteArray(GeographyDataUtil.toBytes(value)));
+    }
+  }
+
+  private static class GeographyDataUtil {
+    private static final String GEOGRAPHY_DATA_CLASS = "org.apache.flink.table.data.GeographyData";
+    private static final Method TO_BYTES = loadToBytesMethod();
+
+    private GeographyDataUtil() {}
+
+    private static byte[] toBytes(Object value) {
+      if (value instanceof byte[]) {
+        return (byte[]) value;
+      }
+
+      try {
+        return (byte[]) TO_BYTES.invoke(value);
+      } catch (ReflectiveOperationException e) {
+        throw new UnsupportedOperationException(
+            "Cannot serialize Flink GeographyData to Parquet WKB", e);
+      }
+    }
+
+    private static Method loadToBytesMethod() {
+      try {
+        return Class.forName(GEOGRAPHY_DATA_CLASS).getMethod("toBytes");
+      } catch (ReflectiveOperationException e) {
+        throw new UnsupportedOperationException("Flink GeographyData is not available", e);
+      }
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkSchemaUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.util.Collections;
 import java.util.List;
@@ -29,6 +30,7 @@ import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.legacy.api.TableSchema;
+import org.apache.flink.table.types.DataType;
 import org.apache.flink.table.types.logical.BinaryType;
 import org.apache.flink.table.types.logical.CharType;
 import org.apache.flink.table.types.logical.LocalZonedTimestampType;
@@ -38,6 +40,7 @@ import org.apache.flink.table.types.logical.TimeType;
 import org.apache.flink.table.types.logical.TimestampType;
 import org.apache.flink.table.types.logical.VarBinaryType;
 import org.apache.flink.table.types.logical.VarCharType;
+import org.apache.flink.table.types.utils.TypeConversions;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -326,6 +329,42 @@ public class TestFlinkSchemaUtil {
     checkSchema(flinkSchema, icebergSchema);
   }
 
+  @TestTemplate
+  public void testGeographyField() {
+    LogicalType geographyType = geographyType();
+    assumeThat(geographyType)
+        .as("Flink GeographyType is not available in this Flink version")
+        .isNotNull();
+
+    DataType geographyDataType = TypeConversions.fromLogicalToDataType(geographyType);
+    DataType requiredGeographyDataType =
+        TypeConversions.fromLogicalToDataType(geographyType.copy(false));
+
+    ResolvedSchema flinkSchema =
+        ResolvedSchema.of(
+            Column.physical("location", geographyDataType),
+            Column.physical("required_location", requiredGeographyDataType),
+            Column.physical("locations", DataTypes.ARRAY(geographyDataType)),
+            Column.physical(
+                "nested",
+                DataTypes.ROW(DataTypes.FIELD("location", geographyDataType, "location field"))));
+
+    Schema icebergSchema =
+        new Schema(
+            Types.NestedField.optional(0, "location", Types.GeographyType.crs84()),
+            Types.NestedField.required(1, "required_location", Types.GeographyType.crs84()),
+            Types.NestedField.optional(
+                2, "locations", Types.ListType.ofOptional(4, Types.GeographyType.crs84())),
+            Types.NestedField.optional(
+                3,
+                "nested",
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        5, "location", Types.GeographyType.crs84(), "location field"))));
+
+    checkSchema(flinkSchema, icebergSchema);
+  }
+
   private void checkSchema(ResolvedSchema flinkSchema, Schema icebergSchema) {
     if (isTableSchema) {
       assertThat(FlinkSchemaUtil.convert(TableSchema.fromResolvedSchema(flinkSchema)).asStruct())
@@ -345,6 +384,17 @@ public class TestFlinkSchemaUtil {
                       FlinkSchemaUtil.toResolvedSchema(FlinkSchemaUtil.convert(icebergSchema)))
                   .asStruct())
           .isEqualTo(icebergSchema.asStruct());
+    }
+  }
+
+  private static LogicalType geographyType() {
+    try {
+      Class<?> geographyType = Class.forName("org.apache.flink.table.types.logical.GeographyType");
+      return (LogicalType) geographyType.getConstructor().newInstance();
+    } catch (ClassNotFoundException e) {
+      return null;
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Cannot instantiate Flink GeographyType", e);
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.TimestampType;
@@ -253,6 +254,21 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
     @Override
     public Optional<Type> visit(LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonType) {
       return Optional.of(Types.BinaryType.get());
+    }
+
+    @Override
+    public Optional<Type> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
+      return Optional.of(Types.GeometryType.of(geometryType.getCrs()));
+    }
+
+    @Override
+    public Optional<Type> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
+      return Optional.of(
+          Types.GeographyType.of(
+              geographyType.getCrs(),
+              EdgeAlgorithm.fromName(geographyType.getAlgorithm().name())));
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -234,7 +234,7 @@ class ParquetMetrics {
       FieldMetrics<?> fieldMetrics = metricsById.get(fieldId);
       if (null == fieldMetrics) {
         return null;
-      } else if (truncateLength <= 0) {
+      } else if (truncateLength <= 0 || isGeospatial(icebergType.typeId())) {
         return new FieldMetrics<>(
             fieldMetrics.id(),
             fieldMetrics.valueCount(),

--- a/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/TypeToMessageType.java
@@ -30,12 +30,15 @@ import java.util.function.BiFunction;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type.NestedType;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.DecimalType;
 import org.apache.iceberg.types.Types.FixedType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
@@ -43,6 +46,7 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
@@ -279,10 +283,27 @@ public class TypeToMessageType {
             .as(LogicalTypeAnnotation.uuidType())
             .id(id)
             .named(name);
+      case GEOMETRY:
+        GeometryType geometry = (GeometryType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(LogicalTypeAnnotation.geometryType(geometry.crs()))
+            .id(id)
+            .named(name);
+      case GEOGRAPHY:
+        GeographyType geography = (GeographyType) primitive;
+        return Types.primitive(BINARY, repetition)
+            .as(LogicalTypeAnnotation.geographyType(geography.crs(), algorithm(geography)))
+            .id(id)
+            .named(name);
 
       default:
         throw new UnsupportedOperationException("Unsupported type for Parquet: " + primitive);
     }
+  }
+
+  private static EdgeInterpolationAlgorithm algorithm(GeographyType geography) {
+    EdgeAlgorithm algorithm = geography.algorithm();
+    return EdgeInterpolationAlgorithm.valueOf(algorithm.name());
   }
 
   private static LogicalTypeAnnotation decimalAnnotation(int precision, int scale) {


### PR DESCRIPTION
Add support for mapping Flink GEOGRAPHY columns to native Iceberg geography types and reading them back through the Flink connector.

This change:
- maps Flink GEOGRAPHY to Iceberg GeographyType for Flink 1.20, 2.0, and 2.1;
- maps Iceberg GeographyType back to Flink GEOGRAPHY when supported;
- adds schema conversion coverage for top-level and nested GEOGRAPHY fields;
- writes Iceberg GEOGRAPHY/GEOMETRY as Parquet BINARY with native Parquet logical annotations;
- reads Parquet GEOGRAPHY values back into Flink GeographyData in the Flink 2.1 connector path;
- suppresses unsafe lower/upper-bound metrics for spatial WKB values while preserving count metrics.

Verified with compile and checkstyle for iceberg-parquet and iceberg-flink-2.1.