### PR TITLE
AWS: Fix GlueCatalog: Add suppressed exception when rollback fails. Throw iceberg AlreadyExistsException rather than aws version

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -344,9 +344,9 @@ public class TestGlueCatalogTable extends GlueTestBase {
                 glueCatalog.renameTable(
                     TableIdentifier.of(namespace, tableName),
                     TableIdentifier.of(namespace, newTableName)))
-        .isInstanceOf(software.amazon.awssdk.services.glue.model.AlreadyExistsException.class)
+        .isInstanceOf(AlreadyExistsException.class)
         .as("should fail to rename to an existing table")
-        .hasMessageContaining("Table already exists");
+        .hasMessageContaining("table already exists");
     // old table can still be read with same metadata
     Table oldTable = glueCatalog.loadTable(id);
     assertThat(oldTable.location()).isEqualTo(table.location());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueCatalog.java
@@ -434,12 +434,17 @@ public class GlueCatalog extends BaseMetastoreCatalog
             .parameters(fromTable.parameters())
             .storageDescriptor(fromTable.storageDescriptor());
 
-    glue.createTable(
-        CreateTableRequest.builder()
-            .catalogId(awsProperties.glueCatalogId())
-            .databaseName(toTableDbName)
-            .tableInput(tableInputBuilder.name(toTableName).build())
-            .build());
+    try {
+      glue.createTable(
+          CreateTableRequest.builder()
+              .catalogId(awsProperties.glueCatalogId())
+              .databaseName(toTableDbName)
+              .tableInput(tableInputBuilder.name(toTableName).build())
+              .build());
+    } catch (software.amazon.awssdk.services.glue.model.AlreadyExistsException e) {
+      throw new AlreadyExistsException(
+          e, "Cannot rename %s to %s because table already exists", from, to);
+    }
     LOG.info("created rename destination table {}", to);
 
     try {
@@ -451,12 +456,16 @@ public class GlueCatalog extends BaseMetastoreCatalog
           from,
           to,
           e);
-      glue.deleteTable(
-          DeleteTableRequest.builder()
-              .catalogId(awsProperties.glueCatalogId())
-              .databaseName(toTableDbName)
-              .name(toTableName)
-              .build());
+      try {
+        dropTable(to, false);
+      } catch (Exception rollbackException) {
+        LOG.error(
+            "Failed to rollback rename of {} to {}, both tables may exist in Glue",
+            from,
+            to,
+            rollbackException);
+        e.addSuppressed(rollbackException);
+      }
       throw e;
     }
 

--- a/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/glue/TestGlueCatalog.java
@@ -31,6 +31,7 @@ import org.apache.iceberg.aws.AwsProperties;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NamespaceNotEmptyException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -421,6 +422,65 @@ public class TestGlueCatalog {
 
     glueCatalog.renameTable(TableIdentifier.of("db", "t"), TableIdentifier.of("db", "x_renamed"));
     assertThat(counter.get()).isEqualTo(0);
+  }
+
+  private void setupRenameTableMocks() {
+    Map<String, String> parameters = Maps.newHashMap();
+    parameters.put(
+        BaseMetastoreTableOperations.TABLE_TYPE_PROP,
+        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
+
+    Mockito.doReturn(
+            GetTableResponse.builder()
+                .table(Table.builder().databaseName("db").name("t").parameters(parameters).build())
+                .build())
+        .when(glue)
+        .getTable(Mockito.any(GetTableRequest.class));
+    Mockito.doReturn(
+            GetDatabaseResponse.builder().database(Database.builder().name("db").build()).build())
+        .when(glue)
+        .getDatabase(Mockito.any(GetDatabaseRequest.class));
+  }
+
+  @Test
+  public void testRenameTableDestinationAlreadyExists() {
+    setupRenameTableMocks();
+    Mockito.doThrow(
+            software.amazon.awssdk.services.glue.model.AlreadyExistsException.builder()
+                .message("Table already exists")
+                .build())
+        .when(glue)
+        .createTable(Mockito.any(CreateTableRequest.class));
+
+    assertThatThrownBy(
+            () ->
+                glueCatalog.renameTable(
+                    TableIdentifier.of("db", "t"), TableIdentifier.of("db", "t_renamed")))
+        .isInstanceOf(AlreadyExistsException.class)
+        .hasMessageContaining("table already exists");
+  }
+
+  @Test
+  public void testRenameTableRollbackFailure() {
+    setupRenameTableMocks();
+    Mockito.doReturn(CreateTableResponse.builder().build())
+        .when(glue)
+        .createTable(Mockito.any(CreateTableRequest.class));
+
+    RuntimeException dropFailure = new RuntimeException("drop failed");
+    RuntimeException rollbackFailure = new RuntimeException("rollback failed");
+    Mockito.doThrow(dropFailure)
+        .doThrow(rollbackFailure)
+        .when(glue)
+        .deleteTable(Mockito.any(DeleteTableRequest.class));
+
+    assertThatThrownBy(
+            () ->
+                glueCatalog.renameTable(
+                    TableIdentifier.of("db", "t"), TableIdentifier.of("db", "t_renamed")))
+        .isSameAs(dropFailure)
+        .satisfies(
+            ex -> assertThat(ex.getSuppressed()).hasSize(1).allMatch(s -> s == rollbackFailure));
   }
 
   @Test


### PR DESCRIPTION
Hey folks.

This addresses a couple of small bugs in `GlueCatalog.renameTable`

*Correct exception*

When the destination table name already exists, an Iceberg `AlreadyExistsException` is thrown rather than the glue variation.

*Original Exception lost during rollback*

In the failure case, when rolling back the new table creation, if that also fails the original exception is lost. They are both now included in the throws with the use of addSuppress.