### PR TITLE
Spark: Apply extra snapshot properties to DELETE operations

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkSQLProperties.java
@@ -56,6 +56,9 @@ public class SparkSQLProperties {
   // When set, new snapshots will be committed to this branch.
   public static final String WAP_BRANCH = "spark.wap.branch";
 
+  // Controls custom snapshot properties from session configuration.
+  public static final String SNAPSHOT_PROPERTY_PREFIX = "spark.sql.iceberg.snapshot-property.";
+
   // Controls write compress options
   public static final String COMPRESSION_CODEC = "spark.sql.iceberg.compression-codec";
   public static final String COMPRESSION_LEVEL = "spark.sql.iceberg.compression-level";

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -51,12 +51,14 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.sql.RuntimeConfig;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.connector.write.RowLevelOperation.Command;
 import org.apache.spark.sql.internal.SQLConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import scala.collection.JavaConverters;
 
 /**
  * A class for common Iceberg configs for Spark writes.
@@ -272,13 +274,15 @@ public class SparkWriteConf {
   public Map<String, String> extraSnapshotMetadata() {
     Map<String, String> extraSnapshotMetadata = Maps.newHashMap();
 
-    writeOptions.forEach(
-        (key, value) -> {
-          if (key.startsWith(SnapshotSummary.EXTRA_METADATA_PREFIX)) {
-            extraSnapshotMetadata.put(
-                key.substring(SnapshotSummary.EXTRA_METADATA_PREFIX.length()), value);
-          }
-        });
+    // Add session configuration properties with SNAPSHOT_PROPERTY_PREFIX if necessary
+    extraSnapshotMetadata.putAll(
+        PropertyUtil.propertiesWithPrefix(
+            JavaConverters.mapAsJavaMap(sessionConf.getAll()),
+            SparkSQLProperties.SNAPSHOT_PROPERTY_PREFIX));
+
+    // Add write options, overriding session configuration if necessary
+    extraSnapshotMetadata.putAll(
+        PropertyUtil.propertiesWithPrefix(writeOptions, SnapshotSummary.EXTRA_METADATA_PREFIX));
 
     return extraSnapshotMetadata;
   }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -62,6 +62,7 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
+import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.SparkSession;
@@ -426,6 +427,10 @@ public class SparkTable
     if (writeBranch != null) {
       deleteFiles.toBranch(writeBranch);
     }
+
+    new SparkWriteConf(sparkSession(), icebergTable, Maps.newHashMap())
+        .extraSnapshotMetadata()
+        .forEach(deleteFiles::set);
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
       CommitMetadata.commitProperties().forEach(deleteFiles::set);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -51,9 +51,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
@@ -640,7 +642,11 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
         () -> {
           sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
           Table table = validationCatalog.loadTable(tableIdent);
-          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+          Snapshot snapshot = table.currentSnapshot();
+          assertThat(snapshot.summary()).containsEntry("test-key", "test-value");
+          assertThat(snapshot.operation()).isEqualTo(DataOperations.DELETE);
+          assertThat(snapshot.summary()).doesNotContainKey("added-data-files");
+          assertThat(snapshot.summary()).containsKey("deleted-data-files");
         });
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -629,6 +629,21 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
         });
   }
 
+  @TestTemplate
+  public void testExtraSnapshotMetadataOnMetadataOnlyDelete() {
+    sql(
+        "INSERT INTO %s VALUES (1, 'a', DATE '2021-01-01', TIMESTAMP '2021-01-01 00:00:00')",
+        tableName);
+
+    withSQLConf(
+        ImmutableMap.of("spark.sql.iceberg.snapshot-property.test-key", "test-value"),
+        () -> {
+          sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
+          Table table = validationCatalog.loadTable(tableIdent);
+          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+        });
+  }
+
   private void checkMode(DistributionMode expectedMode, SparkWriteConf writeConf) {
     assertThat(writeConf.distributionMode()).isEqualTo(expectedMode);
     assertThat(writeConf.copyOnWriteDistributionMode(DELETE)).isEqualTo(expectedMode);

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -63,6 +63,7 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
+import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SnapshotUtil;
 import org.apache.spark.sql.SparkSession;
@@ -468,6 +469,10 @@ public class SparkTable
     if (writeBranch != null) {
       deleteFiles.toBranch(writeBranch);
     }
+
+    new SparkWriteConf(sparkSession(), icebergTable, Maps.newHashMap())
+        .extraSnapshotMetadata()
+        .forEach(deleteFiles::set);
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
       CommitMetadata.commitProperties().forEach(deleteFiles::set);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -771,4 +771,19 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
     assertThat(writeProperties).containsEntry(PARQUET_SHRED_VARIANTS, "true");
     assertThat(writeProperties).containsEntry(TableProperties.PARQUET_VARIANT_BUFFER_SIZE, "200");
   }
+
+  @TestTemplate
+  public void testExtraSnapshotMetadataOnMetadataOnlyDelete() {
+    sql(
+        "INSERT INTO %s VALUES (1, 'a', DATE '2021-01-01', TIMESTAMP '2021-01-01 00:00:00')",
+        tableName);
+
+    withSQLConf(
+        ImmutableMap.of("spark.sql.iceberg.snapshot-property.test-key", "test-value"),
+        () -> {
+          sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
+          Table table = validationCatalog.loadTable(tableIdent);
+          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+        });
+  }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -52,9 +52,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
@@ -783,7 +785,11 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
         () -> {
           sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
           Table table = validationCatalog.loadTable(tableIdent);
-          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+          Snapshot snapshot = table.currentSnapshot();
+          assertThat(snapshot.summary()).containsEntry("test-key", "test-value");
+          assertThat(snapshot.operation()).isEqualTo(DataOperations.DELETE);
+          assertThat(snapshot.summary()).doesNotContainKey("added-data-files");
+          assertThat(snapshot.summary()).containsKey("deleted-data-files");
         });
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkTable.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.spark.SparkV2Filters;
+import org.apache.iceberg.spark.SparkWriteConf;
 import org.apache.iceberg.spark.TimeTravel;
 import org.apache.iceberg.spark.TimeTravel.AsOfTimestamp;
 import org.apache.iceberg.spark.TimeTravel.AsOfVersion;
@@ -282,6 +283,8 @@ public class SparkTable extends BaseSparkTable
     if (writeBranch != null) {
       deleteFiles.toBranch(writeBranch);
     }
+
+    new SparkWriteConf(spark(), table()).extraSnapshotMetadata().forEach(deleteFiles::set);
 
     if (!CommitMetadata.commitProperties().isEmpty()) {
       CommitMetadata.commitProperties().forEach(deleteFiles::set);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -52,9 +52,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.DataOperations;
 import org.apache.iceberg.DistributionMode;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateProperties;
@@ -794,7 +796,11 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
         () -> {
           sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
           Table table = validationCatalog.loadTable(tableIdent);
-          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+          Snapshot snapshot = table.currentSnapshot();
+          assertThat(snapshot.summary()).containsEntry("test-key", "test-value");
+          assertThat(snapshot.operation()).isEqualTo(DataOperations.DELETE);
+          assertThat(snapshot.summary()).doesNotContainKey("added-data-files");
+          assertThat(snapshot.summary()).containsKey("deleted-data-files");
         });
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestSparkWriteConf.java
@@ -782,4 +782,19 @@ public class TestSparkWriteConf extends TestBaseWithCatalog {
     assertThat(writeProperties).containsEntry(PARQUET_SHRED_VARIANTS, "true");
     assertThat(writeProperties).containsEntry(TableProperties.PARQUET_VARIANT_BUFFER_SIZE, "200");
   }
+
+  @TestTemplate
+  public void testExtraSnapshotMetadataOnMetadataOnlyDelete() {
+    sql(
+        "INSERT INTO %s VALUES (1, 'a', DATE '2021-01-01', TIMESTAMP '2021-01-01 00:00:00')",
+        tableName);
+
+    withSQLConf(
+        ImmutableMap.of("spark.sql.iceberg.snapshot-property.test-key", "test-value"),
+        () -> {
+          sql("DELETE FROM %s WHERE date = DATE '2021-01-01'", tableName);
+          Table table = validationCatalog.loadTable(tableIdent);
+          assertThat(table.currentSnapshot().summary()).containsEntry("test-key", "test-value");
+        });
+  }
 }


### PR DESCRIPTION
Propagates the configured extra snapshot properties (`SparkWriteConf.extraSnapshotMetadata()`) to the `DeleteFiles` operation in `SparkTable.deleteWhere`, mirroring the write path in `SparkWrite`, so metadata-only DELETEs carry the user's `snapshot-property.*` session-config metadata in the resulting snapshot summary (previously they were dropped).

Applied to Spark v3.5, v4.0, and v4.1. For v3.5, `SparkWriteConf.extraSnapshotMetadata()` is also brought to parity with v4.0/v4.1 (reads session config in addition to write options), since `deleteWhere` has no write-options injection point and session config is the only mechanism available to inject snapshot properties on a metadata-only delete.

Note: this v3.5 parity change also affects the normal v3.5 write path, not just `deleteWhere`. v3.5 writes now honor `spark.sql.iceberg.snapshot-property.*` session config, which they previously ignored (v3.5 previously read extra snapshot properties only from per-write `snapshot-property.*` options). v4.0/v4.1 already behaved this way, so this aligns v3.5 with them.

Tests: per-version cases set a `snapshot-property.*` session config, run a partition-aligned metadata-only DELETE, and assert the property appears in the snapshot summary.

Closes #15060.

---
AI assistance: authored with assistance by Claude Opus 4.8. I understand the change end-to-end and have verified it locally (per-version tests green; spotless and checkstyle clean).

