### PR TITLE
Core, Data: Validate equality delete field IDs

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -506,6 +506,7 @@ public class Avro {
       Preconditions.checkArgument(
           spec.isUnpartitioned() || partition != null,
           "Partition must not be null for partitioned writes");
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, rowSchema);
 
       meta("delete-type", "equality");
       meta(

--- a/core/src/main/java/org/apache/iceberg/formats/FileWriterBuilderImpl.java
+++ b/core/src/main/java/org/apache/iceberg/formats/FileWriterBuilderImpl.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileWriter;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
@@ -213,6 +214,9 @@ abstract class FileWriterBuilderImpl<W extends FileWriter<D, ?>, D, S>
         spec.isUnpartitioned() || partition != null,
         "Invalid partition, does not match spec: %s",
         spec);
+    if (content == FileContent.EQUALITY_DELETES) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, schema);
+    }
   }
 
   /** Builder for creating {@link DataWriter} instances for writing data files. */

--- a/core/src/main/java/org/apache/iceberg/io/DeleteSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/io/DeleteSchemaUtil.java
@@ -18,8 +18,11 @@
  */
 package org.apache.iceberg.io;
 
+import java.util.Set;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Types;
 
 public class DeleteSchemaUtil {
@@ -53,5 +56,22 @@ public class DeleteSchemaUtil {
             MetadataColumns.DELETE_FILE_ROW_FIELD_NAME,
             rowSchema.asStruct(),
             MetadataColumns.DELETE_FILE_ROW_DOC));
+  }
+
+  public static void validateEqualityFieldIds(int[] equalityFieldIds, Schema equalityDeleteSchema) {
+    Preconditions.checkArgument(
+        equalityFieldIds != null && equalityFieldIds.length > 0,
+        "Equality delete field IDs must not be null or empty");
+    Preconditions.checkArgument(equalityDeleteSchema != null, "Schema must not be null");
+
+    Set<Integer> seenFieldIds = Sets.newHashSetWithExpectedSize(equalityFieldIds.length);
+    for (int fieldId : equalityFieldIds) {
+      Preconditions.checkArgument(
+          seenFieldIds.add(fieldId), "Duplicate equality delete field ID: %s", fieldId);
+      Preconditions.checkArgument(
+          equalityDeleteSchema.findField(fieldId) != null,
+          "Invalid equality delete field ID: %s",
+          fieldId);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDeleteWriters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.avro;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -110,6 +111,57 @@ public class TestAvroDeleteWriters {
     }
 
     assertThat(deletedRecords).as("Deleted records should match expected").isEqualTo(records);
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsEmptyEqualityFieldIds() {
+    OutputFile out = new InMemoryOutputFile();
+
+    assertThatThrownBy(
+            () ->
+                Avro.writeDeletes(out)
+                    .createWriterFunc(DataWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(new int[0])
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Equality delete field IDs must not be null or empty");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsDuplicateEqualityFieldIds() {
+    OutputFile out = new InMemoryOutputFile();
+
+    assertThatThrownBy(
+            () ->
+                Avro.writeDeletes(out)
+                    .createWriterFunc(DataWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(1, 1)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate equality delete field ID: 1");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsMissingEqualityFieldId() {
+    OutputFile out = new InMemoryOutputFile();
+
+    assertThatThrownBy(
+            () ->
+                Avro.writeDeletes(out)
+                    .createWriterFunc(DataWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(99)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid equality delete field ID: 99");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
+++ b/core/src/test/java/org/apache/iceberg/formats/TestFormatModelRegistry.java
@@ -21,9 +21,20 @@ package org.apache.iceberg.formats;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
 
+import java.nio.ByteBuffer;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.MetricsConfig;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.encryption.EncryptedFiles;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
+import org.apache.iceberg.encryption.EncryptionKeyMetadata;
+import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -86,6 +97,25 @@ class TestFormatModelRegistry {
         .hasMessageContaining("Cannot register class");
   }
 
+  @Test
+  void equalityDeleteWriterRejectsMissingEqualityFieldId() {
+    FormatModelRegistry.register(new DummyParquetFormatModel(Object.class, Object.class));
+    EncryptedOutputFile outputFile =
+        EncryptedFiles.encryptedOutput(new InMemoryOutputFile(), EncryptionKeyMetadata.EMPTY);
+    Schema schema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+
+    assertThatThrownBy(
+            () ->
+                FormatModelRegistry.equalityDeleteWriteBuilder(
+                        FileFormat.PARQUET, Object.class, outputFile)
+                    .schema(schema)
+                    .spec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(99)
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid equality delete field ID: 99");
+  }
+
   private static class DummyParquetFormatModel implements FormatModel<Object, Object> {
     private final Class<?> type;
     private final Class<?> schemaType;
@@ -114,12 +144,82 @@ class TestFormatModelRegistry {
 
     @Override
     public ModelWriteBuilder<Object, Object> writeBuilder(EncryptedOutputFile outputFile) {
-      return null;
+      return new DummyModelWriteBuilder();
     }
 
     @Override
     public ReadBuilder<Object, Object> readBuilder(InputFile inputFile) {
       return null;
     }
+  }
+
+  private static class DummyModelWriteBuilder implements ModelWriteBuilder<Object, Object> {
+    @Override
+    public ModelWriteBuilder<Object, Object> schema(Schema schema) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> engineSchema(Object schema) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> set(String property, String value) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> meta(String property, String value) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> content(FileContent content) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> metricsConfig(MetricsConfig metricsConfig) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> overwrite() {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> withFileEncryptionKey(ByteBuffer encryptionKey) {
+      return this;
+    }
+
+    @Override
+    public ModelWriteBuilder<Object, Object> withAADPrefix(ByteBuffer aadPrefix) {
+      return this;
+    }
+
+    @Override
+    public FileAppender<Object> build() {
+      return new NoOpFileAppender();
+    }
+  }
+
+  private static class NoOpFileAppender implements FileAppender<Object> {
+    @Override
+    public void add(Object datum) {}
+
+    @Override
+    public Metrics metrics() {
+      return null;
+    }
+
+    @Override
+    public long length() {
+      return 0;
+    }
+
+    @Override
+    public void close() {}
   }
 }

--- a/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseFileWriterFactory.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.orc.ORC;
 import org.apache.iceberg.parquet.Parquet;
@@ -69,6 +70,10 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T>, 
       Schema equalityDeleteRowSchema,
       SortOrder equalityDeleteSortOrder,
       Map<String, String> writerProperties) {
+    if (equalityDeleteRowSchema != null && equalityFieldIds != null) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, equalityDeleteRowSchema);
+    }
+
     this.table = table;
     this.dataFileFormat = dataFileFormat;
     this.dataSchema = dataSchema;
@@ -92,6 +97,10 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T>, 
       SortOrder equalityDeleteSortOrder,
       Schema positionDeleteRowSchema,
       Map<String, String> writerProperties) {
+    if (equalityDeleteRowSchema != null && equalityFieldIds != null) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, equalityDeleteRowSchema);
+    }
+
     this.table = table;
     this.dataFileFormat = dataFileFormat;
     this.dataSchema = dataSchema;
@@ -115,6 +124,10 @@ public abstract class BaseFileWriterFactory<T> implements FileWriterFactory<T>, 
       Schema equalityDeleteRowSchema,
       SortOrder equalityDeleteSortOrder,
       Schema positionDeleteRowSchema) {
+    if (equalityDeleteRowSchema != null && equalityFieldIds != null) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, equalityDeleteRowSchema);
+    }
+
     this.table = table;
     this.dataFileFormat = dataFileFormat;
     this.dataSchema = dataSchema;

--- a/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/GenericAppenderFactory.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.deletes.EqualityDeleteWriter;
 import org.apache.iceberg.deletes.PositionDeleteWriter;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.FileAppenderFactory;
 import org.apache.iceberg.io.OutputFile;
@@ -132,6 +133,10 @@ public class GenericAppenderFactory implements FileAppenderFactory<Record> {
       int[] equalityFieldIds,
       Schema eqDeleteRowSchema,
       Schema posDeleteRowSchema) {
+    if (eqDeleteRowSchema != null && equalityFieldIds != null) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, eqDeleteRowSchema);
+    }
+
     this.table = table;
     this.config = config == null ? Maps.newHashMap() : config;
 

--- a/data/src/main/java/org/apache/iceberg/data/RegistryBasedFileWriterFactory.java
+++ b/data/src/main/java/org/apache/iceberg/data/RegistryBasedFileWriterFactory.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.encryption.EncryptionKeyMetadata;
 import org.apache.iceberg.formats.FileWriterBuilder;
 import org.apache.iceberg.formats.FormatModelRegistry;
 import org.apache.iceberg.io.DataWriter;
+import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.FileWriterFactory;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -73,6 +74,10 @@ public abstract class RegistryBasedFileWriterFactory<T, S>
       Map<String, String> writerProperties,
       S inputSchema,
       S equalityDeleteInputSchema) {
+    if (equalityDeleteRowSchema != null && equalityFieldIds != null) {
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, equalityDeleteRowSchema);
+    }
+
     this.table = table;
     this.dataFileFormat = dataFileFormat;
     this.inputType = inputType;

--- a/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
+++ b/data/src/test/java/org/apache/iceberg/TestGenericAppenderFactory.java
@@ -136,4 +136,33 @@ public class TestGenericAppenderFactory extends TestAppenderFactory<Record> {
         .hasMessageContaining(
             "Cannot set metrics properties when the table is provided, use table properties instead");
   }
+
+  @TestTemplate
+  void equalityFieldIdsAreValidatedAgainstEqualityDeleteRowSchema() {
+    int equalityFieldId = table.schema().findField("id").fieldId();
+
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                new GenericAppenderFactory(
+                    null,
+                    PartitionSpec.unpartitioned(),
+                    new int[] {equalityFieldId},
+                    table.schema().select("id")));
+  }
+
+  @TestTemplate
+  void equalityFieldIdsAreRejectedWhenMissingFromEqualityDeleteRowSchema() {
+    int equalityFieldId = table.schema().findField("id").fieldId();
+
+    assertThatThrownBy(
+            () ->
+                new GenericAppenderFactory(
+                    table.schema().select("id"),
+                    PartitionSpec.unpartitioned(),
+                    new int[] {equalityFieldId},
+                    table.schema().select("data")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid equality delete field ID: %s", equalityFieldId);
+  }
 }

--- a/data/src/test/java/org/apache/iceberg/data/TestGenericFileWriterFactory.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestGenericFileWriterFactory.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.data;
 
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import java.io.IOException;
 import java.util.List;
 import org.apache.iceberg.Schema;
@@ -64,4 +67,31 @@ public class TestGenericFileWriterFactory extends TestFileWriterFactory<Record> 
   @Override
   @TestTemplate
   public void testPositionDeleteWriterWithRow() throws IOException {}
+
+  @TestTemplate
+  void equalityFieldIdsAreValidatedAgainstEqualityDeleteRowSchema() {
+    int equalityFieldId = table.schema().findField("id").fieldId();
+
+    assertThatNoException()
+        .isThrownBy(
+            () ->
+                newWriterFactory(
+                    table.schema().select("data"),
+                    List.of(equalityFieldId),
+                    table.schema().select("id")));
+  }
+
+  @TestTemplate
+  void equalityFieldIdsAreRejectedWhenMissingFromEqualityDeleteRowSchema() {
+    int equalityFieldId = table.schema().findField("id").fieldId();
+
+    assertThatThrownBy(
+            () ->
+                newWriterFactory(
+                    table.schema().select("id"),
+                    List.of(equalityFieldId),
+                    table.schema().select("data")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid equality delete field ID: %s", equalityFieldId);
+  }
 }

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -619,6 +619,7 @@ public class ORC {
       Preconditions.checkArgument(
           spec.isUnpartitioned() || partition != null,
           "Partition must not be null for partitioned writes");
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, rowSchema);
 
       meta("delete-type", "equality");
       meta(

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcDeleteWriters.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcDeleteWriters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.orc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -104,6 +105,57 @@ public class TestOrcDeleteWriters {
     }
 
     assertThat(deletedRecords).as("Deleted records should match expected").isEqualTo(records);
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsEmptyEqualityFieldIds() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                ORC.writeDeletes(out)
+                    .createWriterFunc(GenericOrcWriter::buildWriter)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(new int[0])
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Equality delete field IDs must not be null or empty");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsDuplicateEqualityFieldIds() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                ORC.writeDeletes(out)
+                    .createWriterFunc(GenericOrcWriter::buildWriter)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(1, 1)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate equality delete field ID: 1");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsMissingEqualityFieldId() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                ORC.writeDeletes(out)
+                    .createWriterFunc(GenericOrcWriter::buildWriter)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(99)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid equality delete field ID: 99");
   }
 
   @Test

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1129,6 +1129,7 @@ public class Parquet {
       Preconditions.checkArgument(
           spec.isUnpartitioned() || partition != null,
           "Partition must not be null for partitioned writes");
+      DeleteSchemaUtil.validateEqualityFieldIds(equalityFieldIds, rowSchema);
 
       meta("delete-type", "equality");
       meta(

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetDeleteWriters.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.parquet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
@@ -109,6 +110,57 @@ public class TestParquetDeleteWriters {
     }
 
     assertThat(deletedRecords).as("Deleted records should match expected").isEqualTo(records);
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsEmptyEqualityFieldIds() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                Parquet.writeDeletes(out)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(new int[0])
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Equality delete field IDs must not be null or empty");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsDuplicateEqualityFieldIds() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                Parquet.writeDeletes(out)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(1, 1)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Duplicate equality delete field ID: 1");
+  }
+
+  @Test
+  public void equalityDeleteWriterRejectsMissingEqualityFieldId() {
+    OutputFile out = Files.localOutput(temp);
+
+    assertThatThrownBy(
+            () ->
+                Parquet.writeDeletes(out)
+                    .createWriterFunc(GenericParquetWriter::create)
+                    .overwrite()
+                    .rowSchema(SCHEMA)
+                    .withSpec(PartitionSpec.unpartitioned())
+                    .equalityFieldIds(99)
+                    .buildEqualityWriter())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid equality delete field ID: 99");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Validate equality delete field IDs against the equality delete row schema.
- Apply validation across data factories and direct Avro/Parquet/ORC writer builders.
- Add regression coverage for empty, duplicate, missing, and projected equality-delete schemas.

## Test Plan
- ./gradlew :iceberg-core:test --tests org.apache.iceberg.avro.TestAvroDeleteWriters --tests org.apache.iceberg.formats.TestFormatModelRegistry :iceberg-data:test --tests org.apache.iceberg.data.TestGenericFileWriterFactory --tests org.apache.iceberg.TestGenericAppenderFactory :iceberg-parquet:test --tests org.apache.iceberg.parquet.TestParquetDeleteWriters :iceberg-orc:test --tests org.apache.iceberg.orc.TestOrcDeleteWriters :iceberg-core:spotlessCheck :iceberg-data:spotlessCheck :iceberg-parquet:spotlessCheck :iceberg-orc:spotlessCheck

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Fix equality delete field ID validation findings, compare with the original PR, and push a single-commit PR.