### PR TITLE
Arrow: Fix vectorized read of all-null DELTA-encoded Parquet pages

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaEncodedValuesReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/parquet/VectorizedDeltaEncodedValuesReader.java
@@ -149,7 +149,7 @@ public class VectorizedDeltaEncodedValuesReader extends ValuesReader
     int remaining = total;
     int currentRowId = rowId;
     // First value
-    if (valuesRead == 0) {
+    if (valuesRead == 0 && total > 0) {
       outputWriter.write(vec, ((long) (currentRowId + valuesRead) * typeWidth), firstValue);
       lastValueRead = firstValue;
       currentRowId++;

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -65,6 +65,7 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
@@ -254,6 +255,17 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
         .build();
   }
 
+  FileAppender<Record> parquetV2WriterWithoutDictionary(Schema schema, File testFile)
+      throws IOException {
+    return Parquet.write(Files.localOutput(testFile))
+        .schema(schema)
+        .createWriterFunc(GenericParquetWriter::create)
+        .named("test")
+        .writerVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+        .set(ParquetOutputFormat.ENABLE_DICTIONARY, "false")
+        .build();
+  }
+
   void assertRecordsMatch(
       Schema schema,
       int expectedSize,
@@ -428,6 +440,37 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       writer.addAll(data);
     }
     assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE);
+  }
+
+  @Test
+  public void testAllNullStringAndBinaryColumnsParquetV2() throws Exception {
+    // V2 string/binary uses DELTA_BYTE_ARRAY; an all-null page decodes to a delta length stream
+    // with totalValueCount == 0.
+    Schema schema =
+        new Schema(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "string_data", Types.StringType.get()),
+            optional(102, "binary_data", Types.BinaryType.get()));
+
+    int stringOrdinal = 1;
+    int binaryOrdinal = 2;
+    File dataFile = temp.resolve("all-null-v2.parquet").toFile();
+    Iterable<Record> data =
+        generateData(
+            schema,
+            100,
+            0L,
+            RandomData.DEFAULT_NULL_PERCENTAGE,
+            record -> {
+              record.set(stringOrdinal, null);
+              record.set(binaryOrdinal, null);
+              return record;
+            });
+    try (FileAppender<Record> writer = parquetV2WriterWithoutDictionary(schema, dataFile)) {
+      writer.addAll(data);
+    }
+
+    assertRecordsMatch(schema, 100, data, dataFile, false, BATCH_SIZE);
   }
 
   @Test

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -65,6 +65,7 @@ import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ParquetProperties;
+import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
@@ -254,6 +255,17 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
         .build();
   }
 
+  FileAppender<Record> parquetV2WriterWithoutDictionary(Schema schema, File testFile)
+      throws IOException {
+    return Parquet.write(Files.localOutput(testFile))
+        .schema(schema)
+        .createWriterFunc(GenericParquetWriter::create)
+        .named("test")
+        .writerVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+        .set(ParquetOutputFormat.ENABLE_DICTIONARY, "false")
+        .build();
+  }
+
   void assertRecordsMatch(
       Schema schema,
       int expectedSize,
@@ -428,6 +440,37 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       writer.addAll(data);
     }
     assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE);
+  }
+
+  @Test
+  public void testAllNullStringAndBinaryColumnsParquetV2() throws Exception {
+    // V2 string/binary uses DELTA_BYTE_ARRAY; an all-null page decodes to a delta length stream
+    // with totalValueCount == 0.
+    Schema schema =
+        new Schema(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "string_data", Types.StringType.get()),
+            optional(102, "binary_data", Types.BinaryType.get()));
+
+    int stringOrdinal = 1;
+    int binaryOrdinal = 2;
+    File dataFile = temp.resolve("all-null-v2.parquet").toFile();
+    Iterable<Record> data =
+        generateData(
+            schema,
+            100,
+            0L,
+            RandomData.DEFAULT_NULL_PERCENTAGE,
+            record -> {
+              record.set(stringOrdinal, null);
+              record.set(binaryOrdinal, null);
+              return record;
+            });
+    try (FileAppender<Record> writer = parquetV2WriterWithoutDictionary(schema, dataFile)) {
+      writer.addAll(data);
+    }
+
+    assertRecordsMatch(schema, 100, data, dataFile, false, BATCH_SIZE);
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -267,6 +267,17 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
         .build();
   }
 
+  FileAppender<Record> parquetV2WriterWithoutDictionary(Schema schema, File testFile)
+      throws IOException {
+    return Parquet.write(Files.localOutput(testFile))
+        .schema(schema)
+        .createWriterFunc(GenericParquetWriter::create)
+        .named("test")
+        .writerVersion(ParquetProperties.WriterVersion.PARQUET_2_0)
+        .set(ParquetOutputFormat.ENABLE_DICTIONARY, "false")
+        .build();
+  }
+
   void assertRecordsMatch(
       Schema schema,
       int expectedSize,
@@ -441,6 +452,37 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
       writer.addAll(data);
     }
     assertRecordsMatch(schema, 30000, data, dataFile, false, BATCH_SIZE);
+  }
+
+  @Test
+  public void testAllNullStringAndBinaryColumnsParquetV2() throws Exception {
+    // V2 string/binary uses DELTA_BYTE_ARRAY; an all-null page decodes to a delta length stream
+    // with totalValueCount == 0.
+    Schema schema =
+        new Schema(
+            required(100, "id", Types.LongType.get()),
+            optional(101, "string_data", Types.StringType.get()),
+            optional(102, "binary_data", Types.BinaryType.get()));
+
+    int stringOrdinal = 1;
+    int binaryOrdinal = 2;
+    File dataFile = temp.resolve("all-null-v2.parquet").toFile();
+    Iterable<Record> data =
+        generateData(
+            schema,
+            100,
+            0L,
+            RandomData.DEFAULT_NULL_PERCENTAGE,
+            record -> {
+              record.set(stringOrdinal, null);
+              record.set(binaryOrdinal, null);
+              return record;
+            });
+    try (FileAppender<Record> writer = parquetV2WriterWithoutDictionary(schema, dataFile)) {
+      writer.addAll(data);
+    }
+
+    assertRecordsMatch(schema, 100, data, dataFile, false, BATCH_SIZE);
   }
 
   @Test


### PR DESCRIPTION
## Problem

Vectorized reads of Parquet V2 files crash with `ArrayIndexOutOfBoundsException: Index 0 out of bounds for length 0` when a string/binary column page using `DELTA_BYTE_ARRAY` / `DELTA_LENGTH_BYTE_ARRAY` has zero non-null values (an all-null page).

```
at VectorizedDeltaEncodedValuesReader.lambda$readIntegers$3(VectorizedDeltaEncodedValuesReader.java:127)
at VectorizedDeltaEncodedValuesReader.readValues(VectorizedDeltaEncodedValuesReader.java:153)
at VectorizedDeltaEncodedValuesReader.readIntegers(VectorizedDeltaEncodedValuesReader.java:122)
```

## Cause

An all-null page decodes to a length stream with `totalValueCount == 0`. `readIntegers(0, …)` allocates a zero-length array, but `readValues` always wrote `firstValue` into `result[0]`.

## Fix

Skip the first-value write when `total == 0`.

## Test

Added a Spark vectorized-read test with all-null string and binary columns in a V2, dictionary-disabled file. It reproduces the crash before the fix and passes after.