### PR TITLE
Core: Include row lineage and key-id in snapshot value methods

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -340,7 +340,10 @@ class BaseSnapshot implements Snapshot {
           && Objects.equal(this.parentId, other.parentId())
           && this.sequenceNumber == other.sequenceNumber()
           && this.timestampMillis == other.timestampMillis()
-          && Objects.equal(this.schemaId, other.schemaId());
+          && Objects.equal(this.schemaId, other.schemaId())
+          && Objects.equal(this.firstRowId, other.firstRowId())
+          && Objects.equal(this.addedRows, other.addedRows())
+          && Objects.equal(this.keyId, other.keyId());
     }
 
     return false;
@@ -349,7 +352,14 @@ class BaseSnapshot implements Snapshot {
   @Override
   public int hashCode() {
     return Objects.hashCode(
-        this.snapshotId, this.parentId, this.sequenceNumber, this.timestampMillis, this.schemaId);
+        this.snapshotId,
+        this.parentId,
+        this.sequenceNumber,
+        this.timestampMillis,
+        this.schemaId,
+        this.firstRowId,
+        this.addedRows,
+        this.keyId);
   }
 
   @Override
@@ -361,6 +371,9 @@ class BaseSnapshot implements Snapshot {
         .add("summary", summary)
         .add("manifest-list", manifestListLocation)
         .add("schema-id", schemaId)
+        .add("first-row-id", firstRowId)
+        .add("added-rows", addedRows)
+        .add("key-id", keyId)
         .toString();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshot.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshot.java
@@ -31,6 +31,36 @@ import org.junit.jupiter.api.extension.ExtendWith;
 public class TestSnapshot extends TestBase {
 
   @TestTemplate
+  public void snapshotValueMethodsIncludeMetadataFields() {
+    Snapshot snapshot =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, 5L, "key-1");
+    Snapshot same =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, 5L, "key-1");
+    Snapshot differentFirstRowId =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 11L, 5L, "key-1");
+    Snapshot differentAddedRows =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, 6L, "key-1");
+    Snapshot differentKeyId =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", 10L, 5L, "key-2");
+    Snapshot withoutMetadataFields =
+        new BaseSnapshot(
+            0, 1, null, 0, DataOperations.APPEND, null, 1, "ml.avro", null, null, null);
+
+    assertThat(snapshot).isEqualTo(same);
+    assertThat(snapshot.hashCode()).isEqualTo(same.hashCode());
+    assertThat(snapshot).isNotEqualTo(differentFirstRowId);
+    assertThat(snapshot).isNotEqualTo(differentAddedRows);
+    assertThat(snapshot).isNotEqualTo(differentKeyId);
+    assertThat(snapshot).isNotEqualTo(withoutMetadataFields);
+    assertThat(snapshot.toString()).contains("first-row-id=10", "added-rows=5", "key-id=key-1");
+  }
+
+  @TestTemplate
   public void testAppendFilesFromTable() {
     table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
 


### PR DESCRIPTION
## Summary

`BaseSnapshot.equals`, `hashCode`, and `toString` now include the snapshot row-lineage fields `firstRowId` and `addedRows`, plus the manifest-list encryption `keyId`.

This keeps snapshot comparisons and hashes aligned with metadata that changes row ID assignment or encrypted manifest-list key selection. It also makes those values visible in snapshot debug output.

The regression coverage is in `TestSnapshot`, alongside the snapshot behavior tests.

## Testing

- `env GRADLE_USER_HOME=/tmp/gradle ./gradlew :iceberg-core:test --tests org.apache.iceberg.TestSnapshot.snapshotValueMethodsIncludeMetadataFields --console=plain`
- `env GRADLE_USER_HOME=/tmp/gradle ./gradlew :iceberg-core:spotlessJavaCheck --console=plain`
- `git diff --check`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Update Apache Iceberg snapshot value methods to include row-lineage metadata and manifest-list key IDs, with focused snapshot test coverage.
