### PR TITLE
Flink: Fix TableMaintenance operator uid instability that breaks savepoint restore

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -23,7 +23,7 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -153,7 +153,7 @@ public class TableMaintenance {
     private final List<MaintenanceTaskBuilder<?>> taskBuilders;
     private final TriggerLockFactory lockFactory;
 
-    private String uidSuffix = "TableMaintenance-" + UUID.randomUUID();
+    private String uidSuffix = null;
     private String slotSharingGroup = null;
     private Duration rateLimit = Duration.ofSeconds(RATE_LIMIT_SECOND_DEFAULT);
     private Duration lockCheckDelay = Duration.ofSeconds(LOCK_CHECK_DELAY_SECOND_DEFAULT);
@@ -267,7 +267,6 @@ public class TableMaintenance {
     /** Builds the task graph for the maintenance tasks. */
     public void append() throws IOException {
       Preconditions.checkArgument(!taskBuilders.isEmpty(), "Provide at least one task");
-      Preconditions.checkNotNull(uidSuffix, "Uid suffix should no be null");
 
       List<String> taskNames = Lists.newArrayListWithCapacity(taskBuilders.size());
       List<TriggerEvaluator> evaluators = Lists.newArrayListWithCapacity(taskBuilders.size());
@@ -279,6 +278,17 @@ public class TableMaintenance {
       try (TableLoader loader = tableLoader.clone()) {
         loader.open();
         String tableName = loader.loadTable().name();
+        if (uidSuffix == null) {
+          this.uidSuffix =
+              "TableMaintenance-"
+                  + tableName
+                  + "-"
+                  + taskBuilders.stream()
+                      .map(MaintenanceTaskBuilder::maintenanceTaskName)
+                      .sorted()
+                      .collect(Collectors.joining("_"));
+        }
+
         DataStream<Trigger> triggers;
         if (lockFactory == null) {
           triggers =

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -279,14 +278,7 @@ public class TableMaintenance {
         loader.open();
         String tableName = loader.loadTable().name();
         if (uidSuffix == null) {
-          this.uidSuffix =
-              "TableMaintenance-"
-                  + tableName
-                  + "-"
-                  + taskBuilders.stream()
-                      .map(MaintenanceTaskBuilder::maintenanceTaskName)
-                      .sorted()
-                      .collect(Collectors.joining("_"));
+          this.uidSuffix = "TableMaintenance-" + tableName;
         }
 
         DataStream<Trigger> triggers;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -351,6 +351,49 @@ class TestTableMaintenance extends OperatorTestBase {
   }
 
   @Test
+  void testUidSuffixUserProvidedIsUsedAsIs() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .uidSuffix(UID_SUFFIX)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .append();
+
+    String tableName = table.name();
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid())
+        .isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + UID_SUFFIX)
+        .doesNotContain(tableName);
+  }
+
+  @Test
+  void testUidSuffixDefaultContainsTableNameAndTaskNames() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .add(new MaintenanceTaskBuilderForTest(false).scheduleOnCommitCount(2))
+        .append();
+
+    String tableName = table.name();
+    String expectedSuffix =
+        "TableMaintenance-" + tableName + "-" + MAINTENANCE_TASK_NAME + "_" + MAINTENANCE_TASK_NAME;
+
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid()).isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + expectedSuffix);
+  }
+
+  @Test
   void testMonitorRatePerSecond() {
     // Sub-second rate limits must not yield infinite (unthrottled) monitor rates.
     assertThat(TableMaintenance.Builder.monitorRatePerSecond(50)).isEqualTo(20.0);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -372,7 +372,7 @@ class TestTableMaintenance extends OperatorTestBase {
   }
 
   @Test
-  void testUidSuffixDefaultContainsTableNameAndTaskNames() throws IOException {
+  void testUidSuffixDefaultContainsTableName() throws IOException {
     TableMaintenance.forChangeStream(
             new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
             tableLoader(),
@@ -382,8 +382,7 @@ class TestTableMaintenance extends OperatorTestBase {
         .append();
 
     String tableName = table.name();
-    String expectedSuffix =
-        "TableMaintenance-" + tableName + "-" + MAINTENANCE_TASK_NAME + "_" + MAINTENANCE_TASK_NAME;
+    String expectedSuffix = "TableMaintenance-" + tableName;
 
     Transformation<?> triggerManager =
         env.getTransformations().stream()


### PR DESCRIPTION
### Motivation
The default value of uidSuffix in TableMaintenance.Builder was previously:
```java
private String uidSuffix = "TableMaintenance-" + UUID.randomUUID();
```
This makes savepointsunusable for job recovery. When users try to restart a maintenance job from a savepoint, they hit the following error:

```
Cannot map checkpoint/savepoint state for operator b1b352db8bd2aef51f7534c353789605
to the new program, because the operator is not available in the new program.
If you want to allow to skip this, you can set the --allowNonRestoredState option on the CLI.
```

Although we can explicitly configure uidSuffix to work around this problem, it shouldn't be a required field.

### Changes
Change the default uidSuffix to be deterministically derived from the table name and the task names

### Limitation

The new approach cannot automatically disambiguate uids in the following scenario:
Within a single Flink job, two TableMaintenance instances are created for the same table, and both pipelines are configured with the same set of maintenance task types (e.g. both contain a RewriteDataFiles, only differing in partition predicates or parameters).

In this case both pipelines see the same tableName and the same sorted set of task names, so the fallback uidSuffix values are identical, causing pipeline-level shared operators to collide.

My understanding is that in this scenario, configuring multiple tasks inside a single TableMaintenance is the appropriate usage. Multiple tasks can be add() into one pipeline, which is more resource-efficient and provides cleaner lock semantics. If a user really needs to split the tasks across multiple TableMaintenance instances, they can still disambiguate by explicitly providing a distinct uidSuffix to each instance.