### PR TITLE
API, Core: Support onKeep/onSkip callback for FilterIterator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -152,10 +152,7 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
 
   /**
    * Filters the given {@link CloseableIterable} with the given predicate, invoking {@code onKeep}
-   * on each accepted element and {@code onSkip} on each rejected element. Observers are invoked
-   * exactly once per element, and only as the underlying iterator is advanced. Use when the caller
-   * wants to attribute both accepted and rejected elements to metrics (for example incrementing a
-   * scanned counter for survivors and a skipped counter for rejected entries).
+   * on each accepted element and {@code onSkip} on each rejected element exactly once.
    *
    * @param iterable The underlying {@link CloseableIterable} to filter.
    * @param <E> The underlying type to be iterated.
@@ -175,13 +172,17 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
             new FilterIterator<E>(iterable.iterator()) {
               @Override
               protected boolean shouldKeep(E item) {
-                if (pred.test(item)) {
-                  onKeep.accept(item);
-                  return true;
-                } else {
-                  onSkip.accept(item);
-                  return false;
-                }
+                return pred.test(item);
+              }
+
+              @Override
+              protected void onKeep(E item) {
+                onKeep.accept(item);
+              }
+
+              @Override
+              protected void onSkip(E item) {
+                onSkip.accept(item);
               }
             },
         iterable);

--- a/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
+++ b/api/src/main/java/org/apache/iceberg/io/CloseableIterable.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -146,18 +147,41 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
   static <E> CloseableIterable<E> filter(
       Counter skipCounter, CloseableIterable<E> iterable, Predicate<E> pred) {
     Preconditions.checkArgument(null != skipCounter, "Invalid counter: null");
+    return filter(iterable, pred, item -> {}, item -> skipCounter.increment());
+  }
+
+  /**
+   * Filters the given {@link CloseableIterable} with the given predicate, invoking {@code onKeep}
+   * on each accepted element and {@code onSkip} on each rejected element. Observers are invoked
+   * exactly once per element, and only as the underlying iterator is advanced. Use when the caller
+   * wants to attribute both accepted and rejected elements to metrics (for example incrementing a
+   * scanned counter for survivors and a skipped counter for rejected entries).
+   *
+   * @param iterable The underlying {@link CloseableIterable} to filter.
+   * @param <E> The underlying type to be iterated.
+   * @param pred The {@link Predicate} that selects elements to keep.
+   * @param onKeep The {@link Consumer} invoked once per element that satisfies {@code pred}.
+   * @param onSkip The {@link Consumer} invoked once per element that does not satisfy {@code pred}.
+   * @return A filtered {@link CloseableIterable} that fires the observers as elements are consumed.
+   */
+  static <E> CloseableIterable<E> filter(
+      CloseableIterable<E> iterable, Predicate<E> pred, Consumer<E> onKeep, Consumer<E> onSkip) {
     Preconditions.checkArgument(null != iterable, "Invalid iterable: null");
     Preconditions.checkArgument(null != pred, "Invalid predicate: null");
+    Preconditions.checkArgument(null != onKeep, "Invalid onKeep consumer: null");
+    Preconditions.checkArgument(null != onSkip, "Invalid onSkip consumer: null");
     return combine(
         () ->
             new FilterIterator<E>(iterable.iterator()) {
               @Override
               protected boolean shouldKeep(E item) {
-                boolean matches = pred.test(item);
-                if (!matches) {
-                  skipCounter.increment();
+                if (pred.test(item)) {
+                  onKeep.accept(item);
+                  return true;
+                } else {
+                  onSkip.accept(item);
+                  return false;
                 }
-                return matches;
               }
             },
         iterable);
@@ -175,18 +199,7 @@ public interface CloseableIterable<T> extends Iterable<T>, Closeable {
    */
   static <T> CloseableIterable<T> count(Counter counter, CloseableIterable<T> iterable) {
     Preconditions.checkArgument(null != counter, "Invalid counter: null");
-    Preconditions.checkArgument(null != iterable, "Invalid iterable: null");
-    return new CloseableIterable<T>() {
-      @Override
-      public CloseableIterator<T> iterator() {
-        return CloseableIterator.count(counter, iterable.iterator());
-      }
-
-      @Override
-      public void close() throws IOException {
-        iterable.close();
-      }
-    };
+    return filter(iterable, item -> true, item -> counter.increment(), item -> {});
   }
 
   static <I, O> CloseableIterable<O> transform(

--- a/api/src/main/java/org/apache/iceberg/io/FilterIterator.java
+++ b/api/src/main/java/org/apache/iceberg/io/FilterIterator.java
@@ -44,6 +44,12 @@ public abstract class FilterIterator<T> implements CloseableIterator<T> {
 
   protected abstract boolean shouldKeep(T item);
 
+  /** Invoked exactly once for each element accepted by {@link #shouldKeep(Object)}. */
+  protected void onKeep(T item) {}
+
+  /** Invoked exactly once for each element rejected by {@link #shouldKeep(Object)}. */
+  protected void onSkip(T item) {}
+
   @Override
   public boolean hasNext() {
     return nextReady || advance();
@@ -56,6 +62,7 @@ public abstract class FilterIterator<T> implements CloseableIterator<T> {
     }
 
     this.nextReady = false;
+    onKeep(next);
 
     return next;
   }
@@ -67,6 +74,7 @@ public abstract class FilterIterator<T> implements CloseableIterator<T> {
         this.nextReady = true;
         return true;
       }
+      onSkip(next);
     }
 
     close();

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -265,7 +265,7 @@ public class TestCloseableIterable {
   }
 
   @Test
-  public void filterWithKeepAndSkipObservers() {
+  public void filterInvokesObserversOnMatchingItems() {
     Counter kept = new DefaultMetricsContext().counter("kept");
     Counter skipped = new DefaultMetricsContext().counter("skipped");
     List<Integer> keptItems = Lists.newArrayList();
@@ -293,7 +293,35 @@ public class TestCloseableIterable {
   }
 
   @Test
-  public void filterWithObserversNullCheck() {
+  public void filterObserversFireExactlyOncePerElement() throws IOException {
+    Counter kept = new DefaultMetricsContext().counter("kept");
+    Counter skipped = new DefaultMetricsContext().counter("skipped");
+    CloseableIterable<Integer> items =
+        CloseableIterable.filter(
+            CloseableIterable.withNoopClose(Arrays.asList(1, 2, 3, 4)),
+            x -> x % 2 == 0,
+            x -> kept.increment(),
+            x -> skipped.increment());
+
+    try (CloseableIterator<Integer> iter = items.iterator()) {
+      // hasNext advances past the odd 1 (skip counted) and prefetches the even 2 (not yet counted)
+      assertThat(iter.hasNext()).isTrue();
+      assertThat(skipped.value()).isEqualTo(1);
+      assertThat(kept.value()).isZero();
+
+      // next delivers the prefetched 2 and increments kept
+      assertThat(iter.next()).isEqualTo(2);
+      assertThat(kept.value()).isEqualTo(1);
+
+      // second hasNext skips past 3 and prefetches 4; kept still 1 until next() is called
+      assertThat(iter.hasNext()).isTrue();
+      assertThat(skipped.value()).isEqualTo(2);
+      assertThat(kept.value()).isEqualTo(1);
+    }
+  }
+
+  @Test
+  public void filterObserversNullCheck() {
     Predicate<Integer> pred = x -> true;
     assertThatThrownBy(() -> CloseableIterable.filter(null, pred, x -> {}, x -> {}))
         .isInstanceOf(IllegalArgumentException.class)

--- a/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
+++ b/api/src/test/java/org/apache/iceberg/io/TestCloseableIterable.java
@@ -265,6 +265,57 @@ public class TestCloseableIterable {
   }
 
   @Test
+  public void filterWithKeepAndSkipObservers() {
+    Counter kept = new DefaultMetricsContext().counter("kept");
+    Counter skipped = new DefaultMetricsContext().counter("skipped");
+    List<Integer> keptItems = Lists.newArrayList();
+    List<Integer> skippedItems = Lists.newArrayList();
+    CloseableIterable<Integer> items =
+        CloseableIterable.filter(
+            CloseableIterable.withNoopClose(Arrays.asList(1, 2, 3, 4, 5)),
+            x -> x % 2 == 0,
+            x -> {
+              kept.increment();
+              keptItems.add(x);
+            },
+            x -> {
+              skipped.increment();
+              skippedItems.add(x);
+            });
+
+    assertThat(items).containsExactly(2, 4);
+
+    assertThat(kept.value()).isEqualTo(2);
+    assertThat(keptItems).containsExactly(2, 4);
+
+    assertThat(skipped.value()).isEqualTo(3);
+    assertThat(skippedItems).containsExactly(1, 3, 5);
+  }
+
+  @Test
+  public void filterWithObserversNullCheck() {
+    Predicate<Integer> pred = x -> true;
+    assertThatThrownBy(() -> CloseableIterable.filter(null, pred, x -> {}, x -> {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid iterable: null");
+
+    assertThatThrownBy(
+            () -> CloseableIterable.filter(CloseableIterable.empty(), null, x -> {}, x -> {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid predicate: null");
+
+    assertThatThrownBy(
+            () -> CloseableIterable.filter(CloseableIterable.empty(), pred, null, x -> {}))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid onKeep consumer: null");
+
+    assertThatThrownBy(
+            () -> CloseableIterable.filter(CloseableIterable.empty(), pred, x -> {}, null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid onSkip consumer: null");
+  }
+
+  @Test
   public void transformNullCheck() {
     assertThatThrownBy(() -> CloseableIterable.transform(CloseableIterable.empty(), null))
         .isInstanceOf(NullPointerException.class)

--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.iceberg.exceptions.RuntimeIOException;
@@ -601,19 +602,19 @@ class DeleteFileIndex {
 
       CloseableIterable<ManifestFile> closeableDeleteManifests =
           CloseableIterable.withNoopClose(deleteManifests);
-      CloseableIterable<ManifestFile> matchingManifests =
+      Predicate<ManifestFile> manifestPredicate =
           evalCache == null
-              ? closeableDeleteManifests
-              : CloseableIterable.filter(
-                  scanMetrics.skippedDeleteManifests(),
-                  closeableDeleteManifests,
-                  manifest ->
-                      manifest.content() == ManifestContent.DELETES
-                          && (manifest.hasAddedFiles() || manifest.hasExistingFiles())
-                          && evalCache.get(manifest.partitionSpecId()).eval(manifest));
-
-      matchingManifests =
-          CloseableIterable.count(scanMetrics.scannedDeleteManifests(), matchingManifests);
+              ? manifest -> true
+              : manifest ->
+                  manifest.content() == ManifestContent.DELETES
+                      && (manifest.hasAddedFiles() || manifest.hasExistingFiles())
+                      && evalCache.get(manifest.partitionSpecId()).eval(manifest);
+      CloseableIterable<ManifestFile> matchingManifests =
+          CloseableIterable.filter(
+              closeableDeleteManifests,
+              manifestPredicate,
+              manifest -> scanMetrics.scannedDeleteManifests().increment(),
+              manifest -> scanMetrics.skippedDeleteManifests().increment());
       return Iterables.transform(
           matchingManifests,
           manifest ->

--- a/core/src/main/java/org/apache/iceberg/ManifestGroup.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestGroup.java
@@ -300,38 +300,31 @@ class ManifestGroup {
 
     CloseableIterable<ManifestFile> closeableDataManifests =
         CloseableIterable.withNoopClose(dataManifests);
+    Predicate<ManifestFile> manifestPredicate =
+        manifest -> {
+          if (evalCache != null && !evalCache.get(manifest.partitionSpecId()).eval(manifest)) {
+            return false;
+          }
+          // only scan manifests that have entries other than deletes
+          // remove any manifests that don't have any existing or added files. if either the added
+          // or existing files count is missing, the manifest must be scanned.
+          if (ignoreDeleted && !(manifest.hasAddedFiles() || manifest.hasExistingFiles())) {
+            return false;
+          }
+          // only scan manifests that have entries other than existing
+          // remove any manifests that don't have any deleted or added files. if either the added or
+          // deleted files count is missing, the manifest must be scanned.
+          if (ignoreExisting && !(manifest.hasAddedFiles() || manifest.hasDeletedFiles())) {
+            return false;
+          }
+          return true;
+        };
     CloseableIterable<ManifestFile> matchingManifests =
-        evalCache == null
-            ? closeableDataManifests
-            : CloseableIterable.filter(
-                scanMetrics.skippedDataManifests(),
-                closeableDataManifests,
-                manifest -> evalCache.get(manifest.partitionSpecId()).eval(manifest));
-
-    if (ignoreDeleted) {
-      // only scan manifests that have entries other than deletes
-      // remove any manifests that don't have any existing or added files. if either the added or
-      // existing files count is missing, the manifest must be scanned.
-      matchingManifests =
-          CloseableIterable.filter(
-              scanMetrics.skippedDataManifests(),
-              matchingManifests,
-              manifest -> manifest.hasAddedFiles() || manifest.hasExistingFiles());
-    }
-
-    if (ignoreExisting) {
-      // only scan manifests that have entries other than existing
-      // remove any manifests that don't have any deleted or added files. if either the added or
-      // deleted files count is missing, the manifest must be scanned.
-      matchingManifests =
-          CloseableIterable.filter(
-              scanMetrics.skippedDataManifests(),
-              matchingManifests,
-              manifest -> manifest.hasAddedFiles() || manifest.hasDeletedFiles());
-    }
-
-    matchingManifests =
-        CloseableIterable.count(scanMetrics.scannedDataManifests(), matchingManifests);
+        CloseableIterable.filter(
+            closeableDataManifests,
+            manifestPredicate,
+            manifest -> scanMetrics.scannedDataManifests().increment(),
+            manifest -> scanMetrics.skippedDataManifests().increment());
 
     return Iterables.transform(
         matchingManifests,

--- a/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
+++ b/core/src/main/java/org/apache/iceberg/PositionDeletesTable.java
@@ -290,13 +290,12 @@ public class PositionDeletesTable extends BaseMetadataTable {
 
       CloseableIterable<ManifestFile> matchingManifests =
           CloseableIterable.filter(
-              scanMetrics().skippedDeleteManifests(),
               CloseableIterable.withNoopClose(manifests),
               manifest ->
                   baseTableEvalCache.get(manifest.partitionSpecId()).eval(manifest)
-                      && deletesTableEvalCache.get(manifest.partitionSpecId()).eval(manifest));
-      matchingManifests =
-          CloseableIterable.count(scanMetrics().scannedDeleteManifests(), matchingManifests);
+                      && deletesTableEvalCache.get(manifest.partitionSpecId()).eval(manifest),
+              manifest -> scanMetrics().scannedDeleteManifests().increment(),
+              manifest -> scanMetrics().skippedDeleteManifests().increment());
 
       Iterable<CloseableIterable<ScanTask>> tasks =
           CloseableIterable.transform(


### PR DESCRIPTION
## What
Add a new filter overload that invokes a Consumer on each accepted and rejected element, so callers can attribute both kept and skipped entries to metrics in a single pass. 

## Why
This help provide a path for hetergeneous entry of `TrackedFile` in v4, where a given entry can carry contentType of DATA, EQUALITY_DELETES, DATA_MANIFEST, or DELETE_MANIFEST within a single root manifest. Callback is better suited than a dedicated counter to allow more flexibility. Plus, import `org.apache.iceberg.metrics.Counter` in `org.apache.iceberg.io. CloseableIterable` is not ideal for a general purpose iteration utility.

## Existing caller
Migrate the manifest-level scan pipelines in `DeleteFileIndex`, `PositionDeletesTable`, and `ManifestGroup` where each previously chained a skip-counting filter with a scan-counting count call. Now replaced with a single filter call with both onKeep and onSkip callback. File-level filters in ManifestReader and ManifestGroup remain on the counter-based overload since ScanMetrics only exposes a skipped counter at that layer.