### PR TITLE
Docs: Fix catalog properties links after docs refactor of #15848

### DIFF
--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -99,7 +99,7 @@ paths:
 
 
         Common catalog configuration settings are documented at
-        https://iceberg.apache.org/docs/latest/configuration/#catalog-properties
+        https://iceberg.apache.org/docs/latest/catalog-properties
 
 
         The catalog configuration also holds an optional `endpoints` field that contains information about the endpoints

--- a/site/docs/terms.md
+++ b/site/docs/terms.md
@@ -28,7 +28,7 @@ You may think of Iceberg as a format for managing data in a single table, but th
 
 The first step when using an Iceberg client is almost always initializing and configuring a catalog. The configured catalog is then used by compute engines to execute catalog operations. Multiple types of compute engines using a shared Iceberg catalog allows them to share a common data layer.
 
-A catalog is almost always configured through the processing engine which passes along a set of properties during initialization. Different processing engines have different ways to configure a catalog. When configuring a catalog, it’s always best to refer to the [Iceberg documentation](docs/latest/configuration.md#catalog-properties) as well as the docs for the specific processing engine being used. Ultimately, these configurations boil down to a common set of catalog properties that will be passed to configure the Iceberg catalog.
+A catalog is almost always configured through the processing engine which passes along a set of properties during initialization. Different processing engines have different ways to configure a catalog. When configuring a catalog, it’s always best to refer to the [Iceberg documentation](../../docs/docs/catalog-properties.md) as well as the docs for the specific processing engine being used. Ultimately, these configurations boil down to a common set of catalog properties that will be passed to configure the Iceberg catalog.
 
 ### Catalog Implementations
 


### PR DESCRIPTION
Fixes stale catalog properties links left after the docs refactor in #15848.

- Updating the REST catalog OpenAPI config description to point to the new catalog properties docs URL.
- Updating the Terms page catalog overview to link to the moved `catalog-properties.md` page.
