### PR TITLE
Flink: Integrate ConvertEqualityDeletes with IcebergSink

### DIFF
--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -163,20 +163,6 @@ INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
 | shred-variants                          | Table write.parquet.shred-variants         | Overrides this table's shred variants for this write |
 | variant-inference-buffer-size           | Table write.parquet.variant-inference-buffer-size | Overrides this table's variant inference buffer size for this write |
 
-#### Post-commit maintenance options
-
-`IcebergSink` can run [table maintenance](flink-maintenance.md#icebergsink-with-post-commit-integration)
-after each commit. The enable flags are listed below; see the maintenance docs for the full per-task
-option set.
-
-| Flink option | Default | Description |
-|--------------|---------|-------------|
-| flink-maintenance.rewrite.enabled | false | Compact data files after commit |
-| flink-maintenance.expire-snapshots.enabled | false | Expire snapshots after commit |
-| flink-maintenance.delete-orphan-files.enabled | false | Delete orphan files after commit |
-| flink-maintenance.convert-equality-deletes.enabled | false | Convert equality deletes to deletion vectors after commit (requires equality fields and format version >= 3) |
-| flink-maintenance.convert-equality-deletes.target-branch | Write branch | Branch the converted DVs are committed to; defaults to the write branch (in-place conversion) |
-
 #### Range distribution statistics type
 
 Config value is a enum type: `Map`, `Sketch`, `Auto`.

--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -163,6 +163,20 @@ INSERT INTO tableName /*+ OPTIONS('upsert-enabled'='true') */
 | shred-variants                          | Table write.parquet.shred-variants         | Overrides this table's shred variants for this write |
 | variant-inference-buffer-size           | Table write.parquet.variant-inference-buffer-size | Overrides this table's variant inference buffer size for this write |
 
+#### Post-commit maintenance options
+
+`IcebergSink` can run [table maintenance](flink-maintenance.md#icebergsink-with-post-commit-integration)
+after each commit. The enable flags are listed below; see the maintenance docs for the full per-task
+option set.
+
+| Flink option | Default | Description |
+|--------------|---------|-------------|
+| flink-maintenance.rewrite.enabled | false | Compact data files after commit |
+| flink-maintenance.expire-snapshots.enabled | false | Expire snapshots after commit |
+| flink-maintenance.delete-orphan-files.enabled | false | Delete orphan files after commit |
+| flink-maintenance.convert-equality-deletes.enabled | false | Convert equality deletes to deletion vectors after commit (requires equality fields and format version >= 3) |
+| flink-maintenance.convert-equality-deletes.target-branch | Write branch | Branch the converted DVs are committed to; defaults to the write branch (in-place conversion) |
+
 #### Range distribution statistics type
 
 Config value is a enum type: `Map`, `Sketch`, `Auto`.

--- a/docs/docs/flink-maintenance.md
+++ b/docs/docs/flink-maintenance.md
@@ -412,7 +412,7 @@ flinkConf.put("flink-maintenance.expire-snapshots.max-snapshot-age-seconds", "60
 flinkConf.put("flink-maintenance.delete-orphan-files.min-age-seconds", "259200");
 
 // Configure convert equality deletes. Converts in place on the write branch by default;
-// set a target branch to instead promote the converted deletion vectors there.
+// set a target branch to promote the converted deletion vectors there instead.
 flinkConf.put("flink-maintenance.convert-equality-deletes.target-branch", "main");
 
 // Configure JDBC lock settings (deprecated, lock configuration is no longer required for a single Flink job)

--- a/docs/docs/flink-maintenance.md
+++ b/docs/docs/flink-maintenance.md
@@ -375,6 +375,18 @@ IcebergSink.forRowData(dataStream)
     .append();
 ```
 
+`convertEqualityDeletes()` converts equality deletes to deletion vectors. Unlike the other tasks, it requires equality field columns (upsert or CDC writes) and a table with format version >= 3. By default, it converts in place on the write branch:
+
+```java
+IcebergSink.forRowData(dataStream)
+    .table(table)
+    .tableLoader(tableLoader)
+    .upsert(true)
+    .equalityFieldColumns(List.of("id"))
+    .convertEqualityDeletes()
+    .append();
+```
+
 ##### Config
 
 All maintenance tasks are configured through string properties:
@@ -386,6 +398,8 @@ Map<String, String> flinkConf = new HashMap<>();
 flinkConf.put("flink-maintenance.rewrite.enabled", "true");
 flinkConf.put("flink-maintenance.expire-snapshots.enabled", "true");
 flinkConf.put("flink-maintenance.delete-orphan-files.enabled", "true");
+// Requires equality field columns (upsert or CDC) and a table with format version >= 3.
+flinkConf.put("flink-maintenance.convert-equality-deletes.enabled", "true");
 
 // Configure rewrite data files
 flinkConf.put("flink-maintenance.rewrite.max-bytes", "1073741824");
@@ -396,6 +410,10 @@ flinkConf.put("flink-maintenance.expire-snapshots.max-snapshot-age-seconds", "60
 
 // Configure delete orphan files
 flinkConf.put("flink-maintenance.delete-orphan-files.min-age-seconds", "259200");
+
+// Configure convert equality deletes. Converts in place on the write branch by default;
+// set a target branch to instead promote the converted deletion vectors there.
+flinkConf.put("flink-maintenance.convert-equality-deletes.target-branch", "main");
 
 // Configure JDBC lock settings (deprecated, lock configuration is no longer required for a single Flink job)
 flinkConf.put("flink-maintenance.lock.type", "jdbc");
@@ -419,6 +437,8 @@ SET 'table.exec.iceberg.use.v2.sink' = 'true';
 SET 'flink-maintenance.rewrite.enabled' = 'true';
 SET 'flink-maintenance.expire-snapshots.enabled' = 'true';
 SET 'flink-maintenance.delete-orphan-files.enabled' = 'true';
+-- Requires equality field columns (upsert) and a table with format version >= 3
+SET 'flink-maintenance.convert-equality-deletes.enabled' = 'true';
 
 -- Configure rewrite data files
 SET 'flink-maintenance.rewrite.max-bytes' = '1073741824';

--- a/docs/docs/flink-maintenance.md
+++ b/docs/docs/flink-maintenance.md
@@ -495,6 +495,7 @@ These keys are used in SQL (SET or table WITH options) or via `IcebergSink.Build
 | `flink-maintenance.rewrite.enabled` | Enable compaction (rewrite data files) | `false` |
 | `flink-maintenance.expire-snapshots.enabled` | Enable expire snapshots | `false` |
 | `flink-maintenance.delete-orphan-files.enabled` | Enable delete orphan files | `false` |
+| `flink-maintenance.convert-equality-deletes.enabled` | Enable converting equality deletes to deletion vectors (requires equality fields and format version >= 3) | `false` |
 
 #### Rewrite Data Files Configuration
 
@@ -533,6 +534,14 @@ These keys are used in SQL (SET or table WITH options) or via `IcebergSink.Build
 | `flink-maintenance.delete-orphan-files.equal-schemes` | Equivalent schemes (format: `s3n=s3,s3a=s3`) | `s3n=s3,s3a=s3` |
 | `flink-maintenance.delete-orphan-files.equal-authorities` | Equivalent authorities (format: `auth1=auth2`) | Not set |
 | `flink-maintenance.delete-orphan-files.prefix-mismatch-mode` | Behavior on prefix mismatch: `ERROR`, `IGNORE`, `DELETE` | `ERROR` |
+
+#### Convert Equality Deletes Configuration
+
+| Key | Description | Default |
+|-----|-------------|---------|
+| `flink-maintenance.convert-equality-deletes.target-branch` | Branch the converted deletion vectors are committed to | Not set (in-place conversion) |
+| `flink-maintenance.convert-equality-deletes.schedule.commit-count` | Trigger after N commits | `1` |
+| `flink-maintenance.convert-equality-deletes.schedule.interval-second` | Trigger after time interval (seconds) | Not set |
 
 ### Lock Configuration (SQL)
 

--- a/docs/docs/flink-writes.md
+++ b/docs/docs/flink-writes.md
@@ -398,6 +398,32 @@ To use SinkV2 based implementation, replace `FlinkSink` with `IcebergSink` in th
      - The `RANGE` distribution mode is not yet available for the `IcebergSink`
      - When using `IcebergSink` use `uidSuffix` instead of the `uidPrefix`
 
+### Post-commit table maintenance
+
+`IcebergSink` can run [table maintenance](flink-maintenance.md#icebergsink-with-post-commit-integration)
+tasks automatically after each commit, so a separate maintenance job is not required. Enable them with
+builder methods (or the equivalent `flink-maintenance.*` write options):
+
+- `rewriteDataFiles()` compacts small data files
+- `expireSnapshots()` expires old snapshots
+- `deleteOrphanFiles()` removes unreferenced files
+- `convertEqualityDeletes()` converts equality deletes to deletion vectors (requires equality fields
+  and table format version >= 3)
+
+```java
+IcebergSink.forRowData(dataStream)
+    .table(table)
+    .tableLoader(tableLoader)
+    .upsert(true)
+    .equalityFieldColumns(List.of("id"))
+    .rewriteDataFiles()
+    .convertEqualityDeletes()
+    .append();
+```
+
+See [IcebergSink with Post-Commit Integration](flink-maintenance.md#icebergsink-with-post-commit-integration)
+for the full options, locking, and the `convertEqualityDeletes` staging/target-branch setup.
+
 ## Flink Dynamic Iceberg Sink
 
 The Flink Dynamic Iceberg Sink (Dynamic Sink) allows:

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteConf.java
@@ -247,6 +247,15 @@ public class FlinkWriteConf {
         .parse();
   }
 
+  public boolean convertEqualityDeletesMode() {
+    return confParser
+        .booleanConf()
+        .option(FlinkWriteOptions.CONVERT_EQUALITY_DELETES_ENABLE.key())
+        .flinkConfig(FlinkWriteOptions.CONVERT_EQUALITY_DELETES_ENABLE)
+        .defaultValue(FlinkWriteOptions.CONVERT_EQUALITY_DELETES_ENABLE.defaultValue())
+        .parse();
+  }
+
   /**
    * NOTE: This may be removed or changed in a future release. This value specifies the interval for
    * refreshing the table instances in sink writer subtasks. If not specified then the default

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkWriteOptions.java
@@ -23,6 +23,7 @@ import org.apache.flink.annotation.Experimental;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ConfigOptions;
 import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.flink.maintenance.api.ConvertEqualityDeletesConfig;
 import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFilesConfig;
 import org.apache.iceberg.flink.maintenance.api.ExpireSnapshotsConfig;
 import org.apache.iceberg.flink.maintenance.api.RewriteDataFilesConfig;
@@ -95,6 +96,11 @@ public class FlinkWriteOptions {
 
   public static final ConfigOption<Boolean> DELETE_ORPHAN_FILES_ENABLE =
       ConfigOptions.key(DeleteOrphanFilesConfig.PREFIX + "enabled")
+          .booleanType()
+          .defaultValue(false);
+
+  public static final ConfigOption<Boolean> CONVERT_EQUALITY_DELETES_ENABLE =
+      ConfigOptions.key(ConvertEqualityDeletesConfig.PREFIX + "enabled")
           .booleanType()
           .defaultValue(false);
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletes.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletes.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.flink.maintenance.api;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -123,6 +124,22 @@ public class ConvertEqualityDeletes {
       Preconditions.checkNotNull(columns, "equalityFieldColumns must not be null");
       Preconditions.checkArgument(!columns.isEmpty(), "equalityFieldColumns must not be empty");
       this.equalityFieldColumns = ImmutableList.copyOf(columns);
+      return this;
+    }
+
+    /**
+     * Configures the scheduling of the conversion.
+     *
+     * @param config properties for the conversion, see {@link ConvertEqualityDeletesConfig} for
+     *     available keys
+     */
+    public Builder config(ConvertEqualityDeletesConfig config) {
+      scheduleOnCommitCount(config.scheduleOnCommitCount());
+      Long intervalSecond = config.scheduleOnIntervalSecond();
+      if (intervalSecond != null) {
+        scheduleOnInterval(Duration.ofSeconds(intervalSecond));
+      }
+
       return this;
     }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletesConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ConvertEqualityDeletesConfig.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import java.util.Map;
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+import org.apache.flink.configuration.ReadableConfig;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.FlinkConfParser;
+
+public class ConvertEqualityDeletesConfig {
+  public static final String PREFIX = FlinkMaintenanceConfig.PREFIX + "convert-equality-deletes.";
+
+  public static final String TARGET_BRANCH = PREFIX + "target-branch";
+  public static final ConfigOption<String> TARGET_BRANCH_OPTION =
+      ConfigOptions.key(TARGET_BRANCH)
+          .stringType()
+          .noDefaultValue()
+          .withDescription(
+              "The branch where converted data files and deletion vectors are committed. "
+                  + "Defaults to the sink's write branch, i.e. an in-place conversion.");
+
+  public static final String SCHEDULE_ON_COMMIT_COUNT = PREFIX + "schedule.commit-count";
+  public static final ConfigOption<Integer> SCHEDULE_ON_COMMIT_COUNT_OPTION =
+      ConfigOptions.key(SCHEDULE_ON_COMMIT_COUNT)
+          .intType()
+          .defaultValue(1)
+          .withDescription(
+              "The number of commits after which to trigger a new equality delete conversion.");
+
+  public static final String SCHEDULE_ON_INTERVAL_SECOND = PREFIX + "schedule.interval-second";
+  public static final ConfigOption<Long> SCHEDULE_ON_INTERVAL_SECOND_OPTION =
+      ConfigOptions.key(SCHEDULE_ON_INTERVAL_SECOND)
+          .longType()
+          .noDefaultValue()
+          .withDescription(
+              "The time interval (in seconds) between two consecutive equality delete conversions.");
+
+  private final FlinkConfParser confParser;
+
+  public ConvertEqualityDeletesConfig(
+      Table table, Map<String, String> writeOptions, ReadableConfig readableConfig) {
+    this.confParser = new FlinkConfParser(table, writeOptions, readableConfig);
+  }
+
+  /** Gets the target branch, or null to convert in place on the sink's write branch. */
+  public String targetBranch() {
+    return confParser
+        .stringConf()
+        .option(TARGET_BRANCH)
+        .flinkConfig(TARGET_BRANCH_OPTION)
+        .parseOptional();
+  }
+
+  /** Gets the number of commits that trigger a conversion. */
+  public int scheduleOnCommitCount() {
+    return confParser
+        .intConf()
+        .option(SCHEDULE_ON_COMMIT_COUNT)
+        .flinkConfig(SCHEDULE_ON_COMMIT_COUNT_OPTION)
+        .defaultValue(SCHEDULE_ON_COMMIT_COUNT_OPTION.defaultValue())
+        .parse();
+  }
+
+  /** Gets the time interval (in seconds) between conversions, or null when not set. */
+  public Long scheduleOnIntervalSecond() {
+    return confParser
+        .longConf()
+        .option(SCHEDULE_ON_INTERVAL_SECOND)
+        .flinkConfig(SCHEDULE_ON_INTERVAL_SECOND_OPTION)
+        .parseOptional();
+  }
+}

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/FlinkMaintenanceConfig.java
@@ -128,6 +128,10 @@ public class FlinkMaintenanceConfig {
     return new DeleteOrphanFilesConfig(table, writeProperties, readableConfig);
   }
 
+  public ConvertEqualityDeletesConfig createConvertEqualityDeletesConfig() {
+    return new ConvertEqualityDeletesConfig(table, writeProperties, readableConfig);
+  }
+
   public LockConfig createLockConfig() {
     return new LockConfig(table, writeProperties, readableConfig);
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -73,6 +73,8 @@ import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.FlinkWriteConf;
 import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.TableLoader;
+import org.apache.iceberg.flink.maintenance.api.ConvertEqualityDeletes;
+import org.apache.iceberg.flink.maintenance.api.ConvertEqualityDeletesConfig;
 import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFiles;
 import org.apache.iceberg.flink.maintenance.api.DeleteOrphanFilesConfig;
 import org.apache.iceberg.flink.maintenance.api.ExpireSnapshots;
@@ -715,6 +717,31 @@ public class IcebergSink
       return this;
     }
 
+    /**
+     * Enables converting equality deletes to deletion vectors as a post-commit maintenance task.
+     * The sink's write branch is read for equality delete files, which are converted to deletion
+     * vectors and committed back to the same branch (or the target branch, if configured). Requires
+     * equality field columns (upsert or CDC) and a table with format version >= 3.
+     *
+     * @see ConvertEqualityDeletesConfig for the default config.
+     */
+    public Builder convertEqualityDeletes() {
+      writeOptions.put(FlinkWriteOptions.CONVERT_EQUALITY_DELETES_ENABLE.key(), "true");
+      return this;
+    }
+
+    /**
+     * Enables converting equality deletes to deletion vectors as a post-commit maintenance task.
+     *
+     * @param config task-specific configuration, see {@link ConvertEqualityDeletesConfig} for
+     *     available keys.
+     */
+    public Builder convertEqualityDeletes(Map<String, String> config) {
+      convertEqualityDeletes();
+      writeOptions.putAll(config);
+      return this;
+    }
+
     @Override
     public Builder toBranch(String branch) {
       writeOptions.put(FlinkWriteOptions.BRANCH.key(), branch);
@@ -792,6 +819,10 @@ public class IcebergSink
         maintenanceTasks.add(DeleteOrphanFiles.builder().config(deleteOrphanFilesConfig));
       }
 
+      if (flinkWriteConf.convertEqualityDeletesMode()) {
+        addConvertEqualityDeletesTask(flinkWriteConf, flinkMaintenanceConfig, equalityFieldIds);
+      }
+
       Set<String> equalityFieldColumnsSet =
           equalityFieldColumns != null ? Sets.newHashSet(equalityFieldColumns) : null;
 
@@ -812,6 +843,32 @@ public class IcebergSink
           maintenanceTasks,
           flinkMaintenanceConfig,
           equalityFieldColumnsSet);
+    }
+
+    private void addConvertEqualityDeletesTask(
+        FlinkWriteConf flinkWriteConf,
+        FlinkMaintenanceConfig flinkMaintenanceConfig,
+        Set<Integer> equalityFieldIds) {
+      Preconditions.checkState(
+          !equalityFieldIds.isEmpty(),
+          "Equality field columns must be set to convert equality deletes to deletion vectors.");
+      ConvertEqualityDeletesConfig convertEqualityDeletesConfig =
+          flinkMaintenanceConfig.createConvertEqualityDeletesConfig();
+      // The sink writes equality deletes to its write branch, so that becomes the staging branch.
+      // The target defaults to the same branch, i.e. an in-place conversion.
+      String targetBranch = convertEqualityDeletesConfig.targetBranch();
+      String convertTargetBranch = targetBranch != null ? targetBranch : flinkWriteConf.branch();
+      List<String> convertEqualityFieldColumns = Lists.newArrayList();
+      for (int fieldId : equalityFieldIds) {
+        convertEqualityFieldColumns.add(table.schema().findColumnName(fieldId));
+      }
+
+      maintenanceTasks.add(
+          ConvertEqualityDeletes.builder()
+              .stagingBranch(flinkWriteConf.branch())
+              .targetBranch(convertTargetBranch)
+              .equalityFieldColumns(convertEqualityFieldColumns)
+              .config(convertEqualityDeletesConfig));
     }
 
     /**

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesConfig.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesConfig.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.maintenance.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.flink.configuration.Configuration;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.flink.maintenance.operator.OperatorTestBase;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestConvertEqualityDeletesConfig extends OperatorTestBase {
+  private Table table;
+  private final Map<String, String> input = Maps.newHashMap();
+
+  @BeforeEach
+  public void before() {
+    this.table = createTable();
+    input.put(ConvertEqualityDeletesConfig.TARGET_BRANCH, "myTarget");
+    input.put(ConvertEqualityDeletesConfig.SCHEDULE_ON_COMMIT_COUNT, "5");
+    input.put(ConvertEqualityDeletesConfig.SCHEDULE_ON_INTERVAL_SECOND, "120");
+    input.put("other.config", "should-be-ignored");
+  }
+
+  @AfterEach
+  public void after() {
+    input.clear();
+  }
+
+  @Test
+  void testConfigParsing() {
+    ConvertEqualityDeletesConfig config =
+        new ConvertEqualityDeletesConfig(table, input, new Configuration());
+
+    assertThat(config.targetBranch()).isEqualTo("myTarget");
+    assertThat(config.scheduleOnCommitCount()).isEqualTo(5);
+    assertThat(config.scheduleOnIntervalSecond()).isEqualTo(120L);
+  }
+
+  @Test
+  void testConfigDefaults() {
+    ConvertEqualityDeletesConfig config =
+        new ConvertEqualityDeletesConfig(table, Maps.newHashMap(), new Configuration());
+
+    assertThat(config.targetBranch()).isNull();
+    assertThat(config.scheduleOnCommitCount()).isEqualTo(1);
+    assertThat(config.scheduleOnIntervalSecond()).isNull();
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkTableMaintenance.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergSinkTableMaintenance.java
@@ -19,11 +19,15 @@
 package org.apache.iceberg.flink.sink;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.jobgraph.JobVertex;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
@@ -31,13 +35,17 @@ import org.apache.flink.streaming.api.graph.StreamGraph;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.types.Row;
 import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.actions.SizeBasedFileRewritePlanner;
+import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.flink.FlinkWriteOptions;
 import org.apache.iceberg.flink.MiniFlinkClusterExtension;
 import org.apache.iceberg.flink.SimpleDataUtil;
@@ -47,14 +55,20 @@ import org.apache.iceberg.flink.maintenance.api.ExpireSnapshotsConfig;
 import org.apache.iceberg.flink.maintenance.api.LockConfig;
 import org.apache.iceberg.flink.maintenance.api.RewriteDataFilesConfig;
 import org.apache.iceberg.flink.util.FlinkCompatibilityUtil;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.util.ContentFileUtil;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
 
 class TestIcebergSinkTableMaintenance extends TestFlinkIcebergSinkBase {
   private static final String[] LOCK_TYPES = new String[] {LockConfig.JdbcLockConfig.JDBC, ""};
+
+  @TempDir private Path tempDir;
 
   private Map<String, String> flinkConf;
 
@@ -162,6 +176,15 @@ class TestIcebergSinkTableMaintenance extends TestFlinkIcebergSinkBase {
   private void setupDeleteOrphanFilesConfig() {
     flinkConf.put(FlinkWriteOptions.DELETE_ORPHAN_FILES_ENABLE.key(), "true");
     flinkConf.put(DeleteOrphanFilesConfig.MIN_AGE_SECONDS, "86400");
+  }
+
+  private void setupConvertEqualityDeletesConfig() {
+    flinkConf.put(FlinkWriteOptions.CONVERT_EQUALITY_DELETES_ENABLE.key(), "true");
+  }
+
+  private void upgradeToFormatV3() {
+    table.updateProperties().set(TableProperties.FORMAT_VERSION, "3").commit();
+    table.refresh();
   }
 
   private void setupLockConfig(String lockType) {
@@ -317,5 +340,120 @@ class TestIcebergSinkTableMaintenance extends TestFlinkIcebergSinkBase {
     List<DataFile> preCompactDataFiles =
         getDataFiles(table.snapshot(table.currentSnapshot().parentId()), table);
     assertThat(preCompactDataFiles).hasSize(3);
+  }
+
+  @ParameterizedTest(name = "lockType = {0}")
+  @FieldSource("LOCK_TYPES")
+  public void testConvertEqualityDeletesOperatorAdded(String lockType) {
+    setupLockConfig(lockType);
+    setupConvertEqualityDeletesConfig();
+    upgradeToFormatV3();
+
+    List<Row> rows = Lists.newArrayList(Row.of(1, "hello"));
+    DataStream<RowData> dataStream =
+        env.addSource(createBoundedSource(rows), ROW_TYPE_INFO)
+            .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
+
+    IcebergSink.forRowData(dataStream)
+        .table(table)
+        .tableLoader(tableLoader)
+        .upsert(true)
+        .equalityFieldColumns(Lists.newArrayList("id"))
+        .setAll(flinkConf)
+        .append();
+
+    StreamGraph streamGraph = env.getStreamGraph();
+    boolean containsConvert = false;
+    for (JobVertex vertex : streamGraph.getJobGraph().getVertices()) {
+      if (vertex.getName().contains("EqConvert")) {
+        containsConvert = true;
+        break;
+      }
+    }
+
+    assertThat(containsConvert).isTrue();
+  }
+
+  @ParameterizedTest(name = "lockType = {0}")
+  @FieldSource("LOCK_TYPES")
+  public void testConvertEqualityDeletesRequiresEqualityFields(String lockType) {
+    setupLockConfig(lockType);
+    setupConvertEqualityDeletesConfig();
+
+    List<Row> rows = Lists.newArrayList(Row.of(1, "hello"));
+    DataStream<RowData> dataStream =
+        env.addSource(createBoundedSource(rows), ROW_TYPE_INFO)
+            .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
+
+    // No equality field columns and no identifier fields on the schema, so there is nothing to
+    // convert.
+    assertThatThrownBy(
+            () ->
+                IcebergSink.forRowData(dataStream)
+                    .table(table)
+                    .tableLoader(tableLoader)
+                    .setAll(flinkConf)
+                    .append())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("Equality field columns must be set");
+  }
+
+  @ParameterizedTest(name = "lockType = {0}")
+  @FieldSource("LOCK_TYPES")
+  public void testConvertEqualityDeletesE2e(String lockType) throws Exception {
+    setupLockConfig(lockType);
+    setupConvertEqualityDeletesConfig();
+    upgradeToFormatV3();
+
+    // Pre-existing row on main. The sink then upserts the same key, writing an equality delete that
+    // removes this row, which the converter resolves to a deletion vector in a single cycle.
+    new GenericAppenderHelper(table, FileFormat.PARQUET, tempDir)
+        .appendToTable(ImmutableList.of(SimpleDataUtil.createRecord(1, "aaa")));
+
+    List<Row> rows = Lists.newArrayList(Row.of(1, "bbb"));
+    DataStream<RowData> dataStream =
+        env.addSource(createBoundedSource(rows), ROW_TYPE_INFO)
+            .map(CONVERTER::toInternal, FlinkCompatibilityUtil.toTypeInfo(SimpleDataUtil.ROW_TYPE));
+
+    IcebergSink.forRowData(dataStream)
+        .table(table)
+        .tableLoader(tableLoader)
+        .upsert(true)
+        .equalityFieldColumns(Lists.newArrayList("id"))
+        .setAll(flinkConf)
+        .append();
+
+    JobClient jobClient = env.executeAsync("Test Convert Equality Deletes E2E");
+    try {
+      Awaitility.await()
+          .atMost(Duration.ofMinutes(2))
+          .pollInterval(Duration.ofMillis(200))
+          .untilAsserted(() -> assertThat(dvCountOnMain(table)).isEqualTo(1));
+      SimpleDataUtil.assertTableRecords(
+          table, ImmutableList.of(SimpleDataUtil.createRecord(1, "bbb")));
+    } finally {
+      jobClient.cancel();
+    }
+  }
+
+  private static long dvCountOnMain(Table table) throws IOException {
+    table.refresh();
+    if (table.currentSnapshot() == null) {
+      return 0;
+    }
+
+    long count = 0;
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile file : reader) {
+          if (ContentFileUtil.isDV(file)) {
+            count++;
+          }
+        }
+      }
+    }
+
+    return count;
   }
 }


### PR DESCRIPTION
This adds the option to run `ConvertEqualityDeletes` as a post-commit maintenance task on `IcebergSink`, similarly to the RewriteDataFiles / ExpireSnapshots / DeleteOrphanFiles post-commit integration. The sink's write branch becomes the converter's staging branch. The target branch defaults to the same branch (in-place conversion). This is also configurable via options on the builder, as well as via properties (see ConvertEqualityDeletesConfig). Equality field columns are derived from the resolved equality field ids of the sink, to ensure they match with the sink's equality fields.

Documentation changes are in separate commits. Ideally, they should be preserved to make backporting of the code changes more straight-forward. 