### PR TITLE
Docs: Update documentation on assume role STS behavior to reflect regional endpoint change

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -69,8 +69,8 @@ public class AwsClientProperties implements Serializable {
 
   /**
    * Used by {@link org.apache.iceberg.aws.AwsClientFactories.DefaultAwsClientFactory} and also
-   * other client factory classes. If set, all AWS clients except STS client will use the given
-   * region instead of the default region chain.
+   * other client factory classes. If set, all AWS clients will use the given region instead of the
+   * default region chain.
    */
   public static final String CLIENT_REGION = "client.region";
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsProperties.java
@@ -154,8 +154,8 @@ public class AwsProperties implements Serializable {
   public static final String CLIENT_ASSUME_ROLE_EXTERNAL_ID = "client.assume-role.external-id";
 
   /**
-   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients except STS client will use
-   * the given region instead of the default region chain.
+   * Used by {@link AssumeRoleAwsClientFactory}. If set, all AWS clients will use the given region
+   * instead of the default region chain.
    *
    * <p>The value must be one of {@link software.amazon.awssdk.regions.Region}, such as 'us-east-1'.
    * For more details, see https://docs.aws.amazon.com/general/latest/gr/rande.html

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -676,7 +676,7 @@ This client factory has the following configurable catalog properties:
 | Property                          | Default                                  | Description                                            |
 | --------------------------------- | ---------------------------------------- | ------------------------------------------------------ |
 | client.assume-role.arn            | null, requires user input                | ARN of the role to assume, e.g. arn:aws:iam::123456789:role/myRoleToAssume  |
-| client.assume-role.region         | null, requires user input                | All AWS clients except the STS client will use the given region instead of the default region chain  |
+| client.assume-role.region         | null, requires user input                | All AWS clients will use the given region instead of the default region chain  |
 | client.assume-role.external-id    | null                                     | An optional [external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)  |
 | client.assume-role.timeout-sec    | 1 hour                                   | Timeout of each assume role session. At the end of the timeout, a new set of role session credentials will be fetched through an STS client.  |
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -106,7 +106,7 @@ Required and optional properties to include while using `sigv4` authentication
 | `rest.session-token`                      | null           | Configure the static session token used for SigV4. |
 | `client.credentials-provider`             | null           | When configured, REST catalog requests will use this provider to get AWS credentials to sign the request instead of reading the default credential chain. |
 | `client.assume-role.arn`            | null, requires user input                | ARN of the role to assume, e.g. arn:aws:iam::123456789:role/myRoleToAssume  |
-| `client.assume-role.region`         | null, requires user input                | All AWS clients except the STS client will use the given region instead of the default region chain  |
+| `client.assume-role.region`         | null, requires user input                | All AWS clients will use the given region instead of the default region chain  |
 | `client.assume-role.external-id`    | null                                     | An optional [external ID](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html)  |
 | `client.assume-role.timeout-sec`    | 1 hour                                   | Timeout of each assume role session. At the end of the timeout, a new set of role session credentials will be fetched through an STS client.  |
 


### PR DESCRIPTION
Updated the assume role documentation to remove the exclusion on the settings being applied to the STS client. #16794 changed the behavior to explicitly add a region to the STS client following the AWS recommended best practices. #10289 flagged that the regional endpoint was now enabled by default in the AWS Java 2.0 SDK.

There was a [documented update that the STS service](https://aws.amazon.com/blogs/security/announcing-upcoming-changes-to-the-aws-security-token-service-global-endpoint/) changed from only being served out of `us-east-1` to becoming regional by default for non opt-in regions. 
> April 18, 2025: AWS has made changes to the AWS Security Token Service (AWS STS) global endpoint (sts.amazonaws.com) in Regions [enabled by default](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-regions.html) to enhance its resiliency and performance. AWS STS requests to the global endpoint are automatically served in the same AWS Region as your workloads. These changes will not be deployed to opt-in Regions. We recommend that you use the appropriate AWS STS regional endpoints. For more information, see [AWS STS global endpoint changes](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_region-endpoints.html#reference_sts_global_endpoint_changes) in the IAM User Guide.

The old behavior to use the global endpoint is now considered [legacy](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html) in the SDK. 
> All new SDK major versions releasing after July 2022 will default to regional. New SDK major versions might remove this setting and use regional behavior. To reduce future impact regarding this change, we recommend you start using regional in your application when possible.

