### PR TITLE
Core: Retry Hadoop version hint before metadata scan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/ConfigProperties.java
@@ -25,4 +25,16 @@ public class ConfigProperties {
   public static final String ENGINE_HIVE_ENABLED = "iceberg.engine.hive.enabled";
   public static final String LOCK_HIVE_ENABLED = "iceberg.engine.hive.lock-enabled";
   public static final String KEEP_HIVE_STATS = "iceberg.hive.keep.stats";
+
+  public static final String VERSION_HINT_NUM_RETRIES = "iceberg.version-hint.retry.num-retries";
+  public static final int VERSION_HINT_NUM_RETRIES_DEFAULT = 2;
+  public static final String VERSION_HINT_RETRY_MIN_WAIT_MS =
+      "iceberg.version-hint.retry.min-wait-ms";
+  public static final long VERSION_HINT_RETRY_MIN_WAIT_MS_DEFAULT = 100L;
+  public static final String VERSION_HINT_RETRY_MAX_WAIT_MS =
+      "iceberg.version-hint.retry.max-wait-ms";
+  public static final long VERSION_HINT_RETRY_MAX_WAIT_MS_DEFAULT = 800L;
+  public static final String VERSION_HINT_RETRY_TOTAL_TIMEOUT_MS =
+      "iceberg.version-hint.retry.total-timeout-ms";
+  public static final long VERSION_HINT_RETRY_TOTAL_TIMEOUT_MS_DEFAULT = 2_000L;
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
@@ -46,6 +47,7 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,41 +315,151 @@ public class HadoopTableOperations implements TableOperations {
   int findVersion() {
     Path versionHintFile = versionHintFile();
     FileSystem fs = getFileSystem(versionHintFile, conf);
+    VersionHintRetryState retryState = new VersionHintRetryState();
 
+    try {
+      return retryReadVersionHint(fs, versionHintFile, retryState);
+
+    } catch (RuntimeException e) {
+      if (e.getCause() instanceof InterruptedException) {
+        throw e;
+      }
+
+      return findVersionFromMetadataDirectory(
+          fs, versionHintFile, e, retryState.metadataRootExists);
+    } catch (IOException e) {
+      return findVersionFromMetadataDirectory(
+          fs, versionHintFile, e, retryState.metadataRootExists);
+    }
+  }
+
+  private int findVersionFromMetadataDirectory(
+      FileSystem fs,
+      Path versionHintFile,
+      Exception versionHintFailure,
+      Boolean knownMetadataRootExists) {
+    try {
+      if (Boolean.FALSE.equals(knownMetadataRootExists)) {
+        return 0;
+      } else if (!Boolean.TRUE.equals(knownMetadataRootExists)
+          && !metadataRootPresent(fs, versionHintFailure)) {
+        return 0;
+      }
+
+      LOG.warn(
+          "Error reading version hint file {}; falling back to metadata directory scan",
+          versionHintFile,
+          versionHintFailure);
+
+      return scanMetadataDirectory(fs);
+    } catch (IOException e) {
+      LOG.warn("Error trying to recover the latest version number for {}", versionHintFile, e);
+      return 0;
+    }
+  }
+
+  private int scanMetadataDirectory(FileSystem fs) throws IOException {
+    FileStatus[] files =
+        fs.listStatus(metadataRoot(), name -> VERSION_PATTERN.matcher(name.getName()).matches());
+    int maxVersion = 0;
+
+    for (FileStatus file : files) {
+      int currentVersion = version(file.getPath().getName());
+      if (currentVersion > maxVersion && getMetadataFile(currentVersion) != null) {
+        maxVersion = currentVersion;
+      }
+    }
+
+    return maxVersion;
+  }
+
+  private int retryReadVersionHint(
+      FileSystem fs, Path versionHintFile, VersionHintRetryState retryState) throws IOException {
+    AtomicInteger recoveredVersion = new AtomicInteger();
+    int numRetries = versionHintNumRetries();
+
+    Tasks.foreach(versionHintFile)
+        .retry(numRetries)
+        .exponentialBackoff(
+            versionHintRetryMinWaitMs(),
+            versionHintRetryMaxWaitMs(),
+            versionHintRetryTotalTimeoutMs(),
+            2.0)
+        .shouldRetryTest(failure -> shouldRetryReadVersionHint(fs, failure, retryState))
+        .run(path -> recoveredVersion.set(readVersionHint(fs, path)), IOException.class);
+
+    return recoveredVersion.get();
+  }
+
+  private boolean shouldRetryReadVersionHint(
+      FileSystem fs, Exception failure, VersionHintRetryState retryState) {
+    if (!(failure instanceof IOException)) {
+      return false;
+    } else if (Boolean.TRUE.equals(retryState.metadataRootExists)) {
+      return true;
+    } else if (Boolean.FALSE.equals(retryState.metadataRootExists)) {
+      return false;
+    }
+
+    try {
+      retryState.metadataRootExists = metadataRootPresent(fs, failure);
+      return retryState.metadataRootExists;
+    } catch (IOException e) {
+      return false;
+    }
+  }
+
+  private boolean metadataRootPresent(FileSystem fs, Exception cause) throws IOException {
+    boolean exists = fs.exists(metadataRoot());
+    if (!exists) {
+      LOG.debug("Metadata for table not found in directory {}", metadataRoot(), cause);
+    }
+
+    return exists;
+  }
+
+  private int readVersionHint(FileSystem fs, Path versionHintFile) throws IOException {
     try (InputStreamReader fsr =
             new InputStreamReader(fs.open(versionHintFile), StandardCharsets.UTF_8);
         BufferedReader in = new BufferedReader(fsr)) {
-      return Integer.parseInt(in.readLine().replace("\n", ""));
-
-    } catch (Exception e) {
-      try {
-        if (fs.exists(metadataRoot())) {
-          LOG.warn("Error reading version hint file {}", versionHintFile, e);
-        } else {
-          LOG.debug("Metadata for table not found in directory {}", metadataRoot(), e);
-          return 0;
-        }
-
-        // List the metadata directory to find the version files, and try to recover the max
-        // available version
-        FileStatus[] files =
-            fs.listStatus(
-                metadataRoot(), name -> VERSION_PATTERN.matcher(name.getName()).matches());
-        int maxVersion = 0;
-
-        for (FileStatus file : files) {
-          int currentVersion = version(file.getPath().getName());
-          if (currentVersion > maxVersion && getMetadataFile(currentVersion) != null) {
-            maxVersion = currentVersion;
-          }
-        }
-
-        return maxVersion;
-      } catch (IOException io) {
-        LOG.warn("Error trying to recover the latest version number for {}", versionHintFile, io);
-        return 0;
-      }
+      return Integer.parseInt(in.readLine());
     }
+  }
+
+  private static class VersionHintRetryState {
+    private Boolean metadataRootExists;
+  }
+
+  private int versionHintNumRetries() {
+    return Math.max(
+        0,
+        conf.getInt(
+            ConfigProperties.VERSION_HINT_NUM_RETRIES,
+            ConfigProperties.VERSION_HINT_NUM_RETRIES_DEFAULT));
+  }
+
+  private long versionHintRetryMinWaitMs() {
+    return Math.max(
+        0L,
+        conf.getLong(
+            ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS,
+            ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS_DEFAULT));
+  }
+
+  private long versionHintRetryMaxWaitMs() {
+    return Math.max(
+        0L,
+        conf.getLong(
+            ConfigProperties.VERSION_HINT_RETRY_MAX_WAIT_MS,
+            ConfigProperties.VERSION_HINT_RETRY_MAX_WAIT_MS_DEFAULT));
+  }
+
+  private long versionHintRetryTotalTimeoutMs() {
+    return Math.max(
+        0L,
+        conf.getLong(
+            ConfigProperties.VERSION_HINT_RETRY_TOTAL_TIMEOUT_MS,
+            ConfigProperties.VERSION_HINT_RETRY_TOTAL_TIMEOUT_MS_DEFAULT));
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopTableOperations.java
@@ -1,0 +1,385 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.hadoop;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FSInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestHadoopTableOperations {
+  @Test
+  public void testVersionHintRetryBeforeMetadataScan() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+    conf.setLong(ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS, 0L);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v3.metadata.json", "");
+    fs.addVersionHintAvailableAfterAttempt(3, "7");
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    assertThat(ops.findVersion()).isEqualTo(7);
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(3);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isZero();
+  }
+
+  @Test
+  public void testVersionHintRetriesCanBeDisabled() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 0);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v1.metadata.json", "");
+    fs.addFile("v3.metadata.json", "");
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    assertThat(ops.findVersion()).isEqualTo(3);
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(1);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void testConfirmedMetadataRootIsNotCheckedAgainBeforeFallbackScan() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+    conf.setLong(ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS, 0L);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v3.metadata.json", "");
+    fs.failMetadataRootExistsAfterCall(1);
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    assertThat(ops.findVersion()).isEqualTo(3);
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(3);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void testCorruptVersionHintDoesNotRetry() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v3.metadata.json", "");
+    fs.addVersionHintAvailableAfterAttempt(1, "not-a-version");
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    assertThat(ops.findVersion()).isEqualTo(3);
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(1);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void testCorruptVersionHintFallsBackWhenThreadAlreadyInterrupted() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v3.metadata.json", "");
+    fs.addVersionHintAvailableAfterAttempt(1, "not-a-version");
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    try {
+      Thread.currentThread().interrupt();
+      assertThat(ops.findVersion()).isEqualTo(3);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      assertThat(fs.versionHintOpenAttempts()).isEqualTo(1);
+      assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+      assertThat(fs.listStatusCalls()).isEqualTo(1);
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  @Test
+  public void testVersionHintRetryStopsAtTotalTimeout() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+    conf.setLong(ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS, 10L);
+    conf.setLong(ConfigProperties.VERSION_HINT_RETRY_TOTAL_TIMEOUT_MS, 1L);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    fs.addFile("v3.metadata.json", "");
+    fs.addVersionHintAvailableAfterAttempt(3, "7");
+
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    assertThat(ops.findVersion()).isEqualTo(3);
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(2);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isEqualTo(1);
+  }
+
+  @Test
+  public void testMissingMetadataRootDoesNotRetryVersionHint() {
+    TestingFileSystem fs = new TestingFileSystem();
+    HadoopTableOperations ops = newTableOps(new Configuration(), fs);
+
+    assertThat(ops.findVersion()).isZero();
+    assertThat(fs.versionHintOpenAttempts()).isEqualTo(1);
+    assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+    assertThat(fs.listStatusCalls()).isZero();
+  }
+
+  @Test
+  public void testInterruptedVersionHintRetryThrows() {
+    Configuration conf = new Configuration();
+    conf.setInt(ConfigProperties.VERSION_HINT_NUM_RETRIES, 2);
+    conf.setLong(ConfigProperties.VERSION_HINT_RETRY_MIN_WAIT_MS, 100L);
+
+    TestingFileSystem fs = new TestingFileSystem();
+    fs.addDirectory("metadata");
+    HadoopTableOperations ops = newTableOps(conf, fs);
+
+    try {
+      Thread.currentThread().interrupt();
+      assertThatThrownBy(ops::findVersion)
+          .isInstanceOf(RuntimeException.class)
+          .hasMessageContaining("InterruptedException")
+          .hasCauseInstanceOf(InterruptedException.class);
+      assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      assertThat(fs.versionHintOpenAttempts()).isEqualTo(1);
+      assertThat(fs.metadataRootExistsCalls()).isEqualTo(1);
+      assertThat(fs.listStatusCalls()).isZero();
+    } finally {
+      Thread.interrupted();
+    }
+  }
+
+  private static HadoopTableOperations newTableOps(Configuration conf, FileSystem fs) {
+    return new HadoopTableOperations(new Path("test:/table"), null, conf, null) {
+      @Override
+      protected FileSystem getFileSystem(Path path, Configuration hadoopConf) {
+        return fs;
+      }
+    };
+  }
+
+  private static class TestingFileSystem extends FileSystem {
+    private final Map<String, byte[]> files = Maps.newLinkedHashMap();
+    private int listStatusCalls = 0;
+    private int metadataRootExistsCalls = 0;
+    private int failMetadataRootExistsAfterCall = Integer.MAX_VALUE;
+    private int versionHintOpenAttempts = 0;
+    private int versionHintAvailableAfterAttempt = Integer.MAX_VALUE;
+
+    private void addDirectory(String name) {
+      files.put(name, null);
+    }
+
+    private void addFile(String name, String content) {
+      files.put(name, content.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private void addVersionHintAvailableAfterAttempt(int openAttempt, String content) {
+      this.versionHintAvailableAfterAttempt = openAttempt;
+      addFile(Util.VERSION_HINT_FILENAME, content);
+    }
+
+    private void failMetadataRootExistsAfterCall(int callCount) {
+      this.failMetadataRootExistsAfterCall = callCount;
+    }
+
+    private int listStatusCalls() {
+      return listStatusCalls;
+    }
+
+    private int versionHintOpenAttempts() {
+      return versionHintOpenAttempts;
+    }
+
+    private int metadataRootExistsCalls() {
+      return metadataRootExistsCalls;
+    }
+
+    @Override
+    public URI getUri() {
+      return URI.create("test:/");
+    }
+
+    @Override
+    public FSDataInputStream open(Path f) throws IOException {
+      return open(f, 4096);
+    }
+
+    @Override
+    public FSDataInputStream open(Path f, int bufferSize) throws IOException {
+      if (Util.VERSION_HINT_FILENAME.equals(f.getName())) {
+        versionHintOpenAttempts += 1;
+        if (versionHintOpenAttempts < versionHintAvailableAfterAttempt) {
+          throw new FileNotFoundException(f.toString());
+        }
+      }
+
+      byte[] content = files.get(f.getName());
+      if (content == null) {
+        throw new FileNotFoundException(f.toString());
+      }
+
+      return new FSDataInputStream(new ByteArrayFSInputStream(content));
+    }
+
+    @Override
+    public FSDataOutputStream create(
+        Path f,
+        FsPermission permission,
+        boolean overwrite,
+        int bufferSize,
+        short replication,
+        long blockSize,
+        Progressable progress) {
+      throw new UnsupportedOperationException("create is not used");
+    }
+
+    @Override
+    public FSDataOutputStream append(Path f, int bufferSize, Progressable progress) {
+      throw new UnsupportedOperationException("append is not used");
+    }
+
+    @Override
+    public boolean rename(Path src, Path dst) {
+      throw new UnsupportedOperationException("rename is not used");
+    }
+
+    @Override
+    public boolean delete(Path f, boolean recursive) {
+      throw new UnsupportedOperationException("delete is not used");
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path f, PathFilter filter) {
+      listStatusCalls += 1;
+      return files.keySet().stream()
+          .filter(name -> name.startsWith("v"))
+          .map(TestingFileSystem::fileStatus)
+          .filter(status -> filter.accept(status.getPath()))
+          .toArray(FileStatus[]::new);
+    }
+
+    @Override
+    public FileStatus[] listStatus(Path f) {
+      return listStatus(f, path -> true);
+    }
+
+    @Override
+    public void setWorkingDirectory(Path newDir) {}
+
+    @Override
+    public Path getWorkingDirectory() {
+      return new Path("test:/");
+    }
+
+    @Override
+    public boolean mkdirs(Path f, FsPermission permission) {
+      throw new UnsupportedOperationException("mkdirs is not used");
+    }
+
+    @Override
+    public boolean exists(Path f) throws IOException {
+      if ("metadata".equals(f.getName())) {
+        metadataRootExistsCalls += 1;
+        if (metadataRootExistsCalls > failMetadataRootExistsAfterCall) {
+          throw new IOException("Injected metadata root exists failure");
+        }
+      }
+
+      return files.containsKey(f.getName());
+    }
+
+    @Override
+    public FileStatus getFileStatus(Path f) throws IOException {
+      if (!exists(f)) {
+        throw new FileNotFoundException(f.toString());
+      }
+
+      return fileStatus(f.getName());
+    }
+
+    private static FileStatus fileStatus(String name) {
+      return new FileStatus(0L, false, 1, 0L, 0L, new Path("test:/table/metadata/" + name));
+    }
+  }
+
+  private static class ByteArrayFSInputStream extends FSInputStream {
+    private final ByteArrayInputStream delegate;
+
+    private ByteArrayFSInputStream(byte[] bytes) {
+      this.delegate = new ByteArrayInputStream(bytes);
+    }
+
+    @Override
+    public void seek(long pos) {
+      delegate.reset();
+      delegate.skip(pos);
+    }
+
+    @Override
+    public long getPos() {
+      return 0;
+    }
+
+    @Override
+    public boolean seekToNewSource(long targetPos) {
+      return false;
+    }
+
+    @Override
+    public int read() {
+      return delegate.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) {
+      return delegate.read(b, off, len);
+    }
+  }
+}

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -112,6 +112,20 @@ Notes:
 
 See the [Encryption](encryption.md) document for additional details.
 
+### Hadoop configuration properties
+
+These properties are set in the Hadoop configuration used by `HadoopCatalog` or `HadoopTables`.
+When using Spark, they can be set with `spark.hadoop.*` or catalog-specific
+`spark.sql.catalog._catalog-name_.hadoop.*` configuration.
+They must be set before a table is loaded and cannot be set as table properties.
+
+| Property                                                 | Default | Description                                                                                  |
+| -------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| iceberg.version-hint.retry.num-retries                   | 2       | Number of times to retry reading `version-hint.text` before falling back to metadata listing |
+| iceberg.version-hint.retry.min-wait-ms                   | 100     | Minimum wait in milliseconds before retrying `version-hint.text`; doubles after each retry up to the max wait |
+| iceberg.version-hint.retry.max-wait-ms                   | 800     | Maximum wait in milliseconds between retries when reading `version-hint.text` |
+| iceberg.version-hint.retry.total-timeout-ms              | 2000    | Total timeout in milliseconds for retrying `version-hint.text` before falling back to metadata listing |
+
 ### Table behavior properties
 
 | Property                           | Default          | Description                                                   |


### PR DESCRIPTION
## Summary

Retry reading Hadoop `version-hint.text` briefly before falling back to scanning the metadata directory.

## Problem

`HadoopTableOperations` updates `version-hint.text` as a best-effort pointer after committing a new metadata file. On object stores such as OSS/S3/GCS, the delete/rename sequence can make the hint file briefly unavailable or not yet visible to readers.

A transient read failure currently falls back immediately to listing the metadata directory, which can be significantly more expensive for tables with many metadata files.

## Fix

Add configurable Hadoop configuration retries for reading `version-hint.text` before metadata directory listing.

Defaults:

```text
iceberg.version-hint.retry.num-retries = 2
iceberg.version-hint.retry.min-wait-ms = 100
iceberg.version-hint.retry.max-wait-ms = 800
iceberg.version-hint.retry.total-timeout-ms = 2000
```

The retry uses Iceberg's `Tasks` utility with capped exponential backoff and only retries `IOException`. Corrupt hint parse failures fall back to metadata listing without retrying.

If the metadata directory does not exist, `findVersion()` keeps the existing fast path and returns `0` without retrying. If retry sleep is interrupted, the interrupt is surfaced instead of falling through to metadata listing.

These keys are Hadoop configuration keys and must be set before table load; they cannot be set as table properties. They intentionally avoid the `iceberg.hadoop.*` prefix to prevent ambiguity with integrations that use `iceberg.hadoop.*` as a pass-through prefix.

## Test plan

```bash
git diff --check
./gradlew :iceberg-core:spotlessJavaCheck :iceberg-core:checkstyleMain :iceberg-core:checkstyleTest :iceberg-core:test --tests org.apache.iceberg.hadoop.TestHadoopTableOperations -x :iceberg-parquet:compileJava
```
