### PR TITLE
Parquet: Read and write geometry and geography WKB values

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.util;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
@@ -157,6 +159,12 @@ public class RandomUtil {
         BigDecimal bigDecimal = new BigDecimal(unscaled, type.scale());
         return negate(choice) ? bigDecimal.negate() : bigDecimal;
 
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // geometry and geography values are stored as WKB
+        return wkbPoint(
+            (random.nextDouble() * 360.0) - 180.0, (random.nextDouble() * 180.0) - 90.0);
+
       default:
         throw new IllegalArgumentException(
             "Cannot generate random value for unknown type: " + primitive);
@@ -202,10 +210,25 @@ public class RandomUtil {
         byte[] uuidBytes = new byte[16];
         random.nextBytes(uuidBytes);
         return uuidBytes;
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // a small set of distinct points so the WKB column stays dictionary encodable
+        return wkbPoint(value, value);
       default:
         throw new IllegalArgumentException(
             "Cannot generate random value for unknown type: " + primitive);
     }
+  }
+
+  /** Encodes a point as little-endian WKB, the on-disk representation for geo values. */
+  private static byte[] wkbPoint(double xCoord, double yCoord) {
+    return ByteBuffer.allocate(21)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put((byte) 1) // byte order: little endian
+        .putInt(1) // WKB geometry type: Point
+        .putDouble(xCoord)
+        .putDouble(yCoord)
+        .array();
   }
 
   private static final long FIFTY_YEARS_IN_MICROS =

--- a/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/RandomUtil.java
@@ -221,7 +221,7 @@ public class RandomUtil {
   }
 
   /** Encodes a point as little-endian WKB, the on-disk representation for geo values. */
-  private static byte[] wkbPoint(double xCoord, double yCoord) {
+  public static byte[] wkbPoint(double xCoord, double yCoord) {
     return ByteBuffer.allocate(21)
         .order(ByteOrder.LITTLE_ENDIAN)
         .put((byte) 1) // byte order: little endian

--- a/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/InternalTestHelpers.java
@@ -91,6 +91,8 @@ public class InternalTestHelpers {
       case FIXED:
       case BINARY:
       case DECIMAL:
+      case GEOMETRY:
+      case GEOGRAPHY:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case STRUCT:

--- a/core/src/test/java/org/apache/iceberg/RandomInternalData.java
+++ b/core/src/test/java/org/apache/iceberg/RandomInternalData.java
@@ -99,6 +99,8 @@ public class RandomInternalData {
       switch (primitive.typeId()) {
         case FIXED:
         case BINARY:
+        case GEOMETRY:
+        case GEOGRAPHY:
           return ByteBuffer.wrap((byte[]) result);
         case UUID:
           return UUID.nameUUIDFromBytes((byte[]) result);

--- a/core/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/data/DataTestHelpers.java
@@ -128,6 +128,8 @@ public class DataTestHelpers {
       case UUID:
       case BINARY:
       case DECIMAL:
+      case GEOMETRY:
+      case GEOGRAPHY:
         assertThat(actual)
             .as("Primitive value should be equal to expected for type " + type)
             .isEqualTo(expected);

--- a/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java
@@ -268,6 +268,8 @@ public class RandomGenericData {
       Object result = randomValue(primitive, random);
       switch (primitive.typeId()) {
         case BINARY:
+        case GEOMETRY:
+        case GEOGRAPHY:
           return ByteBuffer.wrap((byte[]) result);
         case UUID:
           return UUID.nameUUIDFromBytes((byte[]) result);

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -69,6 +69,11 @@ public class TestGenericData extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     writeAndValidate(schema, schema);
   }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -226,6 +226,20 @@ abstract class BaseParquetReaders<T> {
 
     @Override
     public Optional<ParquetValueReader<?>> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+      // geometry values are pure WKB stored in a BINARY column
+      return Optional.of(ParquetValueReaders.byteBuffers(desc));
+    }
+
+    @Override
+    public Optional<ParquetValueReader<?>> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+      // geography values are pure WKB stored in a BINARY column
+      return Optional.of(ParquetValueReaders.byteBuffers(desc));
+    }
+
+    @Override
+    public Optional<ParquetValueReader<?>> visit(
         LogicalTypeAnnotation.UUIDLogicalTypeAnnotation uuidLogicalType) {
       return Optional.of(ParquetValueReaders.uuids(desc));
     }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -268,17 +268,15 @@ abstract class BaseParquetWriter<T> {
     @Override
     public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
-      // reject geometry so it does not silently fall through to the generic binary writer; the
-      // geospatial value path is a separate follow-up
-      throw new UnsupportedOperationException("Cannot write geometry value to Parquet");
+      // geometry values are pure WKB stored in a BINARY column
+      return Optional.of(ParquetValueWriters.byteBuffers(desc));
     }
 
     @Override
     public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyType) {
-      // reject geography so it does not silently fall through to the generic binary writer; the
-      // geospatial value path is a separate follow-up
-      throw new UnsupportedOperationException("Cannot write geography value to Parquet");
+      // geography values are pure WKB stored in a BINARY column
+      return Optional.of(ParquetValueWriters.byteBuffers(desc));
     }
 
     @Override

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestInternalParquet.java
@@ -57,6 +57,11 @@ public class TestInternalParquet extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomInternalData.generate(schema, 100, 1376L);
     writeAndValidate(schema, expected);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -23,7 +23,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -56,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantMetadata;
 import org.apache.iceberg.variants.VariantTestUtil;
@@ -159,16 +159,7 @@ public class TestParquetDataWriter {
   }
 
   private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
-    // little-endian WKB encoding of a point
-    byte[] wkb =
-        ByteBuffer.allocate(21)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .put((byte) 1) // byte order: little endian
-            .putInt(1) // WKB geometry type: Point
-            .putDouble(xCoord)
-            .putDouble(yCoord)
-            .array();
-    return ByteBuffer.wrap(wkb);
+    return ByteBuffer.wrap(RandomUtil.wkbPoint(xCoord, yCoord));
   }
 
   private void testDataWriter(Schema schema, VariantShreddingFunction variantShreddingFunc)

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDataWriter.java
@@ -20,10 +20,10 @@ package org.apache.iceberg.parquet;
 
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -104,36 +104,71 @@ public class TestParquetDataWriter {
   }
 
   @Test
-  public void testGeospatialWriteIsRejected() {
-    Schema geometrySchema =
+  public void testGeospatialRoundTrip() throws IOException {
+    Schema schema =
         new Schema(
             Types.NestedField.required(1, "id", Types.LongType.get()),
-            Types.NestedField.optional(2, "geom", Types.GeometryType.crs84()));
-    assertThatThrownBy(
-            () ->
-                Parquet.writeData(Files.localOutput(createTempFile(temp)))
-                    .schema(geometrySchema)
-                    .createWriterFunc(GenericParquetWriter::create)
-                    .overwrite()
-                    .withSpec(PartitionSpec.unpartitioned())
-                    .build())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Cannot write geometry value to Parquet");
+            Types.NestedField.optional(2, "geom", Types.GeometryType.crs84()),
+            Types.NestedField.optional(3, "geog", Types.GeographyType.crs84()));
 
-    Schema geographySchema =
-        new Schema(
-            Types.NestedField.required(1, "id", Types.LongType.get()),
-            Types.NestedField.optional(2, "geog", Types.GeographyType.crs84()));
-    assertThatThrownBy(
-            () ->
-                Parquet.writeData(Files.localOutput(createTempFile(temp)))
-                    .schema(geographySchema)
-                    .createWriterFunc(GenericParquetWriter::create)
-                    .overwrite()
-                    .withSpec(PartitionSpec.unpartitioned())
-                    .build())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage("Cannot write geography value to Parquet");
+    GenericRecord record = GenericRecord.create(schema);
+    List<Record> geoRecords =
+        ImmutableList.of(
+            record.copy(
+                ImmutableMap.of("id", 1L, "geom", wkbPoint(30, 10), "geog", wkbPoint(-5, 40))),
+            // geog is left null
+            record.copy(ImmutableMap.of("id", 2L, "geom", wkbPoint(0, 0))),
+            // both geo columns are left null
+            record.copy(ImmutableMap.of("id", 3L)));
+
+    OutputFile file = Files.localOutput(createTempFile(temp));
+    DataWriter<Record> dataWriter =
+        Parquet.writeData(file)
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try (dataWriter) {
+      for (Record geoRecord : geoRecords) {
+        dataWriter.write(geoRecord);
+      }
+    }
+
+    assertThat(dataWriter.toDataFile().recordCount()).isEqualTo(geoRecords.size());
+
+    List<Record> writtenRecords;
+    try (CloseableIterable<Record> reader =
+        Parquet.read(file.toInputFile())
+            .project(schema)
+            .createReaderFunc(fileSchema -> GenericParquetReaders.buildReader(schema, fileSchema))
+            .build()) {
+      writtenRecords = Lists.newArrayList(reader);
+    }
+
+    assertThat(writtenRecords).hasSameSizeAs(geoRecords);
+    for (int i = 0; i < geoRecords.size(); i++) {
+      assertThat(writtenRecords.get(i).getField("id")).isEqualTo(geoRecords.get(i).getField("id"));
+      assertThat(writtenRecords.get(i).getField("geom"))
+          .as("geometry WKB should round-trip unchanged")
+          .isEqualTo(geoRecords.get(i).getField("geom"));
+      assertThat(writtenRecords.get(i).getField("geog"))
+          .as("geography WKB should round-trip unchanged")
+          .isEqualTo(geoRecords.get(i).getField("geog"));
+    }
+  }
+
+  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
+    // little-endian WKB encoding of a point
+    byte[] wkb =
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1) // byte order: little endian
+            .putInt(1) // WKB geometry type: Point
+            .putDouble(xCoord)
+            .putDouble(yCoord)
+            .array();
+    return ByteBuffer.wrap(wkb);
   }
 
   private void testDataWriter(Schema schema, VariantShreddingFunction variantShreddingFunc)


### PR DESCRIPTION
Geometry and geography columns map to a BINARY Parquet column carrying a
geometry/geography logical type, the schema mapping added in #16765. That PR
deliberately left the value path as a follow-up: the writer threw
`UnsupportedOperationException` and the reader failed on the unsupported logical
type. This PR wires up the value path.

Geo values are pure WKB, and Iceberg represents them in memory as a `ByteBuffer`
(`Type.TypeID.GEOMETRY` / `GEOGRAPHY` map to `ByteBuffer.class`), so the reader
and writer reuse `ParquetValueReaders`/`ParquetValueWriters.byteBuffers` — the
same primitive already used for BSON. The change is in `BaseParquetReaders` /
`BaseParquetWriter`, so both the generic and internal object models inherit it.

Testing:
- Enables the shared `DataTest` round-trip coverage for geospatial types in the
  generic Parquet reader/writer (`supportsGeospatial()`), exercising geometry and
  geography across multiple CRS and edge algorithms with randomly generated WKB
  values.
- Adds an explicit WKB round-trip test (`TestParquetDataWriter`) covering
  geometry, geography, and null values through the `DataWriter` path.
