### PR TITLE
AWS: Add s3.checksum-algorithm property to configure the SDK checksum algorithm

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -62,8 +62,10 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -171,6 +173,48 @@ public class TestS3OutputStream {
   public void testWriteWithChecksumEnabled() {
     properties.setChecksumEnabled(true);
     writeTest();
+  }
+
+  @Test
+  public void testWriteWithChecksumAlgorithm() throws IOException {
+    S3FileIOProperties checksumProperties =
+        new S3FileIOProperties(
+            ImmutableMap.of(
+                S3FileIOProperties.MULTIPART_SIZE,
+                Integer.toString(FIVE_MBS),
+                S3FileIOProperties.STAGING_DIRECTORY,
+                tmpDir.toString(),
+                S3FileIOProperties.CHECKSUM_ALGORITHM,
+                "CRC64NVME"));
+
+    // single put
+    try (S3OutputStream stream =
+        new S3OutputStream(s3mock, randomURI(), checksumProperties, nullMetrics())) {
+      stream.write(randomData(1024));
+    }
+
+    ArgumentCaptor<PutObjectRequest> putCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3mock).putObject(putCaptor.capture(), (RequestBody) any());
+    assertThat(putCaptor.getValue().checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    // multipart upload
+    reset(s3mock);
+    try (S3OutputStream stream =
+        new S3OutputStream(s3mock, randomURI(), checksumProperties, nullMetrics())) {
+      stream.write(randomData(10 * 1024 * 1024));
+    }
+
+    ArgumentCaptor<CreateMultipartUploadRequest> createCaptor =
+        ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+    verify(s3mock).createMultipartUpload(createCaptor.capture());
+    assertThat(createCaptor.getValue().checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    ArgumentCaptor<UploadPartRequest> partCaptor = ArgumentCaptor.forClass(UploadPartRequest.class);
+    verify(s3mock, times(2)).uploadPart(partCaptor.capture(), (RequestBody) any());
+    assertThat(partCaptor.getAllValues())
+        .allSatisfy(
+            request ->
+                assertThat(request.checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME));
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -60,8 +60,10 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.AbortMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyExistsException;
 import software.amazon.awssdk.services.s3.model.BucketAlreadyOwnedByYouException;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.CompleteMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.CreateMultipartUploadRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectResponse;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -168,6 +170,48 @@ public class TestS3OutputStream {
   public void testWriteWithChecksumEnabled() {
     properties.setChecksumEnabled(true);
     writeTest();
+  }
+
+  @Test
+  public void testWriteWithChecksumAlgorithm() throws IOException {
+    S3FileIOProperties checksumProperties =
+        new S3FileIOProperties(
+            ImmutableMap.of(
+                S3FileIOProperties.MULTIPART_SIZE,
+                Integer.toString(FIVE_MBS),
+                S3FileIOProperties.STAGING_DIRECTORY,
+                tmpDir.toString(),
+                S3FileIOProperties.CHECKSUM_ALGORITHM,
+                "CRC64NVME"));
+
+    // single put
+    try (S3OutputStream stream =
+        new S3OutputStream(s3mock, randomURI(), checksumProperties, nullMetrics())) {
+      stream.write(randomData(1024));
+    }
+
+    ArgumentCaptor<PutObjectRequest> putCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3mock).putObject(putCaptor.capture(), (RequestBody) any());
+    assertThat(putCaptor.getValue().checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    // multipart upload
+    reset(s3mock);
+    try (S3OutputStream stream =
+        new S3OutputStream(s3mock, randomURI(), checksumProperties, nullMetrics())) {
+      stream.write(randomData(10 * 1024 * 1024));
+    }
+
+    ArgumentCaptor<CreateMultipartUploadRequest> createCaptor =
+        ArgumentCaptor.forClass(CreateMultipartUploadRequest.class);
+    verify(s3mock).createMultipartUpload(createCaptor.capture());
+    assertThat(createCaptor.getValue().checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    ArgumentCaptor<UploadPartRequest> partCaptor = ArgumentCaptor.forClass(UploadPartRequest.class);
+    verify(s3mock, times(2)).uploadPart(partCaptor.capture(), (RequestBody) any());
+    assertThat(partCaptor.getAllValues())
+        .allSatisfy(
+            request ->
+                assertThat(request.checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME));
   }
 
   @Test

--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -212,6 +212,15 @@ public class TestS3OutputStream {
         .allSatisfy(
             request ->
                 assertThat(request.checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.CRC64_NVME));
+
+    // the checksum each part upload returns has to reach CompleteMultipartUpload, otherwise S3
+    // rejects the completion with InvalidPart
+    ArgumentCaptor<CompleteMultipartUploadRequest> completeCaptor =
+        ArgumentCaptor.forClass(CompleteMultipartUploadRequest.class);
+    verify(s3mock).completeMultipartUpload(completeCaptor.capture());
+    assertThat(completeCaptor.getValue().multipartUpload().parts())
+        .hasSize(2)
+        .allSatisfy(part -> assertThat(part.checksumCRC64NVME()).isNotNull());
   }
 
   @Test

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import java.net.URI;
 import java.time.Duration;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -53,6 +54,7 @@ import software.amazon.awssdk.services.s3.S3BaseClientBuilder;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
@@ -291,6 +293,20 @@ public class S3FileIOProperties implements Serializable {
 
   public static final boolean CHECKSUM_ENABLED_DEFAULT = false;
 
+  /**
+   * Configures the checksum algorithm the AWS SDK uses for data integrity protection on S3 upload
+   * requests (PutObject, UploadPart). Valid values are the algorithms supported by S3, e.g. {@code
+   * CRC32}, {@code CRC32C}, {@code CRC64NVME}, {@code SHA1}, {@code SHA256} (case-insensitive). If
+   * not set, the AWS SDK default algorithm (CRC32) is used when the SDK calculates a checksum.
+   *
+   * <p>Note that setting a checksum algorithm causes the SDK to calculate a checksum for these
+   * requests even when the SDK request checksum calculation is configured to {@code WHEN_REQUIRED}.
+   *
+   * <p>For more details, see:
+   * https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html
+   */
+  public static final String CHECKSUM_ALGORITHM = "s3.checksum-algorithm";
+
   public static final String REMOTE_SIGNING_ENABLED = "s3.remote-signing-enabled";
 
   public static final boolean REMOTE_SIGNING_ENABLED_DEFAULT = false;
@@ -521,6 +537,7 @@ public class S3FileIOProperties implements Serializable {
   private String stagingDirectory;
   private ObjectCannedACL acl;
   private boolean isChecksumEnabled;
+  private final ChecksumAlgorithm checksumAlgorithm;
   private boolean isChunkedEncodingEnabled;
   private final Set<Tag> writeTags;
   private boolean isWriteTableTagEnabled;
@@ -564,6 +581,7 @@ public class S3FileIOProperties implements Serializable {
     this.deleteBatchSize = DELETE_BATCH_SIZE_DEFAULT;
     this.stagingDirectory = System.getProperty("java.io.tmpdir");
     this.isChecksumEnabled = CHECKSUM_ENABLED_DEFAULT;
+    this.checksumAlgorithm = null;
     this.isChunkedEncodingEnabled = CHUNKED_ENCODING_ENABLED_DEFAULT;
     this.writeTags = Sets.newHashSet();
     this.isWriteTableTagEnabled = WRITE_TABLE_TAG_ENABLED_DEFAULT;
@@ -655,6 +673,7 @@ public class S3FileIOProperties implements Serializable {
         "Cannot support S3 CannedACL " + aclType);
     this.isChecksumEnabled =
         PropertyUtil.propertyAsBoolean(properties, CHECKSUM_ENABLED, CHECKSUM_ENABLED_DEFAULT);
+    this.checksumAlgorithm = parseChecksumAlgorithm(properties.get(CHECKSUM_ALGORITHM));
     this.isChunkedEncodingEnabled =
         PropertyUtil.propertyAsBoolean(
             properties, CHUNKED_ENCODING_ENABLED, CHUNKED_ENCODING_ENABLED_DEFAULT);
@@ -823,6 +842,24 @@ public class S3FileIOProperties implements Serializable {
 
   public boolean isChecksumEnabled() {
     return this.isChecksumEnabled;
+  }
+
+  public ChecksumAlgorithm checksumAlgorithm() {
+    return this.checksumAlgorithm;
+  }
+
+  private static ChecksumAlgorithm parseChecksumAlgorithm(String value) {
+    if (value == null) {
+      return null;
+    }
+
+    ChecksumAlgorithm algorithm = ChecksumAlgorithm.fromValue(value.toUpperCase(Locale.ROOT));
+    Preconditions.checkArgument(
+        ChecksumAlgorithm.knownValues().contains(algorithm),
+        "Invalid checksum algorithm: %s (valid values: %s)",
+        value,
+        ChecksumAlgorithm.knownValues());
+    return algorithm;
   }
 
   public boolean isChunkedEncodingEnabled() {

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3OutputStream.java
@@ -283,6 +283,10 @@ class S3OutputStream extends PositionOutputStream {
       requestBuilder.storageClass(s3FileIOProperties.writeStorageClass());
     }
 
+    if (s3FileIOProperties.checksumAlgorithm() != null) {
+      requestBuilder.checksumAlgorithm(s3FileIOProperties.checksumAlgorithm());
+    }
+
     S3RequestUtil.configureEncryption(s3FileIOProperties, requestBuilder);
     S3RequestUtil.configurePermission(s3FileIOProperties, requestBuilder);
 
@@ -316,6 +320,10 @@ class S3OutputStream extends PositionOutputStream {
                 requestBuilder.contentMD5(BinaryUtils.toBase64(fileAndDigest.digest()));
               }
 
+              if (s3FileIOProperties.checksumAlgorithm() != null) {
+                requestBuilder.checksumAlgorithm(s3FileIOProperties.checksumAlgorithm());
+              }
+
               S3RequestUtil.configureEncryption(s3FileIOProperties, requestBuilder);
 
               UploadPartRequest uploadRequest = requestBuilder.build();
@@ -325,10 +333,26 @@ class S3OutputStream extends PositionOutputStream {
                           () -> {
                             UploadPartResponse response =
                                 s3.uploadPart(uploadRequest, RequestBody.fromFile(f));
-                            return CompletedPart.builder()
-                                .eTag(response.eTag())
-                                .partNumber(uploadRequest.partNumber())
-                                .build();
+                            CompletedPart.Builder completedPartBuilder =
+                                CompletedPart.builder()
+                                    .eTag(response.eTag())
+                                    .partNumber(uploadRequest.partNumber());
+                            if (s3FileIOProperties.checksumAlgorithm() != null) {
+                              // the part checksums calculated for the configured algorithm
+                              // must be passed on to CompleteMultipartUpload
+                              completedPartBuilder
+                                  .checksumCRC32(response.checksumCRC32())
+                                  .checksumCRC32C(response.checksumCRC32C())
+                                  .checksumCRC64NVME(response.checksumCRC64NVME())
+                                  .checksumSHA1(response.checksumSHA1())
+                                  .checksumSHA256(response.checksumSHA256())
+                                  .checksumSHA512(response.checksumSHA512())
+                                  .checksumMD5(response.checksumMD5())
+                                  .checksumXXHASH64(response.checksumXXHASH64())
+                                  .checksumXXHASH3(response.checksumXXHASH3())
+                                  .checksumXXHASH128(response.checksumXXHASH128());
+                            }
+                            return completedPartBuilder.build();
                           },
                           executorService)
                       .whenComplete(
@@ -435,6 +459,10 @@ class S3OutputStream extends PositionOutputStream {
 
       if (isChecksumEnabled) {
         requestBuilder.contentMD5(BinaryUtils.toBase64(completeMessageDigest.digest()));
+      }
+
+      if (s3FileIOProperties.checksumAlgorithm() != null) {
+        requestBuilder.checksumAlgorithm(s3FileIOProperties.checksumAlgorithm());
       }
 
       S3RequestUtil.configureEncryption(s3FileIOProperties, requestBuilder);

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -42,6 +42,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
@@ -107,6 +108,8 @@ public class TestS3FileIOProperties {
 
     assertThat(s3FileIOProperties.isChecksumEnabled())
         .isEqualTo(S3FileIOProperties.CHECKSUM_ENABLED_DEFAULT);
+
+    assertThat(s3FileIOProperties.checksumAlgorithm()).isNull();
 
     assertThat(s3FileIOProperties.writeTags()).isEqualTo(Sets.newHashSet());
 
@@ -312,6 +315,31 @@ public class TestS3FileIOProperties {
     assertThatThrownBy(() -> new S3FileIOProperties(map))
         .isInstanceOf(ValidationException.class)
         .hasMessage("S3 client access key ID and secret access key must be set at the same time");
+  }
+
+  @Test
+  public void testChecksumAlgorithm() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "CRC64NVME");
+    assertThat(new S3FileIOProperties(map).checksumAlgorithm())
+        .isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    // values are case-insensitive
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "sha256");
+    assertThat(new S3FileIOProperties(map).checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.SHA256);
+
+    // unset leaves the SDK default unchanged
+    assertThat(new S3FileIOProperties(Maps.newHashMap()).checksumAlgorithm()).isNull();
+  }
+
+  @Test
+  public void testChecksumAlgorithmInvalid() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "CRC999");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Invalid checksum algorithm: CRC999");
   }
 
   @Test

--- a/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/s3/TestS3FileIOProperties.java
@@ -43,6 +43,7 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 import software.amazon.awssdk.services.s3.S3Configuration;
 import software.amazon.awssdk.services.s3.S3CrtAsyncClientBuilder;
+import software.amazon.awssdk.services.s3.model.ChecksumAlgorithm;
 import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.Tag;
 
@@ -108,6 +109,8 @@ public class TestS3FileIOProperties {
 
     assertThat(s3FileIOProperties.isChecksumEnabled())
         .isEqualTo(S3FileIOProperties.CHECKSUM_ENABLED_DEFAULT);
+
+    assertThat(s3FileIOProperties.checksumAlgorithm()).isNull();
 
     assertThat(s3FileIOProperties.writeTags()).isEqualTo(Sets.newHashSet());
 
@@ -313,6 +316,31 @@ public class TestS3FileIOProperties {
     assertThatThrownBy(() -> new S3FileIOProperties(map))
         .isInstanceOf(ValidationException.class)
         .hasMessage("S3 client access key ID and secret access key must be set at the same time");
+  }
+
+  @Test
+  public void testChecksumAlgorithm() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "CRC64NVME");
+    assertThat(new S3FileIOProperties(map).checksumAlgorithm())
+        .isEqualTo(ChecksumAlgorithm.CRC64_NVME);
+
+    // values are case-insensitive
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "sha256");
+    assertThat(new S3FileIOProperties(map).checksumAlgorithm()).isEqualTo(ChecksumAlgorithm.SHA256);
+
+    // unset leaves the SDK default unchanged
+    assertThat(new S3FileIOProperties(Maps.newHashMap()).checksumAlgorithm()).isNull();
+  }
+
+  @Test
+  public void testChecksumAlgorithmInvalid() {
+    Map<String, String> map = Maps.newHashMap();
+    map.put(S3FileIOProperties.CHECKSUM_ALGORITHM, "CRC999");
+
+    assertThatThrownBy(() -> new S3FileIOProperties(map))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Invalid checksum algorithm: CRC999");
   }
 
   @Test

--- a/docs/docs/aws.md
+++ b/docs/docs/aws.md
@@ -438,6 +438,12 @@ If for any reason you have to use S3A, here are the instructions:
 To ensure integrity of uploaded objects, checksum validations for S3 writes can be turned on by setting catalog property `s3.checksum-enabled` to `true`.
 This is turned off by default.
 
+The checksum algorithm the AWS SDK uses for data integrity protection on S3 upload requests (PutObject, UploadPart) can be configured with the catalog property `s3.checksum-algorithm`.
+Valid values are the [algorithms supported by S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/checking-object-integrity.html), e.g. `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, `SHA256` (case-insensitive).
+If not set, the AWS SDK default algorithm (`CRC32`) is used when the SDK calculates a checksum.
+For example, `CRC64NVME` can be used for efficient full object integrity checks of multipart uploads, and `SHA256` can be used where a cryptographic hash is required.
+Note that setting a checksum algorithm causes the SDK to calculate a checksum for these requests even when the SDK request checksum calculation is configured to `when_required`.
+
 ### S3 Tags
 
 Custom [tags](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-tagging.html) can be added to S3 objects while writing and deleting.


### PR DESCRIPTION
This PR adds a new S3FileIO property to select the checksum algorithm the AWS SDK uses for data integrity protection on S3 upload requests:

- `s3.checksum-algorithm`: valid values are the algorithms supported by S3 — `CRC32`, `CRC32C`, `CRC64NVME`, `SHA1`, `SHA256`, and (since AWS SDK 2.42.x) `MD5`, `SHA512`, `XXHASH3`, `XXHASH64`, `XXHASH128` — case-insensitive. When unset, the AWS SDK default algorithm (CRC32) is used, so there is no behavior change.

### Background

S3FileIO has no way to choose the checksum algorithm today; the SDK always uses its default (CRC32). Users may want `CRC64NVME` for efficient full-object integrity checks of multipart uploads, or `SHA256` where a cryptographic hash is required. See #17178 for details.

### Usage

Set the catalog property `s3.checksum-algorithm` to the desired algorithm name, e.g. with Spark:

```
spark-sql --conf spark.sql.catalog.my_catalog=org.apache.iceberg.spark.SparkCatalog \
    --conf spark.sql.catalog.my_catalog.warehouse=s3://my-bucket/my/key/prefix \
    --conf spark.sql.catalog.my_catalog.s3.checksum-algorithm=CRC64NVME \
    ...
```

### Naming

The property is named `s3.checksum-algorithm` to sit alongside the existing `s3.checksum-enabled`, which also concerns upload checksums. An alternative considered was `s3.write.checksum-algorithm`, following the `s3.write.*` convention used for other upload-only properties (e.g. `s3.write.storage-class`), since this property only affects upload requests. Open to renaming if reviewers prefer that convention. For reference, Hadoop S3A calls the equivalent option `fs.s3a.create.checksum.algorithm`.

### Implementation notes

- The algorithm is applied per request in `S3OutputStream` (`PutObjectRequest`, `CreateMultipartUploadRequest`, `UploadPartRequest`).
- Part checksums returned by `UploadPart` are passed on to `CompleteMultipartUpload` via `CompletedPart`; S3 rejects the completion with `InvalidPart` otherwise when an algorithm is specified.
- One interaction worth noting: setting a request-level checksum algorithm causes the SDK to calculate checksums even when the SDK request checksum calculation is configured to `when_required` (see #17177).

### Testing

- Unit tests in `TestS3FileIOProperties` for parsing (case-insensitivity, invalid values, unset leaves the SDK default untouched)
- Integration test `TestS3OutputStream#testWriteWithChecksumAlgorithm` verifying the algorithm is applied to PutObject, CreateMultipartUpload, and UploadPart requests
- Verified against MinIO (testcontainers) and real AWS S3 with `CRC64NVME` and `SHA256`, for both single PUT and multipart uploads: request headers carry the configured algorithm (`x-amz-sdk-checksum-algorithm` / `x-amz-checksum-*` trailers), uploads and reads succeed, and content roundtrips correctly.

Fixes #17178
