### PR TITLE
Core: Preserve REST table session headers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Manager.java
@@ -160,7 +160,8 @@ public class OAuth2Manager implements AuthManager {
   @Override
   public AuthSession tableSession(RESTClient sharedClient, Map<String, String> properties) {
     AuthConfig config = AuthConfig.fromProperties(properties);
-    Map<String, String> headers = OAuth2Util.authHeaders(config.token());
+    Map<String, String> headers =
+        RESTUtil.merge(RESTUtil.configHeaders(properties), OAuth2Util.authHeaders(config.token()));
     OAuth2Util.AuthSession parent = new OAuth2Util.AuthSession(headers, config);
 
     keepRefreshed = config.keepRefreshed();

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Manager.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Manager.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.rest.RESTClient;
 import org.apache.iceberg.rest.responses.OAuthTokenResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 class TestOAuth2Manager {
@@ -478,6 +479,21 @@ class TestOAuth2Manager {
   }
 
   @Test
+  void standaloneTableSessionTokenProvidedWithCustomHeaders() {
+    Map<String, String> tableProperties =
+        Map.of(OAuth2Properties.TOKEN, "table-token", "header.Polaris-Realm", "tenant-a");
+    try (OAuth2Manager manager = new OAuth2Manager("test");
+        OAuth2Util.AuthSession tableSession =
+            (OAuth2Util.AuthSession) manager.tableSession(client, tableProperties)) {
+      assertThat(tableSession.headers())
+          .containsOnly(
+              entry("Authorization", "Bearer table-token"), entry("Polaris-Realm", "tenant-a"));
+    }
+    Mockito.verify(client).withAuthSession(any());
+    Mockito.verifyNoMoreInteractions(client);
+  }
+
+  @Test
   void standaloneTableSessionCredentialProvided() {
     Map<String, String> tableProperties = Map.of(OAuth2Properties.CREDENTIAL, "client:secret");
     try (OAuth2Manager manager = new OAuth2Manager("test");
@@ -491,6 +507,38 @@ class TestOAuth2Manager {
           .satisfies(cache -> assertThat(cache.sessionCache().asMap()).hasSize(1));
     }
     Mockito.verify(client).withAuthSession(any());
+    Mockito.verify(client)
+        .postForm(
+            any(),
+            eq(
+                Map.of(
+                    "grant_type", "client_credentials",
+                    "client_id", "client",
+                    "client_secret", "secret",
+                    "scope", "catalog")),
+            eq(OAuthTokenResponse.class),
+            eq(Map.of()),
+            any());
+    Mockito.verifyNoMoreInteractions(client);
+  }
+
+  @Test
+  void standaloneTableSessionCredentialProvidedWithCustomHeaders() {
+    Map<String, String> tableProperties =
+        Map.of(OAuth2Properties.CREDENTIAL, "client:secret", "header.Polaris-Realm", "tenant-a");
+    try (OAuth2Manager manager = new OAuth2Manager("test");
+        OAuth2Util.AuthSession tableSession =
+            (OAuth2Util.AuthSession) manager.tableSession(client, tableProperties)) {
+      assertThat(tableSession.headers())
+          .containsOnly(entry("Authorization", "Bearer test"), entry("Polaris-Realm", "tenant-a"));
+    }
+
+    ArgumentCaptor<AuthSession> parentSession = ArgumentCaptor.forClass(AuthSession.class);
+    Mockito.verify(client).withAuthSession(parentSession.capture());
+    assertThat(parentSession.getValue())
+        .isInstanceOfSatisfying(
+            OAuth2Util.AuthSession.class,
+            session -> assertThat(session.headers()).containsEntry("Polaris-Realm", "tenant-a"));
     Mockito.verify(client)
         .postForm(
             any(),


### PR DESCRIPTION
Fixes #17019.

This preserves custom REST `header.*` properties when creating standalone OAuth2 table sessions.

Previously `OAuth2Manager.tableSession` built the parent session only from the bearer token. For REST catalog deployments that rely on custom headers, such as Polaris realm headers for multi-tenant credential vending, the table-level token refresh path dropped those headers before calling the token endpoint.

This change merges configured REST headers with the OAuth2 auth header for the standalone table session parent. The existing auth header still wins if there is an overlap. The added tests cover both the provided-token path and the credential/token-fetch path, including the parent auth session used by the refresh client.

Tests:
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" ./gradlew :iceberg-core:test --tests org.apache.iceberg.rest.auth.TestOAuth2Manager`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) PATH="$JAVA_HOME/bin:$PATH" ./gradlew :iceberg-core:spotlessCheck`
- `git diff --check`

AI disclosure:
- Implemented with assistance from Codex, with manual review of the affected code path and local test execution before submission.
