### PR TITLE
Core: Reject reserved properties in snapshot summary set()

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -98,13 +98,14 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   protected Map<String, String> summary() {
     int createdManifestsCount =
         newManifests.size() + addedManifests.size() + rewrittenAddedManifests.size();
-    summaryBuilder.set(
+    summaryBuilder.setInternal(
         SnapshotSummary.CREATED_MANIFESTS_COUNT, String.valueOf(createdManifestsCount));
-    summaryBuilder.set(SnapshotSummary.KEPT_MANIFESTS_COUNT, String.valueOf(keptManifests.size()));
-    summaryBuilder.set(
+    summaryBuilder.setInternal(
+        SnapshotSummary.KEPT_MANIFESTS_COUNT, String.valueOf(keptManifests.size()));
+    summaryBuilder.setInternal(
         SnapshotSummary.REPLACED_MANIFESTS_COUNT,
         String.valueOf(rewrittenManifests.size() + deletedManifests.size()));
-    summaryBuilder.set(
+    summaryBuilder.setInternal(
         SnapshotSummary.PROCESSED_MANIFEST_ENTRY_COUNT, String.valueOf(entryCount.get()));
     summaryBuilder.setPartitionSummaryLimit(
         0); // do not include partition summaries because data did not change

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -723,9 +723,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       }
     }
 
-    summaryBuilder.set(SnapshotSummary.CREATED_MANIFESTS_COUNT, String.valueOf(manifestsCreated));
-    summaryBuilder.set(SnapshotSummary.KEPT_MANIFESTS_COUNT, String.valueOf(manifestsKept));
-    summaryBuilder.set(
+    summaryBuilder.setInternal(
+        SnapshotSummary.CREATED_MANIFESTS_COUNT, String.valueOf(manifestsCreated));
+    summaryBuilder.setInternal(SnapshotSummary.KEPT_MANIFESTS_COUNT, String.valueOf(manifestsKept));
+    summaryBuilder.setInternal(
         SnapshotSummary.REPLACED_MANIFESTS_COUNT, String.valueOf(replacedManifestsCount));
     return summaryBuilder;
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotSummary.java
@@ -22,8 +22,10 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner.MapJoiner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.ScanTaskUtil;
@@ -66,6 +68,40 @@ public class SnapshotSummary {
   public static final String REPLACED_MANIFESTS_COUNT = "manifests-replaced";
   public static final String KEPT_MANIFESTS_COUNT = "manifests-kept";
   public static final String PROCESSED_MANIFEST_ENTRY_COUNT = "entries-processed";
+
+  static final Set<String> RESERVED_PROPERTIES =
+      ImmutableSet.of(
+          ADDED_FILES_PROP,
+          DELETED_FILES_PROP,
+          TOTAL_DATA_FILES_PROP,
+          ADDED_DELETE_FILES_PROP,
+          ADD_EQ_DELETE_FILES_PROP,
+          REMOVED_EQ_DELETE_FILES_PROP,
+          ADD_POS_DELETE_FILES_PROP,
+          REMOVED_POS_DELETE_FILES_PROP,
+          ADDED_DVS_PROP,
+          REMOVED_DVS_PROP,
+          REMOVED_DELETE_FILES_PROP,
+          TOTAL_DELETE_FILES_PROP,
+          ADDED_RECORDS_PROP,
+          DELETED_RECORDS_PROP,
+          TOTAL_RECORDS_PROP,
+          ADDED_FILE_SIZE_PROP,
+          REMOVED_FILE_SIZE_PROP,
+          TOTAL_FILE_SIZE_PROP,
+          ADDED_POS_DELETES_PROP,
+          REMOVED_POS_DELETES_PROP,
+          TOTAL_POS_DELETES_PROP,
+          ADDED_EQ_DELETES_PROP,
+          REMOVED_EQ_DELETES_PROP,
+          TOTAL_EQ_DELETES_PROP,
+          DELETED_DUPLICATE_FILES,
+          CHANGED_PARTITION_COUNT_PROP,
+          PARTITION_SUMMARY_PROP,
+          CREATED_MANIFESTS_COUNT,
+          REPLACED_MANIFESTS_COUNT,
+          KEPT_MANIFESTS_COUNT,
+          PROCESSED_MANIFEST_ENTRY_COUNT);
 
   public static final MapJoiner MAP_JOINER = Joiner.on(",").withKeyValueSeparator("=");
 
@@ -153,6 +189,14 @@ public class SnapshotSummary {
     }
 
     public void set(String property, String value) {
+      Preconditions.checkArgument(
+          !RESERVED_PROPERTIES.contains(property) && !property.startsWith(CHANGED_PARTITION_PREFIX),
+          "Cannot set reserved snapshot summary property: %s",
+          property);
+      properties.put(property, value);
+    }
+
+    void setInternal(String property, String value) {
       properties.put(property, value);
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotSummary.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
@@ -527,5 +528,37 @@ public class TestSnapshotSummary extends TestBase {
         .containsEntry(SnapshotSummary.CREATED_MANIFESTS_COUNT, "1")
         .containsEntry(SnapshotSummary.KEPT_MANIFESTS_COUNT, "0")
         .containsEntry(SnapshotSummary.REPLACED_MANIFESTS_COUNT, "3");
+  }
+
+  @TestTemplate
+  public void testCannotSetReservedProperty() {
+    assertThatThrownBy(
+            () -> table.newAppend().appendFile(FILE_A).set(SnapshotSummary.ADDED_FILES_PROP, "5"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot set reserved snapshot summary property");
+  }
+
+  @TestTemplate
+  public void testCannotSetPartitionPrefix() {
+    assertThatThrownBy(() -> table.newAppend().appendFile(FILE_A).set("partitions.key=value", "1"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot set reserved snapshot summary property");
+  }
+
+  @TestTemplate
+  public void testCanSetNonReservedProperty() {
+    table.newAppend().appendFile(FILE_A).set("my-custom-prop", "my-value").commit();
+    assertThat(table.currentSnapshot().summary()).containsEntry("my-custom-prop", "my-value");
+  }
+
+  @TestTemplate
+  public void testCanSetOperationProperties() {
+    table
+        .newAppend()
+        .appendFile(FILE_A)
+        .set(SnapshotSummary.STAGED_WAP_ID_PROP, "wap-123")
+        .commit();
+    assertThat(table.currentSnapshot().summary())
+        .containsEntry(SnapshotSummary.STAGED_WAP_ID_PROP, "wap-123");
   }
 }


### PR DESCRIPTION
`SnapshotUpdate.set(String, String)` lets callers supply arbitrary key/value pairs for the snapshot summary. Inside `SnapshotSummary.Builder.build()`, custom properties are copied first and computed metrics overwrite them, which protects a metric key only when the metric is actually computed for the commit. A user-supplied value under a reserved metric key that is not computed (e.g. `set("added-delete-files", "5")` on a commit that adds no delete files) survives into the final summary unchallenged.

This adds reserved-key validation to `SnapshotSummary.Builder.set()` so that reserved metric keys and the `partitions.` prefix are rejected with an `IllegalArgumentException`. Internal callers (`SnapshotProducer`, `BaseRewriteManifests`) that legitimately write reserved keys use a new package-private `setInternal()` bypass. Non-metric operation properties like `wap.id` remain settable through the public API.

Fixes #17009