### PR TITLE
Spark 4.1: Add validation for required fields in add_files procedure

### DIFF
--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestAddFilesProcedure.java
@@ -44,6 +44,7 @@ import org.apache.iceberg.Parameters;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -1082,6 +1083,37 @@ public class TestAddFilesProcedure extends ExtensionsTestBase {
             "SELECT * FROM (SELECT * FROM %s UNION ALL " + "SELECT * from %s) ORDER BY id",
             sourceTableName, sourceTableName),
         sql("SELECT * FROM %s ORDER BY id", tableName));
+  }
+
+  @TestTemplate
+  public void violateNotNullConstraintFromTable() {
+    sql("CREATE TABLE %s STORED AS parquet AS SELECT CAST(NULL AS INT) AS id", sourceTableName);
+    createIcebergTable("id Integer NOT NULL");
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_files('%s', '%s')",
+                    catalogName, tableName, sourceTableName))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Column 'id' is required but contains 1 null value(s)");
+  }
+
+  @TestTemplate
+  public void violateNotNullConstraintFromFileTable() {
+    String createParquet =
+        "CREATE TABLE %s USING parquet LOCATION '%s' AS SELECT CAST(NULL AS INT) AS id";
+    sql(createParquet, sourceTableName, fileTableDir.getAbsolutePath());
+    createIcebergTable("id Integer NOT NULL");
+
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.add_files('%s', '`parquet`.`%s`')",
+                    catalogName, tableName, fileTableDir.getAbsolutePath()))
+        .cause()
+        .isInstanceOf(ValidationException.class)
+        .hasMessageStartingWith("Column 'id' is required but contains 1 null value(s)");
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -57,10 +57,12 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.TableMigrationUtil;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
@@ -78,6 +80,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
@@ -369,6 +372,7 @@ public class SparkTableUtil {
   }
 
   private static Iterator<ManifestFile> buildManifest(
+      Schema schema,
       int formatVersion,
       Long snapshotId,
       SerializableConfiguration conf,
@@ -391,8 +395,14 @@ public class SparkTableUtil {
       ManifestWriter<DataFile> writer =
           ManifestFiles.write(formatVersion, spec, outputFile, snapshotId);
 
+      Set<Integer> requiredFieldIds = requiredFieldIds(schema);
       try (ManifestWriter<DataFile> writerRef = writer) {
-        fileTuples.forEachRemaining(fileTuple -> writerRef.add(fileTuple._2));
+        fileTuples.forEachRemaining(
+            fileTuple -> {
+              DataFile dataFile = fileTuple._2;
+              verifyRequiredFields(schema, requiredFieldIds, dataFile);
+              writerRef.add(dataFile);
+            });
       } catch (IOException e) {
         throw SparkExceptionUtil.toUncheckedException(
             e, "Unable to close the manifest writer: %s", outputPath);
@@ -720,8 +730,13 @@ public class SparkTableUtil {
                 DUPLICATE_FILE_MESSAGE, Joiner.on(",").join((String[]) duplicates.take(10))));
       }
 
+      Set<Integer> requiredFieldIds = requiredFieldIds(targetTable.schema());
       AppendFiles append = targetTable.newAppend();
-      files.forEach(append::appendFile);
+      files.forEach(
+          dataFile -> {
+            verifyRequiredFields(targetTable.schema(), requiredFieldIds, dataFile);
+            append.appendFile(dataFile);
+          });
       append.commit();
     } catch (NoSuchDatabaseException e) {
       throw SparkExceptionUtil.toUncheckedException(
@@ -908,6 +923,7 @@ public class SparkTableUtil {
                 (MapPartitionsFunction<Tuple2<String, DataFile>, ManifestFile>)
                     fileTuple ->
                         buildManifest(
+                            targetTable.schema(),
                             formatVersion,
                             snapshotId,
                             serializableConf,
@@ -966,6 +982,35 @@ public class SparkTableUtil {
           .filter(p -> p.getValues().entrySet().containsAll(partitionFilter.entrySet()))
           .collect(Collectors.toList());
     }
+  }
+
+  private static void verifyRequiredFields(
+      Schema schema, Set<Integer> requiredFieldIds, DataFile dataFile) {
+    if (requiredFieldIds.isEmpty()) {
+      return;
+    }
+
+    Map<Integer, Long> nullValueCounts = dataFile.nullValueCounts();
+    if (nullValueCounts == null) {
+      return;
+    }
+
+    for (int fieldId : requiredFieldIds) {
+      Long nullCount = nullValueCounts.getOrDefault(fieldId, 0L);
+      if (nullCount > 0) {
+        String fieldName = schema.findField(fieldId).name();
+        throw new ValidationException(
+            "Column '%s' is required but contains %d null value(s): %s",
+            fieldName, nullCount, dataFile.location());
+      }
+    }
+  }
+
+  private static Set<Integer> requiredFieldIds(Schema schema) {
+    return TypeUtil.indexById(schema.asStruct()).entrySet().stream()
+        .filter(entry -> entry.getValue().isRequired())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkTableUtil.java
@@ -57,10 +57,12 @@ import org.apache.iceberg.MetadataTableUtils;
 import org.apache.iceberg.MetricsConfig;
 import org.apache.iceberg.PartitionField;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.data.TableMigrationUtil;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.hadoop.HadoopFileIO;
 import org.apache.iceberg.hadoop.SerializableConfiguration;
 import org.apache.iceberg.hadoop.Util;
@@ -78,6 +80,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.source.SparkTable;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.TaskContext;
 import org.apache.spark.api.java.JavaRDD;
@@ -207,6 +210,7 @@ public class SparkTableUtil {
   }
 
   private static Iterator<ManifestFile> buildManifest(
+      Schema schema,
       int formatVersion,
       Long snapshotId,
       SerializableConfiguration conf,
@@ -229,8 +233,14 @@ public class SparkTableUtil {
       ManifestWriter<DataFile> writer =
           ManifestFiles.write(formatVersion, spec, outputFile, snapshotId);
 
+      Set<Integer> requiredFieldIds = requiredFieldIds(schema);
       try (ManifestWriter<DataFile> writerRef = writer) {
-        fileTuples.forEachRemaining(fileTuple -> writerRef.add(fileTuple._2));
+        fileTuples.forEachRemaining(
+            fileTuple -> {
+              DataFile dataFile = fileTuple._2;
+              verifyRequiredFields(schema, requiredFieldIds, dataFile);
+              writerRef.add(dataFile);
+            });
       } catch (IOException e) {
         throw SparkExceptionUtil.toUncheckedException(
             e, "Unable to close the manifest writer: %s", outputPath);
@@ -473,8 +483,13 @@ public class SparkTableUtil {
                 DUPLICATE_FILE_MESSAGE, Joiner.on(",").join((String[]) duplicates.take(10))));
       }
 
+      Set<Integer> requiredFieldIds = requiredFieldIds(targetTable.schema());
       AppendFiles append = targetTable.newAppend();
-      files.forEach(append::appendFile);
+      files.forEach(
+          dataFile -> {
+            verifyRequiredFields(targetTable.schema(), requiredFieldIds, dataFile);
+            append.appendFile(dataFile);
+          });
       append.commit();
     } catch (NoSuchDatabaseException e) {
       throw SparkExceptionUtil.toUncheckedException(
@@ -639,6 +654,7 @@ public class SparkTableUtil {
                 (MapPartitionsFunction<Tuple2<String, DataFile>, ManifestFile>)
                     fileTuple ->
                         buildManifest(
+                            targetTable.schema(),
                             formatVersion,
                             snapshotId,
                             serializableConf,
@@ -662,6 +678,35 @@ public class SparkTableUtil {
       deleteManifests(targetTable.io(), manifests);
       throw e;
     }
+  }
+
+  private static void verifyRequiredFields(
+      Schema schema, Set<Integer> requiredFieldIds, DataFile dataFile) {
+    if (requiredFieldIds.isEmpty()) {
+      return;
+    }
+
+    Map<Integer, Long> nullValueCounts = dataFile.nullValueCounts();
+    if (nullValueCounts == null) {
+      return;
+    }
+
+    for (int fieldId : requiredFieldIds) {
+      Long nullCount = nullValueCounts.getOrDefault(fieldId, 0L);
+      if (nullCount > 0) {
+        String fieldName = schema.findField(fieldId).name();
+        throw new ValidationException(
+            "Column '%s' is required but contains %d null value(s): %s",
+            fieldName, nullCount, dataFile.location());
+      }
+    }
+  }
+
+  private static Set<Integer> requiredFieldIds(Schema schema) {
+    return TypeUtil.indexById(schema.asStruct()).entrySet().stream()
+        .filter(entry -> entry.getValue().isRequired())
+        .map(Map.Entry::getKey)
+        .collect(Collectors.toSet());
   }
 
   private static void deleteManifests(FileIO io, List<ManifestFile> manifests) {


### PR DESCRIPTION
`add_files` bypasses NOT NULL column constraints - importing a Parquet/ORC/Avro
file with null values in a required column silently succeeds, violating the
table's schema integrity.

Validation is skipped when null-value metrics are not collected (e.g., metrics
mode set to `none`), since there is no data to validate against.

- Relates to #10742