### PR TITLE
Core: Close Avro reader when range sync fails in AvroIterable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -78,12 +78,21 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
     FileReader<D> fileReader = initMetadata(newFileReader());
 
     if (start != null) {
-      if (reader instanceof SupportsRowPosition) {
-        ((SupportsRowPosition) reader)
-            .setRowPositionSupplier(
-                Suppliers.memoize(() -> AvroIO.findStartingRowPos(file::newStream, start)));
+      try {
+        if (reader instanceof SupportsRowPosition) {
+          ((SupportsRowPosition) reader)
+              .setRowPositionSupplier(
+                  Suppliers.memoize(() -> AvroIO.findStartingRowPos(file::newStream, start)));
+        }
+        fileReader = new AvroRangeIterator<>(fileReader, start, end);
+      } catch (RuntimeException e) {
+        try {
+          fileReader.close();
+        } catch (IOException closeException) {
+          e.addSuppressed(closeException);
+        }
+        throw e;
       }
-      fileReader = new AvroRangeIterator<>(fileReader, start, end);
     } else if (reader instanceof SupportsRowPosition) {
       ((SupportsRowPosition) reader).setRowPositionSupplier(() -> 0L);
     }

--- a/core/src/test/java/org/apache/iceberg/avro/TestAvroIterable.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestAvroIterable.java
@@ -19,7 +19,9 @@
 package org.apache.iceberg.avro;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.InstanceOfAssertFactories.LIST;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.verify;
@@ -27,6 +29,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.file.SeekableInput;
 import org.apache.avro.io.DatumReader;
@@ -62,6 +65,41 @@ class TestAvroIterable {
           .hasCauseInstanceOf(RuntimeIOException.class);
 
       verify(seekableInput, atLeastOnce()).close();
+    }
+  }
+
+  @Test
+  void readerClosedWhenRangeSyncFails() throws Exception {
+    InputFile inputFile = mock(InputFile.class);
+    SeekableInputStream seekableInputStream = mock(SeekableInputStream.class);
+    SeekableInput seekableInput = mock(SeekableInput.class);
+    DatumReader<?> datumReader = mock(DatumReader.class);
+    DataFileReader<?> fileReader = mock(DataFileReader.class);
+
+    when(inputFile.newStream()).thenReturn(seekableInputStream);
+    when(inputFile.getLength()).thenReturn(100L);
+    when(fileReader.getMetaKeys()).thenReturn(Collections.emptyList());
+    doThrow(new IOException()).when(fileReader).sync(5L);
+    IOException closeException = new IOException("close failed");
+    doThrow(closeException).when(fileReader).close();
+
+    try (MockedStatic<AvroIO> avroIo = mockStatic(AvroIO.class);
+        MockedStatic<DataFileReader> dataFileReaderMock = mockStatic(DataFileReader.class)) {
+      avroIo.when(() -> AvroIO.stream(seekableInputStream, 100L)).thenReturn(seekableInput);
+      dataFileReaderMock
+          .when(() -> DataFileReader.openReader(seekableInput, datumReader))
+          .thenReturn(fileReader);
+
+      AvroIterable<?> iterable = new AvroIterable<>(inputFile, datumReader, 5L, 10L, false);
+
+      assertThatThrownBy(iterable::iterator)
+          .isInstanceOf(RuntimeIOException.class)
+          .hasMessage("Failed to find sync past position 5")
+          .extracting(e -> java.util.Arrays.asList(e.getSuppressed()))
+          .asInstanceOf(LIST)
+          .containsExactly(closeException);
+
+      verify(fileReader, atLeastOnce()).close();
     }
   }
 }


### PR DESCRIPTION
### Problem

On split reads, `AvroIterable.iterator()` opens a `DataFileReader` before configuring row-position tracking and constructing `AvroRangeIterator`. Either setup step can throw before the reader is registered with the `CloseableGroup`, leaking the reader and its underlying stream.

### Solution

Guard both split-path setup steps. If either fails, close the already-open reader, attach any close failure as a suppressed exception, and rethrow the original exception.

### Testing

Added `readerClosedWhenRangeSyncFails`, which makes range synchronization and reader close both fail. The test asserts that the original `RuntimeIOException` is preserved and that the close exception is suppressed, proving that cleanup executes.

- `./gradlew :iceberg-core:test --tests "org.apache.iceberg.avro.TestAvroIterable"`
- `./gradlew :iceberg-core:spotlessCheck`

Both pass locally with JDK 21.

---
**AI Disclosure**
- Model: GPT-5.6 Sol
- Platform/Tool: GitHub Copilot
- Human Oversight: fully reviewed
- Prompt Summary: Address reviewer feedback by guarding all throwing split-reader setup and strengthening the regression test to prove reader cleanup executes.
