### PR TITLE
Core: Read and write geometry and geography values in Avro

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -262,11 +262,8 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
         primitiveSchema = Schema.createFixed("fixed_" + fixed.length(), null, null, fixed.length());
         break;
       case BINARY:
-        primitiveSchema = BINARY_SCHEMA;
-        break;
       case GEOMETRY:
       case GEOGRAPHY:
-        // geometry and geography values are stored as WKB in an Avro bytes field
         primitiveSchema = BINARY_SCHEMA;
         break;
       case DECIMAL:

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -264,6 +264,11 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       case BINARY:
         primitiveSchema = BINARY_SCHEMA;
         break;
+      case GEOMETRY:
+      case GEOGRAPHY:
+        // geometry and geography values are stored as WKB in an Avro bytes field
+        primitiveSchema = BINARY_SCHEMA;
+        break;
       case DECIMAL:
         Types.DecimalType decimal = (Types.DecimalType) primitive;
         primitiveSchema =

--- a/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/avro/AvroTestHelpers.java
@@ -140,6 +140,8 @@ public class AvroTestHelpers {
       case FIXED:
       case BINARY:
       case DECIMAL:
+      case GEOMETRY:
+      case GEOGRAPHY:
         assertThat(actual).as("Primitive value should be equal to expected").isEqualTo(expected);
         break;
       case VARIANT:

--- a/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
+++ b/core/src/test/java/org/apache/iceberg/avro/RandomAvroData.java
@@ -110,6 +110,8 @@ public class RandomAvroData {
         case FIXED:
           return new GenericData.Fixed(typeToSchema.get(primitive), (byte[]) result);
         case BINARY:
+        case GEOMETRY:
+        case GEOGRAPHY:
           return ByteBuffer.wrap((byte[]) result);
         case UUID:
           return UUID.nameUUIDFromBytes((byte[]) result);

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
@@ -22,7 +22,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.iceberg.DataFile;
@@ -41,6 +40,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -162,14 +162,6 @@ public class TestAvroDataWriter {
   }
 
   private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
-    // little-endian WKB encoding of a point
-    return ByteBuffer.wrap(
-        ByteBuffer.allocate(21)
-            .order(ByteOrder.LITTLE_ENDIAN)
-            .put((byte) 1) // byte order: little endian
-            .putInt(1) // WKB geometry type: Point
-            .putDouble(xCoord)
-            .putDouble(yCoord)
-            .array());
+    return ByteBuffer.wrap(RandomUtil.wkbPoint(xCoord, yCoord));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroDataWriter.java
@@ -21,6 +21,8 @@ package org.apache.iceberg.avro;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.file.Path;
 import java.util.List;
 import org.apache.iceberg.DataFile;
@@ -109,5 +111,65 @@ public class TestAvroDataWriter {
     }
 
     assertThat(writtenRecords).as("Written records should match").isEqualTo(records);
+  }
+
+  @Test
+  public void testGeospatialWkbRoundTrip() throws IOException {
+    Schema schema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "geom", Types.GeometryType.crs84()),
+            Types.NestedField.optional(3, "geog", Types.GeographyType.crs84()));
+
+    GenericRecord record = GenericRecord.create(schema);
+    List<Record> geoRecords =
+        ImmutableList.of(
+            record.copy(
+                ImmutableMap.of("id", 1L, "geom", wkbPoint(30, 10), "geog", wkbPoint(-5, 40))),
+            // geog is left null
+            record.copy(ImmutableMap.of("id", 2L, "geom", wkbPoint(0, 0))),
+            // both geo columns are left null
+            record.copy(ImmutableMap.of("id", 3L)));
+
+    OutputFile file = Files.localOutput(temp.toFile());
+    DataWriter<Record> dataWriter =
+        Avro.writeData(file)
+            .schema(schema)
+            .createWriterFunc(org.apache.iceberg.data.avro.DataWriter::create)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build();
+    try (dataWriter) {
+      for (Record geoRecord : geoRecords) {
+        dataWriter.write(geoRecord);
+      }
+    }
+
+    assertThat(dataWriter.toDataFile().recordCount()).isEqualTo(geoRecords.size());
+
+    List<Record> writtenRecords;
+    try (AvroIterable<Record> reader =
+        Avro.read(file.toInputFile())
+            .project(schema)
+            .createResolvingReader(PlannedDataReader::create)
+            .build()) {
+      writtenRecords = Lists.newArrayList(reader);
+    }
+
+    assertThat(writtenRecords)
+        .as("Geometry and geography WKB should round-trip through Avro")
+        .isEqualTo(geoRecords);
+  }
+
+  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
+    // little-endian WKB encoding of a point
+    return ByteBuffer.wrap(
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1) // byte order: little endian
+            .putInt(1) // WKB geometry type: Point
+            .putDouble(xCoord)
+            .putDouble(yCoord)
+            .array());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroEncoderUtil.java
@@ -45,6 +45,11 @@ public class TestAvroEncoderUtil extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(org.apache.iceberg.Schema schema) throws IOException {
     List<GenericData.Record> expected = RandomAvroData.generate(schema, 100, 1990L);
     Map<Type, Schema> typeToSchema = AvroSchemaUtil.convertTypes(schema.asStruct(), "test");

--- a/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestGenericAvro.java
@@ -45,6 +45,11 @@ public class TestGenericAvro extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomAvroData.generate(schema, 100, 0L);
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestInternalAvro.java
@@ -53,6 +53,11 @@ public class TestInternalAvro extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expected = RandomInternalData.generate(schema, 100, 42L);
     writeAndValidate(schema, expected);

--- a/data/src/test/java/org/apache/iceberg/data/avro/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/avro/TestGenericData.java
@@ -100,4 +100,9 @@ public class TestGenericData extends DataTestBase {
   protected boolean supportsVariant() {
     return true;
   }
+
+  @Override
+  protected boolean supportsGeospatial() {
+    return true;
+  }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -68,6 +68,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.util.Pair;
+import org.apache.iceberg.util.RandomUtil;
 import org.apache.iceberg.variants.Variant;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.column.Encoding;
@@ -337,8 +338,11 @@ public class TestParquet {
             optional(1, "geom", Types.GeometryType.crs84()),
             optional(2, "geog", Types.GeographyType.crs84()));
 
-    ByteBuffer geomWkb = ByteBuffer.wrap(new byte[] {0x01, 0x02, 0x03});
-    ByteBuffer geogWkb = ByteBuffer.wrap(new byte[] {0x04, 0x05, 0x06});
+    // Use real WKB points: the geometry/geography columns carry a Parquet geospatial logical type,
+    // so the writer parses each value with a WKB reader to build geospatial statistics. Arbitrary
+    // bytes would fail that parse and be silently omitted from stats.
+    ByteBuffer geomWkb = ByteBuffer.wrap(RandomUtil.wkbPoint(30, 10));
+    ByteBuffer geogWkb = ByteBuffer.wrap(RandomUtil.wkbPoint(-5, 40));
 
     org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
     GenericData.Record record = new GenericData.Record(avroSchema);

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -331,6 +331,39 @@ public class TestParquet {
   }
 
   @Test
+  public void testGeospatialWkbRoundTrip() throws IOException {
+    Schema schema =
+        new Schema(
+            optional(1, "geom", Types.GeometryType.crs84()),
+            optional(2, "geog", Types.GeographyType.crs84()));
+
+    ByteBuffer geomWkb = ByteBuffer.wrap(new byte[] {0x01, 0x02, 0x03});
+    ByteBuffer geogWkb = ByteBuffer.wrap(new byte[] {0x04, 0x05, 0x06});
+
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    GenericData.Record record = new GenericData.Record(avroSchema);
+    record.put("geom", geomWkb);
+    record.put("geog", geogWkb);
+    GenericData.Record nulls = new GenericData.Record(avroSchema);
+
+    File file = createTempFile(temp);
+    write(file, schema, Collections.emptyMap(), ParquetAvroWriter::buildWriter, record, nulls);
+
+    try (CloseableIterable<GenericData.Record> reader =
+        Parquet.read(Files.localInput(file))
+            .project(schema)
+            .createReaderFunc(fileSchema -> ParquetAvroValueReaders.buildReader(schema, fileSchema))
+            .build()) {
+      List<GenericData.Record> rows = Lists.newArrayList(reader);
+      assertThat(rows).hasSize(2);
+      assertThat(rows.get(0).get("geom")).isEqualTo(geomWkb);
+      assertThat(rows.get(0).get("geog")).isEqualTo(geogWkb);
+      assertThat(rows.get(1).get("geom")).isNull();
+      assertThat(rows.get(1).get("geog")).isNull();
+    }
+  }
+
+  @Test
   public void testPerColumnDictionaryEncoding() throws Exception {
     Schema schema =
         new Schema(


### PR DESCRIPTION
## Summary

`TypeToSchema` mapped every Iceberg primitive to an Avro schema except `geometry` and `geography`,
so converting a schema with a geo column threw `UnsupportedOperationException: Unsupported type ID:
GEOMETRY` before any value could be read or written through the Avro object model. This wires up the
value path.

Per the Avro type mapping in the spec, `geometry` and `geography` are stored as an Avro `bytes` field
carrying WKB — the same representation as `binary`:

| Iceberg type | Avro type |
| --- | --- |
| `binary` | `bytes` |
| `geometry` | `bytes` (WKB) |
| `geography` | `bytes` (WKB) |

So `TypeToSchema.primitive()` now maps both geo types to the existing `BINARY_SCHEMA`. The value
read/write paths dispatch on the Avro physical type, so once the schema is `bytes` the existing
`byteBuffers` reader/writer handle geo unchanged in both the generic and internal object models (geo
values are WKB `ByteBuffer`s, exactly like `binary`) — no value-path code changes are needed.

This also closes the parquet-avro object model gap: `ParquetAvroWriter` / `ParquetAvroValueReaders`
build their Avro schema through `AvroSchemaUtil.convert`, which routed into the same `TypeToSchema`
that threw on geo, so geo was unreachable through that path too. Fixing `TypeToSchema` makes it work
transitively, with no parquet-avro code change. This is the follow-up szehon-ho asked about on #16982
(which added the Parquet WKB value path and deliberately left the Avro object model as a follow-up).

### Note on the reverse direction

`SchemaToType` intentionally still maps Avro `bytes → binary`. Plain Avro `bytes` carries no marker to
distinguish geometry/geography from binary, and Iceberg resolves the real column type from the
expected/table schema, never by reverse-inferring from the file's Avro schema — the same way `binary`
and other `bytes`-backed types already behave.

## Test plan

Object-model coverage via the shared `DataTest` geo cases and the Avro encoder/writer entry points:

- Enable `supportsGeospatial()` on the Avro object-model tests — `TestGenericAvro`, `TestInternalAvro`,
  the generic-data `TestGenericData`, and `TestAvroEncoderUtil` (so geo also round-trips through the
  `AvroEncoderUtil.encode`/`decode` entry point, keeping the two generic-model Avro tests in parity).
  This round-trips geometry and geography across multiple CRS and edge algorithms with randomly
  generated WKB values.
- Add the `GEOMETRY`/`GEOGRAPHY` → `ByteBuffer` handling the generic Avro path needs in `RandomAvroData`
  and `AvroTestHelpers`, mirroring the existing `RandomInternalData` / `InternalTestHelpers` handling.
- Explicit WKB round-trip tests:
  - `TestAvroDataWriter.testGeospatialWkbRoundTrip` — geometry/geography through the Avro `DataWriter`
    → `PlannedDataReader` path, including nulls.
  - `TestParquet.testGeospatialWkbRoundTrip` — through `ParquetAvroWriter` → `ParquetAvroValueReaders`,
    covering the parquet-avro object model, including nulls.
- `./gradlew :iceberg-core:test --tests org.apache.iceberg.avro.TestGenericAvro --tests org.apache.iceberg.avro.TestInternalAvro --tests org.apache.iceberg.avro.TestAvroEncoderUtil --tests org.apache.iceberg.avro.TestAvroDataWriter`
- `./gradlew :iceberg-data:test --tests org.apache.iceberg.data.avro.TestGenericData`
- `./gradlew :iceberg-parquet:test --tests org.apache.iceberg.parquet.TestParquet`
