### PR TITLE
Delta: Use POSIX separator instead of File.separator

### DIFF
--- a/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/main/java/org/apache/iceberg/delta/BaseSnapshotDeltaLakeTableAction.java
@@ -24,7 +24,6 @@ import io.delta.standalone.actions.Action;
 import io.delta.standalone.actions.AddFile;
 import io.delta.standalone.actions.RemoveFile;
 import io.delta.standalone.exceptions.DeltaStandaloneException;
-import java.io.File;
 import java.net.URI;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
@@ -82,6 +81,9 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
   private static final String PARQUET_SUFFIX = ".parquet";
   private static final String DELTA_VERSION_TAG_PREFIX = "delta-version-";
   private static final String DELTA_TIMESTAMP_TAG_PREFIX = "delta-ts-";
+  // Use the POSIX separator instead of File.separator because File.separator is dependent on
+  // the client environment and not the target filesystem. POSIX is compatible with S3, GCS, etc
+  private static final String FILE_SEPARATOR = "/";
   private final ImmutableMap.Builder<String, String> additionalPropertiesBuilder =
       ImmutableMap.builder();
   private DeltaLog deltaLog;
@@ -448,13 +450,13 @@ class BaseSnapshotDeltaLakeTableAction implements SnapshotDeltaLakeTable {
    *     (either absolute or relative)
    * @param tableRoot the root path of the delta table
    */
-  private static String getFullFilePath(String path, String tableRoot) {
+  static String getFullFilePath(String path, String tableRoot) {
     URI dataFileUri = URI.create(path);
     String decodedPath = URLDecoder.decode(path, StandardCharsets.UTF_8);
     if (dataFileUri.isAbsolute()) {
       return decodedPath;
     } else {
-      return tableRoot + File.separator + decodedPath;
+      return tableRoot + FILE_SEPARATOR + decodedPath;
     }
   }
 }

--- a/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
+++ b/delta-lake/src/test/java/org/apache/iceberg/delta/TestBaseSnapshotDeltaLakeTableAction.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.delta;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
@@ -97,6 +98,29 @@ public class TestBaseSnapshotDeltaLakeTableAction {
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
             "Delta Lake table does not exist at the given location: %s", sourceTableLocation);
+  }
+
+  @Test
+  public void getFullFilePathJoinsRelativePathWithPosixSeparator() {
+    assertThat(
+            BaseSnapshotDeltaLakeTableAction.getFullFilePath(
+                "part-00000.parquet", "s3://bucket/table"))
+        .isEqualTo("s3://bucket/table/part-00000.parquet");
+  }
+
+  @Test
+  public void getFullFilePathReturnsAbsolutePathUnchanged() {
+    assertThat(
+            BaseSnapshotDeltaLakeTableAction.getFullFilePath(
+                "s3://bucket/other-table/part-00000.parquet", "s3://bucket/table"))
+        .isEqualTo("s3://bucket/other-table/part-00000.parquet");
+  }
+
+  @Test
+  public void getFullFilePathDecodesEncodedRelativePath() {
+    assertThat(
+            BaseSnapshotDeltaLakeTableAction.getFullFilePath("a%20b.parquet", "s3://bucket/table"))
+        .isEqualTo("s3://bucket/table/a b.parquet");
   }
 
   private static class TestCatalog extends BaseMetastoreCatalog {


### PR DESCRIPTION
Closes #17050

## Summary

- `BaseSnapshotDeltaLakeTableAction.getFullFilePath()` joined relative Delta data file paths with `File.separator`, which reflects the client JVM's host OS, not the target filesystem — broken on Windows against S3/GCS/HDFS/local targets.
- Matches `core/RewriteTablePathUtil.FILE_SEPARATOR`, which already fixed the identical problem with the same POSIX-separator constant.
- Lowered `getFullFilePath` from `private` to package-private so it can be unit-tested directly (class itself is already package-private).
- Removed the now-unused `import java.io.File;`.

## Testing done

- Added `TestBaseSnapshotDeltaLakeTableAction#getFullFilePathJoinsRelativePathWithPosixSeparator`, `#getFullFilePathReturnsAbsolutePathUnchanged`, `#getFullFilePathDecodesEncodedRelativePath` covering relative-path joining, absolute-path passthrough, and URL-decoded input.
- `./gradlew :iceberg-delta-lake:check` — 7 tests passed (0 failures).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
