### PR TITLE
Spark: Fix file_list_view prefix matching to exclude sibling paths in DeleteOrphanFiles

### DIFF
--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -750,4 +750,61 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
   }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesFileListViewDoesNotMatchSiblingPaths()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    String tableLocation = table.location();
+    // The sibling path has the table location as a raw string prefix, e.g. /tmp/abc-sibling when
+    // table is at /tmp/abc. Without the trailing-slash fix, startsWith(tableLocation) would
+    // incorrectly match files under this sibling path.
+    String siblingPath = tableLocation + "-sibling";
+
+    Timestamp lastModifiedTimestamp = new Timestamp(10000);
+    String orphanFile = tableLocation + "/orphan.parquet";
+    String siblingFile = siblingPath + "/data.parquet";
+
+    List<FilePathLastModifiedRecord> allFiles = Lists.newArrayList();
+    allFiles.add(new FilePathLastModifiedRecord(orphanFile, lastModifiedTimestamp));
+    allFiles.add(new FilePathLastModifiedRecord(siblingFile, lastModifiedTimestamp));
+    allFiles.add(
+        new FilePathLastModifiedRecord(
+            ReachableFileUtil.versionHintLocation(table), lastModifiedTimestamp));
+    for (String metaFile : ReachableFileUtil.metadataFileLocations(table, true)) {
+      allFiles.add(new FilePathLastModifiedRecord(metaFile, lastModifiedTimestamp));
+    }
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(allFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+    String fileListViewName = "files_view";
+    compareToFileList.createOrReplaceTempView(fileListViewName);
+
+    List<Object[]> orphanFiles =
+        sql(
+            "CALL %s.system.remove_orphan_files("
+                + "table => '%s',"
+                + "dry_run => true,"
+                + "file_list_view => '%s')",
+            catalogName, tableIdent, fileListViewName);
+
+    assertThat(orphanFiles)
+        .as("Files under sibling path must not be identified as orphans for this table")
+        .extracting(row -> row[0])
+        .doesNotContain(siblingFile);
+    assertThat(orphanFiles)
+        .as("Orphan file under the table location must be identified")
+        .extracting(row -> row[0])
+        .contains(orphanFile);
+  }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String locationPrefix = location.endsWith("/") ? location : location + "/";
+      files = files.filter(files.col(FILE_PATH).startsWith(locationPrefix));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -749,4 +749,61 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
   }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesFileListViewDoesNotMatchSiblingPaths()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    String tableLocation = table.location();
+    // The sibling path has the table location as a raw string prefix, e.g. /tmp/abc-sibling when
+    // table is at /tmp/abc. Without the trailing-slash fix, startsWith(tableLocation) would
+    // incorrectly match files under this sibling path.
+    String siblingPath = tableLocation + "-sibling";
+
+    Timestamp lastModifiedTimestamp = new Timestamp(10000);
+    String orphanFile = tableLocation + "/orphan.parquet";
+    String siblingFile = siblingPath + "/data.parquet";
+
+    List<FilePathLastModifiedRecord> allFiles = Lists.newArrayList();
+    allFiles.add(new FilePathLastModifiedRecord(orphanFile, lastModifiedTimestamp));
+    allFiles.add(new FilePathLastModifiedRecord(siblingFile, lastModifiedTimestamp));
+    allFiles.add(
+        new FilePathLastModifiedRecord(
+            ReachableFileUtil.versionHintLocation(table), lastModifiedTimestamp));
+    for (String metaFile : ReachableFileUtil.metadataFileLocations(table, true)) {
+      allFiles.add(new FilePathLastModifiedRecord(metaFile, lastModifiedTimestamp));
+    }
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(allFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+    String fileListViewName = "files_view";
+    compareToFileList.createOrReplaceTempView(fileListViewName);
+
+    List<Object[]> orphanFiles =
+        sql(
+            "CALL %s.system.remove_orphan_files("
+                + "table => '%s',"
+                + "dry_run => true,"
+                + "file_list_view => '%s')",
+            catalogName, tableIdent, fileListViewName);
+
+    assertThat(orphanFiles)
+        .as("Files under sibling path must not be identified as orphans for this table")
+        .extracting(row -> row[0])
+        .doesNotContain(siblingFile);
+    assertThat(orphanFiles)
+        .as("Orphan file under the table location must be identified")
+        .extracting(row -> row[0])
+        .contains(orphanFile);
+  }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String locationPrefix = location.endsWith("/") ? location : location + "/";
+      files = files.filter(files.col(FILE_PATH).startsWith(locationPrefix));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -749,4 +749,61 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
   }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesFileListViewDoesNotMatchSiblingPaths()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    String tableLocation = table.location();
+    // The sibling path has the table location as a raw string prefix, e.g. /tmp/abc-sibling when
+    // table is at /tmp/abc. Without the trailing-slash fix, startsWith(tableLocation) would
+    // incorrectly match files under this sibling path.
+    String siblingPath = tableLocation + "-sibling";
+
+    Timestamp lastModifiedTimestamp = new Timestamp(10000);
+    String orphanFile = tableLocation + "/orphan.parquet";
+    String siblingFile = siblingPath + "/data.parquet";
+
+    List<FilePathLastModifiedRecord> allFiles = Lists.newArrayList();
+    allFiles.add(new FilePathLastModifiedRecord(orphanFile, lastModifiedTimestamp));
+    allFiles.add(new FilePathLastModifiedRecord(siblingFile, lastModifiedTimestamp));
+    allFiles.add(
+        new FilePathLastModifiedRecord(
+            ReachableFileUtil.versionHintLocation(table), lastModifiedTimestamp));
+    for (String metaFile : ReachableFileUtil.metadataFileLocations(table, true)) {
+      allFiles.add(new FilePathLastModifiedRecord(metaFile, lastModifiedTimestamp));
+    }
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(allFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+    String fileListViewName = "files_view";
+    compareToFileList.createOrReplaceTempView(fileListViewName);
+
+    List<Object[]> orphanFiles =
+        sql(
+            "CALL %s.system.remove_orphan_files("
+                + "table => '%s',"
+                + "dry_run => true,"
+                + "file_list_view => '%s')",
+            catalogName, tableIdent, fileListViewName);
+
+    assertThat(orphanFiles)
+        .as("Files under sibling path must not be identified as orphans for this table")
+        .extracting(row -> row[0])
+        .doesNotContain(siblingFile);
+    assertThat(orphanFiles)
+        .as("Orphan file under the table location must be identified")
+        .extracting(row -> row[0])
+        .contains(orphanFile);
+  }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,8 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      String locationPrefix = location.endsWith("/") ? location : location + "/";
+      files = files.filter(files.col(FILE_PATH).startsWith(locationPrefix));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))


### PR DESCRIPTION
## Problem

`filteredCompareToFileList()` in `DeleteOrphanFilesSparkAction` filters the caller-provided `file_list_view` dataset using:

```java
files = files.filter(files.col(FILE_PATH).startsWith(location));
```

Because `location` has no trailing `/`, a sibling path that shares the table location as a raw string prefix is incorrectly included. For example, when the table is at `s3://bucket/my_table`, files under `s3://bucket/my_table_backup/` also satisfy `startsWith("s3://bucket/my_table")` and get pulled into orphan detection for the wrong table.

Fixes #16493.

## Solution

Append `/` to `location` before the prefix match:

```java
String locationPrefix = location.endsWith("/") ? location : location + "/";
files = files.filter(files.col(FILE_PATH).startsWith(locationPrefix));
```

Applied to Spark 3.5, 4.0, and 4.1.

## Testing

Added `testRemoveOrphanFilesFileListViewDoesNotMatchSiblingPaths` to `TestRemoveOrphanFilesProcedure` in all three Spark versions. The test:

1. Creates an empty Iceberg table at a known location
2. Builds a `file_list_view` that includes an orphan file inside the table directory **and** a file under a sibling path (`table-location + "-sibling"`)
3. Runs `remove_orphan_files` with `file_list_view` and `dry_run => true`
4. Asserts the sibling file is **not** identified as an orphan, and the in-table orphan **is** identified