### PR TITLE
Spec: REST KMS credential vending for table encryption

### DIFF
--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -45,7 +45,7 @@ Flink passes in catalog properties through `CREATE CATALOG` statement, see more 
 
 ## REST catalog properties
 
-The following properties configure the behavior of the REST catalog client.
+The following properties configure the behavior of the REST catalog client or may be advertised by a REST catalog server in the configuration response.
 
 | Property                              | Default           | Description                                                                                                                                                                                      |
 |---------------------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -55,6 +55,7 @@ The following properties configure the behavior of the REST catalog client.
 | `rest-page-size`                      | null              | The page size to use when listing namespaces, tables, or other paginated resources.                                                                                                              |
 | `namespace-separator`                 | `%1F`             | The separator character used for namespace levels when communicating with the REST server.                                                                                                       |
 | `scan-planning-mode`                  | `CLIENT`          | Controls where scan planning is performed. Supported values: `CLIENT` (client-side planning), `SERVER` (server-side planning). Can be overridden per-table by the server in LoadTableResponse. |
+| `encryption.kms-type`                 | null              | Advertises the catalog-selected KMS provider clients should use for encrypted tables. This is independent of the table's storage provider and may be used with `key-management-credentials` to initialize or configure the KMS client. The value is an open enum with initial values `aws`, `gcp`, and `azure`; catalogs may return additional values when the catalog and client agree on KMS client resolution and credential config. |
 
 ### Table cache properties
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -35,6 +35,7 @@ Iceberg catalogs support using catalog properties to configure catalog behaviors
 | cache.expiration-interval-ms      | 30000              | How long catalog entries are locally cached, in milliseconds; 0 disables caching, negative values disable expiration |
 | metrics-reporter-impl | org.apache.iceberg.metrics.LoggingMetricsReporter | Custom `MetricsReporter` implementation to use in a catalog. See the [Metrics reporting](metrics-reporting.md) section for additional details |
 | unique-table-location             | false              | Whether to use a unique location for new tables |
+| encryption.kms-type               | null               | a predefined KMS client type to use in a catalog for encrypted tables, for example `aws`, `gcp`, or `azure`. See the [Encryption](encryption.md) document for additional details |
 | encryption.kms-impl               | null               | a custom `KeyManagementClient` implementation to use in a catalog for interactions with KMS (key management service). See the [Encryption](encryption.md) document for additional details |
 
 `HadoopCatalog` and `HiveCatalog` can access the properties in their constructors.
@@ -55,7 +56,7 @@ The following properties configure the behavior of the REST catalog client or ma
 | `rest-page-size`                      | null              | The page size to use when listing namespaces, tables, or other paginated resources.                                                                                                              |
 | `namespace-separator`                 | `%1F`             | The separator character used for namespace levels when communicating with the REST server.                                                                                                       |
 | `scan-planning-mode`                  | `CLIENT`          | Controls where scan planning is performed. Supported values: `CLIENT` (client-side planning), `SERVER` (server-side planning). Can be overridden per-table by the server in LoadTableResponse. |
-| `encryption.kms-type`                 | null              | Advertises the catalog-selected KMS provider clients should use for encrypted tables. This is independent of the table's storage provider and may be used with `key-management-credentials` to initialize or configure the KMS client. The value is an open enum with initial values `aws`, `gcp`, and `azure`; catalogs may return additional values when the catalog and client agree on KMS client resolution and credential config. |
+| `encryption.kms-type`                 | null              | KMS provider type used for encrypted tables. Clients may configure this value, but REST catalog servers may advertise it through `/v1/config`; server `overrides` take precedence over client configuration. When using `key-management-credentials`, clients should use the final catalog configuration value after applying server defaults and overrides. The value is an open enum with initial values `aws`, `gcp`, and `azure`; catalogs may return additional values when the catalog and client agree on KMS client resolution and credential config. |
 
 ### Table cache properties
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -599,9 +599,10 @@ class KeyManagementCredential(BaseModel):
     selected key-management provider.
 
     Clients should select the credential config by matching KMS key identifiers referenced by table
-    encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If no
-    key-management credential matches a KMS key ID required by table encryption metadata, the client
-    must fail the operation with an authorization or missing-credential error.
+    encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If a response
+    includes `key-management-credentials` but no credential matches a KMS key ID required by table
+    encryption metadata, the client must fail the operation with an authorization or missing-credential
+    error.
 
     Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
     and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -598,15 +598,14 @@ class KeyManagementCredential(BaseModel):
     returned from `/v1/config`. The `config` map contains provider-specific properties for the
     selected key-management provider.
 
-    Clients should select the credential config by matching KMS key identifiers referenced by table
-    encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If a response
-    includes `key-management-credentials` but no credential matches a KMS key ID required by table
-    encryption metadata, the client must fail the operation with an authorization or missing-credential
-    error.
+    Catalogs that return `key-management-credentials` for an operation must include credentials for all
+    KMS key IDs required by table encryption metadata. Clients should select the credential config by
+    matching KMS key identifiers referenced by table encryption metadata, such as
+    `EncryptedKey.encrypted-by-id`, against `kms-key-ids`.
 
-    Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
-    and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond
-    their expiration.
+    Credential configs should use provider-specific expiration mechanisms where available and should
+    be scoped to the minimum required KMS operations and listed KMS key IDs where the provider
+    supports it. Clients must not persist credentials beyond any provider-specific expiration.
 
     """
 

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -152,11 +152,6 @@ class ExpressionType(RootModel[str]):
 
 
 class TrueExpression(BaseModel):
-    """
-    Deprecated. Use the bare boolean literal `true` as a predicate instead.
-
-    """
-
     type: Literal['true'] = Field(
         ...,
         examples=[
@@ -186,11 +181,6 @@ class TrueExpression(BaseModel):
 
 
 class FalseExpression(BaseModel):
-    """
-    Deprecated. Use the bare boolean literal `false` as a predicate instead.
-
-    """
-
     type: Literal['false'] = Field(
         ...,
         examples=[
@@ -219,49 +209,8 @@ class FalseExpression(BaseModel):
     )
 
 
-class IdReference(BaseModel):
-    """
-    A bound reference to a field by field ID.
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['reference']
-    id: int
-
-
-class NamedReference(BaseModel):
-    """
-    An unbound reference to a field by name.
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['reference']
-    name: str
-
-
-class Function(RootModel[str]):
-    root: str = Field(..., min_length=1)
-
-
-class Function1(BaseModel):
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    catalog: str | None = None
-    identifier: CatalogObjectIdentifier
-
-
-class TermReference(RootModel[str]):
-    root: str = Field(
-        ...,
-        deprecated=True,
-        description='Deprecated string-form field reference used in older REST predicates. Use Reference (IdReference or NamedReference) instead.\n',
-        examples=[['column-name']],
-    )
+class Reference(RootModel[str]):
+    root: str = Field(..., examples=[['column-name']])
 
 
 class Transform(RootModel[str]):
@@ -320,10 +269,11 @@ class Summary(BaseModel):
     model_config = ConfigDict(
         extra='allow',
     )
-    __annotations__ = {
-        '__pydantic_extra__': Dict[str, str],
-    }
     operation: Literal['append', 'replace', 'overwrite', 'delete']
+
+
+Summary.__annotations__['__pydantic_extra__'] = Dict[str, str]
+Summary.model_rebuild(force=True)
 
 
 class Snapshot(BaseModel):
@@ -639,9 +589,43 @@ class StorageCredential(BaseModel):
     config: dict[str, str]
 
 
+class KeyManagementCredential(BaseModel):
+    """
+    Provider-specific credential config for accessing one or more KMS keys required by an encrypted
+    table operation.
+
+    The key-management provider is advertised in catalog configuration, such as `encryption.kms-type`
+    returned from `/v1/config`. The `config` map contains provider-specific properties for the
+    selected key-management provider.
+
+    Clients should select the credential config by matching KMS key identifiers referenced by table
+    encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If no
+    key-management credential matches a KMS key ID required by table encryption metadata, the client
+    must fail the operation with an authorization or missing-credential error.
+
+    Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
+    and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond
+    their expiration.
+
+    """
+
+    kms_key_ids: list[str] = Field(
+        ...,
+        alias='kms-key-ids',
+        description='KMS key identifiers for which the credential config is relevant.\n\nClients should match these values against KMS key identifiers referenced by table encryption\nmetadata, such as `EncryptedKey.encrypted-by-id`.\n',
+    )
+    config: dict[str, str] = Field(
+        ...,
+        description='Provider-specific credential configuration for accessing the listed KMS key IDs.',
+    )
+
+
 class LoadCredentialsResponse(BaseModel):
     storage_credentials: list[StorageCredential] = Field(
         ..., alias='storage-credentials'
+    )
+    key_management_credentials: list[KeyManagementCredential] | None = Field(
+        None, alias='key-management-credentials'
     )
 
 
@@ -1171,21 +1155,6 @@ class RemoteSignResult(BaseModel):
     headers: MultiValuedMap
 
 
-class RemoteSigningConfig(BaseModel):
-    """
-    Configuration for the remote signer client.
-    """
-
-    properties: dict[str, str] | None = Field(
-        None,
-        description='Static key-value pairs the signer client MUST pass through unchanged in the `properties` field of every `RemoteSignRequest` sent to the signing endpoint.\n',
-    )
-    headers: MultiValuedMap | None = Field(
-        None,
-        description='Static headers the signer client MUST include unchanged in every request to the signing endpoint.\n',
-    )
-
-
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: dict[str, str] | None = Field(
@@ -1200,64 +1169,10 @@ class RenameTableRequest(BaseModel):
     destination: TableIdentifier
 
 
-class Literal1(BaseModel):
-    """
-    A literal is either a bare value, an untyped literal object, or a typed literal object.
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['literal']
-    value: PrimitiveTypeValue
-    data_type: PrimitiveType | None = Field(None, alias='data-type')
-
-
-class LiteralModel(RootModel[PrimitiveTypeValue | Literal1]):
-    root: PrimitiveTypeValue | Literal1 = Field(
-        ...,
-        description='A literal is either a bare value, an untyped literal object, or a typed literal object.\n',
-    )
-
-
-class Literals1(BaseModel):
-    """
-    Literals is either a bare array of literals or a typed object with an explicit data-type applied to all values.
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['literals']
-    values: list[PrimitiveTypeValue]
-    data_type: PrimitiveType = Field(..., alias='data-type')
-
-
-class Literals(RootModel[list[LiteralModel] | Literals1]):
-    root: list[LiteralModel] | Literals1 = Field(
-        ...,
-        description='Literals is either a bare array of literals or a typed object with an explicit data-type applied to all values.\n',
-    )
-
-
-class Reference(RootModel[IdReference | NamedReference]):
-    root: IdReference | NamedReference = Field(
-        ...,
-        description='A reference to a field. Either a bound reference (by field ID) or an unbound reference (by name). The context in which an expression is used determines which form is valid.\n',
-    )
-
-
 class TransformTerm(BaseModel):
-    """
-    Deprecated. Legacy transform-applied-to-a-term form. Use Apply with a Reference argument instead.
-
-    """
-
     type: Literal['transform']
     transform: Transform
-    term: TermReference
+    term: Reference
 
 
 class SetPartitionStatisticsUpdate(BaseUpdate):
@@ -1366,12 +1281,8 @@ class FetchScanTasksRequest(BaseModel):
     plan_task: PlanTask = Field(..., alias='plan-task')
 
 
-class Term(RootModel[TermReference | TransformTerm]):
-    root: TermReference | TransformTerm = Field(
-        ...,
-        deprecated=True,
-        description='Deprecated. Legacy term form used by older REST predicates. Use Reference or Apply instead.\n',
-    )
+class Term(RootModel[Reference | TransformTerm]):
+    root: Reference | TransformTerm
 
 
 class SetStatisticsUpdate(BaseUpdate):
@@ -1409,6 +1320,100 @@ class FunctionDefinitionVersion(BaseModel):
     )
 
 
+class UnaryExpression(BaseModel):
+    type: Literal['is-null', 'not-null', 'is-nan', 'not-nan'] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    term: Term
+
+
+class LiteralExpression(BaseModel):
+    type: Literal[
+        'lt', 'lt-eq', 'gt', 'gt-eq', 'eq', 'not-eq', 'starts-with', 'not-starts-with'
+    ] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    term: Term
+    value: PrimitiveTypeValue
+
+
+class SetExpression(BaseModel):
+    type: Literal['in', 'not-in'] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    term: Term
+    values: list[PrimitiveTypeValue]
+
+
 class StructField(BaseModel):
     id: int
     name: str
@@ -1440,7 +1445,7 @@ class MapType(BaseModel):
     value_required: bool = Field(..., alias='value-required')
 
 
-class AndOrPredicate(BaseModel):
+class AndOrExpression(BaseModel):
     type: Literal['and', 'or'] = Field(
         ...,
         examples=[
@@ -1467,11 +1472,11 @@ class AndOrPredicate(BaseModel):
             ]
         ],
     )
-    left: Predicate
-    right: Predicate
+    left: Expression
+    right: Expression
 
 
-class NotPredicate(BaseModel):
+class NotExpression(BaseModel):
     type: Literal['not'] = Field(
         ...,
         examples=[
@@ -1498,151 +1503,7 @@ class NotPredicate(BaseModel):
             ]
         ],
     )
-    child: Predicate
-
-
-class UnaryPredicate(BaseModel):
-    """
-    A predicate that tests a single value expression. Accepts either 'child' (preferred) or 'term' (deprecated) to identify the operand.
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['is-null', 'not-null', 'is-nan', 'not-nan'] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    child: ValueExpression | None = None
-    term: Term | None = Field(
-        None, deprecated=True, description="Deprecated. Use 'child' instead."
-    )
-
-
-class ComparisonPredicate(BaseModel):
-    """
-    A predicate that compares two value expressions. Accepts either 'left'/'right' (preferred) or 'term'/'value' (deprecated).
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal[
-        'lt', 'lt-eq', 'gt', 'gt-eq', 'eq', 'not-eq', 'starts-with', 'not-starts-with'
-    ] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    left: ValueExpression | None = None
-    right: ValueExpression | None = None
-    term: Term | None = Field(
-        None, deprecated=True, description="Deprecated. Use 'left' instead."
-    )
-    value: LiteralModel | None = Field(
-        None, deprecated=True, description="Deprecated. Use 'right' instead."
-    )
-
-
-class SetPredicate(BaseModel):
-    """
-    A predicate that tests whether a value is in a set of literals. Accepts either 'child' (preferred) or 'term' (deprecated) to identify the operand.
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['in', 'not-in'] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    child: ValueExpression | None = None
-    term: Term | None = Field(
-        None, deprecated=True, description="Deprecated. Use 'child' instead."
-    )
-    values: Literals
-
-
-class Apply(BaseModel):
-    """
-    A function application on zero or more value expressions or predicates.
-
-    """
-
-    model_config = ConfigDict(
-        extra='forbid',
-    )
-    type: Literal['apply']
-    function: Function | CatalogObjectIdentifier | Function1
-    arguments: list[FunctionArgument]
+    child: Expression
 
 
 class TableMetadata(BaseModel):
@@ -1735,17 +1596,18 @@ class LoadTableResult(BaseModel):
     Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
     Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
 
+    ## Key Management Credentials
+
+    Credentials for KMS / key-management systems are provided through the `key-management-credentials` field.
+    Clients must first check whether the respective credentials exist in the `key-management-credentials`
+    field before checking the `config` for credentials.
+    Clients must use `key-management-credentials` consistently with the REST access-delegation credential sourcing rules.
+
     ## Remote Signing
 
-    If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
-    field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
-    SHOULD respect the provided configuration.
-
-    For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
-     - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
-     - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
-    If any of these properties is present, clients SHOULD use them to compute the actual remote signing endpoint URI to contact.
-    If none of these properties is present, clients SHOULD contact the default remote signing endpoint using the catalog's base URI.
+    If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
+     - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+     - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
 
     """
 
@@ -1759,8 +1621,8 @@ class LoadTableResult(BaseModel):
     storage_credentials: list[StorageCredential] | None = Field(
         None, alias='storage-credentials'
     )
-    remote_signing_config: RemoteSigningConfig | None = Field(
-        None, alias='remote-signing-config'
+    key_management_credentials: list[KeyManagementCredential] | None = Field(
+        None, alias='key-management-credentials'
     )
 
 
@@ -1878,7 +1740,7 @@ class LoadViewResult(BaseModel):
 class ScanReport(BaseModel):
     table_name: str = Field(..., alias='table-name')
     snapshot_id: int = Field(..., alias='snapshot-id')
-    filter: Predicate
+    filter: Expression
     schema_id: int = Field(..., alias='schema-id')
     projected_field_ids: list[int] = Field(..., alias='projected-field-ids')
     projected_field_names: list[str] = Field(..., alias='projected-field-names')
@@ -2030,8 +1892,8 @@ class PlanTableScanRequest(BaseModel):
     select: list[FieldName] | None = Field(
         None, description='List of selected schema fields'
     )
-    filter: Predicate | None = Field(
-        None, description='Predicate used to filter the table data'
+    filter: Expression | None = Field(
+        None, description='Expression used to filter the table data'
     )
     min_rows_requested: int | None = Field(
         None,
@@ -2072,7 +1934,7 @@ class FileScanTask(BaseModel):
         alias='delete-file-references',
         description='A list of indices in the delete files array (0-based)',
     )
-    residual_filter: Predicate | None = Field(
+    residual_filter: Expression | None = Field(
         None,
         alias='residual-filter',
         description='An optional filter to be applied to rows in this file scan task.\nIf the residual is not present, the client must produce the residual or use the original filter.',
@@ -2088,34 +1950,25 @@ class Type(RootModel[PrimitiveType | StructType | ListType | MapType]):
     root: PrimitiveType | StructType | ListType | MapType
 
 
-class Predicate(
+class Expression(
     RootModel[
-        bool
-        | TrueExpression
+        TrueExpression
         | FalseExpression
-        | AndOrPredicate
-        | NotPredicate
-        | UnaryPredicate
-        | ComparisonPredicate
-        | SetPredicate
+        | AndOrExpression
+        | NotExpression
+        | SetExpression
+        | LiteralExpression
+        | UnaryExpression
     ]
 ):
     root: (
-        bool
-        | TrueExpression
+        TrueExpression
         | FalseExpression
-        | AndOrPredicate
-        | NotPredicate
-        | UnaryPredicate
-        | ComparisonPredicate
-        | SetPredicate
-    )
-
-
-class ValueExpression(RootModel[LiteralModel | Reference | Apply]):
-    root: LiteralModel | Reference | Apply = Field(
-        ...,
-        description='A value expression: a literal, a field reference, or a function application.\n',
+        | AndOrExpression
+        | NotExpression
+        | SetExpression
+        | LiteralExpression
+        | UnaryExpression
     )
 
 
@@ -2210,6 +2063,11 @@ class CompletedPlanningResult(ScanTasks):
         alias='storage-credentials',
         description='Storage credentials for accessing the files returned in the scan result.\nIf the server returns storage credentials as part of the completed scan planning response, the expectation is for the client to use these credentials to read the files returned in the FileScanTasks as part of the scan result.',
     )
+    key_management_credentials: list[KeyManagementCredential] | None = Field(
+        None,
+        alias='key-management-credentials',
+        description='KMS credentials for encrypted files returned in the scan result.\nIf the server returns key-management credentials as part of the completed scan planning response, the expectation is for the client to use these credentials to access the KMS keys required to read encrypted files returned in the FileScanTasks as part of the scan result.',
+    )
 
 
 class FetchScanTasksResult(ScanTasks):
@@ -2229,10 +2087,6 @@ class FunctionDataType(
         ...,
         description='A type for function parameters or return value. It is encoded either as a type string or as a JSON object for nested types (struct, list, map) following the UDF spec Types section.\n\nPrimitive and semi-structured type strings are encoded based on the Iceberg type JSON representation (e.g., "int", "string", "timestamp", "decimal(9,2)", "variant"). Type strings must contain no spaces or quote characters.\n\nNested types are based on the Iceberg type JSON representation, but the UDF spec only requires a subset of fields (e.g., list requires `type` and `element`; map requires `type`, `key`, and `value`; struct requires `type` and `fields`). Any other fields must be ignored.\n',
     )
-
-
-class FunctionArgument(RootModel[ValueExpression | Predicate]):
-    root: ValueExpression | Predicate
 
 
 class CompletedPlanningWithIDResult(CompletedPlanningResult):
@@ -2279,12 +2133,8 @@ class PlanTableScanResult(
 StructField.model_rebuild()
 ListType.model_rebuild()
 MapType.model_rebuild()
-AndOrPredicate.model_rebuild()
-NotPredicate.model_rebuild()
-UnaryPredicate.model_rebuild()
-ComparisonPredicate.model_rebuild()
-SetPredicate.model_rebuild()
-Apply.model_rebuild()
+AndOrExpression.model_rebuild()
+NotExpression.model_rebuild()
 TableMetadata.model_rebuild()
 ViewMetadata.model_rebuild()
 AddSchemaUpdate.model_rebuild()

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -152,6 +152,11 @@ class ExpressionType(RootModel[str]):
 
 
 class TrueExpression(BaseModel):
+    """
+    Deprecated. Use the bare boolean literal `true` as a predicate instead.
+
+    """
+
     type: Literal['true'] = Field(
         ...,
         examples=[
@@ -181,6 +186,11 @@ class TrueExpression(BaseModel):
 
 
 class FalseExpression(BaseModel):
+    """
+    Deprecated. Use the bare boolean literal `false` as a predicate instead.
+
+    """
+
     type: Literal['false'] = Field(
         ...,
         examples=[
@@ -209,8 +219,49 @@ class FalseExpression(BaseModel):
     )
 
 
-class Reference(RootModel[str]):
-    root: str = Field(..., examples=[['column-name']])
+class IdReference(BaseModel):
+    """
+    A bound reference to a field by field ID.
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['reference']
+    id: int
+
+
+class NamedReference(BaseModel):
+    """
+    An unbound reference to a field by name.
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['reference']
+    name: str
+
+
+class Function(RootModel[str]):
+    root: str = Field(..., min_length=1)
+
+
+class Function1(BaseModel):
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    catalog: str | None = None
+    identifier: CatalogObjectIdentifier
+
+
+class TermReference(RootModel[str]):
+    root: str = Field(
+        ...,
+        deprecated=True,
+        description='Deprecated string-form field reference used in older REST predicates. Use Reference (IdReference or NamedReference) instead.\n',
+        examples=[['column-name']],
+    )
 
 
 class Transform(RootModel[str]):
@@ -269,11 +320,10 @@ class Summary(BaseModel):
     model_config = ConfigDict(
         extra='allow',
     )
+    __annotations__ = {
+        '__pydantic_extra__': Dict[str, str],
+    }
     operation: Literal['append', 'replace', 'overwrite', 'delete']
-
-
-Summary.__annotations__['__pydantic_extra__'] = Dict[str, str]
-Summary.model_rebuild(force=True)
 
 
 class Snapshot(BaseModel):
@@ -601,7 +651,7 @@ class KeyManagementCredential(BaseModel):
     Catalogs that return `key-management-credentials` for an operation must include credentials for all
     KMS key IDs required by table encryption metadata. Clients should select the credential config by
     matching KMS key identifiers referenced by table encryption metadata, such as
-    `EncryptedKey.encrypted-by-id`, against `kms-key-ids`.
+    `encrypted-by-id` fields in table encryption metadata, against `kms-key-ids`.
 
     Credential configs should use provider-specific expiration mechanisms where available and should
     be scoped to the minimum required KMS operations and listed KMS key IDs where the provider
@@ -612,7 +662,7 @@ class KeyManagementCredential(BaseModel):
     kms_key_ids: list[str] = Field(
         ...,
         alias='kms-key-ids',
-        description='KMS key identifiers for which the credential config is relevant.\n\nClients should match these values against KMS key identifiers referenced by table encryption\nmetadata, such as `EncryptedKey.encrypted-by-id`.\n',
+        description='KMS key identifiers for which the credential config is relevant.\n\nClients should match these values against KMS key identifiers referenced by table encryption\nmetadata, such as `encrypted-by-id` fields in table encryption metadata.\n',
     )
     config: dict[str, str] = Field(
         ...,
@@ -1155,6 +1205,21 @@ class RemoteSignResult(BaseModel):
     headers: MultiValuedMap
 
 
+class RemoteSigningConfig(BaseModel):
+    """
+    Configuration for the remote signer client.
+    """
+
+    properties: dict[str, str] | None = Field(
+        None,
+        description='Static key-value pairs the signer client MUST pass through unchanged in the `properties` field of every `RemoteSignRequest` sent to the signing endpoint.\n',
+    )
+    headers: MultiValuedMap | None = Field(
+        None,
+        description='Static headers the signer client MUST include unchanged in every request to the signing endpoint.\n',
+    )
+
+
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: dict[str, str] | None = Field(
@@ -1169,10 +1234,64 @@ class RenameTableRequest(BaseModel):
     destination: TableIdentifier
 
 
+class Literal1(BaseModel):
+    """
+    A literal is either a bare value, an untyped literal object, or a typed literal object.
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['literal']
+    value: PrimitiveTypeValue
+    data_type: PrimitiveType | None = Field(None, alias='data-type')
+
+
+class LiteralModel(RootModel[PrimitiveTypeValue | Literal1]):
+    root: PrimitiveTypeValue | Literal1 = Field(
+        ...,
+        description='A literal is either a bare value, an untyped literal object, or a typed literal object.\n',
+    )
+
+
+class Literals1(BaseModel):
+    """
+    Literals is either a bare array of literals or a typed object with an explicit data-type applied to all values.
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['literals']
+    values: list[PrimitiveTypeValue]
+    data_type: PrimitiveType = Field(..., alias='data-type')
+
+
+class Literals(RootModel[list[LiteralModel] | Literals1]):
+    root: list[LiteralModel] | Literals1 = Field(
+        ...,
+        description='Literals is either a bare array of literals or a typed object with an explicit data-type applied to all values.\n',
+    )
+
+
+class Reference(RootModel[IdReference | NamedReference]):
+    root: IdReference | NamedReference = Field(
+        ...,
+        description='A reference to a field. Either a bound reference (by field ID) or an unbound reference (by name). The context in which an expression is used determines which form is valid.\n',
+    )
+
+
 class TransformTerm(BaseModel):
+    """
+    Deprecated. Legacy transform-applied-to-a-term form. Use Apply with a Reference argument instead.
+
+    """
+
     type: Literal['transform']
     transform: Transform
-    term: Reference
+    term: TermReference
 
 
 class SetPartitionStatisticsUpdate(BaseUpdate):
@@ -1281,8 +1400,12 @@ class FetchScanTasksRequest(BaseModel):
     plan_task: PlanTask = Field(..., alias='plan-task')
 
 
-class Term(RootModel[Reference | TransformTerm]):
-    root: Reference | TransformTerm
+class Term(RootModel[TermReference | TransformTerm]):
+    root: TermReference | TransformTerm = Field(
+        ...,
+        deprecated=True,
+        description='Deprecated. Legacy term form used by older REST predicates. Use Reference or Apply instead.\n',
+    )
 
 
 class SetStatisticsUpdate(BaseUpdate):
@@ -1320,100 +1443,6 @@ class FunctionDefinitionVersion(BaseModel):
     )
 
 
-class UnaryExpression(BaseModel):
-    type: Literal['is-null', 'not-null', 'is-nan', 'not-nan'] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    term: Term
-
-
-class LiteralExpression(BaseModel):
-    type: Literal[
-        'lt', 'lt-eq', 'gt', 'gt-eq', 'eq', 'not-eq', 'starts-with', 'not-starts-with'
-    ] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    term: Term
-    value: PrimitiveTypeValue
-
-
-class SetExpression(BaseModel):
-    type: Literal['in', 'not-in'] = Field(
-        ...,
-        examples=[
-            [
-                'true',
-                'false',
-                'eq',
-                'and',
-                'or',
-                'not',
-                'in',
-                'not-in',
-                'lt',
-                'lt-eq',
-                'gt',
-                'gt-eq',
-                'not-eq',
-                'starts-with',
-                'not-starts-with',
-                'is-null',
-                'not-null',
-                'is-nan',
-                'not-nan',
-            ]
-        ],
-    )
-    term: Term
-    values: list[PrimitiveTypeValue]
-
-
 class StructField(BaseModel):
     id: int
     name: str
@@ -1445,7 +1474,7 @@ class MapType(BaseModel):
     value_required: bool = Field(..., alias='value-required')
 
 
-class AndOrExpression(BaseModel):
+class AndOrPredicate(BaseModel):
     type: Literal['and', 'or'] = Field(
         ...,
         examples=[
@@ -1472,11 +1501,11 @@ class AndOrExpression(BaseModel):
             ]
         ],
     )
-    left: Expression
-    right: Expression
+    left: Predicate
+    right: Predicate
 
 
-class NotExpression(BaseModel):
+class NotPredicate(BaseModel):
     type: Literal['not'] = Field(
         ...,
         examples=[
@@ -1503,7 +1532,151 @@ class NotExpression(BaseModel):
             ]
         ],
     )
-    child: Expression
+    child: Predicate
+
+
+class UnaryPredicate(BaseModel):
+    """
+    A predicate that tests a single value expression. Accepts either 'child' (preferred) or 'term' (deprecated) to identify the operand.
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['is-null', 'not-null', 'is-nan', 'not-nan'] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    child: ValueExpression | None = None
+    term: Term | None = Field(
+        None, deprecated=True, description="Deprecated. Use 'child' instead."
+    )
+
+
+class ComparisonPredicate(BaseModel):
+    """
+    A predicate that compares two value expressions. Accepts either 'left'/'right' (preferred) or 'term'/'value' (deprecated).
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal[
+        'lt', 'lt-eq', 'gt', 'gt-eq', 'eq', 'not-eq', 'starts-with', 'not-starts-with'
+    ] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    left: ValueExpression | None = None
+    right: ValueExpression | None = None
+    term: Term | None = Field(
+        None, deprecated=True, description="Deprecated. Use 'left' instead."
+    )
+    value: LiteralModel | None = Field(
+        None, deprecated=True, description="Deprecated. Use 'right' instead."
+    )
+
+
+class SetPredicate(BaseModel):
+    """
+    A predicate that tests whether a value is in a set of literals. Accepts either 'child' (preferred) or 'term' (deprecated) to identify the operand.
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['in', 'not-in'] = Field(
+        ...,
+        examples=[
+            [
+                'true',
+                'false',
+                'eq',
+                'and',
+                'or',
+                'not',
+                'in',
+                'not-in',
+                'lt',
+                'lt-eq',
+                'gt',
+                'gt-eq',
+                'not-eq',
+                'starts-with',
+                'not-starts-with',
+                'is-null',
+                'not-null',
+                'is-nan',
+                'not-nan',
+            ]
+        ],
+    )
+    child: ValueExpression | None = None
+    term: Term | None = Field(
+        None, deprecated=True, description="Deprecated. Use 'child' instead."
+    )
+    values: Literals
+
+
+class Apply(BaseModel):
+    """
+    A function application on zero or more value expressions or predicates.
+
+    """
+
+    model_config = ConfigDict(
+        extra='forbid',
+    )
+    type: Literal['apply']
+    function: Function | CatalogObjectIdentifier | Function1
+    arguments: list[FunctionArgument]
 
 
 class TableMetadata(BaseModel):
@@ -1599,15 +1772,21 @@ class LoadTableResult(BaseModel):
     ## Key Management Credentials
 
     Credentials for KMS / key-management systems are provided through the `key-management-credentials` field.
-    Clients must first check whether the respective credentials exist in the `key-management-credentials`
-    field before checking the `config` for credentials.
-    Clients must use `key-management-credentials` consistently with the REST access-delegation credential sourcing rules.
+    Clients must first check whether KMS credentials exist in the `key-management-credentials`
+    field before checking the `config` map for KMS credential configuration.
+    Clients must use `key-management-credentials`, if present, consistently with the REST access-delegation credential sourcing rules.
 
     ## Remote Signing
 
-    If remote signing for a specific storage provider is enabled, clients must respect the following configurations when creating a remote signer client:
-     - `signer.endpoint`: the remote signer endpoint. Required. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
-     - `signer.uri`: the base URI to resolve `signer.endpoint` against. Optional. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+    If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
+    field to communicate all signer client settings. When the `remote-signing-config` field is present, clients
+    SHOULD respect the provided configuration.
+
+    For backward compatibility, the following `config` properties are still supported but **DEPRECATED** and SHOULD NOT be used by clients able to consume the remote signing configuration:
+     - `signer.endpoint` **DEPRECATED**.: the remote signer endpoint. Can either be a relative path (to be resolved against `signer.uri`) or an absolute URI.
+     - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
+    If any of these properties is present, clients SHOULD use them to compute the actual remote signing endpoint URI to contact.
+    If none of these properties is present, clients SHOULD contact the default remote signing endpoint using the catalog's base URI.
 
     """
 
@@ -1620,6 +1799,9 @@ class LoadTableResult(BaseModel):
     config: dict[str, str] | None = None
     storage_credentials: list[StorageCredential] | None = Field(
         None, alias='storage-credentials'
+    )
+    remote_signing_config: RemoteSigningConfig | None = Field(
+        None, alias='remote-signing-config'
     )
     key_management_credentials: list[KeyManagementCredential] | None = Field(
         None, alias='key-management-credentials'
@@ -1740,7 +1922,7 @@ class LoadViewResult(BaseModel):
 class ScanReport(BaseModel):
     table_name: str = Field(..., alias='table-name')
     snapshot_id: int = Field(..., alias='snapshot-id')
-    filter: Expression
+    filter: Predicate
     schema_id: int = Field(..., alias='schema-id')
     projected_field_ids: list[int] = Field(..., alias='projected-field-ids')
     projected_field_names: list[str] = Field(..., alias='projected-field-names')
@@ -1892,8 +2074,8 @@ class PlanTableScanRequest(BaseModel):
     select: list[FieldName] | None = Field(
         None, description='List of selected schema fields'
     )
-    filter: Expression | None = Field(
-        None, description='Expression used to filter the table data'
+    filter: Predicate | None = Field(
+        None, description='Predicate used to filter the table data'
     )
     min_rows_requested: int | None = Field(
         None,
@@ -1934,7 +2116,7 @@ class FileScanTask(BaseModel):
         alias='delete-file-references',
         description='A list of indices in the delete files array (0-based)',
     )
-    residual_filter: Expression | None = Field(
+    residual_filter: Predicate | None = Field(
         None,
         alias='residual-filter',
         description='An optional filter to be applied to rows in this file scan task.\nIf the residual is not present, the client must produce the residual or use the original filter.',
@@ -1950,25 +2132,34 @@ class Type(RootModel[PrimitiveType | StructType | ListType | MapType]):
     root: PrimitiveType | StructType | ListType | MapType
 
 
-class Expression(
+class Predicate(
     RootModel[
-        TrueExpression
+        bool
+        | TrueExpression
         | FalseExpression
-        | AndOrExpression
-        | NotExpression
-        | SetExpression
-        | LiteralExpression
-        | UnaryExpression
+        | AndOrPredicate
+        | NotPredicate
+        | UnaryPredicate
+        | ComparisonPredicate
+        | SetPredicate
     ]
 ):
     root: (
-        TrueExpression
+        bool
+        | TrueExpression
         | FalseExpression
-        | AndOrExpression
-        | NotExpression
-        | SetExpression
-        | LiteralExpression
-        | UnaryExpression
+        | AndOrPredicate
+        | NotPredicate
+        | UnaryPredicate
+        | ComparisonPredicate
+        | SetPredicate
+    )
+
+
+class ValueExpression(RootModel[LiteralModel | Reference | Apply]):
+    root: LiteralModel | Reference | Apply = Field(
+        ...,
+        description='A value expression: a literal, a field reference, or a function application.\n',
     )
 
 
@@ -2089,6 +2280,10 @@ class FunctionDataType(
     )
 
 
+class FunctionArgument(RootModel[ValueExpression | Predicate]):
+    root: ValueExpression | Predicate
+
+
 class CompletedPlanningWithIDResult(CompletedPlanningResult):
     plan_id: str = Field(
         ..., alias='plan-id', description='ID used to track a planning request'
@@ -2133,8 +2328,12 @@ class PlanTableScanResult(
 StructField.model_rebuild()
 ListType.model_rebuild()
 MapType.model_rebuild()
-AndOrExpression.model_rebuild()
-NotExpression.model_rebuild()
+AndOrPredicate.model_rebuild()
+NotPredicate.model_rebuild()
+UnaryPredicate.model_rebuild()
+ComparisonPredicate.model_rebuild()
+SetPredicate.model_rebuild()
+Apply.model_rebuild()
 TableMetadata.model_rebuild()
 ViewMetadata.model_rebuild()
 AddSchemaUpdate.model_rebuild()

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2150,12 +2150,15 @@ components:
         Specific properties and handling for `vended-credentials`, `remote-signing`, and `kms-vended-credentials`
         are documented in the `LoadTableResult` schema section of this spec document.
 
-        For encrypted table operations, delegated credential sourcing should be consistent. If a catalog
-        honors REST access delegation for an encrypted table operation, it should provide all delegated
-        credentials required for that operation, including storage credentials and KMS credentials. Clients
-        must not be required to combine catalog-vended storage credentials with client-local or static KMS
-        credentials. If REST access delegation is not used or not honored, the catalog must not return
-        delegated credentials, and the client is responsible for providing all required credentials locally.
+        `kms-vended-credentials` does not subsume `vended-credentials`. Clients that support both storage
+        and KMS credential vending should request both mechanisms for encrypted table operations.
+
+        For encrypted table operations, delegated credential sourcing should be consistent across storage
+        and KMS access. If a catalog honors REST access delegation for such an operation, it should return
+        all delegated credentials required by the operation, including storage credentials and KMS
+        credentials. If the catalog cannot return the complete delegated credential set, it should not
+        return partial delegated credentials for that operation; the client remains responsible for
+        providing all credentials locally.
 
       required: false
       schema:
@@ -3852,9 +3855,10 @@ components:
         selected key-management provider.
 
         Clients should select the credential config by matching KMS key identifiers referenced by table
-        encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If no
-        key-management credential matches a KMS key ID required by table encryption metadata, the client
-        must fail the operation with an authorization or missing-credential error.
+        encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If a response
+        includes `key-management-credentials` but no credential matches a KMS key ID required by table
+        encryption metadata, the client must fail the operation with an authorization or missing-credential
+        error.
 
         Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
         and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3857,7 +3857,7 @@ components:
         Catalogs that return `key-management-credentials` for an operation must include credentials for all
         KMS key IDs required by table encryption metadata. Clients should select the credential config by
         matching KMS key identifiers referenced by table encryption metadata, such as
-        `EncryptedKey.encrypted-by-id`, against `kms-key-ids`.
+        `encrypted-by-id` fields in table encryption metadata, against `kms-key-ids`.
 
         Credential configs should use provider-specific expiration mechanisms where available and should
         be scoped to the minimum required KMS operations and listed KMS key IDs where the provider
@@ -3872,7 +3872,7 @@ components:
             KMS key identifiers for which the credential config is relevant.
 
             Clients should match these values against KMS key identifiers referenced by table encryption
-            metadata, such as `EncryptedKey.encrypted-by-id`.
+            metadata, such as `encrypted-by-id` fields in table encryption metadata.
           items:
             type: string
         config:
@@ -3934,9 +3934,9 @@ components:
         ## Key Management Credentials
 
         Credentials for KMS / key-management systems are provided through the `key-management-credentials` field.
-        Clients must first check whether the respective credentials exist in the `key-management-credentials`
-        field before checking the `config` for credentials.
-        Clients must use `key-management-credentials` consistently with the REST access-delegation credential sourcing rules.
+        Clients must first check whether KMS credentials exist in the `key-management-credentials`
+        field before checking the `config` map for KMS credential configuration.
+        Clients must use `key-management-credentials`, if present, consistently with the REST access-delegation credential sourcing rules.
 
         ## Remote Signing
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2147,8 +2147,15 @@ components:
         to supply access via any or none of the requested mechanisms.
 
 
-        Specific properties and handling for `vended-credentials` and `remote-signing`
+        Specific properties and handling for `vended-credentials`, `remote-signing`, and `kms-vended-credentials`
         are documented in the `LoadTableResult` schema section of this spec document.
+
+        For encrypted table operations, delegated credential sourcing should be consistent. If a catalog
+        honors REST access delegation for an encrypted table operation, it should provide all delegated
+        credentials required for that operation, including storage credentials and KMS credentials. Clients
+        must not be required to combine catalog-vended storage credentials with client-local or static KMS
+        credentials. If REST access delegation is not used or not honored, the catalog must not return
+        delegated credentials, and the client is responsible for providing all required credentials locally.
 
       required: false
       schema:
@@ -2158,9 +2165,10 @@ components:
           enum:
             - vended-credentials
             - remote-signing
+            - kms-vended-credentials
       style: simple
       explode: false
-      example: "vended-credentials,remote-signing"
+      example: "vended-credentials,remote-signing,kms-vended-credentials"
 
     page-token:
       name: pageToken
@@ -3833,6 +3841,43 @@ components:
           additionalProperties:
             type: string
 
+    KeyManagementCredential:
+      type: object
+      description: |
+        Provider-specific credential config for accessing one or more KMS keys required by an encrypted
+        table operation.
+
+        The key-management provider is advertised in catalog configuration, such as `encryption.kms-type`
+        returned from `/v1/config`. The `config` map contains provider-specific properties for the
+        selected key-management provider.
+
+        Clients should select the credential config by matching KMS key identifiers referenced by table
+        encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If no
+        key-management credential matches a KMS key ID required by table encryption metadata, the client
+        must fail the operation with an authorization or missing-credential error.
+
+        Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
+        and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond
+        their expiration.
+      required:
+        - kms-key-ids
+        - config
+      properties:
+        kms-key-ids:
+          type: array
+          description: |
+            KMS key identifiers for which the credential config is relevant.
+
+            Clients should match these values against KMS key identifiers referenced by table encryption
+            metadata, such as `EncryptedKey.encrypted-by-id`.
+          items:
+            type: string
+        config:
+          type: object
+          description: Provider-specific credential configuration for accessing the listed KMS key IDs.
+          additionalProperties:
+            type: string
+
     LoadCredentialsResponse:
       type: object
       required:
@@ -3842,6 +3887,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/StorageCredential'
+        key-management-credentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/KeyManagementCredential'
 
     LoadTableResult:
       description: |
@@ -3879,6 +3928,13 @@ components:
         Credentials for ADLS / GCS / S3 / ... are provided through the `storage-credentials` field.
         Clients must first check whether the respective credentials exist in the `storage-credentials` field before checking the `config` for credentials.
 
+        ## Key Management Credentials
+
+        Credentials for KMS / key-management systems are provided through the `key-management-credentials` field.
+        Clients must first check whether the respective credentials exist in the `key-management-credentials`
+        field before checking the `config` for credentials.
+        Clients must use `key-management-credentials` consistently with the REST access-delegation credential sourcing rules.
+
         ## Remote Signing
 
         If remote signing for a specific storage provider is enabled, the server SHOULD use the `remote-signing-config`
@@ -3911,6 +3967,10 @@ components:
             $ref: '#/components/schemas/StorageCredential'
         remote-signing-config:
           $ref: '#/components/schemas/RemoteSigningConfig'
+        key-management-credentials:
+          type: array
+          items:
+            $ref: '#/components/schemas/KeyManagementCredential'
 
     ScanTasks:
       type: object
@@ -3968,6 +4028,17 @@ components:
                 to read the files returned in the FileScanTasks as part of the scan result.
               items:
                 $ref: '#/components/schemas/StorageCredential'
+            key-management-credentials:
+              type: array
+              description:
+                KMS credentials for encrypted files returned in the scan result.
+
+                If the server returns key-management credentials as part of the completed scan
+                planning response, the expectation is for the client to use these credentials
+                to access the KMS keys required to read encrypted files returned in the
+                FileScanTasks as part of the scan result.
+              items:
+                $ref: '#/components/schemas/KeyManagementCredential'
 
     CompletedPlanningWithIDResult:
       type: object

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -3854,15 +3854,14 @@ components:
         returned from `/v1/config`. The `config` map contains provider-specific properties for the
         selected key-management provider.
 
-        Clients should select the credential config by matching KMS key identifiers referenced by table
-        encryption metadata, such as `EncryptedKey.encrypted-by-id`, against `kms-key-ids`. If a response
-        includes `key-management-credentials` but no credential matches a KMS key ID required by table
-        encryption metadata, the client must fail the operation with an authorization or missing-credential
-        error.
+        Catalogs that return `key-management-credentials` for an operation must include credentials for all
+        KMS key IDs required by table encryption metadata. Clients should select the credential config by
+        matching KMS key identifiers referenced by table encryption metadata, such as
+        `EncryptedKey.encrypted-by-id`, against `kms-key-ids`.
 
-        Credential configs must be time-bounded and should be scoped to the minimum required KMS operations
-        and listed KMS key IDs where the provider supports it. Clients must not persist credentials beyond
-        their expiration.
+        Credential configs should use provider-specific expiration mechanisms where available and should
+        be scoped to the minimum required KMS operations and listed KMS key IDs where the provider
+        supports it. Clients must not persist credentials beyond any provider-specific expiration.
       required:
         - kms-key-ids
         - config


### PR DESCRIPTION
## Summary

Adds REST KMS credential vending to the spec for Iceberg table encryption.

This extends REST access delegation so catalogs can return short-lived, scoped KMS credentials alongside storage credentials. Clients match vended KMS credentials to KMS key IDs referenced by Iceberg encryption metadata and continue to call the KMS directly.

Original design doc: https://docs.google.com/document/d/1VSewbVmjukU5eTiZruCJVmUZcRZvcAsd4JOeC6Lt3fo

## Changes

This PR adds:

- `kms-vended-credentials` as an access-delegation mechanism
- `encryption.kms-type` as a catalog-level KMS provider/type identifier
- `key-management-credentials` to credential-bearing REST responses
- `KeyManagementCredential`, containing:
  - `kms-key-ids`
  - provider-specific credential `config`
- client matching rules between `kms-key-ids` and `EncryptedKey.encrypted-by-id`
- security guidance for vended KMS credentials, including time-bounded credentials and provider-supported scoping

## Credential sourcing

For encrypted table operations, credential sourcing should be consistent with REST access-delegation rules.

If a catalog honors REST access delegation for an encrypted table operation, it should provide all delegated credentials required for that operation, including storage credentials and KMS credentials.

If REST access delegation is not used or not honored, the client remains responsible for providing the required credentials locally.

## Not included

This PR does not add remote KMS wrap/unwrap APIs.

Remote wrap/unwrap may be useful for some environments and can be proposed separately, but it has a different protocol shape and security model because plaintext Iceberg key material would flow through the catalog API.

This PR focuses on KMS credential vending, where the catalog returns short-lived, scoped KMS credentials and clients continue to call the KMS directly.