### PR TITLE
GCP: Add support for configurable KMS endpoint in GcpKeyManagementClient

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -44,6 +44,14 @@ public class GCPProperties implements Serializable {
   public static final String GCS_ENCRYPTION_KEY = "gcs.encryption-key";
   public static final String GCS_USER_PROJECT = "gcs.user-project";
 
+  /**
+   * Configure an alternative endpoint of the KMS service for GcpKeyManagementClient to access.
+   *
+   * <p>This could be used to use KMS key management with any KMS-compatible service that has a
+   * different endpoint
+   */
+  public static final String KMS_ENDPOINT = "kms.endpoint";
+
   public static final String GCS_CHANNEL_READ_CHUNK_SIZE = "gcs.channel.read.chunk-size-bytes";
   public static final String GCS_CHANNEL_WRITE_CHUNK_SIZE = "gcs.channel.write.chunk-size-bytes";
 
@@ -88,6 +96,7 @@ public class GCPProperties implements Serializable {
   private String gcsDecryptionKey;
   private String gcsEncryptionKey;
   private String gcsUserProject;
+  private String kmsEndpoint;
 
   private Integer gcsChannelReadChunkSize;
   private Integer gcsChannelWriteChunkSize;
@@ -152,6 +161,7 @@ public class GCPProperties implements Serializable {
     gcsDecryptionKey = properties.get(GCS_DECRYPTION_KEY);
     gcsEncryptionKey = properties.get(GCS_ENCRYPTION_KEY);
     gcsUserProject = properties.get(GCS_USER_PROJECT);
+    kmsEndpoint = properties.get(KMS_ENDPOINT);
 
     if (properties.containsKey(GCS_CHANNEL_READ_CHUNK_SIZE)) {
       gcsChannelReadChunkSize = Integer.parseInt(properties.get(GCS_CHANNEL_READ_CHUNK_SIZE));
@@ -229,6 +239,10 @@ public class GCPProperties implements Serializable {
 
   public Optional<String> userProject() {
     return Optional.ofNullable(gcsUserProject);
+  }
+
+  public Optional<String> kmsEndpoint() {
+    return Optional.ofNullable(kmsEndpoint);
   }
 
   public Optional<String> oauth2Token() {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -50,7 +50,7 @@ public class GCPProperties implements Serializable {
    * <p>This could be used to use KMS key management with any KMS-compatible service that has a
    * different endpoint
    */
-  public static final String KMS_ENDPOINT = "kms.endpoint";
+  public static final String GCS_KMS_ENDPOINT = "gcs.kms.endpoint";
 
   public static final String GCS_CHANNEL_READ_CHUNK_SIZE = "gcs.channel.read.chunk-size-bytes";
   public static final String GCS_CHANNEL_WRITE_CHUNK_SIZE = "gcs.channel.write.chunk-size-bytes";
@@ -161,7 +161,7 @@ public class GCPProperties implements Serializable {
     gcsDecryptionKey = properties.get(GCS_DECRYPTION_KEY);
     gcsEncryptionKey = properties.get(GCS_ENCRYPTION_KEY);
     gcsUserProject = properties.get(GCS_USER_PROJECT);
-    kmsEndpoint = properties.get(KMS_ENDPOINT);
+    kmsEndpoint = properties.get(GCS_KMS_ENDPOINT);
 
     if (properties.containsKey(GCS_CHANNEL_READ_CHUNK_SIZE)) {
       gcsChannelReadChunkSize = Integer.parseInt(properties.get(GCS_CHANNEL_READ_CHUNK_SIZE));

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GcpKeyManagementClient.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GcpKeyManagementClient.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.gcp;
 
 import com.google.api.gax.core.FixedCredentialsProvider;
+import com.google.api.gax.core.NoCredentialsProvider;
 import com.google.auth.oauth2.OAuth2Credentials;
 import com.google.cloud.kms.v1.DecryptRequest;
 import com.google.cloud.kms.v1.DecryptResponse;
@@ -35,6 +36,7 @@ import org.apache.iceberg.common.DynMethods;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.CloseableGroup;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.util.SerializableMap;
 
 /**
@@ -101,7 +103,8 @@ public class GcpKeyManagementClient implements KeyManagementClient {
     }
   }
 
-  private KeyManagementServiceClient kmsClient() {
+  @VisibleForTesting
+  KeyManagementServiceClient kmsClient() {
     if (kmsClient == null) {
       synchronized (this) {
         if (kmsClient == null) {
@@ -114,9 +117,11 @@ public class GcpKeyManagementClient implements KeyManagementClient {
               OAuth2Credentials oAuth2Credentials =
                   GCPAuthUtils.oauth2CredentialsFromGcpProperties(gcpProperties, closeableGroup);
               kmsBuilder.setCredentialsProvider(FixedCredentialsProvider.create(oAuth2Credentials));
+            } else if (gcpProperties.noAuth()) {
+              kmsBuilder.setCredentialsProvider(NoCredentialsProvider.create());
             }
 
-            // if not OAuth then defaults to GoogleCredentials.getApplicationDefault()
+            // if not (OAuth or no-auth) then defaults to GoogleCredentials.getApplicationDefault()
             this.kmsClient = KeyManagementServiceClient.create(kmsBuilder.build());
             closeableGroup.addCloseable(kmsClient);
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GcpKeyManagementClient.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GcpKeyManagementClient.java
@@ -109,6 +109,7 @@ public class GcpKeyManagementClient implements KeyManagementClient {
           try {
             KeyManagementServiceSettings.Builder kmsBuilder =
                 KeyManagementServiceSettings.newBuilder();
+            gcpProperties.kmsEndpoint().ifPresent(kmsBuilder::setEndpoint);
             if (gcpProperties.oauth2Token().isPresent()) {
               OAuth2Credentials oAuth2Credentials =
                   GCPAuthUtils.oauth2CredentialsFromGcpProperties(gcpProperties, closeableGroup);

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.gcp;
 
+import static org.apache.iceberg.gcp.GCPProperties.GCS_KMS_ENDPOINT;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT;
@@ -76,5 +77,12 @@ public class TestGCPProperties {
         .isPresent()
         .get()
         .isEqualTo("/v1/credentials");
+  }
+
+  @Test
+  public void kmsEndpoint() {
+    GCPProperties gcpProperties =
+        new GCPProperties(ImmutableMap.of(GCS_NO_AUTH, "true", GCS_KMS_ENDPOINT, "example.com"));
+    assertThat(gcpProperties.kmsEndpoint()).hasValue("example.com");
   }
 }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGcpKeyManagementClient.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGcpKeyManagementClient.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp;
+
+import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
+import static org.apache.iceberg.gcp.GCPProperties.KMS_ENDPOINT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class TestGcpKeyManagementClient {
+  @Test
+  void kmsEndpoint() {
+    try (GcpKeyManagementClient client = new GcpKeyManagementClient()) {
+      String endpoint = "example.com:443";
+      client.initialize(Map.of(GCS_NO_AUTH, "true", KMS_ENDPOINT, endpoint));
+
+      assertThat(client.kmsClient().getSettings().getEndpoint()).isEqualTo(endpoint);
+    }
+  }
+
+  @Test
+  void invalidKmsEndpoint() {
+    try (GcpKeyManagementClient client = new GcpKeyManagementClient()) {
+      client.initialize(Map.of(GCS_NO_AUTH, "true", KMS_ENDPOINT, "example.com"));
+
+      assertThatThrownBy(client::kmsClient)
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("invalid endpoint, expecting \"<host>:<port>\"");
+    }
+  }
+}

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGcpKeyManagementClient.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGcpKeyManagementClient.java
@@ -18,8 +18,8 @@
  */
 package org.apache.iceberg.gcp;
 
+import static org.apache.iceberg.gcp.GCPProperties.GCS_KMS_ENDPOINT;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
-import static org.apache.iceberg.gcp.GCPProperties.KMS_ENDPOINT;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -31,7 +31,7 @@ class TestGcpKeyManagementClient {
   void kmsEndpoint() {
     try (GcpKeyManagementClient client = new GcpKeyManagementClient()) {
       String endpoint = "example.com:443";
-      client.initialize(Map.of(GCS_NO_AUTH, "true", KMS_ENDPOINT, endpoint));
+      client.initialize(Map.of(GCS_NO_AUTH, "true", GCS_KMS_ENDPOINT, endpoint));
 
       assertThat(client.kmsClient().getSettings().getEndpoint()).isEqualTo(endpoint);
     }
@@ -40,7 +40,7 @@ class TestGcpKeyManagementClient {
   @Test
   void invalidKmsEndpoint() {
     try (GcpKeyManagementClient client = new GcpKeyManagementClient()) {
-      client.initialize(Map.of(GCS_NO_AUTH, "true", KMS_ENDPOINT, "example.com"));
+      client.initialize(Map.of(GCS_NO_AUTH, "true", GCS_KMS_ENDPOINT, "example.com"));
 
       assertThatThrownBy(client::kmsClient)
           .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
Trino is replacing real SaaS-based tests with [Floci](https://github.com/floci-io/floci). This change allows for configurable KMS endpoints, which benefits the project. 

The endpoints in AwsProperties and AzureProperties are already configurable.

https://github.com/apache/iceberg/blob/05c5d77fde4117a6b9474b4d1191a3bf4e6a6145/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java#L218

https://github.com/apache/iceberg/blob/05c5d77fde4117a6b9474b4d1191a3bf4e6a6145/azure/src/main/java/org/apache/iceberg/azure/AzureProperties.java#L51