### PR TITLE
Spark: Fix DeleteOrphanFilesSparkAction sibling path matching bug

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -225,7 +226,12 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String strippedLocation = LocationUtil.stripTrailingSlash(location);
+      String locationWithTrailingSlash =
+          strippedLocation.endsWith(LocationUtil.PATH_SEPARATOR)
+              ? strippedLocation
+              : strippedLocation + LocationUtil.PATH_SEPARATOR;
+      files = files.filter(files.col(FILE_PATH).startsWith(locationWithTrailingSlash));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1001,7 +1001,10 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
 
     List<FilePathLastModifiedRecord> outsideLocationMockFiles =
-        Lists.newArrayList(new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)));
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)),
+            new FilePathLastModifiedRecord(
+                tableLocation + "-backup/mock1.parquet", new Timestamp(0L)));
 
     Dataset<Row> compareToFileListWithOutsideLocation =
         spark

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -225,7 +226,12 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String strippedLocation = LocationUtil.stripTrailingSlash(location);
+      String locationWithTrailingSlash =
+          strippedLocation.endsWith(LocationUtil.PATH_SEPARATOR)
+              ? strippedLocation
+              : strippedLocation + LocationUtil.PATH_SEPARATOR;
+      files = files.filter(files.col(FILE_PATH).startsWith(locationWithTrailingSlash));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1001,7 +1001,10 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
 
     List<FilePathLastModifiedRecord> outsideLocationMockFiles =
-        Lists.newArrayList(new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)));
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)),
+            new FilePathLastModifiedRecord(
+                tableLocation + "-backup/mock1.parquet", new Timestamp(0L)));
 
     Dataset<Row> compareToFileListWithOutsideLocation =
         spark

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.LocationUtil;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -225,7 +226,12 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String strippedLocation = LocationUtil.stripTrailingSlash(location);
+      String locationWithTrailingSlash =
+          strippedLocation.endsWith(LocationUtil.PATH_SEPARATOR)
+              ? strippedLocation
+              : strippedLocation + LocationUtil.PATH_SEPARATOR;
+      files = files.filter(files.col(FILE_PATH).startsWith(locationWithTrailingSlash));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1002,7 +1002,10 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
     assertThat(actualRecords).as("Rows must match").isEqualTo(expectedRecords);
 
     List<FilePathLastModifiedRecord> outsideLocationMockFiles =
-        Lists.newArrayList(new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)));
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord("/tmp/mock1", new Timestamp(0L)),
+            new FilePathLastModifiedRecord(
+                tableLocation + "-backup/mock1.parquet", new Timestamp(0L)));
 
     Dataset<Row> compareToFileListWithOutsideLocation =
         spark


### PR DESCRIPTION
**This commit fixes issue #16493 where file_list_view was scoped using raw string prefix matching, which allowed sibling paths to fall inside orphan cleanup (e.g. s3://bucket/table-backup matched s3://bucket/table).

Added a trailing slash to the location before prefix matching in filteredCompareToFileList to ensure precise directory scoping.**  


---
**AI Disclosure**
- Model: Gemini 2.5 Pro / Claude Sonnet 4.6
- Platform/Tool: Antigravity IDE
- Human Oversight: fully reviewed
- Prompt Summary: Fix DeleteOrphanFilesSparkAction sibling path matching bug
