### PR TITLE
API: Add indexStatsNames to create field names for content stats

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -32,20 +32,26 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 
 public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
-  private static final Joiner DOT = Joiner.on(".");
-
   private final Deque<String> fieldNames = Lists.newLinkedList();
   private final Deque<String> shortFieldNames = Lists.newLinkedList();
   private final Map<String, Integer> nameToId = Maps.newHashMap();
   private final Map<String, Integer> shortNameToId = Maps.newHashMap();
+  private final Joiner joiner;
   private final Function<String, String> quotingFunc;
+  private final boolean useShortNames;
 
   public IndexByName() {
     this(Function.identity());
   }
 
   public IndexByName(Function<String, String> quotingFunc) {
+    this(".", quotingFunc, false);
+  }
+
+  IndexByName(String separator, Function<String, String> quotingFunc, boolean useShortNames) {
+    this.joiner = Joiner.on(separator);
     this.quotingFunc = quotingFunc;
+    this.useShortNames = useShortNames;
   }
 
   /**
@@ -76,9 +82,15 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
    * @return a map from field ID to name
    */
   public Map<Integer, String> byId() {
+    // a builder is used to swap key and value
     ImmutableMap.Builder<Integer, String> builder = ImmutableMap.builder();
     nameToId.forEach((key, value) -> builder.put(value, key));
-    return builder.build();
+
+    if (useShortNames) {
+      shortNameToId.forEach((key, value) -> builder.put(value, key));
+    }
+
+    return builder.buildKeepingLast();
   }
 
   @Override
@@ -193,7 +205,7 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
     if (!fieldNames.isEmpty()) {
       Iterator<String> quotedFieldNames =
           Iterators.transform(fieldNames.descendingIterator(), quotingFunc::apply);
-      fullName = DOT.join(DOT.join(quotedFieldNames), quotedName);
+      fullName = joiner.join(joiner.join(quotedFieldNames), quotedName);
     }
 
     Integer existingFieldId = nameToId.put(fullName, fieldId);
@@ -208,7 +220,7 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
     if (!shortFieldNames.isEmpty()) {
       Iterator<String> quotedShortFieldNames =
           Iterators.transform(shortFieldNames.descendingIterator(), quotingFunc::apply);
-      String shortName = DOT.join(DOT.join(quotedShortFieldNames), quotedName);
+      String shortName = joiner.join(joiner.join(quotedShortFieldNames), quotedName);
       if (!shortNameToId.containsKey(shortName)) {
         shortNameToId.put(shortName, fieldId);
       }

--- a/api/src/main/java/org/apache/iceberg/types/IndexByName.java
+++ b/api/src/main/java/org/apache/iceberg/types/IndexByName.java
@@ -88,9 +88,10 @@ public class IndexByName extends TypeUtil.SchemaVisitor<Map<String, Integer>> {
 
     if (useShortNames) {
       shortNameToId.forEach((key, value) -> builder.put(value, key));
+      return builder.buildKeepingLast();
     }
 
-    return builder.buildKeepingLast();
+    return builder.build();
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -196,6 +196,19 @@ public class TypeUtil {
   }
 
   /**
+   * Indexes the fields of a struct from ID to a flattened name that can be used for stats struct
+   * field names.
+   *
+   * @param struct a struct type
+   * @return an index from field ID to short names, joined by _
+   */
+  public static Map<Integer, String> indexStatsNames(Types.StructType struct) {
+    IndexByName indexer = new IndexByName("_", Function.identity(), true /* use short names */);
+    visit(struct, indexer);
+    return indexer.byId();
+  }
+
+  /**
    * Creates a mapping from lower-case field names to their corresponding field IDs.
    *
    * <p>This method iterates over the fields of the provided struct and maps each field's name

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -1007,7 +1007,8 @@ public class TestTypeUtil {
                         required(20, "street", Types.StringType.get()),
                         optional(21, "city", Types.StringType.get()),
                         optional(22, "state", Types.StringType.get()),
-                        required(23, "zip", Types.IntegerType.get())))));
+                        required(23, "zip", Types.IntegerType.get()),
+                        required(24, "value", Types.IntegerType.get())))));
 
     Map<Integer, String> statsNameIndex = TypeUtil.indexStatsNames(schema.asStruct());
 
@@ -1033,6 +1034,7 @@ public class TestTypeUtil {
         .containsEntry(21, "addresses_city")
         .containsEntry(22, "addresses_state")
         .containsEntry(23, "addresses_zip")
-        .hasSize(21);
+        .containsEntry(24, "addresses_value") // the leaf takes precedence
+        .hasSize(22);
   }
 }

--- a/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypeUtil.java
@@ -571,7 +571,7 @@ public class TestTypeUtil {
   }
 
   @Test
-  public void testValidateSchemaViaIndexByName() {
+  public void testValidateSchemaViaByName() {
     Types.NestedField nestedType =
         Types.NestedField.required(
             1,
@@ -969,5 +969,70 @@ public class TestTypeUtil {
     assertThat(TypeUtil.ancestorFields(schema, pointsElement.fieldId())).containsExactly(points);
     assertThat(TypeUtil.ancestorFields(schema, 16)).containsExactly(pointsElement, points);
     assertThat(TypeUtil.ancestorFields(schema, 17)).containsExactly(pointsElement, points);
+  }
+
+  @Test
+  public void testIndexStatsNames() {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "data", Types.StringType.get()),
+            optional(
+                3,
+                "location",
+                Types.StructType.of(
+                    required(10, "lat", Types.FloatType.get()),
+                    required(11, "long", Types.FloatType.get()))),
+            optional(4, "values", Types.ListType.ofOptional(12, IntegerType.get())),
+            optional(
+                5,
+                "points",
+                Types.ListType.ofRequired(
+                    13,
+                    Types.StructType.of(
+                        required(14, "x", IntegerType.get()),
+                        required(15, "y", IntegerType.get())))),
+            optional(
+                6,
+                "properties",
+                Types.MapType.ofOptional(16, 17, Types.StringType.get(), Types.StringType.get())),
+            optional(
+                7,
+                "addresses",
+                Types.MapType.ofRequired(
+                    18,
+                    19,
+                    Types.StringType.get(),
+                    Types.StructType.of(
+                        required(20, "street", Types.StringType.get()),
+                        optional(21, "city", Types.StringType.get()),
+                        optional(22, "state", Types.StringType.get()),
+                        required(23, "zip", Types.IntegerType.get())))));
+
+    Map<Integer, String> statsNameIndex = TypeUtil.indexStatsNames(schema.asStruct());
+
+    assertThat(statsNameIndex)
+        .containsEntry(1, "id")
+        .containsEntry(2, "data")
+        .containsEntry(3, "location")
+        .containsEntry(10, "location_lat")
+        .containsEntry(11, "location_long")
+        .containsEntry(4, "values")
+        .containsEntry(12, "values_element")
+        .containsEntry(5, "points")
+        .containsEntry(13, "points_element")
+        .containsEntry(14, "points_x")
+        .containsEntry(15, "points_y")
+        .containsEntry(6, "properties")
+        .containsEntry(16, "properties_key")
+        .containsEntry(17, "properties_value")
+        .containsEntry(7, "addresses")
+        .containsEntry(18, "addresses_key")
+        .containsEntry(19, "addresses_value")
+        .containsEntry(20, "addresses_street")
+        .containsEntry(21, "addresses_city")
+        .containsEntry(22, "addresses_state")
+        .containsEntry(23, "addresses_zip")
+        .hasSize(21);
   }
 }


### PR DESCRIPTION
This introduces a new `TypeUtil` method to index fields in a type that produces names that can be used for stats fields in content stats. These names prefer short names, like `locations.lat` instead of `locations.element.lat` and uses underscores instead of `.` to join names into a single string.

This is exposed through `TypeUtil` to avoid making more of `IndexByName` public.