### PR TITLE
Snowflake: Avoid unbounded FileIO accumulation in SnowflakeCatalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1072,6 +1072,7 @@ project(':iceberg-snowflake') {
 
     testImplementation libs.mockito.junit.jupiter
     testImplementation project(path: ':iceberg-core', configuration: 'testArtifacts')
+    testImplementation libs.awaitility
   }
 }
 

--- a/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
+++ b/snowflake/src/main/java/org/apache/iceberg/snowflake/SnowflakeCatalog.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.hadoop.Configurable;
 import org.apache.iceberg.io.CloseableGroup;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileIOTracker;
 import org.apache.iceberg.jdbc.JdbcCatalog;
 import org.apache.iceberg.jdbc.JdbcClientPool;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -70,6 +71,7 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
   private String catalogName;
   private Map<String, String> catalogProperties;
   private FileIOFactory fileIOFactory;
+  private FileIOTracker fileIOTracker;
   private SnowflakeClient snowflakeClient;
 
   public SnowflakeCatalog() {}
@@ -156,8 +158,10 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     this.fileIOFactory = fileIOFactory;
     this.catalogProperties = properties;
     this.closeableGroup = new CloseableGroup();
+    this.fileIOTracker = new FileIOTracker();
     closeableGroup.addCloseable(snowflakeClient);
     closeableGroup.addCloseable(metricsReporter());
+    closeableGroup.addCloseable(fileIOTracker);
     closeableGroup.setSuppressCloseFailure(true);
   }
 
@@ -253,8 +257,10 @@ public class SnowflakeCatalog extends BaseMetastoreCatalog
     // of schemes registered for S3FileIO and HadoopFileIO). Individual catalogs may need to
     // support tables across different cloud/storage providers with disjoint FileIO implementations.
     FileIO fileIO = fileIOFactory.newFileIO(fileIOImpl, catalogProperties, conf);
-    closeableGroup.addCloseable(fileIO);
-    return new SnowflakeTableOperations(snowflakeClient, fileIO, catalogName, tableIdentifier);
+    SnowflakeTableOperations tableOperations =
+        new SnowflakeTableOperations(snowflakeClient, fileIO, catalogName, tableIdentifier);
+    fileIOTracker.track(tableOperations);
+    return tableOperations;
   }
 
   @Override

--- a/snowflake/src/test/java/org/apache/iceberg/snowflake/TestSnowflakeCatalog.java
+++ b/snowflake/src/test/java/org/apache/iceberg/snowflake/TestSnowflakeCatalog.java
@@ -22,7 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -33,8 +35,10 @@ import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -270,9 +274,57 @@ public class TestSnowflakeCatalog {
     assertThat(fakeClient.isClosed())
         .overridingErrorMessage("expected close() to propagate to snowflakeClient")
         .isTrue();
-    assertThat(fakeFileIO.isClosed())
-        .overridingErrorMessage("expected close() to propagate to fileIO")
-        .isTrue();
+    // FileIOTracker closes tracked FileIO instances via an async removal listener, so the
+    // close may not have happened the instant catalog.close() returns.
+    awaitClosed(fakeFileIO);
+  }
+
+  @Test
+  public void testNewTableOpsTracksFileIOPerCall() throws IOException {
+    List<InMemoryFileIO> createdFileIOs = Lists.newArrayList();
+    SnowflakeCatalog.FileIOFactory trackingFileIOFactory =
+        new SnowflakeCatalog.FileIOFactory() {
+          @Override
+          public FileIO newFileIO(String impl, Map<String, String> prop, Object hadoopConf) {
+            InMemoryFileIO newFileIO = new InMemoryFileIO();
+            createdFileIOs.add(newFileIO);
+            return newFileIO;
+          }
+        };
+
+    SnowflakeCatalog trackingCatalog = new SnowflakeCatalog();
+    trackingCatalog.initialize(TEST_CATALOG_NAME, fakeClient, trackingFileIOFactory, properties);
+
+    trackingCatalog.newTableOps(TableIdentifier.of("DB_1", "SCHEMA_1", "TAB_1"));
+    trackingCatalog.newTableOps(TableIdentifier.of("DB_1", "SCHEMA_1", "TAB_2"));
+    // Reloading the same table must still create and track a fresh FileIO instance rather than
+    // reusing or silently dropping the previous one.
+    trackingCatalog.newTableOps(TableIdentifier.of("DB_1", "SCHEMA_1", "TAB_1"));
+
+    assertThat(createdFileIOs)
+        .overridingErrorMessage("expected a fresh FileIO for every newTableOps() call")
+        .hasSize(3);
+    assertThat(createdFileIOs).noneMatch(InMemoryFileIO::isClosed);
+
+    // Closing the catalog must close every FileIO that was ever tracked, not just the last one.
+    trackingCatalog.close();
+    for (InMemoryFileIO createdFileIO : createdFileIOs) {
+      awaitClosed(createdFileIO);
+    }
+  }
+
+  /**
+   * FileIOTracker closes tracked FileIO instances through a Caffeine removal listener, which runs
+   * asynchronously, so polling is required instead of an immediate assertion.
+   */
+  private static void awaitClosed(InMemoryFileIO fileIO) {
+    Awaitility.await("FileIO gets closed")
+        .atMost(5, TimeUnit.SECONDS)
+        .untilAsserted(
+            () ->
+                assertThat(fileIO.isClosed())
+                    .overridingErrorMessage("expected close() to propagate to fileIO")
+                    .isTrue());
   }
 
   @Test


### PR DESCRIPTION

Closes #17095

## Summary

- `newTableOps()` created a fresh `FileIO` per table load but registered it directly with `closeableGroup`, which never releases individual entries until the whole catalog closes — long-lived catalogs accumulate one `FileIO` per table load indefinitely.
- Track each `FileIO` with core's `FileIOTracker` instead, matching `GlueCatalog#newTableOps`, which already handles the identical "new FileIO per TableOperations" design via `fileIOTracker.track(...)`.
- Sibling code: `aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java` (`initialize()` and `newTableOps()`).

## Testing done

- Added `TestSnowflakeCatalog#testNewTableOpsTracksFileIOPerCall`, verifying a fresh `FileIO` is tracked on every `newTableOps()` call (including reloading the same table) and that all tracked `FileIO` instances close when the catalog closes.
- Adjusted `TestSnowflakeCatalog#testClose` to poll for the `FileIO` close, since `FileIOTracker` closes tracked `FileIO` instances via an asynchronous removal listener.
- `./gradlew :iceberg-snowflake:check` — 66 tests passed, 0 failures.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
