### PR TITLE
Docs: Fix non-existent SortOrderBuilder method in evolution.md example

### DIFF
--- a/docs/docs/evolution.md
+++ b/docs/docs/evolution.md
@@ -93,7 +93,7 @@ and `category` column sorted in descending order with nulls first:
 Table sampleTable = ...;
 sampleTable.replaceSortOrder()
    .asc("id", NullOrder.NULLS_LAST)
-   .dec("category", NullOrder.NULL_FIRST)
+   .desc("category", NullOrder.NULLS_FIRST)
    .commit();
 ```
 


### PR DESCRIPTION

Closes #17082

## Summary

- The `replaceSortOrder` example called `.dec("category", NullOrder.NULL_FIRST)`; neither `dec(...)` nor `NullOrder.NULL_FIRST` exist, so the example fails to compile.
- Changed to `.desc("category", NullOrder.NULLS_FIRST)`, matching the actual `SortOrderBuilder`/`NullOrder` API.
- The line above already used the correct constant naming (`NullOrder.NULLS_LAST`), confirming this was a typo rather than a different intended API.

## Testing done

- Docs-only change, no behavior change — no test added. Verified against `api/src/main/java/org/apache/iceberg/SortOrderBuilder.java` (`desc` methods) and `api/src/main/java/org/apache/iceberg/NullOrder.java` (`NULLS_FIRST`/`NULLS_LAST` constants).

---

**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix the evolution.md example that calls a non-existent `SortOrderBuilder` method.
