### PR TITLE
Hive: Map geometry and geography type to binary in HiveSchemaUtil

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -166,6 +166,8 @@ public final class HiveSchemaUtil {
         return "timestamp";
       case FIXED:
       case BINARY:
+      case GEOMETRY:
+      case GEOGRAPHY:
         return "binary";
       case VARIANT:
         return "unknown";

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveSchemaUtil.java
@@ -141,55 +141,41 @@ public final class HiveSchemaUtil {
   }
 
   private static String convertToTypeString(Type type) {
-    switch (type.typeId()) {
-      case BOOLEAN:
-        return "boolean";
-      case INTEGER:
-        return "int";
-      case LONG:
-        return "bigint";
-      case FLOAT:
-        return "float";
-      case DOUBLE:
-        return "double";
-      case DATE:
-        return "date";
-      case TIME:
-      case STRING:
-      case UUID:
-        return "string";
-      case TIMESTAMP:
+    return switch (type.typeId()) {
+      case BOOLEAN -> "boolean";
+      case INTEGER -> "int";
+      case LONG -> "bigint";
+      case FLOAT -> "float";
+      case DOUBLE -> "double";
+      case DATE -> "date";
+      case TIME, STRING, UUID -> "string";
+      case TIMESTAMP -> {
         Types.TimestampType timestampType = (Types.TimestampType) type;
         if (HiveVersion.min(HiveVersion.HIVE_3) && timestampType.shouldAdjustToUTC()) {
-          return "timestamp with local time zone";
+          yield "timestamp with local time zone";
         }
-        return "timestamp";
-      case FIXED:
-      case BINARY:
-      case GEOMETRY:
-      case GEOGRAPHY:
-        return "binary";
-      case VARIANT:
-        return "unknown";
-      case DECIMAL:
-        final Types.DecimalType decimalType = (Types.DecimalType) type;
-        return String.format("decimal(%s,%s)", decimalType.precision(), decimalType.scale());
-      case STRUCT:
-        final Types.StructType structType = type.asStructType();
-        final String nameToType =
+        yield "timestamp";
+      }
+      case FIXED, BINARY, GEOMETRY, GEOGRAPHY -> "binary";
+      case VARIANT -> "unknown";
+      case DECIMAL -> {
+        Types.DecimalType decimalType = (Types.DecimalType) type;
+        yield String.format("decimal(%s,%s)", decimalType.precision(), decimalType.scale());
+      }
+      case STRUCT -> {
+        Types.StructType structType = type.asStructType();
+        String nameToType =
             structType.fields().stream()
                 .map(f -> String.format("%s:%s", f.name(), convert(f.type())))
                 .collect(Collectors.joining(","));
-        return String.format("struct<%s>", nameToType);
-      case LIST:
-        final Types.ListType listType = type.asListType();
-        return String.format("array<%s>", convert(listType.elementType()));
-      case MAP:
-        final Types.MapType mapType = type.asMapType();
-        return String.format(
-            "map<%s,%s>", convert(mapType.keyType()), convert(mapType.valueType()));
-      default:
-        throw new UnsupportedOperationException(type + " is not supported");
-    }
+        yield String.format("struct<%s>", nameToType);
+      }
+      case LIST -> String.format("array<%s>", convert(type.asListType().elementType()));
+      case MAP -> {
+        Types.MapType mapType = type.asMapType();
+        yield String.format("map<%s,%s>", convert(mapType.keyType()), convert(mapType.valueType()));
+      }
+      default -> throw new UnsupportedOperationException(type + " is not supported");
+    };
   }
 }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveSchemaUtil.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hive.serde2.typeinfo.TypeInfoUtils;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -210,6 +211,44 @@ public class TestHiveSchemaUtil {
     Schema schema = new Schema(optional(0, "variant_field", Types.VariantType.get()));
     List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
     assertThat(hiveSchema).containsExactly(new FieldSchema("variant_field", "unknown", null));
+  }
+
+  @Test
+  public void testGeometryTypeConvertToHiveSchema() {
+    Schema schema = new Schema(optional(0, "geometry_field", Types.GeometryType.crs84()));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("geometry_field", "binary", null));
+  }
+
+  @Test
+  public void testGeometryTypeWithCustomCrsConvertToHiveSchema() {
+    Schema schema = new Schema(optional(0, "geometry_field", Types.GeometryType.of("EPSG:3857")));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("geometry_field", "binary", null));
+  }
+
+  @Test
+  public void testGeographyTypeConvertToHiveSchema() {
+    Schema schema = new Schema(optional(0, "geography_field", Types.GeographyType.crs84()));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("geography_field", "binary", null));
+  }
+
+  @Test
+  public void testGeographyTypeWithCustomCrsConvertToHiveSchema() {
+    Schema schema = new Schema(optional(0, "geography_field", Types.GeographyType.of("EPSG:4326")));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("geography_field", "binary", null));
+  }
+
+  @Test
+  public void testGeographyTypeWithVincentyAlgorithmConvertToHiveSchema() {
+    Schema schema =
+        new Schema(
+            optional(
+                0, "geography_field", Types.GeographyType.of("OGC:CRS84", EdgeAlgorithm.VINCENTY)));
+    List<FieldSchema> hiveSchema = HiveSchemaUtil.convert(schema);
+    assertThat(hiveSchema).containsExactly(new FieldSchema("geography_field", "binary", null));
   }
 
   protected List<FieldSchema> getSupportedFieldSchemas() {


### PR DESCRIPTION
Add GEOMETRY and GEOGRAPHY cases to HiveSchemaUtil.convertToTypeString, mapping them to "binary".

"binary" was chosen instead of "unknown" because geometry/geography are WKB-encoded byte arrays - older readers not familiar with Iceberg/Parquet GEOMETRY can still read the created Parquet files by reading the column as BINARY and converting from WKB to their representation (st_GeomFromWKB() in Hive).
 
Motivation:
Bumped into this while integrating Iceberg geometry support into Apache Impala, which uses the Hive catalog for tests. Creating a table with a geometry  column would throw UnsupportedOperationException from the default
branch of the switch. By patching HiveSchemaUtil in Iceberg I as able to create tables with GEOMETRY columns.