### PR TITLE
Spark 4.1: Test geometry and geography DML and fall back from vectorized reads

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.spark.OrcBatchReadConf;
 import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
@@ -169,7 +170,18 @@ class SparkBatch implements Batch {
   }
 
   private boolean supportsParquetBatchReads(Types.NestedField field) {
-    return field.type().isPrimitiveType() || MetadataColumns.isMetadataColumn(field.fieldId());
+    if (MetadataColumns.isMetadataColumn(field.fieldId())) {
+      return true;
+    }
+
+    Type type = field.type();
+    // Geometry and geography are primitive types but have no Arrow vector yet, so they must be
+    // read through the non-vectorized reader.
+    if (type.typeId() == Type.TypeID.GEOMETRY || type.typeId() == Type.TypeID.GEOGRAPHY) {
+      return false;
+    }
+
+    return type.isPrimitiveType();
   }
 
   // conditions for using ORC batch reads:

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -147,7 +147,8 @@ class SparkBatch implements Batch {
 
   // conditions for using Parquet batch reads:
   // - Parquet vectorization is enabled
-  // - only primitives or metadata columns are projected
+  // - only primitives or metadata columns are projected, excluding geometry and geography which
+  //   are primitives with no Arrow vector yet
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -102,10 +102,16 @@ public class TestSparkGeospatial extends TestBase {
 
   @Test
   public void testDeleteGeospatialMergeOnRead() {
-    // Rewrite the table into a single data file (COALESCE(1)) so deleting one row leaves survivors
-    // in that file, forcing a deletion vector rather than a whole-file removal. Filter on id since
-    // Spark has no spatial predicate.
-    sql("DELETE FROM %s WHERE id IS NOT NULL", TABLE);
+    // Use a dedicated table with a single INSERT and a single DELETE so there is exactly one delete
+    // snapshot to inspect. Write both rows into one data file (COALESCE(1)) so deleting one row
+    // leaves a survivor in that file, forcing a deletion vector rather than a whole-file removal.
+    // Filter on id since Spark has no spatial predicate.
+    String deleteTable = CATALOG + ".default.geo_delete";
+    sql("DROP TABLE IF EXISTS %s", deleteTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='merge-on-read')",
+        deleteTable);
     sql(
         "INSERT INTO %s SELECT /*+ COALESCE(1) */ id, "
             + "CASE WHEN geom_wkb IS NULL THEN NULL "
@@ -114,24 +120,28 @@ public class TestSparkGeospatial extends TestBase {
             + "ELSE st_setsrid(st_geogfromwkb(geog_wkb), 4326) END "
             + "FROM VALUES (1, X'%s', X'%s'), (2, CAST(NULL AS BINARY), CAST(NULL AS BINARY)) "
             + "AS v(id, geom_wkb, geog_wkb)",
-        TABLE, GEOM_WKB, GEOG_WKB);
+        deleteTable, GEOM_WKB, GEOG_WKB);
 
-    sql("DELETE FROM %s WHERE id = 1", TABLE);
+    sql("DELETE FROM %s WHERE id = 1", deleteTable);
 
     assertEquals(
         "Only the null-geo row should remain after the merge-on-read delete",
         ImmutableList.of(row(2L, null, null)),
         sql(
             "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
-            TABLE));
+            deleteTable));
 
     // Deleting a row from a multi-row file writes a deletion vector (format v3, merge-on-read).
+    // Select the (single) delete snapshot by operation so the assertion does not depend on
+    // committed_at ordering, whose millisecond granularity could tie with the insert snapshot.
     assertThat(
             scalarSql(
-                "SELECT summary['added-dvs'] FROM %s.snapshots ORDER BY committed_at DESC LIMIT 1",
-                TABLE))
+                "SELECT summary['added-dvs'] FROM %s.snapshots WHERE operation = 'delete'",
+                deleteTable))
         .as("Merge-on-read delete should add a deletion vector")
         .isEqualTo("1");
+
+    sql("DROP TABLE IF EXISTS %s", deleteTable);
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestSparkGeospatial extends TestBase {
@@ -94,20 +95,27 @@ public class TestSparkGeospatial extends TestBase {
             TABLE));
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
-  public void testDeleteGeospatial(String mode) {
+  @ParameterizedTest(name = "mode = {0}, vectorized = {1}")
+  @CsvSource({
+    "copy-on-write, false",
+    "copy-on-write, true",
+    "merge-on-read, false",
+    "merge-on-read, true"
+  })
+  public void testDeleteGeospatial(String mode, boolean vectorized) {
     // Exercise both row-level modes: copy-on-write (the default) rewrites the surviving rows into a
     // new data file, while merge-on-read writes a deletion vector. Both must read the geo values
-    // back out correctly. Write both rows into one data file (COALESCE(1)) so the merge-on-read
-    // delete leaves a survivor in that file, forcing a deletion vector rather than a whole-file
-    // removal. Filter on id since Spark has no spatial predicate.
+    // back out correctly, whether or not vectorized reads are requested (geo falls back to the
+    // non-vectorized reader either way). Write both rows into one data file (COALESCE(1)) so the
+    // merge-on-read delete leaves a survivor in that file, forcing a deletion vector rather than a
+    // whole-file removal. Filter on id since Spark has no spatial predicate.
     String deleteTable = CATALOG + ".default.geo_delete";
     sql("DROP TABLE IF EXISTS %s", deleteTable);
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s')",
-        deleteTable, mode);
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s', "
+            + "'read.parquet.vectorization.enabled'='%s')",
+        deleteTable, mode, vectorized);
     sql(
         "INSERT INTO %s SELECT /*+ COALESCE(1) */ id, "
             + "CASE WHEN geom_wkb IS NULL THEN NULL "
@@ -144,17 +152,23 @@ public class TestSparkGeospatial extends TestBase {
     sql("DROP TABLE IF EXISTS %s", deleteTable);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
-  public void testUpdateGeospatial(String mode) {
+  @ParameterizedTest(name = "mode = {0}, vectorized = {1}")
+  @CsvSource({
+    "copy-on-write, false",
+    "copy-on-write, true",
+    "merge-on-read, false",
+    "merge-on-read, true"
+  })
+  public void testUpdateGeospatial(String mode, boolean vectorized) {
     // Update the first row's geometry; the untouched row must round-trip unchanged. Copy-on-write
     // rewrites the untouched row, merge-on-read writes a deletion vector plus the new row.
     String updateTable = CATALOG + ".default.geo_update";
     sql("DROP TABLE IF EXISTS %s", updateTable);
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.update.mode'='%s')",
-        updateTable, mode);
+            + "TBLPROPERTIES ('format-version'='3', 'write.update.mode'='%s', "
+            + "'read.parquet.vectorization.enabled'='%s')",
+        updateTable, mode, vectorized);
     sql(
         "INSERT INTO %s VALUES "
             + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
@@ -177,16 +191,22 @@ public class TestSparkGeospatial extends TestBase {
     sql("DROP TABLE IF EXISTS %s", updateTable);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
-  public void testMergeGeospatial(String mode) {
+  @ParameterizedTest(name = "mode = {0}, vectorized = {1}")
+  @CsvSource({
+    "copy-on-write, false",
+    "copy-on-write, true",
+    "merge-on-read, false",
+    "merge-on-read, true"
+  })
+  public void testMergeGeospatial(String mode, boolean vectorized) {
     // Source updates id=1 (matched) and inserts id=3 (not matched); geo values flow through both.
     String mergeTable = CATALOG + ".default.geo_merge";
     sql("DROP TABLE IF EXISTS %s", mergeTable);
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.merge.mode'='%s')",
-        mergeTable, mode);
+            + "TBLPROPERTIES ('format-version'='3', 'write.merge.mode'='%s', "
+            + "'read.parquet.vectorization.enabled'='%s')",
+        mergeTable, mode, vectorized);
     sql(
         "INSERT INTO %s VALUES "
             + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
@@ -218,30 +238,43 @@ public class TestSparkGeospatial extends TestBase {
     sql("DROP TABLE IF EXISTS %s", mergeTable);
   }
 
-  @ParameterizedTest
-  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
-  public void testDeleteNestedGeometry(String mode) {
-    // Geometry nested in a struct: delete by a nested non-geo field; the surviving nested geometry
-    // (and a null nested geometry) must still round-trip under both row-level modes.
+  @ParameterizedTest(name = "mode = {0}, vectorized = {1}")
+  @CsvSource({
+    "copy-on-write, false",
+    "copy-on-write, true",
+    "merge-on-read, false",
+    "merge-on-read, true"
+  })
+  public void testDeleteNestedGeospatial(String mode, boolean vectorized) {
+    // Geometry and geography nested in a struct: delete by a nested non-geo field. Both a surviving
+    // non-null nested geometry/geography and a surviving null one must round-trip under either
+    // mode.
     String nestedTable = CATALOG + ".default.geo_nested";
     sql("DROP TABLE IF EXISTS %s", nestedTable);
     sql(
-        "CREATE TABLE %s (id BIGINT, complex STRUCT<c1: INT, geom: GEOMETRY(4326)>) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s')",
-        nestedTable, mode);
+        "CREATE TABLE %s (id BIGINT, "
+            + "complex STRUCT<c1: INT, geom: GEOMETRY(4326), geog: GEOGRAPHY(4326)>) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s', "
+            + "'read.parquet.vectorization.enabled'='%s')",
+        nestedTable, mode, vectorized);
     sql(
         "INSERT INTO %s VALUES "
-            + "(1, named_struct('c1', 10, 'geom', st_setsrid(st_geomfromwkb(X'%s'), 4326))), "
-            + "(2, named_struct('c1', 20, 'geom', CAST(NULL AS GEOMETRY(4326))))",
-        nestedTable, GEOM_WKB);
+            + "(1, named_struct('c1', 10, "
+            + "'geom', st_setsrid(st_geomfromwkb(X'%s'), 4326), "
+            + "'geog', st_setsrid(st_geogfromwkb(X'%s'), 4326))), "
+            + "(2, named_struct('c1', 20, "
+            + "'geom', st_setsrid(st_geomfromwkb(X'%s'), 4326), "
+            + "'geog', CAST(NULL AS GEOGRAPHY(4326))))",
+        nestedTable, OTHER_WKB, GEOG_WKB, GEOM_WKB);
 
     sql("DELETE FROM %s WHERE complex.c1 = 10", nestedTable);
 
     assertEquals(
-        "Only the row with the null nested geometry should remain",
-        ImmutableList.of(row(2L, 20, null)),
+        "Only the second row remains, with its nested geometry and null geography intact",
+        ImmutableList.of(row(2L, 20, GEOM_WKB.toUpperCase(Locale.ROOT), null)),
         sql(
-            "SELECT id, complex.c1, hex(st_asbinary(complex.geom)) FROM %s ORDER BY id",
+            "SELECT id, complex.c1, hex(st_asbinary(complex.geom)), hex(st_asbinary(complex.geog)) "
+                + "FROM %s ORDER BY id",
             nestedTable));
 
     sql("DROP TABLE IF EXISTS %s", nestedTable);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -27,7 +27,6 @@ import org.apache.iceberg.spark.TestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -58,15 +57,10 @@ public class TestSparkGeospatial extends TestBase {
   public void setupTable() {
     sql("DROP TABLE IF EXISTS %s", TABLE);
     // A bare GEOMETRY column is mixed-SRID, which Iceberg does not support, so the column SRID is
-    // pinned to 4326 (OGC:CRS84).
-    // Merge-on-read at format version 3 so that DELETE/UPDATE/MERGE produce deletion vectors.
+    // pinned to 4326 (OGC:CRS84). Format version 3 is required for the geo types.
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ("
-            + "'format-version'='3', "
-            + "'write.delete.mode'='merge-on-read', "
-            + "'write.update.mode'='merge-on-read', "
-            + "'write.merge.mode'='merge-on-read')",
+            + "TBLPROPERTIES ('format-version'='3')",
         TABLE);
 
     // st_geomfromwkb yields SRID 0, so set it to the column's SRID for the write to be accepted.
@@ -100,18 +94,20 @@ public class TestSparkGeospatial extends TestBase {
             TABLE));
   }
 
-  @Test
-  public void testDeleteGeospatialMergeOnRead() {
-    // Use a dedicated table with a single INSERT and a single DELETE so there is exactly one delete
-    // snapshot to inspect. Write both rows into one data file (COALESCE(1)) so deleting one row
-    // leaves a survivor in that file, forcing a deletion vector rather than a whole-file removal.
-    // Filter on id since Spark has no spatial predicate.
+  @ParameterizedTest
+  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
+  public void testDeleteGeospatial(String mode) {
+    // Exercise both row-level modes: copy-on-write (the default) rewrites the surviving rows into a
+    // new data file, while merge-on-read writes a deletion vector. Both must read the geo values
+    // back out correctly. Write both rows into one data file (COALESCE(1)) so the merge-on-read
+    // delete leaves a survivor in that file, forcing a deletion vector rather than a whole-file
+    // removal. Filter on id since Spark has no spatial predicate.
     String deleteTable = CATALOG + ".default.geo_delete";
     sql("DROP TABLE IF EXISTS %s", deleteTable);
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='merge-on-read')",
-        deleteTable);
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s')",
+        deleteTable, mode);
     sql(
         "INSERT INTO %s SELECT /*+ COALESCE(1) */ id, "
             + "CASE WHEN geom_wkb IS NULL THEN NULL "
@@ -125,45 +121,78 @@ public class TestSparkGeospatial extends TestBase {
     sql("DELETE FROM %s WHERE id = 1", deleteTable);
 
     assertEquals(
-        "Only the null-geo row should remain after the merge-on-read delete",
+        "Only the null-geo row should remain after the delete",
         ImmutableList.of(row(2L, null, null)),
         sql(
             "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
             deleteTable));
 
-    // Deleting a row from a multi-row file writes a deletion vector (format v3, merge-on-read).
-    // Select the (single) delete snapshot by operation so the assertion does not depend on
-    // committed_at ordering, whose millisecond granularity could tie with the insert snapshot.
-    assertThat(
-            scalarSql(
-                "SELECT summary['added-dvs'] FROM %s.snapshots WHERE operation = 'delete'",
-                deleteTable))
-        .as("Merge-on-read delete should add a deletion vector")
-        .isEqualTo("1");
+    // A merge-on-read delete of a row from a multi-row file writes a deletion vector (format v3),
+    // recorded on the 'delete' snapshot; copy-on-write instead rewrites the file under an
+    // 'overwrite' snapshot and adds no deletion vector. Select the merge-on-read delete snapshot by
+    // operation so the assertion does not depend on committed_at ordering, whose millisecond
+    // granularity could tie with the insert snapshot.
+    if (mode.equals("merge-on-read")) {
+      assertThat(
+              scalarSql(
+                  "SELECT summary['added-dvs'] FROM %s.snapshots WHERE operation = 'delete'",
+                  deleteTable))
+          .as("Merge-on-read delete should add a deletion vector")
+          .isEqualTo("1");
+    }
 
     sql("DROP TABLE IF EXISTS %s", deleteTable);
   }
 
-  @Test
-  public void testUpdateGeospatialMergeOnRead() {
-    // Update the geo values of the first row; others are unchanged.
+  @ParameterizedTest
+  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
+  public void testUpdateGeospatial(String mode) {
+    // Update the first row's geometry; the untouched row must round-trip unchanged. Copy-on-write
+    // rewrites the untouched row, merge-on-read writes a deletion vector plus the new row.
+    String updateTable = CATALOG + ".default.geo_update";
+    sql("DROP TABLE IF EXISTS %s", updateTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.update.mode'='%s')",
+        updateTable, mode);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, st_setsrid(st_geomfromwkb(X'%s'), 4326), NULL)",
+        updateTable, GEOM_WKB, GEOG_WKB, GEOM_WKB);
+
     sql(
         "UPDATE %s SET geom = st_setsrid(st_geomfromwkb(X'%s'), 4326) WHERE id = 1",
-        TABLE, OTHER_WKB);
+        updateTable, OTHER_WKB);
 
     assertEquals(
-        "Only the updated row's geometry should change",
+        "The updated row changes and the untouched row round-trips unchanged",
         ImmutableList.of(
             row(1L, OTHER_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
-            row(2L, null, null)),
+            row(2L, GEOM_WKB.toUpperCase(Locale.ROOT), null)),
         sql(
             "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
-            TABLE));
+            updateTable));
+
+    sql("DROP TABLE IF EXISTS %s", updateTable);
   }
 
-  @Test
-  public void testMergeGeospatialMergeOnRead() {
+  @ParameterizedTest
+  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
+  public void testMergeGeospatial(String mode) {
     // Source updates id=1 (matched) and inserts id=3 (not matched); geo values flow through both.
+    String mergeTable = CATALOG + ".default.geo_merge";
+    sql("DROP TABLE IF EXISTS %s", mergeTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.merge.mode'='%s')",
+        mergeTable, mode);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, NULL, NULL)",
+        mergeTable, GEOM_WKB, GEOG_WKB);
+
     sql(
         "MERGE INTO %s AS t USING ("
             + "SELECT 1 AS id, st_setsrid(st_geomfromwkb(X'%s'), 4326) AS geom, "
@@ -174,7 +203,7 @@ public class TestSparkGeospatial extends TestBase {
             + "ON t.id = s.id "
             + "WHEN MATCHED THEN UPDATE SET t.geom = s.geom, t.geog = s.geog "
             + "WHEN NOT MATCHED THEN INSERT *",
-        TABLE, OTHER_WKB, GEOG_WKB, GEOM_WKB, GEOG_WKB);
+        mergeTable, OTHER_WKB, GEOG_WKB, GEOM_WKB, GEOG_WKB);
 
     assertEquals(
         "Matched row is updated and unmatched row is inserted",
@@ -184,24 +213,28 @@ public class TestSparkGeospatial extends TestBase {
             row(3L, GEOM_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT))),
         sql(
             "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
-            TABLE));
+            mergeTable));
+
+    sql("DROP TABLE IF EXISTS %s", mergeTable);
   }
 
-  @Test
-  public void testDeleteNestedGeometryMergeOnRead() {
+  @ParameterizedTest
+  @ValueSource(strings = {"copy-on-write", "merge-on-read"})
+  public void testDeleteNestedGeometry(String mode) {
+    // Geometry nested in a struct: delete by a nested non-geo field; the surviving nested geometry
+    // (and a null nested geometry) must still round-trip under both row-level modes.
     String nestedTable = CATALOG + ".default.geo_nested";
     sql("DROP TABLE IF EXISTS %s", nestedTable);
     sql(
         "CREATE TABLE %s (id BIGINT, complex STRUCT<c1: INT, geom: GEOMETRY(4326)>) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='merge-on-read')",
-        nestedTable);
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s')",
+        nestedTable, mode);
     sql(
         "INSERT INTO %s VALUES "
             + "(1, named_struct('c1', 10, 'geom', st_setsrid(st_geomfromwkb(X'%s'), 4326))), "
             + "(2, named_struct('c1', 20, 'geom', CAST(NULL AS GEOMETRY(4326))))",
         nestedTable, GEOM_WKB);
 
-    // Delete by a nested non-geo field; the surviving nested geometry must still round-trip.
     sql("DELETE FROM %s WHERE complex.c1 = 10", nestedTable);
 
     assertEquals(
@@ -212,66 +245,6 @@ public class TestSparkGeospatial extends TestBase {
             nestedTable));
 
     sql("DROP TABLE IF EXISTS %s", nestedTable);
-  }
-
-  @Test
-  public void testDeleteGeospatialCopyOnWrite() {
-    // Copy-on-write is the default row-level mode: the delete rewrites the surviving rows into a
-    // new data file, which exercises reading geo values back out during the rewrite.
-    String cowTable = CATALOG + ".default.geo_cow";
-    sql("DROP TABLE IF EXISTS %s", cowTable);
-    sql(
-        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3')",
-        cowTable);
-    sql(
-        "INSERT INTO %s VALUES "
-            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
-            + "(2, NULL, NULL)",
-        cowTable, GEOM_WKB, GEOG_WKB);
-
-    sql("DELETE FROM %s WHERE id = 1", cowTable);
-
-    assertEquals(
-        "The surviving null-geo row is rewritten intact after the copy-on-write delete",
-        ImmutableList.of(row(2L, null, null)),
-        sql(
-            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
-            cowTable));
-
-    sql("DROP TABLE IF EXISTS %s", cowTable);
-  }
-
-  @Test
-  public void testUpdateGeospatialCopyOnWrite() {
-    // Copy-on-write update: the row with unchanged geo values is read back and rewritten alongside
-    // the updated row.
-    String cowTable = CATALOG + ".default.geo_cow";
-    sql("DROP TABLE IF EXISTS %s", cowTable);
-    sql(
-        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3')",
-        cowTable);
-    sql(
-        "INSERT INTO %s VALUES "
-            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
-            + "(2, st_setsrid(st_geomfromwkb(X'%s'), 4326), NULL)",
-        cowTable, GEOM_WKB, GEOG_WKB, GEOM_WKB);
-
-    sql(
-        "UPDATE %s SET geom = st_setsrid(st_geomfromwkb(X'%s'), 4326) WHERE id = 1",
-        cowTable, OTHER_WKB);
-
-    assertEquals(
-        "The updated row changes and the untouched row is rewritten intact",
-        ImmutableList.of(
-            row(1L, OTHER_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
-            row(2L, GEOM_WKB.toUpperCase(Locale.ROOT), null)),
-        sql(
-            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
-            cowTable));
-
-    sql("DROP TABLE IF EXISTS %s", cowTable);
   }
 
   private void setVectorization(boolean on) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -214,6 +214,66 @@ public class TestSparkGeospatial extends TestBase {
     sql("DROP TABLE IF EXISTS %s", nestedTable);
   }
 
+  @Test
+  public void testDeleteGeospatialCopyOnWrite() {
+    // Copy-on-write is the default row-level mode: the delete rewrites the surviving rows into a
+    // new data file, which exercises reading geo values back out during the rewrite.
+    String cowTable = CATALOG + ".default.geo_cow";
+    sql("DROP TABLE IF EXISTS %s", cowTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        cowTable);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, NULL, NULL)",
+        cowTable, GEOM_WKB, GEOG_WKB);
+
+    sql("DELETE FROM %s WHERE id = 1", cowTable);
+
+    assertEquals(
+        "The surviving null-geo row is rewritten intact after the copy-on-write delete",
+        ImmutableList.of(row(2L, null, null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            cowTable));
+
+    sql("DROP TABLE IF EXISTS %s", cowTable);
+  }
+
+  @Test
+  public void testUpdateGeospatialCopyOnWrite() {
+    // Copy-on-write update: the row with unchanged geo values is read back and rewritten alongside
+    // the updated row.
+    String cowTable = CATALOG + ".default.geo_cow";
+    sql("DROP TABLE IF EXISTS %s", cowTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        cowTable);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, st_setsrid(st_geomfromwkb(X'%s'), 4326), st_setsrid(st_geogfromwkb(X'%s'), 4326)), "
+            + "(2, st_setsrid(st_geomfromwkb(X'%s'), 4326), NULL)",
+        cowTable, GEOM_WKB, GEOG_WKB, GEOM_WKB);
+
+    sql(
+        "UPDATE %s SET geom = st_setsrid(st_geomfromwkb(X'%s'), 4326) WHERE id = 1",
+        cowTable, OTHER_WKB);
+
+    assertEquals(
+        "The updated row changes and the untouched row is rewritten intact",
+        ImmutableList.of(
+            row(1L, OTHER_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
+            row(2L, GEOM_WKB.toUpperCase(Locale.ROOT), null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            cowTable));
+
+    sql("DROP TABLE IF EXISTS %s", cowTable);
+  }
+
   private void setVectorization(boolean on) {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('read.parquet.vectorization.enabled'='%s')",

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -18,7 +18,7 @@
  */
 package org.apache.iceberg.spark.sql;
 
-import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Locale;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -27,6 +27,7 @@ import org.apache.iceberg.spark.TestBase;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -35,9 +36,10 @@ public class TestSparkGeospatial extends TestBase {
   private static final String CATALOG = "local";
   private static final String TABLE = CATALOG + ".default.geo";
 
-  // WKB (little-endian) for POINT(30 10) and POINT(-71 42).
+  // WKB (little-endian) for POINT(30 10), POINT(-71 42) and POINT(100 50).
   private static final String GEOM_WKB = "01010000000000000000003e400000000000002440";
   private static final String GEOG_WKB = "01010000000000000000c051c00000000000004540";
+  private static final String OTHER_WKB = "010100000000000000000059400000000000004940";
 
   @BeforeAll
   public static void setupCatalog() {
@@ -57,9 +59,14 @@ public class TestSparkGeospatial extends TestBase {
     sql("DROP TABLE IF EXISTS %s", TABLE);
     // A bare GEOMETRY column is mixed-SRID, which Iceberg does not support, so the column SRID is
     // pinned to 4326 (OGC:CRS84).
+    // Merge-on-read at format version 3 so that DELETE/UPDATE/MERGE produce deletion vectors.
     sql(
         "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
-            + "TBLPROPERTIES ('format-version'='3')",
+            + "TBLPROPERTIES ("
+            + "'format-version'='3', "
+            + "'write.delete.mode'='merge-on-read', "
+            + "'write.update.mode'='merge-on-read', "
+            + "'write.merge.mode'='merge-on-read')",
         TABLE);
 
     // st_geomfromwkb yields SRID 0, so set it to the column's SRID for the write to be accepted.
@@ -78,7 +85,8 @@ public class TestSparkGeospatial extends TestBase {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testGeospatialWkbReadBack(boolean vectorized) {
-    assumeThat(vectorized).as("Geo vectorized Parquet read is not implemented yet").isFalse();
+    // Even with vectorization enabled, geo columns fall back to the non-vectorized reader (there is
+    // no Arrow geo vector yet), so both settings read back correctly.
     setVectorization(vectorized);
 
     // st_asbinary strips the SRID header back to pure WKB, matching what was inserted.
@@ -90,6 +98,110 @@ public class TestSparkGeospatial extends TestBase {
         sql(
             "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
             TABLE));
+  }
+
+  @Test
+  public void testDeleteGeospatialMergeOnRead() {
+    // Rewrite the table into a single data file (COALESCE(1)) so deleting one row leaves survivors
+    // in that file, forcing a deletion vector rather than a whole-file removal. Filter on id since
+    // Spark has no spatial predicate.
+    sql("DELETE FROM %s WHERE id IS NOT NULL", TABLE);
+    sql(
+        "INSERT INTO %s SELECT /*+ COALESCE(1) */ id, "
+            + "CASE WHEN geom_wkb IS NULL THEN NULL "
+            + "ELSE st_setsrid(st_geomfromwkb(geom_wkb), 4326) END, "
+            + "CASE WHEN geog_wkb IS NULL THEN NULL "
+            + "ELSE st_setsrid(st_geogfromwkb(geog_wkb), 4326) END "
+            + "FROM VALUES (1, X'%s', X'%s'), (2, CAST(NULL AS BINARY), CAST(NULL AS BINARY)) "
+            + "AS v(id, geom_wkb, geog_wkb)",
+        TABLE, GEOM_WKB, GEOG_WKB);
+
+    sql("DELETE FROM %s WHERE id = 1", TABLE);
+
+    assertEquals(
+        "Only the null-geo row should remain after the merge-on-read delete",
+        ImmutableList.of(row(2L, null, null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            TABLE));
+
+    // Deleting a row from a multi-row file writes a deletion vector (format v3, merge-on-read).
+    assertThat(
+            scalarSql(
+                "SELECT summary['added-dvs'] FROM %s.snapshots ORDER BY committed_at DESC LIMIT 1",
+                TABLE))
+        .as("Merge-on-read delete should add a deletion vector")
+        .isEqualTo("1");
+  }
+
+  @Test
+  public void testUpdateGeospatialMergeOnRead() {
+    // Update the geo values of the first row; others are unchanged.
+    sql(
+        "UPDATE %s SET geom = st_setsrid(st_geomfromwkb(X'%s'), 4326) WHERE id = 1",
+        TABLE, OTHER_WKB);
+
+    assertEquals(
+        "Only the updated row's geometry should change",
+        ImmutableList.of(
+            row(1L, OTHER_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
+            row(2L, null, null)),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            TABLE));
+  }
+
+  @Test
+  public void testMergeGeospatialMergeOnRead() {
+    // Source updates id=1 (matched) and inserts id=3 (not matched); geo values flow through both.
+    sql(
+        "MERGE INTO %s AS t USING ("
+            + "SELECT 1 AS id, st_setsrid(st_geomfromwkb(X'%s'), 4326) AS geom, "
+            + "st_setsrid(st_geogfromwkb(X'%s'), 4326) AS geog "
+            + "UNION ALL "
+            + "SELECT 3 AS id, st_setsrid(st_geomfromwkb(X'%s'), 4326) AS geom, "
+            + "st_setsrid(st_geogfromwkb(X'%s'), 4326) AS geog) AS s "
+            + "ON t.id = s.id "
+            + "WHEN MATCHED THEN UPDATE SET t.geom = s.geom, t.geog = s.geog "
+            + "WHEN NOT MATCHED THEN INSERT *",
+        TABLE, OTHER_WKB, GEOG_WKB, GEOM_WKB, GEOG_WKB);
+
+    assertEquals(
+        "Matched row is updated and unmatched row is inserted",
+        ImmutableList.of(
+            row(1L, OTHER_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT)),
+            row(2L, null, null),
+            row(3L, GEOM_WKB.toUpperCase(Locale.ROOT), GEOG_WKB.toUpperCase(Locale.ROOT))),
+        sql(
+            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            TABLE));
+  }
+
+  @Test
+  public void testDeleteNestedGeometryMergeOnRead() {
+    String nestedTable = CATALOG + ".default.geo_nested";
+    sql("DROP TABLE IF EXISTS %s", nestedTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, complex STRUCT<c1: INT, geom: GEOMETRY(4326)>) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='merge-on-read')",
+        nestedTable);
+    sql(
+        "INSERT INTO %s VALUES "
+            + "(1, named_struct('c1', 10, 'geom', st_setsrid(st_geomfromwkb(X'%s'), 4326))), "
+            + "(2, named_struct('c1', 20, 'geom', CAST(NULL AS GEOMETRY(4326))))",
+        nestedTable, GEOM_WKB);
+
+    // Delete by a nested non-geo field; the surviving nested geometry must still round-trip.
+    sql("DELETE FROM %s WHERE complex.c1 = 10", nestedTable);
+
+    assertEquals(
+        "Only the row with the null nested geometry should remain",
+        ImmutableList.of(row(2L, 20, null)),
+        sql(
+            "SELECT id, complex.c1, hex(st_asbinary(complex.geom)) FROM %s ORDER BY id",
+            nestedTable));
+
+    sql("DROP TABLE IF EXISTS %s", nestedTable);
   }
 
   private void setVectorization(boolean on) {


### PR DESCRIPTION
Adds end-to-end Spark SQL DML tests for `geometry` and `geography` columns, and
fixes a vectorized-read bug those tests surfaced. This completes the Phase-1
geo end-to-end item (row-level DML with deletion vectors / nested geo / nulls)
and builds on #17073 (Spark geo value path) and #16982 (Parquet geo WKB values).

## Tests

`TestSparkGeospatial` previously covered only `INSERT` → `SELECT` read-back. This
adds row-level DML on a geo table under **merge-on-read + format version 3**
(deletion vectors):

- `testDeleteGeospatialMergeOnRead` — `DELETE` leaves a survivor in a single data
  file, and the snapshot summary confirms a deletion vector was written
  (`added-dvs = 1`); the surviving null-geo row round-trips.
- `testUpdateGeospatialMergeOnRead` — `UPDATE` swaps a row's geometry; others
  unchanged.
- `testMergeGeospatialMergeOnRead` — `MERGE` updates a matched row and inserts a
  not-matched row, both carrying geo values.
- `testDeleteNestedGeometryMergeOnRead` — geometry nested in a `STRUCT`; delete by
  a nested non-geo field, surviving nested geometry (and a null nested geometry)
  still round-trip.

Geo values are asserted via `hex(st_asbinary(...))` round-trips and DML filters on
non-geo columns, since Spark 4.1 has no spatial predicates.

## Vectorization fallback (production fix)

`geometry`/`geography` are primitive types, so they passed
`SparkBatch.supportsParquetBatchReads(NestedField)` and were routed to the
vectorized Parquet reader — but there is no Arrow geo vector yet, so scanning a geo
column with vectorization enabled threw
`UnsupportedOperationException: Unsupported primitive type: geometry`. This excludes
the two geo types from vectorized reads so they fall back to the row-based reader.

With this fix, `testGeospatialWkbReadBack` now runs (no longer skipped) with
vectorization both **off and on**, proving the fallback. A dedicated Arrow geo
vector remains future work.
