### PR TITLE
Spark: Aligned compaction commit filtering between fillQueue methods

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -428,7 +428,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     LOG.debug("filling queue from {}, to: {}", fromOffset, toOffset);
     Snapshot currentSnapshot = table().snapshot(fromOffset.snapshotId());
     // this could be a partial snapshot so add it outside the loop
-    if (currentSnapshot != null) {
+    if (currentSnapshot != null && shouldProcess(currentSnapshot)) {
       addMicroBatchToQueue(
           currentSnapshot,
           fromOffset.position(),

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -821,7 +821,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   @TestTemplate
   public void testStreamingWithReplaceSnapshot() throws Exception {
     List<SimpleRecord> batchAddedBeforeCompaction =
-            Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
+        Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
     appendData(batchAddedBeforeCompaction);
     table.refresh();
 
@@ -830,12 +830,12 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     makeRewriteDataFiles();
 
     List<SimpleRecord> batchAddedAfterCompaction =
-            Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
+        Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
     appendData(batchAddedAfterCompaction);
     StreamingQuery query =
-            startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
-    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
-    // from batchAddedBeforeCompaction and fail
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    // without the async planner fix that filters out the compaction snapshots, this assertion will
+    // also observe rows from batchAddedBeforeCompaction and fail
     assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
   }
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -819,6 +819,27 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testStreamingWithReplaceSnapshot() throws Exception {
+    List<SimpleRecord> batchAddedBeforeCompaction =
+            Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
+    appendData(batchAddedBeforeCompaction);
+    table.refresh();
+
+    long timeAfterFirstAppend = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(timeAfterFirstAppend);
+    makeRewriteDataFiles();
+
+    List<SimpleRecord> batchAddedAfterCompaction =
+            Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
+    appendData(batchAddedAfterCompaction);
+    StreamingQuery query =
+            startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
+    // from batchAddedBeforeCompaction and fail
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
+  }
+
+  @TestTemplate
   public void testReadStreamWithSnapshotTypeOverwriteErrorsOut() throws Exception {
     // upgrade table to version 2 - to facilitate creation of Snapshot of type OVERWRITE.
     TableOperations ops = ((BaseTable) table).operations();

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -428,7 +428,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     LOG.debug("filling queue from {}, to: {}", fromOffset, toOffset);
     Snapshot currentSnapshot = table().snapshot(fromOffset.snapshotId());
     // this could be a partial snapshot so add it outside the loop
-    if (currentSnapshot != null) {
+    if (currentSnapshot != null && shouldProcess(currentSnapshot)) {
       addMicroBatchToQueue(
           currentSnapshot,
           fromOffset.position(),

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -828,7 +828,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   @TestTemplate
   public void testStreamingWithReplaceSnapshot() throws Exception {
     List<SimpleRecord> batchAddedBeforeCompaction =
-            Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
+        Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
     appendData(batchAddedBeforeCompaction);
     table.refresh();
 
@@ -837,12 +837,12 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     makeRewriteDataFiles();
 
     List<SimpleRecord> batchAddedAfterCompaction =
-            Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
+        Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
     appendData(batchAddedAfterCompaction);
     StreamingQuery query =
-            startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
-    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
-    // from batchAddedBeforeCompaction and fail
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    // without the async planner fix that filters out the compaction snapshots, this assertion will
+    // also observe rows from batchAddedBeforeCompaction and fail
     assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
   }
 

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -826,6 +826,27 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testStreamingWithReplaceSnapshot() throws Exception {
+    List<SimpleRecord> batchAddedBeforeCompaction =
+            Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
+    appendData(batchAddedBeforeCompaction);
+    table.refresh();
+
+    long timeAfterFirstAppend = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(timeAfterFirstAppend);
+    makeRewriteDataFiles();
+
+    List<SimpleRecord> batchAddedAfterCompaction =
+            Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
+    appendData(batchAddedAfterCompaction);
+    StreamingQuery query =
+            startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
+    // from batchAddedBeforeCompaction and fail
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
+  }
+
+  @TestTemplate
   public void testReadStreamWithSnapshotTypeOverwriteErrorsOut() throws Exception {
     // upgrade table to version 2 - to facilitate creation of Snapshot of type OVERWRITE.
     TableOperations ops = ((BaseTable) table).operations();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/AsyncSparkMicroBatchPlanner.java
@@ -428,7 +428,7 @@ class AsyncSparkMicroBatchPlanner extends BaseSparkMicroBatchPlanner implements 
     LOG.debug("filling queue from {}, to: {}", fromOffset, toOffset);
     Snapshot currentSnapshot = table().snapshot(fromOffset.snapshotId());
     // this could be a partial snapshot so add it outside the loop
-    if (currentSnapshot != null) {
+    if (currentSnapshot != null && shouldProcess(currentSnapshot)) {
       addMicroBatchToQueue(
           currentSnapshot,
           fromOffset.position(),

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -827,6 +827,25 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
+  public void testStreamingWithReplaceSnapshot() throws Exception {
+    List<SimpleRecord> batchAddedBeforeCompaction =
+        Lists.newArrayList(new SimpleRecord(1, "val1"), new SimpleRecord(2, "val2"));
+    appendData(batchAddedBeforeCompaction);
+    table.refresh();
+
+    long timeAfterFirstAppend = table.currentSnapshot().timestampMillis() + 1;
+    waitUntilAfter(timeAfterFirstAppend);
+    makeRewriteDataFiles();
+
+    List<SimpleRecord> batchAddedAfterCompaction =
+        Lists.newArrayList(new SimpleRecord(3, "val3"), new SimpleRecord(4, "val4"));
+    appendData(batchAddedAfterCompaction);
+    StreamingQuery query =
+        startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
+  }
+
+  @TestTemplate
   public void testReadStreamWithSnapshotTypeOverwriteErrorsOut() throws Exception {
     // upgrade table to version 2 - to facilitate creation of Snapshot of type OVERWRITE.
     TableOperations ops = ((BaseTable) table).operations();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -842,8 +842,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     appendData(batchAddedAfterCompaction);
     StreamingQuery query =
         startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
-    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
-    // from batchAddedBeforeCompaction and fail
+    // without the async planner fix that filters out the compaction snapshots, this assertion will
+    // also observe rows from batchAddedBeforeCompaction and fail
     assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -842,6 +842,8 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
     appendData(batchAddedAfterCompaction);
     StreamingQuery query =
         startStream(SparkReadOptions.STREAM_FROM_TIMESTAMP, Long.toString(timeAfterFirstAppend));
+    // without the async planner fix that filters out the compaction snapshots, this assertion will also observe rows
+    // from batchAddedBeforeCompaction and fail
     assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(batchAddedAfterCompaction);
   }
 


### PR DESCRIPTION
Addresses concern (3) from https://github.com/apache/iceberg/issues/17001 

As called out in https://github.com/apache/iceberg/issues/17001.  The async planner has differnet behavior in `fillQueue(Snapshot readFrom)` and `fillQueue(fromOffset, toOffset)` with regard to the start snapshot. Specifically, `fillQueue(fromOffset, toOffset)` includes the first snapshot even it is a replacement commit. This PR aligns the behavior to consistnetly drop the replacement commit by calling the same filtering logic that is already used in `fillQueue(Snapshot readFrom)`. 
Since we are calling `shouldProcess`  from BaseSparkMicroBatchPlanner, this will also respect the configurations `streamingSkipDeleteSnapshots` and `streamingSkipOverwriteSnapshots` and depending on it will throw an exception when running into delete or overwrite snapshots.

Added test illustrates the change in the behavior for the async planner: wihtout the change in the `fillQueue`, the assertion will objserve the rows not only from the second batch, but also from the first batch added before the timestamp passed into the stream initialization.

As this change can be fairly isolated from other issues in https://github.com/apache/iceberg/issues/17001, creating a dedicated PR just for this one.

This change includes adjustments in spark versions 4.1, 4.0 and 3.5