### PR TITLE
API: Reject non-finite floating defaults

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -897,13 +897,44 @@ public class Types {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
       } else if (defaultValue != null) {
+        // Check before conversion so non-finite double-to-float defaults fail clearly instead of
+        // converting to AboveMax or BelowMin sentinels.
+        validateFloatingDefault(type, defaultValue, defaultValue);
         Literal<?> typedDefault = defaultValue.to(type);
         Preconditions.checkArgument(
             typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
+        validateFloatingDefault(type, typedDefault, defaultValue);
         return typedDefault;
       }
 
       return null;
+    }
+
+    private static void validateFloatingDefault(
+        Type type, Literal<?> defaultValue, Literal<?> originalDefault) {
+      if (type.typeId() == Type.TypeID.FLOAT || type.typeId() == Type.TypeID.DOUBLE) {
+        Object value;
+        try {
+          value = defaultValue.value();
+        } catch (UnsupportedOperationException e) {
+          throw new IllegalArgumentException(
+              String.format("Cannot cast default value to %s: %s", type, originalDefault), e);
+        }
+
+        if (value instanceof Float floatDefault) {
+          Preconditions.checkArgument(
+              Float.isFinite(floatDefault),
+              "Invalid default value for %s: %s (must be finite)",
+              type,
+              originalDefault);
+        } else if (value instanceof Double doubleDefault) {
+          Preconditions.checkArgument(
+              Double.isFinite(doubleDefault),
+              "Invalid default value for %s: %s (must be finite)",
+              type,
+              originalDefault);
+        }
+      }
     }
 
     public boolean isOptional() {

--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -897,13 +897,11 @@ public class Types {
         throw new IllegalArgumentException(
             String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
       } else if (defaultValue != null) {
-        // Check before conversion so non-finite double-to-float defaults fail clearly instead of
-        // converting to AboveMax or BelowMin sentinels.
+        // Check before conversion so non-finite double defaults for float fields fail clearly.
         validateFloatingDefault(type, defaultValue, defaultValue);
         Literal<?> typedDefault = defaultValue.to(type);
         Preconditions.checkArgument(
             typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
-        validateFloatingDefault(type, typedDefault, defaultValue);
         return typedDefault;
       }
 
@@ -916,7 +914,7 @@ public class Types {
         Object value;
         try {
           value = defaultValue.value();
-        } catch (UnsupportedOperationException e) {
+        } catch (RuntimeException e) {
           throw new IllegalArgumentException(
               String.format("Cannot cast default value to %s: %s", type, originalDefault), e);
         }

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import org.apache.iceberg.expressions.Literal;
 import org.junit.jupiter.api.Test;
 
 public class TestTypes {
@@ -213,6 +214,60 @@ public class TestTypes {
     assertThat(Types.GeographyType.of("ogc:crs84"))
         .isEqualTo(Types.GeographyType.crs84())
         .hasSameHashCodeAs(Types.GeographyType.crs84());
+  }
+
+  @Test
+  public void defaultValuesMustBeFiniteForFloatingPointTypes() {
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                optional("f")
+                    .withId(1)
+                    .ofType(Types.FloatType.get())
+                    .withInitialDefault(Literal.of(Float.NaN))
+                    .build())
+        .withMessage("Invalid default value for float: NaN (must be finite)");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                optional("f")
+                    .withId(1)
+                    .ofType(Types.FloatType.get())
+                    .withWriteDefault(Literal.of(Float.POSITIVE_INFINITY))
+                    .build())
+        .withMessage("Invalid default value for float: Infinity (must be finite)");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                optional("d")
+                    .withId(1)
+                    .ofType(Types.DoubleType.get())
+                    .withInitialDefault(Literal.of(Double.NEGATIVE_INFINITY))
+                    .build())
+        .withMessage("Invalid default value for double: -Infinity (must be finite)");
+  }
+
+  @Test
+  public void finiteFloatingPointDefaultValuesAreValid() {
+    assertThat(
+            optional("f")
+                .withId(1)
+                .ofType(Types.FloatType.get())
+                .withInitialDefault(Literal.of(1.5F))
+                .build()
+                .initialDefault())
+        .isEqualTo(1.5F);
+
+    assertThat(
+            optional("d")
+                .withId(2)
+                .ofType(Types.DoubleType.get())
+                .withWriteDefault(Literal.of(-2.5D))
+                .build()
+                .writeDefault())
+        .isEqualTo(-2.5D);
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -247,6 +247,28 @@ public class TestTypes {
                     .withInitialDefault(Literal.of(Double.NEGATIVE_INFINITY))
                     .build())
         .withMessage("Invalid default value for double: -Infinity (must be finite)");
+
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(
+            () ->
+                optional("f")
+                    .withId(1)
+                    .ofType(Types.FloatType.get())
+                    .withInitialDefault(Literal.of(Double.NaN))
+                    .build())
+        .withMessage("Invalid default value for float: NaN (must be finite)");
+  }
+
+  @Test
+  public void finiteOutOfRangeFloatingPointDefaultsAreNotRejectedAsNonFinite() {
+    Types.NestedField field =
+        optional("f")
+            .withId(1)
+            .ofType(Types.FloatType.get())
+            .withInitialDefault(Literal.of(1e40D))
+            .build();
+
+    assertThat(field.initialDefaultLiteral()).hasToString("aboveMax");
   }
 
   @Test


### PR DESCRIPTION
Float and double field defaults are stored in schema metadata using Iceberg's JSON single-value serialization. A NaN or +/-Infinity default can currently be set through NestedField default validation even though those values are not portable JSON numbers and cannot safely round-trip through metadata.

Reject non-finite floating-point initial and write defaults during NestedField default validation so invalid defaults fail before schema metadata is written.