### PR TITLE
Spark: Stop streaming queries before dropping table in streaming read test teardown

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -175,7 +175,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @AfterEach
-  public void removeTables() {
+  public void removeTables() throws TimeoutException {
+    // Stop active streams before dropping the table. In async mode the planner's background
+    // thread keeps refreshing the table from the catalog; dropping the table while that thread
+    // is alive lets those refreshes contend with DROP TABLE and stall teardown for seconds.
+    stopStreams();
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -175,7 +175,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @AfterEach
-  public void removeTables() {
+  public void removeTables() throws TimeoutException {
+    // Stop active streams before dropping the table. In async mode the planner's background
+    // thread keeps refreshing the table from the catalog; dropping the table while that thread
+    // is alive lets those refreshes contend with DROP TABLE and stall teardown for seconds.
+    stopStreams();
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -176,7 +176,11 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @AfterEach
-  public void removeTables() {
+  public void removeTables() throws TimeoutException {
+    // Stop active streams before dropping the table. In async mode the planner's background
+    // thread keeps refreshing the table from the catalog; dropping the table while that thread
+    // is alive lets those refreshes contend with DROP TABLE and stall teardown for seconds.
+    stopStreams();
     sql("DROP TABLE IF EXISTS %s", tableName);
   }
 


### PR DESCRIPTION
## Problem

`TestStructuredStreamingRead3` is the largest single class in the Spark CI wall-time report (~1000s). Profiling shows the cost is **not** in the streaming reads (each `processAllAvailable` is <1s) — it's in **teardown**.

The class sets `STREAMING_SNAPSHOT_POLLING_INTERVAL_MS=1` for the `async=true` parameter, so `AsyncSparkMicroBatchPlanner`'s background thread refreshes the table from the catalog ~1000×/second. The class also has two `@AfterEach` methods — `stopStreams()` and `removeTables()` — whose relative order is not guaranteed. When `DROP TABLE` runs while the planner's background thread is still alive, that flood of catalog refreshes contends with the drop and stalls teardown by **~20s per async test execution**.

Measured (instrumenting teardown):

```
DROP TABLE, async=true  : 20142 ms
DROP TABLE, async=false :     9 ms
```

## Change

Stop active streams before dropping the table in `removeTables()`, so the background refresh thread is gone before the drop. One-line behavioral change; `stopStreams()` is unchanged and still runs as its own `@AfterEach`.

## Result

Full-class `TestStructuredStreamingRead3` on spark v3.5: **~305s → ~188s** (66 tests, 0 failures). Applied identically to v3.5, v4.0 and v4.1 (v4.0/v4.1 smoke-tested green).

> Note: the underlying 1ms polling interval refreshing the catalog regardless of need is a planner-side smell worth a separate look; this PR just makes the test teardown robust to it.
