### PR TITLE
AWS: Add properties to configure SDK request checksum calculation and response checksum validation

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -46,6 +46,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
         .build();
@@ -59,6 +60,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
           .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
           .build();
     }
@@ -68,6 +70,7 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .build();
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -112,6 +112,7 @@ public class AwsClientFactories {
           .applyMutation(httpClientProperties::applyHttpClientConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+          .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applySignerConfiguration)
@@ -129,6 +130,7 @@ public class AwsClientFactories {
             .applyMutation(
                 b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
             .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+            .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
             .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
             .build();
       }
@@ -138,6 +140,7 @@ public class AwsClientFactories {
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/lakeformation/LakeFormationAwsClientFactory.java
@@ -82,6 +82,7 @@ public class LakeFormationAwsClientFactory extends AssumeRoleAwsClientFactory {
           .applyMutation(httpClientProperties()::applyHttpClientConfigurations)
           .applyMutation(s3FileIOProperties()::applyEndpointConfigurations)
           .applyMutation(s3FileIOProperties()::applyServiceConfigurations)
+          .applyMutation(s3FileIOProperties()::applyChecksumConfigurations)
           .applyMutation(s3FileIOProperties()::applyRetryConfigurations)
           .credentialsProvider(
               new LakeFormationCredentialsProvider(lakeFormation(), buildTableArn()))

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/DefaultS3FileIOAwsClientFactory.java
@@ -50,6 +50,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(httpClientProperties::applyHttpClientConfigurations)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .applyMutation(
             s3ClientBuilder ->
                 s3FileIOProperties.applyCredentialConfigurations(
@@ -68,6 +69,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
           .applyMutation(awsClientProperties::applyClientRegionConfiguration)
           .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
           .applyMutation(s3FileIOProperties::applyS3CrtConfigurations)
           .build();
     }
@@ -76,6 +78,7 @@ class DefaultS3FileIOAwsClientFactory implements S3FileIOAwsClientFactory {
         .applyMutation(awsClientProperties::applyClientCredentialConfigurations)
         .applyMutation(awsClientProperties::applyLegacyMd5Plugin)
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+        .applyMutation(s3FileIOProperties::applyChecksumConfigurations)
         .build();
   }
 }

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -293,6 +293,31 @@ public class S3FileIOProperties implements Serializable {
 
   public static final boolean CHECKSUM_ENABLED_DEFAULT = false;
 
+  /**
+   * Controls when the AWS SDK calculates a checksum for S3 requests. Valid values are {@code
+   * when_supported} (the SDK calculates a checksum for all requests that support one) and {@code
+   * when_required} (the SDK only calculates a checksum for requests where the S3 API requires one).
+   * If not set, the AWS SDK default is used, which is {@code when_supported} since AWS SDK 2.30.0.
+   *
+   * <p>Set this to {@code when_required} for S3-compatible storage that rejects the additional
+   * checksum headers or trailing checksums that the AWS SDK sends by default.
+   *
+   * <p>For more details, see:
+   * https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html
+   */
+  public static final String REQUEST_CHECKSUM_CALCULATION = "s3.request-checksum-calculation";
+
+  /**
+   * Controls when the AWS SDK validates checksums on S3 responses. Valid values are {@code
+   * when_supported} (the SDK validates the checksum whenever the response contains one) and {@code
+   * when_required} (the SDK only validates the checksum when explicitly requested). If not set, the
+   * AWS SDK default is used, which is {@code when_supported} since AWS SDK 2.30.0.
+   *
+   * <p>For more details, see:
+   * https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html
+   */
+  public static final String RESPONSE_CHECKSUM_VALIDATION = "s3.response-checksum-validation";
+
   public static final String REMOTE_SIGNING_ENABLED = "s3.remote-signing-enabled";
 
   public static final boolean REMOTE_SIGNING_ENABLED_DEFAULT = false;
@@ -523,6 +548,8 @@ public class S3FileIOProperties implements Serializable {
   private String stagingDirectory;
   private ObjectCannedACL acl;
   private boolean isChecksumEnabled;
+  private final RequestChecksumCalculation requestChecksumCalculation;
+  private final ResponseChecksumValidation responseChecksumValidation;
   private boolean isChunkedEncodingEnabled;
   private final Set<Tag> writeTags;
   private boolean isWriteTableTagEnabled;
@@ -566,6 +593,8 @@ public class S3FileIOProperties implements Serializable {
     this.deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
     this.stagingDirectory = System.getProperty("java.io.tmpdir");
     this.isChecksumEnabled = CHECKSUM_ENABLED_DEFAULT;
+    this.requestChecksumCalculation = null;
+    this.responseChecksumValidation = null;
     this.isChunkedEncodingEnabled = CHUNKED_ENCODING_ENABLED_DEFAULT;
     this.writeTags = Sets.newHashSet();
     this.isWriteTableTagEnabled = WRITE_TABLE_TAG_ENABLED_DEFAULT;
@@ -657,6 +686,10 @@ public class S3FileIOProperties implements Serializable {
         "Cannot support S3 CannedACL " + aclType);
     this.isChecksumEnabled =
         PropertyUtil.propertyAsBoolean(properties, CHECKSUM_ENABLED, CHECKSUM_ENABLED_DEFAULT);
+    this.requestChecksumCalculation =
+        RequestChecksumCalculation.fromValue(properties.get(REQUEST_CHECKSUM_CALCULATION));
+    this.responseChecksumValidation =
+        ResponseChecksumValidation.fromValue(properties.get(RESPONSE_CHECKSUM_VALIDATION));
     this.isChunkedEncodingEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, CHUNKED_ENCODING_ENABLED, CHUNKED_ENCODING_ENABLED_DEFAULT);
@@ -825,6 +858,14 @@ public class S3FileIOProperties implements Serializable {
 
   public boolean isChecksumEnabled() {
     return this.isChecksumEnabled;
+  }
+
+  public RequestChecksumCalculation requestChecksumCalculation() {
+    return this.requestChecksumCalculation;
+  }
+
+  public ResponseChecksumValidation responseChecksumValidation() {
+    return this.responseChecksumValidation;
   }
 
   public boolean isChunkedEncodingEnabled() {
@@ -1022,57 +1063,6 @@ public class S3FileIOProperties implements Serializable {
   }
 
   /**
-   * Configure the request checksum calculation and response checksum validation for an S3 client
-   * based on the {@link #CHECKSUM_ENABLED} property.
-   *
-   * <p>When checksums are disabled (default), sets the checksum policies to {@code WHEN_REQUIRED}
-   * to avoid unexpected checksum calculation from the AWS SDK default of {@code WHEN_SUPPORTED}.
-   * When checksums are enabled, sets the policies to {@code WHEN_SUPPORTED}.
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3Client.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
-   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
-   * </pre>
-   */
-  public <T extends S3BaseClientBuilder<T, ?>> void applyChecksumConfigurations(T builder) {
-    RequestChecksumCalculation checksumCalculation =
-        isChecksumEnabled
-            ? RequestChecksumCalculation.WHEN_SUPPORTED
-            : RequestChecksumCalculation.WHEN_REQUIRED;
-    ResponseChecksumValidation checksumValidation =
-        isChecksumEnabled
-            ? ResponseChecksumValidation.WHEN_SUPPORTED
-            : ResponseChecksumValidation.WHEN_REQUIRED;
-    builder.requestChecksumCalculation(checksumCalculation);
-    builder.responseChecksumValidation(checksumValidation);
-  }
-
-  /**
-   * Configure the request checksum calculation and response checksum validation for an S3 CRT
-   * client based on the {@link #CHECKSUM_ENABLED} property.
-   *
-   * <p>Sample usage:
-   *
-   * <pre>
-   *     S3AsyncClient.crtBuilder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
-   * </pre>
-   */
-  public <T extends S3CrtAsyncClientBuilder> void applyChecksumConfigurations(T builder) {
-    RequestChecksumCalculation checksumCalculation =
-        isChecksumEnabled
-            ? RequestChecksumCalculation.WHEN_SUPPORTED
-            : RequestChecksumCalculation.WHEN_REQUIRED;
-    ResponseChecksumValidation checksumValidation =
-        isChecksumEnabled
-            ? ResponseChecksumValidation.WHEN_SUPPORTED
-            : ResponseChecksumValidation.WHEN_REQUIRED;
-    builder.requestChecksumCalculation(checksumCalculation);
-    builder.responseChecksumValidation(checksumValidation);
-  }
-
-  /**
    * Configure a signer for an S3 client.
    *
    * <p>Sample usage:
@@ -1124,6 +1114,49 @@ public class S3FileIOProperties implements Serializable {
   public <T extends S3CrtAsyncClientBuilder> void applyEndpointConfigurations(T builder) {
     if (endpoint != null) {
       builder.endpointOverride(URI.create(endpoint));
+    }
+  }
+
+  /**
+   * Configure the AWS SDK checksum behavior for an S3 sync or async client, based on the {@link
+   * #REQUEST_CHECKSUM_CALCULATION} and {@link #RESPONSE_CHECKSUM_VALIDATION} properties. When a
+   * property is not set, the corresponding AWS SDK default is left unchanged.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   * </pre>
+   */
+  public <T extends S3BaseClientBuilder<T, ?>> void applyChecksumConfigurations(T builder) {
+    if (requestChecksumCalculation != null) {
+      builder.requestChecksumCalculation(requestChecksumCalculation);
+    }
+
+    if (responseChecksumValidation != null) {
+      builder.responseChecksumValidation(responseChecksumValidation);
+    }
+  }
+
+  /**
+   * Configure the AWS SDK checksum behavior for an S3 CRT client, based on the {@link
+   * #REQUEST_CHECKSUM_CALCULATION} and {@link #RESPONSE_CHECKSUM_VALIDATION} properties. When a
+   * property is not set, the corresponding AWS SDK default is left unchanged.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.crtBuilder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   * </pre>
+   */
+  public <T extends S3CrtAsyncClientBuilder> void applyChecksumConfigurations(T builder) {
+    if (requestChecksumCalculation != null) {
+      builder.requestChecksumCalculation(requestChecksumCalculation);
+    }
+
+    if (responseChecksumValidation != null) {
+      builder.responseChecksumValidation(responseChecksumValidation);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -39,6 +39,8 @@ import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.SerializableMap;
 import software.amazon.awssdk.auth.credentials.AnonymousCredentialsProvider;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.core.exception.SdkServiceException;
@@ -1017,6 +1019,57 @@ public class S3FileIOProperties implements Serializable {
                 .accelerateModeEnabled(isAccelerationEnabled)
                 .chunkedEncodingEnabled(isChunkedEncodingEnabled)
                 .build());
+  }
+
+  /**
+   * Configure the request checksum calculation and response checksum validation for an S3 client
+   * based on the {@link #CHECKSUM_ENABLED} property.
+   *
+   * <p>When checksums are disabled (default), sets the checksum policies to {@code WHEN_REQUIRED}
+   * to avoid unexpected checksum calculation from the AWS SDK default of {@code WHEN_SUPPORTED}.
+   * When checksums are enabled, sets the policies to {@code WHEN_SUPPORTED}.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3Client.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   *     S3AsyncClient.builder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   * </pre>
+   */
+  public <T extends S3BaseClientBuilder<T, ?>> void applyChecksumConfigurations(T builder) {
+    RequestChecksumCalculation checksumCalculation =
+        isChecksumEnabled
+            ? RequestChecksumCalculation.WHEN_SUPPORTED
+            : RequestChecksumCalculation.WHEN_REQUIRED;
+    ResponseChecksumValidation checksumValidation =
+        isChecksumEnabled
+            ? ResponseChecksumValidation.WHEN_SUPPORTED
+            : ResponseChecksumValidation.WHEN_REQUIRED;
+    builder.requestChecksumCalculation(checksumCalculation);
+    builder.responseChecksumValidation(checksumValidation);
+  }
+
+  /**
+   * Configure the request checksum calculation and response checksum validation for an S3 CRT
+   * client based on the {@link #CHECKSUM_ENABLED} property.
+   *
+   * <p>Sample usage:
+   *
+   * <pre>
+   *     S3AsyncClient.crtBuilder().applyMutation(s3FileIOProperties::applyChecksumConfigurations)
+   * </pre>
+   */
+  public <T extends S3CrtAsyncClientBuilder> void applyChecksumConfigurations(T builder) {
+    RequestChecksumCalculation checksumCalculation =
+        isChecksumEnabled
+            ? RequestChecksumCalculation.WHEN_SUPPORTED
+            : RequestChecksumCalculation.WHEN_REQUIRED;
+    ResponseChecksumValidation checksumValidation =
+        isChecksumEnabled
+            ? ResponseChecksumValidation.WHEN_SUPPORTED
+            : ResponseChecksumValidation.WHEN_REQUIRED;
+    builder.requestChecksumCalculation(checksumCalculation);
+    builder.responseChecksumValidation(checksumValidation);
   }
 
   /**

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -35,6 +35,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -552,6 +554,46 @@ public class TestS3FileIOProperties {
     s3FileIOProperties.applyS3CrtConfigurations(mockS3CrtAsyncClientBuilder);
 
     Mockito.verify(mockS3CrtAsyncClientBuilder).maxConcurrency(Mockito.any(Integer.class));
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDefault() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsEnabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "true");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_SUPPORTED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDisabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "false");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -110,6 +110,9 @@ public class TestS3FileIOProperties {
     assertThat(s3FileIOProperties.isChecksumEnabled())
         .isEqualTo(S3FileIOProperties.CHECKSUM_ENABLED_DEFAULT);
 
+    assertThat(s3FileIOProperties.requestChecksumCalculation()).isNull();
+    assertThat(s3FileIOProperties.responseChecksumValidation()).isNull();
+
     assertThat(s3FileIOProperties.writeTags()).isEqualTo(Sets.newHashSet());
 
     assertThat(s3FileIOProperties.writeTableTagEnabled())
@@ -557,43 +560,97 @@ public class TestS3FileIOProperties {
   }
 
   @Test
-  public void testApplyChecksumConfigurationsDefault() {
-    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+  public void testApplyChecksumConfigurationsNotSet() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(Maps.newHashMap());
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
 
-    Mockito.verify(mockBuilder)
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3AsyncClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3CrtAsyncClientBuilder);
+
+    Mockito.verifyNoInteractions(
+        mockS3ClientBuilder, mockS3AsyncClientBuilder, mockS3CrtAsyncClientBuilder);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsWhenRequired() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "when_required");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "when_required");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
+
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3AsyncClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3CrtAsyncClientBuilder);
+
+    Mockito.verify(mockS3ClientBuilder)
         .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
-    Mockito.verify(mockBuilder)
+    Mockito.verify(mockS3ClientBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    Mockito.verify(mockS3AsyncClientBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockS3AsyncClientBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    Mockito.verify(mockS3CrtAsyncClientBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockS3CrtAsyncClientBuilder)
         .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
   }
 
   @Test
-  public void testApplyChecksumConfigurationsEnabled() {
+  public void testApplyChecksumConfigurationsWhenSupported() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "true");
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "when_supported");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "when_supported");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
 
-    Mockito.verify(mockBuilder)
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+
+    Mockito.verify(mockS3ClientBuilder)
         .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED);
-    Mockito.verify(mockBuilder)
+    Mockito.verify(mockS3ClientBuilder)
         .responseChecksumValidation(ResponseChecksumValidation.WHEN_SUPPORTED);
   }
 
   @Test
-  public void testApplyChecksumConfigurationsDisabled() {
+  public void testChecksumConfigurationsCaseInsensitive() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "false");
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "WHEN_REQUIRED");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "When_Supported");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
 
-    Mockito.verify(mockBuilder)
-        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
-    Mockito.verify(mockBuilder)
-        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    assertThat(s3FileIOProperties.requestChecksumCalculation())
+        .isEqualTo(RequestChecksumCalculation.WHEN_REQUIRED);
+    assertThat(s3FileIOProperties.responseChecksumValidation())
+        .isEqualTo(ResponseChecksumValidation.WHEN_SUPPORTED);
+  }
+
+  @Test
+  public void testInvalidRequestChecksumCalculation() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "invalid");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unrecognized value for request checksum calculation: invalid");
+  }
+
+  @Test
+  public void testInvalidResponseChecksumValidation() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "invalid");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unrecognized value for response checksum validation: invalid");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -111,6 +111,9 @@ public class TestS3FileIOProperties {
     assertThat(s3FileIOProperties.isChecksumEnabled())
         .isEqualTo(S3FileIOProperties.CHECKSUM_ENABLED_DEFAULT);
 
+    assertThat(s3FileIOProperties.requestChecksumCalculation()).isNull();
+    assertThat(s3FileIOProperties.responseChecksumValidation()).isNull();
+
     assertThat(s3FileIOProperties.writeTags()).isEqualTo(Sets.newHashSet());
 
     assertThat(s3FileIOProperties.writeTableTagEnabled())
@@ -560,43 +563,97 @@ public class TestS3FileIOProperties {
   }
 
   @Test
-  public void testApplyChecksumConfigurationsDefault() {
-    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+  public void testApplyChecksumConfigurationsNotSet() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(Maps.newHashMap());
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
 
-    Mockito.verify(mockBuilder)
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3AsyncClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3CrtAsyncClientBuilder);
+
+    Mockito.verifyNoInteractions(
+        mockS3ClientBuilder, mockS3AsyncClientBuilder, mockS3CrtAsyncClientBuilder);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsWhenRequired() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "when_required");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "when_required");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
+    S3AsyncClientBuilder mockS3AsyncClientBuilder = Mockito.mock(S3AsyncClientBuilder.class);
+    S3CrtAsyncClientBuilder mockS3CrtAsyncClientBuilder =
+        Mockito.mock(S3CrtAsyncClientBuilder.class);
+
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3AsyncClientBuilder);
+    s3FileIOProperties.applyChecksumConfigurations(mockS3CrtAsyncClientBuilder);
+
+    Mockito.verify(mockS3ClientBuilder)
         .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
-    Mockito.verify(mockBuilder)
+    Mockito.verify(mockS3ClientBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    Mockito.verify(mockS3AsyncClientBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockS3AsyncClientBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    Mockito.verify(mockS3CrtAsyncClientBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockS3CrtAsyncClientBuilder)
         .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
   }
 
   @Test
-  public void testApplyChecksumConfigurationsEnabled() {
+  public void testApplyChecksumConfigurationsWhenSupported() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "true");
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "when_supported");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "when_supported");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+    S3ClientBuilder mockS3ClientBuilder = Mockito.mock(S3ClientBuilder.class);
 
-    Mockito.verify(mockBuilder)
+    s3FileIOProperties.applyChecksumConfigurations(mockS3ClientBuilder);
+
+    Mockito.verify(mockS3ClientBuilder)
         .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED);
-    Mockito.verify(mockBuilder)
+    Mockito.verify(mockS3ClientBuilder)
         .responseChecksumValidation(ResponseChecksumValidation.WHEN_SUPPORTED);
   }
 
   @Test
-  public void testApplyChecksumConfigurationsDisabled() {
+  public void testChecksumConfigurationsCaseInsensitive() {
     Map<String, String> properties = Maps.newHashMap();
-    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "false");
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "WHEN_REQUIRED");
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "When_Supported");
     S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
-    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
-    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
 
-    Mockito.verify(mockBuilder)
-        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
-    Mockito.verify(mockBuilder)
-        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+    assertThat(s3FileIOProperties.requestChecksumCalculation())
+        .isEqualTo(RequestChecksumCalculation.WHEN_REQUIRED);
+    assertThat(s3FileIOProperties.responseChecksumValidation())
+        .isEqualTo(ResponseChecksumValidation.WHEN_SUPPORTED);
+  }
+
+  @Test
+  public void testInvalidRequestChecksumCalculation() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.REQUEST_CHECKSUM_CALCULATION, "invalid");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unrecognized value for request checksum calculation: invalid");
+  }
+
+  @Test
+  public void testInvalidResponseChecksumValidation() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.RESPONSE_CHECKSUM_VALIDATION, "invalid");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(properties))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Unrecognized value for response checksum validation: invalid");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -36,6 +36,8 @@ import org.apache.iceberg.rest.RESTCatalogProperties;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
+import software.amazon.awssdk.core.checksums.RequestChecksumCalculation;
+import software.amazon.awssdk.core.checksums.ResponseChecksumValidation;
 import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration;
 import software.amazon.awssdk.core.retry.RetryPolicy;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -555,6 +557,46 @@ public class TestS3FileIOProperties {
     s3FileIOProperties.applyS3CrtConfigurations(mockS3CrtAsyncClientBuilder);
 
     Mockito.verify(mockS3CrtAsyncClientBuilder).maxConcurrency(Mockito.any(Integer.class));
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDefault() {
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties();
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsEnabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "true");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_SUPPORTED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_SUPPORTED);
+  }
+
+  @Test
+  public void testApplyChecksumConfigurationsDisabled() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(S3FileIOProperties.CHECKSUM_ENABLED, "false");
+    S3FileIOProperties s3FileIOProperties = new S3FileIOProperties(properties);
+    S3ClientBuilder mockBuilder = Mockito.mock(S3ClientBuilder.class);
+    s3FileIOProperties.applyChecksumConfigurations(mockBuilder);
+
+    Mockito.verify(mockBuilder)
+        .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED);
+    Mockito.verify(mockBuilder)
+        .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
   }
 
   @Test

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -433,10 +433,14 @@ If for any reason you have to use S3A, here are the instructions:
 3. Add [hadoop-aws](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws) as a runtime dependency of your compute engine.
 4. Configure AWS settings based on [hadoop-aws documentation](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) (make sure you check the version, S3A configuration varies a lot based on the version you use).  
 
-### S3 Write Checksum Verification
+### S3 Checksum Verification
 
 To ensure integrity of uploaded objects, checksum validations for S3 writes can be turned on by setting catalog property `s3.checksum-enabled` to `true`.
 This is turned off by default.
+
+This property controls both the Iceberg-level MD5 checksum validation for uploads and the AWS SDK's checksum calculation and validation policies.
+When set to `false` (default), the SDK's `requestChecksumCalculation` and `responseChecksumValidation` are set to `WHEN_REQUIRED`, avoiding unexpected checksum overhead.
+When set to `true`, these policies are set to `WHEN_SUPPORTED`, enabling checksums whenever the S3 service supports them.
 
 ### S3 Tags
 

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -433,14 +433,33 @@ If for any reason you have to use S3A, here are the instructions:
 3. Add [hadoop-aws](https://mvnrepository.com/artifact/org.apache.hadoop/hadoop-aws) as a runtime dependency of your compute engine.
 4. Configure AWS settings based on [hadoop-aws documentation](https://hadoop.apache.org/docs/current/hadoop-aws/tools/hadoop-aws/index.html) (make sure you check the version, S3A configuration varies a lot based on the version you use).  
 
-### S3 Checksum Verification
+### S3 Write Checksum Verification
 
 To ensure integrity of uploaded objects, checksum validations for S3 writes can be turned on by setting catalog property `s3.checksum-enabled` to `true`.
 This is turned off by default.
 
-This property controls both the Iceberg-level MD5 checksum validation for uploads and the AWS SDK's checksum calculation and validation policies.
-When set to `false` (default), the SDK's `requestChecksumCalculation` and `responseChecksumValidation` are set to `WHEN_REQUIRED`, avoiding unexpected checksum overhead.
-When set to `true`, these policies are set to `WHEN_SUPPORTED`, enabling checksums whenever the S3 service supports them.
+### AWS SDK Checksum Calculation and Validation
+
+Since AWS SDK for Java 2.30.0, the SDK by default calculates a CRC32 checksum for every S3 request that supports one, and validates checksums included in S3 responses.
+See the [AWS SDK data integrity protections documentation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-dataintegrity.html) for more details.
+These SDK-level policies are independent from the `s3.checksum-enabled` property above and can be controlled with the following catalog properties:
+
+| Property                          | Default                     | Description                                                                                       |
+|-----------------------------------|-----------------------------|---------------------------------------------------------------------------------------------------|
+| s3.request-checksum-calculation   | AWS SDK default (`when_supported`) | When the SDK calculates a checksum for S3 requests: `when_supported` or `when_required`   |
+| s3.response-checksum-validation   | AWS SDK default (`when_supported`) | When the SDK validates checksums on S3 responses: `when_supported` or `when_required`     |
+
+Some S3-compatible object storage services do not accept the checksum headers or trailing checksums that the AWS SDK sends by default, and reject uploads with them.
+When using such storage, set `s3.request-checksum-calculation` to `when_required` so that the SDK only calculates checksums for requests where the S3 API requires them:
+
+```
+spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
+    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
+    --conf spark.sql.catalog.my_catalog.type=glue \
+    --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
+    --conf spark.sql.catalog.my_catalog.s3.request-checksum-calculation=when_required \
+    --conf spark.sql.catalog.my_catalog.s3.response-checksum-validation=when_required
+```
 
 ### S3 Tags
 

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -457,9 +457,10 @@ spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCata
     --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
     --conf spark.sql.catalog.my_catalog.type=glue \
     --conf spark.sql.catalog.my_catalog.io-impl=org.apache.iceberg.aws.s3.S3FileIO \
-    --conf spark.sql.catalog.my_catalog.s3.request-checksum-calculation=when_required \
-    --conf spark.sql.catalog.my_catalog.s3.response-checksum-validation=when_required
+    --conf spark.sql.catalog.my_catalog.s3.request-checksum-calculation=when_required
 ```
+
+Response checksum validation is a separate concern and is left at the SDK default above, since checksums that the service returns do not cause uploads to be rejected. Set `s3.response-checksum-validation` to `when_required` as well only if the service also returns checksums that the SDK cannot validate.
 
 ### S3 Tags
 


### PR DESCRIPTION
This PR adds two new S3FileIO properties to control the AWS SDK checksum behavior introduced in AWS SDK 2.30.0:

- `s3.request-checksum-calculation`: controls when the SDK calculates a checksum for S3 requests (`when_supported` / `when_required`)
- `s3.response-checksum-validation`: controls when the SDK validates checksums on S3 responses (`when_supported` / `when_required`)

When a property is not set, the corresponding AWS SDK default (`WHEN_SUPPORTED` since SDK 2.30.0) is left unchanged, so this PR introduces no behavior change for existing users.

### Background

Since AWS SDK 2.30.0, the SDK calculates a CRC32 checksum for all requests that support one (`RequestChecksumCalculation.WHEN_SUPPORTED` by default) and sends it as `x-amz-sdk-checksum-algorithm` / `x-amz-trailer: x-amz-checksum-crc32` headers. Some S3-compatible object stores (e.g. Dell ECS, GCS S3-compatible API) reject these headers, which breaks writes through S3FileIO. S3FileIO currently has no way to configure this SDK behavior; `s3.checksum-enabled` only controls the legacy Content-MD5 checksum. Setting `s3.request-checksum-calculation=when_required` stops the SDK from sending these headers.

This revives and reworks #15391 by @rcjverhoef (thanks!), preserving the original commit. The rework decouples the new knobs from `s3.checksum-enabled` into standalone properties that follow the SDK defaults when unset.

### Design notes

- Defaults intentionally follow the AWS SDK defaults (no behavior change). Flipping the default to `when_required` for better out-of-the-box compatibility with S3-compatible stores would be a behavior change and can be discussed separately on the dev list.
- A follow-up PR (#17178) will add an `s3.checksum-algorithm` property to select the checksum algorithm per request.
- The properties are applied in all S3 client factories (default, assume-role, LakeFormation, S3FileIO default factory), for sync, async, and CRT async clients.

### Testing

- Unit tests in `TestS3FileIOProperties` for parsing, defaults (unset leaves SDK defaults untouched), and builder application
- Verified against MinIO (testcontainers) and real AWS S3 with a header-capturing interceptor: with the default settings PutObject carries `x-amz-sdk-checksum-algorithm: CRC32` and `x-amz-trailer: x-amz-checksum-crc32`; with `when_required` no checksum headers are sent. S3FileIO write/read/delete succeed under both settings.

Fixes #14439

