### PR TITLE
Core: Report metadata file size in commit metrics

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -55,6 +55,7 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
   private String currentMetadataLocation = null;
   private boolean shouldRefresh = true;
   private int version = -1;
+  private volatile Long metadataFileSizeInBytes;
 
   protected BaseMetastoreTableOperations() {}
 
@@ -147,9 +148,11 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
   }
 
   protected String writeNewMetadataIfRequired(boolean newTable, TableMetadata metadata) {
-    return newTable && metadata.metadataFileLocation() != null
-        ? metadata.metadataFileLocation()
-        : writeNewMetadata(metadata, currentVersion() + 1);
+    if (newTable && metadata.metadataFileLocation() != null) {
+      this.metadataFileSizeInBytes = null;
+      return metadata.metadataFileLocation();
+    }
+    return writeNewMetadata(metadata, currentVersion() + 1);
   }
 
   protected String writeNewMetadata(TableMetadata metadata, int newVersion) {
@@ -159,7 +162,8 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
     // write the new metadata
     // use overwrite to avoid negative caching in S3. this is safe because the metadata location is
     // always unique because it includes a UUID.
-    TableMetadataParser.overwrite(metadata, newMetadataLocation);
+    this.metadataFileSizeInBytes =
+        TableMetadataParser.overwriteAndReturnLength(metadata, newMetadataLocation);
 
     return newMetadataLocation.location();
   }
@@ -370,5 +374,10 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
       LOG.warn("Unable to parse version from metadata location: {}", metadataLocation, e);
       return -1;
     }
+  }
+
+  @Override
+  public Long metadataFileSizeInBytes() {
+    return metadataFileSizeInBytes;
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -58,9 +58,12 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.metrics.CommitMetrics;
 import org.apache.iceberg.metrics.CommitMetricsResult;
+import org.apache.iceberg.metrics.CounterResult;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ImmutableCommitMetricsResult;
 import org.apache.iceberg.metrics.ImmutableCommitReport;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.Timer.Timed;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -579,6 +582,18 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         if (event instanceof CreateSnapshotEvent) {
           CreateSnapshotEvent createSnapshotEvent = (CreateSnapshotEvent) event;
 
+          CommitMetricsResult commitMetricsResult =
+              CommitMetricsResult.from(commitMetrics(), createSnapshotEvent.summary());
+          Long metadataFileSizeInBytes = ops().metadataFileSizeInBytes();
+          if (metadataFileSizeInBytes != null) {
+            commitMetricsResult =
+                ImmutableCommitMetricsResult.builder()
+                    .from(commitMetricsResult)
+                    .metadataFileSizeInBytes(
+                        CounterResult.of(MetricsContext.Unit.BYTES, metadataFileSizeInBytes))
+                    .build();
+          }
+
           reporter.report(
               ImmutableCommitReport.builder()
                   .tableName(createSnapshotEvent.tableName())
@@ -586,8 +601,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   .operation(createSnapshotEvent.operation())
                   .sequenceNumber(createSnapshotEvent.sequenceNumber())
                   .metadata(EnvironmentContext.get())
-                  .commitMetrics(
-                      CommitMetricsResult.from(commitMetrics(), createSnapshotEvent.summary()))
+                  .commitMetrics(commitMetricsResult)
                   .build());
         }
       }

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -45,6 +45,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptingFileIO;
@@ -58,9 +59,12 @@ import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.metrics.CommitMetrics;
 import org.apache.iceberg.metrics.CommitMetricsResult;
+import org.apache.iceberg.metrics.CounterResult;
 import org.apache.iceberg.metrics.DefaultMetricsContext;
+import org.apache.iceberg.metrics.ImmutableCommitMetricsResult;
 import org.apache.iceberg.metrics.ImmutableCommitReport;
 import org.apache.iceberg.metrics.LoggingMetricsReporter;
+import org.apache.iceberg.metrics.MetricsContext;
 import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.metrics.Timer.Timed;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
@@ -480,6 +484,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   public void commit() {
     // this is always set to the latest commit attempt's snapshot id.
     AtomicLong newSnapshotId = new AtomicLong(-1L);
+    // this is always set to the metadata file size written by the latest commit attempt, and stays
+    // null when the table operations implementation cannot report it
+    AtomicReference<Long> metadataFileSizeInBytes = new AtomicReference<>();
     try (Timed ignore = commitMetrics().totalDuration().start()) {
       try {
         Tasks.foreach(ops)
@@ -520,6 +527,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   // to ensure that if a concurrent operation assigns the UUID, this operation will
                   // not fail.
                   taskOps.commit(base, updated.withUUID());
+                  metadataFileSizeInBytes.set(taskOps.metadataFileSizeInBytes());
                 });
 
       } catch (CommitStateUnknownException commitStateUnknownException) {
@@ -564,13 +572,13 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
     }
 
     try {
-      notifyListeners();
+      notifyListeners(metadataFileSizeInBytes.get());
     } catch (Throwable e) {
       LOG.warn("Failed to notify event listeners", e);
     }
   }
 
-  private void notifyListeners() {
+  private void notifyListeners(Long metadataFileSizeInBytes) {
     try {
       Object event = updateEvent();
       if (event != null) {
@@ -579,6 +587,17 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         if (event instanceof CreateSnapshotEvent) {
           CreateSnapshotEvent createSnapshotEvent = (CreateSnapshotEvent) event;
 
+          CommitMetricsResult commitMetricsResult =
+              CommitMetricsResult.from(commitMetrics(), createSnapshotEvent.summary());
+          if (metadataFileSizeInBytes != null) {
+            commitMetricsResult =
+                ImmutableCommitMetricsResult.builder()
+                    .from(commitMetricsResult)
+                    .metadataFileSizeInBytes(
+                        CounterResult.of(MetricsContext.Unit.BYTES, metadataFileSizeInBytes))
+                    .build();
+          }
+
           reporter.report(
               ImmutableCommitReport.builder()
                   .tableName(createSnapshotEvent.tableName())
@@ -586,8 +605,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                   .operation(createSnapshotEvent.operation())
                   .sequenceNumber(createSnapshotEvent.sequenceNumber())
                   .metadata(EnvironmentContext.get())
-                  .commitMetrics(
-                      CommitMetricsResult.from(commitMetrics(), createSnapshotEvent.summary()))
+                  .commitMetrics(commitMetricsResult)
                   .build());
         }
       }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -125,13 +126,37 @@ public class TableMetadataParser {
 
   public static void internalWrite(
       TableMetadata metadata, OutputFile outputFile, boolean overwrite) {
+    writeMetadata(metadata, outputFile, overwrite);
+  }
+
+  public static long writeAndReturnLength(TableMetadata metadata, OutputFile outputFile) {
+    PositionOutputStream outputStream = writeMetadata(metadata, outputFile, false);
+    return metadataLength(outputStream, outputFile.location());
+  }
+
+  public static long overwriteAndReturnLength(TableMetadata metadata, OutputFile outputFile) {
+    PositionOutputStream outputStream = writeMetadata(metadata, outputFile, true);
+    return metadataLength(outputStream, outputFile.location());
+  }
+
+  private static long metadataLength(PositionOutputStream stream, String location) {
+    try {
+      return stream.storedLength();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to read stored length for file: %s", location);
+    }
+  }
+
+  private static PositionOutputStream writeMetadata(
+      TableMetadata metadata, OutputFile outputFile, boolean overwrite) {
     boolean isGzip = Codec.fromFileName(outputFile.location()) == Codec.GZIP;
-    OutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
+    PositionOutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
     try (OutputStream ou = isGzip ? new GZIPOutputStream(stream) : stream;
         OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8)) {
       JsonGenerator generator = JsonUtil.factory().createGenerator(writer);
       toJson(metadata, generator);
       generator.flush();
+      return stream;
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile.location());
     }

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -125,13 +126,32 @@ public class TableMetadataParser {
 
   public static void internalWrite(
       TableMetadata metadata, OutputFile outputFile, boolean overwrite) {
+    writeMetadata(metadata, outputFile, overwrite);
+  }
+
+  public static long writeAndReturnLength(TableMetadata metadata, OutputFile outputFile) {
+    return writeMetadata(metadata, outputFile, false);
+  }
+
+  public static long overwriteAndReturnLength(TableMetadata metadata, OutputFile outputFile) {
+    return writeMetadata(metadata, outputFile, true);
+  }
+
+  private static long writeMetadata(
+      TableMetadata metadata, OutputFile outputFile, boolean overwrite) {
     boolean isGzip = Codec.fromFileName(outputFile.location()) == Codec.GZIP;
-    OutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
-    try (OutputStream ou = isGzip ? new GZIPOutputStream(stream) : stream;
-        OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8);
-        JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
-      toJson(metadata, generator);
-      generator.flush();
+    PositionOutputStream stream = overwrite ? outputFile.createOrOverwrite() : outputFile.create();
+    try {
+      try (OutputStream ou = isGzip ? new GZIPOutputStream(stream) : stream;
+          OutputStreamWriter writer = new OutputStreamWriter(ou, StandardCharsets.UTF_8);
+          JsonGenerator generator = JsonUtil.factory().createGenerator(writer)) {
+        toJson(metadata, generator);
+        generator.flush();
+      }
+
+      // gzip and encrypting streams write trailing bytes when closed, so the stored length is
+      // only final once the stream above has been closed
+      return stream.storedLength();
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to write json to file: %s", outputFile.location());
     }

--- a/core/src/main/java/org/apache/iceberg/TableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/TableOperations.java
@@ -127,4 +127,17 @@ public interface TableOperations {
   default boolean requireStrictCleanup() {
     return true;
   }
+
+  /**
+   * Returns the size in bytes of the metadata file written for the most recent commit handled by
+   * this table operations instance.
+   *
+   * <p>This value is optional and may be unavailable for implementations that do not write metadata
+   * files directly or cannot determine the final stored length at write time.
+   *
+   * @return metadata file size in bytes, or null if unavailable
+   */
+  default Long metadataFileSizeInBytes() {
+    return null;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopTableOperations.java
@@ -68,6 +68,7 @@ public class HadoopTableOperations implements TableOperations {
   private volatile TableMetadata currentMetadata = null;
   private volatile Integer version = null;
   private volatile boolean shouldRefresh = true;
+  private volatile Long metadataFileSizeInBytes = null;
 
   protected HadoopTableOperations(
       Path location, FileIO fileIO, Configuration conf, LockManager lockManager) {
@@ -152,7 +153,9 @@ public class HadoopTableOperations implements TableOperations {
     TableMetadataParser.Codec codec = TableMetadataParser.Codec.fromName(codecName);
     String fileExtension = TableMetadataParser.getFileExtension(codec);
     Path tempMetadataFile = metadataPath(UUID.randomUUID() + fileExtension);
-    TableMetadataParser.write(metadata, io().newOutputFile(tempMetadataFile.toString()));
+    this.metadataFileSizeInBytes =
+        TableMetadataParser.writeAndReturnLength(
+            metadata, io().newOutputFile(tempMetadataFile.toString()));
 
     int nextVersion = (current.first() != null ? current.first() : 0) + 1;
     Path finalMetadataFile = metadataFilePath(nextVersion, codec);
@@ -169,6 +172,11 @@ public class HadoopTableOperations implements TableOperations {
     CatalogUtil.deleteRemovedMetadataFiles(io(), base, metadata);
 
     this.shouldRefresh = true;
+  }
+
+  @Override
+  public Long metadataFileSizeInBytes() {
+    return metadataFileSizeInBytes;
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/metrics/CommitMetricsResult.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/CommitMetricsResult.java
@@ -56,6 +56,7 @@ public interface CommitMetricsResult {
   String CREATED_MANIFESTS_COUNT = "manifests-created";
   String REPLACED_MANIFESTS_COUNT = "manifests-replaced";
   String PROCESSED_MANIFEST_ENTRY_COUNT = "manifest-entries-processed";
+  String METADATA_FILE_SIZE_BYTES = "metadata-file-size-bytes";
 
   @Nullable
   TimerResult totalDuration();
@@ -162,6 +163,12 @@ public interface CommitMetricsResult {
   @Nullable
   @Value.Default
   default CounterResult manifestEntriesProcessed() {
+    return null;
+  }
+
+  @Nullable
+  @Value.Default
+  default CounterResult metadataFileSizeInBytes() {
     return null;
   }
 

--- a/core/src/main/java/org/apache/iceberg/metrics/CommitMetricsResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/CommitMetricsResultParser.java
@@ -191,6 +191,11 @@ class CommitMetricsResultParser {
       CounterResultParser.toJson(metrics.manifestEntriesProcessed(), gen);
     }
 
+    if (null != metrics.metadataFileSizeInBytes()) {
+      gen.writeFieldName(CommitMetricsResult.METADATA_FILE_SIZE_BYTES);
+      CounterResultParser.toJson(metrics.metadataFileSizeInBytes(), gen);
+    }
+
     gen.writeEndObject();
   }
 
@@ -254,6 +259,8 @@ class CommitMetricsResultParser {
         .manifestsKept(CounterResultParser.fromJson(CommitMetricsResult.KEPT_MANIFESTS_COUNT, json))
         .manifestEntriesProcessed(
             CounterResultParser.fromJson(CommitMetricsResult.PROCESSED_MANIFEST_ENTRY_COUNT, json))
+        .metadataFileSizeInBytes(
+            CounterResultParser.fromJson(CommitMetricsResult.METADATA_FILE_SIZE_BYTES, json))
         .build();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
+++ b/core/src/test/java/org/apache/iceberg/TestCommitReporting.java
@@ -90,6 +90,7 @@ public class TestCommitReporting extends TestBase {
     assertThat(metrics.manifestsCreated().value()).isEqualTo(1L);
     assertThat(metrics.manifestsKept().value()).isEqualTo(0L);
     assertThat(metrics.manifestsReplaced().value()).isEqualTo(1L);
+    assertThat(metrics.metadataFileSizeInBytes()).isNull();
   }
 
   @TestTemplate
@@ -140,6 +141,7 @@ public class TestCommitReporting extends TestBase {
     assertThat(metrics.manifestsCreated().value()).isEqualTo(1L);
     assertThat(metrics.manifestsKept().value()).isEqualTo(0L);
     assertThat(metrics.manifestsReplaced().value()).isEqualTo(0L);
+    assertThat(metrics.metadataFileSizeInBytes()).isNull();
 
     // now remove those 2 positional + 1 equality delete files
     table
@@ -183,6 +185,7 @@ public class TestCommitReporting extends TestBase {
     assertThat(metrics.manifestsCreated().value()).isEqualTo(1L);
     assertThat(metrics.manifestsKept().value()).isEqualTo(0L);
     assertThat(metrics.manifestsReplaced().value()).isEqualTo(1L);
+    assertThat(metrics.metadataFileSizeInBytes()).isNull();
   }
 
   @TestTemplate
@@ -212,5 +215,6 @@ public class TestCommitReporting extends TestBase {
     assertThat(metrics.manifestsKept().value()).isEqualTo(0L);
     assertThat(metrics.manifestsReplaced().value()).isEqualTo(2L);
     assertThat(metrics.manifestEntriesProcessed().value()).isEqualTo(2L);
+    assertThat(metrics.metadataFileSizeInBytes()).isNull();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -58,6 +59,9 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -505,5 +509,32 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     @Override
     public void initialize(Map<String, String> properties) {}
+  }
+
+  @Test
+  public void testCommitReportContainsMetadataFileSizeInBytes() {
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations ops = (HadoopTableOperations) baseTable.operations();
+
+    AtomicReference<CommitReport> capturedReport = new AtomicReference<>();
+    MetricsReporter reporter =
+        report -> {
+          if (report instanceof CommitReport) {
+            capturedReport.set((CommitReport) report);
+          }
+        };
+
+    Table tableWithReporter = new BaseTable(ops, baseTable.name(), reporter);
+    tableWithReporter.newFastAppend().appendFile(FILE_A).commit();
+
+    CommitReport commitReport = capturedReport.get();
+    assertThat(commitReport).isNotNull();
+    assertThat(commitReport.commitMetrics().metadataFileSizeInBytes()).isNotNull();
+    assertThat(commitReport.commitMetrics().metadataFileSizeInBytes().unit())
+        .isEqualTo(MetricsContext.Unit.BYTES);
+
+    long expectedSize = ops.io().newInputFile(ops.current().metadataFileLocation()).getLength();
+    assertThat(commitReport.commitMetrics().metadataFileSizeInBytes().value())
+        .isEqualTo(expectedSize);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestHadoopCommits.java
@@ -41,6 +41,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -58,6 +59,9 @@ import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.UpdateSchema;
 import org.apache.iceberg.exceptions.CommitFailedException;
+import org.apache.iceberg.metrics.CommitReport;
+import org.apache.iceberg.metrics.MetricsContext;
+import org.apache.iceberg.metrics.MetricsReporter;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -507,5 +511,68 @@ public class TestHadoopCommits extends HadoopTableTestBase {
 
     @Override
     public void initialize(Map<String, String> properties) {}
+  }
+
+  @Test
+  public void commitReportContainsMetadataFileSizeInBytes() {
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations ops = (HadoopTableOperations) baseTable.operations();
+
+    AtomicReference<CommitReport> capturedReport = new AtomicReference<>();
+    MetricsReporter reporter =
+        report -> {
+          if (report instanceof CommitReport) {
+            capturedReport.set((CommitReport) report);
+          }
+        };
+
+    Table tableWithReporter = new BaseTable(ops, baseTable.name(), reporter);
+    tableWithReporter.newFastAppend().appendFile(FILE_A).commit();
+
+    CommitReport commitReport = capturedReport.get();
+    assertThat(commitReport).isNotNull();
+    assertThat(reportedMetadataFileSize(commitReport)).isEqualTo(metadataFileSize(ops));
+  }
+
+  @Test
+  public void eachCommitReportsTheMetadataFileSizeItWrote() {
+    BaseTable baseTable = (BaseTable) table;
+    HadoopTableOperations ops = (HadoopTableOperations) baseTable.operations();
+
+    List<CommitReport> capturedReports = Lists.newArrayList();
+    MetricsReporter reporter =
+        report -> {
+          if (report instanceof CommitReport) {
+            capturedReports.add((CommitReport) report);
+          }
+        };
+
+    Table tableWithReporter = new BaseTable(ops, baseTable.name(), reporter);
+
+    tableWithReporter.newFastAppend().appendFile(FILE_A).commit();
+    long firstMetadataFileSize = metadataFileSize(ops);
+
+    tableWithReporter.newFastAppend().appendFile(FILE_B).commit();
+    long secondMetadataFileSize = metadataFileSize(ops);
+
+    assertThat(secondMetadataFileSize)
+        .as(
+            "Each commit must write a differently sized metadata file for this test to be meaningful")
+        .isNotEqualTo(firstMetadataFileSize);
+
+    assertThat(capturedReports).hasSize(2);
+    assertThat(reportedMetadataFileSize(capturedReports.get(0))).isEqualTo(firstMetadataFileSize);
+    assertThat(reportedMetadataFileSize(capturedReports.get(1))).isEqualTo(secondMetadataFileSize);
+  }
+
+  private long reportedMetadataFileSize(CommitReport report) {
+    assertThat(report.commitMetrics().metadataFileSizeInBytes()).isNotNull();
+    assertThat(report.commitMetrics().metadataFileSizeInBytes().unit())
+        .isEqualTo(MetricsContext.Unit.BYTES);
+    return report.commitMetrics().metadataFileSizeInBytes().value();
+  }
+
+  private long metadataFileSize(TableOperations ops) {
+    return ops.io().newInputFile(ops.current().metadataFileLocation()).getLength();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/metrics/TestCommitMetricsResultParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestCommitMetricsResultParser.java
@@ -129,6 +129,7 @@ public class TestCommitMetricsResultParser {
     assertThat(result.manifestsReplaced().value()).isEqualTo(4L);
     assertThat(result.manifestsKept().value()).isEqualTo(6L);
     assertThat(result.manifestEntriesProcessed().value()).isEqualTo(20L);
+    assertThat(result.metadataFileSizeInBytes()).isNull();
 
     String expectedJson =
         "{\n"
@@ -270,5 +271,21 @@ public class TestCommitMetricsResultParser {
     assertThat(json).isEqualTo(expectedJson);
     assertThat(CommitMetricsResultParser.fromJson(json))
         .isEqualTo(ImmutableCommitMetricsResult.builder().build());
+  }
+
+  @Test
+  public void roundTripSerdeWithMetadataFileSizeInBytes() {
+    CommitMetricsResult result =
+        ImmutableCommitMetricsResult.builder()
+            .metadataFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 123L))
+            .build();
+
+    String json = CommitMetricsResultParser.toJson(result, true);
+
+    assertThat(json)
+        .contains("\"metadata-file-size-bytes\"")
+        .contains("\"unit\" : \"bytes\"")
+        .contains("\"value\" : 123");
+    assertThat(CommitMetricsResultParser.fromJson(json)).isEqualTo(result);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/metrics/TestCommitReportParser.java
+++ b/core/src/test/java/org/apache/iceberg/metrics/TestCommitReportParser.java
@@ -300,4 +300,28 @@ public class TestCommitReportParser {
     assertThat(CommitReportParser.fromJson(json)).isEqualTo(commitReport);
     assertThat(json).isEqualTo(expectedJson);
   }
+
+  @Test
+  public void roundTripSerdeWithMetadataFileSizeInCommitMetrics() {
+    String tableName = "roundTripTableName";
+    CommitReport commitReport =
+        ImmutableCommitReport.builder()
+            .tableName(tableName)
+            .snapshotId(23L)
+            .operation("DELETE")
+            .sequenceNumber(4L)
+            .commitMetrics(
+                ImmutableCommitMetricsResult.builder()
+                    .metadataFileSizeInBytes(CounterResult.of(MetricsContext.Unit.BYTES, 123L))
+                    .build())
+            .build();
+
+    String json = CommitReportParser.toJson(commitReport, true);
+
+    assertThat(json)
+        .contains("\"metadata-file-size-bytes\"")
+        .contains("\"unit\" : \"bytes\"")
+        .contains("\"value\" : 123");
+    assertThat(CommitReportParser.fromJson(json)).isEqualTo(commitReport);
+  }
 }

--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -41,6 +41,7 @@ A [`CommitReport`](https://github.com/apache/iceberg/blob/main/core/src/main/jav
 * number of added/removed data/delete files
 * number of added/removed equality/positional delete files
 * number of added/removed equality/positional deletes
+* metadata file size in bytes for the committed table metadata file (optional, may be null depending on catalog implementation)
 
 ## Available Metrics Reporters
 
@@ -109,7 +110,8 @@ CommitReport{
         totalPositionalDeletes=CounterResult{unit=COUNT, value=0}, 
         addedEqualityDeletes=null, 
         removedEqualityDeletes=null, 
-        totalEqualityDeletes=CounterResult{unit=COUNT, value=0}}, 
+        totalEqualityDeletes=CounterResult{unit=COUNT, value=0},
+        metadataFileSizeInBytes=CounterResult{unit=BYTES, value=1234}}, 
     metadata={
         iceberg-version=Apache Iceberg 1.4.0-SNAPSHOT (commit 4868d2823004c8c256a50ea7c25cff94314cc135)}}
 ```

--- a/docs/docs/metrics-reporting.md
+++ b/docs/docs/metrics-reporting.md
@@ -41,6 +41,7 @@ A [`CommitReport`](https://github.com/apache/iceberg/blob/main/core/src/main/jav
 * number of added/removed data/delete files
 * number of added/removed equality/positional delete files
 * number of added/removed equality/positional deletes
+* size in bytes of the table metadata file written by the commit, when available (some catalogs do not write metadata files directly)
 
 ## Available Metrics Reporters
 
@@ -109,7 +110,8 @@ CommitReport{
         totalPositionalDeletes=CounterResult{unit=COUNT, value=0}, 
         addedEqualityDeletes=null, 
         removedEqualityDeletes=null, 
-        totalEqualityDeletes=CounterResult{unit=COUNT, value=0}}, 
+        totalEqualityDeletes=CounterResult{unit=COUNT, value=0},
+        metadataFileSizeInBytes=CounterResult{unit=BYTES, value=1234}}, 
     metadata={
         iceberg-version=Apache Iceberg 1.4.0-SNAPSHOT (commit 4868d2823004c8c256a50ea7c25cff94314cc135)}}
 ```


### PR DESCRIPTION
## Summary
- Add an optional `metadata-file-size-bytes` metric to `CommitMetricsResult` and JSON serde.
- Capture metadata file size at write time via new additive APIs in `TableMetadataParser` and expose it through `TableOperations#metadataFileSizeInBytes()`.
- Populate `CommitReport` with this metric in `SnapshotProducer` when the table operations implementation provides the value.
- Add coverage in core metrics parser/report parser tests and Hadoop commit reporting tests.
- Update metrics reporting docs for the new commit metric.

## Why
- Exposes useful commit metadata size telemetry to `MetricsReporter` consumers.
- Captures size during write to avoid an extra metadata-file read after commit.

## Compatibility
- Existing `TableMetadataParser.write/overwrite/internalWrite` behavior remains intact.
- New APIs are additive (`writeAndReturnLength`, `overwriteAndReturnLength`).
- Metric is optional and may be `null` for table operations that cannot provide write-time size.

## Test plan
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.metrics.TestCommitMetricsResultParser`
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.metrics.TestCommitReportParser`
- [x] `./gradlew :iceberg-core:test --tests org.apache.iceberg.hadoop.TestHadoopCommits`
- [x] `./gradlew :iceberg-core:spotlessCheck`
