### PR TITLE
Kafka Connect: Fix UUID conversion for Parquet writes

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -47,7 +47,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
-import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableProperties;
@@ -71,7 +70,6 @@ import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.ShreddedObject;
 import org.apache.iceberg.variants.ValueArray;
 import org.apache.iceberg.variants.Variant;
@@ -506,23 +504,12 @@ class RecordConverter {
   }
 
   protected Object convertUUID(Object value) {
-    UUID uuid;
     if (value instanceof String) {
-      uuid = UUID.fromString((String) value);
+      return UUID.fromString((String) value);
     } else if (value instanceof UUID) {
-      uuid = (UUID) value;
-    } else {
-      throw new IllegalArgumentException("Cannot convert to UUID: " + value.getClass().getName());
+      return (UUID) value;
     }
-
-    if (FileFormat.PARQUET
-        .name()
-        .toLowerCase(Locale.ROOT)
-        .equals(config.writeProps().get(TableProperties.DEFAULT_FILE_FORMAT))) {
-      return UUIDUtil.convert(uuid);
-    } else {
-      return uuid;
-    }
+    throw new IllegalArgumentException("Cannot convert to UUID: " + value.getClass().getName());
   }
 
   protected ByteBuffer convertBase64Binary(Object value) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -77,7 +77,6 @@ import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
 import org.apache.iceberg.types.Types.VariantType;
 import org.apache.iceberg.util.DateTimeUtil;
-import org.apache.iceberg.util.UUIDUtil;
 import org.apache.iceberg.variants.PhysicalType;
 import org.apache.iceberg.variants.Variant;
 import org.apache.iceberg.variants.VariantValue;
@@ -280,7 +279,7 @@ public class TestRecordConverter {
         ImmutableMap.<String, Object>builder().put("uuid", UUID_VAL.toString()).build();
 
     Record record = converter.convert(data);
-    assertThat(record.getField("uuid")).isEqualTo(UUIDUtil.convert(UUID_VAL));
+    assertThat(record.getField("uuid")).isEqualTo(UUID_VAL);
   }
 
   @Test


### PR DESCRIPTION
Closes #17076

## Summary

- `RecordConverter.convertUUID()` returned `byte[]` for UUID columns when the target file format is Parquet, but the Parquet UUID writer (`ParquetValueWriters.uuids()`) expects a `java.util.UUID` and converts to bytes itself, so writes threw `ClassCastException: class [B cannot be cast to class java.util.UUID`.
- Removes the `byte[]` branch so `convertUUID()` always returns `UUID`, matching ORC (`GenericOrcWriters.uuids()`) and Avro, which already accept `UUID` directly.
- The `byte[]` conversion matched the writer contract before PR #11904 changed `ParquetValueWriters`' UUID writer to accept `UUID` directly; `kafka-connect` was not updated to follow — this restores the correct contract.
- Note: open PR #16654 ("Kafka Connect: Precompute UUID-as-bytes flag in RecordConverter") touches the same method but explicitly preserves the current `byte[]` behavior, so it does not fix this bug; whichever of the two merges first, the other will need a rebase.

## Testing done

- Updated `TestRecordConverter#testUUIDConversionWithParquet` to assert the field equals the original `UUID`, replacing the `UUIDUtil.convert(UUID_VAL)` byte[] expectation.
- `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:check` passes — `TestRecordConverter` 59/59, full module 122/122, 0 failures.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and update the test.
