### PR TITLE
OpenAPI: Retry REST test server start on wrapped BindException

### DIFF
--- a/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerExtension.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerExtension.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.net.BindException;
+import org.junit.jupiter.api.Test;
+
+public class TestRESTServerExtension {
+
+  @Test
+  public void recognizesBindExceptionWrappedInIOException() {
+    // Jetty surfaces a bind conflict as an IOException whose cause is the real BindException, so
+    // the retry in RESTServerExtension#beforeAll must scan the cause chain to recognize it.
+    IOException wrapped =
+        new IOException(
+            "Failed to bind to 0.0.0.0/0.0.0.0:35673", new BindException("Address already in use"));
+    // A direct `catch (BindException)` would have missed this, which is why the retry never fired.
+    assertThat(wrapped).isNotInstanceOf(BindException.class);
+    assertThat(RESTServerExtension.isBindException(wrapped)).isTrue();
+  }
+
+  @Test
+  public void recognizesDirectBindException() {
+    assertThat(RESTServerExtension.isBindException(new BindException("Address already in use")))
+        .isTrue();
+  }
+
+  @Test
+  public void ignoresNonBindFailures() {
+    assertThat(RESTServerExtension.isBindException(new RuntimeException("boom"))).isFalse();
+    assertThat(RESTServerExtension.isBindException(new IOException("disk error"))).isFalse();
+  }
+
+  @Test
+  public void handlesNullThrowable() {
+    assertThat(RESTServerExtension.isBindException(null)).isFalse();
+  }
+}

--- a/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerExtension.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerExtension.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.net.BindException;
+import java.net.ServerSocket;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+public class TestRESTServerExtension {
+
+  @Test
+  public void recognizesRealBindFailureFromServer() throws IOException {
+    // Guards the premise the retry depends on. #13017's retry went dead because it assumed the
+    // server surfaces a direct BindException, so provoke a real bind conflict and assert the
+    // failure the server actually throws is still recognized. A dependency upgrade that changes
+    // the wrapping fails here instead of silently disabling the retry again.
+    try (ServerSocket occupied = new ServerSocket(0)) {
+      Map<String, String> config = Maps.newHashMap();
+      config.put(RESTCatalogServer.REST_PORT, String.valueOf(occupied.getLocalPort()));
+      RESTCatalogServer server = new RESTCatalogServer(config);
+
+      assertThatThrownBy(() -> server.start(false))
+          .hasMessageContaining("Failed to bind to")
+          .matches(RESTServerExtension::isBindException, "recognized as a bind failure");
+    }
+  }
+
+  @Test
+  public void recognizesBindExceptionWrappedInIOException() {
+    // Jetty surfaces a bind conflict as an IOException whose cause is the real BindException, so
+    // the retry in RESTServerExtension#beforeAll must scan the cause chain to recognize it.
+    IOException wrapped =
+        new IOException(
+            "Failed to bind to 0.0.0.0/0.0.0.0:35673", new BindException("Address already in use"));
+    // A direct `catch (BindException)` would have missed this, which is why the retry never fired.
+    assertThat(wrapped).isNotInstanceOf(BindException.class);
+    assertThat(RESTServerExtension.isBindException(wrapped)).isTrue();
+  }
+
+  @Test
+  public void recognizesDirectBindException() {
+    assertThat(RESTServerExtension.isBindException(new BindException("Address already in use")))
+        .isTrue();
+  }
+
+  @Test
+  public void ignoresNonBindFailures() {
+    assertThat(RESTServerExtension.isBindException(new RuntimeException("boom"))).isFalse();
+    assertThat(RESTServerExtension.isBindException(new IOException("disk error"))).isFalse();
+  }
+
+  @Test
+  public void handlesNullThrowable() {
+    assertThat(RESTServerExtension.isBindException(null)).isFalse();
+  }
+}

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerExtension.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerExtension.java
@@ -18,9 +18,9 @@
  */
 package org.apache.iceberg.rest;
 
-import java.io.UncheckedIOException;
 import java.net.BindException;
 import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
@@ -70,12 +70,12 @@ public class RESTServerExtension implements BeforeAllCallback, AfterAllCallback 
           this.localServer = new RESTCatalogServer(config);
           this.localServer.start(false);
           break;
-        } catch (BindException e) {
-          if (!findFreePort || i == maxAttempts - 1) {
-            throw new UncheckedIOException("Failed to start REST server", e);
-          }
         } catch (Exception e) {
-          throw new RuntimeException("Failed to start REST server", e);
+          // Jetty wraps the underlying BindException in an IOException ("Failed to bind to ..."),
+          // so inspect the whole cause chain rather than catching BindException directly.
+          if (!findFreePort || !isBindException(e) || i == maxAttempts - 1) {
+            throw new RuntimeException("Failed to start REST server", e);
+          }
         }
       }
 
@@ -91,5 +91,15 @@ public class RESTServerExtension implements BeforeAllCallback, AfterAllCallback 
     if (client != null) {
       client.close();
     }
+  }
+
+  @VisibleForTesting
+  static boolean isBindException(Throwable throwable) {
+    for (Throwable cause = throwable; cause != null; cause = cause.getCause()) {
+      if (cause instanceof BindException) {
+        return true;
+      }
+    }
+    return false;
   }
 }


### PR DESCRIPTION
## Summary

`RESTServerExtension#beforeAll` starts an embedded REST catalog server for tests on an OS-assigned free port (`RCKUtils.findFreePort()` opens `ServerSocket(0)`, reads the port, and closes it). Because Jetty binds to that port only later in `httpServer.start()`, there is a TOCTOU window in which a parallel test JVM fork can grab the same ephemeral port, producing `java.net.BindException: Address already in use`.

PR #13017 added a 10-attempt retry to paper over that window, but it never fires. It re-rolls the port only inside `catch (BindException e)`, while Jetty surfaces the failure as a `java.io.IOException("Failed to bind to ...")` whose cause is the real `BindException`. Since `IOException` is not a `BindException`, control falls through to the generic `catch (Exception e)`, which rethrows immediately with no retry, so a single lost port race aborts the whole test class with `initializationError`.

This changes the catch to detect a bind failure by scanning the exception's cause chain, so the existing retry actually re-rolls the port on a wrapped `BindException`. The deeper TOCTOU window is inherent to probe-then-bind and is left as-is; retry is the agreed mitigation. This is a follow-up to the two earlier attempts at this same flakiness: #13017 (add the retry) and #13992 (enable `SO_REUSEPORT`, which only covers the `TIME_WAIT` case, not an active bind by another fork).

Observed as a flaky failure of `TestAddFilesProcedure > initializationError` in the `spark-tests (17, 3.5, 2.12, extensions)` job (which then fail-fast cancels the sibling `core` jobs), e.g. on the unrelated PR #17065: https://github.com/apache/iceberg/actions/runs/28645321282/job/84950457116

```
java.lang.RuntimeException: Failed to start REST server
    at org.apache.iceberg.rest.RESTServerExtension.beforeAll(RESTServerExtension.java:78)
Caused by: java.io.IOException: Failed to bind to 0.0.0.0/0.0.0.0:35673
    at org.apache.iceberg.rest.RESTCatalogServer.start(RESTCatalogServer.java:130)
Caused by: java.net.BindException: Address already in use
```

## Testing

Added `TestRESTServerExtension` covering the cause-chain detection: the exact CI shape (an `IOException` wrapping a `BindException`, asserting it is not itself a `BindException` so a direct `catch` would miss it), a direct `BindException`, non-bind failures, and `null`.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Make the embedded REST test server retry startup when the OS-assigned free port is taken, detecting BindException wrapped inside Jetty's IOException.
