### PR TITLE
Core: Add Puffin files metadata table

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetadataTable.java
@@ -49,7 +49,8 @@ public abstract class BaseMetadataTable extends BaseReadOnlyTable implements Ser
           MetadataTableType.DELETE_FILES,
           MetadataTableType.MANIFESTS,
           MetadataTableType.PARTITIONS,
-          MetadataTableType.POSITION_DELETES);
+          MetadataTableType.POSITION_DELETES,
+          MetadataTableType.PUFFIN_FILES);
 
   private final PartitionSpec spec = PartitionSpec.unpartitioned();
   private final SortOrder sortOrder = SortOrder.unsorted();

--- a/core/src/main/java/org/apache/iceberg/MetadataTableType.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableType.java
@@ -36,7 +36,8 @@ public enum MetadataTableType {
   ALL_FILES,
   ALL_MANIFESTS,
   ALL_ENTRIES,
-  POSITION_DELETES;
+  POSITION_DELETES,
+  PUFFIN_FILES;
 
   public static MetadataTableType from(String name) {
     try {

--- a/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
+++ b/core/src/main/java/org/apache/iceberg/MetadataTableUtils.java
@@ -88,6 +88,8 @@ public class MetadataTableUtils {
         return new AllEntriesTable(baseTable, metadataTableName);
       case POSITION_DELETES:
         return new PositionDeletesTable(baseTable, metadataTableName);
+      case PUFFIN_FILES:
+        return new PuffinFilesTable(baseTable, metadataTableName);
       default:
         throw new NoSuchTableException(
             "Unknown metadata table type: %s for %s", type, metadataTableName);

--- a/core/src/main/java/org/apache/iceberg/PuffinFileReferences.java
+++ b/core/src/main/java/org/apache/iceberg/PuffinFileReferences.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+
+final class PuffinFileReferences {
+
+  static final String SOURCE_STATISTICS = "statistics";
+  static final String SOURCE_DELETION_VECTOR = "deletion_vector";
+
+  // Delete manifests do not store Puffin blob metadata. Iceberg currently defines Puffin delete
+  // files as deletion-vector-v1 blobs over the row-position metadata field.
+  private static final List<String> DV_REFERENCED_BLOB_TYPES =
+      ImmutableList.of(StandardBlobTypes.DV_V1);
+  private static final List<Integer> DV_REFERENCED_FIELD_IDS =
+      ImmutableList.of(MetadataColumns.ROW_POSITION.fieldId());
+
+  private PuffinFileReferences() {}
+
+  static PuffinFileReference fromStatisticsFile(long snapshotId, StatisticsFile statisticsFile) {
+    List<BlobMetadata> blobs = statisticsFile.blobMetadata();
+
+    List<String> referencedBlobTypes =
+        blobs.stream().map(BlobMetadata::type).distinct().collect(ImmutableList.toImmutableList());
+
+    List<Integer> referencedFieldIds =
+        blobs.stream()
+            .flatMap(blob -> blob.fields().stream())
+            .distinct()
+            .collect(ImmutableList.toImmutableList());
+
+    return new PuffinFileReference(
+        snapshotId,
+        statisticsFile.path(),
+        SOURCE_STATISTICS,
+        statisticsFile.fileSizeInBytes(),
+        blobs.size(),
+        referencedBlobTypes,
+        referencedFieldIds);
+  }
+
+  static PuffinFileReference fromDeletionVectorFile(
+      long snapshotId, String path, long fileSizeInBytes, int referencedBlobCount) {
+    return new PuffinFileReference(
+        snapshotId,
+        path,
+        SOURCE_DELETION_VECTOR,
+        fileSizeInBytes,
+        referencedBlobCount,
+        DV_REFERENCED_BLOB_TYPES,
+        DV_REFERENCED_FIELD_IDS);
+  }
+
+  static StaticDataTask.Row toRow(Schema baseTableSchema, PuffinFileReference puffinFile) {
+    ImmutableList.Builder<StaticDataTask.Row> referencedFields =
+        ImmutableList.builderWithExpectedSize(puffinFile.referencedFieldIds().size());
+
+    for (Integer fieldId : puffinFile.referencedFieldIds()) {
+      referencedFields.add(
+          StaticDataTask.Row.of(fieldId, currentFieldName(baseTableSchema, fieldId)));
+    }
+
+    return StaticDataTask.Row.of(
+        puffinFile.snapshotId(),
+        puffinFile.filePath(),
+        puffinFile.source(),
+        puffinFile.fileSizeInBytes(),
+        puffinFile.referencedBlobCount(),
+        puffinFile.referencedBlobTypes(),
+        referencedFields.build());
+  }
+
+  private static String currentFieldName(Schema baseTableSchema, int fieldId) {
+    if (fieldId == MetadataColumns.ROW_POSITION.fieldId()) {
+      return MetadataColumns.ROW_POSITION.name();
+    }
+
+    // Field IDs are authoritative. Names are resolved against the current table schema and may be
+    // null when a field has been dropped.
+    return baseTableSchema.findColumnName(fieldId);
+  }
+
+  static class DeletionVectorFileAccumulator {
+    private final long snapshotId;
+    private final String path;
+    private final long fileSizeInBytes;
+    private final Set<DeletionVectorBlobKey> referencedBlobs = Sets.newLinkedHashSet();
+
+    DeletionVectorFileAccumulator(long snapshotId, String path, long fileSizeInBytes) {
+      this.snapshotId = snapshotId;
+      this.path = path;
+      this.fileSizeInBytes = fileSizeInBytes;
+    }
+
+    void add(long entryFileSizeInBytes, long contentOffset, long contentSizeInBytes) {
+      Preconditions.checkState(
+          fileSizeInBytes == entryFileSizeInBytes,
+          "Deletion vectors in the same Puffin file have different file sizes: "
+              + "path=%s, snapshotId=%s, expected=%s, actual=%s",
+          path,
+          snapshotId,
+          fileSizeInBytes,
+          entryFileSizeInBytes);
+
+      referencedBlobs.add(new DeletionVectorBlobKey(contentOffset, contentSizeInBytes));
+    }
+
+    PuffinFileReference toPuffinFileReference() {
+      return PuffinFileReferences.fromDeletionVectorFile(
+          snapshotId, path, fileSizeInBytes, referencedBlobs.size());
+    }
+  }
+
+  record PuffinFileReference(
+      long snapshotId,
+      String filePath,
+      String source,
+      long fileSizeInBytes,
+      int referencedBlobCount,
+      List<String> referencedBlobTypes,
+      List<Integer> referencedFieldIds) {}
+
+  private record DeletionVectorBlobKey(long contentOffset, long contentSizeInBytes) {}
+}

--- a/core/src/main/java/org/apache/iceberg/PuffinFilesTable.java
+++ b/core/src/main/java/org/apache/iceberg/PuffinFilesTable.java
@@ -1,0 +1,441 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.iceberg.exceptions.RuntimeIOException;
+import org.apache.iceberg.expressions.Binder;
+import org.apache.iceberg.expressions.BoundReference;
+import org.apache.iceberg.expressions.Evaluator;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.ExpressionVisitors;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.Literal;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ContentFileUtil;
+
+/**
+ * A {@link Table} implementation that exposes Puffin files associated with a selected snapshot.
+ *
+ * <p>Deletion vector files are derived from the selected snapshot's live delete manifests.
+ * Statistics files are derived from the statistics files currently registered in table metadata for
+ * the selected snapshot.
+ *
+ * <p>Statistics registration may be updated independently of snapshots. Therefore, time travel
+ * queries return the statistics files currently associated with the selected snapshot, rather than
+ * the statistics registration state at the time the snapshot was committed.
+ *
+ * <p>Each row represents a Puffin file associated with the selected snapshot through one metadata
+ * source. A physical Puffin file may appear more than once if it is associated through multiple
+ * sources.
+ */
+public class PuffinFilesTable extends BaseMetadataTable {
+
+  private static final String SOURCE_COLUMN = "source";
+
+  private static final List<String> DV_SCAN_COLUMNS =
+      ImmutableList.of(
+          DataFile.FILE_PATH.name(),
+          DataFile.FILE_FORMAT.name(),
+          DataFile.FILE_SIZE.name(),
+          DataFile.CONTENT_OFFSET.name(),
+          DataFile.CONTENT_SIZE.name());
+
+  private static final Schema PUFFIN_FILES_SCHEMA =
+      new Schema(
+          Types.NestedField.required(
+              1, "snapshot_id", Types.LongType.get(), "ID of the selected snapshot"),
+          Types.NestedField.required(
+              2,
+              "file_path",
+              Types.StringType.get(),
+              "Fully qualified location of the Puffin file"),
+          Types.NestedField.required(
+              3,
+              "source",
+              Types.StringType.get(),
+              "Metadata source that associates the Puffin file with the selected snapshot"),
+          Types.NestedField.required(
+              4,
+              "file_size_in_bytes",
+              Types.LongType.get(),
+              "Total size of the Puffin file in bytes"),
+          Types.NestedField.required(
+              5,
+              "referenced_blob_count",
+              Types.IntegerType.get(),
+              "Number of distinct blobs in the Puffin file referenced by the selected snapshot"),
+          Types.NestedField.required(
+              6,
+              "referenced_blob_types",
+              Types.ListType.ofRequired(7, Types.StringType.get()),
+              "Distinct types of blobs referenced by the selected snapshot"),
+          Types.NestedField.required(
+              8,
+              "referenced_fields",
+              Types.ListType.ofRequired(
+                  9,
+                  Types.StructType.of(
+                      Types.NestedField.required(
+                          10,
+                          "field_id",
+                          Types.IntegerType.get(),
+                          "Field ID referenced by at least one blob"),
+                      Types.NestedField.optional(
+                          11,
+                          "current_field_name",
+                          Types.StringType.get(),
+                          "Name currently assigned to the field ID; null if no longer present"))),
+              "Distinct fields referenced across the selected blobs"));
+
+  PuffinFilesTable(Table table) {
+    this(table, table.name() + ".puffin_files");
+  }
+
+  PuffinFilesTable(Table table, String name) {
+    super(table, name);
+  }
+
+  @Override
+  public TableScan newScan() {
+    return new PuffinFilesTableScan(table());
+  }
+
+  @Override
+  public Schema schema() {
+    return PUFFIN_FILES_SCHEMA;
+  }
+
+  @Override
+  MetadataTableType metadataTableType() {
+    return MetadataTableType.PUFFIN_FILES;
+  }
+
+  private DataTask task(BaseTableScan scan) {
+    Snapshot snapshot = scan.snapshot();
+    Preconditions.checkState(snapshot != null, "Cannot plan Puffin files without a snapshot");
+
+    Schema baseTableSchema = table().schema();
+    Evaluator evaluator = new Evaluator(schema().asStruct(), scan.filter(), scan.isCaseSensitive());
+    SourceEvaluator sourceEvaluator =
+        new SourceEvaluator(scan.filter(), schema().asStruct(), scan.isCaseSensitive());
+
+    List<PuffinFileReferences.PuffinFileReference> matchingFiles =
+        puffinFiles(snapshot, sourceEvaluator).stream()
+            .filter(
+                puffinFile ->
+                    evaluator.eval(PuffinFileReferences.toRow(baseTableSchema, puffinFile)))
+            .collect(ImmutableList.toImmutableList());
+
+    return StaticDataTask.of(
+        table().io().newInputFile(taskLocation(snapshot)),
+        schema(),
+        scan.schema(),
+        matchingFiles,
+        puffinFile -> PuffinFileReferences.toRow(baseTableSchema, puffinFile));
+  }
+
+  private String taskLocation(Snapshot snapshot) {
+    if (snapshot.manifestListLocation() != null) {
+      return snapshot.manifestListLocation();
+    }
+
+    String metadataFileLocation = table().operations().current().metadataFileLocation();
+    Preconditions.checkState(
+        metadataFileLocation != null,
+        "Cannot determine a metadata file location for Puffin files table %s",
+        name());
+
+    return metadataFileLocation;
+  }
+
+  private List<PuffinFileReferences.PuffinFileReference> puffinFiles(
+      Snapshot snapshot, SourceEvaluator sourceEvaluator) {
+    ImmutableList.Builder<PuffinFileReferences.PuffinFileReference> rows = ImmutableList.builder();
+    long snapshotId = snapshot.snapshotId();
+
+    if (sourceEvaluator.mayMatch(PuffinFileReferences.SOURCE_STATISTICS)) {
+      for (StatisticsFile statisticsFile : table().statisticsFiles()) {
+        if (statisticsFile.snapshotId() == snapshotId) {
+          rows.add(PuffinFileReferences.fromStatisticsFile(snapshotId, statisticsFile));
+        }
+      }
+    }
+
+    if (sourceEvaluator.mayMatch(PuffinFileReferences.SOURCE_DELETION_VECTOR)) {
+      rows.addAll(deletionVectorPuffinFiles(snapshot));
+    }
+
+    return rows.build();
+  }
+
+  private List<PuffinFileReferences.PuffinFileReference> deletionVectorPuffinFiles(
+      Snapshot snapshot) {
+    Map<String, PuffinFileReferences.DeletionVectorFileAccumulator> dvFiles =
+        Maps.newLinkedHashMap();
+    long snapshotId = snapshot.snapshotId();
+
+    for (ManifestFile deleteManifest : snapshot.deleteManifests(table().io())) {
+      try (ManifestReader<DeleteFile> reader =
+              ManifestFiles.readDeleteManifest(deleteManifest, table().io(), table().specs())
+                  .select(DV_SCAN_COLUMNS);
+          CloseableIterable<ManifestEntry<DeleteFile>> entries = reader.liveEntries()) {
+
+        for (ManifestEntry<DeleteFile> entry : entries) {
+          DeleteFile deleteFile = entry.file();
+          if (!ContentFileUtil.isDV(deleteFile)) {
+            continue;
+          }
+
+          String path = deleteFile.location();
+          Long contentOffset = deleteFile.contentOffset();
+          Long contentSizeInBytes = deleteFile.contentSizeInBytes();
+
+          Preconditions.checkState(
+              contentOffset != null,
+              "Missing content offset for deletion vector in Puffin file: %s",
+              path);
+          Preconditions.checkState(
+              contentSizeInBytes != null,
+              "Missing content size for deletion vector in Puffin file: %s",
+              path);
+
+          dvFiles
+              .computeIfAbsent(
+                  path,
+                  ignored ->
+                      new PuffinFileReferences.DeletionVectorFileAccumulator(
+                          snapshotId, path, deleteFile.fileSizeInBytes()))
+              .add(deleteFile.fileSizeInBytes(), contentOffset, contentSizeInBytes);
+        }
+
+      } catch (IOException e) {
+        throw new RuntimeIOException(
+            e, "Failed to read delete manifest: %s", deleteManifest.path());
+      }
+    }
+
+    return dvFiles.values().stream()
+        .map(PuffinFileReferences.DeletionVectorFileAccumulator::toPuffinFileReference)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  /**
+   * Conservatively evaluates an {@link Expression} using a Puffin file source known at planning
+   * time.
+   */
+  private static class SourceEvaluator {
+    private final Expression boundExpr;
+
+    private SourceEvaluator(Expression expr, Types.StructType structType, boolean caseSensitive) {
+      Expression rewritten = Expressions.rewriteNot(expr);
+      this.boundExpr = Binder.bind(structType, rewritten, caseSensitive);
+    }
+
+    private boolean mayMatch(String source) {
+      return new SourceEvalVisitor().eval(source);
+    }
+
+    private class SourceEvalVisitor extends ExpressionVisitors.BoundExpressionVisitor<Boolean> {
+      private static final boolean ROWS_MIGHT_MATCH = true;
+      private static final boolean ROWS_CANNOT_MATCH = false;
+
+      private String source;
+
+      private boolean eval(String puffinSource) {
+        this.source = puffinSource;
+        return ExpressionVisitors.visitEvaluator(boundExpr, this);
+      }
+
+      @Override
+      public Boolean alwaysTrue() {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public Boolean alwaysFalse() {
+        return ROWS_CANNOT_MATCH;
+      }
+
+      @Override
+      public Boolean not(Boolean result) {
+        return !result;
+      }
+
+      @Override
+      public Boolean and(Boolean leftResult, Boolean rightResult) {
+        return leftResult && rightResult;
+      }
+
+      @Override
+      public Boolean or(Boolean leftResult, Boolean rightResult) {
+        return leftResult || rightResult;
+      }
+
+      @Override
+      public <T> Boolean isNull(BoundReference<T> ref) {
+        if (sourceColumn(ref)) {
+          return ROWS_CANNOT_MATCH; // source should not be null
+        } else {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      @Override
+      public <T> Boolean notNull(BoundReference<T> ref) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean isNaN(BoundReference<T> ref) {
+        if (sourceColumn(ref)) {
+          return ROWS_CANNOT_MATCH; // source should not be nan
+        } else {
+          return ROWS_MIGHT_MATCH;
+        }
+      }
+
+      @Override
+      public <T> Boolean notNaN(BoundReference<T> ref) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean eq(BoundReference<T> ref, Literal<T> lit) {
+        if (sourceColumn(ref)) {
+          Literal<CharSequence> stringLit = lit.to(Types.StringType.get());
+          if (!sourceMatch(stringLit.value())) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notEq(BoundReference<T> ref, Literal<T> lit) {
+        if (sourceColumn(ref)) {
+          Literal<CharSequence> stringLit = lit.to(Types.StringType.get());
+          if (sourceMatch(stringLit.value())) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
+        if (sourceColumn(ref)) {
+          if (literalSet.stream().noneMatch(this::sourceMatch)) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
+        if (sourceColumn(ref)) {
+          if (literalSet.stream().anyMatch(this::sourceMatch)) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean startsWith(BoundReference<T> ref, Literal<T> lit) {
+        if (sourceColumn(ref)) {
+          Literal<CharSequence> stringLit = lit.to(Types.StringType.get());
+          if (!source.startsWith(stringLit.value().toString())) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      @Override
+      public <T> Boolean notStartsWith(BoundReference<T> ref, Literal<T> lit) {
+        if (sourceColumn(ref)) {
+          Literal<CharSequence> stringLit = lit.to(Types.StringType.get());
+          if (source.startsWith(stringLit.value().toString())) {
+            return ROWS_CANNOT_MATCH;
+          }
+        }
+        return ROWS_MIGHT_MATCH;
+      }
+
+      private <T> boolean sourceColumn(BoundReference<T> ref) {
+        return ref.fieldId() == PUFFIN_FILES_SCHEMA.findField(SOURCE_COLUMN).fieldId();
+      }
+
+      private boolean sourceMatch(Object value) {
+        return value instanceof CharSequence && source.contentEquals((CharSequence) value);
+      }
+    }
+  }
+
+  private class PuffinFilesTableScan extends StaticTableScan {
+
+    PuffinFilesTableScan(Table table) {
+      super(
+          table, PUFFIN_FILES_SCHEMA, MetadataTableType.PUFFIN_FILES, PuffinFilesTable.this::task);
+    }
+
+    PuffinFilesTableScan(Table table, TableScanContext context) {
+      super(
+          table,
+          PUFFIN_FILES_SCHEMA,
+          MetadataTableType.PUFFIN_FILES,
+          PuffinFilesTable.this::task,
+          context);
+    }
+
+    @Override
+    protected TableScan newRefinedScan(Table table, Schema schema, TableScanContext context) {
+      return new PuffinFilesTableScan(table, context);
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -22,6 +22,10 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -39,6 +43,9 @@ import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.puffin.StandardBlobTypes;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterators;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -1082,6 +1089,60 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void puffinFilesTableSchema() {
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    Types.StructType actual = puffinFilesTable.newScan().schema().asStruct();
+    Types.StructType expected =
+        new Schema(
+                required(1, "snapshot_id", Types.LongType.get(), "ID of the selected snapshot"),
+                required(
+                    2,
+                    "file_path",
+                    Types.StringType.get(),
+                    "Fully qualified location of the Puffin file"),
+                required(
+                    3,
+                    "source",
+                    Types.StringType.get(),
+                    "Metadata source that associates the Puffin file with the selected snapshot"),
+                required(
+                    4,
+                    "file_size_in_bytes",
+                    Types.LongType.get(),
+                    "Total size of the Puffin file in bytes"),
+                required(
+                    5,
+                    "referenced_blob_count",
+                    Types.IntegerType.get(),
+                    "Number of distinct blobs in the Puffin file referenced by the selected snapshot"),
+                required(
+                    6,
+                    "referenced_blob_types",
+                    Types.ListType.ofRequired(7, Types.StringType.get()),
+                    "Distinct types of blobs referenced by the selected snapshot"),
+                required(
+                    8,
+                    "referenced_fields",
+                    Types.ListType.ofRequired(
+                        9,
+                        Types.StructType.of(
+                            required(
+                                10,
+                                "field_id",
+                                Types.IntegerType.get(),
+                                "Field ID referenced by at least one blob"),
+                            optional(
+                                11,
+                                "current_field_name",
+                                Types.StringType.get(),
+                                "Name currently assigned to the field ID; null if no longer present"))),
+                    "Distinct fields referenced across the selected blobs"))
+            .asStruct();
+
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @TestTemplate
   public void partitionSpecEvolutionAdditive() {
     preparePartitionedTable();
 
@@ -2014,6 +2075,662 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
     }
 
     assertThat(actualContents).containsExactlyInAnyOrder(0, 0, 0, 0, 2, 2);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableNoPuffinFiles() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Table puffinFilesTable = new PuffinFilesTable(table);
+
+    assertThat(rowCount(puffinFilesTable.newScan()))
+        .as("Puffin files table should have no rows without statistics files or deletion vectors")
+        .isEqualTo(0);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableStatisticsFile() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "test",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot, StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1, ImmutableList.of(1)),
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(2))));
+
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+    assertThat(rows).hasSize(1);
+
+    StructLike row = rows.get(0);
+    assertThat(row.get(0, Long.class)).isEqualTo(snapshot.snapshotId());
+    assertThat(row.get(1, String.class)).isEqualTo(statisticsFile.path());
+    assertThat(row.get(2, String.class)).isEqualTo("statistics");
+    assertThat(row.get(3, Long.class)).isEqualTo(617L);
+    assertThat(row.get(4, Integer.class)).isEqualTo(2);
+    assertThat(row.get(5, List.class))
+        .containsExactly(StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1);
+    assertReferencedFields(row, referencedField(1, "id"), referencedField(2, "data"));
+  }
+
+  @TestTemplate
+  public void puffinFilesTableProjection() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "projected",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    TableScan scan =
+        new PuffinFilesTable(table).newScan().select("file_path", "referenced_blob_count");
+
+    Types.StructType expected =
+        new Schema(
+                required(
+                    2,
+                    "file_path",
+                    Types.StringType.get(),
+                    "Fully qualified location of the Puffin file"),
+                required(
+                    5,
+                    "referenced_blob_count",
+                    Types.IntegerType.get(),
+                    "Number of distinct blobs in the Puffin file referenced by the selected snapshot"))
+            .asStruct();
+
+    assertThat(scan.schema().asStruct()).isEqualTo(expected);
+
+    List<StructLike> rows = rows(scan);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(0, String.class)).isEqualTo(statisticsFile.path());
+    assertThat(rows.get(0).get(1, Integer.class)).isEqualTo(1);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableAggregatesReferencedMetadata() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "mixed",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot, StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1, ImmutableList.of(1)),
+                newBlobMetadata(
+                    snapshot, StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1, ImmutableList.of(1)),
+                newBlobMetadata(snapshot, "test-custom-blob-v1", ImmutableList.of(2))));
+
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+    assertThat(rows).hasSize(1);
+
+    StructLike row = rows.get(0);
+    assertThat(row.get(4, Integer.class)).isEqualTo(3);
+    assertThat(row.get(5, List.class))
+        .containsExactly(StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1, "test-custom-blob-v1");
+    assertReferencedFields(row, referencedField(1, "id"), referencedField(2, "data"));
+  }
+
+  @TestTemplate
+  public void puffinFilesTableResolvesRenamedFieldNames() throws IOException {
+    table.updateSchema().addColumn("renamed_column", Types.IntegerType.get()).commit();
+    int fieldId = table.schema().findField("renamed_column").fieldId();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "rename",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(fieldId))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    table.updateSchema().renameColumn("renamed_column", "new_name").commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+    assertThat(rows).hasSize(1);
+    assertReferencedFields(rows.get(0), referencedField(fieldId, "new_name"));
+  }
+
+  @TestTemplate
+  public void puffinFilesTableStatisticsTimeTravel() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot firstSnapshot = table.currentSnapshot();
+    StatisticsFile firstStatistics =
+        newStatisticsFile(
+            firstSnapshot,
+            "first",
+            ImmutableList.of(
+                newBlobMetadata(
+                    firstSnapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(firstStatistics).commit();
+
+    table.newFastAppend().appendFile(FILE_B).commit();
+    Snapshot secondSnapshot = table.currentSnapshot();
+    StatisticsFile secondStatistics =
+        newStatisticsFile(
+            secondSnapshot,
+            "second",
+            ImmutableList.of(
+                newBlobMetadata(
+                    secondSnapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(2))));
+    table.updateStatistics().setStatistics(secondStatistics).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+
+    List<StructLike> firstRows =
+        rows(puffinFilesTable.newScan().useSnapshot(firstSnapshot.snapshotId()));
+    assertThat(firstRows).hasSize(1);
+    assertThat(firstRows.get(0).get(0, Long.class)).isEqualTo(firstSnapshot.snapshotId());
+    assertThat(firstRows.get(0).get(1, String.class)).isEqualTo(firstStatistics.path());
+
+    List<StructLike> secondRows =
+        rows(puffinFilesTable.newScan().useSnapshot(secondSnapshot.snapshotId()));
+    assertThat(secondRows).hasSize(1);
+    assertThat(secondRows.get(0).get(0, Long.class)).isEqualTo(secondSnapshot.snapshotId());
+    assertThat(secondRows.get(0).get(1, String.class)).isEqualTo(secondStatistics.path());
+  }
+
+  @TestTemplate
+  public void puffinFilesTableUsesCurrentStatisticsRegistrationForTimeTravel() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    Snapshot snapshot = table.currentSnapshot();
+
+    StatisticsFile firstStatistics =
+        newStatisticsFile(
+            snapshot,
+            "registered-first",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(firstStatistics).commit();
+
+    StatisticsFile replacementStatistics =
+        newStatisticsFile(
+            snapshot,
+            "registered-replacement",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(2))));
+    table.updateStatistics().setStatistics(replacementStatistics).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    List<StructLike> replacementRows =
+        rows(puffinFilesTable.newScan().useSnapshot(snapshot.snapshotId()));
+    assertThat(replacementRows).hasSize(1);
+    assertThat(replacementRows.get(0).get(1, String.class)).isEqualTo(replacementStatistics.path());
+
+    table.updateStatistics().removeStatistics(snapshot.snapshotId()).commit();
+
+    assertThat(rows(puffinFilesTable.newScan().useSnapshot(snapshot.snapshotId()))).isEmpty();
+  }
+
+  @TestTemplate
+  public void puffinFilesTableIgnoresNonPuffinDeleteFiles() throws IOException {
+    assumeThat(formatVersion).as("This test requires a V2 table").isEqualTo(2);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.newRowDelta().addDeletes(fileADeletes()).commit();
+
+    assertThat(rows(new PuffinFilesTable(table).newScan())).isEmpty();
+  }
+
+  @TestTemplate
+  public void puffinFilesTableIncludesStatisticsAndDeletionVectors() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    String puffinPath = table.location() + "/data/current-dv.puffin";
+    DeleteFile deletionVector = newDeletionVector(puffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(deletionVector).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "current",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+    assertThat(rows).hasSize(2);
+
+    Map<String, StructLike> rowsBySource =
+        rows.stream().collect(Collectors.toMap(row -> row.get(2, String.class), row -> row));
+    assertThat(rowsBySource).containsOnlyKeys("statistics", "deletion_vector");
+    assertThat(rowsBySource.get("statistics").get(1, String.class))
+        .isEqualTo(statisticsFile.path());
+    assertThat(rowsBySource.get("deletion_vector").get(1, String.class)).isEqualTo(puffinPath);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableAppliesSourceFilter() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    String puffinPath = table.location() + "/data/source-filter-dv.puffin";
+    DeleteFile deletionVector = newDeletionVector(puffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(deletionVector).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "source-filter",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    List<StructLike> statisticsRows =
+        rows(puffinFilesTable.newScan().filter(Expressions.equal("source", "statistics")));
+    assertThat(statisticsRows).hasSize(1);
+    assertThat(statisticsRows.get(0).get(1, String.class)).isEqualTo(statisticsFile.path());
+    assertThat(statisticsRows.get(0).get(2, String.class)).isEqualTo("statistics");
+
+    List<StructLike> deletionVectorRows =
+        rows(puffinFilesTable.newScan().filter(Expressions.equal("source", "deletion_vector")));
+    assertThat(deletionVectorRows).hasSize(1);
+    assertThat(deletionVectorRows.get(0).get(1, String.class)).isEqualTo(puffinPath);
+    assertThat(deletionVectorRows.get(0).get(2, String.class)).isEqualTo("deletion_vector");
+
+    assertThat(rows(puffinFilesTable.newScan().filter(Expressions.equal("source", "unknown"))))
+        .isEmpty();
+  }
+
+  @TestTemplate
+  public void puffinFilesTablePrunesDeletionVectorSource() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    File tableLocation = temp.resolve("source-pruning").toFile();
+    TestTables.LocalFileIO spyFileIO = spy(new TestTables.LocalFileIO());
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations("source_pruning", tableLocation, spyFileIO);
+    this.table =
+        TestTables.create(
+            tableLocation,
+            "source_pruning",
+            SCHEMA,
+            SPEC,
+            SortOrder.unsorted(),
+            formatVersion,
+            ops);
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    String puffinPath = table.location() + "/data/pruned-dv.puffin";
+    DeleteFile deletionVector = newDeletionVector(puffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(deletionVector).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    String deleteManifestPath = snapshot.deleteManifests(table.io()).get(0).path();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "pruned",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    clearInvocations(spyFileIO);
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    List<StructLike> rows =
+        rows(puffinFilesTable.newScan().filter(Expressions.equal("source", "statistics")));
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(1, String.class)).isEqualTo(statisticsFile.path());
+    verify(spyFileIO, never()).newInputFile(deleteManifestPath);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableAppliesFilePathFilter() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "residual",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    Expression filter = Expressions.equal("file_path", "/missing.puffin");
+
+    try (CloseableIterable<FileScanTask> tasks =
+        puffinFilesTable.newScan().filter(filter).planFiles()) {
+      List<FileScanTask> plannedTasks = Lists.newArrayList(tasks);
+      assertThat(plannedTasks).hasSize(1);
+      assertThat(plannedTasks.get(0).residual()).isEqualTo(Expressions.alwaysTrue());
+      assertThat(Lists.newArrayList(plannedTasks.get(0).asDataTask().rows())).isEmpty();
+    }
+  }
+
+  @TestTemplate
+  public void puffinFilesTableDoesNotPruneNonSourceNegation() throws IOException {
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "non-source-negation",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(1))));
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+    List<StructLike> rows =
+        rows(
+            puffinFilesTable
+                .newScan()
+                .filter(Expressions.not(Expressions.equal("file_path", "/missing.puffin"))));
+
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).get(1, String.class)).isEqualTo(statisticsFile.path());
+  }
+
+  @TestTemplate
+  public void puffinFilesTableAggregatesDeletionVectorsByPuffinPath() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    String puffinPath = table.location() + "/data/shared-dvs.puffin";
+    DeleteFile firstDV = newDeletionVector(puffinPath, 200L, FILE_A, 4L, 42L, 1L);
+    DeleteFile secondDV = newDeletionVector(puffinPath, 200L, FILE_B, 46L, 44L, 2L);
+    table.newRowDelta().addDeletes(firstDV).addDeletes(secondDV).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+
+    assertThat(rows).hasSize(1);
+    StructLike row = rows.get(0);
+    assertThat(row.get(0, Long.class)).isEqualTo(snapshot.snapshotId());
+    assertThat(row.get(1, String.class)).isEqualTo(puffinPath);
+    assertThat(row.get(2, String.class)).isEqualTo("deletion_vector");
+    assertThat(row.get(3, Long.class)).isEqualTo(200L);
+    assertThat(row.get(4, Integer.class)).isEqualTo(2);
+    assertThat(row.get(5, List.class)).containsExactly(StandardBlobTypes.DV_V1);
+    assertReferencedFields(
+        row,
+        referencedField(
+            MetadataColumns.ROW_POSITION.fieldId(), MetadataColumns.ROW_POSITION.name()));
+  }
+
+  @TestTemplate
+  public void puffinFilesTableKeepsIdenticalBlobRangesInDifferentFiles() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    String firstPuffinPath = table.location() + "/data/first-dv.puffin";
+    String secondPuffinPath = table.location() + "/data/second-dv.puffin";
+    DeleteFile firstDV = newDeletionVector(firstPuffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    DeleteFile secondDV = newDeletionVector(secondPuffinPath, 100L, FILE_B, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(firstDV).addDeletes(secondDV).commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+    assertThat(rows).hasSize(2);
+
+    Map<String, StructLike> rowsByPath =
+        rows.stream().collect(Collectors.toMap(row -> row.get(1, String.class), row -> row));
+    assertThat(rowsByPath).containsOnlyKeys(firstPuffinPath, secondPuffinPath);
+    assertThat(rowsByPath.get(firstPuffinPath).get(4, Integer.class)).isEqualTo(1);
+    assertThat(rowsByPath.get(secondPuffinPath).get(4, Integer.class)).isEqualTo(1);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableDeletionVectorTimeTravel() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    String firstPuffinPath = table.location() + "/data/first-snapshot-dv.puffin";
+    DeleteFile firstDV = newDeletionVector(firstPuffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(firstDV).commit();
+    Snapshot firstSnapshot = table.currentSnapshot();
+
+    String secondPuffinPath = table.location() + "/data/second-snapshot-dv.puffin";
+    DeleteFile secondDV = newDeletionVector(secondPuffinPath, 100L, FILE_B, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(secondDV).commit();
+    Snapshot secondSnapshot = table.currentSnapshot();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+
+    List<StructLike> firstRows =
+        rows(puffinFilesTable.newScan().useSnapshot(firstSnapshot.snapshotId()));
+    assertThat(firstRows).hasSize(1);
+    assertThat(firstRows.get(0).get(0, Long.class)).isEqualTo(firstSnapshot.snapshotId());
+    assertThat(firstRows.get(0).get(1, String.class)).isEqualTo(firstPuffinPath);
+
+    List<StructLike> secondRows =
+        rows(puffinFilesTable.newScan().useSnapshot(secondSnapshot.snapshotId()));
+    assertThat(secondRows).hasSize(2);
+    assertThat(secondRows.stream().map(row -> row.get(0, Long.class)).collect(Collectors.toSet()))
+        .containsOnly(secondSnapshot.snapshotId());
+    assertThat(secondRows.stream().map(row -> row.get(1, String.class)).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(firstPuffinPath, secondPuffinPath);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableScanOnBranch() throws IOException {
+    assumeThat(formatVersion).as("Deletion vectors require V3 tables").isGreaterThanOrEqualTo(3);
+
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+
+    String branchPuffinPath = table.location() + "/data/branch-dv.puffin";
+    DeleteFile branchDV = newDeletionVector(branchPuffinPath, 100L, FILE_A, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(branchDV).commit();
+    table.manageSnapshots().createBranch("testBranch").commit();
+
+    String mainPuffinPath = table.location() + "/data/main-dv.puffin";
+    DeleteFile mainDV = newDeletionVector(mainPuffinPath, 100L, FILE_B, 4L, 44L, 1L);
+    table.newRowDelta().addDeletes(mainDV).commit();
+
+    Table puffinFilesTable = new PuffinFilesTable(table);
+
+    List<StructLike> branchRows = rows(puffinFilesTable.newScan().useRef("testBranch"));
+    assertThat(branchRows).hasSize(1);
+    assertThat(branchRows.get(0).get(1, String.class)).isEqualTo(branchPuffinPath);
+
+    List<StructLike> mainRows = rows(puffinFilesTable.newScan());
+    assertThat(mainRows).hasSize(2);
+    assertThat(mainRows.stream().map(row -> row.get(1, String.class)).collect(Collectors.toSet()))
+        .containsExactlyInAnyOrder(branchPuffinPath, mainPuffinPath);
+  }
+
+  @TestTemplate
+  public void puffinFilesTableAllowsNullNamesForDroppedFields() throws IOException {
+    table.updateSchema().addColumn("dropped_column", Types.IntegerType.get()).commit();
+    int fieldId = table.schema().findField("dropped_column").fieldId();
+
+    table.newFastAppend().appendFile(FILE_A).commit();
+
+    Snapshot snapshot = table.currentSnapshot();
+    StatisticsFile statisticsFile =
+        newStatisticsFile(
+            snapshot,
+            "dropped",
+            ImmutableList.of(
+                newBlobMetadata(
+                    snapshot,
+                    StandardBlobTypes.APACHE_DATASKETCHES_THETA_V1,
+                    ImmutableList.of(fieldId))));
+
+    table.updateStatistics().setStatistics(statisticsFile).commit();
+    table.updateSchema().deleteColumn("dropped_column").commit();
+
+    List<StructLike> rows = rows(new PuffinFilesTable(table).newScan());
+
+    assertThat(rows).hasSize(1);
+    assertReferencedFields(rows.get(0), referencedField(fieldId, null));
+  }
+
+  @TestTemplate
+  public void puffinFilesTableEmptyTable() throws IOException {
+    Table puffinFilesTable = new PuffinFilesTable(table);
+
+    assertThat(rowCount(puffinFilesTable.newScan()))
+        .as("Puffin files table should be empty when the table has no snapshot")
+        .isEqualTo(0);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static void assertReferencedFields(StructLike row, ReferencedField... expectedFields) {
+    List<StructLike> actualFields = row.get(6, List.class);
+    assertThat(actualFields).hasSize(expectedFields.length);
+
+    for (int index = 0; index < expectedFields.length; index += 1) {
+      ReferencedField expectedField = expectedFields[index];
+      StructLike actualField = actualFields.get(index);
+
+      assertThat(actualField.get(0, Integer.class))
+          .as("Referenced field ID at position %s", index)
+          .isEqualTo(expectedField.fieldId());
+      assertThat(actualField.get(1, String.class))
+          .as("Current field name at position %s", index)
+          .isEqualTo(expectedField.currentFieldName());
+    }
+  }
+
+  private static ReferencedField referencedField(int fieldId, String currentFieldName) {
+    return new ReferencedField(fieldId, currentFieldName);
+  }
+
+  private static class ReferencedField {
+    private final int fieldId;
+    private final String currentFieldName;
+
+    private ReferencedField(int fieldId, String currentFieldName) {
+      this.fieldId = fieldId;
+      this.currentFieldName = currentFieldName;
+    }
+
+    private int fieldId() {
+      return fieldId;
+    }
+
+    private String currentFieldName() {
+      return currentFieldName;
+    }
+  }
+
+  private StatisticsFile newStatisticsFile(
+      Snapshot snapshot, String suffix, List<BlobMetadata> blobMetadata) {
+    String statisticsPath =
+        table.location() + "/metadata/" + snapshot.snapshotId() + "-" + suffix + ".stats";
+    return new GenericStatisticsFile(
+        snapshot.snapshotId(), statisticsPath, 617L, 523L, blobMetadata);
+  }
+
+  private BlobMetadata newBlobMetadata(Snapshot snapshot, String type, List<Integer> fieldIds) {
+    return new GenericBlobMetadata(
+        type,
+        snapshot.snapshotId(),
+        snapshot.sequenceNumber(),
+        fieldIds,
+        ImmutableMap.of("ndv", "2"));
+  }
+
+  private DeleteFile newDeletionVector(
+      String puffinPath,
+      long puffinFileSize,
+      DataFile referencedDataFile,
+      long contentOffset,
+      long contentSizeInBytes,
+      long recordCount) {
+    return FileMetadata.deleteFileBuilder(table.spec())
+        .ofPositionDeletes()
+        .withFormat(FileFormat.PUFFIN)
+        .withPath(puffinPath)
+        .withPartition(referencedDataFile.partition())
+        .withFileSizeInBytes(puffinFileSize)
+        .withReferencedDataFile(referencedDataFile.location())
+        .withContentOffset(contentOffset)
+        .withContentSizeInBytes(contentSizeInBytes)
+        .withRecordCount(recordCount)
+        .build();
+  }
+
+  private static List<StructLike> rows(TableScan scan) throws IOException {
+    ImmutableList.Builder<StructLike> rows = ImmutableList.builder();
+
+    try (CloseableIterable<FileScanTask> tasks = scan.planFiles()) {
+      for (FileScanTask task : tasks) {
+        assertThat(task).isInstanceOf(DataTask.class);
+
+        try (CloseableIterable<StructLike> taskRows = task.asDataTask().rows()) {
+          for (StructLike row : taskRows) {
+            rows.add(copyRow(row));
+          }
+        }
+      }
+    }
+
+    return rows.build();
+  }
+
+  private static StructLike copyRow(StructLike row) {
+    Object[] values = new Object[row.size()];
+
+    for (int pos = 0; pos < row.size(); pos += 1) {
+      values[pos] = row.get(pos, Object.class);
+    }
+
+    return TestHelpers.Row.of(values);
   }
 
   private int rowCount(TableScan scan) throws IOException {


### PR DESCRIPTION
### Summary
This PR adds a new puffin_files metadata table that exposes Puffin files associated with an Iceberg snapshot.
The metadata table reports Puffin files referenced through two metadata sources:

- Registered statistics files from Table#statisticsFiles()
- Deletion vector files referenced by live delete manifest entries

The implementation does not open Puffin files, read Puffin footers, or parse blob payload bytes. All reported information is derived from Iceberg table metadata and delete manifests.
Each row represents a Puffin file associated with the selected snapshot through one metadata source. A physical Puffin file may appear more than once if it is associated through multiple sources.
The table contains the following columns:
| Column | Description |
|---|---|
| `snapshot_id` | ID of the selected snapshot |
| `file_path` | Fully qualified location of the Puffin file |
| `source` | Metadata source: `statistics` or `deletion_vector` |
| `file_size_in_bytes` | Total size of the Puffin file in bytes |
| `referenced_blob_count` | Number of distinct blobs in the file referenced by the selected snapshot |
| `referenced_blob_types` | Distinct types of referenced blobs |
| `referenced_fields` | Distinct referenced fields, represented as `field_id` and `current_field_name` pairs |
### Example 
SQL
```sql 
SELECT * FROM catalog.db.table.puffin_files; 
```
Example output: 
| snapshot_id | file_path | source | file_size_in_bytes | referenced_blob_count | referenced_blob_types | referenced_fields |
|---|---|---|---:|---:|---|---|
| `1234567890` | `.../1234567890-table.stats` | `statistics` | `2144` | `2` | `["apache-datasketches-theta-v1"]` | `[{"field_id":1,"current_field_name":"id"},{"field_id":2,"current_field_name":"data"}]` |
| `1234567890` | `.../00000-4-deletes.puffin` | `deletion_vector` | `525` | `1` | `["deletion-vector-v1"]` | `[{"field_id":<ROW_POSITION_FIELD_ID>,"current_field_name":"_pos"}]` |
| `1234567890` | `.../00000-17-deletes.puffin` | `deletion_vector` | `907` | `1` | `["deletion-vector-v1"]` | `[{"field_id":<ROW_POSITION_FIELD_ID>,"current_field_name":"_pos"}]` |

### Time travel 
The `puffin_files` metadata table supports snapshot time travel: 
```sql 
SELECT * FROM catalog.db.table.puffin_files VERSION AS OF 1234567890; 
``` 
Deletion vector files are derived from the selected snapshot's live delete manifests. 
Statistics files are selected from the statistics files currently registered in table metadata for the selected snapshot ID. 
Statistics registration can be updated independently of data snapshots. As a result, a time travel query returns the statistics files currently associated with the selected snapshot rather than reconstructing the statistics registration state from the time the snapshot was committed. 
The table also supports snapshot references such as branches and tags through the standard metadata table scan APIs.

### Motivation 
Iceberg stores multiple types of metadata in Puffin files, including table statistics and deletion vectors, but there is currently no metadata table that provides a unified view of the Puffin files associated with a snapshot. 
Users currently need to inspect table metadata JSON and delete manifests separately to understand Puffin file usage. 
Exposing this information through a metadata table makes it easier to: 
- Inspect statistics files written by procedures such as `compute_table_stats` 
- Identify Puffin files that contain deletion vectors 
- Determine how many blobs in a Puffin file are referenced by a snapshot 
- Inspect the blob types and fields associated with those references 
- Compare Puffin file references across snapshots, branches, and tags 
- Debug stale, replaced, or unexpected Puffin metadata without reading Puffin payloads

### Tests 
The added tests cover: 
```
- Metadata table schema and field documentation 
- Tables without Puffin references 
- Registered statistics files 
- Column projection 
- Statistics blob type and field ID aggregation 
- Field rename and dropped-field name resolution 
- Statistics snapshot time travel 
- Statistics replacement and removal 
- Ignoring non-Puffin delete files 
- Statistics and deletion vectors associated with the same snapshot 
- Multiple deletion vector blobs in one Puffin file 
- Deletion vector snapshot time travel 
```