### PR TITLE
Spec: Clarify field `id` handling in `AddSchemaUpdate` and `CreateTableRequest`

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1516,6 +1516,10 @@ class ViewMetadata(BaseModel):
 
 
 class AddSchemaUpdate(BaseUpdate):
+    """
+    Adds a schema to the table. The field IDs in `schema` are assigned by the client. The client assigns them so that the schema stays consistent with the data files, partition specs, and sort orders it writes or co-commits, which reference fields by their field ID (`StructField.id`). Servers SHOULD preserve the field IDs submitted by the client on add-schema, as reassigning them would require re-deriving and rewriting every such reference, including in already-written data files.
+    """
+
     action: Literal['add-schema']
     schema_: Schema = Field(..., alias='schema')
     last_column_id: int | None = Field(
@@ -1636,6 +1640,10 @@ class CommitTransactionRequest(BaseModel):
 
 
 class CreateTableRequest(BaseModel):
+    """
+    Table creation request. The field IDs in `schema` are assigned by the client, but because a newly created table has no committed data, a server MAY (re)assign them when creating the table.
+    """
+
     name: str
     location: str | None = None
     schema_: Schema = Field(..., alias='schema')

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1517,7 +1517,7 @@ class ViewMetadata(BaseModel):
 
 class AddSchemaUpdate(BaseUpdate):
     """
-    Adds a schema to the table. The field IDs in `schema` are assigned by the client. The client assigns them so that the schema stays consistent with the data files, partition specs, and sort orders it writes or co-commits, which reference fields by their field ID (`StructField.id`). Servers SHOULD preserve the field IDs submitted by the client on add-schema, as reassigning them would require re-deriving and rewriting every such reference, including in already-written data files.
+    Adds a schema. The field IDs (`StructField.id`) in `schema` are assigned by the client. A server SHOULD preserve them rather than reassigning them - a field ID is the durable identifier of a field, and reassigning it can break references that depend on it.
     """
 
     action: Literal['add-schema']

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3120,6 +3120,13 @@ components:
     AddSchemaUpdate:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
+      description:
+        Adds a schema to the table. The field IDs in `schema` are assigned by the client. The client
+        assigns them so that the schema stays consistent with the data files, partition specs, and
+        sort orders it writes or co-commits, which reference fields by their field ID
+        (`StructField.id`). Servers SHOULD preserve the field IDs submitted by the client on
+        add-schema, as reassigning them would require re-deriving and rewriting every such reference,
+        including in already-written data files.
       required:
         - action
         - schema
@@ -3930,6 +3937,9 @@ components:
 
     CreateTableRequest:
       type: object
+      description:
+        Table creation request. The field IDs in `schema` are assigned by the client, but because a newly
+        created table has no committed data, a server MAY (re)assign them when creating the table.
       required:
         - name
         - schema

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3121,12 +3121,9 @@ components:
       allOf:
         - $ref: '#/components/schemas/BaseUpdate'
       description:
-        Adds a schema to the table. The field IDs in `schema` are assigned by the client. The client
-        assigns them so that the schema stays consistent with the data files, partition specs, and
-        sort orders it writes or co-commits, which reference fields by their field ID
-        (`StructField.id`). Servers SHOULD preserve the field IDs submitted by the client on
-        add-schema, as reassigning them would require re-deriving and rewriting every such reference,
-        including in already-written data files.
+        Adds a schema. The field IDs (`StructField.id`) in `schema` are assigned by the client. A
+        server SHOULD preserve them rather than reassigning them - a field ID is the durable identifier
+        of a field, and reassigning it can break references that depend on it.
       required:
         - action
         - schema


### PR DESCRIPTION
The REST catalog spec does not explicitly state how a REST Catalog Server should handle field IDs on schema updates.

This PR clarifies the docs to state:

1. Field IDs SHOULD NOT be reassigned on `AddSchemaUpdate`, as doing so would make the schema inconsistent with the field IDs already referenced by committed or co-committed data files.
2. Field IDs MAY be reassigned on `CreateTableRequest`, since a new table has no committed data referencing them yet.

This matches the behavior implemented in Iceberg core, which the reference REST server (RCK / iceberg-rest-fixture) is built on, and which open source implementations such as Apache Polaris reuse.