### PR TITLE
Flink: Fix watermark extractor error message showing field id instead of file

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -97,8 +97,9 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
               Preconditions.checkArgument(
                   scanTask.file().lowerBounds() != null
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
-                  "Missing statistics for column name = %s in file = %s",
+                  "Missing statistics for column name = %s with fieldId = %s in file = %s",
                   eventTimeFieldName,
+                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -99,7 +99,6 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
                   "Missing statistics for column name = %s in file = %s",
                   eventTimeFieldName,
-                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -180,11 +180,14 @@ public class TestColumnStatsWatermarkExtractor {
     assumeThat(columnName).isEqualTo("timestamp_column");
 
     // Create an extractor for a column we do not have statistics
+    IcebergSourceSplit split = split(0);
     ColumnStatsWatermarkExtractor extractor =
         new ColumnStatsWatermarkExtractor(10, "missing_field");
-    assertThatThrownBy(() -> extractor.extractWatermark(split(0)))
+    assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing statistics for column");
+        .hasMessage(
+            "Missing statistics for column name = missing_field in file = "
+                + split.task().files().iterator().next().file());
   }
 
   private IcebergSourceSplit split(int id) throws IOException {

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -186,7 +186,7 @@ public class TestColumnStatsWatermarkExtractor {
     assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Missing statistics for column name = missing_field in file = "
+            "Missing statistics for column name = missing_field with fieldId = 10 in file = "
                 + split.task().files().iterator().next().file());
   }
 

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -97,8 +97,9 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
               Preconditions.checkArgument(
                   scanTask.file().lowerBounds() != null
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
-                  "Missing statistics for column name = %s in file = %s",
+                  "Missing statistics for column name = %s with fieldId = %s in file = %s",
                   eventTimeFieldName,
+                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -99,7 +99,6 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
                   "Missing statistics for column name = %s in file = %s",
                   eventTimeFieldName,
-                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -180,11 +180,14 @@ public class TestColumnStatsWatermarkExtractor {
     assumeThat(columnName).isEqualTo("timestamp_column");
 
     // Create an extractor for a column we do not have statistics
+    IcebergSourceSplit split = split(0);
     ColumnStatsWatermarkExtractor extractor =
         new ColumnStatsWatermarkExtractor(10, "missing_field");
-    assertThatThrownBy(() -> extractor.extractWatermark(split(0)))
+    assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing statistics for column");
+        .hasMessage(
+            "Missing statistics for column name = missing_field in file = "
+                + split.task().files().iterator().next().file());
   }
 
   private IcebergSourceSplit split(int id) throws IOException {

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -186,7 +186,7 @@ public class TestColumnStatsWatermarkExtractor {
     assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Missing statistics for column name = missing_field in file = "
+            "Missing statistics for column name = missing_field with fieldId = 10 in file = "
                 + split.task().files().iterator().next().file());
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -97,8 +97,9 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
               Preconditions.checkArgument(
                   scanTask.file().lowerBounds() != null
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
-                  "Missing statistics for column name = %s in file = %s",
+                  "Missing statistics for column name = %s with fieldId = %s in file = %s",
                   eventTimeFieldName,
+                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java
@@ -99,7 +99,6 @@ public class ColumnStatsWatermarkExtractor implements SplitWatermarkExtractor, S
                       && scanTask.file().lowerBounds().get(eventTimeFieldId) != null,
                   "Missing statistics for column name = %s in file = %s",
                   eventTimeFieldName,
-                  eventTimeFieldId,
                   scanTask.file());
               return timeUnit.toMillis(
                   Conversions.fromByteBuffer(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -180,11 +180,14 @@ public class TestColumnStatsWatermarkExtractor {
     assumeThat(columnName).isEqualTo("timestamp_column");
 
     // Create an extractor for a column we do not have statistics
+    IcebergSourceSplit split = split(0);
     ColumnStatsWatermarkExtractor extractor =
         new ColumnStatsWatermarkExtractor(10, "missing_field");
-    assertThatThrownBy(() -> extractor.extractWatermark(split(0)))
+    assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Missing statistics for column");
+        .hasMessage(
+            "Missing statistics for column name = missing_field in file = "
+                + split.task().files().iterator().next().file());
   }
 
   private IcebergSourceSplit split(int id) throws IOException {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java
@@ -186,7 +186,7 @@ public class TestColumnStatsWatermarkExtractor {
     assertThatThrownBy(() -> extractor.extractWatermark(split))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage(
-            "Missing statistics for column name = missing_field in file = "
+            "Missing statistics for column name = missing_field with fieldId = 10 in file = "
                 + split.task().files().iterator().next().file());
   }
 


### PR DESCRIPTION

```markdown
### What

`ColumnStatsWatermarkExtractor.extractWatermark` builds its "missing statistics"
error with a `Preconditions.checkArgument` format string that has exactly two
`%s` placeholders:

```
"Missing statistics for column name = %s in file = %s"
```

but passes three arguments to it: `eventTimeFieldName`, `eventTimeFieldId`, and
`scanTask.file()`. Guava's `lenientFormat` fills the two `%s` slots with the
first two arguments and appends any extras in trailing brackets. As a result the
message renders the numeric field id where the file is supposed to be, and dumps
the actual file in an overflow bracket, for example:

```
Missing statistics for column name = ts in file = 5 [GenericDataFile{...}]
```

The `file =` slot shows `5` (the field id) instead of the file, which is
misleading when diagnosing a table that is missing lower bounds for the
watermark column.

### Why

The `file =` label should point at the file that lacks statistics. Printing the
field id there (and hiding the file in brackets) makes the diagnostic harder to
act on. The bug is present identically in the v1.20, v2.0, and v2.1 Flink
modules.

### How

Remove the redundant `eventTimeFieldId` argument so the two remaining arguments
(column name and file) line up with the two placeholders. The message text is
unchanged; `eventTimeFieldId` is still used by the surrounding null-check guard
and the `Conversions.fromByteBuffer` lookup, so nothing else is affected.

The existing `testEmptyStatistics` assertion is strengthened from a substring
check to an exact `hasMessage(...)` that computes the expected file from the
split, so it now fails if the file slot is ever wrong again. Verified this is a
genuine red/green guard: with the extra argument re-added the test fails with
`... in file = 10 [<file>]`; with the fix it passes.

### Tests

- `TestColumnStatsWatermarkExtractor` passes for all three Flink modules
  (v1.20, v2.0, v2.1) run with `-DflinkVersions=1.20,2.0,2.1`.
- `spotlessCheck` is clean for the three modules.

One concern per PR: only the argument fix and its regression assertion are
touched, applied identically across the three module copies.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: opencode
- Human Oversight: partially reviewed
- Prompt Summary: Locate and fix a Flink `ColumnStatsWatermarkExtractor` error
  message that printed the watermark column's field id in the "file =" slot
  instead of the file, remove the stray format argument, and add a regression
  assertion. Diff and tests were independently reviewed and run before opening.
```

---

## Files changed (6 files, +15/-9)

- `flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java` (-1)
- `flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java` (+5/-2)
- `flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java` (-1)
- `flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java` (+5/-2)
- `flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/reader/ColumnStatsWatermarkExtractor.java` (-1)
- `flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/reader/TestColumnStatsWatermarkExtractor.java` (+5/-2)
