### PR TITLE
Flink: Remove converted equality deletes for same-branch conversion

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertCommitter.java
@@ -81,6 +81,7 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
       "equality-convert-staging-snapshot";
 
   private static final String ADDED_DV_NUM_METRIC = "addedDvNum";
+  private static final String REMOVED_EQ_DELETE_NUM_METRIC = "removedEqDeleteNum";
   private static final String COMMIT_DURATION_MS_METRIC = "commitDurationMs";
 
   private final String tableName;
@@ -97,6 +98,7 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
   private transient Counter addedDataFileNumCounter;
   private transient Counter addedDataFileSizeCounter;
   private transient Counter addedDvNumCounter;
+  private transient Counter removedEqDeleteNumCounter;
   private transient Counter commitDurationMsCounter;
 
   public EqualityConvertCommitter(
@@ -130,6 +132,7 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
     this.addedDataFileSizeCounter =
         taskMetricGroup.counter(TableMaintenanceMetrics.ADDED_DATA_FILE_SIZE_METRIC);
     this.addedDvNumCounter = taskMetricGroup.counter(ADDED_DV_NUM_METRIC);
+    this.removedEqDeleteNumCounter = taskMetricGroup.counter(REMOVED_EQ_DELETE_NUM_METRIC);
     this.commitDurationMsCounter = taskMetricGroup.counter(COMMIT_DURATION_MS_METRIC);
   }
 
@@ -225,11 +228,13 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
     long durationMs = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNano);
     commitDurationMsCounter.inc(durationMs);
 
+    int removedEqDeletes = stagingOnTargetBranch ? planResult.eqDeleteFiles().size() : 0;
     LOG.info(
-        "Committed {} data files and {} DV files to branch '{}' for table {} in {} ms. "
-            + "Processed staging snapshot {}.",
+        "Committed {} data files and {} DV files, removed {} equality delete files on branch '{}' "
+            + "for table {} in {} ms. Processed staging snapshot {}.",
         planResult.dataFiles().size(),
         allDvFiles.size(),
+        removedEqDeletes,
         targetBranch,
         tableName,
         durationMs,
@@ -245,11 +250,17 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
     }
 
     addedDvNumCounter.inc(allDvFiles.size());
+    removedEqDeleteNumCounter.inc(removedEqDeletes);
   }
 
   @VisibleForTesting
   void commit(RowDelta rowDelta) {
     rowDelta.commit();
+  }
+
+  @VisibleForTesting
+  long removedEqDeleteNum() {
+    return removedEqDeleteNumCounter.getCount();
   }
 
   /**
@@ -315,7 +326,16 @@ public class EqualityConvertCommitter extends AbstractStreamOperator<Trigger>
       rowDelta.addDeletes(dvFile);
     }
 
-    if (!stagingOnTargetBranch) {
+    if (stagingOnTargetBranch) {
+      // In-place conversion: the equality deletes are already on the target branch. Their rows
+      // are now covered by DVs, so remove them; readers then stop loading and applying equality
+      // deletes.
+      for (DeleteFile eqDeleteFile : planResult.eqDeleteFiles()) {
+        rowDelta.removeDeletes(eqDeleteFile);
+      }
+    } else {
+      // Separate target branch: the writer's DVs exist only on staging, so add them to the target
+      // (addStagingDeletes skips any superseded DVs).
       addStagingDeletes(rowDelta, referencedDataFiles, planResult.stagingDVFiles());
     }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlan.java
@@ -37,6 +37,9 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
  * @param dataFiles new staging data files committed in the cycle
  * @param stagingDVFiles staging DVs passed through to main, used by DVWriter to merge with
  *     newly-created DVs
+ * @param eqDeleteFiles equality delete files resolved this cycle. Removed by the committer when
+ *     staging and target are the same branch, so readers stop applying them once the equivalent DVs
+ *     commit. Empty on a separate target branch, where the eq deletes remain on staging.
  * @param stagingSnapshotId staging snapshot the cycle resolved against, or {@link
  *     #NO_OP_STAGING_SNAPSHOT_ID} for a no-op cycle
  * @param mainSnapshotId main branch snapshot ID the index was resolved against, used for commit
@@ -49,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 public record EqualityConvertPlan(
     List<DataFile> dataFiles,
     List<DeleteFile> stagingDVFiles,
+    List<DeleteFile> eqDeleteFiles,
     long stagingSnapshotId,
     Long mainSnapshotId,
     long triggerTimestamp,
@@ -66,6 +70,7 @@ public record EqualityConvertPlan(
   public static EqualityConvertPlan noOp(
       Long mainSnapshotId, long triggerTimestamp, long doneTimestamp) {
     return new EqualityConvertPlan(
+        ImmutableList.of(),
         ImmutableList.of(),
         ImmutableList.of(),
         NO_OP_STAGING_SNAPSHOT_ID,

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/EqualityConvertPlanner.java
@@ -461,6 +461,7 @@ public class EqualityConvertPlanner extends AbstractStreamOperator<ReadCommand>
             new EqualityConvertPlan(
                 inputs.newDataFiles(),
                 inputs.stagingDVFiles(),
+                inputs.eqDeleteFiles(),
                 stagingSnapshot.snapshotId(),
                 currentMainSnapshotId,
                 triggerTs,

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesE2E.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestConvertEqualityDeletesE2E.java
@@ -29,6 +29,7 @@ import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
@@ -126,6 +127,10 @@ class TestConvertEqualityDeletesE2E extends OperatorTestBase {
           .pollInterval(Duration.ofMillis(200))
           .untilAsserted(() -> assertThat(dvCountOnMain(table)).isEqualTo(2));
       SimpleDataUtil.assertTableRecords(table, ImmutableList.of(createRecord(3, "c")));
+
+      // In-place conversion (staging == main) removes the converted equality deletes so reads no
+      // longer apply them. On a separate staging branch, main never holds equality deletes.
+      assertThat(eqDeleteCountOnMain(table)).isZero();
     } finally {
       closeJobClient(jobClient);
     }
@@ -159,6 +164,27 @@ class TestConvertEqualityDeletesE2E extends OperatorTestBase {
           ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
         for (DeleteFile file : reader) {
           if (ContentFileUtil.isDV(file)) {
+            count++;
+          }
+        }
+      }
+    }
+
+    return count;
+  }
+
+  private static long eqDeleteCountOnMain(Table table) throws IOException {
+    table.refresh();
+    if (table.currentSnapshot() == null) {
+      return 0;
+    }
+
+    long count = 0;
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile file : reader) {
+          if (file.content() == FileContent.EQUALITY_DELETES) {
             count++;
           }
         }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertCommitter.java
@@ -20,7 +20,9 @@ package org.apache.iceberg.flink.maintenance.operator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.flink.streaming.api.watermark.Watermark;
@@ -28,10 +30,14 @@ import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
 import org.apache.flink.streaming.util.TwoInputStreamOperatorTestHarness;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileContent;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Files;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFiles;
 import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.PartitionData;
+import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.RowDelta;
 import org.apache.iceberg.SnapshotRef;
 import org.apache.iceberg.Table;
@@ -40,11 +46,15 @@ import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.maintenance.api.Trigger;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 class TestEqualityConvertCommitter extends OperatorTestBase {
+
+  @TempDir private Path tempDir;
 
   @Test
   void commitsDataFilesToMainBranch() throws Exception {
@@ -63,6 +73,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               stagingSnapshotId,
               snapshotIdBefore,
@@ -100,6 +111,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               42L,
               snapshotIdBefore,
@@ -158,6 +170,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
               Lists.newArrayList(),
+              Lists.newArrayList(),
               42L,
               snapshotIdBefore,
               doneTs - 1,
@@ -193,6 +206,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               stagingSnapshotId,
               mainSnapshotIdAtPlan,
@@ -251,6 +265,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
               Lists.newArrayList(),
+              Lists.newArrayList(),
               stagingSnapshotId,
               mainSnapshotIdAtPlan,
               doneTs - 1,
@@ -272,6 +287,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan replay =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               stagingSnapshotId,
               mainSnapshotIdAtPlan,
@@ -317,6 +333,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               777L,
               mainSnapshotIdAtPlan,
@@ -367,6 +384,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
+              Lists.newArrayList(),
               Lists.newArrayList(),
               42L,
               snapshotIdBefore,
@@ -422,6 +440,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
           new EqualityConvertPlan(
               Lists.newArrayList(stagingDataFile),
               Lists.newArrayList(),
+              Lists.newArrayList(),
               888L,
               mainSnapshotIdAtPlan,
               doneTs - 1,
@@ -473,6 +492,7 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
           new EqualityConvertPlan(
               Lists.newArrayList(),
               Lists.newArrayList(stagingDv),
+              Lists.newArrayList(),
               123L,
               mainSnapshotId,
               doneTs - 1,
@@ -493,6 +513,66 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
       List<DeleteFile> dvs = deletesForDataFile(table, dataFile.location());
       assertThat(dvs).hasSize(1);
       assertThat(dvs.get(0).location()).isEqualTo(mergedDv.location());
+    }
+  }
+
+  @Test
+  void removesConvertedEqualityDeletesOnSharedBranch() throws Exception {
+    // Shared branch: the writer's equality deletes are already on the target branch. Once the cycle
+    // resolves them to DVs, the committer removes the equality delete files in the same commit so
+    // readers stop applying them.
+    Table table = createTableWithDelete(3);
+    insert(table, 1, "a");
+
+    DataFile dataFile = getFirstDataFile(table);
+
+    DeleteFile eqDelete = writeEqualityDelete(table, 1, "a");
+    table.newRowDelta().addDeletes(eqDelete).commit();
+    table.refresh();
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+    assertThat(equalityDeletes(table)).hasSize(1);
+
+    // The cycle resolved the eq delete to a DV covering row position 0 of the data file.
+    DeleteFile convertedDv = writeDV(table, dataFile.location(), 0L);
+
+    EqualityConvertCommitter committer =
+        new EqualityConvertCommitter(
+            DUMMY_TABLE_NAME,
+            DUMMY_TASK_NAME,
+            tableLoader(),
+            SnapshotRef.MAIN_BRANCH,
+            SnapshotRef.MAIN_BRANCH);
+    try (TwoInputStreamOperatorTestHarness<DVWriteResult, EqualityConvertPlan, Trigger> harness =
+        new TwoInputStreamOperatorTestHarness<>(committer)) {
+      harness.open();
+
+      long doneTs = System.currentTimeMillis();
+      EqualityConvertPlan planResult =
+          new EqualityConvertPlan(
+              Lists.newArrayList(),
+              Lists.newArrayList(),
+              Lists.newArrayList(eqDelete),
+              123L,
+              mainSnapshotId,
+              doneTs - 1,
+              doneTs);
+
+      harness.processElement1(
+          new StreamRecord<>(
+              new DVWriteResult(Lists.newArrayList(convertedDv), Lists.newArrayList()), doneTs));
+      harness.processElement2(new StreamRecord<>(planResult, doneTs - 1));
+      harness.processBothWatermarks(new Watermark(doneTs));
+
+      assertThat(harness.extractOutputValues()).hasSize(1);
+
+      table.refresh();
+      // The equality delete file is gone; only the converted DV remains for the data file.
+      assertThat(equalityDeletes(table)).isEmpty();
+      List<DeleteFile> dvs = deletesForDataFile(table, dataFile.location());
+      assertThat(dvs).hasSize(1);
+      assertThat(dvs.get(0).location()).isEqualTo(convertedDv.location());
+
+      assertThat(committer.removedEqDeleteNum()).isEqualTo(1);
     }
   }
 
@@ -537,6 +617,35 @@ class TestEqualityConvertCommitter extends OperatorTestBase {
     }
 
     return deletes;
+  }
+
+  private static List<DeleteFile> equalityDeletes(Table table) {
+    List<DeleteFile> deletes = Lists.newArrayList();
+    for (ManifestFile manifest : table.currentSnapshot().deleteManifests(table.io())) {
+      try (ManifestReader<DeleteFile> reader =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs())) {
+        for (DeleteFile file : reader) {
+          if (file.content() == FileContent.EQUALITY_DELETES) {
+            deletes.add(file.copy());
+          }
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    return deletes;
+  }
+
+  private DeleteFile writeEqualityDelete(Table table, Integer id, String data) throws IOException {
+    File file = File.createTempFile("junit", null, tempDir.toFile());
+    assertThat(file.delete()).isTrue();
+    return FileHelpers.writeDeleteFile(
+        table,
+        Files.localOutput(file),
+        new PartitionData(PartitionSpec.unpartitioned().partitionType()),
+        Lists.newArrayList(SimpleDataUtil.createRecord(id, data)),
+        table.schema());
   }
 
   private static DeleteFile writeDV(Table table, String dataFilePath, long... positions)

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertDVWriter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestEqualityConvertDVWriter.java
@@ -210,7 +210,13 @@ class TestEqualityConvertDVWriter extends OperatorTestBase {
       long time = System.currentTimeMillis();
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
-              Lists.newArrayList(), Lists.newArrayList(stagingDV), 1L, null, 0L, 0L);
+              Lists.newArrayList(),
+              Lists.newArrayList(stagingDV),
+              Lists.newArrayList(),
+              1L,
+              null,
+              0L,
+              0L);
 
       // New position 1 in the same file. Must merge it with the staged position 0.
       harness.processElement1(
@@ -245,7 +251,13 @@ class TestEqualityConvertDVWriter extends OperatorTestBase {
       long time = System.currentTimeMillis();
       EqualityConvertPlan planResult =
           new EqualityConvertPlan(
-              Lists.newArrayList(), Lists.newArrayList(), 1L, plannedSnapshotId, 0L, 0L);
+              Lists.newArrayList(),
+              Lists.newArrayList(),
+              Lists.newArrayList(),
+              1L,
+              plannedSnapshotId,
+              0L,
+              0L);
 
       harness.processElement1(
           new StreamRecord<>(new DVPosition(dataFilePath, 0, 0, EMPTY_PARTITION, 0L), time));
@@ -447,7 +459,8 @@ class TestEqualityConvertDVWriter extends OperatorTestBase {
   }
 
   private static EqualityConvertPlan emptyEqualityConvertPlan() {
-    return new EqualityConvertPlan(Lists.newArrayList(), Lists.newArrayList(), 1L, null, 0L, 0L);
+    return new EqualityConvertPlan(
+        Lists.newArrayList(), Lists.newArrayList(), Lists.newArrayList(), 1L, null, 0L, 0L);
   }
 
   private static String getFirstDataFilePath(Table table) {


### PR DESCRIPTION
`ConvertEqualityDeletes` has two operational modes:

1. "in-place", where equality deletes are written directly to the target branch and subsequently converted to deletion vectors on the same branch.
2. Separate staging branch, where a staging branch holds equality deletes before they are converted and committed to a main/target branch.

When `ConvertEqualityDeletes` is run in "in-place" mode, equality deletes are written directly on the target branch. We then convert them to deletion vectors, but leave the equality delete files in the resulting snapshot. Consequently, readers will still load and apply them and perform merge-on-read, which is redundant at this point because the DVs written already cover the rows the equality deletes would remove. Hence, this change removes the equality delete files in the same commit that writes the DVs.

Separate branch mode is unchanged: after converting equality deletes from the staging branch, we commit DVs to a target branch which remains free of equality deletes.