### PR TITLE
Docs: add Collate to vendors.md

### DIFF
--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -65,6 +65,10 @@ the same copy of data using Spark and run analytics or AI with our
 [Machine Learning](https://www.cloudera.com/products/machine-learning.html) tools on private
 or any public cloud.
 
+### [Collate](https://www.getcollate.io/)
+
+Collate is an AI-native data catalog and governance platform built on [OpenMetadata](https://open-metadata.org/), the open-source (Apache 2.0) context layer. It brings together every Apache Iceberg table into a single source of governed context — with column-level lineage, data profiling, and no-code data quality tests — by connecting through the engines that already query Iceberg (e.g., Trino, Snowflake, BigQuery).
+
 ### [Confluent](https://confluent.io)
 
 [Confluent](https://www.confluent.io/) provides [Tableflow](https://www.confluent.io/product/tableflow/), a managed service for streaming data from Apache Kafka topics into Apache Iceberg tables. Tableflow automates schema evolution through Schema Registry integration and handles table maintenance tasks including compaction automatically.


### PR DESCRIPTION
Hi! This is William, Developer Advocate at Collate — we'd like to add Collate to the vendors page. Collate is built on OpenMetadata, the open-source context layer we maintain. It brings governed lineage, profiling, and data quality assurance to Iceberg tables by connecting through the query engines teams already use, including Trino, Snowflake, and BigQuery. Happy to adjust the wording if need be.