### PR TITLE
Parquet: Decode ENUM/JSON columns as UTF-8 in row-group filter conversions

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
@@ -94,6 +94,12 @@ class ParquetConversions {
     if (type.getOriginalType() != null) {
       switch (type.getOriginalType()) {
         case UTF8:
+        case ENUM:
+        case JSON:
+          // ENUM and JSON are UTF-8 strings that map to Iceberg StringType (see MessageTypeToType),
+          // so they must be decoded to a CharSequence like UTF8; otherwise read-time row-group
+          // filters compare a ByteBuffer against a CharSequence literal and throw
+          // ClassCastException
           // decode to CharSequence to avoid copying into a new String
           return binary -> StandardCharsets.UTF_8.decode(((Binary) binary).toByteBuffer());
         case DECIMAL:

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetConversions.java
@@ -96,10 +96,6 @@ class ParquetConversions {
         case UTF8:
         case ENUM:
         case JSON:
-          // ENUM and JSON are UTF-8 strings that map to Iceberg StringType (see MessageTypeToType),
-          // so they must be decoded to a CharSequence like UTF8; otherwise read-time row-group
-          // filters compare a ByteBuffer against a CharSequence literal and throw
-          // ClassCastException
           // decode to CharSequence to avoid copying into a new String
           return binary -> StandardCharsets.UTF_8.decode(((Binary) binary).toByteBuffer());
         case DECIMAL:

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.io.api.Binary;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.PrimitiveType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.junit.jupiter.api.Test;
+
+public class TestParquetConversions {
+
+  private static PrimitiveType binaryWith(LogicalTypeAnnotation annotation) {
+    return org.apache.parquet.schema.Types.required(PrimitiveTypeName.BINARY)
+        .as(annotation)
+        .named("s");
+  }
+
+  @Test
+  public void testStringConverterDecodesUtf8EnumAndJson() {
+    Binary value = Binary.fromString("hello");
+
+    // UTF8, ENUM and JSON all map to Iceberg StringType (MessageTypeToType), so the converter must
+    // decode each to a CharSequence. Before the fix, ENUM/JSON fell through to the binary path and
+    // returned a ByteBuffer, which broke read-time row-group filtering with a ClassCastException.
+    for (LogicalTypeAnnotation annotation :
+        new LogicalTypeAnnotation[] {
+          LogicalTypeAnnotation.stringType(),
+          LogicalTypeAnnotation.enumType(),
+          LogicalTypeAnnotation.jsonType()
+        }) {
+      Object converted =
+          ParquetConversions.converterFromParquet(binaryWith(annotation), Types.StringType.get())
+              .apply(value);
+
+      assertThat(converted)
+          .as("%s should decode to a CharSequence", annotation)
+          .isInstanceOf(CharSequence.class);
+      assertThat(converted.toString()).isEqualTo("hello");
+    }
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetConversions.java
@@ -20,28 +20,24 @@ package org.apache.iceberg.parquet;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.apache.iceberg.types.Types;
+import org.apache.iceberg.types.Types.StringType;
 import org.apache.parquet.io.api.Binary;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestParquetConversions {
+class TestParquetConversions {
 
   private static PrimitiveType binaryWith(LogicalTypeAnnotation annotation) {
-    return org.apache.parquet.schema.Types.required(PrimitiveTypeName.BINARY)
-        .as(annotation)
-        .named("s");
+    return Types.required(PrimitiveTypeName.BINARY).as(annotation).named("s");
   }
 
   @Test
-  public void testStringConverterDecodesUtf8EnumAndJson() {
+  void stringConverterDecodesUtf8EnumAndJson() {
     Binary value = Binary.fromString("hello");
 
-    // UTF8, ENUM and JSON all map to Iceberg StringType (MessageTypeToType), so the converter must
-    // decode each to a CharSequence. Before the fix, ENUM/JSON fell through to the binary path and
-    // returned a ByteBuffer, which broke read-time row-group filtering with a ClassCastException.
     for (LogicalTypeAnnotation annotation :
         new LogicalTypeAnnotation[] {
           LogicalTypeAnnotation.stringType(),
@@ -49,7 +45,7 @@ public class TestParquetConversions {
           LogicalTypeAnnotation.jsonType()
         }) {
       Object converted =
-          ParquetConversions.converterFromParquet(binaryWith(annotation), Types.StringType.get())
+          ParquetConversions.converterFromParquet(binaryWith(annotation), StringType.get())
               .apply(value);
 
       assertThat(converted)

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetricsRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetMetricsRowGroupFilter.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.iceberg.expressions.Expressions.equal;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.stream.Stream;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types.StringType;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
+import org.apache.parquet.schema.Types;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestParquetMetricsRowGroupFilter {
+  @TempDir private File temp;
+
+  private static Stream<LogicalTypeAnnotation> stringAnnotations() {
+    return Stream.of(LogicalTypeAnnotation.enumType(), LogicalTypeAnnotation.jsonType());
+  }
+
+  @ParameterizedTest
+  @MethodSource("stringAnnotations")
+  void annotatedStringsWithoutFieldIds(LogicalTypeAnnotation annotation) throws IOException {
+    MessageType writeSchema =
+        new MessageType("test", Types.optional(PrimitiveTypeName.BINARY).as(annotation).named("s"));
+    File file = new File(temp, "strings.parquet");
+    String value = "\"café\"";
+    try (ParquetWriter<Group> writer =
+        ExampleParquetWriter.builder(ParquetIO.file(Files.localOutput(file)))
+            .withType(writeSchema)
+            .build()) {
+      SimpleGroupFactory groups = new SimpleGroupFactory(writeSchema);
+      writer.write(groups.newGroup().append("s", value));
+    }
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(Files.localInput(file)))) {
+      MessageType fileSchema = reader.getFileMetaData().getSchema();
+      assertThat(ParquetSchemaUtil.hasIds(fileSchema)).isFalse();
+      Schema schema = ParquetSchemaUtil.convert(fileSchema);
+      assertThat(schema.findType("s")).isEqualTo(StringType.get());
+      assertThat(reader.getRowGroups()).hasSize(1);
+      BlockMetaData rowGroup = reader.getRowGroups().get(0);
+      assertThat(rowGroup.getColumns().get(0).getStatistics().hasNonNullValue()).isTrue();
+
+      MessageType schemaWithIds = ParquetSchemaUtil.addFallbackIds(fileSchema);
+      assertThat(
+              new ParquetMetricsRowGroupFilter(schema, equal("s", value))
+                  .shouldRead(schemaWithIds, rowGroup))
+          .isTrue();
+      assertThat(
+              new ParquetMetricsRowGroupFilter(schema, equal("s", "\"aaa\""))
+                  .shouldRead(schemaWithIds, rowGroup))
+          .isFalse();
+      assertThat(
+              new ParquetMetricsRowGroupFilter(schema, equal("s", "\"zzz\""))
+                  .shouldRead(schemaWithIds, rowGroup))
+          .isFalse();
+    }
+  }
+}


### PR DESCRIPTION
`ParquetConversions.converterFromParquet` special-cased only the `UTF8` original type, so for `ENUM`- or `JSON`-annotated Parquet columns it fell through to the binary path and returned a `ByteBuffer`. Iceberg maps both `ENUM` and `JSON` to `StringType` (see `MessageTypeToType`), so at read time the metrics/dictionary row-group filters compared that `ByteBuffer` against a `CharSequence` predicate literal and threw:

```
class java.nio.HeapByteBuffer cannot be cast to class java.lang.CharSequence
```

This is reachable for files written by other engines (e.g. Flink, which uses JSON columns) and added via `add_files`: querying such a column with a predicate triggers row-group filtering.

This change treats `ENUM` and `JSON` like `UTF8` and decodes them to a `CharSequence`. The import/metrics path (`ParquetConversions.convertValue`) already switches on the Iceberg type and was unaffected.

Adds `TestParquetConversions` covering the ENUM/JSON conversion paths.