### PR TITLE
KafkaConnect: Add JMX metrics for commit pipeline

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -117,35 +117,37 @@ abstract class Channel {
   protected abstract boolean receive(Envelope envelope);
 
   protected void consumeAvailable(Duration pollDuration) {
-    long start = System.currentTimeMillis();
-    try {
-      ConsumerRecords<String, byte[]> records = consumer.poll(pollDuration);
-      while (!records.isEmpty()) {
-        records.forEach(
-            record -> {
-              // the consumer stores the offsets that corresponds to the next record to consume,
-              // so increment the record offset by one
-              controlTopicOffsets.put(record.partition(), record.offset() + 1);
+    // The blocking poll is intentionally left untimed here: the coordinator polls with a 1s
+    // duration so an idle poll would dominate the signal, and the poll is already covered by the
+    // Kafka consumer's own metrics. We time only the per-record decode and process steps.
+    ConsumerRecords<String, byte[]> records = consumer.poll(pollDuration);
+    while (!records.isEmpty()) {
+      records.forEach(
+          record -> {
+            // the consumer stores the offsets that corresponds to the next record to consume,
+            // so increment the record offset by one
+            controlTopicOffsets.put(record.partition(), record.offset() + 1);
 
-              Event event = AvroUtil.decode(record.value());
+            long readStart = System.nanoTime();
+            Event event = AvroUtil.decode(record.value());
+            getChannelMetrics().recordMessageRead((System.nanoTime() - readStart) / 1_000_000L);
 
-              if (event.groupId().equals(connectGroupId)) {
-                LOG.debug("Received event of type: {}", event.type().name());
-                if (receive(new Envelope(event, record.partition(), record.offset()))) {
-                  LOG.info("Handled event of type: {}", event.type().name());
-                }
+            if (event.groupId().equals(connectGroupId)) {
+              LOG.debug("Received event of type: {}", event.type().name());
+              long processStart = System.nanoTime();
+              boolean handled = receive(new Envelope(event, record.partition(), record.offset()));
+              getChannelMetrics()
+                  .recordMessageProcess((System.nanoTime() - processStart) / 1_000_000L);
+              if (handled) {
+                LOG.info("Handled event of type: {}", event.type().name());
               }
-            });
-        records = consumer.poll(pollDuration);
-      }
-    } finally {
-      recordConsumeTime(System.currentTimeMillis() - start);
+            }
+          });
+      records = consumer.poll(pollDuration);
     }
   }
 
-  protected void recordConsumeTime(long elapsedMs) {
-    // default no-op; subclasses override to forward to their metrics
-  }
+  protected abstract ChannelMetrics getChannelMetrics();
 
   protected Map<Integer, Long> controlTopicOffsets() {
     return controlTopicOffsets;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -130,14 +130,13 @@ abstract class Channel {
 
             long readStart = System.nanoTime();
             Event event = AvroUtil.decode(record.value());
-            getChannelMetrics().recordMessageRead((System.nanoTime() - readStart) / 1_000_000L);
+            getChannelMetrics().recordMessageRead((System.nanoTime() - readStart) / 1_000L);
 
             if (event.groupId().equals(connectGroupId)) {
               LOG.debug("Received event of type: {}", event.type().name());
               long processStart = System.nanoTime();
               boolean handled = receive(new Envelope(event, record.partition(), record.offset()));
-              getChannelMetrics()
-                  .recordMessageProcess((System.nanoTime() - processStart) / 1_000_000L);
+              getChannelMetrics().recordMessageProcess((System.nanoTime() - processStart) / 1_000L);
               if (handled) {
                 LOG.info("Handled event of type: {}", event.type().name());
               }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -117,25 +117,34 @@ abstract class Channel {
   protected abstract boolean receive(Envelope envelope);
 
   protected void consumeAvailable(Duration pollDuration) {
-    ConsumerRecords<String, byte[]> records = consumer.poll(pollDuration);
-    while (!records.isEmpty()) {
-      records.forEach(
-          record -> {
-            // the consumer stores the offsets that corresponds to the next record to consume,
-            // so increment the record offset by one
-            controlTopicOffsets.put(record.partition(), record.offset() + 1);
+    long start = System.currentTimeMillis();
+    try {
+      ConsumerRecords<String, byte[]> records = consumer.poll(pollDuration);
+      while (!records.isEmpty()) {
+        records.forEach(
+            record -> {
+              // the consumer stores the offsets that corresponds to the next record to consume,
+              // so increment the record offset by one
+              controlTopicOffsets.put(record.partition(), record.offset() + 1);
 
-            Event event = AvroUtil.decode(record.value());
+              Event event = AvroUtil.decode(record.value());
 
-            if (event.groupId().equals(connectGroupId)) {
-              LOG.debug("Received event of type: {}", event.type().name());
-              if (receive(new Envelope(event, record.partition(), record.offset()))) {
-                LOG.info("Handled event of type: {}", event.type().name());
+              if (event.groupId().equals(connectGroupId)) {
+                LOG.debug("Received event of type: {}", event.type().name());
+                if (receive(new Envelope(event, record.partition(), record.offset()))) {
+                  LOG.info("Handled event of type: {}", event.type().name());
+                }
               }
-            }
-          });
-      records = consumer.poll(pollDuration);
+            });
+        records = consumer.poll(pollDuration);
+      }
+    } finally {
+      recordConsumeTime(System.currentTimeMillis() - start);
     }
+  }
+
+  protected void recordConsumeTime(long elapsedMs) {
+    // default no-op; subclasses override to forward to their metrics
   }
 
   protected Map<Integer, Long> controlTopicOffsets() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
@@ -67,10 +67,14 @@ abstract class ChannelMetrics implements AutoCloseable {
     try {
       this.messageReadTime =
           createTimerSensor(
-              "channel-message-read-time", "Time to Avro-decode one control message in ms", tags);
+              "channel-message-read-time",
+              "Time to Avro-decode one control message in microseconds",
+              tags);
       this.messageProcessTime =
           createTimerSensor(
-              "channel-message-process-time", "Time to process one control message in ms", tags);
+              "channel-message-process-time",
+              "Time to process one control message in microseconds",
+              tags);
     } catch (RuntimeException e) {
       closeQuietly(e);
       throw e;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base for the per-task/per-connector JMX metric registries. Owns the {@link Metrics} registry, the
+ * sensor-creation helpers shared by the worker and coordinator, and the two channel-level timers
+ * that every {@link Channel} feeds while draining the control topic.
+ */
+abstract class ChannelMetrics implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ChannelMetrics.class);
+
+  /** JMX domain; dotted to sit alongside Kafka's own {@code kafka.connect.*} beans in jconsole. */
+  static final String NAMESPACE = "iceberg.kafka.connect";
+
+  private final Metrics metrics;
+  private final String group;
+
+  private final Sensor messageReadTime;
+  private final Sensor messageProcessTime;
+
+  ChannelMetrics(String group, String connector, String task) {
+    this.group = group;
+    this.metrics =
+        new Metrics(
+            new MetricConfig(),
+            Collections.singletonList(new JmxReporter()),
+            Time.SYSTEM,
+            new KafkaMetricsContext(NAMESPACE));
+    Map<String, String> tags = metricTags(connector, task, null);
+    try {
+      this.messageReadTime =
+          createTimerSensor(
+              "channel-message-read-time", "Time to Avro-decode one control message in ms", tags);
+      this.messageProcessTime =
+          createTimerSensor(
+              "channel-message-process-time", "Time to process one control message in ms", tags);
+    } catch (RuntimeException e) {
+      closeQuietly(e);
+      throw e;
+    }
+  }
+
+  void recordMessageRead(long elapsedMs) {
+    messageReadTime.record((double) elapsedMs);
+  }
+
+  void recordMessageProcess(long elapsedMs) {
+    messageProcessTime.record((double) elapsedMs);
+  }
+
+  @Override
+  public void close() {
+    try {
+      metrics.close();
+    } catch (Exception e) {
+      LOG.warn("Error closing {}", getClass().getSimpleName(), e);
+    }
+  }
+
+  /**
+   * Closes the registry while an in-flight constructor failure is unwinding, to avoid MBean leaks.
+   */
+  protected void closeQuietly(RuntimeException failure) {
+    try {
+      metrics.close();
+    } catch (Exception suppressed) {
+      failure.addSuppressed(suppressed);
+    }
+  }
+
+  /** Registers a lazily-evaluated gauge that reads {@code supplier} each time JMX polls it. */
+  protected void addGauge(
+      String name, String description, Map<String, String> tags, Supplier<Long> supplier) {
+    metrics.addMetric(
+        new MetricName(name, group, description, tags),
+        (Gauge<Long>) (config, now) -> supplier.get());
+  }
+
+  protected Sensor createTimerSensor(
+      String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = metrics.sensor(sensorName(baseName, tags));
+    sensor.add(new MetricName(baseName + "-avg", group, description + " (avg)", tags), new Avg());
+    sensor.add(new MetricName(baseName + "-max", group, description + " (max)", tags), new Max());
+    sensor.add(
+        new MetricName(baseName + "-total", group, description + " (total)", tags),
+        new CumulativeSum());
+    sensor.add(
+        new MetricName(baseName + "-count", group, description + " (count)", tags),
+        new CumulativeCount());
+    return sensor;
+  }
+
+  protected Sensor createCounterSensor(
+      String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = metrics.sensor(sensorName(baseName, tags));
+    sensor.add(new MetricName(baseName + "-total", group, description, tags), new CumulativeSum());
+    return sensor;
+  }
+
+  /**
+   * Builds the JMX tag map shared by worker and coordinator metrics. {@code commitMode} is only set
+   * on the coordinator's per-commit sensors ({@code full}/{@code partial}); pass {@code null} to
+   * omit it.
+   */
+  static Map<String, String> metricTags(String connector, String task, String commitMode) {
+    Map<String, String> tags = new LinkedHashMap<>();
+    tags.put("connector", connector);
+    tags.put("task", task);
+    if (commitMode != null) {
+      tags.put("commitMode", commitMode);
+    }
+    return tags;
+  }
+
+  // Sensor registry names are global per Metrics instance, so distinct tag sets (e.g. the
+  // partial/full commit timers) need distinct sensor names to avoid clobbering each other.
+  private static String sensorName(String baseName, Map<String, String> tags) {
+    StringBuilder sb = new StringBuilder(baseName);
+    tags.forEach((k, v) -> sb.append('.').append(k).append('.').append(v));
+    return sb.toString();
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/ChannelMetrics.java
@@ -29,10 +29,8 @@ import org.apache.kafka.common.metrics.KafkaMetricsContext;
 import org.apache.kafka.common.metrics.MetricConfig;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
 import org.apache.kafka.common.metrics.stats.CumulativeCount;
 import org.apache.kafka.common.metrics.stats.CumulativeSum;
-import org.apache.kafka.common.metrics.stats.Max;
 import org.apache.kafka.common.utils.Time;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,8 +47,13 @@ abstract class ChannelMetrics implements AutoCloseable {
   /** JMX domain; dotted to sit alongside Kafka's own {@code kafka.connect.*} beans in jconsole. */
   static final String NAMESPACE = "iceberg.kafka.connect";
 
-  private final Metrics metrics;
   private final String group;
+  private final Object closeLock = new Object();
+
+  // Nulled out by the first close() so a second close cannot unregister MBeans that a replacement
+  // instance (e.g. a newly elected coordinator in the same JVM) has since registered under the same
+  // ObjectName. Only written under closeLock; volatile so readers see the null without locking.
+  private volatile Metrics metrics;
 
   private final Sensor messageReadTime;
   private final Sensor messageProcessTime;
@@ -81,18 +84,31 @@ abstract class ChannelMetrics implements AutoCloseable {
     }
   }
 
-  void recordMessageRead(long elapsedMs) {
-    messageReadTime.record((double) elapsedMs);
+  void recordMessageRead(long elapsedMicros) {
+    messageReadTime.record((double) elapsedMicros);
   }
 
-  void recordMessageProcess(long elapsedMs) {
-    messageProcessTime.record((double) elapsedMs);
+  void recordMessageProcess(long elapsedMicros) {
+    messageProcessTime.record((double) elapsedMicros);
   }
 
+  /**
+   * Closes the underlying registry, unregistering its MBeans. Idempotent: callers may close from
+   * more than one shutdown path (the coordinator closes from both {@code terminate()} and {@code
+   * stop()}) and only the first call unregisters anything.
+   */
   @Override
   public void close() {
+    Metrics toClose;
+    synchronized (closeLock) {
+      toClose = metrics;
+      this.metrics = null;
+    }
+    if (toClose == null) {
+      return;
+    }
     try {
-      metrics.close();
+      toClose.close();
     } catch (Exception e) {
       LOG.warn("Error closing {}", getClass().getSimpleName(), e);
     }
@@ -102,8 +118,16 @@ abstract class ChannelMetrics implements AutoCloseable {
    * Closes the registry while an in-flight constructor failure is unwinding, to avoid MBean leaks.
    */
   protected void closeQuietly(RuntimeException failure) {
+    Metrics toClose;
+    synchronized (closeLock) {
+      toClose = metrics;
+      this.metrics = null;
+    }
+    if (toClose == null) {
+      return;
+    }
     try {
-      metrics.close();
+      toClose.close();
     } catch (Exception suppressed) {
       failure.addSuppressed(suppressed);
     }
@@ -117,16 +141,21 @@ abstract class ChannelMetrics implements AutoCloseable {
         (Gauge<Long>) (config, now) -> supplier.get());
   }
 
+  /**
+   * Creates a timer sensor reporting a cumulative total and a cumulative sample count. Both stats
+   * are cumulative on purpose: the sampled {@code Avg}/{@code Max} stats only cover the default 30s
+   * x 2 sample window, which is far shorter than a typical commit interval, so they would read NaN
+   * most of the time. A consumer can derive an average or a rate from the total and the count.
+   */
   protected Sensor createTimerSensor(
       String baseName, String description, Map<String, String> tags) {
     Sensor sensor = metrics.sensor(sensorName(baseName, tags));
-    sensor.add(new MetricName(baseName + "-avg", group, description + " (avg)", tags), new Avg());
-    sensor.add(new MetricName(baseName + "-max", group, description + " (max)", tags), new Max());
     sensor.add(
-        new MetricName(baseName + "-total", group, description + " (total)", tags),
+        new MetricName(baseName + "-total", group, description + " (cumulative total)", tags),
         new CumulativeSum());
     sensor.add(
-        new MetricName(baseName + "-count", group, description + " (count)", tags),
+        new MetricName(
+            baseName + "-count", group, description + " (number of sampled points)", tags),
         new CumulativeCount());
     return sensor;
   }
@@ -148,7 +177,7 @@ abstract class ChannelMetrics implements AutoCloseable {
     tags.put("connector", connector);
     tags.put("task", task);
     if (commitMode != null) {
-      tags.put("commitMode", commitMode);
+      tags.put("commit-mode", commitMode);
     }
     return tags;
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitState.java
@@ -102,6 +102,14 @@ class CommitState {
     commitBuffer.clear();
   }
 
+  int commitBufferSize() {
+    return commitBuffer.size();
+  }
+
+  int readyBufferSize() {
+    return readyBuffer.size();
+  }
+
   boolean isCommitTimedOut() {
     if (!isCommitInProgress()) {
       return false;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -205,7 +205,7 @@ class Coordinator extends Channel {
           e);
     } finally {
       commitState.endCurrentCommit();
-      coordinatorMetrics.recordCommit(partialCommit, (System.nanoTime() - start) / 1_000_000L);
+      coordinatorMetrics.recordCommit(partialCommit, (System.nanoTime() - start) / 1_000L);
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -143,8 +143,8 @@ class Coordinator extends Channel {
   }
 
   @Override
-  protected void recordConsumeTime(long elapsedMs) {
-    coordinatorMetrics.recordConsume(elapsedMs);
+  protected ChannelMetrics getChannelMetrics() {
+    return coordinatorMetrics;
   }
 
   @Override
@@ -164,7 +164,7 @@ class Coordinator extends Channel {
   }
 
   private void commit(boolean partialCommit) {
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     try {
       doCommit(partialCommit);
       if (!partialCommit) {
@@ -205,7 +205,7 @@ class Coordinator extends Channel {
           e);
     } finally {
       commitState.endCurrentCommit();
-      coordinatorMetrics.recordCommit(System.currentTimeMillis() - start);
+      coordinatorMetrics.recordCommit(partialCommit, (System.nanoTime() - start) / 1_000_000L);
     }
   }
 
@@ -453,8 +453,15 @@ class Coordinator extends Channel {
       }
     } catch (InterruptedException e) {
       throw new ConnectException("Interrupted while waiting for coordinator shutdown", e);
-    } finally {
-      coordinatorMetrics.close();
     }
+  }
+
+  @Override
+  void stop() {
+    // stop() runs at the very end of the CoordinatorThread run loop, after process() (and any
+    // commit() recording) can no longer fire, so closing the registry here avoids racing a
+    // record* call against a closed Metrics instance.
+    super.stop();
+    coordinatorMetrics.close();
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -82,6 +82,7 @@ class Coordinator extends Channel {
   private final String snapshotOffsetsProp;
   private final ExecutorService exec;
   private final CommitState commitState;
+  private final CoordinatorMetrics coordinatorMetrics;
   private final AtomicLong partialCommitFailures = new AtomicLong();
   private volatile boolean terminated;
   private final String taskId;
@@ -116,6 +117,11 @@ class Coordinator extends Channel {
                 .build());
     this.commitState = new CommitState(config);
     this.taskId = config.connectorName() + "-" + config.taskId();
+    this.coordinatorMetrics =
+        new CoordinatorMetrics(
+            config.connectorName(),
+            () -> (long) commitState.commitBufferSize(),
+            () -> (long) commitState.readyBufferSize());
   }
 
   void process() {
@@ -125,6 +131,7 @@ class Coordinator extends Channel {
       Event event =
           new Event(config.connectGroupId(), new StartCommit(commitState.currentCommitId()));
       send(event);
+      coordinatorMetrics.incStartCommit();
       LOG.info("Coordinator {} initiated commit {}", taskId, commitState.currentCommitId());
     }
 
@@ -133,6 +140,11 @@ class Coordinator extends Channel {
     if (commitState.isCommitTimedOut()) {
       commit(true);
     }
+  }
+
+  @Override
+  protected void recordConsumeTime(long elapsedMs) {
+    coordinatorMetrics.recordConsume(elapsedMs);
   }
 
   @Override
@@ -152,6 +164,7 @@ class Coordinator extends Channel {
   }
 
   private void commit(boolean partialCommit) {
+    long start = System.currentTimeMillis();
     try {
       doCommit(partialCommit);
       if (!partialCommit) {
@@ -192,6 +205,7 @@ class Coordinator extends Channel {
           e);
     } finally {
       commitState.endCurrentCommit();
+      coordinatorMetrics.recordCommit(System.currentTimeMillis() - start);
     }
   }
 
@@ -216,6 +230,7 @@ class Coordinator extends Channel {
             config.connectGroupId(),
             new CommitComplete(commitState.currentCommitId(), validThroughTs));
     send(event);
+    coordinatorMetrics.incCommitComplete();
 
     LOG.info(
         "Coordinator {} completed commit {}, committed to {} table(s), valid-through {}",
@@ -438,6 +453,8 @@ class Coordinator extends Channel {
       }
     } catch (InterruptedException e) {
       throw new ConnectException("Interrupted while waiting for coordinator shutdown", e);
+    } finally {
+      coordinatorMetrics.close();
     }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -446,6 +446,13 @@ class Coordinator extends Channel {
 
     exec.shutdownNow();
 
+    // Unregister the MBeans here rather than waiting for the CoordinatorThread to reach stop():
+    // stopCoordinator() does not join that thread, so a newly elected coordinator in the same JVM
+    // could otherwise register the same connector-level ObjectName first and then have it
+    // unregistered by this instance's late close(). ChannelMetrics#close() is idempotent, so the
+    // close() in stop() below is a no-op once this has run.
+    coordinatorMetrics.close();
+
     // wait for coordinator termination, else cause the sink task to fail
     try {
       if (!exec.awaitTermination(1, TimeUnit.MINUTES)) {
@@ -459,8 +466,8 @@ class Coordinator extends Channel {
   @Override
   void stop() {
     // stop() runs at the very end of the CoordinatorThread run loop, after process() (and any
-    // commit() recording) can no longer fire, so closing the registry here avoids racing a
-    // record* call against a closed Metrics instance.
+    // commit() recording) can no longer fire, so closing the registry here covers the shutdown
+    // paths that never call terminate().
     super.stop();
     coordinatorMetrics.close();
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
@@ -42,22 +42,24 @@ class CoordinatorMetrics extends ChannelMetrics {
       this.fullCommitTime =
           createTimerSensor(
               "commit-time",
-              "Time spent in Coordinator.commit() in ms",
+              "Time spent in Coordinator.commit() in microseconds",
               metricTags(connector, TASK, FULL));
       this.partialCommitTime =
           createTimerSensor(
               "commit-time",
-              "Time spent in Coordinator.commit() in ms",
+              "Time spent in Coordinator.commit() in microseconds",
               metricTags(connector, TASK, PARTIAL));
+      // Counters are bumped only after send() succeeds, so they count events successfully emitted;
+      // a failed send leaves them unmoved even though the commit is already in progress.
       this.startCommit =
           createCounterSensor(
               "start-commit",
-              "Number of START_COMMIT events emitted",
+              "Number of successfully emitted START_COMMIT events",
               metricTags(connector, TASK, null));
       this.commitComplete =
           createCounterSensor(
               "commit-complete",
-              "Number of COMMIT_COMPLETE events emitted",
+              "Number of successfully emitted COMMIT_COMPLETE events",
               metricTags(connector, TASK, null));
 
       addGauge(

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
@@ -18,89 +18,66 @@
  */
 package org.apache.iceberg.connect.channel;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.Map;
 import java.util.function.Supplier;
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.Gauge;
-import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.metrics.KafkaMetricsContext;
-import org.apache.kafka.common.metrics.MetricConfig;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.CumulativeSum;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.utils.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class CoordinatorMetrics implements AutoCloseable {
+class CoordinatorMetrics extends ChannelMetrics {
 
-  private static final Logger LOG = LoggerFactory.getLogger(CoordinatorMetrics.class);
   private static final String GROUP = "coordinator-metrics";
-  private static final String NAMESPACE = "iceberg-kafka-connect-metrics";
+  // The coordinator is a single per-connector task, so it reports a fixed task tag.
+  private static final String TASK = "coordinator";
+  private static final String FULL = "full";
+  private static final String PARTIAL = "partial";
 
-  private final Metrics metrics;
-  private final Sensor commitTime;
-  private final Sensor consumeTime;
+  // Commit timers are tagged by commitMode (partial vs full) so the two paths stay separable.
+  private final Sensor fullCommitTime;
+  private final Sensor partialCommitTime;
   private final Sensor startCommit;
   private final Sensor commitComplete;
 
   CoordinatorMetrics(
       String connector, Supplier<Long> commitBufferSize, Supplier<Long> readyBufferSize) {
-    Map<String, String> tags = new LinkedHashMap<>();
-    tags.put("connector", connector);
-
-    Metrics newMetrics =
-        new Metrics(
-            new MetricConfig(),
-            Collections.singletonList(new JmxReporter()),
-            Time.SYSTEM,
-            new KafkaMetricsContext(NAMESPACE));
+    super(GROUP, connector, TASK);
     try {
-      this.commitTime =
+      this.fullCommitTime =
           createTimerSensor(
-              newMetrics, "commit-time", "Time spent in Coordinator.commit() in ms", tags);
-      this.consumeTime =
+              "commit-time",
+              "Time spent in Coordinator.commit() in ms",
+              metricTags(connector, TASK, FULL));
+      this.partialCommitTime =
           createTimerSensor(
-              newMetrics,
-              "consume-available-time",
-              "Time spent in Channel.consumeAvailable() (coordinator side) in ms",
-              tags);
+              "commit-time",
+              "Time spent in Coordinator.commit() in ms",
+              metricTags(connector, TASK, PARTIAL));
       this.startCommit =
           createCounterSensor(
-              newMetrics, "start-commit", "Number of START_COMMIT events emitted", tags);
+              "start-commit",
+              "Number of START_COMMIT events emitted",
+              metricTags(connector, TASK, null));
       this.commitComplete =
           createCounterSensor(
-              newMetrics, "commit-complete", "Number of COMMIT_COMPLETE events emitted", tags);
+              "commit-complete",
+              "Number of COMMIT_COMPLETE events emitted",
+              metricTags(connector, TASK, null));
 
-      newMetrics.addMetric(
-          new MetricName(
-              "commit-buffer-size", GROUP, "Current size of CommitState.commitBuffer", tags),
-          (Gauge<Long>) (config, now) -> commitBufferSize.get());
-      newMetrics.addMetric(
-          new MetricName(
-              "ready-buffer-size", GROUP, "Current size of CommitState.readyBuffer", tags),
-          (Gauge<Long>) (config, now) -> readyBufferSize.get());
+      addGauge(
+          "commit-buffer-size",
+          "Current size of CommitState.commitBuffer",
+          metricTags(connector, TASK, null),
+          commitBufferSize);
+      addGauge(
+          "ready-buffer-size",
+          "Current size of CommitState.readyBuffer",
+          metricTags(connector, TASK, null),
+          readyBufferSize);
     } catch (RuntimeException e) {
-      try {
-        newMetrics.close();
-      } catch (Exception suppressed) {
-        e.addSuppressed(suppressed);
-      }
+      closeQuietly(e);
       throw e;
     }
-    this.metrics = newMetrics;
   }
 
-  void recordCommit(long elapsedMs) {
-    commitTime.record((double) elapsedMs);
-  }
-
-  void recordConsume(long elapsedMs) {
-    consumeTime.record((double) elapsedMs);
+  void recordCommit(boolean partialCommit, long elapsedMs) {
+    (partialCommit ? partialCommitTime : fullCommitTime).record((double) elapsedMs);
   }
 
   void incStartCommit() {
@@ -109,32 +86,5 @@ class CoordinatorMetrics implements AutoCloseable {
 
   void incCommitComplete() {
     commitComplete.record(1);
-  }
-
-  @Override
-  public void close() {
-    try {
-      metrics.close();
-    } catch (Exception e) {
-      LOG.warn("Error closing CoordinatorMetrics", e);
-    }
-  }
-
-  private Sensor createTimerSensor(
-      Metrics registry, String baseName, String description, Map<String, String> tags) {
-    Sensor sensor = registry.sensor(baseName);
-    sensor.add(new MetricName(baseName + "-avg", GROUP, description + " (avg)", tags), new Avg());
-    sensor.add(new MetricName(baseName + "-max", GROUP, description + " (max)", tags), new Max());
-    sensor.add(
-        new MetricName(baseName + "-total", GROUP, description + " (total)", tags),
-        new CumulativeSum());
-    return sensor;
-  }
-
-  private Sensor createCounterSensor(
-      Metrics registry, String baseName, String description, Map<String, String> tags) {
-    Sensor sensor = registry.sensor(baseName);
-    sensor.add(new MetricName(baseName + "-total", GROUP, description, tags), new CumulativeSum());
-    return sensor;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class CoordinatorMetrics implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoordinatorMetrics.class);
+  private static final String GROUP = "coordinator-metrics";
+  private static final String NAMESPACE = "iceberg-kafka-connect-metrics";
+
+  private final Metrics metrics;
+  private final Sensor commitTime;
+  private final Sensor consumeTime;
+  private final Sensor startCommit;
+  private final Sensor commitComplete;
+
+  CoordinatorMetrics(
+      String connector, Supplier<Long> commitBufferSize, Supplier<Long> readyBufferSize) {
+    Map<String, String> tags = new LinkedHashMap<>();
+    tags.put("connector", connector);
+
+    Metrics newMetrics =
+        new Metrics(
+            new MetricConfig(),
+            Collections.singletonList(new JmxReporter()),
+            Time.SYSTEM,
+            new KafkaMetricsContext(NAMESPACE));
+    try {
+      this.commitTime =
+          createTimerSensor(
+              newMetrics, "commit-time", "Time spent in Coordinator.commit() in ms", tags);
+      this.consumeTime =
+          createTimerSensor(
+              newMetrics,
+              "consume-available-time",
+              "Time spent in Channel.consumeAvailable() (coordinator side) in ms",
+              tags);
+      this.startCommit =
+          createCounterSensor(
+              newMetrics, "start-commit", "Number of START_COMMIT events emitted", tags);
+      this.commitComplete =
+          createCounterSensor(
+              newMetrics, "commit-complete", "Number of COMMIT_COMPLETE events emitted", tags);
+
+      newMetrics.addMetric(
+          new MetricName(
+              "commit-buffer-size", GROUP, "Current size of CommitState.commitBuffer", tags),
+          (Gauge<Long>) (config, now) -> commitBufferSize.get());
+      newMetrics.addMetric(
+          new MetricName(
+              "ready-buffer-size", GROUP, "Current size of CommitState.readyBuffer", tags),
+          (Gauge<Long>) (config, now) -> readyBufferSize.get());
+    } catch (RuntimeException e) {
+      try {
+        newMetrics.close();
+      } catch (Exception suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
+    }
+    this.metrics = newMetrics;
+  }
+
+  void recordCommit(long elapsedMs) {
+    commitTime.record((double) elapsedMs);
+  }
+
+  void recordConsume(long elapsedMs) {
+    consumeTime.record((double) elapsedMs);
+  }
+
+  void incStartCommit() {
+    startCommit.record(1);
+  }
+
+  void incCommitComplete() {
+    commitComplete.record(1);
+  }
+
+  @Override
+  public void close() {
+    try {
+      metrics.close();
+    } catch (Exception e) {
+      LOG.warn("Error closing CoordinatorMetrics", e);
+    }
+  }
+
+  private Sensor createTimerSensor(
+      Metrics registry, String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = registry.sensor(baseName);
+    sensor.add(new MetricName(baseName + "-avg", GROUP, description + " (avg)", tags), new Avg());
+    sensor.add(new MetricName(baseName + "-max", GROUP, description + " (max)", tags), new Max());
+    sensor.add(
+        new MetricName(baseName + "-total", GROUP, description + " (total)", tags),
+        new CumulativeSum());
+    return sensor;
+  }
+
+  private Sensor createCounterSensor(
+      Metrics registry, String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = registry.sensor(baseName);
+    sensor.add(new MetricName(baseName + "-total", GROUP, description, tags), new CumulativeSum());
+    return sensor;
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorMetrics.java
@@ -28,6 +28,9 @@ class CoordinatorMetrics extends ChannelMetrics {
   private static final String TASK = "coordinator";
   private static final String FULL = "full";
   private static final String PARTIAL = "partial";
+  // Recorded from a finally block, so it covers commits that failed as well as ones that succeeded.
+  private static final String COMMIT_TIME_DESC =
+      "Time spent in Coordinator.commit() in microseconds, whether the commit succeeded or failed";
 
   // Commit timers are tagged by commitMode (partial vs full) so the two paths stay separable.
   private final Sensor fullCommitTime;
@@ -40,15 +43,9 @@ class CoordinatorMetrics extends ChannelMetrics {
     super(GROUP, connector, TASK);
     try {
       this.fullCommitTime =
-          createTimerSensor(
-              "commit-time",
-              "Time spent in Coordinator.commit() in microseconds",
-              metricTags(connector, TASK, FULL));
+          createTimerSensor("commit-time", COMMIT_TIME_DESC, metricTags(connector, TASK, FULL));
       this.partialCommitTime =
-          createTimerSensor(
-              "commit-time",
-              "Time spent in Coordinator.commit() in microseconds",
-              metricTags(connector, TASK, PARTIAL));
+          createTimerSensor("commit-time", COMMIT_TIME_DESC, metricTags(connector, TASK, PARTIAL));
       // Counters are bumped only after send() succeeds, so they count events successfully emitted;
       // a failed send leaves them unmoved even though the commit is already in progress.
       this.startCommit =
@@ -78,8 +75,8 @@ class CoordinatorMetrics extends ChannelMetrics {
     }
   }
 
-  void recordCommit(boolean partialCommit, long elapsedMs) {
-    (partialCommit ? partialCommitTime : fullCommitTime).record((double) elapsedMs);
+  void recordCommit(boolean partialCommit, long elapsedMicros) {
+    (partialCommit ? partialCommitTime : fullCommitTime).record((double) elapsedMicros);
   }
 
   void incStartCommit() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -59,8 +59,7 @@ class Worker extends Channel {
     this.config = config;
     this.context = context;
     this.sinkWriter = sinkWriter;
-    this.workerMetrics =
-        new WorkerMetrics(config.connectorName(), config.connectorName() + "-" + config.taskId());
+    this.workerMetrics = new WorkerMetrics(config.connectorName(), config.taskId());
   }
 
   void process() {
@@ -68,8 +67,8 @@ class Worker extends Channel {
   }
 
   @Override
-  protected void recordConsumeTime(long elapsedMs) {
-    workerMetrics.recordConsume(elapsedMs);
+  protected ChannelMetrics getChannelMetrics() {
+    return workerMetrics;
   }
 
   @Override
@@ -118,7 +117,11 @@ class Worker extends Channel {
 
     send(events, results.sourceOffsets());
 
-    workerMetrics.incDataWritten(results.writerResults().size());
+    long fileCount =
+        results.writerResults().stream()
+            .mapToLong(result -> result.dataFiles().size() + result.deleteFiles().size())
+            .sum();
+    workerMetrics.incDataWritten(fileCount);
     workerMetrics.incDataComplete();
 
     return true;
@@ -132,11 +135,11 @@ class Worker extends Channel {
   }
 
   void save(Collection<SinkRecord> sinkRecords) {
-    long start = System.currentTimeMillis();
+    long start = System.nanoTime();
     try {
       sinkWriter.save(sinkRecords);
     } finally {
-      workerMetrics.recordSave(System.currentTimeMillis() - start);
+      workerMetrics.recordSave((System.nanoTime() - start) / 1_000_000L);
     }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -139,7 +139,7 @@ class Worker extends Channel {
     try {
       sinkWriter.save(sinkRecords);
     } finally {
-      workerMetrics.recordSave((System.nanoTime() - start) / 1_000_000L);
+      workerMetrics.recordSave((System.nanoTime() - start) / 1_000L);
     }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -41,6 +41,7 @@ class Worker extends Channel {
   private final IcebergSinkConfig config;
   private final SinkTaskContext context;
   private final SinkWriter sinkWriter;
+  private final WorkerMetrics workerMetrics;
 
   Worker(
       IcebergSinkConfig config,
@@ -58,10 +59,17 @@ class Worker extends Channel {
     this.config = config;
     this.context = context;
     this.sinkWriter = sinkWriter;
+    this.workerMetrics =
+        new WorkerMetrics(config.connectorName(), config.connectorName() + "-" + config.taskId());
   }
 
   void process() {
     consumeAvailable(Duration.ZERO);
+  }
+
+  @Override
+  protected void recordConsumeTime(long elapsedMs) {
+    workerMetrics.recordConsume(elapsedMs);
   }
 
   @Override
@@ -110,6 +118,9 @@ class Worker extends Channel {
 
     send(events, results.sourceOffsets());
 
+    workerMetrics.incDataWritten(results.writerResults().size());
+    workerMetrics.incDataComplete();
+
     return true;
   }
 
@@ -117,9 +128,15 @@ class Worker extends Channel {
   void stop() {
     super.stop();
     sinkWriter.close();
+    workerMetrics.close();
   }
 
   void save(Collection<SinkRecord> sinkRecords) {
-    sinkWriter.save(sinkRecords);
+    long start = System.currentTimeMillis();
+    try {
+      sinkWriter.save(sinkRecords);
+    } finally {
+      workerMetrics.recordSave(System.currentTimeMillis() - start);
+    }
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Worker.java
@@ -121,7 +121,7 @@ class Worker extends Channel {
         results.writerResults().stream()
             .mapToLong(result -> result.dataFiles().size() + result.deleteFiles().size())
             .sum();
-    workerMetrics.incDataWritten(fileCount);
+    workerMetrics.incDataFilesWritten(fileCount);
     workerMetrics.incDataComplete();
 
     return true;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
@@ -18,113 +18,42 @@
  */
 package org.apache.iceberg.connect.channel;
 
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Map;
-import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.metrics.JmxReporter;
-import org.apache.kafka.common.metrics.KafkaMetricsContext;
-import org.apache.kafka.common.metrics.MetricConfig;
-import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.metrics.Sensor;
-import org.apache.kafka.common.metrics.stats.Avg;
-import org.apache.kafka.common.metrics.stats.CumulativeSum;
-import org.apache.kafka.common.metrics.stats.Max;
-import org.apache.kafka.common.utils.Time;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-class WorkerMetrics implements AutoCloseable {
+class WorkerMetrics extends ChannelMetrics {
 
-  private static final Logger LOG = LoggerFactory.getLogger(WorkerMetrics.class);
   private static final String GROUP = "worker-metrics";
-  private static final String NAMESPACE = "iceberg-kafka-connect-metrics";
 
-  private final Metrics metrics;
   private final Sensor saveTime;
-  private final Sensor consumeTime;
   private final Sensor dataWritten;
   private final Sensor dataComplete;
 
-  WorkerMetrics(String connector, String taskId) {
-    Map<String, String> tags = new LinkedHashMap<>();
-    tags.put("connector", connector);
-    tags.put("task", taskId);
-
-    Metrics newMetrics =
-        new Metrics(
-            new MetricConfig(),
-            Collections.singletonList(new JmxReporter()),
-            Time.SYSTEM,
-            new KafkaMetricsContext(NAMESPACE));
+  WorkerMetrics(String connector, String task) {
+    super(GROUP, connector, task);
+    Map<String, String> tags = metricTags(connector, task, null);
     try {
-      this.saveTime =
-          createTimerSensor(newMetrics, "save-time", "Time spent in Worker.save() in ms", tags);
-      this.consumeTime =
-          createTimerSensor(
-              newMetrics,
-              "consume-available-time",
-              "Time spent in Channel.consumeAvailable() (worker side) in ms",
-              tags);
+      this.saveTime = createTimerSensor("save-time", "Time spent in Worker.save() in ms", tags);
       this.dataWritten =
           createCounterSensor(
-              newMetrics, "data-written", "Number of DATA_WRITTEN events emitted", tags);
+              "data-written", "Number of data/delete files reported in DATA_WRITTEN events", tags);
       this.dataComplete =
-          createCounterSensor(
-              newMetrics, "data-complete", "Number of DATA_COMPLETE events emitted", tags);
+          createCounterSensor("data-complete", "Number of DATA_COMPLETE events emitted", tags);
     } catch (RuntimeException e) {
-      try {
-        newMetrics.close();
-      } catch (Exception suppressed) {
-        e.addSuppressed(suppressed);
-      }
+      closeQuietly(e);
       throw e;
     }
-    this.metrics = newMetrics;
   }
 
   void recordSave(long elapsedMs) {
     saveTime.record((double) elapsedMs);
   }
 
-  void recordConsume(long elapsedMs) {
-    consumeTime.record((double) elapsedMs);
-  }
-
   void incDataWritten(long count) {
-    if (count > 0) {
-      dataWritten.record((double) count);
-    }
+    dataWritten.record((double) count);
   }
 
   void incDataComplete() {
     dataComplete.record(1);
-  }
-
-  @Override
-  public void close() {
-    try {
-      metrics.close();
-    } catch (Exception e) {
-      LOG.warn("Error closing WorkerMetrics", e);
-    }
-  }
-
-  private Sensor createTimerSensor(
-      Metrics registry, String baseName, String description, Map<String, String> tags) {
-    Sensor sensor = registry.sensor(baseName);
-    sensor.add(new MetricName(baseName + "-avg", GROUP, description + " (avg)", tags), new Avg());
-    sensor.add(new MetricName(baseName + "-max", GROUP, description + " (max)", tags), new Max());
-    sensor.add(
-        new MetricName(baseName + "-total", GROUP, description + " (total)", tags),
-        new CumulativeSum());
-    return sensor;
-  }
-
-  private Sensor createCounterSensor(
-      Metrics registry, String baseName, String description, Map<String, String> tags) {
-    Sensor sensor = registry.sensor(baseName);
-    sensor.add(new MetricName(baseName + "-total", GROUP, description, tags), new CumulativeSum());
-    return sensor;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
@@ -33,12 +33,18 @@ class WorkerMetrics extends ChannelMetrics {
     super(GROUP, connector, task);
     Map<String, String> tags = metricTags(connector, task, null);
     try {
-      this.saveTime = createTimerSensor("save-time", "Time spent in Worker.save() in ms", tags);
+      this.saveTime =
+          createTimerSensor("save-time", "Time spent in Worker.save() in microseconds", tags);
+      // Counters are bumped only after send() succeeds, so they count events successfully emitted;
+      // a failed send leaves them unmoved even though the files are already on disk.
       this.dataWritten =
           createCounterSensor(
-              "data-written", "Number of data/delete files reported in DATA_WRITTEN events", tags);
+              "data-written",
+              "Number of data/delete files in successfully emitted DATA_WRITTEN events",
+              tags);
       this.dataComplete =
-          createCounterSensor("data-complete", "Number of DATA_COMPLETE events emitted", tags);
+          createCounterSensor(
+              "data-complete", "Number of successfully emitted DATA_COMPLETE events", tags);
     } catch (RuntimeException e) {
       closeQuietly(e);
       throw e;

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+import org.apache.kafka.common.metrics.stats.Max;
+import org.apache.kafka.common.utils.Time;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class WorkerMetrics implements AutoCloseable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(WorkerMetrics.class);
+  private static final String GROUP = "worker-metrics";
+  private static final String NAMESPACE = "iceberg-kafka-connect-metrics";
+
+  private final Metrics metrics;
+  private final Sensor saveTime;
+  private final Sensor consumeTime;
+  private final Sensor dataWritten;
+  private final Sensor dataComplete;
+
+  WorkerMetrics(String connector, String taskId) {
+    Map<String, String> tags = new LinkedHashMap<>();
+    tags.put("connector", connector);
+    tags.put("task", taskId);
+
+    Metrics newMetrics =
+        new Metrics(
+            new MetricConfig(),
+            Collections.singletonList(new JmxReporter()),
+            Time.SYSTEM,
+            new KafkaMetricsContext(NAMESPACE));
+    try {
+      this.saveTime =
+          createTimerSensor(newMetrics, "save-time", "Time spent in Worker.save() in ms", tags);
+      this.consumeTime =
+          createTimerSensor(
+              newMetrics,
+              "consume-available-time",
+              "Time spent in Channel.consumeAvailable() (worker side) in ms",
+              tags);
+      this.dataWritten =
+          createCounterSensor(
+              newMetrics, "data-written", "Number of DATA_WRITTEN events emitted", tags);
+      this.dataComplete =
+          createCounterSensor(
+              newMetrics, "data-complete", "Number of DATA_COMPLETE events emitted", tags);
+    } catch (RuntimeException e) {
+      try {
+        newMetrics.close();
+      } catch (Exception suppressed) {
+        e.addSuppressed(suppressed);
+      }
+      throw e;
+    }
+    this.metrics = newMetrics;
+  }
+
+  void recordSave(long elapsedMs) {
+    saveTime.record((double) elapsedMs);
+  }
+
+  void recordConsume(long elapsedMs) {
+    consumeTime.record((double) elapsedMs);
+  }
+
+  void incDataWritten(long count) {
+    if (count > 0) {
+      dataWritten.record((double) count);
+    }
+  }
+
+  void incDataComplete() {
+    dataComplete.record(1);
+  }
+
+  @Override
+  public void close() {
+    try {
+      metrics.close();
+    } catch (Exception e) {
+      LOG.warn("Error closing WorkerMetrics", e);
+    }
+  }
+
+  private Sensor createTimerSensor(
+      Metrics registry, String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = registry.sensor(baseName);
+    sensor.add(new MetricName(baseName + "-avg", GROUP, description + " (avg)", tags), new Avg());
+    sensor.add(new MetricName(baseName + "-max", GROUP, description + " (max)", tags), new Max());
+    sensor.add(
+        new MetricName(baseName + "-total", GROUP, description + " (total)", tags),
+        new CumulativeSum());
+    return sensor;
+  }
+
+  private Sensor createCounterSensor(
+      Metrics registry, String baseName, String description, Map<String, String> tags) {
+    Sensor sensor = registry.sensor(baseName);
+    sensor.add(new MetricName(baseName + "-total", GROUP, description, tags), new CumulativeSum());
+    return sensor;
+  }
+}

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/WorkerMetrics.java
@@ -26,7 +26,7 @@ class WorkerMetrics extends ChannelMetrics {
   private static final String GROUP = "worker-metrics";
 
   private final Sensor saveTime;
-  private final Sensor dataWritten;
+  private final Sensor dataFilesWritten;
   private final Sensor dataComplete;
 
   WorkerMetrics(String connector, String task) {
@@ -37,9 +37,9 @@ class WorkerMetrics extends ChannelMetrics {
           createTimerSensor("save-time", "Time spent in Worker.save() in microseconds", tags);
       // Counters are bumped only after send() succeeds, so they count events successfully emitted;
       // a failed send leaves them unmoved even though the files are already on disk.
-      this.dataWritten =
+      this.dataFilesWritten =
           createCounterSensor(
-              "data-written",
+              "data-files-written",
               "Number of data/delete files in successfully emitted DATA_WRITTEN events",
               tags);
       this.dataComplete =
@@ -51,12 +51,12 @@ class WorkerMetrics extends ChannelMetrics {
     }
   }
 
-  void recordSave(long elapsedMs) {
-    saveTime.record((double) elapsedMs);
+  void recordSave(long elapsedMicros) {
+    saveTime.record((double) elapsedMicros);
   }
 
-  void incDataWritten(long count) {
-    dataWritten.record((double) count);
+  void incDataFilesWritten(long count) {
+    dataFilesWritten.record((double) count);
   }
 
   void incDataComplete() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -103,6 +103,8 @@ public class ChannelTestBase {
     when(config.connectGroupId()).thenReturn(CONNECT_CONSUMER_GROUP_ID);
     when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
     when(config.commitMaxConsecutiveFailures()).thenReturn(1);
+    when(config.connectorName()).thenReturn("test-connector");
+    when(config.taskId()).thenReturn("0");
 
     TopicPartitionInfo partitionInfo = mock(TopicPartitionInfo.class);
     when(partitionInfo.partition()).thenReturn(0);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitState.java
@@ -26,6 +26,7 @@ import java.time.OffsetDateTime;
 import java.util.UUID;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.Payload;
 import org.apache.iceberg.connect.events.TopicPartitionOffset;
@@ -148,6 +149,35 @@ public class TestCommitState {
 
     assertThat(commitState.validThroughTs(false)).isNull();
     assertThat(commitState.validThroughTs(true)).isNull();
+  }
+
+  @Test
+  public void testBufferSizes() {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    CommitState commitState = new CommitState(config);
+
+    assertThat(commitState.commitBufferSize()).isEqualTo(0);
+    assertThat(commitState.readyBufferSize()).isEqualTo(0);
+
+    commitState.startNewCommit();
+
+    commitState.addResponse(wrapInEnvelope(mock(DataWritten.class)));
+
+    DataComplete dataComplete = mock(DataComplete.class);
+    when(dataComplete.commitId()).thenReturn(commitState.currentCommitId());
+    when(dataComplete.assignments()).thenReturn(ImmutableList.of());
+    Event readyEvent = mock(Event.class);
+    when(readyEvent.payload()).thenReturn(dataComplete);
+    commitState.addReady(new Envelope(readyEvent, 0, 0L));
+
+    assertThat(commitState.commitBufferSize()).isEqualTo(1);
+    assertThat(commitState.readyBufferSize()).isEqualTo(1);
+
+    commitState.clearResponses();
+    commitState.endCurrentCommit();
+
+    assertThat(commitState.commitBufferSize()).isEqualTo(0);
+    assertThat(commitState.readyBufferSize()).isEqualTo(0);
   }
 
   private Envelope wrapInEnvelope(Payload payload) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -409,31 +409,36 @@ public class TestCoordinator extends ChannelTestBase {
     SinkTaskContext context = mock(SinkTaskContext.class);
     Coordinator coordinator =
         new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
+    try {
+      coordinator.start();
 
-    initConsumer();
+      initConsumer();
 
-    coordinator.process();
+      coordinator.process();
 
-    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(0);
+      assertThat(coordinator.partialCommitFailureCount()).isEqualTo(0);
 
-    UUID commitId =
-        ((StartCommit) AvroUtil.decode(producer.history().get(0).value()).payload()).commitId();
-    Event commitResponse =
-        new Event(
-            config.connectGroupId(),
-            new DataWritten(
-                StructType.of(),
-                commitId,
-                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
-                ImmutableList.of(EventTestUtil.createDataFile()),
-                ImmutableList.of()));
-    byte[] bytes = AvroUtil.encode(commitResponse);
-    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+      UUID commitId =
+          ((StartCommit) AvroUtil.decode(producer.history().get(0).value()).payload()).commitId();
+      Event commitResponse =
+          new Event(
+              config.connectGroupId(),
+              new DataWritten(
+                  StructType.of(),
+                  commitId,
+                  TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                  ImmutableList.of(EventTestUtil.createDataFile()),
+                  ImmutableList.of()));
+      byte[] bytes = AvroUtil.encode(commitResponse);
+      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
 
-    coordinator.process();
+      coordinator.process();
 
-    assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1);
+      assertThat(coordinator.partialCommitFailureCount()).isEqualTo(1);
+    } finally {
+      coordinator.terminate();
+      coordinator.stop();
+    }
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -26,9 +26,12 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.lang.management.ManagementFactory;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -532,17 +535,17 @@ public class TestCoordinator extends ChannelTestBase {
     SinkTaskContext taskContext = mock(SinkTaskContext.class);
     Coordinator coordinator =
         new Coordinator(catalog, config, ImmutableList.of(), clientFactory, taskContext);
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName name =
+        new ObjectName(
+            "iceberg.kafka.connect:type=coordinator-metrics,connector=jmx-coord-connector,*");
     try {
-      javax.management.MBeanServer server =
-          java.lang.management.ManagementFactory.getPlatformMBeanServer();
-      javax.management.ObjectName name =
-          new javax.management.ObjectName(
-              "iceberg-kafka-connect-metrics:type=coordinator-metrics,"
-                  + "connector=jmx-coord-connector");
       assertThat(server.queryNames(name, null)).isNotEmpty();
     } finally {
       coordinator.terminate();
       coordinator.stop();
     }
+    // stop() must unregister the MBeans, else a task restart hits InstanceAlreadyExistsException
+    assertThat(server.queryNames(name, null)).isEmpty();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -344,47 +344,52 @@ public class TestCoordinator extends ChannelTestBase {
     SinkTaskContext context = mock(SinkTaskContext.class);
     Coordinator coordinator =
         new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
+    try {
+      coordinator.start();
 
-    // init consumer after subscribe()
-    initConsumer();
+      // init consumer after subscribe()
+      initConsumer();
 
-    coordinator.process();
+      coordinator.process();
 
-    assertThat(producer.transactionCommitted()).isTrue();
-    assertThat(producer.history()).hasSize(1);
+      assertThat(producer.transactionCommitted()).isTrue();
+      assertThat(producer.history()).hasSize(1);
 
-    byte[] bytes = producer.history().get(0).value();
-    Event commitRequest = AvroUtil.decode(bytes);
-    assertThat(commitRequest.type()).isEqualTo(PayloadType.START_COMMIT);
+      byte[] bytes = producer.history().get(0).value();
+      Event commitRequest = AvroUtil.decode(bytes);
+      assertThat(commitRequest.type()).isEqualTo(PayloadType.START_COMMIT);
 
-    UUID commitId = ((StartCommit) commitRequest.payload()).commitId();
+      UUID commitId = ((StartCommit) commitRequest.payload()).commitId();
 
-    Event commitResponse =
-        new Event(
-            config.connectGroupId(),
-            new DataWritten(
-                StructType.of(),
-                commitId,
-                TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
-                dataFiles,
-                deleteFiles));
-    bytes = AvroUtil.encode(commitResponse);
-    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+      Event commitResponse =
+          new Event(
+              config.connectGroupId(),
+              new DataWritten(
+                  StructType.of(),
+                  commitId,
+                  TableReference.of("catalog", TableIdentifier.of("db", "tbl"), null),
+                  dataFiles,
+                  deleteFiles));
+      bytes = AvroUtil.encode(commitResponse);
+      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
 
-    Event commitReady =
-        new Event(
-            config.connectGroupId(),
-            new DataComplete(
-                commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));
-    bytes = AvroUtil.encode(commitReady);
-    consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
+      Event commitReady =
+          new Event(
+              config.connectGroupId(),
+              new DataComplete(
+                  commitId, ImmutableList.of(new TopicPartitionOffset("topic", 1, 1L, ts))));
+      bytes = AvroUtil.encode(commitReady);
+      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 2, "key", bytes));
 
-    when(config.commitIntervalMs()).thenReturn(0);
+      when(config.commitIntervalMs()).thenReturn(0);
 
-    coordinator.process();
+      coordinator.process();
 
-    return commitId;
+      return commitId;
+    } finally {
+      coordinator.terminate();
+      coordinator.stop();
+    }
   }
 
   @Test
@@ -518,5 +523,26 @@ public class TestCoordinator extends ChannelTestBase {
     table.refresh();
     assertThat(table.snapshots()).hasSize(2);
     assertThat(table.currentSnapshot().summary()).containsEntry(OFFSETS_SNAPSHOT_PROP, "{\"0\":7}");
+  }
+
+  @Test
+  public void testCoordinatorRegistersJmxMetrics() throws Exception {
+    when(config.connectorName()).thenReturn("jmx-coord-connector");
+
+    SinkTaskContext taskContext = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, taskContext);
+    try {
+      javax.management.MBeanServer server =
+          java.lang.management.ManagementFactory.getPlatformMBeanServer();
+      javax.management.ObjectName name =
+          new javax.management.ObjectName(
+              "iceberg-kafka-connect-metrics:type=coordinator-metrics,"
+                  + "connector=jmx-coord-connector");
+      assertThat(server.queryNames(name, null)).isNotEmpty();
+    } finally {
+      coordinator.terminate();
+      coordinator.stop();
+    }
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+
+public class TestCoordinatorMetrics {
+
+  private static final String CONNECTOR = "test-connector";
+
+  @Test
+  public void testRegistersAndUnregistersMBeans() throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName query =
+        new ObjectName(
+            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
+
+    AtomicLong commitSize = new AtomicLong();
+    AtomicLong readySize = new AtomicLong();
+    try (CoordinatorMetrics metrics =
+        new CoordinatorMetrics(CONNECTOR, commitSize::get, readySize::get)) {
+      Set<ObjectName> registered = server.queryNames(query, null);
+      assertThat(registered).isNotEmpty();
+    }
+    Set<ObjectName> afterClose = server.queryNames(query, null);
+    assertThat(afterClose).isEmpty();
+  }
+
+  @Test
+  public void testTimingMetrics() throws Exception {
+    try (CoordinatorMetrics metrics = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+      metrics.recordCommit(50);
+      metrics.recordCommit(150);
+
+      assertThat(readDouble("commit-time-avg")).isEqualTo(100.0);
+      assertThat(readDouble("commit-time-max")).isEqualTo(150.0);
+      assertThat(readDouble("commit-time-total")).isEqualTo(200.0);
+
+      metrics.recordConsume(5);
+      metrics.recordConsume(15);
+      assertThat(readDouble("consume-available-time-avg")).isEqualTo(10.0);
+      assertThat(readDouble("consume-available-time-max")).isEqualTo(15.0);
+      assertThat(readDouble("consume-available-time-total")).isEqualTo(20.0);
+    }
+  }
+
+  @Test
+  public void testCounters() throws Exception {
+    try (CoordinatorMetrics metrics = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+      metrics.incStartCommit();
+      metrics.incStartCommit();
+      metrics.incStartCommit();
+      metrics.incCommitComplete();
+
+      assertThat(readDouble("start-commit-total")).isEqualTo(3.0);
+      assertThat(readDouble("commit-complete-total")).isEqualTo(1.0);
+    }
+  }
+
+  @Test
+  public void testGaugesReadLazily() throws Exception {
+    AtomicLong commitSize = new AtomicLong(0);
+    AtomicLong readySize = new AtomicLong(0);
+    try (CoordinatorMetrics metrics =
+        new CoordinatorMetrics(CONNECTOR, commitSize::get, readySize::get)) {
+
+      assertThat(readLong("commit-buffer-size")).isEqualTo(0L);
+      assertThat(readLong("ready-buffer-size")).isEqualTo(0L);
+
+      commitSize.set(7);
+      readySize.set(3);
+      assertThat(readLong("commit-buffer-size")).isEqualTo(7L);
+      assertThat(readLong("ready-buffer-size")).isEqualTo(3L);
+
+      commitSize.set(0);
+      readySize.set(0);
+      assertThat(readLong("commit-buffer-size")).isEqualTo(0L);
+      assertThat(readLong("ready-buffer-size")).isEqualTo(0L);
+    }
+  }
+
+  @Test
+  public void testCloseAllowsReregistration() throws Exception {
+    try (CoordinatorMetrics first = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+      assertThat(first).isNotNull();
+    }
+    try (CoordinatorMetrics second = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+      assertThat(second).isNotNull();
+    }
+  }
+
+  private static double readDouble(String name) throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName objectName =
+        new ObjectName(
+            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
+    return ((Number) server.getAttribute(objectName, name)).doubleValue();
+  }
+
+  private static long readLong(String name) throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName objectName =
+        new ObjectName(
+            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
+    return ((Number) server.getAttribute(objectName, name)).longValue();
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.management.ManagementFactory;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
@@ -29,19 +30,19 @@ import org.junit.jupiter.api.Test;
 
 public class TestCoordinatorMetrics {
 
-  private static final String CONNECTOR = "test-connector";
+  private final String connector = "test-connector-" + UUID.randomUUID();
 
   @Test
   public void testRegistersAndUnregistersMBeans() throws Exception {
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
     ObjectName query =
         new ObjectName(
-            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
+            "iceberg.kafka.connect:type=coordinator-metrics,connector=" + connector + ",*");
 
     AtomicLong commitSize = new AtomicLong();
     AtomicLong readySize = new AtomicLong();
     try (CoordinatorMetrics metrics =
-        new CoordinatorMetrics(CONNECTOR, commitSize::get, readySize::get)) {
+        new CoordinatorMetrics(connector, commitSize::get, readySize::get)) {
       Set<ObjectName> registered = server.queryNames(query, null);
       assertThat(registered).isNotEmpty();
     }
@@ -51,25 +52,31 @@ public class TestCoordinatorMetrics {
 
   @Test
   public void testTimingMetrics() throws Exception {
-    try (CoordinatorMetrics metrics = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
-      metrics.recordCommit(50);
-      metrics.recordCommit(150);
+    try (CoordinatorMetrics metrics = new CoordinatorMetrics(connector, () -> 0L, () -> 0L)) {
+      metrics.recordCommit(false, 50);
+      metrics.recordCommit(false, 150);
 
-      assertThat(readDouble("commit-time-avg")).isEqualTo(100.0);
-      assertThat(readDouble("commit-time-max")).isEqualTo(150.0);
-      assertThat(readDouble("commit-time-total")).isEqualTo(200.0);
+      assertThat(readCommitDouble("full", "commit-time-avg")).isEqualTo(100.0);
+      assertThat(readCommitDouble("full", "commit-time-max")).isEqualTo(150.0);
+      assertThat(readCommitDouble("full", "commit-time-total")).isEqualTo(200.0);
+      assertThat(readCommitDouble("full", "commit-time-count")).isEqualTo(2.0);
 
-      metrics.recordConsume(5);
-      metrics.recordConsume(15);
-      assertThat(readDouble("consume-available-time-avg")).isEqualTo(10.0);
-      assertThat(readDouble("consume-available-time-max")).isEqualTo(15.0);
-      assertThat(readDouble("consume-available-time-total")).isEqualTo(20.0);
+      metrics.recordCommit(true, 20);
+      assertThat(readCommitDouble("partial", "commit-time-total")).isEqualTo(20.0);
+      // partial commits do not pollute the full-commit total
+      assertThat(readCommitDouble("full", "commit-time-total")).isEqualTo(200.0);
+
+      metrics.recordMessageRead(5);
+      metrics.recordMessageRead(15);
+      assertThat(readDouble("channel-message-read-time-avg")).isEqualTo(10.0);
+      assertThat(readDouble("channel-message-read-time-max")).isEqualTo(15.0);
+      assertThat(readDouble("channel-message-read-time-total")).isEqualTo(20.0);
     }
   }
 
   @Test
   public void testCounters() throws Exception {
-    try (CoordinatorMetrics metrics = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+    try (CoordinatorMetrics metrics = new CoordinatorMetrics(connector, () -> 0L, () -> 0L)) {
       metrics.incStartCommit();
       metrics.incStartCommit();
       metrics.incStartCommit();
@@ -85,7 +92,7 @@ public class TestCoordinatorMetrics {
     AtomicLong commitSize = new AtomicLong(0);
     AtomicLong readySize = new AtomicLong(0);
     try (CoordinatorMetrics metrics =
-        new CoordinatorMetrics(CONNECTOR, commitSize::get, readySize::get)) {
+        new CoordinatorMetrics(connector, commitSize::get, readySize::get)) {
 
       assertThat(readLong("commit-buffer-size")).isEqualTo(0L);
       assertThat(readLong("ready-buffer-size")).isEqualTo(0L);
@@ -104,27 +111,34 @@ public class TestCoordinatorMetrics {
 
   @Test
   public void testCloseAllowsReregistration() throws Exception {
-    try (CoordinatorMetrics first = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+    try (CoordinatorMetrics first = new CoordinatorMetrics(connector, () -> 0L, () -> 0L)) {
       assertThat(first).isNotNull();
     }
-    try (CoordinatorMetrics second = new CoordinatorMetrics(CONNECTOR, () -> 0L, () -> 0L)) {
+    try (CoordinatorMetrics second = new CoordinatorMetrics(connector, () -> 0L, () -> 0L)) {
       assertThat(second).isNotNull();
     }
   }
 
-  private static double readDouble(String name) throws Exception {
-    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-    ObjectName objectName =
-        new ObjectName(
-            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
-    return ((Number) server.getAttribute(objectName, name)).doubleValue();
+  private double readDouble(String name) throws Exception {
+    return ((Number) attribute(connectorName(), name)).doubleValue();
   }
 
-  private static long readLong(String name) throws Exception {
+  private long readLong(String name) throws Exception {
+    return ((Number) attribute(connectorName(), name)).longValue();
+  }
+
+  private double readCommitDouble(String commitMode, String name) throws Exception {
+    return ((Number) attribute(connectorName() + ",commitMode=" + commitMode, name)).doubleValue();
+  }
+
+  private String connectorName() {
+    return "iceberg.kafka.connect:type=coordinator-metrics,connector="
+        + connector
+        + ",task=coordinator";
+  }
+
+  private static Object attribute(String objectName, String name) throws Exception {
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
-    ObjectName objectName =
-        new ObjectName(
-            "iceberg-kafka-connect-metrics:type=coordinator-metrics,connector=" + CONNECTOR);
-    return ((Number) server.getAttribute(objectName, name)).longValue();
+    return server.getAttribute(new ObjectName(objectName), name);
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorMetrics.java
@@ -56,8 +56,6 @@ public class TestCoordinatorMetrics {
       metrics.recordCommit(false, 50);
       metrics.recordCommit(false, 150);
 
-      assertThat(readCommitDouble("full", "commit-time-avg")).isEqualTo(100.0);
-      assertThat(readCommitDouble("full", "commit-time-max")).isEqualTo(150.0);
       assertThat(readCommitDouble("full", "commit-time-total")).isEqualTo(200.0);
       assertThat(readCommitDouble("full", "commit-time-count")).isEqualTo(2.0);
 
@@ -68,9 +66,8 @@ public class TestCoordinatorMetrics {
 
       metrics.recordMessageRead(5);
       metrics.recordMessageRead(15);
-      assertThat(readDouble("channel-message-read-time-avg")).isEqualTo(10.0);
-      assertThat(readDouble("channel-message-read-time-max")).isEqualTo(15.0);
       assertThat(readDouble("channel-message-read-time-total")).isEqualTo(20.0);
+      assertThat(readDouble("channel-message-read-time-count")).isEqualTo(2.0);
     }
   }
 
@@ -119,6 +116,27 @@ public class TestCoordinatorMetrics {
     }
   }
 
+  @Test
+  public void testRepeatedCloseDoesNotUnregisterReplacement() throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName query =
+        new ObjectName(
+            "iceberg.kafka.connect:type=coordinator-metrics,connector=" + connector + ",*");
+
+    // The coordinator closes from both terminate() and stop(); a re-elected coordinator can
+    // register the same ObjectName in between. The second close must not take the new beans down.
+    CoordinatorMetrics old = new CoordinatorMetrics(connector, () -> 0L, () -> 0L);
+    old.close();
+
+    try (CoordinatorMetrics replacement = new CoordinatorMetrics(connector, () -> 0L, () -> 0L)) {
+      assertThat(server.queryNames(query, null)).isNotEmpty();
+      old.close();
+      assertThat(server.queryNames(query, null)).isNotEmpty();
+      assertThat(replacement).isNotNull();
+    }
+    assertThat(server.queryNames(query, null)).isEmpty();
+  }
+
   private double readDouble(String name) throws Exception {
     return ((Number) attribute(connectorName(), name)).doubleValue();
   }
@@ -128,7 +146,7 @@ public class TestCoordinatorMetrics {
   }
 
   private double readCommitDouble(String commitMode, String name) throws Exception {
-    return ((Number) attribute(connectorName() + ",commitMode=" + commitMode, name)).doubleValue();
+    return ((Number) attribute(connectorName() + ",commit-mode=" + commitMode, name)).doubleValue();
   }
 
   private String connectorName() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -24,8 +24,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
+import java.lang.management.ManagementFactory;
 import java.util.Map;
 import java.util.UUID;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.data.IcebergWriterResult;
 import org.apache.iceberg.connect.data.Offset;
@@ -121,16 +124,16 @@ public class TestWorker extends ChannelTestBase {
 
     SinkTaskContext taskContext = mock(SinkTaskContext.class);
     Worker worker = new Worker(config, clientFactory, mock(SinkWriter.class), taskContext);
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName name =
+        new ObjectName(
+            "iceberg.kafka.connect:type=worker-metrics,connector=jmx-test-connector,task=3");
     try {
-      javax.management.MBeanServer server =
-          java.lang.management.ManagementFactory.getPlatformMBeanServer();
-      javax.management.ObjectName name =
-          new javax.management.ObjectName(
-              "iceberg-kafka-connect-metrics:type=worker-metrics,"
-                  + "connector=jmx-test-connector,task=jmx-test-connector-3");
       assertThat(server.queryNames(name, null)).isNotEmpty();
     } finally {
       worker.stop();
     }
+    // stop() must unregister the MBeans, else a task restart hits InstanceAlreadyExistsException
+    assertThat(server.queryNames(name, null)).isEmpty();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -84,36 +84,40 @@ public class TestWorker extends ChannelTestBase {
       when(sinkWriter.completeWrite()).thenReturn(sinkWriterResult);
 
       Worker worker = new Worker(config, clientFactory, sinkWriter, context);
-      worker.start();
+      try {
+        worker.start();
 
-      // init consumer after subscribe()
-      initConsumer();
+        // init consumer after subscribe()
+        initConsumer();
 
-      // save a record
-      Map<String, Object> value = ImmutableMap.of();
-      SinkRecord rec = new SinkRecord(SRC_TOPIC_NAME, 0, null, "key", null, value, 0L);
-      worker.save(ImmutableList.of(rec));
+        // save a record
+        Map<String, Object> value = ImmutableMap.of();
+        SinkRecord rec = new SinkRecord(SRC_TOPIC_NAME, 0, null, "key", null, value, 0L);
+        worker.save(ImmutableList.of(rec));
 
-      UUID commitId = UUID.randomUUID();
-      Event commitRequest = new Event(config.connectGroupId(), new StartCommit(commitId));
-      byte[] bytes = AvroUtil.encode(commitRequest);
-      consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
+        UUID commitId = UUID.randomUUID();
+        Event commitRequest = new Event(config.connectGroupId(), new StartCommit(commitId));
+        byte[] bytes = AvroUtil.encode(commitRequest);
+        consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 1, "key", bytes));
 
-      worker.process();
+        worker.process();
 
-      assertThat(producer.history()).hasSize(2);
+        assertThat(producer.history()).hasSize(2);
 
-      Event event = AvroUtil.decode(producer.history().get(0).value());
-      assertThat(event.payload().type()).isEqualTo(PayloadType.DATA_WRITTEN);
-      DataWritten dataWritten = (DataWritten) event.payload();
-      assertThat(dataWritten.commitId()).isEqualTo(commitId);
+        Event event = AvroUtil.decode(producer.history().get(0).value());
+        assertThat(event.payload().type()).isEqualTo(PayloadType.DATA_WRITTEN);
+        DataWritten dataWritten = (DataWritten) event.payload();
+        assertThat(dataWritten.commitId()).isEqualTo(commitId);
 
-      event = AvroUtil.decode(producer.history().get(1).value());
-      assertThat(event.type()).isEqualTo(PayloadType.DATA_COMPLETE);
-      DataComplete dataComplete = (DataComplete) event.payload();
-      assertThat(dataComplete.commitId()).isEqualTo(commitId);
-      assertThat(dataComplete.assignments()).hasSize(1);
-      assertThat(dataComplete.assignments().get(0).offset()).isEqualTo(1L);
+        event = AvroUtil.decode(producer.history().get(1).value());
+        assertThat(event.type()).isEqualTo(PayloadType.DATA_COMPLETE);
+        DataComplete dataComplete = (DataComplete) event.payload();
+        assertThat(dataComplete.commitId()).isEqualTo(commitId);
+        assertThat(dataComplete.assignments()).hasSize(1);
+        assertThat(dataComplete.assignments().get(0).offset()).isEqualTo(1L);
+      } finally {
+        worker.stop();
+      }
     }
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -113,4 +113,24 @@ public class TestWorker extends ChannelTestBase {
       assertThat(dataComplete.assignments().get(0).offset()).isEqualTo(1L);
     }
   }
+
+  @Test
+  public void testWorkerRegistersJmxMetrics() throws Exception {
+    when(config.connectorName()).thenReturn("jmx-test-connector");
+    when(config.taskId()).thenReturn("3");
+
+    SinkTaskContext taskContext = mock(SinkTaskContext.class);
+    Worker worker = new Worker(config, clientFactory, mock(SinkWriter.class), taskContext);
+    try {
+      javax.management.MBeanServer server =
+          java.lang.management.ManagementFactory.getPlatformMBeanServer();
+      javax.management.ObjectName name =
+          new javax.management.ObjectName(
+              "iceberg-kafka-connect-metrics:type=worker-metrics,"
+                  + "connector=jmx-test-connector,task=jmx-test-connector-3");
+      assertThat(server.queryNames(name, null)).isNotEmpty();
+    } finally {
+      worker.stop();
+    }
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.management.ManagementFactory;
+import java.util.Set;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import org.junit.jupiter.api.Test;
+
+public class TestWorkerMetrics {
+
+  private static final String CONNECTOR = "test-connector";
+  private static final String TASK_ID = "test-connector-7";
+
+  @Test
+  public void testRegistersAndUnregistersMBeans() throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName query =
+        new ObjectName(
+            "iceberg-kafka-connect-metrics:type=worker-metrics,connector="
+                + CONNECTOR
+                + ",task="
+                + TASK_ID);
+
+    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, TASK_ID)) {
+      Set<ObjectName> registered = server.queryNames(query, null);
+      assertThat(registered).isNotEmpty();
+    }
+
+    Set<ObjectName> afterClose = server.queryNames(query, null);
+    assertThat(afterClose).isEmpty();
+  }
+
+  @Test
+  public void testTimingMetrics() throws Exception {
+    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, "task-timing")) {
+      metrics.recordSave(100);
+      metrics.recordSave(200);
+
+      assertThat(readDouble("worker-metrics", "save-time-avg", "task-timing")).isEqualTo(150.0);
+      assertThat(readDouble("worker-metrics", "save-time-max", "task-timing")).isEqualTo(200.0);
+      assertThat(readDouble("worker-metrics", "save-time-total", "task-timing")).isEqualTo(300.0);
+
+      metrics.recordConsume(10);
+      metrics.recordConsume(30);
+
+      assertThat(readDouble("worker-metrics", "consume-available-time-avg", "task-timing"))
+          .isEqualTo(20.0);
+      assertThat(readDouble("worker-metrics", "consume-available-time-max", "task-timing"))
+          .isEqualTo(30.0);
+      assertThat(readDouble("worker-metrics", "consume-available-time-total", "task-timing"))
+          .isEqualTo(40.0);
+    }
+  }
+
+  @Test
+  public void testCounters() throws Exception {
+    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, "task-counter")) {
+      metrics.incDataWritten(3);
+      metrics.incDataWritten(2);
+      metrics.incDataComplete();
+      metrics.incDataComplete();
+
+      assertThat(readDouble("worker-metrics", "data-written-total", "task-counter")).isEqualTo(5.0);
+      assertThat(readDouble("worker-metrics", "data-complete-total", "task-counter"))
+          .isEqualTo(2.0);
+    }
+  }
+
+  @Test
+  public void testCloseAllowsReregistration() throws Exception {
+    String task = "task-reregister";
+    try (WorkerMetrics first = new WorkerMetrics(CONNECTOR, task)) {
+      assertThat(first).isNotNull();
+    }
+    try (WorkerMetrics second = new WorkerMetrics(CONNECTOR, task)) {
+      assertThat(second).isNotNull();
+    }
+  }
+
+  private static double readDouble(String group, String name, String taskId) throws Exception {
+    MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+    ObjectName objectName =
+        new ObjectName(
+            "iceberg-kafka-connect-metrics:type="
+                + group
+                + ",connector="
+                + CONNECTOR
+                + ",task="
+                + taskId);
+    return ((Number) server.getAttribute(objectName, name)).doubleValue();
+  }
+}

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
@@ -22,26 +22,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.lang.management.ManagementFactory;
 import java.util.Set;
+import java.util.UUID;
 import javax.management.MBeanServer;
 import javax.management.ObjectName;
 import org.junit.jupiter.api.Test;
 
 public class TestWorkerMetrics {
 
-  private static final String CONNECTOR = "test-connector";
-  private static final String TASK_ID = "test-connector-7";
+  private final String connector = "test-connector-" + UUID.randomUUID();
+  private final String taskId = connector + "-7";
 
   @Test
   public void testRegistersAndUnregistersMBeans() throws Exception {
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
     ObjectName query =
         new ObjectName(
-            "iceberg-kafka-connect-metrics:type=worker-metrics,connector="
-                + CONNECTOR
-                + ",task="
-                + TASK_ID);
+            "iceberg.kafka.connect:type=worker-metrics,connector=" + connector + ",task=" + taskId);
 
-    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, TASK_ID)) {
+    try (WorkerMetrics metrics = new WorkerMetrics(connector, taskId)) {
       Set<ObjectName> registered = server.queryNames(query, null);
       assertThat(registered).isNotEmpty();
     }
@@ -52,61 +50,61 @@ public class TestWorkerMetrics {
 
   @Test
   public void testTimingMetrics() throws Exception {
-    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, "task-timing")) {
+    try (WorkerMetrics metrics = new WorkerMetrics(connector, taskId)) {
       metrics.recordSave(100);
       metrics.recordSave(200);
 
-      assertThat(readDouble("worker-metrics", "save-time-avg", "task-timing")).isEqualTo(150.0);
-      assertThat(readDouble("worker-metrics", "save-time-max", "task-timing")).isEqualTo(200.0);
-      assertThat(readDouble("worker-metrics", "save-time-total", "task-timing")).isEqualTo(300.0);
+      assertThat(readDouble("save-time-avg")).isEqualTo(150.0);
+      assertThat(readDouble("save-time-max")).isEqualTo(200.0);
+      assertThat(readDouble("save-time-total")).isEqualTo(300.0);
+      assertThat(readDouble("save-time-count")).isEqualTo(2.0);
 
-      metrics.recordConsume(10);
-      metrics.recordConsume(30);
+      metrics.recordMessageRead(10);
+      metrics.recordMessageRead(30);
 
-      assertThat(readDouble("worker-metrics", "consume-available-time-avg", "task-timing"))
-          .isEqualTo(20.0);
-      assertThat(readDouble("worker-metrics", "consume-available-time-max", "task-timing"))
-          .isEqualTo(30.0);
-      assertThat(readDouble("worker-metrics", "consume-available-time-total", "task-timing"))
-          .isEqualTo(40.0);
+      assertThat(readDouble("channel-message-read-time-avg")).isEqualTo(20.0);
+      assertThat(readDouble("channel-message-read-time-max")).isEqualTo(30.0);
+      assertThat(readDouble("channel-message-read-time-total")).isEqualTo(40.0);
+
+      metrics.recordMessageProcess(5);
+      metrics.recordMessageProcess(15);
+
+      assertThat(readDouble("channel-message-process-time-avg")).isEqualTo(10.0);
+      assertThat(readDouble("channel-message-process-time-max")).isEqualTo(15.0);
+      assertThat(readDouble("channel-message-process-time-total")).isEqualTo(20.0);
     }
   }
 
   @Test
   public void testCounters() throws Exception {
-    try (WorkerMetrics metrics = new WorkerMetrics(CONNECTOR, "task-counter")) {
+    try (WorkerMetrics metrics = new WorkerMetrics(connector, taskId)) {
       metrics.incDataWritten(3);
       metrics.incDataWritten(2);
+      // empty poll cycle still records 0 so data-written and data-complete stay comparable
+      metrics.incDataWritten(0);
       metrics.incDataComplete();
       metrics.incDataComplete();
 
-      assertThat(readDouble("worker-metrics", "data-written-total", "task-counter")).isEqualTo(5.0);
-      assertThat(readDouble("worker-metrics", "data-complete-total", "task-counter"))
-          .isEqualTo(2.0);
+      assertThat(readDouble("data-written-total")).isEqualTo(5.0);
+      assertThat(readDouble("data-complete-total")).isEqualTo(2.0);
     }
   }
 
   @Test
   public void testCloseAllowsReregistration() throws Exception {
-    String task = "task-reregister";
-    try (WorkerMetrics first = new WorkerMetrics(CONNECTOR, task)) {
+    try (WorkerMetrics first = new WorkerMetrics(connector, taskId)) {
       assertThat(first).isNotNull();
     }
-    try (WorkerMetrics second = new WorkerMetrics(CONNECTOR, task)) {
+    try (WorkerMetrics second = new WorkerMetrics(connector, taskId)) {
       assertThat(second).isNotNull();
     }
   }
 
-  private static double readDouble(String group, String name, String taskId) throws Exception {
+  private double readDouble(String name) throws Exception {
     MBeanServer server = ManagementFactory.getPlatformMBeanServer();
     ObjectName objectName =
         new ObjectName(
-            "iceberg-kafka-connect-metrics:type="
-                + group
-                + ",connector="
-                + CONNECTOR
-                + ",task="
-                + taskId);
+            "iceberg.kafka.connect:type=worker-metrics,connector=" + connector + ",task=" + taskId);
     return ((Number) server.getAttribute(objectName, name)).doubleValue();
   }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorkerMetrics.java
@@ -54,38 +54,34 @@ public class TestWorkerMetrics {
       metrics.recordSave(100);
       metrics.recordSave(200);
 
-      assertThat(readDouble("save-time-avg")).isEqualTo(150.0);
-      assertThat(readDouble("save-time-max")).isEqualTo(200.0);
       assertThat(readDouble("save-time-total")).isEqualTo(300.0);
       assertThat(readDouble("save-time-count")).isEqualTo(2.0);
 
       metrics.recordMessageRead(10);
       metrics.recordMessageRead(30);
 
-      assertThat(readDouble("channel-message-read-time-avg")).isEqualTo(20.0);
-      assertThat(readDouble("channel-message-read-time-max")).isEqualTo(30.0);
       assertThat(readDouble("channel-message-read-time-total")).isEqualTo(40.0);
+      assertThat(readDouble("channel-message-read-time-count")).isEqualTo(2.0);
 
       metrics.recordMessageProcess(5);
       metrics.recordMessageProcess(15);
 
-      assertThat(readDouble("channel-message-process-time-avg")).isEqualTo(10.0);
-      assertThat(readDouble("channel-message-process-time-max")).isEqualTo(15.0);
       assertThat(readDouble("channel-message-process-time-total")).isEqualTo(20.0);
+      assertThat(readDouble("channel-message-process-time-count")).isEqualTo(2.0);
     }
   }
 
   @Test
   public void testCounters() throws Exception {
     try (WorkerMetrics metrics = new WorkerMetrics(connector, taskId)) {
-      metrics.incDataWritten(3);
-      metrics.incDataWritten(2);
-      // empty poll cycle still records 0 so data-written and data-complete stay comparable
-      metrics.incDataWritten(0);
+      metrics.incDataFilesWritten(3);
+      metrics.incDataFilesWritten(2);
+      // empty poll cycle still records 0 so data-files-written and data-complete stay comparable
+      metrics.incDataFilesWritten(0);
       metrics.incDataComplete();
       metrics.incDataComplete();
 
-      assertThat(readDouble("data-written-total")).isEqualTo(5.0);
+      assertThat(readDouble("data-files-written-total")).isEqualTo(5.0);
       assertThat(readDouble("data-complete-total")).isEqualTo(2.0);
     }
   }


### PR DESCRIPTION
Expose runtime visibility into the Iceberg Kafka Connect commit pipeline using kafka-clients' built-in Metrics framework with a JmxReporter (no new dependencies).

Two package-private classes own per-task and per-connector Metrics registries:
  WorkerMetrics       — tags {connector, task}
  CoordinatorMetrics  — tag  {connector}

Exposed MBeans under the iceberg-kafka-connect-metrics domain:

  type=worker-metrics
    save-time-{avg,max,total}
    consume-available-time-{avg,max,total}
    data-written-total
    data-complete-total

  type=coordinator-metrics
    commit-time-{avg,max,total}
    consume-available-time-{avg,max,total}
    start-commit-total
    commit-complete-total
    commit-buffer-size       (gauge, lazy)
    ready-buffer-size        (gauge, lazy)

Wiring:
  - Channel.consumeAvailable wraps its body in a timer and calls a new recordConsumeTime(long) hook overridden by Worker and Coordinator. The initial poll inside Channel.start() is timed too.
  - Worker times save() and counts DATA_WRITTEN/DATA_COMPLETE emissions; closes its registry in stop().
  - Coordinator times commit() (covering doCommit + endCurrentCommit on both success and failure paths), counts START_COMMIT/ COMMIT_COMPLETE emissions, and exposes lazy-supplier gauges backed by CommitState.commitBufferSize() / readyBufferSize(); closes its registry in terminate().
  - CommitState gains commitBufferSize() / readyBufferSize() accessors.

Construction is hardened against partial-init MBean leaks: the Metrics registry is built into a local, sensors and gauges are registered inside a try block, and on RuntimeException the local registry is closed before rethrowing.

Tests: TestWorkerMetrics (4 tests), TestCoordinatorMetrics (5 tests) verify observable JMX behavior via the live MBeanServer. Registration assertions added to TestWorker and TestCoordinator. ChannelTestBase gains default config.connectorName()/taskId() stubs so existing Worker/Coordinator tests keep constructing without NPE inside the JMX tag map. TestCoordinator's coordinatorTest() helper now terminates and stops the Coordinator in a finally block to release the CoordinatorMetrics registry between tests.