### PR TITLE
AWS: Apply glue/kms endpoint overrides in AssumeRoleAwsClientFactory

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -81,6 +81,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     return GlueClient.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsProperties::applyGlueEndpointConfigurations)
         .applyMutation(awsClientProperties::applyRetryConfigurations)
         .build();
   }
@@ -90,6 +91,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
     return KmsClient.builder()
         .applyMutation(this::applyAssumeRoleConfigurations)
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
+        .applyMutation(awsProperties::applyKmsEndpointConfigurations)
         .applyMutation(awsClientProperties::applyRetryConfigurations)
         .build();
   }

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -97,6 +97,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
     if (isTableRegisteredWithLakeFormation()) {
       return KmsClient.builder()
           .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
+          .applyMutation(awsProperties()::applyKmsEndpointConfigurations)
           .applyMutation(awsClientProperties()::applyRetryConfigurations)
           .credentialsProvider(
               new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.net.URI;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.iceberg.TestHelpers;
@@ -271,6 +272,40 @@ public class TestAwsClientFactories {
         getAwsClientFactoryByCredentialsProvider(DummyValidProvider.class.getName());
     DynamoDbClient dynamoClient = factory.dynamo();
     assertAwsClientSetsAdaptiveRetryPolicy(dynamoClient);
+  }
+
+  @Test
+  public void testAssumeRoleGlueClientAppliesEndpointOverride() {
+    Map<String, String> properties = getAssumeRoleClientFactoryProperties();
+    properties.put(AwsProperties.GLUE_CATALOG_ENDPOINT, "https://glue.custom.endpoint");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    assertThat(factory.glue().serviceClientConfiguration().endpointOverride())
+        .hasValue(URI.create("https://glue.custom.endpoint"));
+  }
+
+  @Test
+  public void testAssumeRoleKmsClientAppliesEndpointOverride() {
+    Map<String, String> properties = getAssumeRoleClientFactoryProperties();
+    properties.put(AwsProperties.KMS_ENDPOINT, "https://kms.custom.endpoint");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    assertThat(factory.kms().serviceClientConfiguration().endpointOverride())
+        .hasValue(URI.create("https://kms.custom.endpoint"));
+  }
+
+  @Test
+  public void testAssumeRoleGlueKmsClientEndpointOverrideIsNoopByDefault() {
+    Map<String, String> properties = getAssumeRoleClientFactoryProperties();
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+    assertThat(factory.glue().serviceClientConfiguration().endpointOverride()).isEmpty();
+    assertThat(factory.kms().serviceClientConfiguration().endpointOverride()).isEmpty();
+  }
+
+  private Map<String, String> getAssumeRoleClientFactoryProperties() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    return properties;
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/lakeformation/TestLakeFormationAwsClientFactory.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws.lakeformation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.iceberg.aws.AwsProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.glue.GlueClient;
+import software.amazon.awssdk.services.glue.model.GetTableRequest;
+import software.amazon.awssdk.services.glue.model.GetTableResponse;
+import software.amazon.awssdk.services.glue.model.Table;
+import software.amazon.awssdk.services.kms.KmsClient;
+
+public class TestLakeFormationAwsClientFactory {
+
+  @Test
+  public void testKmsClientAppliesEndpointOverrideForRegisteredTable() {
+    GlueClient mockGlueClient = Mockito.mock(GlueClient.class);
+    Mockito.when(mockGlueClient.getTable(Mockito.any(GetTableRequest.class)))
+        .thenReturn(
+            GetTableResponse.builder()
+                .table(Table.builder().isRegisteredWithLakeFormation(true).build())
+                .build());
+
+    LakeFormationAwsClientFactory factory =
+        new LakeFormationAwsClientFactory() {
+          @Override
+          public GlueClient glue() {
+            return mockGlueClient;
+          }
+        };
+    factory.initialize(getLakeFormationClientFactoryProperties());
+
+    KmsClient kmsClient = factory.kms();
+    assertThat(kmsClient.serviceClientConfiguration().endpointOverride())
+        .hasValue(URI.create("https://kms.custom.endpoint"));
+  }
+
+  private Map<String, String> getLakeFormationClientFactoryProperties() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    properties.put(
+        AwsProperties.CLIENT_ASSUME_ROLE_TAGS_PREFIX
+            + LakeFormationAwsClientFactory.LF_AUTHORIZED_CALLER,
+        "emr");
+    properties.put(AwsProperties.LAKE_FORMATION_DB_NAME, "test-db");
+    properties.put(AwsProperties.LAKE_FORMATION_TABLE_NAME, "test-table");
+    properties.put(AwsProperties.GLUE_ACCOUNT_ID, "123456789012");
+    properties.put(AwsProperties.KMS_ENDPOINT, "https://kms.custom.endpoint");
+    return properties;
+  }
+}


### PR DESCRIPTION
Closes #17047

## Summary

- `AssumeRoleAwsClientFactory.glue()`/`.kms()` did not apply the `glue.endpoint`/`kms.endpoint` overrides configured via `AwsProperties`, unlike their `dynamo()` sibling in the same class, which already calls `applyMutation(awsProperties::applyDynamoDbEndpointConfigurations)`.
- `AwsClientFactories.DefaultAwsClientFactory.glue()`/`.kms()` already apply these endpoint overrides; this change restores parity for the assume-role code path.
- `LakeFormationAwsClientFactory.kms()` (registered-table branch) had the same gap and is fixed the same way; its `glue()` is inherited from `AssumeRoleAwsClientFactory` and needed no separate change.
- `glue.endpoint`/`kms.endpoint` remain no-ops when unset (`AwsProperties#configureEndpoint` only calls `endpointOverride()` when the property is non-null), so behavior for existing users without these properties is unchanged.

## Testing done

- Added `TestAwsClientFactories#testAssumeRoleGlueClientAppliesEndpointOverride`, `#testAssumeRoleKmsClientAppliesEndpointOverride` (assert `serviceClientConfiguration().endpointOverride()` equals the configured URI), and `#testAssumeRoleGlueKmsClientEndpointOverrideIsNoopByDefault` (asserts empty override when unset).
- Added `TestLakeFormationAwsClientFactory#testKmsClientAppliesEndpointOverrideForRegisteredTable`, stubbing `glue()` with a mocked `GlueClient` to make the registered-table branch of `kms()` reachable without Docker/network access.
- `./gradlew :iceberg-aws:check -x integrationTest` — 225 tests passed (integrationTest requires Docker/testcontainers and was not run locally, per project convention).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
