### PR TITLE
Infra: Unpin apache/infrastructure-actions/allowlist-check

### DIFF
--- a/.github/workflows/asf-allowlist-check.yml
+++ b/.github/workflows/asf-allowlist-check.yml
@@ -39,4 +39,5 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       with:
         persist-credentials: false
-    - uses: apache/infrastructure-actions/allowlist-check@4e9c961f587f72b170874b6f5cd4ac15f7f26eb8  # main
+    # Intentionally unpinned to always use the latest allowlist from the ASF.
+    - uses: apache/infrastructure-actions/allowlist-check@main # zizmor: ignore[unpinned-uses]


### PR DESCRIPTION
Apache Polaris unpins the version for `apache/infrastructure-actions/allowlist-check` action:
https://github.com/apache/polaris/blob/3260a0c6e28d2ee29b96a959007fab42e0590fe8/.github/workflows/ci.yml#L92-L93

- Relates to https://github.com/apache/iceberg/pull/16987