### PR TITLE
Parquet: Fix variant shredding of large decimals (precision > 18)

### DIFF
--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
@@ -447,7 +447,7 @@ class TestFlinkVariantShreddingType extends CatalogTestBase {
             "value",
             shreddedPrimitive(
                 PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY,
-                16,
+                9, // decimalRequiredBytes(21)
                 LogicalTypeAnnotation.decimalType(6, 21)));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
     MessageType expectedSchema = parquetSchema(address);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/VariantShreddingAnalyzer.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.variants.PhysicalType;
 import org.apache.iceberg.variants.VariantArray;
@@ -347,7 +348,7 @@ public abstract class VariantShreddingAnalyzer<T, S> {
           .named(TYPED_VALUE);
     } else {
       return Types.optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-          .length(16)
+          .length(TypeUtil.decimalRequiredBytes(maxPrecision))
           .as(LogicalTypeAnnotation.decimalType(maxScale, maxPrecision))
           .named(TYPED_VALUE);
     }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantShreddingAnalyzer.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantShreddingAnalyzer.java
@@ -21,11 +21,13 @@ package org.apache.iceberg.parquet;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.VariantMetadata;
@@ -36,6 +38,8 @@ import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class TestVariantShreddingAnalyzer {
 
@@ -249,6 +253,35 @@ public class TestVariantShreddingAnalyzer {
         .isEqualTo(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
   }
 
+  @ParameterizedTest
+  @CsvSource({"20, 9", "28, 12", "33, 14"})
+  public void testDecimalExceedingPrecisionUsesMinimumFixedLength(
+      int precision, int expectedLength) {
+    DirectAnalyzer analyzer = new DirectAnalyzer();
+
+    // Precision > 18 shreds to FIXED_LEN_BYTE_ARRAY; the declared length must equal what the
+    // writer emits (decimalRequiredBytes).
+    VariantMetadata meta = Variants.metadata("val");
+    ShreddedObject row = Variants.object(meta);
+    row.put("val", Variants.of(new BigDecimal(BigInteger.TEN.pow(precision - 1))));
+
+    Type schema = analyzer.analyzeAndCreateSchema(List.of(row), 0);
+    assertThat(schema).isNotNull();
+
+    GroupType valGroup = schema.asGroupType().getType("val").asGroupType();
+    PrimitiveType valPrimitive = valGroup.getType("typed_value").asPrimitiveType();
+
+    LogicalTypeAnnotation.DecimalLogicalTypeAnnotation decimal =
+        (LogicalTypeAnnotation.DecimalLogicalTypeAnnotation)
+            valPrimitive.getLogicalTypeAnnotation();
+    assertThat(decimal.getPrecision()).isEqualTo(precision);
+    assertThat(valPrimitive.getPrimitiveTypeName())
+        .isEqualTo(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY);
+    assertThat(valPrimitive.getTypeLength())
+        .isEqualTo(expectedLength)
+        .isEqualTo(TypeUtil.decimalRequiredBytes(precision));
+  }
+
   @Test
   public void testDecimalForExactPrecision() {
     DirectAnalyzer analyzer = new DirectAnalyzer();
@@ -270,6 +303,10 @@ public class TestVariantShreddingAnalyzer {
             valPrimitive.getLogicalTypeAnnotation();
     assertThat(decimal.getPrecision()).isEqualTo(38);
     assertThat(decimal.getScale()).isEqualTo(18);
+    // Precision 38 is the max and requires the full 16-byte FIXED width.
+    assertThat(valPrimitive.getTypeLength())
+        .isEqualTo(TypeUtil.decimalRequiredBytes(38))
+        .isEqualTo(16);
   }
 
   @Test

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -215,6 +215,34 @@ public class TestVariantWriters {
     InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
   }
 
+  @Test
+  public void testShreddedDecimal16RoundTripUsesWriterCompatibleFixedLength() throws IOException {
+    // A DECIMAL16 value (20-digit integer) shreds to a FIXED_LEN_BYTE_ARRAY typed_value whose
+    // declared length must equal decimalRequiredBytes, or the write fails. toParquetSchema shreds
+    // DECIMAL16 as BINARY, so this fixed-length path is otherwise untested.
+    VariantValue value = Variants.of(new BigDecimal("12345678901234567890"));
+    Variant variant = Variant.of(EMPTY_METADATA, value);
+    Record record = RECORD.copy("id", 1, "var", variant);
+
+    VariantShreddingAnalyzer<VariantValue, Void> analyzer =
+        new VariantShreddingAnalyzer<>() {
+          @Override
+          protected List<VariantValue> extractVariantValues(List<VariantValue> rows, int idx) {
+            return rows;
+          }
+
+          @Override
+          protected int resolveColumnIndex(Void engineSchema, String columnName) {
+            throw new UnsupportedOperationException("Not used in this test");
+          }
+        };
+
+    Record actual =
+        writeAndRead((id, name) -> analyzer.analyzeAndCreateSchema(List.of(value), 0), record);
+
+    InternalTestHelpers.assertEquals(SCHEMA.asStruct(), record, actual);
+  }
+
   @ParameterizedTest
   @FieldSource("VARIANTS")
   public void testMixedShredding(Variant variant) throws IOException {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
@@ -554,7 +554,7 @@ public class TestVariantShredding extends CatalogTestBase {
         field(
             "value",
             optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-                .length(16)
+                .length(9) // decimalRequiredBytes(21)
                 .as(LogicalTypeAnnotation.decimalType(6, 21))
                 .named("typed_value"));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
@@ -992,6 +992,24 @@ public class TestVariantShredding extends CatalogTestBase {
     assertThat(rows.get(3)[1]).isEqualTo(new BigDecimal("123456.7800"));
     assertThat(rows.get(4)[1]).isEqualTo(new BigDecimal("1.2345"));
     assertThat(rows.get(5)[1]).isEqualTo(new BigDecimal("12.3000"));
+  }
+
+  @TestTemplate
+  public void testShreddedLargeIntegerVariantReadBack() {
+    // DECIMAL16 (20-digit integer, above Long.MAX_VALUE) shreds to a FIXED_LEN_BYTE_ARRAY
+    // typed_value whose declared length must equal what FixedDecimalWriter emits.
+    spark.conf().set(SparkSQLProperties.SHRED_VARIANTS, "true");
+
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"v\":12345678901234567890}')), "
+            + "(2, parse_json('{\"v\":-12345678901234567890}'))",
+        tableName);
+
+    List<Object[]> values =
+        sql("SELECT variant_get(address, '$.v', 'decimal(38,0)') FROM %s ORDER BY id", tableName);
+    assertThat(values.get(0)[0]).isEqualTo(new BigDecimal("12345678901234567890"));
+    assertThat(values.get(1)[0]).isEqualTo(new BigDecimal("-12345678901234567890"));
   }
 
   private void verifyParquetSchema(Table table, MessageType expectedSchema) throws IOException {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/variant/TestVariantShredding.java
@@ -554,7 +554,7 @@ public class TestVariantShredding extends CatalogTestBase {
         field(
             "value",
             optional(PrimitiveType.PrimitiveTypeName.FIXED_LEN_BYTE_ARRAY)
-                .length(16)
+                .length(9) // decimalRequiredBytes(21)
                 .as(LogicalTypeAnnotation.decimalType(6, 21))
                 .named("typed_value"));
     GroupType address = variant("address", 2, Type.Repetition.REQUIRED, objectFields(value));
@@ -992,6 +992,24 @@ public class TestVariantShredding extends CatalogTestBase {
     assertThat(rows.get(3)[1]).isEqualTo(new BigDecimal("123456.7800"));
     assertThat(rows.get(4)[1]).isEqualTo(new BigDecimal("1.2345"));
     assertThat(rows.get(5)[1]).isEqualTo(new BigDecimal("12.3000"));
+  }
+
+  @TestTemplate
+  public void testShreddedLargeIntegerVariantReadBack() {
+    // DECIMAL16 (20-digit integer, above Long.MAX_VALUE) shreds to a FIXED_LEN_BYTE_ARRAY
+    // typed_value whose declared length must equal what FixedDecimalWriter emits.
+    spark.conf().set(SparkSQLProperties.SHRED_VARIANTS, "true");
+
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"v\":12345678901234567890}')), "
+            + "(2, parse_json('{\"v\":-12345678901234567890}'))",
+        tableName);
+
+    List<Object[]> values =
+        sql("SELECT variant_get(address, '$.v', 'decimal(38,0)') FROM %s ORDER BY id", tableName);
+    assertThat(values.get(0)[0]).isEqualTo(new BigDecimal("12345678901234567890"));
+    assertThat(values.get(1)[0]).isEqualTo(new BigDecimal("-12345678901234567890"));
   }
 
   private void verifyParquetSchema(Table table, MessageType expectedSchema) throws IOException {


### PR DESCRIPTION
`VariantShreddingAnalyzer` shredded a decimal with precision > 18 into a `FIXED_LEN_BYTE_ARRAY` typed_value with a hardcoded length of 16. The writer (`FixedDecimalWriter`) instead emits the minimum number of bytes for the precision, `TypeUtil.decimalRequiredBytes` (e.g. 9 bytes for precision 20), so the write fails with `IllegalArgumentException: 'Fixed Binary size 9 does not match field type length 16'`. This breaks write/read of any variant holding an int128-range value (stored as DECIMAL16), such as an integer with 19-34 digits.

The hardcoded 16 was the only fixed-decimal width in the codebase not derived from decimalRequiredBytes; TypeToMessageType and every Parquet decimal writer already use it. decimalRequiredBytes is 9-15 bytes for precision 19-35 and 16 bytes only for precision 36-38, so the constant matched the writer just at 36-38; for precision 19-35 the declared length exceeded the bytes the writer emits. Set the length to TypeUtil.decimalRequiredBytes(maxPrecision) to realign this outlier. Precision <= 18 is unaffected (INT32/INT64).