### PR TITLE
Spec: Clarify content file uniqueness within a snapshot

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -678,11 +678,9 @@ A manifest file must store the partition spec and other metadata as properties i
 
 Within a snapshot, each content file may be referenced by at most one manifest entry across all manifests. A snapshot in which more than one entry references the same content file has undefined behavior. Writers are not required to validate uniqueness at commit time.
 
-The schema of a manifest file is defined by the `manifest_entry` struct, described in the following section.
-
 #### Manifest Entry Fields
 
-The `manifest_entry` struct consists of the following fields:
+The schema of a manifest file is defined by the `manifest_entry` struct, which consists of the following fields:
 
 === "v1 - v3"
     | v1         | v2 and v3  | Field id, name                | Type                                                      | Description |

--- a/format/spec.md
+++ b/format/spec.md
@@ -83,7 +83,7 @@ This table format tracks individual data files in a table instead of directories
 
 Table state is maintained in metadata files. All changes to table state create a new metadata file and replace the old metadata with an atomic swap. The table metadata file tracks the table schema, partitioning config, custom properties, and snapshots of the table contents. A snapshot represents the state of a table at some time and is used to access the complete set of data files in the table.
 
-Data files in snapshots are tracked by one or more manifest files that contain a row for each data file in the table, the file's partition data, and its metrics. The data in a snapshot is the union of all live files in its manifests; each live file must appear at most once (see [Content file uniqueness](#content-file-uniqueness)). Manifest files are reused across snapshots to avoid rewriting metadata that is slow-changing. Manifests can track data files with any subset of a table and are not associated with partitions.
+Data files in snapshots are tracked by one or more manifest files that contain a row for each data file in the table, the file's partition data, and its metrics. The data in a snapshot is the union of all live files in its manifests; each live file may only appear once (see [Content file uniqueness](#content-file-uniqueness)). Manifest files are reused across snapshots to avoid rewriting metadata that is slow-changing. Manifests can track data files with any subset of a table and are not associated with partitions.
 
 The manifests that make up a snapshot are stored in a manifest list file. Each manifest list stores metadata about manifests, including partition stats and data file counts. These stats are used to avoid reading manifests that are not required for an operation.
 
@@ -662,10 +662,6 @@ A manifest may store either data files or delete files, but not both because man
 
 A manifest stores files for a single partition spec. When a table’s partition spec changes, old files remain in the older manifest and newer files are written to a new manifest. This is required because a manifest file’s schema is based on its partition spec (see below). The partition spec of each manifest is also used to transform predicates on the table's data rows into predicates on partition values that are used during job planning to select files from a manifest.
 
-#### Content file uniqueness
-
-Within a snapshot, each content file must be referenced by at most one live entry across all manifests. A snapshot in which more than one live entry references the same content file has undefined behavior. Writers are not required to validate uniqueness at commit time.
-
 A manifest file must store the partition spec and other metadata as properties in the Avro file's key-value metadata:
 
 === "v1 - v3"
@@ -677,6 +673,10 @@ A manifest file must store the partition spec and other metadata as properties i
     | _optional_ | _required_ | `partition-spec-id` | ID of the partition spec used to write the manifest as a string                                                                             |
     | _optional_ | _required_ | `format-version`    | Table format version number of the manifest as a string                                                                                     |
     |            | _required_ | `content`           | Type of content files tracked by the manifest: "data" or "deletes"                                                                          |
+
+#### Content file uniqueness
+
+Within a snapshot, each content file may be referenced by at most one manifest entry across all manifests. A snapshot in which more than one entry references the same content file has undefined behavior. Writers are not required to validate uniqueness at commit time.
 
 The schema of a manifest file is defined by the `manifest_entry` struct, described in the following section.
 
@@ -1066,7 +1066,7 @@ Scan predicates are also used to filter data and delete files using column bound
 
 Data files that match the query filter must be read by the scan.
 
-Duplicate live content file entries violate [content file uniqueness](#content-file-uniqueness). When duplicates are present, table behavior (including scan results) is undefined. Reader implementations may raise an error but are not required to do so.
+Manifest entries that reference the same content file violate [content file uniqueness](#content-file-uniqueness). When duplicates are present, table behavior (including scan results) is undefined. Reader implementations may raise an error but are not required to do so.
 
 Delete files and deletion vector metadata that match the filters must be applied to data files at read time, limited by the following scope rules.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -83,7 +83,7 @@ This table format tracks individual data files in a table instead of directories
 
 Table state is maintained in metadata files. All changes to table state create a new metadata file and replace the old metadata with an atomic swap. The table metadata file tracks the table schema, partitioning config, custom properties, and snapshots of the table contents. A snapshot represents the state of a table at some time and is used to access the complete set of data files in the table.
 
-Data files in snapshots are tracked by one or more manifest files that contain a row for each data file in the table, the file's partition data, and its metrics. The data in a snapshot is the union of all files in its manifests. Manifest files are reused across snapshots to avoid rewriting metadata that is slow-changing. Manifests can track data files with any subset of a table and are not associated with partitions.
+Data files in snapshots are tracked by one or more manifest files that contain a row for each data file in the table, the file's partition data, and its metrics. The data in a snapshot is the union of all live files in its manifests; each live file must appear at most once (see [Content file uniqueness](#content-file-uniqueness)). Manifest files are reused across snapshots to avoid rewriting metadata that is slow-changing. Manifests can track data files with any subset of a table and are not associated with partitions.
 
 The manifests that make up a snapshot are stored in a manifest list file. Each manifest list stores metadata about manifests, including partition stats and data file counts. These stats are used to avoid reading manifests that are not required for an operation.
 
@@ -700,6 +700,10 @@ The `sequence_number` field represents the data sequence number and must never c
 The `file_sequence_number` field represents the sequence number of the snapshot that added the file and must also remain unchanged upon assigning at commit. The file sequence number can't be used for pruning delete files as the data within the file may have an older data sequence number.
 The data and file sequence numbers are inherited only if the entry status is 1 (added). If the entry status is 0 (existing) or 2 (deleted), the entry must include both sequence numbers explicitly.
 
+#### Content file uniqueness
+
+Within a snapshot, each live manifest entry must be uniquely defined by `file_path` across all manifest files. A snapshot with multiple live entries for the same `file_path` has undefined behavior. Writers are not required to validate uniqueness because doing so can be expensive at commit time.
+
 Notes:
 
 1. Technically, data files can be deleted when the last snapshot that contains the file as “live” data is garbage collected. But this is harder to detect and requires finding the diff of multiple snapshots. It is easier to track what files are deleted in a snapshot and delete them when that snapshot expires.  It is not recommended to add a deleted file back to a table. Adding a deleted file can lead to edge cases where incremental deletes can break table snapshots.
@@ -1062,7 +1066,7 @@ Scan predicates are also used to filter data and delete files using column bound
 
 Data files that match the query filter must be read by the scan.
 
-Note that for any snapshot, all file paths marked with "ADDED" or "EXISTING" may appear at most once across all manifest files in the snapshot. If a file path appears more than once, the results of the scan are undefined. Reader implementations may raise an error in this case, but are not required to do so.
+Duplicate live content file entries violate [content file uniqueness](#content-file-uniqueness). When duplicates are present, table behavior (including scan results) is undefined. Reader implementations may raise an error but are not required to do so.
 
 Delete files and deletion vector metadata that match the filters must be applied to data files at read time, limited by the following scope rules.
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -662,6 +662,10 @@ A manifest may store either data files or delete files, but not both because man
 
 A manifest stores files for a single partition spec. When a table’s partition spec changes, old files remain in the older manifest and newer files are written to a new manifest. This is required because a manifest file’s schema is based on its partition spec (see below). The partition spec of each manifest is also used to transform predicates on the table's data rows into predicates on partition values that are used during job planning to select files from a manifest.
 
+#### Content file uniqueness
+
+Within a snapshot, each content file must be referenced by at most one live entry across all manifests. A snapshot in which more than one live entry references the same content file has undefined behavior. Writers are not required to validate uniqueness at commit time.
+
 A manifest file must store the partition spec and other metadata as properties in the Avro file's key-value metadata:
 
 === "v1 - v3"
@@ -699,10 +703,6 @@ Iceberg v2 adds data and file sequence numbers to the entry and makes the snapsh
 The `sequence_number` field represents the data sequence number and must never change after a file is added to the dataset. The data sequence number represents a relative age of the file content and should be used for planning which delete files apply to a data file.
 The `file_sequence_number` field represents the sequence number of the snapshot that added the file and must also remain unchanged upon assigning at commit. The file sequence number can't be used for pruning delete files as the data within the file may have an older data sequence number.
 The data and file sequence numbers are inherited only if the entry status is 1 (added). If the entry status is 0 (existing) or 2 (deleted), the entry must include both sequence numbers explicitly.
-
-#### Content file uniqueness
-
-Within a snapshot, each live manifest entry must be uniquely defined by `file_path` across all manifest files. A snapshot with multiple live entries for the same `file_path` has undefined behavior. Writers are not required to validate uniqueness because doing so can be expensive at commit time.
 
 Notes:
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -676,7 +676,7 @@ A manifest file must store the partition spec and other metadata as properties i
 
 #### Content file uniqueness
 
-Within a snapshot, each content file may be referenced by at most one manifest entry across all manifests. A snapshot in which more than one entry references the same content file has undefined behavior. Writers are not required to validate uniqueness at commit time.
+Within a snapshot, each content file must be referenced by at most one manifest entry across all manifests; otherwise, the snapshot has undefined behavior. Writers are not required to validate uniqueness at commit time.
 
 #### Manifest Entry Fields
 

--- a/format/spec.md
+++ b/format/spec.md
@@ -676,7 +676,7 @@ A manifest file must store the partition spec and other metadata as properties i
 
 #### Content file uniqueness
 
-Within a snapshot, each content file must be referenced by at most one manifest entry across all manifests; otherwise, the snapshot has undefined behavior. Writers are not required to validate uniqueness at commit time.
+Within a snapshot, each content file must be referenced by at most one live manifest entry across all manifests; otherwise, the snapshot has undefined behavior. Writers should not produce multiple manifest entries for the same content file in a snapshot (for example, both ADDED and DELETED entries for the same file). Writers are not required to validate uniqueness at commit time.
 
 #### Manifest Entry Fields
 
@@ -1064,7 +1064,7 @@ Scan predicates are also used to filter data and delete files using column bound
 
 Data files that match the query filter must be read by the scan.
 
-Manifest entries that reference the same content file violate [content file uniqueness](#content-file-uniqueness). When duplicates are present, table behavior (including scan results) is undefined. Reader implementations may raise an error but are not required to do so.
+Duplicate live manifest entries for the same content file violate [content file uniqueness](#content-file-uniqueness). When duplicate live entries are present, table behavior (including scan results) is undefined. Reader implementations may raise an error but are not required to do so.
 
 Delete files and deletion vector metadata that match the filters must be applied to data files at read time, limited by the following scope rules.
 


### PR DESCRIPTION
From a discussion we had on AMT - We want to make completely clear that entities should be unique within a table

Define undefined behavior when duplicate live entries exist in a snapshot and note that writers are not required to validate uniqueness at commit time.