### PR TITLE
Core: Test geometry and geography metrics keep counts without bounds

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -29,6 +29,7 @@ import java.io.File;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.CharBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
@@ -265,6 +266,39 @@ public abstract class TestMetrics {
     } else {
       assertBounds(13, TimestampType.withoutZone(), -1_900_300L, -7_000L, metricsWithStats);
     }
+  }
+
+  @TestTemplate
+  public void testMetricsForGeospatialTypes() throws IOException {
+    // Geometry and geography are only written by the Parquet path; other formats do not support
+    // the geo types yet.
+    assumeThat(fileFormat()).isEqualTo(FileFormat.PARQUET);
+
+    Schema schema =
+        new Schema(
+            required(1, "id", LongType.get()),
+            optional(2, "geom", Types.GeometryType.crs84()),
+            optional(3, "geog", Types.GeographyType.crs84()));
+
+    Record first = GenericRecord.create(schema);
+    first.setField("id", 1L);
+    first.setField("geom", wkbPoint(30, 10));
+    first.setField("geog", wkbPoint(-5, 40));
+    Record second = GenericRecord.create(schema);
+    second.setField("id", 2L);
+    // both geo columns are left null
+
+    Metrics metrics = getMetrics(schema, first, second);
+    MetricsWithStats metricsWithStats =
+        new MetricsWithStats(metrics, MetricsUtil.fromMetrics(schema, metrics));
+    assertThat(metrics.recordCount()).isEqualTo(2L);
+
+    // geometry and geography keep value/null counts but no bounds: lexicographic WKB min/max is not
+    // meaningful, so bounds are intentionally skipped (spatial bounds are a separate follow-up).
+    assertCounts(2, 2L, 1L, metricsWithStats);
+    assertBounds(2, Types.GeometryType.crs84(), null, null, metricsWithStats);
+    assertCounts(3, 2L, 1L, metricsWithStats);
+    assertBounds(3, Types.GeographyType.crs84(), null, null, metricsWithStats);
   }
 
   @TestTemplate
@@ -812,6 +846,18 @@ public abstract class TestMetrics {
 
     assertBounds(3, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metricsWithStats);
     assertBounds(5, LongType.get(), Long.MAX_VALUE, Long.MAX_VALUE, metricsWithStats);
+  }
+
+  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
+    // little-endian WKB encoding of a point
+    return ByteBuffer.wrap(
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1) // byte order: little endian
+            .putInt(1) // WKB geometry type: Point
+            .putDouble(xCoord)
+            .putDouble(yCoord)
+            .array());
   }
 
   protected void assertCounts(


### PR DESCRIPTION
`TestMetrics` is the canonical per-type metrics test — it pins the
value/null-count and lower/upper-bound behavior of every primitive type across
the Parquet and ORC formats — but it had no geometry/geography coverage.

Geo columns were given counts-only metrics in #16850 (Parquet skips the
lexicographic WKB min/max, which is not meaningful for spatial data), and that
behavior was only covered by an isolated test in `TestParquet`. This adds
`testMetricsForGeospatialTypes` to the canonical suite, asserting that geometry
and geography keep value/null counts while intentionally producing no bounds.
Real spatial bounds (`geo_lower` / `geo_upper`) remain a separate follow-up.

Geo values are only written by the Parquet path today, so the test is skipped
for other formats (ORC).

Testing: `TestParquetMetrics.testMetricsForGeospatialTypes` runs across all four
format versions and passes; `TestOrcMetrics` skips it via the format assumption.
