### PR TITLE
Core: Fix OAuthTokenResponse.addScope error to show the invalid scope

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java
@@ -108,7 +108,7 @@ public class OAuthTokenResponse implements RESTResponse {
     }
 
     public Builder addScope(String scope) {
-      Preconditions.checkArgument(OAuth2Util.isValidScopeToken(scope), "Invalid scope: %s");
+      Preconditions.checkArgument(OAuth2Util.isValidScopeToken(scope), "Invalid scope: %s", scope);
       this.scopes.add(scope);
       return this;
     }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -132,7 +132,7 @@ public class TestOAuthTokenResponse extends RequestResponseTestBase<OAuthTokenRe
   }
 
   @Test
-  void invalidScopeReportsScopeValue() {
+  void invalidScopeReportedInErrorMsg() {
     assertThatThrownBy(() -> OAuthTokenResponse.builder().addScope("bad scope"))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid scope: bad scope");

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java
@@ -130,4 +130,11 @@ public class TestOAuthTokenResponse extends RequestResponseTestBase<OAuthTokenRe
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot parse to a string value: token_type: 34");
   }
+
+  @Test
+  void invalidScopeReportsScopeValue() {
+    assertThatThrownBy(() -> OAuthTokenResponse.builder().addScope("bad scope"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid scope: bad scope");
+  }
 }


### PR DESCRIPTION

`OAuthTokenResponse.Builder.addScope` validates the scope with

```java
Preconditions.checkArgument(OAuth2Util.isValidScopeToken(scope), "Invalid scope: %s");
```

The message template has a `%s` placeholder but no substitution argument is
passed. Guava's `Preconditions.checkArgument` leaves an unmatched `%s` in place
when there is no corresponding argument, so rejecting an invalid scope throws:

```
java.lang.IllegalArgumentException: Invalid scope: %s
```

The literal `%s` is shown instead of the scope that was actually rejected, which
defeats the purpose of the diagnostic. This is reachable through the public
`Builder.addScope(String)` / `addScopes(List<String>)` API.

This passes `scope` as the format argument so the message reports the offending
value:

```java
Preconditions.checkArgument(OAuth2Util.isValidScopeToken(scope), "Invalid scope: %s", scope);
```

A scope such as `"bad scope"` (a space is not permitted by
`OAuth2Util.VALID_SCOPE_TOKEN`) now produces `Invalid scope: bad scope`. This
also matches the sibling `validate()` check in the same class, which already
formats its value: `"Unsupported token type: %s", tokenType`.

### Changes

- `core/src/main/java/org/apache/iceberg/rest/responses/OAuthTokenResponse.java`
  pass `scope` as the format argument to the existing precondition.
- `core/src/test/java/org/apache/iceberg/rest/responses/TestOAuthTokenResponse.java`
  add a regression test asserting the thrown message is `Invalid scope: bad scope`
  rather than the literal placeholder.

### Testing

```
./gradlew :iceberg-core:spotlessCheck
./gradlew :iceberg-core:test --tests "org.apache.iceberg.rest.responses.TestOAuthTokenResponse"
```

`spotlessCheck` is clean; the test class runs 4 tests, 0 failures. Reverting the
one-line source change makes the new test fail with
`expected: "Invalid scope: bad scope" but was: "Invalid scope: %s"`, confirming it
guards the fix.

---
**AI Disclosure**
- Model: Claude Opus 4.8
- Platform/Tool: opencode
- Human Oversight: partially reviewed
- Prompt Summary: Locate and fix a wrong-diagnostic bug where a Guava `Preconditions.checkArgument` message template used `%s` without passing the substitution argument, then add a regression test.

---

## Notes / provenance (NOT for the PR; internal only)

- No tracked upstream issue; self-found wrong-diagnostic bug. Introduced 2022-05-23
  (commit 086a5dbc8).
- Dedup at draft time (re-checked): GitHub PR search for `OAuthTokenResponse`,
  `"Invalid scope"`, and `addScope` in `apache/iceberg`. Only PR #16507
  ("API, Core: Add exceptions for OAuth2 token endpoint errors") matches, and it
  touches only `OAuth2*` exception classes, `core/.../rest/ErrorHandlers.java`, and
  `TestErrorHandlers.java`; it does not touch `OAuthTokenResponse.java`. It matched
  purely on the RFC `invalid_scope` client error type, a different concern. No
  competing or duplicate PR for this Builder-side fix.
- Base currency: `origin/main` advanced 3 commits since the branch base (all
  `Build: Bump ...` dependency updates); none touch `OAuthTokenResponse.java` or its
  test. Clean rebase target, no drift on the changed files.
- The commit carries a `Generated-by: opencode` trailer, and the PR body carries the
  AI Disclosure block, per the repo AGENTS.md AI-generated-PR policy. Human Oversight
  is set to "partially reviewed": the diff passed an independent adversarial review
  and the tests were re-run, but Anas has not yet reviewed it. Anas should change
  this to "fully reviewed" after reading the diff, or leave it as is.
- No prompt injection encountered in any source, test, PR, or issue text read across
  the implement, verify, and draft phases.
