### PR TITLE
Aliyun: Prefer static credentials over RRSA auto-detection

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunClientFactories.java
@@ -119,8 +119,15 @@ public class AliyunClientFactories {
 
       String endpoint = aliyunProperties.ossEndpoint();
 
-      // Check if RRSA environment is available
-      if (isRrsaEnvironmentAvailable()) {
+      // Check if RRSA environment is available, but only fall back to it when the user has not
+      // explicitly configured a complete static credential pair (both access key id and secret).
+      // A fully configured static credential pair should take precedence over environment-based
+      // auto-detection, matching the sibling aws module (see
+      // AwsClientProperties#credentialsProvider, which only uses the static pair when both
+      // accessKeyId and secretAccessKey are set, falling back to auto-detection otherwise).
+      if ((Strings.isNullOrEmpty(aliyunProperties.accessKeyId())
+              || Strings.isNullOrEmpty(aliyunProperties.accessKeySecret()))
+          && isRrsaEnvironmentAvailable()) {
         try {
           LOG.info(
               "Detected RRSA environment variables, creating OSS client with RRSA credentials for endpoint: {}",

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/TestAliyunClientFactories.java
@@ -123,6 +123,74 @@ public class TestAliyunClientFactories {
     }
   }
 
+  /**
+   * When RRSA environment variables are present but the user has explicitly configured static
+   * credentials (both access key id and secret), the static credentials must take precedence over
+   * RRSA auto-detection.
+   */
+  @Test
+  @SetEnvironmentVariable(
+      key = "ALIBABA_CLOUD_OIDC_PROVIDER_ARN",
+      value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+  @SetEnvironmentVariable(
+      key = "ALIBABA_CLOUD_ROLE_ARN",
+      value = "acs:ram::123456789:role/test-rrsa-role")
+  @SetEnvironmentVariable(key = "ALIBABA_CLOUD_OIDC_TOKEN_FILE", value = "/tmp/oidc-token")
+  public void testExplicitStaticCredentialsTakePrecedenceOverRrsa() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AliyunProperties.OSS_ENDPOINT, "https://oss-cn-hangzhou.aliyuncs.com");
+    properties.put(AliyunProperties.CLIENT_ACCESS_KEY_ID, "test-access-key-id");
+    properties.put(AliyunProperties.CLIENT_ACCESS_KEY_SECRET, "test-access-key-secret");
+
+    AliyunClientFactories.DefaultAliyunClientFactory factory =
+        new AliyunClientFactories.DefaultAliyunClientFactory();
+    factory.initialize(properties);
+    assertThat(factory.isRrsaEnvironmentAvailable()).isTrue();
+
+    // Should not throw, since the static credentials branch is chosen instead of the RRSA branch
+    // (which would fail fast on the non-existent OIDC token file).
+    OSS client = factory.newOSSClient();
+    assertThat(client).as("OSS client should be created with static credentials").isNotNull();
+    client.shutdown();
+  }
+
+  /**
+   * When only the access key id is configured (access key secret is missing), RRSA auto-detection
+   * must still be used - the fallback requires both fields to be set.
+   */
+  @Test
+  @SetEnvironmentVariable(
+      key = "ALIBABA_CLOUD_OIDC_PROVIDER_ARN",
+      value = "acs:ram::123456789:oidc-provider/ack-rrsa-test")
+  @SetEnvironmentVariable(
+      key = "ALIBABA_CLOUD_ROLE_ARN",
+      value = "acs:ram::123456789:role/test-rrsa-role")
+  @SetEnvironmentVariable(key = "ALIBABA_CLOUD_OIDC_TOKEN_FILE", value = "/tmp/oidc-token")
+  public void testRrsaUsedWhenAccessKeySecretMissing() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AliyunProperties.OSS_ENDPOINT, "https://oss-cn-hangzhou.aliyuncs.com");
+    properties.put(AliyunProperties.CLIENT_ACCESS_KEY_ID, "test-access-key-id");
+
+    AliyunClientFactories.DefaultAliyunClientFactory factory =
+        new AliyunClientFactories.DefaultAliyunClientFactory();
+    factory.initialize(properties);
+    assertThat(factory.isRrsaEnvironmentAvailable()).isTrue();
+
+    OSS client = factory.newOSSClient();
+    assertThat(client).as("OSS client should be created with RRSA").isNotNull();
+
+    try {
+      client.doesBucketExist("test-bucket");
+      throw new AssertionError(
+          "Expected operation to fail with fake RRSA credentials, but it succeeded");
+    } catch (Exception e) {
+      // Expected - fake RRSA credentials should cause failure
+      assertThat(e).isNotNull();
+    } finally {
+      client.shutdown();
+    }
+  }
+
   @Test
   public void testIsRrsaEnvironmentAvailableWithoutEnvVars() {
     // Verify that isRrsaEnvironmentAvailable returns false when env vars are not set


### PR DESCRIPTION

Closes #17046

## Summary

- `DefaultAliyunClientFactory.newOSSClient()` always checked RRSA environment variables first, silently overriding explicit `client.access-key-id`/`client.access-key-secret` configuration whenever a pod happened to have RRSA env vars set (e.g. ACK auto-injection).
- Now RRSA is only used as a fallback when the static credential pair is incomplete (either field missing), matching the precedence in the sibling aws module (`AwsClientProperties#credentialsProvider`, which prefers a fully configured static pair over auto-detection).
- Existing RRSA-only users (no static credentials configured) see no behavior change.

## Testing done

- Added `TestAliyunClientFactories#testExplicitStaticCredentialsTakePrecedenceOverRrsa`: RRSA env vars + complete static credentials configured -> static credentials used (no exception from the nonexistent RRSA token file path).
- Added `TestAliyunClientFactories#testRrsaUsedWhenAccessKeySecretMissing`: RRSA env vars + only `access-key-id` configured (secret missing) -> RRSA path still used, avoiding a regression for incomplete static config.
- `./gradlew :iceberg-aliyun:check` - 40 existing + 2 new = 42 tests passed (spotlessCheck, checkstyle, errorProne all passed).
- `iceberg-aliyun` is not a revapi-tracked module; no revapi run needed.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
