### PR TITLE
Spark 4.1: Add Spark REST_CATALOG_PURGE property to delegate DROP TABLE PURGE to REST catalogs

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalog.java
@@ -55,6 +55,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.spark.actions.SparkActions;
 import org.apache.iceberg.spark.source.SparkChangelogTable;
 import org.apache.iceberg.spark.source.SparkTable;
@@ -85,6 +86,8 @@ import org.apache.spark.sql.connector.catalog.ViewInfo;
 import org.apache.spark.sql.connector.expressions.Transform;
 import org.apache.spark.sql.types.StructType;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Spark TableCatalog implementation that wraps an Iceberg {@link Catalog}.
@@ -116,6 +119,8 @@ import org.apache.spark.sql.util.CaseInsensitiveStringMap;
  * <p>
  */
 public class SparkCatalog extends BaseCatalog {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SparkCatalog.class);
   private static final Set<String> DEFAULT_NS_KEYS = ImmutableSet.of(TableCatalog.PROP_OWNER);
   private static final Splitter COMMA = Splitter.on(",");
   private static final Joiner COMMA_JOINER = Joiner.on(",");
@@ -130,6 +135,8 @@ public class SparkCatalog extends BaseCatalog {
   private ViewCatalog asViewCatalog = null;
   private String[] defaultNamespace = null;
   private HadoopTables tables;
+  private boolean restCatalogPurge;
+  private boolean isRestCatalog;
 
   /**
    * Build an Iceberg {@link Catalog} to be used by this Spark catalog adapter.
@@ -301,7 +308,7 @@ public class SparkCatalog extends BaseCatalog {
 
   @Override
   public boolean dropTable(Identifier ident) {
-    return dropTableWithoutPurging(ident);
+    return catalogDropTable(ident);
   }
 
   @Override
@@ -314,7 +321,17 @@ public class SparkCatalog extends BaseCatalog {
       String metadataFileLocation =
           ((HasTableOperations) table).operations().current().metadataFileLocation();
 
-      boolean dropped = dropTableWithoutPurging(ident);
+      if (isRestCatalog && !isPathIdentifier(ident)) {
+        if (restCatalogPurge) {
+          return icebergCatalog.dropTable(buildIdentifier(ident), true);
+        } else {
+          LOG.info(
+              "Set '{}' to true to use the REST catalog's capabilities to purge the table.",
+              SparkCatalogProperties.REST_CATALOG_PURGE);
+        }
+      }
+
+      boolean dropped = catalogDropTable(ident);
 
       if (dropped) {
         // check whether the metadata file exists because HadoopCatalog/HadoopTables
@@ -332,7 +349,7 @@ public class SparkCatalog extends BaseCatalog {
     }
   }
 
-  private boolean dropTableWithoutPurging(Identifier ident) {
+  private boolean catalogDropTable(Identifier ident) {
     if (isPathIdentifier(ident)) {
       return tables.dropTable(((PathIdentifier) ident).location(), false /* don't purge data */);
     } else {
@@ -702,6 +719,12 @@ public class SparkCatalog extends BaseCatalog {
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS,
             CatalogProperties.CACHE_EXPIRATION_INTERVAL_MS_DEFAULT);
 
+    this.restCatalogPurge =
+        PropertyUtil.propertyAsBoolean(
+            options,
+            SparkCatalogProperties.REST_CATALOG_PURGE,
+            SparkCatalogProperties.REST_CATALOG_PURGE_DEFAULT);
+
     // An expiration interval of 0ms effectively disables caching.
     // Do not wrap with CachingCatalog.
     if (cacheExpirationIntervalMs == 0) {
@@ -709,6 +732,13 @@ public class SparkCatalog extends BaseCatalog {
     }
 
     Catalog catalog = buildIcebergCatalog(name, options);
+    this.isRestCatalog = catalog instanceof RESTCatalog;
+
+    Preconditions.checkArgument(
+        !restCatalogPurge || isRestCatalog,
+        "Cannot enable '%s': the configured catalog is not a REST catalog: %s",
+        SparkCatalogProperties.REST_CATALOG_PURGE,
+        catalog.getClass().getName());
 
     this.catalogName = name;
     SparkSession sparkSession = SparkSession.getActiveSession().get();

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalogProperties.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkCatalogProperties.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+public final class SparkCatalogProperties {
+
+  private SparkCatalogProperties() {}
+
+  /**
+   * Controls whether Spark should delegate DROP TABLE PURGE requests to the REST catalog instead of
+   * performing client-side file deletion.
+   *
+   * <p>When enabled, Spark sends the purge request to the REST catalog, allowing the catalog to
+   * handle deletion.
+   *
+   * <p>Defaults to false for backward compatibility.
+   */
+  public static final String REST_CATALOG_PURGE = "rest-catalog-purge";
+
+  public static final boolean REST_CATALOG_PURGE_DEFAULT = false;
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestRestDropPurgeTable.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/TestRestDropPurgeTable.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark;
+
+import static org.apache.iceberg.spark.SparkCatalogProperties.REST_CATALOG_PURGE;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.File;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.RESTCatalog;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.connector.catalog.Identifier;
+import org.apache.spark.sql.connector.catalog.TableCatalog;
+import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+/**
+ * Tests for the REST catalog purge delegation feature in {@link SparkCatalog}.
+ *
+ * <p>Verifies that {@link SparkCatalogProperties#REST_CATALOG_PURGE} controls whether Spark
+ * delegates DROP TABLE PURGE to the REST catalog or performs client-side file deletion.
+ */
+public class TestRestDropPurgeTable extends TestBase {
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+
+  private static final Identifier SPARK_ID = Identifier.of(new String[] {"ns"}, "test_table");
+
+  @TempDir private File tableDir;
+
+  private RESTCatalog restCatalogMock;
+
+  private SparkCatalog createCatalog(boolean catalogPurge) {
+    Table table =
+        new HadoopTables(new Configuration())
+            .create(SCHEMA, PartitionSpec.unpartitioned(), tableDir.getAbsolutePath());
+
+    restCatalogMock = mock(RESTCatalog.class);
+    when(restCatalogMock.loadTable(any())).thenReturn(table);
+    when(restCatalogMock.dropTable(any(), anyBoolean())).thenReturn(true);
+
+    SparkCatalog catalog =
+        new SparkCatalog() {
+          @Override
+          protected Catalog buildIcebergCatalog(String name, CaseInsensitiveStringMap options) {
+            return restCatalogMock;
+          }
+        };
+    catalog.initialize(
+        "test_catalog",
+        new CaseInsensitiveStringMap(
+            ImmutableMap.of(REST_CATALOG_PURGE, Boolean.toString(catalogPurge))));
+    return catalog;
+  }
+
+  @Test
+  void purgeTableDelegatesToCatalogWhenEnabled() {
+    SparkCatalog catalog = createCatalog(true);
+    catalog.purgeTable(SPARK_ID);
+    verify(restCatalogMock).dropTable(any(), eq(true));
+  }
+
+  @Test
+  void purgeNotDelegatedToCatalogWhenDisabled() {
+    SparkCatalog catalog = createCatalog(false);
+    catalog.purgeTable(SPARK_ID);
+    verify(restCatalogMock).dropTable(any(), eq(false));
+  }
+
+  @Test
+  void initializationFailsWhenPurgeEnabledWithNonRestCatalog() {
+    SparkCatalog catalog =
+        new SparkCatalog() {
+          @Override
+          protected Catalog buildIcebergCatalog(String name, CaseInsensitiveStringMap options) {
+            return new InMemoryCatalog();
+          }
+        };
+    assertThatThrownBy(
+            () ->
+                catalog.initialize(
+                    "test_catalog",
+                    new CaseInsensitiveStringMap(ImmutableMap.of(REST_CATALOG_PURGE, "true"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(REST_CATALOG_PURGE);
+  }
+
+  @Test
+  void purgeTableDelegatesToCatalogWhenEnabledViaSessionCatalog() {
+    Table table =
+        new HadoopTables(new Configuration())
+            .create(SCHEMA, PartitionSpec.unpartitioned(), tableDir.getAbsolutePath());
+
+    RESTCatalog sessionRestCatalogMock = mock(RESTCatalog.class);
+    when(sessionRestCatalogMock.loadTable(any())).thenReturn(table);
+    when(sessionRestCatalogMock.dropTable(any(), anyBoolean())).thenReturn(true);
+
+    SparkSessionCatalog<SparkCatalog> sessionCatalog =
+        new SparkSessionCatalog<SparkCatalog>() {
+          @Override
+          protected TableCatalog buildSparkCatalog(String name, CaseInsensitiveStringMap options) {
+            SparkCatalog sparkCatalog =
+                new SparkCatalog() {
+                  @Override
+                  protected Catalog buildIcebergCatalog(
+                      String catalogName, CaseInsensitiveStringMap catalogOptions) {
+                    return sessionRestCatalogMock;
+                  }
+                };
+            sparkCatalog.initialize(name, options);
+            return sparkCatalog;
+          }
+        };
+
+    sessionCatalog.initialize(
+        "spark_catalog", new CaseInsensitiveStringMap(ImmutableMap.of(REST_CATALOG_PURGE, "true")));
+
+    sessionCatalog.purgeTable(SPARK_ID);
+
+    verify(sessionRestCatalogMock).dropTable(any(), eq(true));
+  }
+}


### PR DESCRIPTION
Backport of #15614 to Spark 4.1.

Adds the `rest-catalog-purge` catalog property. When enabled and the configured catalog is a REST catalog, Spark delegates `DROP TABLE ... PURGE` to the catalog (sending `purgeRequested=true`) instead of performing client-side file deletion. Defaults to `false`, so non-REST catalogs and existing behavior are unaffected.

This is a clean backport with no logic changes from the Spark 3.5 implementation. Companion to #17185 (Spark 4.0).