### PR TITLE
Core: Add metadata table for discovering metadata tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -36,7 +36,8 @@ public enum MetadataTableType {
   ALL_FILES,
   ALL_MANIFESTS,
   ALL_ENTRIES,
-  POSITION_DELETES;
+  POSITION_DELETES,
+  METADATA_TABLES;
 
   public static MetadataTableType from(String name) {
     try {

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -88,6 +88,8 @@ public class MetadataTableUtils {
         return new AllEntriesTable(baseTable, metadataTableName);
       case POSITION_DELETES:
         return new PositionDeletesTable(baseTable, metadataTableName);
+      case METADATA_TABLES:
+        return new MetadataTablesTable(baseTable, metadataTableName);
       default:
         throw new NoSuchTableException(
             "Unknown metadata table type: %s for %s", type, metadataTableName);

--- a/core/src/main/java/org/apache/iceberg/MetadataTablesTable.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTablesTable.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+
+/** A {@link Table} implementation that exposes a table's metadata tables as rows. */
+public class MetadataTablesTable extends BaseMetadataTable {
+
+  private static final Schema METADATA_TABLES_SCHEMA =
+      new Schema(Types.NestedField.required(1, "metadata_table_name", Types.StringType.get()));
+
+  MetadataTablesTable(Table table) {
+    this(table, table.name() + ".metadata_tables");
+  }
+
+  MetadataTablesTable(Table table, String name) {
+    super(table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new MetadataTablesScan(table());
+  }
+
+  @Override
+  public Schema schema() {
+    return METADATA_TABLES_SCHEMA;
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.METADATA_TABLES;
+  }
+
+  private DataTask task(BaseTableScan scan) {
+    String location =
+        table().operations().current().metadataFileLocation() != null
+            ? table().operations().current().metadataFileLocation()
+            : scan.table().location();
+
+    List<String> sortedMetadataTableTypes =
+        Arrays.stream(MetadataTableType.values())
+            .map(type -> type.name().toLowerCase(Locale.ROOT))
+            .sorted()
+            .collect(ImmutableList.toImmutableList());
+
+    return StaticDataTask.of(
+        table().io().newInputFile(location),
+        schema(),
+        scan.schema(),
+        sortedMetadataTableTypes,
+        StaticDataTask.Row::of);
+  }
+
+  private class MetadataTablesScan extends StaticTableScan {
+
+    MetadataTablesScan(Table table) {
+      super(
+          table,
+          METADATA_TABLES_SCHEMA,
+          MetadataTableType.METADATA_TABLES,
+          MetadataTablesTable.this::task);
+    }
+
+    MetadataTablesScan(Table table, TableScanContext context) {
+      super(
+          table,
+          METADATA_TABLES_SCHEMA,
+          MetadataTableType.METADATA_TABLES,
+          MetadataTablesTable.this::task,
+          context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new MetadataTablesScan(table, context);
+    }
+
+    @Override
+    public CloseableIterable<FileScanTask> planFiles() {
+      return CloseableIterable.withNoopClose(MetadataTablesTable.this.task(this));
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -25,8 +25,10 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -38,6 +40,7 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -1831,6 +1834,30 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     assertThat(rowCount(deleteFilesTable.newScan()))
         .as("DeleteFilesTable on main should have 2 delete files")
         .isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void testMetadataTablesTableScan() throws IOException {
+    Table metadataTablesTable = new MetadataTablesTable(table);
+
+    List<String> actualTables = Lists.newArrayList();
+    try (CloseableIterable<FileScanTask> tasks = metadataTablesTable.newScan().planFiles()) {
+      for (FileScanTask task : tasks) {
+        try (CloseableIterable<StructLike> rows = task.asDataTask().rows()) {
+          for (StructLike row : rows) {
+            actualTables.add(row.get(0, String.class));
+          }
+        }
+      }
+    }
+
+    List<String> expectedTables =
+        Arrays.stream(MetadataTableType.values())
+            .map(metadataTableType -> metadataTableType.name().toLowerCase(Locale.ROOT))
+            .sorted()
+            .collect(ImmutableList.toImmutableList());
+
+    assertThat(actualTables).containsExactlyElementsOf(expectedTables);
   }
 
   private int rowCount(TableScan scan) throws IOException {

--- a/docs/docs/spark-queries.md
+++ b/docs/docs/spark-queries.md
@@ -340,6 +340,32 @@ To inspect a table's history, snapshots, and other metadata, Iceberg supports me
 
 Metadata tables are identified by adding the metadata table name after the original table name. For example, history for `db.table` is read using `db.table.history`.
 
+### Metadata Tables
+To list the metadata tables supported by a table:
+
+```sql
+SELECT * FROM prod.db.table.metadata_tables;
+```
+
+| metadata_table_name  |
+|----------------------|
+| all_data_files       |
+| all_delete_files     |
+| all_entries          |
+| all_files            |
+| all_manifests        |
+| data_files           |
+| delete_files         |
+| entries              |
+| files                |
+| history              |
+| manifests            |
+| metadata_log_entries |
+| metadata_tables      |
+| partitions           |
+| refs                 |
+| snapshots            |
+
 ### History
 
 To show table history:


### PR DESCRIPTION
close #17132 

## Summary

This PR adds a new Iceberg metadata table, metadata_tables, to make available metadata tables discoverable through the existing metadata table mechanism.

For example, in Spark users can query:
```sql
SELECT * FROM catalog.db.table.metadata_tables;
```
Result:
```
entries
files
data_files
delete_files
history
metadata_log_entries
snapshots
refs
manifests
partitions
all_data_files
all_delete_files
all_files
all_manifests
all_entries
position_deletes
metadata_tables
```

The new metadata table returns the supported metadata table names

This avoids requiring users to know all metadata table names ahead of time from documentation or source code.

Also, replace selected hard-coded metadata table suffixes in tests and metadata table implementations with MetadataTableType#tableName, enhance code robustness.