### PR TITLE
Common: Fix NPE when binding AlwaysNull field in DynFields

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynFields.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynFields.java
@@ -133,6 +133,11 @@ public class DynFields {
     public void set(Object target, Void value) {}
 
     @Override
+    public BoundField<Void> bind(Object target) {
+      return new BoundField<>(this, target);
+    }
+
+    @Override
     public String toString() {
       return "Field(AlwaysNull)";
     }

--- a/common/src/test/java/org/apache/iceberg/common/TestDynFields.java
+++ b/common/src/test/java/org/apache/iceberg/common/TestDynFields.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.common;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import org.junit.jupiter.api.Test;
+
+class TestDynFields {
+  @Test
+  void defaultAlwaysNullBuildDoesNotThrow() {
+    assertThatCode(() -> DynFields.builder().defaultAlwaysNull().build(new Object()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void defaultAlwaysNullBoundFieldGetReturnsNull() {
+    DynFields.BoundField<Void> field = DynFields.builder().defaultAlwaysNull().build(new Object());
+    assertThat(field.get()).isNull();
+  }
+
+  @Test
+  void defaultAlwaysNullBuildCheckedDoesNotThrow() {
+    assertThatCode(() -> DynFields.builder().defaultAlwaysNull().buildChecked(new Object()))
+        .doesNotThrowAnyException();
+  }
+
+  @Test
+  void defaultAlwaysNullBuildCheckedBoundFieldGetReturnsNull() throws NoSuchFieldException {
+    DynFields.BoundField<Void> field =
+        DynFields.builder().defaultAlwaysNull().buildChecked(new Object());
+    assertThat(field.get()).isNull();
+  }
+}


### PR DESCRIPTION
Closes #17044

## Summary

- `DynFields.Builder.build(target)`/`buildChecked(target)` threw `NullPointerException` instead of returning a field bound to `null` when `defaultAlwaysNull()` was set and no matching field was found.
- `AlwaysNull` (a singleton with a `null` backing `Field`) did not override `bind(Object)`, so it inherited `UnboundField.bind()`, which dereferences the null field.
- Adds a `bind(Object)` override to `AlwaysNull`, matching the sibling no-op singleton `DynMethods.UnboundMethod.NOOP.bind()`, which already avoids this issue the same way.

## Testing done

- Added `TestDynFields` covering `build(target)`/`buildChecked(target)` with `defaultAlwaysNull()`: no exception thrown, and the bound field's `get()` returns `null`.
- `./gradlew :iceberg-common:check` — passed (spotlessCheck, checkstyle, revapi, test all green; 4 new tests pass).
- `./gradlew :iceberg-common:revapi` — passed; no public API change (`AlwaysNull` is a private nested class).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
