### PR TITLE
Core: Recover from duplicate deletion vectors by merging at read time

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
+++ b/core/src/main/java/org/apache/iceberg/DeleteFileIndex.java
@@ -59,6 +59,8 @@ import org.apache.iceberg.util.ContentFileUtil;
 import org.apache.iceberg.util.PartitionMap;
 import org.apache.iceberg.util.PartitionSet;
 import org.apache.iceberg.util.Tasks;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An index of {@link DeleteFile delete files} by sequence number.
@@ -68,6 +70,7 @@ import org.apache.iceberg.util.Tasks;
  * file.
  */
 class DeleteFileIndex {
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteFileIndex.class);
   private static final DeleteFile[] EMPTY_DELETES = new DeleteFile[0];
 
   private final EqualityDeletes globalDeletes;
@@ -75,6 +78,7 @@ class DeleteFileIndex {
   private final PartitionMap<PositionDeletes> posDeletesByPartition;
   private final Map<String, PositionDeletes> posDeletesByPath;
   private final Map<String, DeleteFile> dvByPath;
+  private final Map<String, List<DeleteFile>> duplicateDvsByPath;
   private final boolean hasEqDeletes;
   private final boolean hasPosDeletes;
   private final boolean isEmpty;
@@ -84,15 +88,20 @@ class DeleteFileIndex {
       PartitionMap<EqualityDeletes> eqDeletesByPartition,
       PartitionMap<PositionDeletes> posDeletesByPartition,
       Map<String, PositionDeletes> posDeletesByPath,
-      Map<String, DeleteFile> dvByPath) {
+      Map<String, DeleteFile> dvByPath,
+      Map<String, List<DeleteFile>> duplicateDvsByPath) {
     this.globalDeletes = globalDeletes;
     this.eqDeletesByPartition = eqDeletesByPartition;
     this.posDeletesByPartition = posDeletesByPartition;
     this.posDeletesByPath = posDeletesByPath;
     this.dvByPath = dvByPath;
+    this.duplicateDvsByPath = duplicateDvsByPath;
     this.hasEqDeletes = globalDeletes != null || eqDeletesByPartition != null;
     this.hasPosDeletes =
-        posDeletesByPartition != null || posDeletesByPath != null || dvByPath != null;
+        posDeletesByPartition != null
+            || posDeletesByPath != null
+            || dvByPath != null
+            || duplicateDvsByPath != null;
     this.isEmpty = !hasEqDeletes && !hasPosDeletes;
   }
 
@@ -137,6 +146,12 @@ class DeleteFileIndex {
       deleteFiles = Iterables.concat(deleteFiles, dvByPath.values());
     }
 
+    if (duplicateDvsByPath != null) {
+      for (List<DeleteFile> dvs : duplicateDvsByPath.values()) {
+        deleteFiles = Iterables.concat(deleteFiles, dvs);
+      }
+    }
+
     return deleteFiles;
   }
 
@@ -155,11 +170,11 @@ class DeleteFileIndex {
 
     DeleteFile[] global = findGlobalDeletes(sequenceNumber, file);
     DeleteFile[] eqPartition = findEqPartitionDeletes(sequenceNumber, file);
-    DeleteFile dv = findDV(sequenceNumber, file);
-    if (dv != null && global == null && eqPartition == null) {
-      return new DeleteFile[] {dv};
-    } else if (dv != null) {
-      return concat(global, eqPartition, new DeleteFile[] {dv});
+    DeleteFile[] dvs = findDVs(sequenceNumber, file);
+    if (dvs != null && global == null && eqPartition == null) {
+      return dvs;
+    } else if (dvs != null) {
+      return concat(global, eqPartition, dvs);
     } else {
       DeleteFile[] posPartition = findPosPartitionDeletes(sequenceNumber, file);
       DeleteFile[] posPath = findPathDeletes(sequenceNumber, file);
@@ -199,20 +214,44 @@ class DeleteFileIndex {
     return deletes == null ? EMPTY_DELETES : deletes.filter(seq);
   }
 
-  private DeleteFile findDV(long seq, DataFile dataFile) {
-    if (dvByPath == null) {
+  private DeleteFile[] findDVs(long seq, DataFile dataFile) {
+    if (dvByPath == null && duplicateDvsByPath == null) {
       return null;
     }
 
-    DeleteFile dv = dvByPath.get(dataFile.location());
-    if (dv != null) {
-      ValidationException.check(
-          dv.dataSequenceNumber() >= seq,
-          "DV data sequence number (%s) must be greater than or equal to data file sequence number (%s)",
-          dv.dataSequenceNumber(),
-          seq);
+    String path = dataFile.location();
+
+    // Check for duplicate DVs first (rare corruption case)
+    if (duplicateDvsByPath != null) {
+      List<DeleteFile> dvs = duplicateDvsByPath.get(path);
+      if (dvs != null) {
+        for (DeleteFile dv : dvs) {
+          ValidationException.check(
+              dv.dataSequenceNumber() >= seq,
+              "DV data sequence number (%s) must be greater than or equal to"
+                  + " data file sequence number (%s)",
+              dv.dataSequenceNumber(),
+              seq);
+        }
+        return dvs.toArray(EMPTY_DELETES);
+      }
     }
-    return dv;
+
+    // Common case: single DV per data file
+    if (dvByPath != null) {
+      DeleteFile dv = dvByPath.get(path);
+      if (dv != null) {
+        ValidationException.check(
+            dv.dataSequenceNumber() >= seq,
+            "DV data sequence number (%s) must be greater than or equal to"
+                + " data file sequence number (%s)",
+            dv.dataSequenceNumber(),
+            seq);
+        return new DeleteFile[] {dv};
+      }
+    }
+
+    return null;
   }
 
   @SuppressWarnings("checkstyle:CyclomaticComplexity")
@@ -498,12 +537,13 @@ class DeleteFileIndex {
       PartitionMap<PositionDeletes> posDeletesByPartition = PartitionMap.create(specsById);
       Map<String, PositionDeletes> posDeletesByPath = Maps.newHashMap();
       Map<String, DeleteFile> dvByPath = Maps.newHashMap();
+      Map<String, List<DeleteFile>> duplicateDvsByPath = null;
 
       for (DeleteFile file : files) {
         switch (file.content()) {
           case POSITION_DELETES:
             if (ContentFileUtil.isDV(file)) {
-              add(dvByPath, file);
+              duplicateDvsByPath = addDV(dvByPath, duplicateDvsByPath, file);
             } else {
               add(posDeletesByPath, posDeletesByPartition, file);
             }
@@ -522,17 +562,91 @@ class DeleteFileIndex {
           eqDeletesByPartition.isEmpty() ? null : eqDeletesByPartition,
           posDeletesByPartition.isEmpty() ? null : posDeletesByPartition,
           posDeletesByPath.isEmpty() ? null : posDeletesByPath,
-          dvByPath.isEmpty() ? null : dvByPath);
+          dvByPath.isEmpty() ? null : dvByPath,
+          duplicateDvsByPath);
     }
 
-    private void add(Map<String, DeleteFile> dvByPath, DeleteFile dv) {
+    /**
+     * Adds a DV to the index, handling duplicate DVs for the same data file gracefully.
+     *
+     * <p>Per the spec, at most one DV per data file is allowed. However, metadata corruption may
+     * result in multiple DVs. Rather than throwing (which would brick the table), this method:
+     *
+     * <ul>
+     *   <li>Byte-identical DVs (same location, offset, size): silently deduplicated
+     *   <li>Different DVs: accumulated for union at read time, with a warning logged
+     * </ul>
+     *
+     * @see <a href="https://github.com/apache/iceberg/issues/17206">GitHub issue #17206</a>
+     */
+    private Map<String, List<DeleteFile>> addDV(
+        Map<String, DeleteFile> dvByPath,
+        Map<String, List<DeleteFile>> currentDuplicates,
+        DeleteFile dv) {
       String path = dv.referencedDataFile();
-      DeleteFile existingDV = dvByPath.putIfAbsent(path, dv);
-      if (existingDV != null) {
-        throw new ValidationException(
-            "Can't index multiple DVs for %s: %s and %s",
-            path, ContentFileUtil.dvDesc(dv), ContentFileUtil.dvDesc(existingDV));
+
+      // If the path is already in the duplicates map, handle there and return.
+      // This is critical for correctness: once a path migrates to duplicateDvsByPath,
+      // subsequent DVs must go there too (not back into dvByPath via putIfAbsent).
+      if (currentDuplicates != null) {
+        List<DeleteFile> existingDuplicates = currentDuplicates.get(path);
+        if (existingDuplicates != null) {
+          // Dedupe if byte-identical to any existing entry
+          for (DeleteFile existing : existingDuplicates) {
+            if (isByteIdenticalDV(existing, dv)) {
+              LOG.debug(
+                  "Deduplicated byte-identical DV for {}: {}", path, ContentFileUtil.dvDesc(dv));
+              return currentDuplicates;
+            }
+          }
+          // Genuinely different - append to the existing list
+          LOG.warn(
+              "Spec violation: additional different DV for {} (issue #17206). "
+                  + "Will be merged (unioned) at read time to avoid data loss. DV: {}",
+              path,
+              ContentFileUtil.dvDesc(dv));
+          existingDuplicates.add(dv);
+          return currentDuplicates;
+        }
       }
+
+      // Path not yet in duplicates map - try the single-DV map
+      DeleteFile existingDV = dvByPath.putIfAbsent(path, dv);
+      if (existingDV == null) {
+        // Common case: first DV for this data file
+        return currentDuplicates;
+      }
+
+      // Duplicate DV detected - check if byte-identical
+      if (isByteIdenticalDV(existingDV, dv)) {
+        LOG.debug("Deduplicated byte-identical DV for {}: {}", path, ContentFileUtil.dvDesc(dv));
+        return currentDuplicates;
+      }
+
+      // Genuinely different DVs - spec violation, but recover by collecting for union at read time
+      LOG.warn(
+          "Spec violation: multiple different DVs for {} (issue #17206). "
+              + "Deletes will be merged (unioned) at read time to avoid data loss. "
+              + "DVs: {} and {}",
+          path,
+          ContentFileUtil.dvDesc(existingDV),
+          ContentFileUtil.dvDesc(dv));
+
+      // Move from single-DV map to duplicate map
+      Map<String, List<DeleteFile>> duplicates =
+          currentDuplicates != null ? currentDuplicates : Maps.newHashMap();
+
+      List<DeleteFile> dvList = Lists.newArrayList();
+      dvList.add(dvByPath.remove(path));
+      dvList.add(dv);
+      duplicates.put(path, dvList);
+      return duplicates;
+    }
+
+    private static boolean isByteIdenticalDV(DeleteFile dvOne, DeleteFile dvTwo) {
+      return dvOne.location().equals(dvTwo.location())
+          && dvOne.contentOffset().equals(dvTwo.contentOffset())
+          && dvOne.contentSizeInBytes().equals(dvTwo.contentSizeInBytes());
     }
 
     private void add(

--- a/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
@@ -147,6 +147,10 @@ public class ContentFileUtil {
     return Iterables.size(deleteFiles) == 1 && Iterables.all(deleteFiles, ContentFileUtil::isDV);
   }
 
+  public static boolean containsOnlyDVs(Iterable<DeleteFile> deleteFiles) {
+    return !Iterables.isEmpty(deleteFiles) && Iterables.all(deleteFiles, ContentFileUtil::isDV);
+  }
+
   public static String dvDesc(DeleteFile deleteFile) {
     return String.format(
         "DV{location=%s, offset=%s, length=%s, referencedDataFile=%s}",

--- a/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
+++ b/core/src/test/java/org/apache/iceberg/DeleteFileIndexTestBase.java
@@ -774,16 +774,60 @@ public abstract class DeleteFileIndexTestBase<
   }
 
   @TestTemplate
-  public void testMultipleDVs() {
+  public void testDuplicateDVsDifferentContent() {
+    // Regression test for GitHub issue #17206: duplicate DVs must not brick scans.
+    // Two different DVs for the same data file should be indexed without throwing,
+    // and forDataFile() must return both so they can be merged (unioned) at read time.
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
-    DeleteFile dv1 = withDataSequenceNumber(1, newDV(FILE_A));
+    DeleteFile dv1 = withDataSequenceNumber(2, newDV(FILE_A));
     DeleteFile dv2 = withDataSequenceNumber(2, newDV(FILE_A));
+    // newDV generates random paths/offsets, so dv1 and dv2 are genuinely different DVs
     List<DeleteFile> dvs = Arrays.asList(dv1, dv2);
 
-    assertThatThrownBy(() -> DeleteFileIndex.builderFor(dvs).specsById(table.specs()).build())
-        .isInstanceOf(ValidationException.class)
-        .hasMessageContaining("Can't index multiple DVs for %s", FILE_A.location());
+    DeleteFileIndex index = DeleteFileIndex.builderFor(dvs).specsById(table.specs()).build();
+
+    DeleteFile[] fileADeletes = index.forDataFile(0, FILE_A);
+    assertThat(fileADeletes).as("Both DVs must be returned for union at read time").hasSize(2);
+    assertThat(ContentFileUtil.isDV(fileADeletes[0])).isTrue();
+    assertThat(ContentFileUtil.isDV(fileADeletes[1])).isTrue();
+  }
+
+  @TestTemplate
+  public void testDuplicateDVsByteIdentical() {
+    // Byte-identical DVs (same location, offset, and size) should be silently deduplicated.
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    DeleteFile dv =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/dv.puffin")
+            .withFileSizeInBytes(100)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(5)
+            .withReferencedDataFile(FILE_A.location())
+            .withContentOffset(0L)
+            .withContentSizeInBytes(64L)
+            .build();
+    DeleteFile dvCopy =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/dv.puffin")
+            .withFileSizeInBytes(100)
+            .withPartition(FILE_A.partition())
+            .withRecordCount(5)
+            .withReferencedDataFile(FILE_A.location())
+            .withContentOffset(0L)
+            .withContentSizeInBytes(64L)
+            .build();
+
+    List<DeleteFile> dvs =
+        Arrays.asList(withDataSequenceNumber(2, dv), withDataSequenceNumber(2, dvCopy));
+    DeleteFileIndex index = DeleteFileIndex.builderFor(dvs).specsById(table.specs()).build();
+
+    DeleteFile[] fileADeletes = index.forDataFile(0, FILE_A);
+    assertThat(fileADeletes).as("Byte-identical DVs must be deduplicated to one").hasSize(1);
+    assertThat(ContentFileUtil.isDV(fileADeletes[0])).isTrue();
   }
 
   @TestTemplate
@@ -795,5 +839,27 @@ public abstract class DeleteFileIndexTestBase<
     assertThatThrownBy(() -> index.forDataFile(2, FILE_A))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("must be greater than or equal to data file sequence number");
+  }
+
+  @TestTemplate
+  public void testThreeDifferentDVsAllRetained() {
+    // Regression test for issue #17206: a 3rd different DV must not be silently lost.
+    // After the 2nd DV migrates the path into duplicateDvsByPath, a 3rd DV must also
+    // be appended there rather than re-inserted into dvByPath (which would be ignored).
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    DeleteFile dv1 = withDataSequenceNumber(2, newDV(FILE_A));
+    DeleteFile dv2 = withDataSequenceNumber(2, newDV(FILE_A));
+    DeleteFile dv3 = withDataSequenceNumber(2, newDV(FILE_A));
+    // newDV generates random paths/offsets, so all three are genuinely different
+    List<DeleteFile> dvs = Arrays.asList(dv1, dv2, dv3);
+
+    DeleteFileIndex index = DeleteFileIndex.builderFor(dvs).specsById(table.specs()).build();
+
+    DeleteFile[] fileADeletes = index.forDataFile(0, FILE_A);
+    assertThat(fileADeletes)
+        .as("All 3 different DVs must be retained for union at read time")
+        .hasSize(3);
+    assertThat(fileADeletes).allMatch(ContentFileUtil::isDV);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -215,4 +215,49 @@ public class TestBitmapPositionDeleteIndex {
     index.forEach(positions::add);
     return positions;
   }
+
+  @Test
+  public void testEndToEndDVBitmapUnion() {
+    // End-to-end integration test for issue #17206: two different DV blobs for the same data
+    // file with known positions {0,2} and {1,3}. After serialize → deserialize → merge (the
+    // exact pipeline BaseDeleteLoader.readAndMergeDVs uses), all four positions {0,1,2,3} must
+    // be marked as deleted.
+    BitmapPositionDeleteIndex dv1Index = new BitmapPositionDeleteIndex();
+    dv1Index.delete(0L);
+    dv1Index.delete(2L);
+
+    BitmapPositionDeleteIndex dv2Index = new BitmapPositionDeleteIndex();
+    dv2Index.delete(1L);
+    dv2Index.delete(3L);
+
+    // Serialize each DV (mimics what a Puffin writer produces)
+    ByteBuffer dv1Bytes = dv1Index.serialize();
+    ByteBuffer dv2Bytes = dv2Index.serialize();
+
+    // Deserialize each (mimics BaseDeleteLoader.readDV)
+    DeleteFile mockDv1 = mockDV(dv1Bytes.remaining(), 2);
+    DeleteFile mockDv2 = mockDV(dv2Bytes.remaining(), 2);
+    PositionDeleteIndex deserialized1 =
+        PositionDeleteIndex.deserialize(toByteArray(dv1Bytes), mockDv1);
+    PositionDeleteIndex deserialized2 =
+        PositionDeleteIndex.deserialize(toByteArray(dv2Bytes), mockDv2);
+
+    // Merge (mimics PositionDeleteIndexUtil.merge in readAndMergeDVs)
+    PositionDeleteIndex merged =
+        PositionDeleteIndexUtil.merge(Lists.newArrayList(deserialized1, deserialized2));
+
+    // Assert the union: all 4 positions {0, 1, 2, 3} must be deleted
+    assertThat(merged.isDeleted(0L)).as("Position 0 must be deleted").isTrue();
+    assertThat(merged.isDeleted(1L)).as("Position 1 must be deleted").isTrue();
+    assertThat(merged.isDeleted(2L)).as("Position 2 must be deleted").isTrue();
+    assertThat(merged.isDeleted(3L)).as("Position 3 must be deleted").isTrue();
+    assertThat(merged.isDeleted(4L)).as("Position 4 must NOT be deleted").isFalse();
+    assertThat(merged.cardinality()).isEqualTo(4L);
+  }
+
+  private static byte[] toByteArray(ByteBuffer buffer) {
+    byte[] bytes = new byte[buffer.remaining()];
+    buffer.get(bytes);
+    return bytes;
+  }
 }

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -163,9 +163,25 @@ public class BaseDeleteLoader implements DeleteLoader {
       DeleteFile dv = Iterables.getOnlyElement(deleteFiles);
       validateDV(dv, filePath);
       return readDV(dv);
+    } else if (ContentFileUtil.containsOnlyDVs(deleteFiles)) {
+      // Multiple DVs for the same data file - spec violation recovery (issue #17206).
+      // Read each DV and merge (union) the position bitmaps to preserve all deletes.
+      return readAndMergeDVs(deleteFiles, filePath);
     } else {
       return getOrReadPosDeletes(deleteFiles, filePath);
     }
+  }
+
+  private PositionDeleteIndex readAndMergeDVs(
+      Iterable<DeleteFile> deleteFiles, CharSequence filePath) {
+    Iterable<PositionDeleteIndex> indexes =
+        execute(
+            deleteFiles,
+            dv -> {
+              validateDV(dv, filePath);
+              return readDV(dv);
+            });
+    return PositionDeleteIndexUtil.merge(indexes);
   }
 
   private PositionDeleteIndex readDV(DeleteFile dv) {


### PR DESCRIPTION
Closes #17206.

## Problem

When a snapshot contains more than one deletion vector (DV) referencing the same data file, scan planning fails permanently in `DeleteFileIndex.Builder.add(...)` with `Can't index multiple DVs for <data-file>`. The table becomes unreadable from every engine, and there is no built-in way to recover it.

The spec forbids more than one DV per data file per snapshot, so this state is metadata corruption and the `ValidationException` is a correct detection of an invalid state. This is the read-side manifestation of the write-side conflict-detection gap addressed by #15966: that change prevents future corruption, but it cannot heal tables that are already corrupted, which remain bricked.

## Change

Recover from the corruption on the read path without losing any deletes:

- DVs continue to be indexed one-per-data-file in `dvByPath` (the healthy fast path, with no added overhead).
- When a second DV is seen for the same data file, the path moves to an overflow map (`duplicateDvsByPath`), which is null on healthy tables:
  - Byte-identical duplicates (same location, offset, and length) are deduplicated silently (logged at DEBUG) - this covers the same DV referenced from two manifest entries.
  - Genuinely different DVs are retained and their position bitmaps are unioned at read time via the existing merge path (`PositionDeleteIndexUtil.merge`), and a WARNING is logged about the spec violation. No new Puffin files are written on the read path.
- The union preserves all deletes from all DVs; a DV is never silently dropped (which would resurrect deleted rows).

## Testing

- `DeleteFileIndex` tests covering two and three different DVs for the same data file (all retained and applied), and byte-identical deduplication.
- An end-to-end test that serializes two DV bitmaps with positions `{0, 2}` and `{1, 3}`, deserializes and merges them, and asserts all four positions are deleted.
- Existing `DeleteFileIndex` behavior is unchanged; spotless and checkstyle pass.
