### PR TITLE
ORC: Fix garbled exception message for invalid timestamp unit attribute

### DIFF
--- a/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitor.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcToIcebergVisitor.java
@@ -172,7 +172,7 @@ class OrcToIcebergVisitor extends OrcSchemaVisitor<Optional<Types.NestedField>> 
         } else if (unit.equalsIgnoreCase(ORCSchemaUtil.NANOS)) {
           builder.ofType(Types.TimestampNanoType.withoutZone());
         } else {
-          throw new IllegalStateException("Invalid Timestamp type unit: %s" + unit);
+          throw new IllegalStateException(String.format("Invalid Timestamp type unit: %s", unit));
         }
 
         break;
@@ -183,7 +183,7 @@ class OrcToIcebergVisitor extends OrcSchemaVisitor<Optional<Types.NestedField>> 
         } else if (tsUnit.equalsIgnoreCase(ORCSchemaUtil.NANOS)) {
           builder.ofType(Types.TimestampNanoType.withZone());
         } else {
-          throw new IllegalStateException("Invalid Timestamp type unit: %s" + tsUnit);
+          throw new IllegalStateException(String.format("Invalid Timestamp type unit: %s", tsUnit));
         }
 
         break;

--- a/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestORCSchemaUtil.java
@@ -242,6 +242,32 @@ public class TestORCSchemaUtil {
   }
 
   @Test
+  public void testInvalidTimestampUnit() {
+    TypeDescription timestampCol = TypeDescription.createTimestamp();
+    timestampCol.setAttribute(ICEBERG_ID_ATTRIBUTE, "1");
+    timestampCol.setAttribute(ORCSchemaUtil.TIMESTAMP_UNIT, "SECONDS");
+    TypeDescription orcSchema =
+        TypeDescription.createStruct().addField("timestampCol", timestampCol);
+
+    assertThatThrownBy(() -> ORCSchemaUtil.convert(orcSchema))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Invalid Timestamp type unit: SECONDS");
+  }
+
+  @Test
+  public void testInvalidTimestampInstantUnit() {
+    TypeDescription timestampTzCol = TypeDescription.createTimestampInstant();
+    timestampTzCol.setAttribute(ICEBERG_ID_ATTRIBUTE, "1");
+    timestampTzCol.setAttribute(ORCSchemaUtil.TIMESTAMP_UNIT, "SECONDS");
+    TypeDescription orcSchema =
+        TypeDescription.createStruct().addField("timestampTzCol", timestampTzCol);
+
+    assertThatThrownBy(() -> ORCSchemaUtil.convert(orcSchema))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessage("Invalid Timestamp type unit: SECONDS");
+  }
+
+  @Test
   public void testSkipNonIcebergColumns() {
     TypeDescription schema = TypeDescription.createStruct();
     TypeDescription intCol = TypeDescription.createInt();


### PR DESCRIPTION
Closes #17097

## Summary

- `OrcToIcebergVisitor.primitive()` built the exception for an invalid `iceberg.timestamp-unit` attribute with `"Invalid Timestamp type unit: %s" + unit` (string concatenation) instead of `String.format`, so `%s` was never substituted and stayed in the message, e.g. `Invalid Timestamp type unit: %sSECONDS`.
- Both the `TIMESTAMP` and `TIMESTAMP_INSTANT` branches had the same bug; this fixes both.
- Matches the sibling pattern in `GenericOrcReader.java`, which already uses `String.format("Invalid iceberg type %s corresponding to ORC type %s", ...)` for a similar invalid-type exception.

## Testing done

- Added `TestORCSchemaUtil#testInvalidTimestampUnit` and `#testInvalidTimestampInstantUnit`, each asserting `IllegalStateException` with the correctly substituted message when `iceberg.timestamp-unit` is set to an unsupported value.
- `./gradlew :iceberg-orc:check` — 10 tests passed (TestORCSchemaUtil), including the 2 new tests.
- `./gradlew :iceberg-orc:revapi` — passed as part of `:iceberg-orc:check` (package-private class, no public API impact).

