### PR TITLE
Core: Use mocks in TrackedFile tests

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -46,31 +46,19 @@ class TestTrackedFileStruct {
   private static final PartitionData PARTITION = Mockito.mock(PartitionData.class);
   private static final PartitionData PARTITION_COPY = Mockito.mock(PartitionData.class);
 
+  private static final DeletionVector DELETION_VECTOR = Mockito.mock(DeletionVector.class);
+  private static final DeletionVector DELETION_VECTOR_COPY = Mockito.mock(DeletionVector.class);
+
+  private static final ManifestInfo MANIFEST_INFO = Mockito.mock(ManifestInfo.class);
+  private static final ManifestInfo MANIFEST_INFO_COPY = Mockito.mock(ManifestInfo.class);
+
   static {
     Mockito.when(TRACKING.copy()).thenReturn(TRACKING_COPY);
     Mockito.when(PARTITION.copy()).thenReturn(PARTITION_COPY);
+    Mockito.when(DELETION_VECTOR.copy()).thenReturn(DELETION_VECTOR_COPY);
+    Mockito.when(MANIFEST_INFO.copy()).thenReturn(MANIFEST_INFO_COPY);
   }
 
-  private static final DeletionVectorStruct DELETION_VECTOR =
-      DeletionVectorStruct.builder()
-          .location("s3://bucket/dv.puffin")
-          .offset(100L)
-          .sizeInBytes(50L)
-          .cardinality(5L)
-          .build();
-
-  private static final ManifestInfoStruct MANIFEST_INFO =
-      ManifestInfoStruct.builder()
-          .addedFilesCount(10)
-          .existingFilesCount(20)
-          .deletedFilesCount(3)
-          .replacedFilesCount(2)
-          .addedRowsCount(1000L)
-          .existingRowsCount(2000L)
-          .deletedRowsCount(300L)
-          .replacedRowsCount(200L)
-          .minSequenceNumber(5L)
-          .build();
 
   private static final ContentStats CONTENT_STATS = Mockito.mock(ContentStats.class);
 
@@ -225,17 +213,14 @@ class TestTrackedFileStruct {
     assertThat(copy.fileSizeInBytes()).isEqualTo(512L);
     assertThat(copy.specId()).isEqualTo(1);
     assertThat(copy.sortOrderId()).isEqualTo(5);
-    assertThat(copy.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(copy.manifestInfo().addedFilesCount()).isEqualTo(10);
-    assertThat(copy.manifestInfo().addedRowsCount()).isEqualTo(1000L);
+    assertThat(copy.deletionVector()).isSameAs(DELETION_VECTOR_COPY);
+    assertThat(copy.manifestInfo()).isSameAs(MANIFEST_INFO_COPY);
     assertThat(copy.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
     assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
     assertThat(copy.partition()).isSameAs(PARTITION_COPY);
 
     // mutable fields are deep-copied, not shared with the original
-    assertThat(copy.deletionVector()).isNotSameAs(file.deletionVector());
-    assertThat(copy.manifestInfo()).isNotSameAs(file.manifestInfo());
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
   }
 
@@ -279,8 +264,8 @@ class TestTrackedFileStruct {
             7,
             null,
             1,
-            DELETION_VECTOR,
-            MANIFEST_INFO,
+            null, // DeletionVector has its own serialization tests
+            null, // ManifestInfo has its own serialization tests
             ByteBuffer.wrap(new byte[] {1, 2, 3}),
             ImmutableList.of(50L),
             ImmutableList.of(1, 2, 3));
@@ -297,19 +282,11 @@ class TestTrackedFileStruct {
     assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
     assertThat(deserialized.specId()).isEqualTo(7);
     assertThat(deserialized.sortOrderId()).isEqualTo(1);
-    assertThat(deserialized.deletionVector().location()).isEqualTo("s3://bucket/dv.puffin");
-    assertThat(deserialized.manifestInfo().addedFilesCount()).isEqualTo(10);
-    assertThat(deserialized.manifestInfo().addedRowsCount()).isEqualTo(1000L);
+    assertThat(deserialized.deletionVector()).isNull();
+    assertThat(deserialized.manifestInfo()).isNull();
     assertThat(deserialized.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(deserialized.splitOffsets()).containsExactly(50L);
     assertThat(deserialized.equalityIds()).containsExactly(1, 2, 3);
-  }
-
-  private static PartitionData newPartition(int idBucket, String category) {
-    PartitionData partition = new PartitionData(PARTITION_TYPE);
-    partition.set(0, idBucket);
-    partition.set(1, category);
-    return partition;
   }
 
   private static int pos(String fieldName) {

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -216,7 +216,7 @@ class TestTrackedFileStruct {
     TrackedFile copy = file.copy();
 
     assertThat(copy).isInstanceOf(TrackedFileStruct.class);
-    assertThat(copy.tracking()).isEqualTo(TRACKING_COPY);
+    assertThat(copy.tracking()).isSameAs(TRACKING_COPY);
     assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
     assertThat(copy.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
     assertThat(copy.location()).isEqualTo("s3://bucket/data/00000-0-file.parquet");

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -21,15 +21,14 @@ package org.apache.iceberg;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.ByteBuffer;
-import java.util.Comparator;
 import java.util.List;
 import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
-import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
 
 class TestTrackedFileStruct {
   private static final int FORMAT_VERSION_V4 = 4;
@@ -41,15 +40,16 @@ class TestTrackedFileStruct {
   private static final List<Types.NestedField> FIELDS =
       TrackedFile.schemaWithContentStats(PARTITION_TYPE, Types.StructType.of()).fields();
 
-  private static final Comparator<StructLike> PARTITION_COMPARATOR =
-      Comparators.forType(PARTITION_TYPE);
-  private static final Comparator<StructLike> TRACKING_COMPARATOR =
-      Comparators.forType(Tracking.schema());
+  private static final Tracking TRACKING = Mockito.mock(Tracking.class);
+  private static final Tracking TRACKING_COPY = Mockito.mock(Tracking.class);
 
-  private static final Tracking TRACKING =
-      new TrackingStruct(EntryStatus.ADDED, 42L, 10L, 10L, 43L, 1000L, null, null);
+  private static final PartitionData PARTITION = Mockito.mock(PartitionData.class);
+  private static final PartitionData PARTITION_COPY = Mockito.mock(PartitionData.class);
 
-  private static final PartitionData PARTITION = newPartition(7, "music");
+  static {
+    Mockito.when(TRACKING.copy()).thenReturn(TRACKING_COPY);
+    Mockito.when(PARTITION.copy()).thenReturn(PARTITION_COPY);
+  }
 
   private static final DeletionVectorStruct DELETION_VECTOR =
       DeletionVectorStruct.builder()
@@ -72,15 +72,7 @@ class TestTrackedFileStruct {
           .minSequenceNumber(5L)
           .build();
 
-  private static final ContentStats CONTENT_STATS =
-      BaseContentStats.builder()
-          .withTableSchema(
-              new Schema(
-                  Types.NestedField.optional(1, "id", Types.IntegerType.get()),
-                  Types.NestedField.optional(2, "data", Types.FloatType.get())))
-          .withFieldStats(BaseFieldStats.builder().fieldId(1).build())
-          .withFieldStats(BaseFieldStats.builder().fieldId(2).build())
-          .build();
+  private static final ContentStats CONTENT_STATS = Mockito.mock(ContentStats.class);
 
   @Test
   void fieldAccess() {
@@ -224,8 +216,7 @@ class TestTrackedFileStruct {
     TrackedFile copy = file.copy();
 
     assertThat(copy).isInstanceOf(TrackedFileStruct.class);
-    assertThat(TRACKING_COMPARATOR.compare((StructLike) copy.tracking(), (StructLike) TRACKING))
-        .isEqualTo(0);
+    assertThat(copy.tracking()).isEqualTo(TRACKING_COPY);
     assertThat(copy.contentType()).isEqualTo(FileContent.DATA);
     assertThat(copy.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
     assertThat(copy.location()).isEqualTo("s3://bucket/data/00000-0-file.parquet");
@@ -240,12 +231,9 @@ class TestTrackedFileStruct {
     assertThat(copy.keyMetadata()).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
     assertThat(copy.splitOffsets()).containsExactly(100L, 200L);
     assertThat(copy.equalityIds()).containsExactly(1, 2, 3);
-
-    assertThat(PARTITION_COMPARATOR.compare(copy.partition(), PARTITION)).isEqualTo(0);
+    assertThat(copy.partition()).isSameAs(PARTITION_COPY);
 
     // mutable fields are deep-copied, not shared with the original
-    assertThat(copy.tracking()).isNotSameAs(file.tracking());
-    assertThat(copy.partition()).isNotSameAs(file.partition());
     assertThat(copy.deletionVector()).isNotSameAs(file.deletionVector());
     assertThat(copy.manifestInfo()).isNotSameAs(file.manifestInfo());
     assertThat(copy.keyMetadata()).isNotSameAs(file.keyMetadata());
@@ -280,12 +268,12 @@ class TestTrackedFileStruct {
   void serializationRoundTrip(RoundTripSerializer<TrackedFileStruct> serializer) throws Exception {
     TrackedFileStruct file =
         new TrackedFileStruct(
-            TRACKING,
+            null, // TrackingStruct has its own serialization tests
             FileContent.DATA,
             FORMAT_VERSION_V4,
             "s3://bucket/data/file.parquet",
             FileFormat.PARQUET,
-            PARTITION,
+            null, // PartitionData has its own serialization tests
             100L,
             1024L,
             7,
@@ -299,15 +287,12 @@ class TestTrackedFileStruct {
 
     TrackedFileStruct deserialized = serializer.apply(file);
 
-    assertThat(
-            TRACKING_COMPARATOR.compare(
-                (StructLike) deserialized.tracking(), (StructLike) TRACKING))
-        .isEqualTo(0);
+    assertThat(deserialized.tracking()).isNull();
     assertThat(deserialized.contentType()).isEqualTo(FileContent.DATA);
     assertThat(deserialized.formatVersion()).isEqualTo(FORMAT_VERSION_V4);
     assertThat(deserialized.location()).isEqualTo("s3://bucket/data/file.parquet");
     assertThat(deserialized.fileFormat()).isEqualTo(FileFormat.PARQUET);
-    assertThat(PARTITION_COMPARATOR.compare(deserialized.partition(), PARTITION)).isEqualTo(0);
+    assertThat(deserialized.partition()).isNull();
     assertThat(deserialized.recordCount()).isEqualTo(100L);
     assertThat(deserialized.fileSizeInBytes()).isEqualTo(1024L);
     assertThat(deserialized.specId()).isEqualTo(7);

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileStruct.java
@@ -59,7 +59,6 @@ class TestTrackedFileStruct {
     Mockito.when(MANIFEST_INFO.copy()).thenReturn(MANIFEST_INFO_COPY);
   }
 
-
   private static final ContentStats CONTENT_STATS = Mockito.mock(ContentStats.class);
 
   @Test


### PR DESCRIPTION
This updates `TestTrackedFileStruct` to use mock objects for plumbing tests rather than creating instances of `TrackingStruct` and `PartitionData`.