### PR TITLE
Docs: Fix type mismatch in JDBC catalog Java API example

### DIFF
--- a/docs/docs/jdbc.md
+++ b/docs/docs/jdbc.md
@@ -65,5 +65,5 @@ properties.put(JdbcCatalog.PROPERTY_PREFIX + "user", "admin");
 properties.put(JdbcCatalog.PROPERTY_PREFIX + "password", "pass");
 properties.put(CatalogProperties.WAREHOUSE_LOCATION, "s3://warehouse/path");
 Configuration hadoopConf = new Configuration(); // configs if you use HadoopFileIO
-JdbcCatalog catalog = CatalogUtil.buildIcebergCatalog("test_jdbc_catalog", properties, hadoopConf);
+JdbcCatalog catalog = (JdbcCatalog) CatalogUtil.buildIcebergCatalog("test_jdbc_catalog", properties, hadoopConf);
 ```


### PR DESCRIPTION

Closes #17083

## Summary

- The JDBC catalog Java API example assigned `CatalogUtil.buildIcebergCatalog(...)`'s result directly to a `JdbcCatalog` variable, but the method's only declared return type is `Catalog`, causing an "incompatible types" compile error.
- Added an explicit `(JdbcCatalog)` cast so the example compiles as written.

## Testing done

- Docs-only change, no behavior change — no test added. Verified against `core/src/main/java/org/apache/iceberg/CatalogUtil.java` line 312 (`public static Catalog buildIcebergCatalog(...)`).

---

**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix the type mismatch in the JDBC catalog Java API example.
