### PR TITLE
Docs: Fix reversed Flink binary/varbinary to Iceberg type mapping

### DIFF
--- a/docs/docs/flink.md
+++ b/docs/docs/flink.md
@@ -349,8 +349,8 @@ Flink types are converted to Iceberg types according to the following table:
 | char                | string                     |               |
 | varchar             | string                     |               |
 | string              | string                     |               |
-| binary              | binary                     |               |
-| varbinary           | fixed                      |               |
+| binary              | fixed                      |               |
+| varbinary           | binary                     |               |
 | decimal             | decimal                    |               |
 | date                | date                       |               |
 | time                | time                       |               |


### PR DESCRIPTION

Closes #17088

## Summary

- The "Flink to Iceberg" type mapping table listed `binary -> binary` and `varbinary -> fixed`, the exact opposite of what `FlinkTypeToType.visit(BinaryType)`/`visit(VarBinaryType)` actually produce (`binary -> fixed`, `varbinary -> binary`).
- The reverse "Iceberg to Flink" table on the same page already documents this pairing correctly, so the two tables were self-contradictory.
- Swapped the two table cells to match `flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkTypeToType.java` line 85-91.

## Testing done

- Docs-only change, no behavior change — no test added. Verified by re-reading `FlinkTypeToType.java`/`TypeToFlinkType.java` and confirming the fix matches both.


