### PR TITLE
Azure: Translate not-found errors in ADLSInputStream mid-stream reads

### DIFF
--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSInputStream.java
@@ -114,7 +114,13 @@ class ADLSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     positionStream();
 
-    int bytesRead = stream.read();
+    int bytesRead;
+    try {
+      bytesRead = stream.read();
+    } catch (IOException e) {
+      throwNotFoundIfNotPresent(e.getCause(), location);
+      throw e;
+    }
     if (bytesRead == -1) {
       return -1;
     }
@@ -132,7 +138,13 @@ class ADLSInputStream extends SeekableInputStream implements RangeReadable {
     Preconditions.checkState(!closed, "Cannot read: already closed");
     positionStream();
 
-    int bytesRead = stream.read(b, off, len);
+    int bytesRead;
+    try {
+      bytesRead = stream.read(b, off, len);
+    } catch (IOException e) {
+      throwNotFoundIfNotPresent(e.getCause(), location);
+      throw e;
+    }
     if (bytesRead == -1) {
       return -1;
     }

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSInputStream.java
@@ -19,17 +19,23 @@
 package org.apache.iceberg.azure.adlsv2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.http.HttpResponse;
+import com.azure.storage.blob.models.BlobStorageException;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.implementation.models.InternalDataLakeFileOpenInputStreamResult;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
+import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -122,5 +128,32 @@ class TestADLSInputStream {
     adlsInputStream.readTail(new byte[0], 0, 0);
 
     verify(inputStream).close();
+  }
+
+  @Test
+  void readTranslatesNotFoundOnMidStreamRead() throws IOException {
+    IOException notFound = new IOException(blobNotFoundException());
+    when(inputStream.read()).thenThrow(notFound);
+
+    assertThatThrownBy(() -> adlsInputStream.read())
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Location does not exist");
+  }
+
+  @Test
+  void readBufferTranslatesNotFoundOnMidStreamRead() throws IOException {
+    IOException notFound = new IOException(blobNotFoundException());
+    when(inputStream.read(any(byte[].class), anyInt(), anyInt())).thenThrow(notFound);
+
+    assertThatThrownBy(() -> adlsInputStream.read(new byte[10], 0, 10))
+        .isInstanceOf(NotFoundException.class)
+        .hasMessageContaining("Location does not exist");
+  }
+
+  private static BlobStorageException blobNotFoundException() {
+    HttpResponse response = mock(HttpResponse.class);
+    when(response.getHeaders())
+        .thenReturn(new HttpHeaders().set("x-ms-error-code", "BlobNotFound"));
+    return new BlobStorageException("The specified blob does not exist.", response, null);
   }
 }


### PR DESCRIPTION
Closes #17062

## Summary

- `ADLSInputStream.read()`/`read(byte[], int, int)` propagated the raw `IOException` from `stream.read(...)` when the file was deleted after the stream opened, instead of translating it to `NotFoundException`.
- `openRange()` in the same class already does this translation; this change makes `read()`/`read(byte[], int, int)` consistent with it, and with `GCSInputStream`'s `GCSExceptionUtil.throwNotFoundIfNotPresent` pattern.
- Follow-up to issue #13528 (fixed by PR #15806/#15734), which covered `openRange`/`readFully`/`readTail` but missed the mid-stream `read` methods.
- azure is outside the REVAPI-checked module set and `ADLSInputStream` is package-private, so no API compatibility impact.

## Testing done

- Added `TestADLSInputStream#readTranslatesNotFoundOnMidStreamRead` and `#readBufferTranslatesNotFoundOnMidStreamRead`, covering `read()` and `read(byte[], int, int)` throwing `NotFoundException` when the mocked stream raises an `IOException` wrapping a `BlobStorageException` with `x-ms-error-code: BlobNotFound`.
- `./gradlew :iceberg-azure:test --tests "org.apache.iceberg.azure.adlsv2.TestADLSInputStream"` — 6 tests passed.
- `./gradlew :iceberg-azure:spotlessCheck :iceberg-azure:checkstyleMain :iceberg-azure:checkstyleTest` — passed. (`:iceberg-azure:check` also runs `integrationTest`, which requires Docker/Azurite and was not available in this environment, so unit test/style/checkstyle were verified separately as shown above.)
- revapi: not applicable (azure module is outside REVAPI scope).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
