### PR TITLE
Spark: Document broadcast size-map scaling in rewrite table action

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -327,6 +327,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Map<String, Long> rewrittenDeleteFileSizes = rewritePositionDeletes(deleteFilesToRewrite);
 
     // rebuild manifest files
+    // The size map holds one entry per distinct rewritten delete-file location. It is collected to
+    // the driver and broadcast to the manifest-rewrite tasks, so its footprint scales with the
+    // number of distinct delete files being rewritten rather than the table's total file count.
     RewriteContentFileResult rewriteManifestResult =
         rewriteManifests(
             deltaSnapshots,

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -327,6 +327,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Map<String, Long> rewrittenDeleteFileSizes = rewritePositionDeletes(deleteFilesToRewrite);
 
     // rebuild manifest files
+    // The size map holds one entry per distinct rewritten delete-file location. It is collected to
+    // the driver and broadcast to the manifest-rewrite tasks, so its footprint scales with the
+    // number of distinct delete files being rewritten rather than the table's total file count.
     RewriteContentFileResult rewriteManifestResult =
         rewriteManifests(
             deltaSnapshots,

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -327,6 +327,9 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Map<String, Long> rewrittenDeleteFileSizes = rewritePositionDeletes(deleteFilesToRewrite);
 
     // rebuild manifest files
+    // The size map holds one entry per distinct rewritten delete-file location. It is collected to
+    // the driver and broadcast to the manifest-rewrite tasks, so its footprint scales with the
+    // number of distinct delete files being rewritten rather than the table's total file count.
     RewriteContentFileResult rewriteManifestResult =
         rewriteManifests(
             deltaSnapshots,


### PR DESCRIPTION
## What changes are included in this PR?

Follow-up to #15470. That PR introduced a per-delete-file size map that is collected to the driver and broadcast to the manifest-rewrite tasks of `RewriteTablePathSparkAction`. During review I asked whether the broadcast map's memory footprint had been considered for delete-heavy tables ([review comment](https://github.com/apache/iceberg/pull/15470#pullrequestreview)).

This adds a short comment near the broadcast site documenting the scaling assumption: the map holds one entry per distinct rewritten delete-file location, so its footprint scales with the number of distinct delete files being rewritten rather than the table's total file count. No behavior change.

The comment is added identically to the v3.5, v4.0, and v4.1 Spark modules.

## How are these changes tested?

Comment-only change; no functional change, so no new tests.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Cursor
- Human Oversight: fully reviewed
- Prompt Summary: Add a comment documenting the broadcast size-map scaling assumption raised in review of #15470.