### PR TITLE
Core: Fix reference to nested column added to map/list in same transaction

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
+++ b/core/src/main/java/org/apache/iceberg/SchemaUpdate.java
@@ -167,6 +167,12 @@ class SchemaUpdate implements UpdateSchema {
 
     // update tracking for moves
     addedNameToId.put(caseSensitivityAwareName(fullName), newId);
+    if (parent != null) {
+      // Also index the short name (e.g. locations.alt, not the canonical locations.value.alt)
+      // so later operations can reference the column, unless it already maps a column.
+      String shortName = caseSensitivityAwareName(parent + "." + name);
+      addedNameToId.putIfAbsent(shortName, newId);
+    }
     if (parentId != TABLE_ROOT_ID) {
       idToParent.put(newId, parentId);
     }

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -612,6 +612,44 @@ public class TestSchemaUpdate {
   }
 
   @Test
+  public void testUpdateColumnAddedToMapValueOrListElementInSameTransaction() {
+    // A column added to a map value or list element struct is referenced by its short name
+    // ("locations.alt", not "locations.value.alt") later in the same transaction.
+    Schema updated =
+        new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+            .addColumn("locations", "alt", Types.FloatType.get())
+            .updateColumnDoc("locations.alt", "altitude")
+            .addColumn("points", "z", Types.LongType.get())
+            .updateColumnDoc("points.z", "z coordinate")
+            .apply();
+
+    Types.StructType locationsValue =
+        updated.findField("locations").type().asMapType().valueType().asStructType();
+    assertThat(locationsValue.field("alt").doc()).isEqualTo("altitude");
+
+    Types.StructType pointsElement =
+        updated.findField("points").type().asListType().elementType().asStructType();
+    assertThat(pointsElement.field("z").doc()).isEqualTo("z coordinate");
+  }
+
+  @Test
+  public void testAddedNestedShortNameDoesNotShadowSiblingCanonicalName() {
+    // "z" owns the canonical name "points.element.z"; a sibling named "element.z" has the
+    // same short name but must not shadow it, so "points.element.z" still resolves to "z".
+    Schema updated =
+        new SchemaUpdate(SCHEMA, SCHEMA_LAST_COLUMN_ID)
+            .addColumn("points", "z", Types.LongType.get())
+            .addColumn("points", "element.z", Types.IntegerType.get())
+            .updateColumnDoc("points.element.z", "the canonical z column")
+            .apply();
+
+    Types.StructType pointsElement =
+        updated.findField("points").type().asListType().elementType().asStructType();
+    assertThat(pointsElement.field("z").doc()).isEqualTo("the canonical z column");
+    assertThat(pointsElement.field("element.z").doc()).isNull();
+  }
+
+  @Test
   public void testAddNestedStruct() {
     Schema schema = new Schema(required(1, "id", Types.IntegerType.get()));
     Types.StructType struct =


### PR DESCRIPTION
## Problem

`SchemaUpdate` records a column added in the current transaction in `addedNameToId`, keyed by the column's name, so that a later operation in the same transaction (`updateColumn`, `updateColumnDoc`, `requireColumn`, `makeColumnOptional`, or a move) can resolve the not-yet-committed column.

For a column added into a **map value struct** or a **list element struct**, `internalAddColumn` builds the key from the parent's canonical name via `schema.findColumnName(parentId)`, which includes the synthetic `value` / `element` segment:

```java
fullName = schema.findColumnName(parentId) + "." + name;   // e.g. "locations.value.alt"
addedNameToId.put(caseSensitivityAwareName(fullName), newId);
```

But callers address such a column by its **user-facing short name** (`locations.alt`, `points.z`) — the form the schema's own name index exposes for map value / list element structs. `findForUpdate` first tries `findField(name)` (which can't see the pending column) and then falls back to `addedNameToId.get(name)`, so the lookup misses and the operation fails with `Cannot update missing column: locations.alt`.

Only the full canonical path (`locations.value.alt`) works today, which is not the name users write.

## Example

```java
new SchemaUpdate(schema, lastColumnId)
    .addColumn("locations", "alt", Types.FloatType.get()) // into a map<..., struct> value
    .updateColumnDoc("locations.alt", "altitude")          // -> IllegalArgumentException today
    .apply();
```

## Fix

Also index the user-facing short name in `addedNameToId` for nested adds, so the shorthand resolves. This mirrors how the schema's own `IndexByName` tracks both the full and short paths (dropping `value`/`element` for structs nested in a map value / list element). Top-level and plain-struct adds are unaffected because their short name equals the full name.

## Tests

Added `TestSchemaUpdate.testUpdateColumnAddedToMapValueOrListElementInSameTransaction`: adds a field into a map value struct and a list element struct, then references each by its short name (`locations.alt`, `points.z`) in the same transaction. It fails before the change with `Cannot update missing column` and passes after. The full `TestSchemaUpdate` suite remains green.
