### PR TITLE
Dell: Implement newInputFile(String, long) to avoid redundant HEAD calls

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsFileIO.java
@@ -59,6 +59,11 @@ public class EcsFileIO implements FileIO {
   }
 
   @Override
+  public InputFile newInputFile(String path, long length) {
+    return EcsInputFile.fromLocation(path, length, client(), dellProperties, metrics);
+  }
+
+  @Override
   public OutputFile newOutputFile(String path) {
     return EcsOutputFile.fromLocation(path, client(), dellProperties, metrics);
   }

--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsInputFile.java
@@ -20,11 +20,14 @@ package org.apache.iceberg.dell.ecs;
 
 import com.emc.object.s3.S3Client;
 import org.apache.iceberg.dell.DellProperties;
+import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.metrics.MetricsContext;
 
 class EcsInputFile extends BaseEcsFile implements InputFile {
+
+  private Long length = null;
 
   public static EcsInputFile fromLocation(String location, S3Client client) {
     return new EcsInputFile(
@@ -42,8 +45,28 @@ class EcsInputFile extends BaseEcsFile implements InputFile {
     return new EcsInputFile(client, new EcsURI(location), dellProperties, metrics);
   }
 
+  static EcsInputFile fromLocation(
+      String location,
+      long length,
+      S3Client client,
+      DellProperties dellProperties,
+      MetricsContext metrics) {
+    return new EcsInputFile(client, new EcsURI(location), length, dellProperties, metrics);
+  }
+
   EcsInputFile(S3Client client, EcsURI uri, DellProperties dellProperties, MetricsContext metrics) {
     super(client, uri, dellProperties, metrics);
+  }
+
+  EcsInputFile(
+      S3Client client,
+      EcsURI uri,
+      long length,
+      DellProperties dellProperties,
+      MetricsContext metrics) {
+    super(client, uri, dellProperties, metrics);
+    ValidationException.check(length >= 0, "Invalid file length: %s", length);
+    this.length = length;
   }
 
   /**
@@ -53,7 +76,10 @@ class EcsInputFile extends BaseEcsFile implements InputFile {
    */
   @Override
   public long getLength() {
-    return getObjectMetadata().getContentLength();
+    if (length == null) {
+      length = getObjectMetadata().getContentLength();
+    }
+    return length;
   }
 
   @Override

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsInputFile.java
@@ -19,12 +19,16 @@
 package org.apache.iceberg.dell.ecs;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.emc.object.s3.request.PutObjectRequest;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import org.apache.iceberg.dell.DellProperties;
 import org.apache.iceberg.dell.mock.ecs.EcsS3MockRule;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.relocated.com.google.common.io.ByteStreams;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -32,6 +36,36 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class TestEcsInputFile {
 
   @RegisterExtension public static EcsS3MockRule rule = EcsS3MockRule.create();
+
+  @Test
+  public void testKnownLengthAvoidsHeadRequest() {
+    String objectName = rule.randomObjectName();
+    EcsInputFile inputFile =
+        EcsInputFile.fromLocation(
+            new EcsURI(rule.bucket(), objectName).toString(),
+            10L,
+            rule.client(),
+            new DellProperties(),
+            MetricsContext.nullMetrics());
+
+    // The object is never created, so any getObjectMetadata() call would fail. Getting the
+    // length back without error proves it came from the cached value, not a HEAD request.
+    assertThat(inputFile.getLength()).isEqualTo(10L);
+  }
+
+  @Test
+  public void testNegativeLengthIsRejected() {
+    assertThatThrownBy(
+            () ->
+                EcsInputFile.fromLocation(
+                    new EcsURI(rule.bucket(), rule.randomObjectName()).toString(),
+                    -1L,
+                    rule.client(),
+                    new DellProperties(),
+                    MetricsContext.nullMetrics()))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Invalid file length");
+  }
 
   @Test
   public void testAbsentFile() {


### PR DESCRIPTION
Closes #17054

## Summary

- `EcsFileIO` never overrode `FileIO#newInputFile(String, long)`, so the known length passed by callers (`DataFile`/`DeleteFile`/`ManifestFile`) fell back to the `api/` default and was discarded.
- `EcsInputFile#getLength()` had no cached length, so it issued a fresh `getObjectMetadata()` HEAD request to ECS on every call.
- This matches `S3FileIO`/`GCSFileIO`/`ADLSFileIO`/`OSSFileIO`, which all override `newInputFile(String, long)` and cache the length (e.g. `aliyun/.../OSSFileIO.java`, `OSSInputFile.java`).

## Testing done

- Added `TestEcsInputFile#testKnownLengthAvoidsHeadRequest` (length is returned from cache without the mock backend ever creating the object) and `TestEcsInputFile#testNegativeLengthIsRejected` (negative length throws `ValidationException`).
- `./gradlew :iceberg-dell:check` — 27 tests passed, 0 failures.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
