### PR TITLE
Core: Add feature flag to skip inherited Authorization header in token request

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthConfig.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthConfig.java
@@ -64,6 +64,11 @@ public interface AuthConfig {
     return OAuth2Properties.TOKEN_EXCHANGE_ENABLED_DEFAULT;
   }
 
+  @Value.Default
+  default boolean skipInheritedAuthHeaderInTokenRequest() {
+    return OAuth2Properties.SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST_DEFAULT;
+  }
+
   @Nullable
   @Value.Default
   default String oauth2ServerUri() {
@@ -94,6 +99,11 @@ public interface AuthConfig {
                 properties,
                 OAuth2Properties.TOKEN_EXCHANGE_ENABLED,
                 OAuth2Properties.TOKEN_EXCHANGE_ENABLED_DEFAULT))
+        .skipInheritedAuthHeaderInTokenRequest(
+            PropertyUtil.propertyAsBoolean(
+                properties,
+                OAuth2Properties.SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST,
+                OAuth2Properties.SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST_DEFAULT))
         .expiresAtMillis(expiresAtMillis(properties))
         .build();
   }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Properties.java
@@ -64,6 +64,16 @@ public class OAuth2Properties {
   /** Optional param resource for OAuth2. */
   public static final String RESOURCE = "resource";
 
+  /**
+   * When enabled, the Authorization header inherited from the parent session is not forwarded when
+   * fetching a new token via the client credentials flow. This prevents strict identity providers
+   * from rejecting the token request due to using multiple authentication methods.
+   */
+  public static final String SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST =
+      "skip-inherited-auth-header-in-token-request";
+
+  public static final boolean SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST_DEFAULT = false;
+
   /** Scope for OAuth2 flows. */
   public static final String CATALOG_SCOPE = "catalog";
 

--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -41,6 +41,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.ErrorHandlers;
 import org.apache.iceberg.rest.HTTPHeaders;
@@ -657,10 +658,15 @@ public class OAuth2Util {
         String credential,
         AuthSession parent) {
       long startTimeMillis = System.currentTimeMillis();
+      Map<String, String> headers =
+          parent.config().skipInheritedAuthHeaderInTokenRequest()
+              ? Maps.filterKeys(
+                  parent.headers(), key -> !AUTHORIZATION_HEADER.equalsIgnoreCase(key))
+              : parent.headers();
       OAuthTokenResponse response =
           fetchToken(
               client,
-              parent.headers(),
+              headers,
               credential,
               parent.scope(),
               parent.oauth2ServerUri(),

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -688,6 +688,92 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @ParameterizedTest
   @ValueSource(strings = {"v1/oauth/tokens", "https://auth-server.com/token"})
+  public void testCatalogCredentialSkipsInheritedAuthHeader(String oauth2ServerUri) {
+    Map<String, String> emptyHeaders = ImmutableMap.of();
+    Map<String, String> contextHeaders =
+        ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=user");
+    Map<String, String> catalogHeaders =
+        ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=catalog");
+    Map<String, String> catalogCredentialBody =
+        ImmutableMap.of(
+            "grant_type", "client_credentials",
+            "client_id", "catalog",
+            "client_secret", "secret",
+            "scope", "catalog");
+    Map<String, String> contextCredentialBody =
+        ImmutableMap.of(
+            "grant_type", "client_credentials",
+            "client_id", "user",
+            "client_secret", "secret",
+            "scope", "catalog");
+
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    SessionCatalog.SessionContext context =
+        new SessionCatalog.SessionContext(
+            UUID.randomUUID().toString(),
+            "user",
+            ImmutableMap.of("credential", "user:secret"),
+            ImmutableMap.of());
+
+    RESTCatalog catalog = new RESTCatalog(context, (config) -> adapter);
+    catalog.initialize(
+        "prod",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            "credential",
+            "catalog:secret",
+            OAuth2Properties.OAUTH2_SERVER_URI,
+            oauth2ServerUri,
+            OAuth2Properties.SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST,
+            "true"));
+
+    assertThat(catalog.tableExists(TBL)).isFalse();
+
+    // call for initial token (client credentials from initialize provided)
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.POST,
+                oauth2ServerUri,
+                emptyHeaders,
+                ImmutableMap.of(),
+                catalogCredentialBody),
+            eq(OAuthTokenResponse.class),
+            any(),
+            any());
+    // use the catalog token for config
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.GET, ResourcePaths.config(), catalogHeaders),
+            eq(ConfigResponse.class),
+            any(),
+            any());
+    // call for context token (only client credentials from context provided + no inherited
+    // Authorization header)
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.POST,
+                oauth2ServerUri,
+                emptyHeaders,
+                ImmutableMap.of(),
+                contextCredentialBody),
+            eq(OAuthTokenResponse.class),
+            any(),
+            any());
+    // use the context token for table existence check
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), contextHeaders),
+            any(),
+            any(),
+            any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"v1/oauth/tokens", "https://auth-server.com/token"})
   public void testCatalogCredentialWithClientCredential(String oauth2ServerUri) {
     Map<String, String> emptyHeaders = ImmutableMap.of();
     Map<String, String> contextHeaders =
@@ -798,6 +884,95 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
     Mockito.verify(adapter)
         .execute(
             matches(HTTPMethod.POST, oauth2ServerUri, catalogHeaders),
+            eq(OAuthTokenResponse.class),
+            any(),
+            any());
+    // use the context token for table existence check
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.HEAD, RESOURCE_PATHS.table(TBL), contextHeaders),
+            any(),
+            any(),
+            any());
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"v1/oauth/tokens", "https://auth-server.com/token"})
+  public void testCatalogBearerTokenAndCredentialSkipsInheritedAuthHeader(String oauth2ServerUri) {
+    Map<String, String> emptyHeaders = ImmutableMap.of();
+    Map<String, String> initHeaders = ImmutableMap.of("Authorization", "Bearer bearer-token");
+    Map<String, String> contextHeaders =
+        ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=user");
+    Map<String, String> catalogHeaders =
+        ImmutableMap.of("Authorization", "Bearer client-credentials-token:sub=catalog");
+    Map<String, String> catalogCredentialBody =
+        ImmutableMap.of(
+            "grant_type", "client_credentials",
+            "client_id", "catalog",
+            "client_secret", "secret",
+            "scope", "catalog");
+    Map<String, String> contextCredentialBody =
+        ImmutableMap.of(
+            "grant_type", "client_credentials",
+            "client_id", "user",
+            "client_secret", "secret",
+            "scope", "catalog");
+
+    RESTCatalogAdapter adapter = Mockito.spy(new RESTCatalogAdapter(backendCatalog));
+
+    SessionCatalog.SessionContext context =
+        new SessionCatalog.SessionContext(
+            UUID.randomUUID().toString(),
+            "user",
+            ImmutableMap.of("credential", "user:secret"),
+            ImmutableMap.of());
+
+    RESTCatalog catalog = new RESTCatalog(context, (config) -> adapter);
+    catalog.initialize(
+        "prod",
+        ImmutableMap.of(
+            CatalogProperties.URI,
+            "ignored",
+            "credential",
+            "catalog:secret",
+            "token",
+            "bearer-token",
+            OAuth2Properties.OAUTH2_SERVER_URI,
+            oauth2ServerUri,
+            OAuth2Properties.SKIP_INHERITED_AUTH_HEADER_IN_TOKEN_REQUEST,
+            "true"));
+
+    assertThat(catalog.tableExists(TBL)).isFalse();
+
+    // use the provided bearer token + client_id/client_secret keypair for initial token
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.POST,
+                oauth2ServerUri,
+                initHeaders,
+                ImmutableMap.of(),
+                catalogCredentialBody),
+            eq(OAuthTokenResponse.class),
+            any(),
+            any());
+    // use the catalog credential token for config
+    Mockito.verify(adapter)
+        .execute(
+            matches(HTTPMethod.GET, ResourcePaths.config(), catalogHeaders),
+            eq(ConfigResponse.class),
+            any(),
+            any());
+    // call for context token (only client credentials from context provided + no inherited
+    // Authorization header)
+    Mockito.verify(adapter)
+        .execute(
+            matches(
+                HTTPMethod.POST,
+                oauth2ServerUri,
+                emptyHeaders,
+                ImmutableMap.of(),
+                contextCredentialBody),
             eq(OAuthTokenResponse.class),
             any(),
             any());

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -93,6 +93,7 @@ Required and optional properties to include while using `oauth2` authentication
 | `scope`                 | `catalog`         | Additional scope for `oauth2`.                                                                                                                                        |
 | `audience`              | null              | Optional param to specify token `audience`                                                                                                                            |
 | `resource`              | null              | Optional param to specify `resource`                                                                                                                                  |
+| `skip-inherited-auth-header-in-token-request` | false | When enabled, the `Authorization` header inherited from the parent session is not forwarded when fetching a new token via the client credentials flow. This prevents strict identity providers from rejecting the token request due to multiple authentication methods. |
 
 #### Google auth properties
 Required and optional properties to include while using `google` authentication


### PR DESCRIPTION
#### Description
When `RESTSessionCatalog` is configured with a client_credentials, 
initSession() exchanges that credential for token, which becomes the `Authorization: Bearer ...` header on the catalog session. 
If a `SessionContext` also carries a credential (the pattern used by Trino when `iceberg.rest-catalog.session=NONE`) the first catalog operation triggers `contextualSession()` -> `fromCredential()`, which inherits the catalog parent session headers and forwards existing `Authorization` header  alongside `client_id+client_secret` in body to the authorization server.

Some OAuth2 authorization servers (in particular Okta) rejects such requests for token which contains both `Authorization: Bearer abcs` header and `client_id+client_secret` key pair (please see example how to check it directly on Okta).

This PR is a proposition of filtering out `Authorization` header from headers inherited from parent session for token call in client credentials flow.
To not break any existing use case scenario the filtering is hidden behind `skip-inherited-auth-header-in-token-request` feature flag passed as config property to `RESTSessionCatalog`.

#### Reproduction of behavior directly on Okta
```bash
CLIENT_ID="<CLIENT_ID>"
CLIENT_SECRET="<CLIENT_SECRET>"
OKTA_TOKEN_URL="<https://...okta.com/oauth2/.../v1/token>"
OKTA_SCOPE="datacatalog"

# successful request
ACCESS_TOKEN=$(curl -X POST "$OKTA_TOKEN_URL" \
--header "Accept: application/json" \
--header "Content-Type: application/x-www-form-urlencoded" \
--header "X-Client-Version: Apache Iceberg 1.10.1-e.1 (commit 57448704eb9967abee52da13672326592e9ebe25)" \
--data "grant_type=client_credentials" \
--data "client_id=$CLIENT_ID" \
--data "client_secret=$CLIENT_SECRET" \
--data "scope=$OKTA_SCOPE" | jq -r '.access_token')
# results: 200 + {"token_type":"Bearer","expires_in":3600,"access_token":"...","scope":"datacatalog"}

# subsequent request which inherit Authorization header from session
curl -X POST "$OKTA_TOKEN_URL" \
--header "Authorization: Bearer $ACCESS_TOKEN" \
--header "Accept: application/json" \
--header "Content-Type: application/x-www-form-urlencoded" \
--header "X-Client-Version: Apache Iceberg 1.10.1-e.1 (commit 57448704eb9967abee52da13672326592e9ebe25)" \
--data "grant_type=client_credentials" \
--data "client_id=$CLIENT_ID" \
--data "client_secret=$CLIENT_SECRET" \
--data "scope=$OKTA_SCOPE"

# results:
# 401 + {"errorCode":"invalid_client","errorSummary":"No client credentials found.","errorLink":"invalid_client","errorId":"...","errorCauses":[]}
```
