### PR TITLE
Kafka Connect: Include connector name in commit thread names

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -219,7 +219,7 @@ public class CommitterImpl implements Committer {
       LOG.info("Task {} elected leader, starting commit coordinator", taskId);
       Coordinator coordinator =
           new Coordinator(catalog, config, membersWhenWorkerIsCoordinator, clientFactory, context);
-      coordinatorThread = new CoordinatorThread(coordinator);
+      coordinatorThread = new CoordinatorThread(coordinator, config.connectorName());
       coordinatorThread.start();
     }
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -110,10 +110,14 @@ class Coordinator extends Channel {
             new LinkedBlockingQueue<>(),
             new ThreadFactoryBuilder()
                 .setDaemon(true)
-                .setNameFormat("iceberg-committer" + "-%d")
+                .setNameFormat(committerThreadNameFormat(config.connectorName()))
                 .build());
     this.commitState = new CommitState(config);
     this.taskId = config.connectorName() + "-" + config.taskId();
+  }
+
+  static String committerThreadNameFormat(String connectorName) {
+    return "iceberg-committer-" + connectorName + "-%d";
   }
 
   void process() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -33,6 +33,11 @@ class CoordinatorThread extends Thread {
     this.coordinator = coordinator;
   }
 
+  CoordinatorThread(Coordinator coordinator, String connectorName) {
+    super(THREAD_NAME + "-" + connectorName);
+    this.coordinator = coordinator;
+  }
+
   @Override
   public void run() {
     try {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinatorThread.java
@@ -45,4 +45,18 @@ public class TestCoordinatorThread {
     verify(coordinator, timeout(1000)).stop();
     assertThat(coordinatorThread.isTerminated()).isTrue();
   }
+
+  @Test
+  public void threadNameIncludesConnectorName() {
+    Coordinator coordinator = mock(Coordinator.class);
+    CoordinatorThread coordinatorThread = new CoordinatorThread(coordinator, "inventory-sink");
+
+    assertThat(coordinatorThread.getName()).isEqualTo("iceberg-coord-inventory-sink");
+  }
+
+  @Test
+  public void committerThreadNameFormatIncludesConnectorName() {
+    assertThat(Coordinator.committerThreadNameFormat("inventory-sink"))
+        .isEqualTo("iceberg-committer-inventory-sink-%d");
+  }
 }


### PR DESCRIPTION
Fixes #16354.

This updates the Kafka Connect sink commit thread names to include the connector name:

- coordinator threads now use `iceberg-coord-<connector-name>` when started by a committer
- committer worker pool threads now use `iceberg-committer-<connector-name>-%d`

This makes thread dumps and worker logs easier to attribute when multiple Iceberg sink connectors run in the same Kafka Connect worker. The existing package-private `CoordinatorThread(Coordinator)` constructor is kept unchanged for existing tests/internal callers.

Validation:

- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:test --tests org.apache.iceberg.connect.channel.TestCoordinatorThread --tests org.apache.iceberg.connect.channel.TestCommitterImpl --no-daemon`
- `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:spotlessCheck --no-daemon`
- `git diff --check`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: fully reviewed
- Prompt Summary: Implement a small Kafka Connect thread naming fix for Apache Iceberg issue #16354 with local tests and project-style checks.