### PR TITLE
Kafka Connect: Set engine metadata in EnvironmentContext

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkTask.java
@@ -21,10 +21,12 @@ package org.apache.iceberg.connect;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.AppInfoParser;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 import org.slf4j.Logger;
@@ -45,6 +47,8 @@ public class IcebergSinkTask extends SinkTask {
 
   @Override
   public void start(Map<String, String> props) {
+    EnvironmentContext.put(EnvironmentContext.ENGINE_NAME, "kafka-connect");
+    EnvironmentContext.put(EnvironmentContext.ENGINE_VERSION, AppInfoParser.getVersion());
     this.config = new IcebergSinkConfig(props);
     this.catalog = CatalogUtils.loadCatalog(config);
     this.committer = CommitterFactory.createCommitter(config);

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkTask.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkTask.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.EnvironmentContext;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.kafka.common.utils.AppInfoParser;
+import org.junit.jupiter.api.Test;
+
+class TestIcebergSinkTask {
+
+  @Test
+  void startSetsEnvironmentContext() {
+    String previousName = EnvironmentContext.remove(EnvironmentContext.ENGINE_NAME);
+    String previousVersion = EnvironmentContext.remove(EnvironmentContext.ENGINE_VERSION);
+    IcebergSinkTask task = new IcebergSinkTask();
+
+    try {
+      task.start(taskConfig());
+
+      assertThat(EnvironmentContext.get())
+          .containsEntry(EnvironmentContext.ENGINE_NAME, "kafka-connect")
+          .containsEntry(EnvironmentContext.ENGINE_VERSION, AppInfoParser.getVersion());
+    } finally {
+      task.stop();
+      restoreEnvironmentContext(EnvironmentContext.ENGINE_NAME, previousName);
+      restoreEnvironmentContext(EnvironmentContext.ENGINE_VERSION, previousVersion);
+    }
+  }
+
+  private static Map<String, String> taskConfig() {
+    return ImmutableMap.of(
+        "name", "test-connector",
+        "task.id", "0",
+        "topics", "mytopic",
+        "iceberg.tables", "mytable",
+        "iceberg.catalog.catalog-impl", InMemoryCatalog.class.getName());
+  }
+
+  private static void restoreEnvironmentContext(String key, String value) {
+    if (value != null) {
+      EnvironmentContext.put(key, value);
+    } else {
+      EnvironmentContext.remove(key);
+    }
+  }
+}


### PR DESCRIPTION
Set Kafka Connect engine name and version during task startup so commits include the Kafka runtime context.