### PR TITLE
Core: Fail rewrite_data_files when the starting snapshot has been expired

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
+++ b/core/src/main/java/org/apache/iceberg/actions/BaseCommitService.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -59,6 +60,7 @@ abstract class BaseCommitService<T> implements Closeable {
   private final ConcurrentLinkedQueue<T> committedRewrites;
   private final int rewritesPerCommit;
   private final AtomicBoolean running = new AtomicBoolean(false);
+  private final AtomicReference<RuntimeException> fatalError = new AtomicReference<>(null);
   private final long timeoutInMS;
   private int succeededCommits = 0;
 
@@ -207,6 +209,12 @@ abstract class BaseCommitService<T> implements Closeable {
     Preconditions.checkState(
         completedRewrites.isEmpty(),
         "File groups offered after service was closed, " + "they were not successfully committed.");
+
+    // Propagate non-retriable errors that occurred in the committer thread
+    RuntimeException error = fatalError.get();
+    if (error != null) {
+      throw error;
+    }
   }
 
   private void commitReadyCommitGroups() {
@@ -229,6 +237,12 @@ abstract class BaseCommitService<T> implements Closeable {
         commitOrClean(batch);
         committedRewrites.addAll(batch);
         succeededCommits++;
+      } catch (IllegalStateException e) {
+        // Non-retriable state errors (e.g., expired starting snapshot) should fail the action
+        // immediately rather than being silently swallowed as a tolerable partial-progress failure
+        LOG.error("Non-retriable failure during rewrite commit, aborting action", e);
+        fatalError.compareAndSet(null, e);
+        throw e;
       } catch (Exception e) {
         LOG.error("Failure during rewrite commit process, partial progress enabled. Ignoring", e);
       }

--- a/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
+++ b/core/src/main/java/org/apache/iceberg/actions/RewriteDataFilesCommitManager.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.actions;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.exceptions.CleanableFailure;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -95,7 +96,15 @@ public class RewriteDataFilesCommitManager {
 
     RewriteFiles rewrite = table.newRewrite().validateFromSnapshot(startingSnapshotId);
     if (useStartingSequenceNumber) {
-      long sequenceNumber = table.snapshot(startingSnapshotId).sequenceNumber();
+      Snapshot startingSnapshot = table.snapshot(startingSnapshotId);
+      Preconditions.checkState(
+          startingSnapshot != null,
+          "Cannot commit rewrite: starting snapshot %s has been expired. "
+              + "This is likely due to a concurrent expire_snapshots operation. "
+              + "Ensure expire_snapshots does not run concurrently with rewrite_data_files, "
+              + "or increase the snapshot retention period.",
+          startingSnapshotId);
+      long sequenceNumber = startingSnapshot.sequenceNumber();
       rewrite.dataSequenceNumber(sequenceNumber);
     }
 

--- a/core/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesCommitManager.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestRewriteDataFilesCommitManager.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.Parameters;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.TestBase;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.DataFileSet;
+import org.apache.iceberg.util.DeleteFileSet;
+import org.junit.jupiter.api.TestTemplate;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith(ParameterizedTestExtension.class)
+public class TestRewriteDataFilesCommitManager extends TestBase {
+
+  @Parameters(name = "formatVersion = {0}")
+  protected static List<Object> parameters() {
+    return Arrays.asList(2);
+  }
+
+  @TestTemplate
+  public void testCommitFailsWhenStartingSnapshotExpired() {
+    // 1. Create a snapshot with data files
+    table.newAppend().appendFile(FILE_A).commit();
+    Snapshot startingSnapshot = table.currentSnapshot();
+    long startingSnapshotId = startingSnapshot.snapshotId();
+
+    // 2. Make another commit to advance the table
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // 3. Expire the starting snapshot
+    table.expireSnapshots().expireSnapshotId(startingSnapshotId).commit();
+
+    // Confirm the starting snapshot is now null
+    assertThat(table.snapshot(startingSnapshotId)).isNull();
+
+    // 4. Create a commit manager pointing at the expired starting snapshot
+    RewriteDataFilesCommitManager commitManager =
+        new RewriteDataFilesCommitManager(table, startingSnapshotId, true);
+
+    // 5. Create a mock RewriteFileGroup
+    RewriteFileGroup mockGroup = mock(RewriteFileGroup.class);
+    when(mockGroup.rewrittenFiles()).thenReturn(DataFileSet.of(ImmutableSet.of(FILE_A)));
+    when(mockGroup.addedFiles()).thenReturn(DataFileSet.of(ImmutableSet.of(FILE_B)));
+    when(mockGroup.danglingDVs()).thenReturn(DeleteFileSet.create());
+
+    Set<RewriteFileGroup> fileGroups = Sets.newHashSet(mockGroup);
+
+    // 6. Attempt commitFileGroups - should throw IllegalStateException about expired snapshot
+    assertThatThrownBy(() -> commitManager.commitFileGroups(fileGroups))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("starting snapshot")
+        .hasMessageContaining("expired");
+  }
+
+  @TestTemplate
+  public void testCommitServicePropagatesExpiredSnapshotError() {
+    // 1. Create a snapshot with data files
+    table.newAppend().appendFile(FILE_A).commit();
+    Snapshot startingSnapshot = table.currentSnapshot();
+    long startingSnapshotId = startingSnapshot.snapshotId();
+
+    // 2. Make another commit to advance the table
+    table.newAppend().appendFile(FILE_B).commit();
+
+    // 3. Expire the starting snapshot
+    table.expireSnapshots().expireSnapshotId(startingSnapshotId).commit();
+
+    // 4. Create a commit manager with partial progress service
+    RewriteDataFilesCommitManager commitManager =
+        new RewriteDataFilesCommitManager(table, startingSnapshotId, true);
+    RewriteDataFilesCommitManager.CommitService commitService = commitManager.service(1);
+    commitService.start();
+
+    // 5. Create a mock RewriteFileGroup
+    RewriteFileGroup mockGroup = mock(RewriteFileGroup.class);
+    when(mockGroup.rewrittenFiles()).thenReturn(DataFileSet.of(ImmutableSet.of(FILE_A)));
+    when(mockGroup.addedFiles()).thenReturn(DataFileSet.of(ImmutableSet.of(FILE_B)));
+    when(mockGroup.danglingDVs()).thenReturn(DeleteFileSet.create());
+
+    // 6. Offer the group - with rewritesPerCommit=1, the commit is attempted immediately
+    //    and the IllegalStateException should propagate rather than being silently swallowed
+    assertThatThrownBy(() -> commitService.offer(mockGroup))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("starting snapshot")
+        .hasMessageContaining("expired");
+  }
+}


### PR DESCRIPTION
Closes #17202.

## Problem

When `rewrite_data_files` runs with partial progress enabled and a concurrent `expire_snapshots` removes the rewrite's starting snapshot before the file-group commits complete, the action either throws a `NullPointerException` or silently completes with zero committed rewrites - losing all compaction progress with no error surfaced to the caller.

- `RewriteDataFilesCommitManager#commitFileGroups` calls `table.snapshot(startingSnapshotId).sequenceNumber()`, which throws `NullPointerException` because `Table#snapshot(long)` returns `null` for an expired snapshot (`use-starting-sequence-number` defaults to `true`).
- `BaseCommitService#commitReadyCommitGroups` catches and ignores the failure via a catch-all, so it is counted as a tolerable partial-progress failure and only a `LOG.warn` is emitted.

## Change

- Null-guard the starting snapshot in `commitFileGroups` with a clear message indicating the starting snapshot has been expired (likely by a concurrent `expire_snapshots`).
- Propagate the non-retriable `IllegalStateException` from `BaseCommitService` instead of swallowing it, while still tolerating genuine retriable commit conflicts (`ValidationException` / `CommitFailedException`) as before.

## Testing

Added `TestRewriteDataFilesCommitManager` with two tests that reproduce both failure paths (the NPE and the silent swallow). Both fail on the unpatched code and pass with the fix. Existing `TestCommitService` behavior is unchanged.
