### PR TITLE
Parquet: Fix boolean filter pushdown UnsupportedOperationException

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetFilters.java
@@ -223,7 +223,7 @@ class ParquetFilters {
 
     // TODO: this needs to convert to handle BigDecimal and UUID
     Object value = lit.value();
-    if (value instanceof Number) {
+    if (value instanceof Number || value instanceof Boolean) {
       return (C) lit.value();
     } else if (value instanceof CharSequence) {
       return (C) Binary.fromString(value.toString());

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -25,8 +25,10 @@ import static org.apache.iceberg.TableProperties.PARQUET_DICT_ENCODING_ENABLED_C
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MAX_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_CHECK_MIN_RECORD_COUNT;
 import static org.apache.iceberg.TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES;
+import static org.apache.iceberg.expressions.Expressions.equal;
 import static org.apache.iceberg.expressions.Expressions.greaterThan;
 import static org.apache.iceberg.expressions.Expressions.greaterThanOrEqual;
+import static org.apache.iceberg.expressions.Expressions.notEqual;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.createTempFile;
 import static org.apache.iceberg.parquet.ParquetWritingTestUtils.write;
 import static org.apache.iceberg.relocated.com.google.common.collect.Iterables.getOnlyElement;
@@ -677,6 +679,44 @@ public class TestParquet {
     List<Long> ids =
         filterIds(schema, file, greaterThan("ts", "2024-01-01T04:00:00.000000500+04:00"));
     assertThat(ids).containsExactlyInAnyOrder(3L, 4L, 5L);
+  }
+
+  @Test
+  public void booleanEqualityFilterPushdown() throws IOException {
+    // Boolean literals must reach getParquetPrimitive() without throwing
+    // UnsupportedOperationException; only Number/CharSequence/ByteBuffer were handled before.
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), required(2, "b", Types.BooleanType.get()));
+
+    Record template = org.apache.iceberg.data.GenericRecord.create(schema);
+    List<Record> records =
+        Lists.newArrayList(
+            template.copy(ImmutableMap.of("id", 1L, "b", true)),
+            template.copy(ImmutableMap.of("id", 2L, "b", false)),
+            template.copy(ImmutableMap.of("id", 3L, "b", true)));
+
+    File file = writeNanoRecords(schema, records);
+
+    assertThat(filterIds(schema, file, equal("b", true))).containsExactlyInAnyOrder(1L, 3L);
+  }
+
+  @Test
+  public void booleanInequalityFilterPushdown() throws IOException {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), required(2, "b", Types.BooleanType.get()));
+
+    Record template = org.apache.iceberg.data.GenericRecord.create(schema);
+    List<Record> records =
+        Lists.newArrayList(
+            template.copy(ImmutableMap.of("id", 1L, "b", true)),
+            template.copy(ImmutableMap.of("id", 2L, "b", false)),
+            template.copy(ImmutableMap.of("id", 3L, "b", true)));
+
+    File file = writeNanoRecords(schema, records);
+
+    assertThat(filterIds(schema, file, notEqual("b", false))).containsExactlyInAnyOrder(1L, 3L);
   }
 
   private File writeNanoRecords(Schema schema, List<Record> records) throws IOException {


### PR DESCRIPTION
Closes #17092

## Summary

- `ParquetFilters.getParquetPrimitive()` handled `Number`, `CharSequence`, and `ByteBuffer` literals but not `Boolean`, so `EQ`/`NOT_EQ` predicates on boolean columns threw `UnsupportedOperationException` while building the Parquet read builder, failing the read before any rows were returned.
- Adds `Boolean` to the existing `Number` branch (direct cast, same pattern), since `FilterApi.eq(BooleanColumn, Boolean)` expects the literal as-is.
- No other literal types (decimal/UUID, handled separately in open PR #16621) are touched.

## Testing done

- Added `TestParquet#booleanEqualityFilterPushdown` and `TestParquet#booleanInequalityFilterPushdown`, each writing a boolean-column Parquet file and reading it back through `Parquet.read(...).filter(...)`, asserting the correct rows are returned instead of throwing.
- `./gradlew :iceberg-parquet:check` — 705 tests passed (0 failures/errors), spotlessCheck/checkstyle/revapi included.
- `./gradlew :iceberg-parquet:revapi` — passed (no public API change; `ParquetFilters` is package-private, `getParquetPrimitive` is private static).

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
