### PR TITLE
Flink: Support local-timestamp-* in Avro<->RowData converters

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroSchemaUtil.java
@@ -56,12 +56,24 @@ public class AvroSchemaUtil {
   private static final Schema.Type RECORD = Schema.Type.RECORD;
 
   public static Schema convert(org.apache.iceberg.Schema schema, String tableName) {
-    return convert(schema, ImmutableMap.of(schema.asStruct(), tableName));
+    return convert(schema, tableName, true);
+  }
+
+  public static Schema convert(
+      org.apache.iceberg.Schema schema, String tableName, boolean legacyTimestampMapping) {
+    return convert(schema, ImmutableMap.of(schema.asStruct(), tableName), legacyTimestampMapping);
   }
 
   public static Schema convert(
       org.apache.iceberg.Schema schema, Map<Types.StructType, String> names) {
-    return TypeUtil.visit(schema, new TypeToSchema.WithTypeToName(names));
+    return convert(schema, names, true);
+  }
+
+  public static Schema convert(
+      org.apache.iceberg.Schema schema,
+      Map<Types.StructType, String> names,
+      boolean legacyTimestampMapping) {
+    return TypeUtil.visit(schema, new TypeToSchema.WithTypeToName(names, legacyTimestampMapping));
   }
 
   public static Schema convert(Type type) {
@@ -69,24 +81,50 @@ public class AvroSchemaUtil {
   }
 
   public static Schema convert(Types.StructType type, String name) {
-    return convert(type, ImmutableMap.of(type, name));
+    return convert(type, name, true);
+  }
+
+  public static Schema convert(Types.StructType type, String name, boolean legacyTimestampMapping) {
+    return convert(type, ImmutableMap.of(type, name), legacyTimestampMapping);
   }
 
   public static Schema convert(Type type, Map<Types.StructType, String> names) {
-    return TypeUtil.visit(type, new TypeToSchema.WithTypeToName(names));
+    return convert(type, names, true);
+  }
+
+  public static Schema convert(
+      Type type, Map<Types.StructType, String> names, boolean legacyTimestampMapping) {
+    return TypeUtil.visit(type, new TypeToSchema.WithTypeToName(names, legacyTimestampMapping));
   }
 
   public static Schema convert(
       Type type, BiFunction<Integer, Types.StructType, String> namesFunction) {
-    return TypeUtil.visit(type, new TypeToSchema.WithNamesFunction(namesFunction));
+    return convert(type, namesFunction, true);
+  }
+
+  public static Schema convert(
+      Type type,
+      BiFunction<Integer, Types.StructType, String> namesFunction,
+      boolean legacyTimestampMapping) {
+    return TypeUtil.visit(
+        type, new TypeToSchema.WithNamesFunction(namesFunction, legacyTimestampMapping));
   }
 
   public static Type convert(Schema schema) {
-    return AvroSchemaVisitor.visit(schema, new SchemaToType(schema));
+    return convert(schema, true);
+  }
+
+  public static Type convert(Schema schema, boolean legacyTimestampMapping) {
+    return AvroSchemaVisitor.visit(schema, new SchemaToType(schema, legacyTimestampMapping));
   }
 
   public static org.apache.iceberg.Schema toIceberg(Schema schema) {
-    final List<Types.NestedField> fields = convert(schema).asNestedType().asStructType().fields();
+    return toIceberg(schema, true);
+  }
+
+  public static org.apache.iceberg.Schema toIceberg(Schema schema, boolean legacyTimestampMapping) {
+    final List<Types.NestedField> fields =
+        convert(schema, legacyTimestampMapping).asNestedType().asStructType().fields();
     return new org.apache.iceberg.Schema(fields);
   }
 
@@ -118,8 +156,13 @@ public class AvroSchemaUtil {
   }
 
   public static Map<Type, Schema> convertTypes(Types.StructType type, String name) {
+    return convertTypes(type, name, true);
+  }
+
+  public static Map<Type, Schema> convertTypes(
+      Types.StructType type, String name, boolean legacyTimestampMapping) {
     TypeToSchema.WithTypeToName converter =
-        new TypeToSchema.WithTypeToName(ImmutableMap.of(type, name));
+        new TypeToSchema.WithTypeToName(ImmutableMap.of(type, name), legacyTimestampMapping);
     TypeUtil.visit(type, converter);
     return ImmutableMap.copyOf(converter.getConversionMap());
   }

--- a/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
+++ b/core/src/main/java/org/apache/iceberg/avro/SchemaToType.java
@@ -30,12 +30,14 @@ import org.apache.iceberg.types.Types;
 
 class SchemaToType extends AvroSchemaVisitor<Type> {
   private final Schema root;
+  private final boolean legacyTimestampMapping;
 
-  SchemaToType(Schema root) {
+  SchemaToType(Schema root, boolean legacyTimestampMapping) {
     this.root = root;
     if (root.getType() == Schema.Type.RECORD) {
       this.nextId = root.getFields().size();
     }
+    this.legacyTimestampMapping = legacyTimestampMapping;
   }
 
   private int nextId = 1;
@@ -177,6 +179,7 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
     return Types.VariantType.get();
   }
 
+  @SuppressWarnings("checkstyle:CyclomaticComplexity")
   public Type logicalType(Schema primitive, LogicalType logical) {
     String name = logical.getName();
     if (logical instanceof LogicalTypes.Decimal) {
@@ -193,16 +196,27 @@ class SchemaToType extends AvroSchemaVisitor<Type> {
 
     } else if (logical instanceof LogicalTypes.TimestampMillis
         || logical instanceof LogicalTypes.TimestampMicros) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
+      if (!legacyTimestampMapping || AvroSchemaUtil.isTimestamptz(primitive)) {
         return Types.TimestampType.withZone();
       } else {
         return Types.TimestampType.withoutZone();
       }
 
     } else if (logical instanceof LogicalTypes.TimestampNanos) {
-      if (AvroSchemaUtil.isTimestamptz(primitive)) {
+      if (!legacyTimestampMapping || AvroSchemaUtil.isTimestamptz(primitive)) {
         return Types.TimestampNanoType.withZone();
       } else {
+        return Types.TimestampNanoType.withoutZone();
+      }
+
+    } else if (logical instanceof LogicalTypes.LocalTimestampMillis
+        || logical instanceof LogicalTypes.LocalTimestampMicros) {
+      if (!legacyTimestampMapping) {
+        return Types.TimestampType.withoutZone();
+      }
+
+    } else if (logical instanceof LogicalTypes.LocalTimestampNanos) {
+      if (!legacyTimestampMapping) {
         return Types.TimestampNanoType.withoutZone();
       }
 

--- a/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
+++ b/core/src/main/java/org/apache/iceberg/avro/TypeToSchema.java
@@ -50,6 +50,10 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema TIMESTAMPTZ_NANO_SCHEMA =
       LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+  private static final Schema LOCAL_TIMESTAMP_SCHEMA =
+      LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+  private static final Schema LOCAL_TIMESTAMP_NANO_SCHEMA =
+      LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
   private static final Schema STRING_SCHEMA = Schema.create(Schema.Type.STRING);
   private static final Schema UUID_SCHEMA =
       LogicalTypes.uuid().addToSchema(Schema.createFixed("uuid_fixed", null, null, 16));
@@ -64,9 +68,12 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
   private final Deque<Integer> fieldIds = Lists.newLinkedList();
   private final BiFunction<Integer, Types.StructType, String> namesFunction;
+  private final boolean legacyTimestampMapping;
 
-  TypeToSchema(BiFunction<Integer, Types.StructType, String> namesFunction) {
+  TypeToSchema(
+      BiFunction<Integer, Types.StructType, String> namesFunction, boolean legacyTimestampMapping) {
     this.namesFunction = namesFunction;
+    this.legacyTimestampMapping = legacyTimestampMapping;
   }
 
   @Override
@@ -240,15 +247,19 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
       case TIMESTAMP:
         if (((Types.TimestampType) primitive).shouldAdjustToUTC()) {
           primitiveSchema = TIMESTAMPTZ_SCHEMA;
-        } else {
+        } else if (legacyTimestampMapping) {
           primitiveSchema = TIMESTAMP_SCHEMA;
+        } else {
+          primitiveSchema = LOCAL_TIMESTAMP_SCHEMA;
         }
         break;
       case TIMESTAMP_NANO:
         if (((Types.TimestampNanoType) primitive).shouldAdjustToUTC()) {
           primitiveSchema = TIMESTAMPTZ_NANO_SCHEMA;
-        } else {
+        } else if (legacyTimestampMapping) {
           primitiveSchema = TIMESTAMP_NANO_SCHEMA;
+        } else {
+          primitiveSchema = LOCAL_TIMESTAMP_NANO_SCHEMA;
         }
         break;
       case STRING:
@@ -288,8 +299,8 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
 
     private final Map<Type, Schema> results = Maps.newHashMap();
 
-    WithTypeToName(Map<Types.StructType, String> names) {
-      super((id, struct) -> names.get(struct));
+    WithTypeToName(Map<Types.StructType, String> names, boolean legacyTimestampMapping) {
+      super((id, struct) -> names.get(struct), legacyTimestampMapping);
     }
 
     Map<Type, Schema> getConversionMap() {
@@ -310,8 +321,10 @@ abstract class TypeToSchema extends TypeUtil.SchemaVisitor<Schema> {
   static class WithNamesFunction extends TypeToSchema {
     private final Map<String, Schema> schemaCache = Maps.newHashMap();
 
-    WithNamesFunction(BiFunction<Integer, Types.StructType, String> namesFunction) {
-      super(namesFunction);
+    WithNamesFunction(
+        BiFunction<Integer, Types.StructType, String> namesFunction,
+        boolean legacyTimestampMapping) {
+      super(namesFunction, legacyTimestampMapping);
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestSchemaConversions.java
@@ -112,6 +112,36 @@ public class TestSchemaConversions {
     assertThat(AvroSchemaUtil.convert(avroType)).isEqualTo(expectedIcebergType);
   }
 
+  @Test
+  public void testTimestampTypesWithLegacyMappingDisabled() {
+    String name = "timestamps";
+    Schema ts = LogicalTypes.localTimestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema tsTz = LogicalTypes.timestampMicros().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema tsNs = LogicalTypes.localTimestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema tsTzNs = LogicalTypes.timestampNanos().addToSchema(Schema.create(Schema.Type.LONG));
+    Schema avroSchema =
+        record(
+            name,
+            requiredField(0, "ts", ts),
+            requiredField(1, "ts_tz", addAdjustToUtc(tsTz, true)),
+            requiredField(2, "ts_ns", tsNs),
+            requiredField(3, "ts_tz_ns", addAdjustToUtc(tsTzNs, true)));
+
+    Types.StructType icebergSchema =
+        Types.StructType.of(
+            required(0, "ts", Types.TimestampType.withoutZone()),
+            required(1, "ts_tz", Types.TimestampType.withZone()),
+            required(2, "ts_ns", Types.TimestampNanoType.withoutZone()),
+            required(3, "ts_tz_ns", Types.TimestampNanoType.withZone()));
+
+    assertThat(AvroSchemaUtil.convert(avroSchema, false))
+        .as("Test conversion from Avro schema")
+        .isEqualTo(icebergSchema);
+    assertThat(AvroSchemaUtil.convert(icebergSchema, name, false))
+        .as("Test conversion to Avro schema")
+        .isEqualTo(avroSchema);
+  }
+
   private Schema addAdjustToUtc(Schema schema, boolean adjustToUTC) {
     schema.addProp(AvroSchemaUtil.ADJUST_TO_UTC_PROP, adjustToUTC);
     return schema;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/AvroGenericRecordToRowDataMapper.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/AvroGenericRecordToRowDataMapper.java
@@ -42,8 +42,8 @@ public class AvroGenericRecordToRowDataMapper implements MapFunction<GenericReco
 
   private final AvroToRowDataConverters.AvroToRowDataConverter converter;
 
-  AvroGenericRecordToRowDataMapper(RowType rowType) {
-    this.converter = AvroToRowDataConverters.createRowConverter(rowType);
+  AvroGenericRecordToRowDataMapper(RowType rowType, boolean legacyTimestampMapping) {
+    this.converter = AvroToRowDataConverters.createRowConverter(rowType, legacyTimestampMapping);
   }
 
   @Override
@@ -51,11 +51,17 @@ public class AvroGenericRecordToRowDataMapper implements MapFunction<GenericReco
     return (RowData) converter.convert(genericRecord);
   }
 
-  /** Create a mapper based on Avro schema. */
   public static AvroGenericRecordToRowDataMapper forAvroSchema(Schema avroSchema) {
-    DataType dataType = AvroSchemaConverter.convertToDataType(avroSchema.toString());
+    return forAvroSchema(avroSchema, true);
+  }
+
+  /** Create a mapper based on Avro schema. */
+  public static AvroGenericRecordToRowDataMapper forAvroSchema(
+      Schema avroSchema, boolean legacyTimestampMapping) {
+    DataType dataType =
+        AvroSchemaConverter.convertToDataType(avroSchema.toString(), legacyTimestampMapping);
     LogicalType logicalType = TypeConversions.fromDataToLogicalType(dataType);
     RowType rowType = RowType.of(logicalType.getChildren().toArray(new LogicalType[0]));
-    return new AvroGenericRecordToRowDataMapper(rowType);
+    return new AvroGenericRecordToRowDataMapper(rowType, legacyTimestampMapping);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/RowDataToAvroGenericRecordConverter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/RowDataToAvroGenericRecordConverter.java
@@ -42,8 +42,9 @@ public class RowDataToAvroGenericRecordConverter implements Function<RowData, Ge
   private final RowDataToAvroConverters.RowDataToAvroConverter converter;
   private final Schema avroSchema;
 
-  private RowDataToAvroGenericRecordConverter(RowType rowType, Schema avroSchema) {
-    this.converter = RowDataToAvroConverters.createConverter(rowType);
+  private RowDataToAvroGenericRecordConverter(
+      RowType rowType, Schema avroSchema, boolean legacyTimestampMapping) {
+    this.converter = RowDataToAvroConverters.createConverter(rowType, legacyTimestampMapping);
     this.avroSchema = avroSchema;
   }
 
@@ -52,19 +53,30 @@ public class RowDataToAvroGenericRecordConverter implements Function<RowData, Ge
     return (GenericRecord) converter.convert(avroSchema, rowData);
   }
 
-  /** Create a converter based on Iceberg schema */
   public static RowDataToAvroGenericRecordConverter fromIcebergSchema(
       String tableName, org.apache.iceberg.Schema icebergSchema) {
+    return fromIcebergSchema(tableName, icebergSchema, true);
+  }
+
+  /** Create a converter based on Iceberg schema */
+  public static RowDataToAvroGenericRecordConverter fromIcebergSchema(
+      String tableName, org.apache.iceberg.Schema icebergSchema, boolean legacyTimestampMapping) {
     RowType rowType = FlinkSchemaUtil.convert(icebergSchema);
-    Schema avroSchema = AvroSchemaUtil.convert(icebergSchema, tableName);
-    return new RowDataToAvroGenericRecordConverter(rowType, avroSchema);
+    Schema avroSchema = AvroSchemaUtil.convert(icebergSchema, tableName, legacyTimestampMapping);
+    return new RowDataToAvroGenericRecordConverter(rowType, avroSchema, legacyTimestampMapping);
+  }
+
+  public static RowDataToAvroGenericRecordConverter fromAvroSchema(Schema avroSchema) {
+    return fromAvroSchema(avroSchema, true);
   }
 
   /** Create a mapper based on Avro schema */
-  public static RowDataToAvroGenericRecordConverter fromAvroSchema(Schema avroSchema) {
-    DataType dataType = AvroSchemaConverter.convertToDataType(avroSchema.toString());
+  public static RowDataToAvroGenericRecordConverter fromAvroSchema(
+      Schema avroSchema, boolean legacyTimestampMapping) {
+    DataType dataType =
+        AvroSchemaConverter.convertToDataType(avroSchema.toString(), legacyTimestampMapping);
     LogicalType logicalType = TypeConversions.fromDataToLogicalType(dataType);
     RowType rowType = RowType.of(logicalType.getChildren().toArray(new LogicalType[0]));
-    return new RowDataToAvroGenericRecordConverter(rowType, avroSchema);
+    return new RowDataToAvroGenericRecordConverter(rowType, avroSchema, legacyTimestampMapping);
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/AvroGenericRecordConverterBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/AvroGenericRecordConverterBase.java
@@ -21,11 +21,21 @@ package org.apache.iceberg.flink;
 import org.junit.jupiter.api.Test;
 
 public abstract class AvroGenericRecordConverterBase {
-  protected abstract void testConverter(DataGenerator dataGenerator) throws Exception;
+  protected void testConverter(DataGenerator dataGenerator) throws Exception {
+    testConverter(dataGenerator, true);
+  }
+
+  protected abstract void testConverter(DataGenerator dataGenerator, boolean legacyTimestampMapping)
+      throws Exception;
 
   @Test
   public void testPrimitiveTypes() throws Exception {
     testConverter(new DataGenerators.Primitives());
+  }
+
+  @Test
+  public void testPrimitiveTypesWithLegacyTimestampMappingDisabled() throws Exception {
+    testConverter(new DataGenerators.Primitives(false), false);
   }
 
   @Test

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/DataGenerators.java
@@ -147,8 +147,17 @@ public class DataGenerators {
           fixedFields);
     }
 
-    private final org.apache.avro.Schema avroSchema =
-        fixupAvroSchemaConvertedFromIcebergSchema(AvroSchemaUtil.convert(icebergSchema, "table"));
+    private final org.apache.avro.Schema avroSchema;
+
+    public Primitives() {
+      this(true);
+    }
+
+    public Primitives(boolean legacyTimestampMapping) {
+      avroSchema =
+          fixupAvroSchemaConvertedFromIcebergSchema(
+              AvroSchemaUtil.convert(icebergSchema, "table", legacyTimestampMapping));
+    }
 
     @Override
     public Schema icebergSchema() {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestAvroGenericRecordToRowDataMapper.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestAvroGenericRecordToRowDataMapper.java
@@ -26,11 +26,13 @@ import org.apache.iceberg.flink.DataGenerator;
 
 public class TestAvroGenericRecordToRowDataMapper extends AvroGenericRecordConverterBase {
   @Override
-  protected void testConverter(DataGenerator dataGenerator) throws Exception {
+  protected void testConverter(DataGenerator dataGenerator, boolean legacyTimestampMapping)
+      throws Exception {
     // Need to use avroSchema from DataGenerator because some primitive types have special Avro
     // type handling. Hence the Avro schema converted from Iceberg schema won't work.
     AvroGenericRecordToRowDataMapper mapper =
-        AvroGenericRecordToRowDataMapper.forAvroSchema(dataGenerator.avroSchema());
+        AvroGenericRecordToRowDataMapper.forAvroSchema(
+            dataGenerator.avroSchema(), legacyTimestampMapping);
     RowData expected = dataGenerator.generateFlinkRowData();
     RowData actual = mapper.map(dataGenerator.generateAvroGenericRecord());
     assertThat(actual).isEqualTo(expected);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestRowDataToAvroGenericRecordConverter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestRowDataToAvroGenericRecordConverter.java
@@ -26,9 +26,10 @@ import org.apache.iceberg.flink.DataGenerator;
 
 public class TestRowDataToAvroGenericRecordConverter extends AvroGenericRecordConverterBase {
   @Override
-  protected void testConverter(DataGenerator dataGenerator) {
+  protected void testConverter(DataGenerator dataGenerator, boolean legacyTimestampMapping) {
     RowDataToAvroGenericRecordConverter converter =
-        RowDataToAvroGenericRecordConverter.fromAvroSchema(dataGenerator.avroSchema());
+        RowDataToAvroGenericRecordConverter.fromAvroSchema(
+            dataGenerator.avroSchema(), legacyTimestampMapping);
     GenericRecord expected = dataGenerator.generateAvroGenericRecord();
     GenericRecord actual = converter.apply(dataGenerator.generateFlinkRowData());
     assertThat(actual).isEqualTo(expected);


### PR DESCRIPTION
Based on #17196. The first commit is from the base branch, so please review only the second commit 739bdcf841678375b76e7124bc331e53d9cc23e7.

This PR adds the `legacyTimestampMapping` flag to `AvroGenericRecordToRowDataMapper` and `RowDataToAvroGenericRecordConverter` to support conversions to and from Avro `local-timestamp-*` values.