### PR TITLE
Spark: Remove dangling v2 file-scoped position delete files in RemoveDanglingDeletes

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RemoveDanglingDeletesSparkAction.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.actions;
 
 import static org.apache.spark.sql.functions.col;
 import static org.apache.spark.sql.functions.min;
+import static org.apache.spark.sql.functions.when;
 
 import java.util.Collections;
 import java.util.List;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Partitioning;
 import org.apache.iceberg.RewriteFiles;
@@ -93,7 +95,7 @@ class RemoveDanglingDeletesSparkAction
     RewriteFiles rewriteFiles = table.newRewrite();
     DeleteFileSet danglingDeletes = DeleteFileSet.create();
     danglingDeletes.addAll(findDanglingDeletes());
-    danglingDeletes.addAll(findDanglingDvs());
+    danglingDeletes.addAll(findDanglingFileScopedDeletes());
 
     for (DeleteFile deleteFile : danglingDeletes) {
       LOG.debug("Removing dangling delete file {}", deleteFile.location());
@@ -175,24 +177,49 @@ class RemoveDanglingDeletesSparkAction
         .collect(Collectors.toList());
   }
 
-  private List<DeleteFile> findDanglingDvs() {
-    Dataset<Row> dvs =
-        loadMetadataTable(table, MetadataTableType.DELETE_FILES)
-            .where(col("file_format").equalTo(FileFormat.PUFFIN.name()));
+  private List<DeleteFile> findDanglingFileScopedDeletes() {
+    Dataset<Row> deleteFiles = loadMetadataTable(table, MetadataTableType.DELETE_FILES);
     Dataset<Row> dataFiles = loadMetadataTable(table, MetadataTableType.DATA_FILES);
 
-    // a DV not pointing to a valid data file path is implicitly a dangling delete
-    List<Row> danglingDvs =
-        dvs.join(
+    int pathFieldId = MetadataColumns.DELETE_FILE_PATH.fieldId();
+
+    // Derive the effective referenced data file path:
+    // - For DVs (PUFFIN format): use the referenced_data_file column directly
+    // - For file-scoped position deletes: derive from lower/upper bounds of the file_path field
+    //   (field ID 2147483546) when they are equal, indicating a single referenced data file
+    Column lowerPathBound = col("lower_bounds").getItem(pathFieldId);
+    Column upperPathBound = col("upper_bounds").getItem(pathFieldId);
+    Column effectiveRef =
+        when(col("file_format").equalTo(FileFormat.PUFFIN.name()), col("referenced_data_file"))
+            .otherwise(
+                when(
+                    col("content")
+                        .equalTo(1) // POSITION_DELETES
+                        .and(lowerPathBound.isNotNull())
+                        .and(upperPathBound.isNotNull())
+                        .and(lowerPathBound.equalTo(upperPathBound)),
+                    lowerPathBound.cast("string")));
+
+    // Filter to only file-scoped deletes (those with a derivable referenced data file)
+    Dataset<Row> fileScopedDeletes =
+        deleteFiles
+            .withColumn("effective_ref", effectiveRef)
+            .where(col("effective_ref").isNotNull());
+
+    // A file-scoped delete not pointing to a valid data file path is dangling
+    List<Row> danglingRows =
+        fileScopedDeletes
+            .join(
                 dataFiles,
-                dvs.col("referenced_data_file").equalTo(dataFiles.col("file_path")),
+                fileScopedDeletes.col("effective_ref").equalTo(dataFiles.col("file_path")),
                 "leftouter")
             .filter(dataFiles.col("file_path").isNull())
-            .select(dvs.col("*"))
+            .select(fileScopedDeletes.col("*"))
+            .drop("effective_ref")
             .collectAsList();
-    return danglingDvs.stream()
+    return danglingRows.stream()
         // map on driver because SparkDeleteFile is not serializable
-        .map(row -> deleteFileWrapper(dvs.schema(), row))
+        .map(row -> deleteFileWrapper(deleteFiles.schema(), row))
         .collect(Collectors.toList());
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveDanglingDeleteAction.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,6 +35,8 @@ import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Metrics;
 import org.apache.iceberg.Parameter;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.Parameters;
@@ -509,6 +513,108 @@ public class TestRemoveDanglingDeleteAction extends TestBase {
             Tuple2.apply(2L, FILE_C.location()),
             Tuple2.apply(2L, fileADeletes.location()));
     assertThat(actualAfter).containsExactlyInAnyOrderElementsOf(expectedAfter);
+  }
+
+  @TestTemplate
+  public void testFileScopedPositionDeleteWithMissingDataFile() {
+    // Only v2 — v3 uses DVs which are already handled by findDanglingDvs
+    assumeThat(formatVersion).isEqualTo(2);
+    setupPartitionedTable();
+
+    // Step 1: Add data files A and B in partition c1=a (seq 1)
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_A2).commit();
+
+    // Step 2: Add a file-scoped position delete referencing only FILE_A (seq 2)
+    // Set lower_bounds and upper_bounds for DELETE_FILE_PATH field to FILE_A's path
+    int pathFieldId = MetadataColumns.DELETE_FILE_PATH.fieldId();
+    ByteBuffer pathBytes = ByteBuffer.wrap(FILE_A.location().getBytes(StandardCharsets.UTF_8));
+    DeleteFile fileScopedPosDelete =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-delete-for-a.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("c1=a")
+            .withMetrics(
+                new Metrics(
+                    1L,
+                    null,
+                    null,
+                    null,
+                    null,
+                    ImmutableMap.of(pathFieldId, pathBytes),
+                    ImmutableMap.of(pathFieldId, pathBytes)))
+            .build();
+    table.newRowDelta().addDeletes(fileScopedPosDelete).commit();
+
+    // Step 3: Remove FILE_A via overwrite, keep FILE_A2 (seq 3)
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    // Now: fileScopedPosDelete has seq=2, partition c1=a min_data_sequence_number = 1 (from
+    // FILE_A2)
+    // findDanglingDeletes() won't catch it because seq 2 >= min 1
+    // findDanglingDvs() won't catch it because it's not PUFFIN format
+    // BUG: the position delete for the now-absent FILE_A lingers forever
+
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+
+    // Assert the file-scoped pos-delete IS removed since FILE_A no longer exists
+    Set<CharSequence> removedDeleteFiles =
+        StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(removedDeleteFiles)
+        .as("Expected file-scoped position delete for missing data file to be removed")
+        .containsExactly(fileScopedPosDelete.location());
+  }
+
+  @TestTemplate
+  public void testPartitionScopedPositionDeleteNotRemovedWhenDataFileExists() {
+    // Only v2 — partition-scoped deletes should NOT be removed even if they reference
+    // multiple data files and some of them are gone
+    assumeThat(formatVersion).isEqualTo(2);
+    setupPartitionedTable();
+
+    // Step 1: Add data files A and A2 in partition c1=a (seq 1)
+    table.newAppend().appendFile(FILE_A).appendFile(FILE_A2).commit();
+
+    // Step 2: Add a partition-scoped position delete (no file_path bounds or different bounds)
+    // This means lower_bounds != upper_bounds for DELETE_FILE_PATH field
+    int pathFieldId = MetadataColumns.DELETE_FILE_PATH.fieldId();
+    ByteBuffer pathBytesA = ByteBuffer.wrap(FILE_A.location().getBytes(StandardCharsets.UTF_8));
+    ByteBuffer pathBytesA2 = ByteBuffer.wrap(FILE_A2.location().getBytes(StandardCharsets.UTF_8));
+    DeleteFile partitionScopedPosDelete =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/pos-delete-partition-scoped.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("c1=a")
+            .withMetrics(
+                new Metrics(
+                    2L,
+                    null,
+                    null,
+                    null,
+                    null,
+                    ImmutableMap.of(pathFieldId, pathBytesA),
+                    ImmutableMap.of(pathFieldId, pathBytesA2)))
+            .build();
+    table.newRowDelta().addDeletes(partitionScopedPosDelete).commit();
+
+    // Step 3: Remove FILE_A via overwrite, keep FILE_A2 (seq 3)
+    table.newOverwrite().deleteFile(FILE_A).addFile(FILE_B).commit();
+
+    // The partition-scoped delete still covers FILE_A2 which exists, so it must NOT be removed
+    RemoveDanglingDeleteFiles.Result result =
+        SparkActions.get().removeDanglingDeleteFiles(table).execute();
+
+    Set<CharSequence> removedDeleteFiles =
+        StreamSupport.stream(result.removedDeleteFiles().spliterator(), false)
+            .map(DeleteFile::location)
+            .collect(Collectors.toSet());
+    assertThat(removedDeleteFiles)
+        .as("Partition-scoped position delete should NOT be removed")
+        .isEmpty();
   }
 
   private List<Tuple2<Long, String>> liveEntries() {


### PR DESCRIPTION
Closes #17203.

## Problem

`RemoveDanglingDeletesSparkAction` removes dangling deletion vectors (v3, PUFFIN) but not dangling v2 file-scoped position-delete files (PARQUET). A file-scoped position delete whose referenced data file has been removed, but whose sequence number is `>=` the partition's minimum data sequence number, is never cleaned up and lingers in table metadata indefinitely.

- `findDanglingDvs()` restricts the referenced-data-file check to `file_format == PUFFIN`.
- `findDanglingDeletes()` only removes position deletes whose `sequence_number < min_data_sequence_number`.

A v2 file-scoped position delete whose referenced data file is gone, but whose sequence number stays `>=` the partition minimum (because another live data file in the partition keeps the minimum low), is caught by neither.

## Change

Generalize the referenced-data-file left-join (previously DV-only) to also cover v2 file-scoped position deletes: derive the referenced data file from the delete file's `lower_bounds`/`upper_bounds` for the `file_path` field when they are equal, then left-join against the data files and flag entries with no match.

A guard restricts this to single-data-file (file-scoped) deletes only: partition-scoped position deletes (which have differing lower/upper bounds) and equality deletes are excluded, so no delete that may still cover live data is ever removed. Existing DV handling is preserved (PUFFIN files continue to use `referenced_data_file` directly).

## Testing

Extended `TestRemoveDanglingDeleteAction` with a case that removes a file-scoped position delete when its referenced data file is gone, and a case asserting a partition-scoped position delete is not removed. The new file-scoped case fails on the unpatched code and passes with the fix; existing DV and sequence-number cases continue to pass.
