### PR TITLE
Core: Fix concurrent mutation of deleteFiles during parallel manifest filtering

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -71,7 +72,10 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
   private final Map<Integer, PartitionSpec> specsById;
   private final PartitionSet deleteFilePartitions;
-  private final Set<F> deleteFiles = newFileSet();
+  // Manifests are filtered in parallel and workers add expression-deleted files to this set.
+  // SynchronizedSet protects individual operations; iteration must remain after filtering completes
+  // or be guarded by synchronized(deleteFiles).
+  private final Set<F> deleteFiles = Collections.synchronizedSet(newFileSet());
   private final Set<String> manifestsWithDeletes = Sets.newHashSet();
   private final PartitionSet dropPartitions;
   private final CharSequenceSet deletePaths = CharSequenceSet.empty();
@@ -82,7 +86,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
   private long minSequenceNumber = 0;
   private boolean failAnyDelete = false;
   private boolean failMissingDeletePaths = false;
-  private int duplicateDeleteCount = 0;
+  private final AtomicInteger duplicateDeleteCount = new AtomicInteger(0);
   private boolean caseSensitive = true;
   private boolean allDeletesReferenceManifests = true;
   // this is only being used for the DeleteManifestFilterManager to detect orphaned DVs for removed
@@ -264,7 +268,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
       }
     }
 
-    summaryBuilder.incrementDuplicateDeletes(duplicateDeleteCount);
+    summaryBuilder.incrementDuplicateDeletes(duplicateDeleteCount.get());
 
     return summaryBuilder;
   }
@@ -542,7 +546,7 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
                             "Deleting a duplicate path from manifest {}: {}",
                             manifest.path(),
                             file.location());
-                        duplicateDeleteCount += 1;
+                        duplicateDeleteCount.incrementAndGet();
                       } else {
                         // only add the file to deletes if it is a new delete
                         // this keeps the snapshot summary accurate for non-duplicate data

--- a/core/src/test/java/org/apache/iceberg/TestOverwrite.java
+++ b/core/src/test/java/org/apache/iceberg/TestOverwrite.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg;
 
+import static org.apache.iceberg.expressions.Expressions.alwaysTrue;
 import static org.apache.iceberg.expressions.Expressions.and;
 import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.lessThan;
@@ -334,5 +335,56 @@ public class TestOverwrite extends TestBase {
         .hasMessageStartingWith("Cannot append file with rows that do not match filter");
 
     assertThat(latestSnapshot(base, branch).snapshotId()).isEqualTo(baseId);
+  }
+
+  @TestTemplate
+  public void testFullOverwriteAcrossManyManifests() {
+    // A full overwrite filters existing manifests in parallel and records every removed file in
+    // ManifestFilterManager's shared deleteFiles set. The colliding file locations below
+    // concentrate many concurrent adds in the same hash bucket, guarding against regressions that
+    // mutate the
+    // set without synchronization.
+    table.updateProperties().set(TableProperties.MANIFEST_MERGE_ENABLED, "false").commit();
+
+    int manifestCount = 16;
+    int filesPerManifest = 64;
+
+    // FILE_0_TO_4 and FILE_5_TO_9 were appended together in createTestTable.
+    int liveFiles = 2;
+    int globalIndex = 0;
+    for (int i = 0; i < manifestCount; i++) {
+      AppendFiles append = table.newAppend();
+      for (int j = 0; j < filesPerManifest; j++) {
+        append.appendFile(
+            DataFiles.builder(PARTITION_BY_DATE)
+                .withPath(collidingLocation(globalIndex))
+                .withFormat(FileFormat.PARQUET)
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .withPartitionPath("date=2018-06-08")
+                .build());
+        liveFiles += 1;
+        globalIndex += 1;
+      }
+      commit(table, append, branch);
+    }
+
+    Snapshot overwriteSnapshot =
+        commit(table, table.newOverwrite().overwriteByRowFilter(alwaysTrue()), branch);
+
+    assertThat(overwriteSnapshot.operation()).isEqualTo(DataOperations.DELETE);
+    assertThat(overwriteSnapshot.summary())
+        .containsEntry(SnapshotSummary.DELETED_FILES_PROP, String.valueOf(liveFiles))
+        .doesNotContainKey(SnapshotSummary.DELETED_DUPLICATE_FILES);
+  }
+
+  // Builds unique file locations with identical String.hashCode() values. DataFileSet hashes by
+  // location, so these paths exercise contention in ManifestFilterManager's shared deleteFiles set.
+  private static String collidingLocation(int index) {
+    StringBuilder location = new StringBuilder("/path/to/collide-");
+    for (int bit = 0; bit < 12; bit++) {
+      location.append(((index >> bit) & 1) == 0 ? "Aa" : "BB");
+    }
+    return location.toString();
   }
 }


### PR DESCRIPTION
closes https://github.com/apache/iceberg/issues/16978

### Summary

- Fix a race in `ManifestFilterManager` where parallel manifest filtering concurrently mutates the shared `deleteFiles` set, corrupting its backing store.
- Make `duplicateDeleteCount` thread-safe with `AtomicInteger`.
- Add a high-contention regression test for concurrent adds to `deleteFiles` during a full overwrite across many manifests.

### Problem

`ManifestFilterManager.filterManifests()` filters manifests in parallel via `Tasks.range(...).executeWith(workerPoolSupplier.get())`. During expression-based deletes, each worker thread calls `deleteFiles.add(fileCopy)` on a shared instance-level set backed by `WrapperSet` / `LinkedHashSet`, which is not thread-safe.

Under heavy concurrent adds (large overwrites spanning many manifests), the backing `LinkedHashMap` can corrupt. Observed symptoms include `ClassCastException: LinkedHashMap$Entry cannot be cast to HashMap$TreeNode`, `StackOverflowError`, and hangs.

`duplicateDeleteCount` is also incremented from worker threads with a non-atomic `++`, which can lose increments.

### Fix

Wrap `deleteFiles` with `Collections.synchronizedSet(newFileSet())` so concurrent `add`/`contains` calls from worker threads are safe, and convert `duplicateDeleteCount` to `AtomicInteger`.

`Collections.synchronizedSet` synchronizes individual method calls. Iteration is not auto-synchronized, so iterating `deleteFiles` must remain after the parallel filtering phase (current behavior) or be guarded by `synchronized (deleteFiles)`. This invariant is documented at the field.

### Why `Collections.synchronizedSet`

The fix is intentionally minimal and confined to `ManifestFilterManager`, while preserving the existing semantics of `deleteFiles` exactly:

- **Location-based matching.** `newFileSet()` returns a `DataFileSet` / `DeleteFileSet`, which match files by `file.location()` via `WrapperSet`. A raw concurrent set keyed on `DataFile` / `DeleteFile` would use object identity because the file classes do not override `equals`/`hashCode`. That would break the explicit `deleteFile(...)` path: the caller-supplied file instance added to `deleteFiles` would not match the separate file instance read back from a manifest during filtering.
- **Insertion order.** `WrapperSet` documents that it [maintains insertion order](https://github.com/apache/iceberg/blob/874e4096e5d16fddbbf43b91f20e248616232cc3/api/src/main/java/org/apache/iceberg/util/WrapperSet.java#L33-L40). It is a shared `api/` type used outside this path, so re-backing it with a non-ordered concurrent map to fix one caller would silently change that contract for every consumer.

### Test plan

- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestOverwrite`
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestDeleteFiles`
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.TestOverwriteWithValidation`
- [x] `./gradlew :iceberg-core:spotlessApply :iceberg-core:spotlessJavaCheck`

`testFullOverwriteAcrossManyManifests` disables manifest merging and appends 16 manifests of 64 files each, using file locations engineered to share one `String.hashCode()` so that `DataFileSet` wrapper hashes all collide into a single bucket. A full overwrite (`alwaysTrue()`) then forces many worker threads to add to `deleteFiles` concurrently, concentrating contention in that bucket. Without the fix this reproduces the corruption (ClassCastException / StackOverflowError / hang); with the fix it passes consistently.

**AI Disclosure**
LLM is used to research codebase standards and draft the regression test that actually fails without the fix, and drafting the PR description.


------------

Seems like since I opened the issue yesterday there are already 2 open PRs attempted to close the issue, hence  adding some thoughts:

A deferred-merge alternative, where worker threads collect deleted files into a concurrent structure and the caller merges them into `deleteFiles` after the parallel phase, is also behavior-preserving: expression-deleted files added to `deleteFiles` during filtering are not needed by other workers to decide expression matches, and the actual post-phase consumers (`filesToBeDeleted()` and required-delete validation) run after `Tasks.range(...)` joins. It is a reasonable design with a lock-free hot path that is has higher throughput potential, but more invasive. This is available in https://github.com/apache/iceberg/pull/16980

My PR prefers the synchronized wrapper for its minimal change and exact preservation of `WrapperSet` semantics; a deferred merge is a sensible alternative if we have proof on the lock contention.

In object-store-backed deployments, each manifest is read from S3/GCS, so millisecond-scale I/O per manifest dominates both the microseconds of CPU and the nanoseconds of lock. So i would expect the lock to be genuinely negligible here. If the env is local FS, warm cache, manifests of many tiny entries, high core count, then there is merit to the deferred-merge approach.

Deferring the decision to the community and maintainers.
