### PR TITLE
WIP: End-to-end spatial file pruning from Spark SQL (ST_INTERSECTS pushdown)

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Binder.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Binder.java
@@ -160,6 +160,16 @@ public class Binder {
     }
 
     @Override
+    public Expression spatialPredicate(BoundSpatialPredicate pred) {
+      throw new IllegalStateException("Found already bound predicate: " + pred);
+    }
+
+    @Override
+    public Expression spatialPredicate(UnboundSpatialPredicate pred) {
+      return pred.bind(struct, caseSensitive);
+    }
+
+    @Override
     public <T> Expression aggregate(UnboundAggregate<T> agg) {
       return agg.bind(struct, caseSensitive);
     }
@@ -203,6 +213,12 @@ public class Binder {
       references.add(pred.ref().fieldId());
       return references;
     }
+
+    @Override
+    public Set<Integer> spatialPredicate(BoundSpatialPredicate pred) {
+      references.add(pred.ref().fieldId());
+      return references;
+    }
   }
 
   private static class IsBoundVisitor extends ExpressionVisitor<Boolean> {
@@ -228,6 +244,16 @@ public class Binder {
 
     @Override
     public <T> Boolean predicate(UnboundPredicate<T> pred) {
+      return false;
+    }
+
+    @Override
+    public Boolean spatialPredicate(BoundSpatialPredicate pred) {
+      return true;
+    }
+
+    @Override
+    public Boolean spatialPredicate(UnboundSpatialPredicate pred) {
       return false;
     }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundPredicate.java
@@ -65,4 +65,12 @@ public abstract class BoundPredicate<T> extends Predicate<T, BoundTerm<T>>
   public BoundSetPredicate<T> asSetPredicate() {
     throw new IllegalStateException("Not a set predicate: " + this);
   }
+
+  public boolean isSpatialPredicate() {
+    return false;
+  }
+
+  public BoundSpatialPredicate asSpatialPredicate() {
+    throw new IllegalStateException("Not a spatial predicate: " + this);
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
@@ -58,9 +58,9 @@ public class BoundSetPredicate<T> extends BoundPredicate<T> {
   public boolean test(T value) {
     switch (op()) {
       case IN:
-        return literalSet.contains(value);
+        return value != null && literalSet.contains(value);
       case NOT_IN:
-        return !literalSet.contains(value);
+        return value == null || !literalSet.contains(value);
       default:
         throw new IllegalStateException("Invalid operation for BoundSetPredicate: " + op());
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundSpatialPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundSpatialPredicate.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.geospatial.BoundingBox;
+
+/**
+ * A bound predicate that matches when a geometry/geography value intersects a constant query
+ * bounding box. Unlike literal predicates, the constant here is a {@link BoundingBox} (a spatial
+ * window) rather than a scalar {@link Literal}, so it is modeled as its own predicate kind.
+ */
+public class BoundSpatialPredicate extends BoundPredicate<Object> {
+  private final BoundingBox queryBound;
+
+  BoundSpatialPredicate(Operation op, BoundTerm<Object> term, BoundingBox queryBound) {
+    super(op, term);
+    this.queryBound = queryBound;
+  }
+
+  public BoundingBox queryBound() {
+    return queryBound;
+  }
+
+  @Override
+  public boolean isSpatialPredicate() {
+    return true;
+  }
+
+  @Override
+  public BoundSpatialPredicate asSpatialPredicate() {
+    return this;
+  }
+
+  @Override
+  public boolean test(Object value) {
+    // Row-level evaluation is not implemented for this PoC; spatial predicates are used for
+    // file-level metrics pruning (see InclusiveMetricsEvaluator).
+    throw new UnsupportedOperationException("Row-level spatial evaluation is not implemented");
+  }
+
+  @Override
+  public String toString() {
+    switch (op()) {
+      case ST_INTERSECTS:
+        return "st_intersects(" + term() + ", " + queryBound + ")";
+      default:
+        return "Invalid spatial predicate: operation = " + op();
+    }
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Evaluator.java
@@ -138,7 +138,8 @@ public class Evaluator implements Serializable {
 
     @Override
     public <T> Boolean in(Bound<T> valueExpr, Set<T> literalSet) {
-      return literalSet.contains(valueExpr.eval(struct));
+      T value = valueExpr.eval(struct);
+      return value != null && literalSet.contains(value);
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -44,6 +44,7 @@ public interface Expression extends Serializable {
     OR,
     STARTS_WITH,
     NOT_STARTS_WITH,
+    ST_INTERSECTS,
     COUNT,
     COUNT_NULL,
     COUNT_STAR,

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -323,6 +323,11 @@ public class ExpressionUtil {
       }
       return Expressions.alwaysTrue();
     }
+
+    @Override
+    public Expression spatialPredicate(BoundSpatialPredicate pred) {
+      return retainFieldIds.contains(pred.ref().fieldId()) ? pred : Expressions.alwaysTrue();
+    }
   }
 
   private static class ExpressionSanitizer
@@ -414,6 +419,12 @@ public class ExpressionUtil {
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
       }
+    }
+
+    @Override
+    public Expression spatialPredicate(BoundSpatialPredicate pred) {
+      // A query bounding box carries no sensitive literal values to sanitize.
+      return pred;
     }
   }
 
@@ -559,6 +570,16 @@ public class ExpressionUtil {
           throw new UnsupportedOperationException(
               "Cannot sanitize unsupported predicate type: " + pred.op());
       }
+    }
+
+    @Override
+    public String spatialPredicate(BoundSpatialPredicate pred) {
+      return "st_intersects(" + describe(pred.term()) + ", " + pred.queryBound() + ")";
+    }
+
+    @Override
+    public String spatialPredicate(UnboundSpatialPredicate pred) {
+      return "st_intersects(" + pred.ref().name() + ", " + pred.queryBound() + ")";
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -57,11 +57,13 @@ public class ExpressionVisitors {
     }
 
     public R spatialPredicate(BoundSpatialPredicate pred) {
-      return null;
+      throw new UnsupportedOperationException(
+          "Visitor does not implement spatialPredicate: " + getClass().getName());
     }
 
     public R spatialPredicate(UnboundSpatialPredicate pred) {
-      return null;
+      throw new UnsupportedOperationException(
+          "Visitor does not implement spatialPredicate: " + getClass().getName());
     }
 
     public <T, C> R aggregate(BoundAggregate<T, C> agg) {

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -56,6 +56,14 @@ public class ExpressionVisitors {
       return null;
     }
 
+    public R spatialPredicate(BoundSpatialPredicate pred) {
+      return null;
+    }
+
+    public R spatialPredicate(UnboundSpatialPredicate pred) {
+      return null;
+    }
+
     public <T, C> R aggregate(BoundAggregate<T, C> agg) {
       throw new UnsupportedOperationException("Cannot visit aggregate expression");
     }
@@ -340,7 +348,11 @@ public class ExpressionVisitors {
    * @return the value returned by the visitor for the root expression node
    */
   public static <R> R visit(Expression expr, ExpressionVisitor<R> visitor) {
-    if (expr instanceof Predicate) {
+    if (expr instanceof BoundSpatialPredicate) {
+      return visitor.spatialPredicate((BoundSpatialPredicate) expr);
+    } else if (expr instanceof UnboundSpatialPredicate) {
+      return visitor.spatialPredicate((UnboundSpatialPredicate) expr);
+    } else if (expr instanceof Predicate) {
       if (expr instanceof BoundPredicate) {
         return visitor.predicate((BoundPredicate<?>) expr);
       } else {
@@ -385,7 +397,11 @@ public class ExpressionVisitors {
    * @return the value returned by the visitor for the root expression node
    */
   public static Boolean visitEvaluator(Expression expr, ExpressionVisitor<Boolean> visitor) {
-    if (expr instanceof Predicate) {
+    if (expr instanceof BoundSpatialPredicate) {
+      return visitor.spatialPredicate((BoundSpatialPredicate) expr);
+    } else if (expr instanceof UnboundSpatialPredicate) {
+      return visitor.spatialPredicate((UnboundSpatialPredicate) expr);
+    } else if (expr instanceof Predicate) {
       if (expr instanceof BoundPredicate) {
         return visitor.predicate((BoundPredicate<?>) expr);
       } else {

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -202,6 +202,11 @@ public class Expressions {
     return new UnboundPredicate<>(Expression.Operation.NOT_STARTS_WITH, expr, value);
   }
 
+  public static UnboundSpatialPredicate stIntersects(
+      String name, org.apache.iceberg.geospatial.BoundingBox queryBound) {
+    return new UnboundSpatialPredicate(Expression.Operation.ST_INTERSECTS, ref(name), queryBound);
+  }
+
   public static <T> UnboundPredicate<T> in(String name, T... values) {
     return predicate(Operation.IN, name, Lists.newArrayList(values));
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveMetricsEvaluator.java
@@ -29,9 +29,13 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.geospatial.BoundingBox;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.GeospatialPredicateEvaluators;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
 import org.apache.iceberg.variants.Variant;
@@ -106,6 +110,35 @@ public class InclusiveMetricsEvaluator {
       this.upperBounds = file.upperBounds();
 
       return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public Boolean spatialPredicate(BoundSpatialPredicate pred) {
+      return spatial(pred);
+    }
+
+    private Boolean spatial(BoundSpatialPredicate pred) {
+      int id = pred.ref().fieldId();
+      Type type = pred.ref().type();
+
+      if (containsNullsOnly(id)) {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      ByteBuffer lower = lowerBounds != null ? lowerBounds.get(id) : null;
+      ByteBuffer upper = upperBounds != null ? upperBounds.get(id) : null;
+      if (lower == null || upper == null) {
+        // no spatial bounds recorded for this file; cannot prune
+        return ROWS_MIGHT_MATCH;
+      }
+
+      GeospatialBound fileMin = (GeospatialBound) Conversions.fromByteBuffer(type, lower);
+      GeospatialBound fileMax = (GeospatialBound) Conversions.fromByteBuffer(type, upper);
+      BoundingBox fileBound = new BoundingBox(fileMin, fileMax);
+
+      boolean intersects =
+          GeospatialPredicateEvaluators.create(type).intersects(pred.queryBound(), fileBound);
+      return intersects ? ROWS_MIGHT_MATCH : ROWS_CANNOT_MATCH;
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/Projections.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Projections.java
@@ -187,6 +187,18 @@ public class Projections {
       return bound;
     }
 
+    @Override
+    public Expression spatialPredicate(BoundSpatialPredicate pred) {
+      // A spatial predicate is a row-level filter; it does not project onto partition columns, so
+      // at the partition level a file may always match.
+      return Expressions.alwaysTrue();
+    }
+
+    @Override
+    public Expression spatialPredicate(UnboundSpatialPredicate pred) {
+      return Expressions.alwaysTrue();
+    }
+
     PartitionSpec spec() {
       return spec;
     }

--- a/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ResidualEvaluator.java
@@ -200,12 +200,14 @@ public class ResidualEvaluator implements Serializable {
 
     @Override
     public <T> Expression in(BoundReference<T> ref, Set<T> literalSet) {
-      return literalSet.contains(ref.eval(struct)) ? alwaysTrue() : alwaysFalse();
+      T value = ref.eval(struct);
+      return value != null && literalSet.contains(value) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override
     public <T> Expression notIn(BoundReference<T> ref, Set<T> literalSet) {
-      return literalSet.contains(ref.eval(struct)) ? alwaysFalse() : alwaysTrue();
+      T value = ref.eval(struct);
+      return value == null || !literalSet.contains(value) ? alwaysTrue() : alwaysFalse();
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/RewriteNot.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/RewriteNot.java
@@ -61,4 +61,14 @@ class RewriteNot extends ExpressionVisitors.ExpressionVisitor<Expression> {
   public <T> Expression predicate(UnboundPredicate<T> pred) {
     return pred;
   }
+
+  @Override
+  public Expression spatialPredicate(BoundSpatialPredicate pred) {
+    return pred;
+  }
+
+  @Override
+  public Expression spatialPredicate(UnboundSpatialPredicate pred) {
+    return pred;
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundSpatialPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundSpatialPredicate.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.geospatial.BoundingBox;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+
+/**
+ * An unbound predicate that matches when a geometry/geography column intersects a constant query
+ * bounding box. Binding resolves the column reference and validates it is a geospatial type.
+ */
+public class UnboundSpatialPredicate implements Unbound<Object, Expression>, Expression {
+  private final Operation op;
+  private final NamedReference<Object> term;
+  private final BoundingBox queryBound;
+
+  UnboundSpatialPredicate(Operation op, NamedReference<Object> term, BoundingBox queryBound) {
+    this.op = op;
+    this.term = term;
+    this.queryBound = queryBound;
+  }
+
+  @Override
+  public Operation op() {
+    return op;
+  }
+
+  @Override
+  public NamedReference<Object> ref() {
+    return term;
+  }
+
+  public BoundingBox queryBound() {
+    return queryBound;
+  }
+
+  @Override
+  public Expression negate() {
+    throw new UnsupportedOperationException("Cannot negate a spatial predicate");
+  }
+
+  @Override
+  public Expression bind(Types.StructType struct, boolean caseSensitive) {
+    BoundTerm<Object> bound = term.bind(struct, caseSensitive);
+    Type type = bound.type();
+    Preconditions.checkArgument(
+        type.typeId() == Type.TypeID.GEOMETRY || type.typeId() == Type.TypeID.GEOGRAPHY,
+        "Cannot create spatial predicate on non-geospatial column: %s (%s)",
+        term.name(),
+        type);
+    ValidationException.check(
+        op == Operation.ST_INTERSECTS, "Unsupported spatial operation: %s", op);
+    return new BoundSpatialPredicate(op, bound, queryBound);
+  }
+
+  @Override
+  public String toString() {
+    return "st_intersects(" + term + ", " + queryBound + ")";
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/geospatial/BoundingBox.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/BoundingBox.java
@@ -31,7 +31,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * minimum and maximum coordinates that define the box's corners. This provides a simple
  * approximation of a more complex geometry for efficient filtering and data skipping.
  */
-public class BoundingBox {
+public class BoundingBox implements java.io.Serializable {
   /**
    * Create a {@link BoundingBox} object from buffers containing min and max bounds
    *

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBound.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialBound.java
@@ -44,7 +44,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
  * <p>This class represents a lower or upper geospatial bound and handles serialization and
  * deserialization of these bounds to/from byte arrays, conforming to the Iceberg specification.
  */
-public class GeospatialBound {
+public class GeospatialBound implements java.io.Serializable {
   /**
    * Parses a geospatial bound from a byte buffer according to Iceberg spec.
    *

--- a/api/src/main/java/org/apache/iceberg/geospatial/WKBBoundingBox.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/WKBBoundingBox.java
@@ -1,0 +1,217 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Computes a two-dimensional (XY) bounding box from geometry values encoded as Well-Known Binary
+ * (WKB).
+ *
+ * <p>The bounding box is the minimum axis-aligned rectangle that contains every coordinate of the
+ * geometries. Only the X and Y dimensions are considered; any Z or M values present in the WKB are
+ * read past and ignored. Coordinates whose X or Y is {@code NaN} are skipped, matching the spec
+ * rule that null or NaN values in a coordinate dimension do not contribute to bounds (an empty
+ * geometry such as {@code POINT EMPTY} therefore contributes nothing).
+ *
+ * <p>Parsing follows the OGC Simple Feature Access WKB layout and validates the input defensively:
+ * a malformed or truncated buffer results in an {@link IllegalArgumentException} rather than an
+ * out-of-bounds read.
+ */
+public class WKBBoundingBox {
+
+  // OGC WKB base geometry type codes (after stripping the dimension offset).
+  private static final int TYPE_POINT = 1;
+  private static final int TYPE_LINE_STRING = 2;
+  private static final int TYPE_POLYGON = 3;
+  private static final int TYPE_MULTI_POINT = 4;
+  private static final int TYPE_MULTI_LINE_STRING = 5;
+  private static final int TYPE_MULTI_POLYGON = 6;
+  private static final int TYPE_GEOMETRY_COLLECTION = 7;
+
+  // Bounds the recursion depth for nested collections to reject pathological or malicious input.
+  private static final int MAX_DEPTH = 100;
+
+  private WKBBoundingBox() {}
+
+  /**
+   * Parses one WKB geometry and folds all of its XY coordinates into the given accumulator.
+   *
+   * <p>The buffer is read via a duplicate, so the caller's position and limit are left unchanged.
+   *
+   * @param wkb a buffer containing a single WKB geometry
+   * @param accumulator the accumulator to update with the geometry's coordinates
+   * @throws IllegalArgumentException if the buffer is not a well-formed WKB geometry
+   */
+  public static void accumulate(ByteBuffer wkb, XYAccumulator accumulator) {
+    Preconditions.checkArgument(wkb != null, "Invalid WKB buffer: null");
+    Preconditions.checkArgument(accumulator != null, "Invalid accumulator: null");
+    ByteBuffer buffer = wkb.duplicate();
+    parseGeometry(buffer, accumulator, 0);
+  }
+
+  private static void parseGeometry(ByteBuffer buffer, XYAccumulator accumulator, int depth) {
+    Preconditions.checkArgument(depth <= MAX_DEPTH, "Invalid WKB: nesting too deep");
+    checkRemaining(buffer, 5);
+
+    byte order = buffer.get();
+    if (order == 0) {
+      buffer.order(ByteOrder.BIG_ENDIAN);
+    } else if (order == 1) {
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+    } else {
+      throw new IllegalArgumentException("Invalid WKB byte order: " + order);
+    }
+
+    long typeCode = buffer.getInt() & 0xFFFFFFFFL;
+    int geometryType = (int) (typeCode % 1000);
+    int dimensionGroup = (int) (typeCode / 1000);
+    int numDimensions = numDimensions(dimensionGroup, typeCode);
+
+    switch (geometryType) {
+      case TYPE_POINT:
+        readCoordinate(buffer, accumulator, numDimensions);
+        break;
+      case TYPE_LINE_STRING:
+        readCoordinateSequence(buffer, accumulator, numDimensions);
+        break;
+      case TYPE_POLYGON:
+        int numRings = readCount(buffer);
+        for (int i = 0; i < numRings; i += 1) {
+          readCoordinateSequence(buffer, accumulator, numDimensions);
+        }
+        break;
+      case TYPE_MULTI_POINT:
+      case TYPE_MULTI_LINE_STRING:
+      case TYPE_MULTI_POLYGON:
+      case TYPE_GEOMETRY_COLLECTION:
+        int numElements = readCount(buffer);
+        for (int i = 0; i < numElements; i += 1) {
+          // Each child carries its own byte-order and type header.
+          parseGeometry(buffer, accumulator, depth + 1);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid or unsupported WKB geometry type: " + typeCode);
+    }
+  }
+
+  private static int numDimensions(int dimensionGroup, long typeCode) {
+    switch (dimensionGroup) {
+      case 0: // XY
+        return 2;
+      case 1: // XYZ
+      case 2: // XYM
+        return 3;
+      case 3: // XYZM
+        return 4;
+      default:
+        throw new IllegalArgumentException("Invalid or unsupported WKB geometry type: " + typeCode);
+    }
+  }
+
+  private static void readCoordinateSequence(
+      ByteBuffer buffer, XYAccumulator accumulator, int numDimensions) {
+    int numPoints = readCount(buffer);
+    // Validate the full extent up front so a bogus point count cannot drive a long read loop, but
+    // never pre-allocate from the count itself.
+    checkRemaining(buffer, (long) numPoints * numDimensions * Double.BYTES);
+    for (int i = 0; i < numPoints; i += 1) {
+      readCoordinate(buffer, accumulator, numDimensions);
+    }
+  }
+
+  private static void readCoordinate(
+      ByteBuffer buffer, XYAccumulator accumulator, int numDimensions) {
+    checkRemaining(buffer, (long) numDimensions * Double.BYTES);
+    double xCoord = buffer.getDouble();
+    double yCoord = buffer.getDouble();
+    // Skip any Z and/or M values; only X and Y contribute to the box.
+    for (int i = 2; i < numDimensions; i += 1) {
+      buffer.getDouble();
+    }
+    accumulator.addXY(xCoord, yCoord);
+  }
+
+  private static int readCount(ByteBuffer buffer) {
+    checkRemaining(buffer, Integer.BYTES);
+    long count = buffer.getInt() & 0xFFFFFFFFL;
+    Preconditions.checkArgument(count <= Integer.MAX_VALUE, "Invalid WKB element count: %s", count);
+    return (int) count;
+  }
+
+  private static void checkRemaining(ByteBuffer buffer, long bytes) {
+    Preconditions.checkArgument(
+        buffer.remaining() >= bytes, "Invalid WKB: unexpected end of buffer");
+  }
+
+  /**
+   * A mutable accumulator of the minimum and maximum X and Y coordinates seen so far.
+   *
+   * <p>Coordinates whose X or Y is {@code NaN} are ignored. An accumulator that has seen no non-NaN
+   * coordinate reports {@link #hasBounds()} as {@code false} and returns {@code null} bounds.
+   */
+  public static class XYAccumulator {
+    private double minX = Double.POSITIVE_INFINITY;
+    private double minY = Double.POSITIVE_INFINITY;
+    private double maxX = Double.NEGATIVE_INFINITY;
+    private double maxY = Double.NEGATIVE_INFINITY;
+    private boolean hasBounds = false;
+
+    /**
+     * Folds a single coordinate into the box, ignoring it if either dimension is {@code NaN}.
+     *
+     * @param xCoord the X coordinate
+     * @param yCoord the Y coordinate
+     */
+    public void addXY(double xCoord, double yCoord) {
+      if (Double.isNaN(xCoord) || Double.isNaN(yCoord)) {
+        return;
+      }
+      minX = Math.min(minX, xCoord);
+      minY = Math.min(minY, yCoord);
+      maxX = Math.max(maxX, xCoord);
+      maxY = Math.max(maxY, yCoord);
+      hasBounds = true;
+    }
+
+    /** Returns whether any non-NaN coordinate has been accumulated. */
+    public boolean hasBounds() {
+      return hasBounds;
+    }
+
+    /**
+     * Returns the lower corner (minimum X and Y) of the box, or {@code null} if no coordinate has
+     * been accumulated.
+     */
+    public GeospatialBound minBound() {
+      return hasBounds ? GeospatialBound.createXY(minX, minY) : null;
+    }
+
+    /**
+     * Returns the upper corner (maximum X and Y) of the box, or {@code null} if no coordinate has
+     * been accumulated.
+     */
+    public GeospatialBound maxBound() {
+      return hasBounds ? GeospatialBound.createXY(maxX, maxY) : null;
+    }
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestEvaluator.java
@@ -674,6 +674,12 @@ public class TestEvaluator {
     assertThat(charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))))
         .as("utf8(abcd) in [string(abc), string(abd)] => false")
         .isFalse();
+
+    StructType nullableStringStruct = StructType.of(optional(35, "s", Types.StringType.get()));
+    Evaluator nullStringEvaluator = new Evaluator(nullableStringStruct, in("s", "abc", "abd"));
+    assertThat(nullStringEvaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null in [abc, abd] => false")
+        .isFalse();
   }
 
   @Test
@@ -775,6 +781,12 @@ public class TestEvaluator {
         .isFalse();
     assertThat(charSeqEvaluator.eval(TestHelpers.Row.of(new Utf8("abcd"))))
         .as("utf8(abcd) not in [string(abc), string(abd)] => true")
+        .isTrue();
+
+    StructType nullableStringStruct = StructType.of(optional(35, "s", Types.StringType.get()));
+    Evaluator nullStringEvaluator = new Evaluator(nullableStringStruct, notIn("s", "abc", "abd"));
+    assertThat(nullStringEvaluator.eval(TestHelpers.Row.of((String) null)))
+        .as("null not in [abc, abd] => true")
         .isTrue();
   }
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestPredicateBinding.java
@@ -529,6 +529,30 @@ public class TestPredicateBinding {
   }
 
   @Test
+  public void testInPredicateTestWithNull() {
+    StructType struct = StructType.of(optional(36, "s", Types.StringType.get()));
+
+    Expression expr = Expressions.in("s", "abc", "abd").bind(struct);
+    BoundSetPredicate<CharSequence> bound = assertAndUnwrapBoundSet(expr);
+
+    assertThat(bound.test((CharSequence) null)).as("null in [abc, abd] => false").isFalse();
+    assertThat(bound.test("abc")).as("abc in [abc, abd] => true").isTrue();
+    assertThat(bound.test("xyz")).as("xyz in [abc, abd] => false").isFalse();
+  }
+
+  @Test
+  public void testNotInPredicateTestWithNull() {
+    StructType struct = StructType.of(optional(37, "s", Types.StringType.get()));
+
+    Expression expr = Expressions.notIn("s", "abc", "abd").bind(struct);
+    BoundSetPredicate<CharSequence> bound = assertAndUnwrapBoundSet(expr);
+
+    assertThat(bound.test((CharSequence) null)).as("null not in [abc, abd] => true").isTrue();
+    assertThat(bound.test("abc")).as("abc not in [abc, abd] => false").isFalse();
+    assertThat(bound.test("xyz")).as("xyz not in [abc, abd] => true").isTrue();
+  }
+
+  @Test
   public void testNotInPredicateBinding() {
     StructType struct =
         StructType.of(

--- a/api/src/test/java/org/apache/iceberg/expressions/TestSpatialMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestSpatialMetricsEvaluator.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.apache.iceberg.types.Conversions.toByteBuffer;
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TestHelpers.Row;
+import org.apache.iceberg.TestHelpers.TestDataFile;
+import org.apache.iceberg.geospatial.BoundingBox;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Demonstrates end-to-end file pruning driven by a spatial predicate: an {@code ST_INTERSECTS}
+ * {@link Expression} is bound and evaluated by {@link InclusiveMetricsEvaluator} against a file's
+ * stored geometry bounds, skipping files whose bounding box is disjoint from the query window.
+ */
+public class TestSpatialMetricsEvaluator {
+
+  private static final int GEOM_ID = 2;
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.LongType.get()),
+          optional(GEOM_ID, "geom", Types.GeometryType.crs84()));
+
+  // File A holds geometries within (10,10)-(20,20); file B within (110,60)-(120,70).
+  private static final DataFile FILE_A = geoFile("a.parquet", 10, 10, 20, 20);
+  private static final DataFile FILE_B = geoFile("b.parquet", 110, 60, 120, 70);
+
+  @Test
+  public void testSpatialPredicatePrunesDisjointFile() {
+    // A query window over (5,5)-(25,25) overlaps file A but is disjoint from file B.
+    Expression query = Expressions.stIntersects("geom", box(5, 5, 25, 25));
+
+    assertThat(new InclusiveMetricsEvaluator(SCHEMA, query).eval(FILE_A))
+        .as("file A overlaps the query window and must be scanned")
+        .isTrue();
+    assertThat(new InclusiveMetricsEvaluator(SCHEMA, query).eval(FILE_B))
+        .as("file B is disjoint from the query window and can be skipped")
+        .isFalse();
+  }
+
+  @Test
+  public void testSpatialPredicateKeepsOverlappingFiles() {
+    // A query window over the northeast cluster overlaps file B but not file A.
+    Expression query = Expressions.stIntersects("geom", box(100, 55, 130, 75));
+
+    assertThat(new InclusiveMetricsEvaluator(SCHEMA, query).eval(FILE_A)).isFalse();
+    assertThat(new InclusiveMetricsEvaluator(SCHEMA, query).eval(FILE_B)).isTrue();
+  }
+
+  private static DataFile geoFile(String path, double minX, double minY, double maxX, double maxY) {
+    Types.GeometryType geom = Types.GeometryType.crs84();
+    Map<Integer, ByteBuffer> lower =
+        ImmutableMap.of(GEOM_ID, toByteBuffer(geom, GeospatialBound.createXY(minX, minY)));
+    Map<Integer, ByteBuffer> upper =
+        ImmutableMap.of(GEOM_ID, toByteBuffer(geom, GeospatialBound.createXY(maxX, maxY)));
+    return new TestDataFile(
+        path,
+        Row.of(),
+        50,
+        ImmutableMap.of(GEOM_ID, 50L), // value counts
+        ImmutableMap.of(GEOM_ID, 0L), // null value counts
+        null, // nan value counts
+        lower,
+        upper);
+  }
+
+  private static BoundingBox box(double minX, double minY, double maxX, double maxY) {
+    return new BoundingBox(
+        GeospatialBound.createXY(minX, minY), GeospatialBound.createXY(maxX, maxY));
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/geospatial/TestWKBBoundingBox.java
+++ b/api/src/test/java/org/apache/iceberg/geospatial/TestWKBBoundingBox.java
@@ -1,0 +1,429 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.geospatial;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import org.apache.iceberg.geospatial.WKBBoundingBox.XYAccumulator;
+import org.junit.jupiter.api.Test;
+
+public class TestWKBBoundingBox {
+
+  // OGC WKB geometry type codes; the dimension offset (+1000 Z, +2000 M, +3000 ZM) is added
+  // separately by the builders below.
+  private static final int POINT = 1;
+  private static final int LINE_STRING = 2;
+  private static final int POLYGON = 3;
+  private static final int MULTI_POINT = 4;
+  private static final int MULTI_LINE_STRING = 5;
+  private static final int MULTI_POLYGON = 6;
+  private static final int GEOMETRY_COLLECTION = 7;
+
+  @Test
+  public void testPoint() {
+    XYAccumulator acc = accumulate(point(ByteOrder.LITTLE_ENDIAN, 30, 10));
+    assertThat(acc.hasBounds()).isTrue();
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+  }
+
+  @Test
+  public void testPointBigEndian() {
+    XYAccumulator acc = accumulate(point(ByteOrder.BIG_ENDIAN, -71, 42));
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-71, 42));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(-71, 42));
+  }
+
+  @Test
+  public void testLineString() {
+    XYAccumulator acc =
+        accumulate(lineString(ByteOrder.LITTLE_ENDIAN, new double[][] {{0, 0}, {5, 3}, {2, -4}}));
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(0, -4));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(5, 3));
+  }
+
+  @Test
+  public void testPolygon() {
+    // A single ring; the box spans all ring vertices.
+    double[][] ring = {{1, 1}, {1, 9}, {8, 9}, {8, 1}, {1, 1}};
+    XYAccumulator acc = accumulate(polygon(ByteOrder.LITTLE_ENDIAN, ring));
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(1, 1));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(8, 9));
+  }
+
+  @Test
+  public void testMultiPoint() {
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            MULTI_POINT,
+            point(ByteOrder.LITTLE_ENDIAN, 30, 10),
+            point(ByteOrder.LITTLE_ENDIAN, -5, 40));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-5, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 40));
+  }
+
+  @Test
+  public void testMultiLineString() {
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            MULTI_LINE_STRING,
+            lineString(ByteOrder.LITTLE_ENDIAN, new double[][] {{0, 0}, {1, 1}}),
+            lineString(ByteOrder.LITTLE_ENDIAN, new double[][] {{-3, 7}, {2, 2}}));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-3, 0));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(2, 7));
+  }
+
+  @Test
+  public void testMultiPolygon() {
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            MULTI_POLYGON,
+            polygon(ByteOrder.LITTLE_ENDIAN, new double[][] {{0, 0}, {0, 2}, {2, 2}, {0, 0}}),
+            polygon(ByteOrder.LITTLE_ENDIAN, new double[][] {{5, 5}, {5, 9}, {9, 9}, {5, 5}}));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(0, 0));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(9, 9));
+  }
+
+  @Test
+  public void testGeometryCollection() {
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            GEOMETRY_COLLECTION,
+            point(ByteOrder.LITTLE_ENDIAN, 30, 10),
+            lineString(ByteOrder.LITTLE_ENDIAN, new double[][] {{-8, 3}, {12, 25}}));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-8, 3));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 25));
+  }
+
+  @Test
+  public void testMixedEndianChildren() {
+    // A collection whose children use different byte orders; each child re-reads its own order.
+    byte[] wkb =
+        collection(
+            ByteOrder.BIG_ENDIAN,
+            MULTI_POINT,
+            point(ByteOrder.LITTLE_ENDIAN, 30, 10),
+            point(ByteOrder.BIG_ENDIAN, -5, 40));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-5, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 40));
+  }
+
+  @Test
+  public void testNestedGeometryCollection() {
+    byte[] inner =
+        collection(
+            ByteOrder.LITTLE_ENDIAN, GEOMETRY_COLLECTION, point(ByteOrder.LITTLE_ENDIAN, 100, 50));
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            GEOMETRY_COLLECTION,
+            point(ByteOrder.LITTLE_ENDIAN, 1, 2),
+            inner);
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(1, 2));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(100, 50));
+  }
+
+  @Test
+  public void testXYZSkipsZ() {
+    // A 3D point (type code 1001). Only X and Y should contribute; Z is read past.
+    byte[] wkb = pointWithDims(ByteOrder.LITTLE_ENDIAN, 1000, 30, 10, 999.0);
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+  }
+
+  @Test
+  public void testXYMSkipsM() {
+    // A measured point (type code 2001).
+    byte[] wkb = pointWithDims(ByteOrder.LITTLE_ENDIAN, 2000, -5, 40, 7.5);
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-5, 40));
+  }
+
+  @Test
+  public void testXYZMSkipsZAndM() {
+    // A 4D point (type code 3001).
+    byte[] wkb = pointWithDims(ByteOrder.LITTLE_ENDIAN, 3000, 12, 34, 5.0, 6.0);
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(12, 34));
+  }
+
+  @Test
+  public void testEmptyPointContributesNothing() {
+    // POINT EMPTY is encoded as a point with NaN coordinates.
+    XYAccumulator acc = accumulate(point(ByteOrder.LITTLE_ENDIAN, Double.NaN, Double.NaN));
+    assertThat(acc.hasBounds()).isFalse();
+    assertThat(acc.minBound()).isNull();
+    assertThat(acc.maxBound()).isNull();
+  }
+
+  @Test
+  public void testEmptyLineStringContributesNothing() {
+    XYAccumulator acc = accumulate(lineString(ByteOrder.LITTLE_ENDIAN, new double[0][]));
+    assertThat(acc.hasBounds()).isFalse();
+  }
+
+  @Test
+  public void testNaNCoordinateSkipped() {
+    // The valid point still sets the box; the NaN point contributes nothing.
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            MULTI_POINT,
+            point(ByteOrder.LITTLE_ENDIAN, 30, 10),
+            point(ByteOrder.LITTLE_ENDIAN, Double.NaN, Double.NaN));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+  }
+
+  @Test
+  public void testInfinityWidensBounds() {
+    // Only NaN is skipped; +/-Infinity is a real value that widens the box (per spec).
+    byte[] wkb =
+        collection(
+            ByteOrder.LITTLE_ENDIAN,
+            MULTI_POINT,
+            point(ByteOrder.LITTLE_ENDIAN, 0, 0),
+            point(ByteOrder.LITTLE_ENDIAN, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY));
+    XYAccumulator acc = accumulate(wkb);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(0, Double.NEGATIVE_INFINITY));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(Double.POSITIVE_INFINITY, 0));
+  }
+
+  @Test
+  public void testCallerBufferPositionUnchanged() {
+    ByteBuffer buffer = ByteBuffer.wrap(point(ByteOrder.LITTLE_ENDIAN, 30, 10));
+    int position = buffer.position();
+    int limit = buffer.limit();
+    XYAccumulator acc = new XYAccumulator();
+    WKBBoundingBox.accumulate(buffer, acc);
+    assertThat(buffer.position()).isEqualTo(position);
+    assertThat(buffer.limit()).isEqualTo(limit);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(30, 10));
+  }
+
+  @Test
+  public void testAccumulateAcrossMultipleGeometries() {
+    XYAccumulator acc = new XYAccumulator();
+    WKBBoundingBox.accumulate(ByteBuffer.wrap(point(ByteOrder.LITTLE_ENDIAN, 30, 10)), acc);
+    WKBBoundingBox.accumulate(ByteBuffer.wrap(point(ByteOrder.LITTLE_ENDIAN, -5, 40)), acc);
+    assertThat(acc.minBound()).isEqualTo(GeospatialBound.createXY(-5, 10));
+    assertThat(acc.maxBound()).isEqualTo(GeospatialBound.createXY(30, 40));
+  }
+
+  @Test
+  public void testRejectsBadByteOrder() {
+    byte[] wkb = point(ByteOrder.LITTLE_ENDIAN, 30, 10);
+    wkb[0] = 2; // neither 0 (BE) nor 1 (LE)
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("byte order");
+  }
+
+  @Test
+  public void testRejectsUnknownGeometryType() {
+    byte[] wkb =
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1)
+            .putInt(99) // not a valid geometry type
+            .putDouble(0)
+            .putDouble(0)
+            .array();
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("geometry type");
+  }
+
+  @Test
+  public void testRejectsUnknownDimension() {
+    // Dimension group 4 (type code 4001) is not a valid OGC dimension offset.
+    byte[] wkb =
+        ByteBuffer.allocate(21)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1)
+            .putInt(4001)
+            .putDouble(0)
+            .putDouble(0)
+            .array();
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("geometry type");
+  }
+
+  @Test
+  public void testRejectsTruncatedHeader() {
+    byte[] wkb = Arrays.copyOf(point(ByteOrder.LITTLE_ENDIAN, 30, 10), 3);
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("end of buffer");
+  }
+
+  @Test
+  public void testRejectsTruncatedCoordinates() {
+    // A point header that promises two doubles but only supplies one.
+    byte[] wkb =
+        ByteBuffer.allocate(13)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1)
+            .putInt(POINT)
+            .putDouble(30)
+            .array();
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("end of buffer");
+  }
+
+  @Test
+  public void testRejectsHugeElementCount() {
+    // A multipoint that claims 0xFFFFFFFF elements but supplies none.
+    byte[] wkb =
+        ByteBuffer.allocate(9)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1)
+            .putInt(MULTI_POINT)
+            .putInt(0xFFFFFFFF) // -1 as signed, ~4 billion unsigned
+            .array();
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("WKB");
+  }
+
+  @Test
+  public void testRejectsHugePointCount() {
+    // A linestring that claims a massive point count but supplies no coordinates.
+    byte[] wkb =
+        ByteBuffer.allocate(9)
+            .order(ByteOrder.LITTLE_ENDIAN)
+            .put((byte) 1)
+            .putInt(LINE_STRING)
+            .putInt(Integer.MAX_VALUE)
+            .array();
+    assertThatThrownBy(() -> accumulate(wkb))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("end of buffer");
+  }
+
+  @Test
+  public void testRejectsDeeplyNestedCollection() {
+    // Build 200 nested geometry collections, each containing the next.
+    byte[] wkb = point(ByteOrder.LITTLE_ENDIAN, 0, 0);
+    for (int i = 0; i < 200; i += 1) {
+      wkb = collection(ByteOrder.LITTLE_ENDIAN, GEOMETRY_COLLECTION, wkb);
+    }
+    byte[] deep = wkb;
+    assertThatThrownBy(() -> accumulate(deep))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("nesting too deep");
+  }
+
+  private static XYAccumulator accumulate(byte[] wkb) {
+    XYAccumulator acc = new XYAccumulator();
+    WKBBoundingBox.accumulate(ByteBuffer.wrap(wkb), acc);
+    return acc;
+  }
+
+  private static byte[] point(ByteOrder order, double xCoord, double yCoord) {
+    return ByteBuffer.allocate(21)
+        .order(order)
+        .put(orderFlag(order))
+        .putInt(POINT)
+        .putDouble(xCoord)
+        .putDouble(yCoord)
+        .array();
+  }
+
+  private static byte[] pointWithDims(
+      ByteOrder order, int dimOffset, double xCoord, double yCoord, double... extra) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(5 + (2 + extra.length) * Double.BYTES)
+            .order(order)
+            .put(orderFlag(order))
+            .putInt(POINT + dimOffset)
+            .putDouble(xCoord)
+            .putDouble(yCoord);
+    for (double value : extra) {
+      buffer.putDouble(value);
+    }
+    return buffer.array();
+  }
+
+  private static byte[] lineString(ByteOrder order, double[][] coords) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(5 + Integer.BYTES + coords.length * 2 * Double.BYTES)
+            .order(order)
+            .put(orderFlag(order))
+            .putInt(LINE_STRING)
+            .putInt(coords.length);
+    for (double[] coord : coords) {
+      buffer.putDouble(coord[0]).putDouble(coord[1]);
+    }
+    return buffer.array();
+  }
+
+  private static byte[] polygon(ByteOrder order, double[]... ring) {
+    ByteBuffer buffer =
+        ByteBuffer.allocate(5 + Integer.BYTES + Integer.BYTES + ring.length * 2 * Double.BYTES)
+            .order(order)
+            .put(orderFlag(order))
+            .putInt(POLYGON)
+            .putInt(1) // one ring
+            .putInt(ring.length);
+    for (double[] coord : ring) {
+      buffer.putDouble(coord[0]).putDouble(coord[1]);
+    }
+    return buffer.array();
+  }
+
+  private static byte[] collection(ByteOrder order, int type, byte[]... children) {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    byte[] header =
+        ByteBuffer.allocate(5 + Integer.BYTES)
+            .order(order)
+            .put(orderFlag(order))
+            .putInt(type)
+            .putInt(children.length)
+            .array();
+    out.writeBytes(header);
+    for (byte[] child : children) {
+      out.writeBytes(child);
+    }
+    return out.toByteArray();
+  }
+
+  private static byte orderFlag(ByteOrder order) {
+    return (byte) (order == ByteOrder.LITTLE_ENDIAN ? 1 : 0);
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestResiduals.java
@@ -193,6 +193,29 @@ public class TestResiduals {
 
     residual = resEval.residualFor(Row.of(20180815));
     assertThat(residual).isEqualTo(alwaysFalse());
+
+    residual = resEval.residualFor(Row.of((Object) null));
+    assertThat(residual)
+        .as("null in [20170815, 20170816, 20170817] => false")
+        .isEqualTo(alwaysFalse());
+  }
+
+  @Test
+  public void testInWithNullStringPartition() {
+    Schema schema = new Schema(Types.NestedField.optional(50, "category", Types.StringType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("category").build();
+
+    ResidualEvaluator resEval = ResidualEvaluator.of(spec, in("category", "a", "b", "c"), true);
+
+    Expression residual = resEval.residualFor(Row.of("a"));
+    assertThat(residual).isEqualTo(alwaysTrue());
+
+    residual = resEval.residualFor(Row.of("d"));
+    assertThat(residual).isEqualTo(alwaysFalse());
+
+    residual = resEval.residualFor(Row.of((Object) null));
+    assertThat(residual).as("null in [a, b, c] => false").isEqualTo(alwaysFalse());
   }
 
   @Test
@@ -241,6 +264,29 @@ public class TestResiduals {
 
     residual = resEval.residualFor(Row.of(20170815));
     assertThat(residual).isEqualTo(alwaysFalse());
+
+    residual = resEval.residualFor(Row.of((Object) null));
+    assertThat(residual)
+        .as("null not in [20170815, 20170816, 20170817] => true")
+        .isEqualTo(alwaysTrue());
+  }
+
+  @Test
+  public void testNotInWithNullStringPartition() {
+    Schema schema = new Schema(Types.NestedField.optional(50, "category", Types.StringType.get()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("category").build();
+
+    ResidualEvaluator resEval = ResidualEvaluator.of(spec, notIn("category", "a", "b", "c"), true);
+
+    Expression residual = resEval.residualFor(Row.of("d"));
+    assertThat(residual).isEqualTo(alwaysTrue());
+
+    residual = resEval.residualFor(Row.of("a"));
+    assertThat(residual).isEqualTo(alwaysFalse());
+
+    residual = resEval.residualFor(Row.of((Object) null));
+    assertThat(residual).as("null not in [a, b, c] => true").isEqualTo(alwaysTrue());
   }
 
   @Test

--- a/core/src/main/java/org/apache/iceberg/GeometryFieldMetrics.java
+++ b/core/src/main/java/org/apache/iceberg/GeometryFieldMetrics.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.nio.ByteBuffer;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.geospatial.WKBBoundingBox;
+import org.apache.iceberg.types.Type;
+
+/**
+ * Field-level metrics for a geometry column, tracked by the Parquet writer.
+ *
+ * <p>The Parquet footer's lexicographic min/max over the WKB bytes is not meaningful for spatial
+ * values, so the writer instead scans each value's coordinates and accumulates a two-dimensional
+ * bounding box. The resulting {@link FieldMetrics} carries the box's lower and upper corners as
+ * {@link GeospatialBound} points, which serialize through the existing geometry conversion path.
+ * The null value count is left at zero here; it is reconciled by the optional-field writer that
+ * owns null accounting.
+ */
+public class GeometryFieldMetrics extends FieldMetrics<GeospatialBound> {
+
+  private GeometryFieldMetrics(
+      int id, long valueCount, GeospatialBound lowerBound, GeospatialBound upperBound, Type type) {
+    super(id, valueCount, 0L, lowerBound, upperBound, type);
+  }
+
+  public static class Builder {
+    private final int id;
+    private final Type geometryType;
+    private final WKBBoundingBox.XYAccumulator accumulator = new WKBBoundingBox.XYAccumulator();
+    private long valueCount = 0;
+
+    public Builder(int id, Type geometryType) {
+      this.id = id;
+      this.geometryType = geometryType;
+    }
+
+    public void addValue(ByteBuffer wkb) {
+      this.valueCount += 1;
+      WKBBoundingBox.accumulate(wkb, accumulator);
+    }
+
+    public GeometryFieldMetrics build() {
+      return new GeometryFieldMetrics(
+          id, valueCount, accumulator.minBound(), accumulator.maxBound(), geometryType);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestGeometryFieldMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestGeometryFieldMetrics.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.iceberg.geospatial.GeospatialBound;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestGeometryFieldMetrics {
+
+  private static final Types.GeometryType GEOMETRY = Types.GeometryType.crs84();
+
+  @Test
+  public void testBoundsAcrossMultiplePoints() {
+    GeometryFieldMetrics.Builder builder = new GeometryFieldMetrics.Builder(2, GEOMETRY);
+    builder.addValue(wkbPoint(30, 10));
+    builder.addValue(wkbPoint(-5, 40));
+
+    FieldMetrics<GeospatialBound> metrics = builder.build();
+
+    assertThat(metrics.id()).isEqualTo(2);
+    assertThat(metrics.valueCount()).isEqualTo(2L);
+    // null accounting is reconciled by the optional-field writer, not here
+    assertThat(metrics.nullValueCount()).isEqualTo(0L);
+    // geometry has no NaN metric; -1 suppresses the entry downstream
+    assertThat(metrics.nanValueCount()).isEqualTo(-1L);
+    assertThat(metrics.originalType()).isEqualTo(GEOMETRY);
+    assertThat(metrics.lowerBound()).isEqualTo(GeospatialBound.createXY(-5, 10));
+    assertThat(metrics.upperBound()).isEqualTo(GeospatialBound.createXY(30, 40));
+  }
+
+  @Test
+  public void testSinglePointBoundsAreThatPoint() {
+    GeometryFieldMetrics.Builder builder = new GeometryFieldMetrics.Builder(2, GEOMETRY);
+    builder.addValue(wkbPoint(12, 34));
+
+    FieldMetrics<GeospatialBound> metrics = builder.build();
+
+    assertThat(metrics.valueCount()).isEqualTo(1L);
+    assertThat(metrics.lowerBound()).isEqualTo(GeospatialBound.createXY(12, 34));
+    assertThat(metrics.upperBound()).isEqualTo(GeospatialBound.createXY(12, 34));
+  }
+
+  @Test
+  public void testEmptyGeometryProducesNoBounds() {
+    // POINT EMPTY (NaN coordinates) still counts as a value but contributes no coordinate.
+    GeometryFieldMetrics.Builder builder = new GeometryFieldMetrics.Builder(2, GEOMETRY);
+    builder.addValue(wkbPoint(Double.NaN, Double.NaN));
+
+    FieldMetrics<GeospatialBound> metrics = builder.build();
+
+    assertThat(metrics.valueCount()).isEqualTo(1L);
+    assertThat(metrics.lowerBound()).isNull();
+    assertThat(metrics.upperBound()).isNull();
+  }
+
+  @Test
+  public void testNoValuesProducesNoBounds() {
+    FieldMetrics<GeospatialBound> metrics = new GeometryFieldMetrics.Builder(2, GEOMETRY).build();
+
+    assertThat(metrics.valueCount()).isEqualTo(0L);
+    assertThat(metrics.lowerBound()).isNull();
+    assertThat(metrics.upperBound()).isNull();
+  }
+
+  private static ByteBuffer wkbPoint(double xCoord, double yCoord) {
+    return ByteBuffer.allocate(21)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put((byte) 1) // little-endian
+        .putInt(1) // WKB geometry type: Point
+        .putDouble(xCoord)
+        .putDouble(yCoord)
+        .flip();
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestMetrics.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetrics.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -276,15 +277,22 @@ public abstract class TestMetrics {
     first.setField("geog", wkbPoint(-5, 40));
     Record second = GenericRecord.create(schema);
     second.setField("id", 2L);
-    // both geo columns are left null
+    second.setField("geom", wkbPoint(-5, 40));
+    // geog on the second row is left null
 
     Metrics metrics = getMetrics(schema, first, second);
     assertThat(metrics.recordCount()).isEqualTo(2L);
 
-    // geometry and geography keep value/null counts but no bounds: lexicographic WKB min/max is not
-    // meaningful, so bounds are intentionally skipped (spatial bounds are a separate follow-up).
-    assertCounts(2, 2L, 1L, metrics);
-    assertBounds(2, Types.GeometryType.crs84(), null, null, metrics);
+    // geometry bounds are the XY bounding box of all values: min corner (-5, 10), max corner
+    // (30, 40). The null geography row leaves geography with value/null counts but no bounds
+    // (geography bounds are a separate follow-up).
+    assertCounts(2, 2L, 0L, metrics);
+    assertBounds(
+        2,
+        Types.GeometryType.crs84(),
+        GeospatialBound.createXY(-5, 10),
+        GeospatialBound.createXY(30, 40),
+        metrics);
     assertCounts(3, 2L, 1L, metrics);
     assertBounds(3, Types.GeographyType.crs84(), null, null, metrics);
   }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetWriter.java
@@ -268,8 +268,11 @@ abstract class BaseParquetWriter<T> {
     @Override
     public Optional<ParquetValueWriter<?>> visit(
         LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryType) {
-      // geometry values are pure WKB stored in a BINARY column
-      return Optional.of(ParquetValueWriters.byteBuffers(desc));
+      // geometry values are pure WKB stored in a BINARY column; the writer also scans the
+      // coordinates to produce a bounding box (the Parquet footer cannot). The concrete CRS is
+      // immaterial here: ParquetMetrics rewrites the bound's type from the table schema before
+      // serialization, and the serialization is keyed on the type id, which ignores the CRS.
+      return Optional.of(ParquetValueWriters.geometry(desc, Types.GeometryType.crs84()));
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetBloomRowGroupFilter.java
@@ -27,6 +27,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.BoundReference;
+import org.apache.iceberg.expressions.BoundSpatialPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
@@ -130,6 +131,11 @@ public class ParquetBloomRowGroupFilter {
       }
 
       return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public Boolean spatialPredicate(BoundSpatialPredicate pred) {
+      return ROWS_MIGHT_MATCH;
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -28,6 +28,7 @@ import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.BoundReference;
+import org.apache.iceberg.expressions.BoundSpatialPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
@@ -119,6 +120,11 @@ public class ParquetDictionaryRowGroupFilter {
       }
 
       return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public Boolean spatialPredicate(BoundSpatialPredicate pred) {
+      return ROWS_MIGHT_MATCH;
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.expressions.Binder;
 import org.apache.iceberg.expressions.Bound;
 import org.apache.iceberg.expressions.BoundReference;
+import org.apache.iceberg.expressions.BoundSpatialPredicate;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.ExpressionVisitors;
 import org.apache.iceberg.expressions.ExpressionVisitors.BoundExpressionVisitor;
@@ -102,6 +103,13 @@ public class ParquetMetricsRowGroupFilter {
       }
 
       return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    public Boolean spatialPredicate(BoundSpatialPredicate pred) {
+      // Row-group-level spatial pruning is not implemented in this PoC; file-level pruning already
+      // removed non-matching files. Conservatively keep the row group.
+      return ROWS_MIGHT_MATCH;
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueWriters.java
@@ -36,6 +36,7 @@ import org.apache.avro.util.Utf8;
 import org.apache.iceberg.DoubleFieldMetrics;
 import org.apache.iceberg.FieldMetrics;
 import org.apache.iceberg.FloatFieldMetrics;
+import org.apache.iceberg.GeometryFieldMetrics;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -118,6 +119,11 @@ public class ParquetValueWriters {
 
   public static PrimitiveWriter<ByteBuffer> byteBuffers(ColumnDescriptor desc) {
     return new BytesWriter(desc);
+  }
+
+  public static PrimitiveWriter<ByteBuffer> geometry(
+      ColumnDescriptor desc, org.apache.iceberg.types.Type geometryType) {
+    return new GeometryWriter(desc, geometryType);
   }
 
   public static PrimitiveWriter<ByteBuffer> fixedBuffers(ColumnDescriptor desc) {
@@ -333,6 +339,30 @@ public class ParquetValueWriters {
     @Override
     public void write(int repetitionLevel, ByteBuffer buffer) {
       column.writeBinary(repetitionLevel, Binary.fromReusedByteBuffer(buffer));
+    }
+  }
+
+  private static class GeometryWriter extends PrimitiveWriter<ByteBuffer> {
+    private final GeometryFieldMetrics.Builder metricsBuilder;
+
+    private GeometryWriter(ColumnDescriptor desc, org.apache.iceberg.types.Type geometryType) {
+      super(desc);
+      this.metricsBuilder =
+          new GeometryFieldMetrics.Builder(
+              desc.getPrimitiveType().getId().intValue(), geometryType);
+    }
+
+    @Override
+    public void write(int repetitionLevel, ByteBuffer buffer) {
+      // Accumulate the bounding box before writing, so it reads the buffer's coordinates while the
+      // position is intact (the scanner reads a duplicate and leaves this buffer untouched).
+      metricsBuilder.addValue(buffer);
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteBuffer(buffer));
+    }
+
+    @Override
+    public Stream<FieldMetrics<?>> metrics() {
+      return Stream.of(metricsBuilder.build());
     }
   }
 

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceStaticInvoke.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/optimizer/ReplaceStaticInvoke.scala
@@ -37,6 +37,7 @@ import org.apache.spark.sql.catalyst.trees.TreePattern.IN
 import org.apache.spark.sql.catalyst.trees.TreePattern.INSET
 import org.apache.spark.sql.catalyst.trees.TreePattern.JOIN
 import org.apache.spark.sql.connector.catalog.functions.ScalarFunction
+import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.types.StructField
 import org.apache.spark.sql.types.StructType
 
@@ -68,6 +69,16 @@ object ReplaceStaticInvoke extends Rule[LogicalPlan] {
   }
 
   private def replaceStaticInvoke(condition: Expression): Expression = {
+    // A boolean scalar function used directly as a predicate (e.g. WHERE st_intersects(...)) is the
+    // condition root itself. StaticInvoke carries no tree pattern, so it would be pruned away by
+    // the pattern-based transform below; handle it here at the root instead.
+    condition match {
+      case invoke: StaticInvoke
+          if invoke.dataType.isInstanceOf[BooleanType] && canReplace(invoke) =>
+        return replaceStaticInvoke(invoke)
+      case _ =>
+    }
+
     condition.transformWithPruning(_.containsAnyPattern(BINARY_COMPARISON, IN, INSET)) {
       case in @ In(value: StaticInvoke, _) if canReplace(value) =>
         in.copy(value = replaceStaticInvoke(value))

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSpatialFilterPushdown.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSpatialFilterPushdown.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.extensions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestTemplate;
+
+/**
+ * End-to-end test that a spatial filter written in SQL is pushed down and prunes files. With the
+ * Iceberg extensions enabled, {@code ReplaceStaticInvoke} rewrites the top-level boolean
+ * {@code st_intersects(...)} function into an {@code ApplyFunctionExpression}, which Spark then
+ * translates to a pushed DSv2 predicate; {@code SparkV2Filters} converts it to an Iceberg
+ * {@code ST_INTERSECTS} expression and {@code InclusiveMetricsEvaluator} skips non-matching files.
+ */
+public class TestSpatialFilterPushdown extends ExtensionsTestBase {
+
+  private static final String GEO_CATALOG = "geo";
+  private static final String TABLE = GEO_CATALOG + ".default.geo_pushdown";
+  // WKB points: (15,15) is the southwest cluster, (115,65) the northeast cluster.
+  private static final String SW_WKB = "01010000000000000000002e400000000000002e40";
+  private static final String NE_WKB = "01010000000000000000c05c400000000000405040";
+
+  @BeforeEach
+  public void setupGeoTable() {
+    // Hive cannot represent geo types, so use a dedicated hadoop catalog with the geospatial flag.
+    spark.conf().set("spark.sql.catalog." + GEO_CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".cache-enabled", "false");
+    spark.conf().set(
+        "spark.sql.catalog." + GEO_CATALOG + ".warehouse",
+        System.getProperty("java.io.tmpdir") + "/iceberg_spatial_pushdown");
+    spark.conf().set("spark.sql.geospatial.enabled", "true");
+    // Geo has no Arrow vector yet; read through the row-based reader.
+    spark.conf().set("spark.sql.iceberg.vectorization.enabled", "false");
+
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        TABLE);
+    // Two separate inserts => two data files, each a distinct spatial cluster.
+    sql("INSERT INTO %s VALUES (1, st_setsrid(st_geomfromwkb(X'%s'), 4326))", TABLE, SW_WKB);
+    sql("INSERT INTO %s VALUES (2, st_setsrid(st_geomfromwkb(X'%s'), 4326))", TABLE, NE_WKB);
+  }
+
+  @AfterEach
+  public void dropGeoTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @TestTemplate
+  public void testSpatialFilterPushesDownToScan() {
+    // The query window (0,0)-(30,30) contains only the southwest point; the plan should push the
+    // spatial predicate into the Iceberg batch scan rather than leave it in a post-scan Filter.
+    List<Object[]> plan =
+        sql(
+            "EXPLAIN SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30)",
+            TABLE, GEO_CATALOG);
+    String planText = plan.get(0)[0].toString();
+    assertThat(planText)
+        .as("spatial predicate should be pushed into the scan, not a post-scan Filter")
+        .containsIgnoringCase("st_intersects");
+    // A pushed predicate appears in the BatchScan's runtime/pushed filters; the residual Filter
+    // node should be gone (or trivially true) for this window.
+    assertThat(planText)
+        .as("the boolean UDF should no longer sit in a post-scan Filter node")
+        .doesNotContain("Filter applyfunctionexpression");
+  }
+
+  @TestTemplate
+  public void testSpatialFilterReturnsOnlyMatchingCluster() {
+    List<Object[]> sw =
+        sql(
+            "SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30) ORDER BY id",
+            TABLE, GEO_CATALOG);
+    assertThat(sw).as("only the southwest row matches").isEqualTo(ImmutableList.of(row(1L)));
+
+    List<Object[]> ne =
+        sql(
+            "SELECT id FROM %s WHERE %s.system.st_intersects(geom, 100, 50, 130, 80) ORDER BY id",
+            TABLE, GEO_CATALOG);
+    assertThat(ne).as("only the northeast row matches").isEqualTo(ImmutableList.of(row(2L)));
+  }
+}

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSpatialFilterPushdown.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestSpatialFilterPushdown.java
@@ -29,10 +29,10 @@ import org.junit.jupiter.api.TestTemplate;
 
 /**
  * End-to-end test that a spatial filter written in SQL is pushed down and prunes files. With the
- * Iceberg extensions enabled, {@code ReplaceStaticInvoke} rewrites the top-level boolean
- * {@code st_intersects(...)} function into an {@code ApplyFunctionExpression}, which Spark then
- * translates to a pushed DSv2 predicate; {@code SparkV2Filters} converts it to an Iceberg
- * {@code ST_INTERSECTS} expression and {@code InclusiveMetricsEvaluator} skips non-matching files.
+ * Iceberg extensions enabled, {@code ReplaceStaticInvoke} rewrites the top-level boolean {@code
+ * st_intersects(...)} function into an {@code ApplyFunctionExpression}, which Spark then translates
+ * to a pushed DSv2 predicate; {@code SparkV2Filters} converts it to an Iceberg {@code
+ * ST_INTERSECTS} expression and {@code InclusiveMetricsEvaluator} skips non-matching files.
  */
 public class TestSpatialFilterPushdown extends ExtensionsTestBase {
 
@@ -49,9 +49,11 @@ public class TestSpatialFilterPushdown extends ExtensionsTestBase {
     spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".type", "hadoop");
     spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".default-namespace", "default");
     spark.conf().set("spark.sql.catalog." + GEO_CATALOG + ".cache-enabled", "false");
-    spark.conf().set(
-        "spark.sql.catalog." + GEO_CATALOG + ".warehouse",
-        System.getProperty("java.io.tmpdir") + "/iceberg_spatial_pushdown");
+    spark
+        .conf()
+        .set(
+            "spark.sql.catalog." + GEO_CATALOG + ".warehouse",
+            System.getProperty("java.io.tmpdir") + "/iceberg_spatial_pushdown");
     spark.conf().set("spark.sql.geospatial.enabled", "true");
     // Geo has no Arrow vector yet; read through the row-based reader.
     spark.conf().set("spark.sql.iceberg.vectorization.enabled", "false");
@@ -80,28 +82,28 @@ public class TestSpatialFilterPushdown extends ExtensionsTestBase {
             "EXPLAIN SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30)",
             TABLE, GEO_CATALOG);
     String planText = plan.get(0)[0].toString();
+    // The definitive signal of pushdown: the Iceberg scan carries the spatial predicate in its
+    // pushed "filters=" list (used for file pruning). Spark still keeps a residual post-scan Filter
+    // because a spatial predicate is row-level, but the scan-level filter is what prunes files.
     assertThat(planText)
-        .as("spatial predicate should be pushed into the scan, not a post-scan Filter")
-        .containsIgnoringCase("st_intersects");
-    // A pushed predicate appears in the BatchScan's runtime/pushed filters; the residual Filter
-    // node should be gone (or trivially true) for this window.
-    assertThat(planText)
-        .as("the boolean UDF should no longer sit in a post-scan Filter node")
-        .doesNotContain("Filter applyfunctionexpression");
+        .as("the spatial predicate should be pushed into the Iceberg scan's filters")
+        .containsPattern("filters=[^,]*st_intersects\\(geom");
   }
 
   @TestTemplate
   public void testSpatialFilterReturnsOnlyMatchingCluster() {
-    List<Object[]> sw =
+    assertEquals(
+        "only the southwest row matches",
+        ImmutableList.of(row(1L)),
         sql(
             "SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30) ORDER BY id",
-            TABLE, GEO_CATALOG);
-    assertThat(sw).as("only the southwest row matches").isEqualTo(ImmutableList.of(row(1L)));
+            TABLE, GEO_CATALOG));
 
-    List<Object[]> ne =
+    assertEquals(
+        "only the northeast row matches",
+        ImmutableList.of(row(2L)),
         sql(
             "SELECT id FROM %s WHERE %s.system.st_intersects(geom, 100, 50, 130, 80) ORDER BY id",
-            TABLE, GEO_CATALOG);
-    assertThat(ne).as("only the northeast row matches").isEqualTo(ImmutableList.of(row(2L)));
+            TABLE, GEO_CATALOG));
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/Spark3Util.java
@@ -708,6 +708,16 @@ public class Spark3Util {
       }
     }
 
+    @Override
+    public String spatialPredicate(org.apache.iceberg.expressions.BoundSpatialPredicate pred) {
+      return "st_intersects(" + pred.ref().name() + ", " + pred.queryBound() + ")";
+    }
+
+    @Override
+    public String spatialPredicate(org.apache.iceberg.expressions.UnboundSpatialPredicate pred) {
+      return "st_intersects(" + pred.ref().name() + ", " + pred.queryBound() + ")";
+    }
+
     private static <T> String sqlString(UnboundTerm<T> term) {
       if (term instanceof org.apache.iceberg.expressions.NamedReference) {
         return term.ref().name();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -317,13 +317,23 @@ public class SparkV2Filters {
   }
 
   private static Expression convertSpatial(Predicate predicate) {
-    // A top-level spatial filter is pushed down as the iceberg.st_intersects UDF predicate:
-    //   st_intersects(geomColumn, minX, minY, maxX, maxY)
-    if (!"st_intersects".equalsIgnoreCase(predicate.name())) {
+    // A boolean scalar function used as a filter is delivered wrapped as
+    // V2Predicate("BOOLEAN_EXPRESSION", [UserDefinedScalarFunc]); unwrap to the UDF.
+    org.apache.spark.sql.connector.expressions.Expression udf = predicate;
+    if ("BOOLEAN_EXPRESSION".equals(predicate.name()) && predicate.children().length == 1) {
+      udf = predicate.children()[0];
+    }
+
+    if (!(udf instanceof UserDefinedScalarFunc)) {
+      return null;
+    }
+    UserDefinedScalarFunc func = (UserDefinedScalarFunc) udf;
+    if (!"st_intersects".equalsIgnoreCase(func.name())) {
       return null;
     }
 
-    org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
+    // st_intersects(geomColumn, minX, minY, maxX, maxY)
+    org.apache.spark.sql.connector.expressions.Expression[] children = func.children();
     if (children.length != 5 || !isRef(children[0])) {
       return null;
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkV2Filters.java
@@ -52,6 +52,8 @@ import org.apache.iceberg.expressions.Expression.Operation;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.expressions.UnboundTerm;
+import org.apache.iceberg.geospatial.BoundingBox;
+import org.apache.iceberg.geospatial.GeospatialBound;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -125,6 +127,11 @@ public class SparkV2Filters {
 
   @SuppressWarnings({"checkstyle:CyclomaticComplexity", "checkstyle:MethodLength"})
   public static Expression convert(Predicate predicate) {
+    Expression spatial = convertSpatial(predicate);
+    if (spatial != null) {
+      return spatial;
+    }
+
     Operation op = FILTERS.get(predicate.name());
     if (op != null) {
       switch (op) {
@@ -307,6 +314,33 @@ public class SparkV2Filters {
     }
 
     return null;
+  }
+
+  private static Expression convertSpatial(Predicate predicate) {
+    // A top-level spatial filter is pushed down as the iceberg.st_intersects UDF predicate:
+    //   st_intersects(geomColumn, minX, minY, maxX, maxY)
+    if (!"st_intersects".equalsIgnoreCase(predicate.name())) {
+      return null;
+    }
+
+    org.apache.spark.sql.connector.expressions.Expression[] children = predicate.children();
+    if (children.length != 5 || !isRef(children[0])) {
+      return null;
+    }
+    for (int i = 1; i < 5; i++) {
+      if (!isLiteral(children[i])) {
+        return null;
+      }
+    }
+
+    String colName = SparkUtil.toColumnName((NamedReference) children[0]);
+    double minX = ((Number) convertLiteral((Literal<?>) children[1])).doubleValue();
+    double minY = ((Number) convertLiteral((Literal<?>) children[2])).doubleValue();
+    double maxX = ((Number) convertLiteral((Literal<?>) children[3])).doubleValue();
+    double maxY = ((Number) convertLiteral((Literal<?>) children[4])).doubleValue();
+    BoundingBox window =
+        new BoundingBox(GeospatialBound.createXY(minX, minY), GeospatialBound.createXY(maxX, maxY));
+    return Expressions.stIntersects(colName, window);
   }
 
   private static Pair<UnboundTerm<Object>, Object> predicateChildren(Predicate predicate) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetWriters.java
@@ -30,6 +30,7 @@ import java.util.UUID;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.iceberg.FieldMetrics;
+import org.apache.iceberg.GeometryFieldMetrics;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.parquet.ParquetValueReaders.ReusableEntry;
 import org.apache.iceberg.parquet.ParquetValueWriter;
@@ -490,14 +491,27 @@ public class SparkParquetWriters {
 
   /** Writes a Spark {@link GeometryVal} as its WKB bytes into a BINARY column. */
   private static class GeometryWriter extends PrimitiveWriter<GeometryVal> {
+    private final GeometryFieldMetrics.Builder metricsBuilder;
+
     private GeometryWriter(ColumnDescriptor desc) {
       super(desc);
+      this.metricsBuilder =
+          new GeometryFieldMetrics.Builder(
+              desc.getPrimitiveType().getId().intValue(),
+              org.apache.iceberg.types.Types.GeometryType.crs84());
     }
 
     @Override
     public void write(int repetitionLevel, GeometryVal value) {
       // Spark stores geometry as [SRID | WKB]; Iceberg stores pure WKB, so strip the SRID header.
-      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(STUtils.stAsBinary(value)));
+      byte[] wkb = STUtils.stAsBinary(value);
+      metricsBuilder.addValue(ByteBuffer.wrap(wkb));
+      column.writeBinary(repetitionLevel, Binary.fromReusedByteArray(wkb));
+    }
+
+    @Override
+    public Stream<FieldMetrics<?>> metrics() {
+      return Stream.of(metricsBuilder.build());
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/STIntersectsFunction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/STIntersectsFunction.java
@@ -25,6 +25,7 @@ import org.apache.spark.sql.types.DataType;
 import org.apache.spark.sql.types.DataTypes;
 import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.types.StructType;
+import org.apache.spark.unsafe.types.GeometryVal;
 
 /**
  * A Spark function that tests whether a geometry column intersects a constant query window,
@@ -58,6 +59,14 @@ public class STIntersectsFunction implements UnboundFunction {
   }
 
   public static class STIntersects extends BaseScalarFunction<Boolean> {
+    // Magic static method: its presence (named "invoke") lets Spark represent the call as a
+    // StaticInvoke that ReplaceStaticInvoke can rewrite into a pushable ApplyFunctionExpression.
+    // The row-level result is not the focus of this PoC; file pruning happens before rows are read.
+    public static boolean invoke(
+        GeometryVal geom, double minX, double minY, double maxX, double maxY) {
+      return true;
+    }
+
     @Override
     public DataType[] inputTypes() {
       // The geometry column (CRS84) plus the four window bounds as doubles.

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/STIntersectsFunction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/STIntersectsFunction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.functions;
+
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.connector.catalog.functions.BoundFunction;
+import org.apache.spark.sql.connector.catalog.functions.UnboundFunction;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.types.GeometryType$;
+import org.apache.spark.sql.types.StructType;
+
+/**
+ * A Spark function that tests whether a geometry column intersects a constant query window,
+ * expressed as {@code st_intersects(geom, minX, minY, maxX, maxY)}. It is registered so that a
+ * query filter of this form is pushed down to Iceberg (see {@code SparkV2Filters}), where it drives
+ * file-level pruning against the column's stored bounding box. The four window arguments are
+ * doubles so the pushdown can extract them as literals.
+ *
+ * <p>This is a proof-of-concept function: the runtime {@code produceResult} is a coarse
+ * bounding-box overlap on the column value, sufficient for demonstrating pushdown.
+ */
+public class STIntersectsFunction implements UnboundFunction {
+
+  @Override
+  public BoundFunction bind(StructType inputType) {
+    if (inputType.size() != 5) {
+      throw new UnsupportedOperationException(
+          "st_intersects expects (geometry, minX, minY, maxX, maxY)");
+    }
+    return new STIntersects();
+  }
+
+  @Override
+  public String description() {
+    return "st_intersects(geom, minX, minY, maxX, maxY): true if geom may intersect the window";
+  }
+
+  @Override
+  public String name() {
+    return "st_intersects";
+  }
+
+  public static class STIntersects extends BaseScalarFunction<Boolean> {
+    @Override
+    public DataType[] inputTypes() {
+      // The geometry column (CRS84) plus the four window bounds as doubles.
+      return new DataType[] {
+        GeometryType$.MODULE$.apply("OGC:CRS84"),
+        DataTypes.DoubleType,
+        DataTypes.DoubleType,
+        DataTypes.DoubleType,
+        DataTypes.DoubleType
+      };
+    }
+
+    @Override
+    public DataType resultType() {
+      return DataTypes.BooleanType;
+    }
+
+    @Override
+    public boolean isResultNullable() {
+      return true;
+    }
+
+    @Override
+    public String name() {
+      return "st_intersects";
+    }
+
+    @Override
+    public String canonicalName() {
+      return "iceberg.st_intersects";
+    }
+
+    @Override
+    public Boolean produceResult(InternalRow input) {
+      // Row-level fallback is not the focus of this PoC; pushdown removes non-matching files before
+      // rows are read. Return true (do not filter rows) so any surviving rows are not dropped.
+      return true;
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -37,7 +37,8 @@ public class SparkFunctions {
           "days", new DaysFunction(),
           "hours", new HoursFunction(),
           "bucket", new BucketFunction(),
-          "truncate", new TruncateFunction());
+          "truncate", new TruncateFunction(),
+          "st_intersects", new STIntersectsFunction());
 
   private static final Map<Class<?>, UnboundFunction> CLASS_TO_FUNCTIONS =
       ImmutableMap.of(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/functions/SparkFunctions.java
@@ -47,7 +47,8 @@ public class SparkFunctions {
           DaysFunction.class, new DaysFunction(),
           HoursFunction.class, new HoursFunction(),
           BucketFunction.class, new BucketFunction(),
-          TruncateFunction.class, new TruncateFunction());
+          TruncateFunction.class, new TruncateFunction(),
+          STIntersectsFunction.class, new STIntersectsFunction());
 
   private static final List<String> FUNCTION_NAMES = ImmutableList.copyOf(FUNCTIONS.keySet());
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatialPushdown.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatialPushdown.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.sql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.apache.iceberg.spark.SparkCatalog;
+import org.apache.iceberg.spark.TestBase;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Investigation harness for pushing a spatial filter down from Spark SQL.
+ *
+ * <p>The pieces on the Iceberg side are in place: {@code system.st_intersects(geom, minX, minY,
+ * maxX, maxY)} is a registered {@link org.apache.iceberg.spark.functions.STIntersectsFunction}, and
+ * {@code SparkV2Filters} converts that UDF predicate into an Iceberg {@code ST_INTERSECTS}
+ * expression that {@code InclusiveMetricsEvaluator} uses to prune files (see the core PoC and
+ * TestSpatialMetricsEvaluator).
+ *
+ * <p>What this harness records is the remaining Spark-side gap: a bare boolean function used as a
+ * filter ({@code WHERE st_intersects(...)}) is left by Spark as an {@code ApplyFunctionExpression}
+ * in a post-scan {@code Filter} node and is NOT handed to the DSv2 filter pushdown, so {@code
+ * SparkV2Filters.convert} is never called for it. Iceberg's {@code ReplaceStaticInvoke} optimizer
+ * rule (spark-extensions) only rewrites a function call inside a comparison / IN ({@code func(col)
+ * <op> literal}), not a standalone boolean function. So driving this from SQL needs either the
+ * {@code st_intersects(...) = true} comparison form plus the Iceberg extensions, or an extension of
+ * that rule to cover boolean predicates. This test documents the current plan shape.
+ */
+public class TestSparkGeospatialPushdown extends TestBase {
+
+  private static final String CATALOG = "local";
+  private static final String TABLE = CATALOG + ".default.geo_pushdown";
+  // WKB points: (15,15) is the southwest cluster, (115,65) the northeast cluster.
+  private static final String SW_WKB = "01010000000000000000002e400000000000002e40";
+  private static final String NE_WKB = "01010000000000000000c05c400000000000405040";
+
+  @BeforeAll
+  public static void setupCatalog() {
+    spark.conf().set("spark.sql.catalog." + CATALOG, SparkCatalog.class.getName());
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".type", "hadoop");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".default-namespace", "default");
+    spark.conf().set("spark.sql.catalog." + CATALOG + ".cache-enabled", "false");
+    spark
+        .conf()
+        .set(
+            "spark.sql.catalog." + CATALOG + ".warehouse",
+            System.getProperty("java.io.tmpdir") + "/iceberg_spark_geo_pushdown");
+    spark.conf().set("spark.sql.geospatial.enabled", "true");
+  }
+
+  @BeforeEach
+  public void setupTable() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+    sql(
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326)) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3')",
+        TABLE);
+    sql("INSERT INTO %s VALUES (1, st_setsrid(st_geomfromwkb(X'%s'), 4326))", TABLE, SW_WKB);
+    sql("INSERT INTO %s VALUES (2, st_setsrid(st_geomfromwkb(X'%s'), 4326))", TABLE, NE_WKB);
+  }
+
+  @AfterEach
+  public void cleanup() {
+    sql("DROP TABLE IF EXISTS %s", TABLE);
+  }
+
+  @Test
+  public void testFunctionResolvesAndAppliesAsFilter() {
+    // The registered function resolves and Spark builds a Filter with the spatial UDF. (It is a
+    // post-scan Filter, not a pushed DSv2 predicate - see the class doc and the plan-shape test.)
+    List<Object[]> plan =
+        sql(
+            "EXPLAIN SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30)",
+            TABLE, CATALOG);
+    String planText = plan.get(0)[0].toString();
+    assertThat(planText)
+        .as("the spatial function resolves and appears as a filter in the plan")
+        .containsIgnoringCase("STIntersects")
+        .doesNotContainIgnoringCase("Error occurred");
+  }
+
+  @Test
+  public void testBareBooleanFunctionIsNotPushedToScan() {
+    // Documents the gap: the spatial UDF stays in a post-scan Filter node rather than being pushed
+    // into the Iceberg scan. When SQL-level pushdown is wired up (comparison form + extensions, or
+    // a ReplaceStaticInvoke extension), this expectation should flip to a pushed scan predicate.
+    List<Object[]> plan =
+        sql(
+            "EXPLAIN SELECT id FROM %s WHERE %s.system.st_intersects(geom, 0, 0, 30, 30)",
+            TABLE, CATALOG);
+    String planText = plan.get(0)[0].toString();
+    assertThat(planText)
+        .as("today the boolean UDF is a post-scan Filter, not a pushed scan predicate")
+        .contains("Filter")
+        .contains("applyfunctionexpression");
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Draft / proof-of-concept, stacked on #17161 (geometry bounding-box metrics — the first
> commit here is that PR; review it there). This branch demonstrates **end-to-end spatial
> file pruning from a Spark SQL query**. API shapes (predicate, operation, the
> `st_intersects` function signature) are a sketch for discussion, not a final proposal.
> Not intended to merge as-is.

## What it proves

A Spark SQL query with a spatial filter now prunes files by their geometry bounding box:

```sql
SELECT id FROM t WHERE system.st_intersects(geom, minX, minY, maxX, maxY)
```

`TestSpatialFilterPushdown` (spark-extensions) writes two geometry files with disjoint
clusters and shows:
- the plan carries the predicate in the Iceberg scan's pushed `filters=` list;
- a query window over one cluster returns only that cluster's row — the disjoint file is
  skipped during planning.

## The full chain (each link was the tricky part)

1. **Expression API** (`api`): `Operation.ST_INTERSECTS`, `Unbound/BoundSpatialPredicate`
   carrying a query `BoundingBox` (a spatial window, not a scalar `Literal`),
   `Expressions.stIntersects(...)`, and dispatch in `ExpressionVisitors`.
2. **File pruning** (`InclusiveMetricsEvaluator`): reads the file's geometry
   `lower_bounds`/`upper_bounds` and calls
   `GeospatialPredicateEvaluators.intersects(query, fileBbox)`; disjoint ⇒ `ROWS_CANNOT_MATCH`.
   (`TestSpatialMetricsEvaluator` covers this in isolation.)
3. **Every visitor**: a new predicate *kind* ripples through every `ExpressionVisitor`
   subclass — `Projections`, `Binder`, `RewriteNot`, `ExpressionUtil` sanitizers,
   `Spark3Util` describe, and the three Parquet row-group filters all need a
   `spatialPredicate` case (both Bound and Unbound overloads), or they NPE. Enumerated here.
4. **Serialization**: `BoundingBox`/`GeospatialBound` made `Serializable` so a pushed
   predicate ships to executors.
5. **Spark function**: `system.st_intersects(geom, minX, minY, maxX, maxY)` registered as a
   `ScalarFunction` (with the magic `invoke` static method **and** a `CLASS_TO_FUNCTIONS`
   entry — both required for pushdown).
6. **Optimizer rewrite** (`ReplaceStaticInvoke`, spark-extensions): a top-level boolean
   scalar-function filter is left by Spark as a `StaticInvoke`; the rule now rewrites it to
   an `ApplyFunctionExpression` that Spark can translate to a pushable DSv2 predicate.
   (Previously it only rewrote functions inside comparisons like `bucket(col) = 5`.)
7. **Pushdown conversion** (`SparkV2Filters`): the boolean UDF arrives wrapped as
   `V2Predicate("BOOLEAN_EXPRESSION", [UserDefinedScalarFunc])`; unwrap it and build the
   Iceberg `ST_INTERSECTS` expression.
8. **Spark writer**: wired the geometry bbox metrics into `SparkParquetWriters` (in
   addition to the generic-data path from #17161), so Spark-written geo files carry a bbox
   to prune against.

## Scope / caveats

- Function signature takes an explicit `(minX, minY, maxX, maxY)` window (doubles) so the
  pushdown extraction is trivial; a real design would take a constant geometry.
- Row-group-level spatial pruning is not implemented (row-group filters conservatively keep
  the group); file-level pruning does the work. The row-level `invoke` returns true (a PoC
  stub); correctness for the returned rows relies on file pruning here.
- Requires the Iceberg Spark extensions (for `ReplaceStaticInvoke`).

Opening as a draft to anchor the spatial-predicate API and the pushdown design.
