### PR TITLE
Dell: Handle EOF in EcsSeekableInputStream reads

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsSeekableInputStream.java
@@ -79,16 +79,25 @@ class EcsSeekableInputStream extends SeekableInputStream {
   @Override
   public int read() throws IOException {
     checkAndUseNewPos();
+    int bytesRead = internalStream.read();
+    if (bytesRead == -1) {
+      return -1;
+    }
+
     pos += 1;
     readBytes.increment();
     readOperations.increment();
-    return internalStream.read();
+    return bytesRead;
   }
 
   @Override
   public int read(byte[] b, int off, int len) throws IOException {
     checkAndUseNewPos();
     int delta = internalStream.read(b, off, len);
+    if (delta == -1) {
+      return -1;
+    }
+
     pos += delta;
     readBytes.increment(delta);
     readOperations.increment();

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsSeekableInputStream.java
@@ -30,6 +30,8 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 
 public class TestEcsSeekableInputStream {
 
+  private static final int EOF = -1;
+
   @RegisterExtension public static EcsS3MockRule rule = EcsS3MockRule.create();
 
   @Test
@@ -88,6 +90,41 @@ public class TestEcsSeekableInputStream {
       assertThat(new String(buffer, StandardCharsets.UTF_8))
           .as("The first 3 bytes should be 012")
           .isEqualTo("012");
+    }
+  }
+
+  @Test
+  public void readAtEndOfStreamReturnsEofWithoutAdvancingPos() throws IOException {
+    String objectName = rule.randomObjectName();
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, "01".getBytes()));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      assertThat(input.read()).isEqualTo('0');
+      assertThat(input.read()).isEqualTo('1');
+      assertThat(input.read()).as("Read past end of stream should return EOF").isEqualTo(EOF);
+      assertThat(input.getPos()).as("getPos() should not advance on EOF").isEqualTo(2);
+    }
+  }
+
+  @Test
+  public void readBytesAtEndOfStreamReturnsEofWithoutAdvancingPos() throws IOException {
+    String objectName = rule.randomObjectName();
+    byte[] data = "0123456789".getBytes();
+    rule.client().putObject(new PutObjectRequest(rule.bucket(), objectName, data));
+
+    try (EcsSeekableInputStream input =
+        new EcsSeekableInputStream(
+            rule.client(), new EcsURI(rule.bucket(), objectName), MetricsContext.nullMetrics())) {
+      byte[] buffer = new byte[data.length];
+      assertThat(input.read(buffer, 0, buffer.length))
+          .as("First read should consume the whole object")
+          .isEqualTo(data.length);
+      assertThat(input.read(buffer, 0, buffer.length))
+          .as("Read past end of stream should return EOF")
+          .isEqualTo(EOF);
+      assertThat(input.getPos()).as("getPos() should not advance on EOF").isEqualTo(data.length);
     }
   }
 }


### PR DESCRIPTION
Relates to #16062

## Summary

- `EcsSeekableInputStream.read()` and `read(byte[], int, int)` advanced `pos` and incremented the read metrics before checking whether the underlying stream returned EOF (`-1`), violating the `InputStream` contract.
- For the bulk read overload, `readBytes.increment(-1)` decremented the counter on every EOF instead of leaving it unchanged.
- Matches the fix already merged for S3/ADLS/GCS in #16055; PR #16266 attempted the same fix for Dell/Aliyun but was closed by stale-bot with no committer objection.

## Testing done

- Added `TestEcsSeekableInputStream#readAtEndOfStreamReturnsEofWithoutAdvancingPos` and `#readBytesAtEndOfStreamReturnsEofWithoutAdvancingPos` covering EOF for both `read()` and `read(byte[], int, int)`.
- `./gradlew :iceberg-dell:check` — 6 tests passed (4 existing + 2 new), spotlessCheck/checkstyle passed.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
