### PR TITLE
API: Propagate allowMissing to nested structs in StructProjection

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -123,7 +123,9 @@ public class StructProjection implements StructLike {
             case STRUCT:
               nestedProjections[pos] =
                   new StructProjection(
-                      dataField.type().asStructType(), projectedField.type().asStructType());
+                      dataField.type().asStructType(),
+                      projectedField.type().asStructType(),
+                      allowMissing);
               break;
             case MAP:
               MapType projectedMap = projectedField.type().asMapType();

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.iceberg.StructLike;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.NestedField;
+import org.apache.iceberg.types.Types.StructType;
+import org.junit.jupiter.api.Test;
+
+class TestStructProjection {
+
+  // projected schema asks for the optional "middle" field nested inside "person"
+  private static final StructType PROJECTED_STRUCT =
+      StructType.of(
+          NestedField.required(1, "id", Types.LongType.get()),
+          NestedField.required(
+              2,
+              "person",
+              StructType.of(
+                  NestedField.required(3, "first", Types.StringType.get()),
+                  NestedField.optional(4, "middle", Types.StringType.get()),
+                  NestedField.required(5, "last", Types.StringType.get()))));
+
+  // data schema is missing the optional "middle" field inside the nested "person" struct
+  private static final StructType DATA_STRUCT_MISSING_NESTED_FIELD =
+      StructType.of(
+          NestedField.required(1, "id", Types.LongType.get()),
+          NestedField.required(
+              2,
+              "person",
+              StructType.of(
+                  NestedField.required(3, "first", Types.StringType.get()),
+                  NestedField.required(5, "last", Types.StringType.get()))));
+
+  @Test
+  void createAllowMissingAllowsMissingOptionalFieldInNestedStruct() {
+    Row person = Row.of("John", "Doe");
+    Row row = Row.of(1L, person);
+
+    StructProjection projection =
+        StructProjection.createAllowMissing(DATA_STRUCT_MISSING_NESTED_FIELD, PROJECTED_STRUCT);
+    projection.wrap(row);
+
+    StructLike projectedPerson = projection.get(1, StructLike.class);
+    assertThat(projectedPerson.get(1, String.class)).isNull();
+  }
+
+  @Test
+  void createStillThrowsForMissingOptionalFieldInNestedStruct() {
+    assertThatThrownBy(
+            () -> StructProjection.create(DATA_STRUCT_MISSING_NESTED_FIELD, PROJECTED_STRUCT))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot find field");
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestStructProjection.java
@@ -21,8 +21,10 @@ package org.apache.iceberg.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Set;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
@@ -44,26 +46,20 @@ class TestStructProjection {
 
   // data schema is missing the optional "middle" field inside the nested "person" struct
   private static final StructType DATA_STRUCT_MISSING_NESTED_FIELD =
-      StructType.of(
-          NestedField.required(1, "id", Types.LongType.get()),
-          NestedField.required(
-              2,
-              "person",
-              StructType.of(
-                  NestedField.required(3, "first", Types.StringType.get()),
-                  NestedField.required(5, "last", Types.StringType.get()))));
+      TypeUtil.selectNot(PROJECTED_STRUCT, Set.of(4));
 
   @Test
   void createAllowMissingAllowsMissingOptionalFieldInNestedStruct() {
-    Row person = Row.of("John", "Doe");
-    Row row = Row.of(1L, person);
+    Row row = Row.of(1L, Row.of("John", "Doe"));
 
     StructProjection projection =
         StructProjection.createAllowMissing(DATA_STRUCT_MISSING_NESTED_FIELD, PROJECTED_STRUCT);
     projection.wrap(row);
 
     StructLike projectedPerson = projection.get(1, StructLike.class);
+    assertThat(projectedPerson.get(0, String.class)).isEqualTo("John");
     assertThat(projectedPerson.get(1, String.class)).isNull();
+    assertThat(projectedPerson.get(2, String.class)).isEqualTo("Doe");
   }
 
   @Test


### PR DESCRIPTION

Closes #16123

## Summary

- `StructProjection`'s private 3-arg constructor recurses into a STRUCT field via the 2-arg constructor, which always passes `allowMissing=false`.
- As a result, `StructProjection.createAllowMissing(...)` still throws `IllegalArgumentException` for a missing optional field inside a nested struct, even though the top-level struct allows it.
- Fix: pass the outer `allowMissing` value through to the recursive constructor call in the STRUCT case, so nested structs behave the same as the top level.
- Related PRs (same bug, not duplicates): #15984 (closed by stale-bot, no design objection), #16168 (closed by author as duplicate of #15984).

## Testing done

- Added `TestStructProjection#createAllowMissingAllowsMissingOptionalFieldInNestedStruct` and `#createStillThrowsForMissingOptionalFieldInNestedStruct`, covering the positive (allowMissing) and negative (strict create) cases for a missing optional nested field.
- Verified red -> green: the new positive-case test fails with `IllegalArgumentException` against the unmodified constructor, and passes after the fix.
- `./gradlew :iceberg-api:check` — 1197 tests passed, 0 failures.
- `./gradlew :iceberg-api:revapi` — passed (only a private constructor call site changed).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
