### PR TITLE
Core: Fix ShreddedObject.put not clearing prior remove marker

### DIFF
--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -95,6 +95,7 @@ public class ShreddedObject implements VariantObject {
 
     // allow setting fields that are contained in unshredded. this avoids read-time failures and
     // simplifies replacing field values.
+    removedFields.remove(field);
     shreddedFields.put(field, value);
     this.serializationState = null;
   }

--- a/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
@@ -280,6 +280,28 @@ public class TestShreddedObject {
     assertThat(actual.get("b")).as("removed field must not be serialized").isNull();
   }
 
+  @Test
+  public void testPutAfterRemoveClearsRemoveMarker() {
+    ShreddedObject object = createShreddedObject(FIELDS);
+    VariantMetadata metadata = object.metadata();
+
+    object.remove("b");
+    assertThat(object.get("b")).as("removed field should be hidden from reads").isNull();
+
+    object.put("b", Variants.of("rewritten"));
+    assertThat(object.get("b")).as("put after remove should restore the field").isNotNull();
+    assertThat(object.get("b").asPrimitive().get()).isEqualTo("rewritten");
+    assertThat(object.numFields()).as("numFields should include the re-added field").isEqualTo(3);
+    assertThat(object.fieldNames()).contains("b");
+
+    // the query API and the serialized bytes must agree on which fields are present
+    VariantValue serialized = roundTripMinimalBuffer(object, metadata);
+    assertThat(serialized).isInstanceOf(SerializedObject.class);
+    SerializedObject actual = (SerializedObject) serialized;
+    assertThat(actual.numFields()).isEqualTo(3);
+    VariantTestUtil.assertVariantString(actual.get("b"), "rewritten");
+  }
+
   @ParameterizedTest
   @ValueSource(ints = {300, 70_000, 16_777_300})
   public void testMultiByteOffsets(int len) {


### PR DESCRIPTION

Closes #17063

## Summary

- `ShreddedObject.put(field, value)` left a prior `remove(field)` marker in `removedFields`, so `remove()` followed by `put()` of the same field made `get()`/`fieldNames()`/`numFields()` report the field missing while `writeTo()` still serialized it with the new value.
- Fix clears `removedFields.remove(field)` in `put()`, mirroring how `remove()` already clears `shreddedFields` for the field.
- Query API and serialized bytes now agree after a remove-then-put sequence.

## Testing done

- Added `TestShreddedObject#testPutAfterRemoveClearsRemoveMarker` covering `remove()` then `put()` of the same field, asserting `get()`/`numFields()`/`fieldNames()` reflect the new value and the `writeTo()` round trip serializes it.
- `./gradlew :iceberg-core:test --tests "org.apache.iceberg.variants.TestShreddedObject"` — 23 tests passed.
- `./gradlew :iceberg-core:check` — spotlessCheck, checkstyleMain/Test/Jmh passed; full test suite timed out in CI session (large module), covered by the targeted test above instead.
- `./gradlew :iceberg-core:revapi` — passed (backward compatible, no signature change).



**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
