### PR TITLE
GCP: Fix listNamespaces to return empty list for existing namespaces

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreCatalog.java
@@ -232,6 +232,9 @@ public class BigQueryMetastoreCatalog extends BaseMetastoreCatalog
   @Override
   public List<Namespace> listNamespaces(Namespace namespace) {
     if (!namespace.isEmpty()) {
+      if (namespaceExists(namespace)) {
+        return ImmutableList.of();
+      }
       throw new NoSuchNamespaceException("Namespace does not exist: %s", namespace);
     }
 

--- a/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
+++ b/bigquery/src/test/java/org/apache/iceberg/gcp/bigquery/TestBigQueryCatalog.java
@@ -208,4 +208,12 @@ public class TestBigQueryCatalog extends CatalogTests<BigQueryMetastoreCatalog> 
     assertThat(catalog.isValidIdentifier(TableIdentifier.of(Namespace.empty(), "table1")))
         .isFalse();
   }
+
+  @Test
+  public void testListNamespacesWithExistingNamespaceReturnsEmptyList() {
+    Namespace namespace = Namespace.of("existing_namespace");
+    catalog.createNamespace(namespace);
+
+    assertThat(catalog.listNamespaces(namespace)).isEmpty();
+  }
 }


### PR DESCRIPTION

Closes #17058

## Summary

- `listNamespaces(Namespace)` threw `NoSuchNamespaceException` for any non-empty namespace, even existing ones, contradicting its own Javadoc ("always returns an empty list" for an existing single-level namespace).
- Now checks `namespaceExists(namespace)`: returns `ImmutableList.of()` if it exists, throws only if it does not.
- Matches `HiveCatalog#listNamespaces(Namespace)` (hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java line 530-537), which uses the same existence-check-then-throw pattern.

## Testing done

- Added `TestBigQueryCatalog#testListNamespacesWithExistingNamespaceReturnsEmptyList` covering the existing-namespace case.
- `./gradlew :iceberg-bigquery:check` — 110 tests, 0 failures, 0 errors (23 skipped, pre-existing `@Disabled` cases unrelated to this change).

---

**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix `listNamespaces` to return an empty list for an existing namespace instead of throwing, with a test.
