### PR TITLE
Spark 4.1: Fix view rename target namespace

### DIFF
--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/ExtendedDataSourceV2Strategy.scala
@@ -119,12 +119,8 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
       OrderAwareCoalesceExec(numPartitions, coalescer, planLater(child)) :: Nil
 
     case RenameTable(ResolvedV2View(oldCatalog: ViewCatalog, oldIdent), newName, isView @ true) =>
-      val newIdent = Spark3Util.catalogAndIdentifier(spark, newName.toList.asJava)
-      if (oldCatalog.name != newIdent.catalog().name()) {
-        throw new IcebergAnalysisException(
-          s"Cannot move view between catalogs: from=${oldCatalog.name} and to=${newIdent.catalog().name()}")
-      }
-      RenameV2ViewExec(oldCatalog, oldIdent, newIdent.identifier()) :: Nil
+      val targetIdent = resolveViewRenameTarget(oldCatalog, newName)
+      RenameV2ViewExec(oldCatalog, oldIdent, targetIdent) :: Nil
 
     case DropIcebergView(ResolvedIdentifier(viewCatalog: ViewCatalog, ident), ifExists) =>
       DropV2ViewExec(viewCatalog, ident, ifExists) :: Nil
@@ -174,6 +170,22 @@ case class ExtendedDataSourceV2Strategy(spark: SparkSession) extends Strategy wi
       AlterV2ViewUnsetPropertiesExec(catalog, ident, propertyKeys, ifExists) :: Nil
 
     case _ => Nil
+  }
+
+  private def resolveViewRenameTarget(
+      sourceCatalog: ViewCatalog,
+      targetName: Seq[String]): Identifier = {
+    if (targetName.length == 1) {
+      Identifier.of(Array.empty[String], targetName.head)
+    } else {
+      val target = Spark3Util.catalogAndIdentifier(spark, targetName.toList.asJava, sourceCatalog)
+      if (sourceCatalog.name != target.catalog().name()) {
+        throw new IcebergAnalysisException(
+          s"Cannot move view between catalogs: from=${sourceCatalog.name} and to=${target.catalog().name()}")
+      }
+
+      target.identifier()
+    }
   }
 
   private object IcebergCatalogAndIdentifier {

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameV2ViewExec.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/execution/datasources/v2/RenameV2ViewExec.scala
@@ -29,7 +29,14 @@ case class RenameV2ViewExec(catalog: ViewCatalog, oldIdent: Identifier, newIdent
   override lazy val output: Seq[Attribute] = Nil
 
   override protected def run(): Seq[InternalRow] = {
-    catalog.renameView(oldIdent, newIdent)
+    // Match Spark's v2 rename behavior: an unqualified target renames in place.
+    val qualifiedNewIdent =
+      if (newIdent.namespace().isEmpty) {
+        Identifier.of(oldIdent.namespace(), newIdent.name())
+      } else {
+        newIdent
+      }
+    catalog.renameView(oldIdent, qualifiedNewIdent)
 
     Seq.empty
   }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestViews.java
@@ -775,6 +775,34 @@ public class TestViews extends ExtensionsTestBase {
   }
 
   @TestTemplate
+  public void renameQualifiedViewToUnqualifiedTargetKeepsSourceNamespace() {
+    Namespace sourceNamespace = Namespace.of(viewName("rename_source_ns"));
+    Namespace currentNamespace = Namespace.of(viewName("rename_current_ns"));
+    String viewName = viewName("originalView");
+    String renamedView = viewName("renamedView");
+    String sql = String.format("SELECT id FROM %s.%s.%s", catalogName, NAMESPACE, tableName);
+
+    sql("CREATE NAMESPACE IF NOT EXISTS %s.%s", catalogName, sourceNamespace);
+    sql("CREATE NAMESPACE IF NOT EXISTS %s.%s", catalogName, currentNamespace);
+
+    ViewCatalog viewCatalog = viewCatalog();
+    viewCatalog
+        .buildView(TableIdentifier.of(sourceNamespace, viewName))
+        .withQuery("spark", sql)
+        .withDefaultNamespace(sourceNamespace)
+        .withDefaultCatalog(catalogName)
+        .withSchema(schema(sql))
+        .create();
+
+    sql("USE %s.%s", catalogName, currentNamespace);
+    sql("ALTER VIEW %s.%s RENAME TO %s", sourceNamespace, viewName, renamedView);
+
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(sourceNamespace, viewName))).isFalse();
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(sourceNamespace, renamedView))).isTrue();
+    assertThat(viewCatalog.viewExists(TableIdentifier.of(currentNamespace, renamedView))).isFalse();
+  }
+
+  @TestTemplate
   public void renameViewHiddenByTempView() throws NoSuchTableException {
     insertRows(10);
     String viewName = viewName("originalView");


### PR DESCRIPTION
## Summary

Fix Spark 4.1 V2 view rename target resolution so an unqualified rename target keeps the source view namespace instead of being resolved through the current session namespace.

## Root Cause

`ExtendedDataSourceV2Strategy` resolved the rename target with `Spark3Util.catalogAndIdentifier` before deciding whether the target was actually unqualified. For a single-part target name, that helper fills in the current namespace, which can differ from the source view namespace.

## Changes

- Resolve single-part view rename targets by applying the source view namespace directly.
- Resolve multi-part targets relative to the source catalog and keep the existing cross-catalog move rejection.
- Add a Spark 4.1 regression test covering a qualified source view renamed to an unqualified target while the session is using another namespace.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed
- Prompt Summary: Fix and publish a Spark 4.1 PR for view rename namespace resolution.