### PR TITLE
Core: Fix concurrent modification of deleteFiles in ManifestFilterManager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -22,7 +22,9 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
@@ -82,7 +84,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private long minSequenceNumber = 0;
   private boolean failAnyDelete = false;
   private boolean failMissingDeletePaths = false;
-  private int duplicateDeleteCount = 0;
+  private final AtomicInteger duplicateDeleteCount = new AtomicInteger(0);
   private boolean caseSensitive = true;
   private boolean allDeletesReferenceManifests = true;
   // this is only being used for the DeleteManifestFilterManager to detect orphaned DVs for removed
@@ -217,6 +219,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     boolean trustManifestReferences = canTrustManifestReferences(manifests);
     ManifestFile[] filtered = new ManifestFile[manifests.size()];
+    // collect files deleted by expression match across parallel workers, then merge below
+    Queue<F> expressionDeletedFiles = new ConcurrentLinkedQueue<>();
     // open all of the manifest files in parallel, use index to avoid reordering
     Tasks.range(filtered.length)
         .stopOnFailure()
@@ -225,9 +229,17 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
         .run(
             index -> {
               ManifestFile manifest =
-                  filterManifest(tableSchema, manifests.get(index), trustManifestReferences);
+                  filterManifest(
+                      tableSchema,
+                      manifests.get(index),
+                      trustManifestReferences,
+                      expressionDeletedFiles);
               filtered[index] = manifest;
             });
+
+    // merge files deleted by expression into deleteFiles on the single calling thread,
+    // avoiding any concurrent access to the non-thread-safe deleteFiles set
+    expressionDeletedFiles.forEach(deleteFiles::add);
 
     validateRequiredDeletes(filtered);
 
@@ -264,7 +276,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       }
     }
 
-    summaryBuilder.incrementDuplicateDeletes(duplicateDeleteCount);
+    summaryBuilder.incrementDuplicateDeletes(duplicateDeleteCount.get());
 
     return summaryBuilder;
   }
@@ -366,7 +378,10 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
    * @return a ManifestReader that is a filtered version of the input manifest.
    */
   private ManifestFile filterManifest(
-      Schema tableSchema, ManifestFile manifest, boolean trustManifestReferences) {
+      Schema tableSchema,
+      ManifestFile manifest,
+      boolean trustManifestReferences,
+      Queue<F> expressionDeletedFiles) {
     ManifestFile cached = filteredManifests.get(manifest);
     if (cached != null) {
       return cached;
@@ -385,7 +400,8 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       // manifest without copying data. if a manifest does have a file to remove, this will break
       // out of the loop and move on to filtering the manifest.
       if (manifestHasDeletedFiles(evaluator, manifest, reader)) {
-        ManifestFile filtered = filterManifestWithDeletedFiles(evaluator, manifest, reader);
+        ManifestFile filtered =
+            filterManifestWithDeletedFiles(evaluator, manifest, reader, expressionDeletedFiles);
         replacedManifestsCount.incrementAndGet();
         return filtered;
       } else {
@@ -496,7 +512,10 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   @SuppressWarnings({"CollectionUndefinedEquality", "checkstyle:CyclomaticComplexity"})
   private ManifestFile filterManifestWithDeletedFiles(
-      PartitionAndMetricsEvaluator evaluator, ManifestFile manifest, ManifestReader<F> reader) {
+      PartitionAndMetricsEvaluator evaluator,
+      ManifestFile manifest,
+      ManifestReader<F> reader,
+      Queue<F> expressionDeletedFiles) {
     boolean isDelete = reader.isDeleteManifestReader();
     // when this point is reached, there is at least one file that will be deleted in the
     // manifest. produce a copy of the manifest with all deleted files removed.
@@ -533,16 +552,17 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                     if (allRowsMatch) {
                       writer.delete(entry);
                       F fileCopy = file.copyWithoutStats();
-                      // add the file here in case it was deleted using an expression. The
-                      // DeleteManifestFilterManager will then remove its matching DV
-                      deleteFiles.add(fileCopy);
+                      // add the file to the queue so the calling thread can later merge it into
+                      // deleteFiles. DeleteManifestFilterManager uses deleteFiles to find and
+                      // remove matching Deletion Vectors for expression-matched deletions.
+                      expressionDeletedFiles.add(fileCopy);
 
                       if (deletedFiles.contains(file)) {
                         LOG.warn(
                             "Deleting a duplicate path from manifest {}: {}",
                             manifest.path(),
                             file.location());
-                        duplicateDeleteCount += 1;
+                        duplicateDeleteCount.incrementAndGet();
                       } else {
                         // only add the file to deletes if it is a new delete
                         // this keeps the snapshot summary accurate for non-duplicate data

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -742,14 +742,22 @@ public class TestDeleteFiles extends TestBase {
 
   @TestTemplate
   public void testConcurrentManifestFilteringWithExpression() {
-    // append each file in a separate commit so each gets its own manifest,
-    // ensuring all 4 manifests are processed concurrently by the worker pool
-    commit(table, table.newAppend().appendFile(FILE_A), branch);
-    commit(table, table.newAppend().appendFile(FILE_B), branch);
-    commit(table, table.newAppend().appendFile(FILE_C), branch);
-    commit(table, table.newAppend().appendFile(FILE_D), branch);
+    // each file gets its own manifest so all manifests are processed concurrently by the worker
+    // pool; colliding paths share a String.hashCode() value, concentrating concurrent adds into
+    // the same DataFileSet hash bucket to expose races in unfixed code deterministically
+    int fileCount = 128;
+    for (int i = 0; i < fileCount; i++) {
+      DataFile file =
+          DataFiles.builder(SPEC)
+              .withPath(collidingPath(i))
+              .withFileSizeInBytes(10)
+              .withPartitionPath("data_bucket=" + (i % BUCKETS_NUMBER))
+              .withRecordCount(1)
+              .build();
+      commit(table, table.newAppend().appendFile(file), branch);
+    }
 
-    ExecutorService pool = Executors.newFixedThreadPool(4);
+    ExecutorService pool = Executors.newFixedThreadPool(16);
     try {
       commit(
           table,
@@ -763,7 +771,17 @@ public class TestDeleteFiles extends TestBase {
     }
 
     assertThat(latestSnapshot(table, branch).summary())
-        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, "4");
+        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(fileCount));
+  }
+
+  // "Aa" and "BB" are a classic Java hash-collision pair (both hash to 2112), so all generated
+  // paths share the same String.hashCode() and land in the same DataFileSet hash bucket
+  private static String collidingPath(int index) {
+    StringBuilder path = new StringBuilder("/path/to/collide-");
+    for (int bit = 0; bit < 7; bit++) {
+      path.append(((index >> bit) & 1) == 0 ? "Aa" : "BB");
+    }
+    return path.append(".parquet").toString();
   }
 
   private static ByteBuffer longToBuffer(long value) {

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -26,6 +26,8 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.ManifestEntry.Status;
@@ -736,6 +738,32 @@ public class TestDeleteFiles extends TestBase {
         ids(deleteSnap.snapshotId(), deleteSnap.snapshotId()),
         files(dv1, dv2),
         statuses(Status.DELETED, Status.DELETED));
+  }
+
+  @TestTemplate
+  public void testConcurrentManifestFilteringWithExpression() {
+    // append each file in a separate commit so each gets its own manifest,
+    // ensuring all 4 manifests are processed concurrently by the worker pool
+    commit(table, table.newAppend().appendFile(FILE_A), branch);
+    commit(table, table.newAppend().appendFile(FILE_B), branch);
+    commit(table, table.newAppend().appendFile(FILE_C), branch);
+    commit(table, table.newAppend().appendFile(FILE_D), branch);
+
+    ExecutorService pool = Executors.newFixedThreadPool(4);
+    try {
+      commit(
+          table,
+          table
+              .newOverwrite()
+              .overwriteByRowFilter(Expressions.alwaysTrue())
+              .scanManifestsWith(pool),
+          branch);
+    } finally {
+      pool.shutdown();
+    }
+
+    assertThat(latestSnapshot(table, branch).summary())
+        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, "4");
   }
 
   private static ByteBuffer longToBuffer(long value) {


### PR DESCRIPTION
  When multiple worker threads processed manifests in parallel via
  Tasks.range(), expression-matched files were written directly to the
  non-thread-safe deleteFiles set, causing data races and incorrect
  deleted-file counts.
  
  Close #16978

  Fix by collecting expression-deleted files into a ConcurrentLinkedQueue
  during parallel filtering, then merging into deleteFiles on the calling
  thread after all workers complete. Also convert duplicateDeleteCount
  from int to AtomicInteger to safely handle concurrent increments across
  worker threads.

  Add a regression test that appends 128 files in separate commits (one
  manifest each) and deletes all via overwriteByRowFilter with a 16-thread
  pool. File paths are constructed using the "Aa"/"BB" Java hash-collision
  pair so all locations share the same String.hashCode(), concentrating
  concurrent adds into the same DataFileSet hash bucket and making the
  race deterministically reproducible on。unfixed code.