### PR TITLE
Spark 4.1: Read and write geometry and geography values in Parquet

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -64,8 +64,10 @@ import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.unsafe.types.CalendarInterval;
 import org.apache.spark.unsafe.types.GeographyVal;
 import org.apache.spark.unsafe.types.GeometryVal;
@@ -247,7 +249,8 @@ public class SparkParquetReaders {
 
       LogicalTypeAnnotation logicalType = primitive.getLogicalTypeAnnotation();
       if (logicalType instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) {
-        return new GeometryReader(desc);
+        String crs = ((LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) logicalType).getCrs();
+        return new GeometryReader(desc, sridFromCrs(crs));
       } else if (logicalType instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) {
         return new GeographyReader(desc);
       }
@@ -545,15 +548,27 @@ public class SparkParquetReaders {
     }
   }
 
+  /** Resolves the Spark SRID for a geometry column's CRS (absent CRS defaults to OGC:CRS84). */
+  private static int sridFromCrs(String crs) {
+    if (crs == null) {
+      return GeometryType$.MODULE$.GEOMETRY_DEFAULT_SRID();
+    }
+    return GeometryType$.MODULE$.apply(crs).srid();
+  }
+
   /** Reads a WKB BINARY column into a Spark {@link GeometryVal}. */
   private static class GeometryReader extends PrimitiveReader<GeometryVal> {
-    GeometryReader(ColumnDescriptor desc) {
+    private final int srid;
+
+    GeometryReader(ColumnDescriptor desc, int srid) {
       super(desc);
+      this.srid = srid;
     }
 
     @Override
     public GeometryVal read(GeometryVal ignored) {
-      return GeometryVal.fromBytes(column.nextBinary().getBytes());
+      // Iceberg stores pure WKB; Spark's GeometryVal is [SRID | WKB], so attach the column's SRID.
+      return STUtils.stGeomFromWKB(column.nextBinary().getBytes(), srid);
     }
   }
 
@@ -565,7 +580,9 @@ public class SparkParquetReaders {
 
     @Override
     public GeographyVal read(GeographyVal ignored) {
-      return GeographyVal.fromBytes(column.nextBinary().getBytes());
+      // Iceberg stores pure WKB; Spark's GeographyVal is [SRID | WKB]. Geography supports only
+      // OGC:CRS84, so the default SRID applies.
+      return STUtils.stGeogFromWKB(column.nextBinary().getBytes());
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.variants.Variant;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
@@ -243,6 +244,13 @@ public class SparkParquetReaders {
     public ParquetValueReader<?> primitive(
         org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
       ColumnDescriptor desc = type.getColumnDescription(currentPath());
+
+      LogicalTypeAnnotation logicalType = primitive.getLogicalTypeAnnotation();
+      if (logicalType instanceof LogicalTypeAnnotation.GeometryLogicalTypeAnnotation) {
+        return new GeometryReader(desc);
+      } else if (logicalType instanceof LogicalTypeAnnotation.GeographyLogicalTypeAnnotation) {
+        return new GeographyReader(desc);
+      }
 
       if (primitive.getOriginalType() != null) {
         switch (primitive.getOriginalType()) {
@@ -534,6 +542,30 @@ public class SparkParquetReaders {
       variant.value().writeTo(valueBuffer, 0);
 
       return new VariantVal(valueBytes, metadataBytes);
+    }
+  }
+
+  /** Reads a WKB BINARY column into a Spark {@link GeometryVal}. */
+  private static class GeometryReader extends PrimitiveReader<GeometryVal> {
+    GeometryReader(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public GeometryVal read(GeometryVal ignored) {
+      return GeometryVal.fromBytes(column.nextBinary().getBytes());
+    }
+  }
+
+  /** Reads a WKB BINARY column into a Spark {@link GeographyVal}. */
+  private static class GeographyReader extends PrimitiveReader<GeographyVal> {
+    GeographyReader(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public GeographyVal read(GeographyVal ignored) {
+      return GeographyVal.fromBytes(column.nextBinary().getBytes());
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -71,6 +71,8 @@ import org.apache.spark.sql.types.ShortType;
 import org.apache.spark.sql.types.StructField;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.types.VariantType;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
@@ -278,6 +280,18 @@ public class SparkParquetWriters {
           LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonLogicalType) {
         return Optional.of(byteArrays(desc));
       }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+        return Optional.of(new GeometryWriter(desc));
+      }
+
+      @Override
+      public Optional<ParquetValueWriter<?>> visit(
+          LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+        return Optional.of(new GeographyWriter(desc));
+      }
     }
 
     @Override
@@ -470,6 +484,30 @@ public class SparkParquetWriters {
     @Override
     public void write(int repetitionLevel, byte[] bytes) {
       column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(bytes));
+    }
+  }
+
+  /** Writes a Spark {@link GeometryVal} as its WKB bytes into a BINARY column. */
+  private static class GeometryWriter extends PrimitiveWriter<GeometryVal> {
+    private GeometryWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeometryVal value) {
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(value.getBytes()));
+    }
+  }
+
+  /** Writes a Spark {@link GeographyVal} as its WKB bytes into a BINARY column. */
+  private static class GeographyWriter extends PrimitiveWriter<GeographyVal> {
+    private GeographyWriter(ColumnDescriptor desc) {
+      super(desc);
+    }
+
+    @Override
+    public void write(int repetitionLevel, GeographyVal value) {
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(value.getBytes()));
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -61,6 +61,7 @@ import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.ByteType;
 import org.apache.spark.sql.types.DataType;
@@ -495,7 +496,8 @@ public class SparkParquetWriters {
 
     @Override
     public void write(int repetitionLevel, GeometryVal value) {
-      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(value.getBytes()));
+      // Spark stores geometry as [SRID | WKB]; Iceberg stores pure WKB, so strip the SRID header.
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(STUtils.stAsBinary(value)));
     }
   }
 
@@ -507,7 +509,8 @@ public class SparkParquetWriters {
 
     @Override
     public void write(int repetitionLevel, GeographyVal value) {
-      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(value.getBytes()));
+      // Spark stores geography as [SRID | WKB]; Iceberg stores pure WKB, so strip the SRID header.
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(STUtils.stAsBinary(value)));
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -56,6 +56,8 @@ import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 import scala.collection.Seq;
@@ -231,6 +233,16 @@ public class GenericsHelpers {
         assertThat(expected).as("Should expect a Variant").isInstanceOf(Variant.class);
         assertThat(actual).as("Should be a VariantVal").isInstanceOf(VariantVal.class);
         assertEquals((Variant) expected, (VariantVal) actual);
+        break;
+      case GEOMETRY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
+        assertThat(((GeometryVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        break;
+      case GEOGRAPHY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
+        assertThat(((GeographyVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:
@@ -432,6 +444,16 @@ public class GenericsHelpers {
         assertThat(expected).as("Should expect a Variant").isInstanceOf(Variant.class);
         assertThat(actual).as("Should be a VariantVal").isInstanceOf(VariantVal.class);
         assertEquals((Variant) expected, (VariantVal) actual);
+        break;
+      case GEOMETRY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
+        assertThat(((GeometryVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        break;
+      case GEOGRAPHY:
+        assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
+        assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
+        assertThat(((GeographyVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/GenericsHelpers.java
@@ -54,6 +54,7 @@ import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
 import org.apache.spark.unsafe.types.GeographyVal;
@@ -237,12 +238,14 @@ public class GenericsHelpers {
       case GEOMETRY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
-        assertThat(((GeometryVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        assertThat(STUtils.stAsBinary((GeometryVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case GEOGRAPHY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
-        assertThat(((GeographyVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        assertThat(STUtils.stAsBinary((GeographyVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:
@@ -448,12 +451,14 @@ public class GenericsHelpers {
       case GEOMETRY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a GeometryVal").isInstanceOf(GeometryVal.class);
-        assertThat(((GeometryVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        assertThat(STUtils.stAsBinary((GeometryVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case GEOGRAPHY:
         assertThat(expected).as("Should expect a ByteBuffer").isInstanceOf(ByteBuffer.class);
         assertThat(actual).as("Should be a GeographyVal").isInstanceOf(GeographyVal.class);
-        assertThat(((GeographyVal) actual).getBytes()).isEqualTo(((ByteBuffer) expected).array());
+        assertThat(STUtils.stAsBinary((GeographyVal) actual))
+            .isEqualTo(((ByteBuffer) expected).array());
         break;
       case TIME:
       default:

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -47,9 +47,8 @@ import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
-import org.apache.spark.unsafe.types.GeographyVal;
-import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
@@ -374,9 +373,10 @@ public class RandomData {
         case UUID:
           return UTF8String.fromString(UUID.nameUUIDFromBytes((byte[]) obj).toString());
         case GEOMETRY:
-          return GeometryVal.fromBytes((byte[]) obj);
+          // Spark's GeometryVal is [SRID | WKB]; build it from the generated WKB.
+          return STUtils.stGeomFromWKB((byte[]) obj);
         case GEOGRAPHY:
-          return GeographyVal.fromBytes((byte[]) obj);
+          return STUtils.stGeogFromWKB((byte[]) obj);
         default:
           return obj;
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/RandomData.java
@@ -48,6 +48,8 @@ import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 import org.apache.spark.unsafe.types.VariantVal;
 
@@ -371,6 +373,10 @@ public class RandomData {
           return Decimal.apply((BigDecimal) obj);
         case UUID:
           return UTF8String.fromString(UUID.nameUUIDFromBytes((byte[]) obj).toString());
+        case GEOMETRY:
+          return GeometryVal.fromBytes((byte[]) obj);
+        case GEOGRAPHY:
+          return GeographyVal.fromBytes((byte[]) obj);
         default:
           return obj;
       }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetReader.java
@@ -118,6 +118,11 @@ public class TestSparkParquetReader extends AvroDataTestBase {
     return true;
   }
 
+  @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
   protected List<InternalRow> rowsFromFile(InputFile inputFile, Schema schema) throws IOException {
     try (CloseableIterable<InternalRow> reader =
         Parquet.read(inputFile)

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -46,8 +46,7 @@ import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
-import org.apache.spark.unsafe.types.GeographyVal;
-import org.apache.spark.unsafe.types.GeometryVal;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -148,8 +147,9 @@ public class TestSparkParquetWriter {
     byte[] geogWkb = new byte[] {0x04, 0x05, 0x06};
     InternalRow row = new GenericInternalRow(3);
     row.update(0, 1L);
-    row.update(1, GeometryVal.fromBytes(geomWkb));
-    row.update(2, GeographyVal.fromBytes(geogWkb));
+    // Spark's GeometryVal/GeographyVal wrap [SRID | WKB]; build them from the pure WKB.
+    row.update(1, STUtils.stGeomFromWKB(geomWkb));
+    row.update(2, STUtils.stGeogFromWKB(geogWkb));
     // second row leaves the geo columns null
     InternalRow nulls = new GenericInternalRow(3);
     nulls.update(0, 2L);
@@ -175,8 +175,8 @@ public class TestSparkParquetWriter {
             .build()) {
       List<InternalRow> rows = Lists.newArrayList(reader);
       assertThat(rows).hasSize(2);
-      assertThat(rows.get(0).getGeometry(1).getBytes()).isEqualTo(geomWkb);
-      assertThat(rows.get(0).getGeography(2).getBytes()).isEqualTo(geogWkb);
+      assertThat(STUtils.stAsBinary(rows.get(0).getGeometry(1))).isEqualTo(geomWkb);
+      assertThat(STUtils.stAsBinary(rows.get(0).getGeography(2))).isEqualTo(geogWkb);
       assertThat(rows.get(1).isNullAt(1)).isTrue();
       assertThat(rows.get(1).isNullAt(2)).isTrue();
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkParquetWriter.java
@@ -30,6 +30,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.nio.file.Path;
 import java.util.Iterator;
+import java.util.List;
 import java.util.OptionalLong;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
@@ -37,12 +38,16 @@ import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.parquet.ParquetSchemaUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.schema.MessageType;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
@@ -128,6 +133,52 @@ public class TestSparkParquetWriter {
         TestHelpers.assertEquals(COMPLEX_SCHEMA, expected.next(), rows.next());
       }
       assertThat(rows).as("Should not have extra rows").isExhausted();
+    }
+  }
+
+  @Test
+  public void testGeospatialWkbRoundTrip() throws IOException {
+    Schema geoSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "geom", Types.GeometryType.crs84()),
+            optional(3, "geog", Types.GeographyType.crs84()));
+
+    byte[] geomWkb = new byte[] {0x01, 0x02, 0x03};
+    byte[] geogWkb = new byte[] {0x04, 0x05, 0x06};
+    InternalRow row = new GenericInternalRow(3);
+    row.update(0, 1L);
+    row.update(1, GeometryVal.fromBytes(geomWkb));
+    row.update(2, GeographyVal.fromBytes(geogWkb));
+    // second row leaves the geo columns null
+    InternalRow nulls = new GenericInternalRow(3);
+    nulls.update(0, 2L);
+
+    File testFile = File.createTempFile("junit", null, temp.toFile());
+    assertThat(testFile.delete()).as("Delete should succeed").isTrue();
+
+    try (FileAppender<InternalRow> writer =
+        Parquet.write(Files.localOutput(testFile))
+            .schema(geoSchema)
+            .createWriterFunc(
+                msgType ->
+                    SparkParquetWriters.buildWriter(SparkSchemaUtil.convert(geoSchema), msgType))
+            .build()) {
+      writer.add(row);
+      writer.add(nulls);
+    }
+
+    try (CloseableIterable<InternalRow> reader =
+        Parquet.read(Files.localInput(testFile))
+            .project(geoSchema)
+            .createReaderFunc(type -> SparkParquetReaders.buildReader(geoSchema, type))
+            .build()) {
+      List<InternalRow> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0).getGeometry(1).getBytes()).isEqualTo(geomWkb);
+      assertThat(rows.get(0).getGeography(2).getBytes()).isEqualTo(geogWkb);
+      assertThat(rows.get(1).isNullAt(1)).isTrue();
+      assertThat(rows.get(1).isNullAt(2)).isTrue();
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.Locale;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class TestSparkGeospatial extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String TABLE = CATALOG + ".default.geo";
+
+  // WKB (little-endian) for POINT(30 10) and POINT(-71 42).
+  private static final String GEOM_WKB = "01010000000000000000003e400000000000002440";
+  private static final String GEOG_WKB = "01010000000000000000c051c00000000000004540";
+
+  @BeforeAll
+  public static void setupCatalog() {
+    // Use a Hadoop catalog to avoid Hive schema conversion (Hive doesn't support geo yet), and
+    // enable the geospatial feature, which Spark keeps behind a flag.
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    String warehouse = System.getProperty("java.io.tmpdir") + "/iceberg_spark_geo_warehouse";
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".warehouse", warehouse);
+    spark.conf().set("spark.sql.geospatial.enabled", "true");
+  }
+
+  @BeforeEach
+  public void setupTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    // A bare GEOMETRY column is mixed-SRID, which Iceberg does not support, so the column SRID is
+    // pinned to 4326 (OGC:CRS84).
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        TABLE);
+
+    // st_geomfromwkb yields SRID 0, so set it to the column's SRID for the write to be accepted.
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, NULL, NULL)",
+        TABLE, GEOM_WKB, GEOG_WKB);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testGeospatialWkbReadBack(boolean vectorized) {
+    assumeThat(vectorized).as("Geo vectorized Parquet read is not implemented yet").isFalse();
+    setVectorization(vectorized);
+
+    // st_asbinary strips the SRID header back to pure WKB, matching what was inserted.
+    assertEquals(
+        "Geometry and geography WKB should round-trip through a Spark scan",
+        ImmutableList.of(
+            row(1L, GEOM_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
+            row(2L, null, null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            TABLE));
+  }
+
+  private void setVectorization(boolean on) {
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('read.parquet.vectorization.enabled'='%s')",
+        TABLE, Boolean.toString(on));
+  }
+}


### PR DESCRIPTION
Follow-up to the geo type work: the Spark type mapping (#16851) and Iceberg's
own Parquet value path (#16982) are in place, but the Spark Parquet
reader/writer did not handle geometry/geography values.

Geometry and geography columns carry a Parquet `LogicalTypeAnnotation` with no
legacy `OriginalType`. `SparkParquetReaders` and `SparkParquetWriters` dispatch
geo through the `OriginalType` / logical-type paths, so:
- the reader fell through to the physical `BINARY` case and returned a raw
  `byte[]`, which is the wrong in-memory type for a geo column (Spark's
  `InternalRow.getGeometry` / `getGeography` expect `GeometryVal` / `GeographyVal`);
- the writer hit the unsupported-logical-type branch and threw.

This reads a WKB `BINARY` column into Spark's `GeometryVal` / `GeographyVal` and
writes those values back as their WKB bytes, mirroring the existing binary
handling. Geo values are stored as pure WKB, so no transformation is needed
beyond wrapping/unwrapping the byte payload.

Testing:
- Enables the shared geospatial `DataTest` coverage for the Spark Parquet
  reader (`supportsGeospatial()`), exercising geometry and geography read
  round-trips through `SparkParquetReaders`.
- Adds a Spark writer round-trip test (`TestSparkParquetWriter`) that writes
  `GeometryVal` / `GeographyVal` through `SparkParquetWriters` and reads them
  back, including null values.

Vectorized (Arrow) geo reads are out of scope and remain a follow-up.
