### PR TITLE
Core, Flink, Spark: Fix unsupported error placeholders

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -199,7 +199,7 @@ abstract class BaseCommitService<T> implements Closeable {
     Preconditions.checkArgument(
         !timeout && completedRewrites.isEmpty(),
         "Timeout occurred when waiting for commits to complete. "
-            + "{} file groups committed. {} file groups remain uncommitted. "
+            + "%s file groups committed. %s file groups remain uncommitted. "
             + "Retry this operation to attempt rewriting the failed groups.",
         committedRewrites.size(),
         completedRewrites.size());

--- a/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestCommitService.java
@@ -97,7 +97,10 @@ public class TestCommitService extends TestBase {
     // [5-7].
     assertThatThrownBy(commitService::close)
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Timeout occurred when waiting for commits");
+        .hasMessageContaining("Timeout occurred when waiting for commits")
+        .hasMessageNotContaining("{}")
+        .hasMessageMatching(
+            ".*\\d+ file groups committed\\. \\d+ file groups remain uncommitted\\..*");
 
     // Wait for the commitService to finish. Committed all file groups or aborted remaining file
     // groups.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
@@ -101,7 +101,7 @@ public class ListFileSystemFiles extends ProcessFunction<Trigger, String> {
         Predicate<FileInfo> predicate = fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
         Preconditions.checkArgument(
             io instanceof SupportsPrefixOperations,
-            "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+            "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
             io);
 
         FileSystemWalker.listDirRecursivelyWithFileIO(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
@@ -101,7 +101,7 @@ public class ListFileSystemFiles extends ProcessFunction<Trigger, String> {
         Predicate<FileInfo> predicate = fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
         Preconditions.checkArgument(
             io instanceof SupportsPrefixOperations,
-            "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+            "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
             io);
 
         FileSystemWalker.listDirRecursivelyWithFileIO(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListFileSystemFiles.java
@@ -101,7 +101,7 @@ public class ListFileSystemFiles extends ProcessFunction<Trigger, String> {
         Predicate<FileInfo> predicate = fileInfo -> fileInfo.createdAtMillis() < olderThanTimestamp;
         Preconditions.checkArgument(
             io instanceof SupportsPrefixOperations,
-            "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+            "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
             io);
 
         FileSystemWalker.listDirRecursivelyWithFileIO(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -419,7 +419,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
-          "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+          "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
           table.io());
 
       Predicate<org.apache.iceberg.io.FileInfo> predicate =

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -129,7 +129,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
   @Override
   public synchronized void stop() {
     Preconditions.checkArgument(
-        !stopped, "AsyncSparkMicroBatchPlanner for {} was already stopped", table().name());
+        !stopped, "AsyncSparkMicroBatchPlanner for %s was already stopped", table().name());
     stopped = true;
     LOG.info("Stopping AsyncSparkMicroBatchPlanner for table: {}", table().name());
     executor.shutdownNow();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkReadConf;
 import org.junit.jupiter.api.Test;
 
 class TestAsyncSparkMicroBatchPlanner {
@@ -51,6 +54,22 @@ class TestAsyncSparkMicroBatchPlanner {
 
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(readFrom, null)).isFalse();
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(null, capOffset)).isFalse();
+  }
+
+  @Test
+  void stoppingTwiceIncludesTableNameInError() {
+    Table table = mock(Table.class);
+    SparkReadConf readConf = mock(SparkReadConf.class);
+    when(table.name()).thenReturn("test_table");
+    when(readConf.streamingSnapshotPollingIntervalMs()).thenReturn(1000L);
+
+    AsyncSparkMicroBatchPlanner planner =
+        new AsyncSparkMicroBatchPlanner(table, readConf, StreamingOffset.START_OFFSET, null, null);
+    planner.stop();
+
+    assertThatThrownBy(planner::stop)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("AsyncSparkMicroBatchPlanner for test_table was already stopped");
   }
 
   private Snapshot mockSnapshot(long snapshotId) {

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -419,7 +419,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
-          "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+          "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
           table.io());
 
       Predicate<org.apache.iceberg.io.FileInfo> predicate =

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -129,7 +129,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
   @Override
   public synchronized void stop() {
     Preconditions.checkArgument(
-        !stopped, "AsyncSparkMicroBatchPlanner for {} was already stopped", table().name());
+        !stopped, "AsyncSparkMicroBatchPlanner for %s was already stopped", table().name());
     stopped = true;
     LOG.info("Stopping AsyncSparkMicroBatchPlanner for table: {}", table().name());
     executor.shutdownNow();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkReadConf;
 import org.junit.jupiter.api.Test;
 
 class TestAsyncSparkMicroBatchPlanner {
@@ -51,6 +54,22 @@ class TestAsyncSparkMicroBatchPlanner {
 
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(readFrom, null)).isFalse();
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(null, capOffset)).isFalse();
+  }
+
+  @Test
+  void stoppingTwiceIncludesTableNameInError() {
+    Table table = mock(Table.class);
+    SparkReadConf readConf = mock(SparkReadConf.class);
+    when(table.name()).thenReturn("test_table");
+    when(readConf.streamingSnapshotPollingIntervalMs()).thenReturn(1000L);
+
+    AsyncSparkMicroBatchPlanner planner =
+        new AsyncSparkMicroBatchPlanner(table, readConf, StreamingOffset.START_OFFSET, null, null);
+    planner.stop();
+
+    assertThatThrownBy(planner::stop)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("AsyncSparkMicroBatchPlanner for test_table was already stopped");
   }
 
   private Snapshot mockSnapshot(long snapshotId) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -419,7 +419,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     if (usePrefixListing) {
       Preconditions.checkArgument(
           table.io() instanceof SupportsPrefixOperations,
-          "Cannot use prefix listing with FileIO {} which does not support prefix operations.",
+          "Cannot use prefix listing with FileIO %s which does not support prefix operations.",
           table.io());
 
       Predicate<org.apache.iceberg.io.FileInfo> predicate =

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -129,7 +129,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
   @Override
   public synchronized void stop() {
     Preconditions.checkArgument(
-        !stopped, "AsyncSparkMicroBatchPlanner for {} was already stopped", table().name());
+        !stopped, "AsyncSparkMicroBatchPlanner for %s was already stopped", table().name());
     stopped = true;
     LOG.info("Stopping AsyncSparkMicroBatchPlanner for table: {}", table().name());
     executor.shutdownNow();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestAsyncSparkMicroBatchPlanner.java
@@ -19,10 +19,13 @@
 package org.apache.iceberg.spark.source;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.spark.SparkReadConf;
 import org.junit.jupiter.api.Test;
 
 class TestAsyncSparkMicroBatchPlanner {
@@ -51,6 +54,22 @@ class TestAsyncSparkMicroBatchPlanner {
 
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(readFrom, null)).isFalse();
     assertThat(AsyncSparkMicroBatchPlanner.reachedAvailableNowCap(null, capOffset)).isFalse();
+  }
+
+  @Test
+  void stoppingTwiceIncludesTableNameInError() {
+    Table table = mock(Table.class);
+    SparkReadConf readConf = mock(SparkReadConf.class);
+    when(table.name()).thenReturn("test_table");
+    when(readConf.streamingSnapshotPollingIntervalMs()).thenReturn(1000L);
+
+    AsyncSparkMicroBatchPlanner planner =
+        new AsyncSparkMicroBatchPlanner(table, readConf, StreamingOffset.START_OFFSET, null, null);
+    planner.stop();
+
+    assertThatThrownBy(planner::stop)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("AsyncSparkMicroBatchPlanner for test_table was already stopped");
   }
 
   private Snapshot mockSnapshot(long snapshotId) {


### PR DESCRIPTION
### What changed

Fixes Guava `Preconditions` messages that used unsupported SLF4J-style `{}` placeholders:

- the core commit-timeout message
- prefix-listing validation in Flink 1.20, 2.0, and 2.1
- prefix-listing validation in Spark 3.5, 4.0, and 4.1
- the repeated-stop error in the asynchronous Spark micro-batch planner for Spark 3.5, 4.0, and 4.1

Each placeholder now uses `%s`, so the relevant counts, `FileIO`, or table name appears inline rather than leaving literal braces and appending values at the end.

### Tests

Added or strengthened focused assertions for the core timeout and asynchronous Spark planner messages.

```text
./gradlew spotlessApply
./gradlew -DsparkVersions=3.5,4.0,4.1 :iceberg-core:test --tests org.apache.iceberg.actions.TestCommitService :iceberg-spark:iceberg-spark-3.5_2.12:test --tests org.apache.iceberg.spark.source.TestAsyncSparkMicroBatchPlanner :iceberg-spark:iceberg-spark-4.0_2.13:test --tests org.apache.iceberg.spark.source.TestAsyncSparkMicroBatchPlanner :iceberg-spark:iceberg-spark-4.1_2.13:test --tests org.apache.iceberg.spark.source.TestAsyncSparkMicroBatchPlanner
```

---
**AI Disclosure**
- Model: GPT-5.6-sol
- Platform/Tool: GitHub Copilot
- Human Oversight: fully reviewed
- Prompt Summary: Address maintainer feedback by fixing the listed malformed Guava placeholder messages across core, Flink, and Spark, and add focused regression coverage.
