### PR TITLE
API: Reject geometry/geography CRS containing type-string delimiters

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -591,6 +591,10 @@ public class Types {
 
     private GeometryType(String crs) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
+      // The type serializes as geometry(<crs>) and parses the CRS as everything up to the closing
+      // paren, so a CRS containing ')' would not round-trip through the type string.
+      Preconditions.checkArgument(
+          crs == null || crs.indexOf(')') < 0, "Invalid CRS, cannot contain ')': %s", crs);
       // an omitted CRS canonicalizes to the default; a provided value is kept as-is (case
       // preserved)
       this.crs = crs == null ? DEFAULT_CRS : crs;
@@ -663,6 +667,12 @@ public class Types {
 
     private GeographyType(String crs, EdgeAlgorithm algorithm) {
       Preconditions.checkArgument(crs == null || !crs.isEmpty(), "Invalid CRS: (empty string)");
+      // The type serializes as geography(<crs>, <algorithm>) and parses the CRS as everything up to
+      // the ',' or closing paren, so a CRS containing ',' or ')' would not round-trip.
+      Preconditions.checkArgument(
+          crs == null || (crs.indexOf(',') < 0 && crs.indexOf(')') < 0),
+          "Invalid CRS, cannot contain ',' or ')': %s",
+          crs);
       // an omitted CRS/algorithm canonicalizes to the default; a provided CRS is kept as-is (case
       // preserved)
       this.crs = crs == null ? DEFAULT_CRS : crs;

--- a/api/src/test/java/org/apache/iceberg/types/TestTypes.java
+++ b/api/src/test/java/org/apache/iceberg/types/TestTypes.java
@@ -216,6 +216,31 @@ public class TestTypes {
   }
 
   @Test
+  public void testGeospatialCrsRejectsUnrepresentableCharacters() {
+    // The type string is geometry(<crs>) / geography(<crs>, <algorithm>) and the parser reads the
+    // CRS up to ')' (geometry) or ',' / ')' (geography). A CRS containing those delimiters could
+    // not round-trip through the type string, so it is rejected at construction rather than
+    // silently truncated on parse.
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Types.GeometryType.of("foo)bar"))
+        .withMessageContaining("Invalid CRS, cannot contain ')'");
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Types.GeographyType.of("foo)bar"))
+        .withMessageContaining("Invalid CRS, cannot contain ',' or ')'");
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Types.GeographyType.of("foo,bar"))
+        .withMessageContaining("Invalid CRS, cannot contain ',' or ')'");
+    assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> Types.GeographyType.of("foo,bar", EdgeAlgorithm.KARNEY))
+        .withMessageContaining("Invalid CRS, cannot contain ',' or ')'");
+
+    // A geometry CRS may still contain a comma: geometry has no ',' delimiter in its type string.
+    assertThat(Types.GeometryType.of("foo,bar").toString()).isEqualTo("geometry(foo,bar)");
+    assertThat(Types.fromPrimitiveString(Types.GeometryType.of("foo,bar").toString()))
+        .isEqualTo(Types.GeometryType.of("foo,bar"));
+  }
+
+  @Test
   public void testNestedFieldBuilderIdCheck() {
     assertThatExceptionOfType(NullPointerException.class)
         .isThrownBy(() -> optional("field").ofType(Types.StringType.get()).build())


### PR DESCRIPTION
## Summary

Reject a geometry/geography CRS that contains a character it could not round-trip through the type string.

`GeometryType` serializes as `geometry(<crs>)` and `GeographyType` as `geography(<crs>, <algorithm>)`. `Types.fromPrimitiveString` parses the CRS out of that string with:

```
GEOMETRY_PARAMETERS  = geometry\s*(?:\(\s*([^)]*?)\s*\))?
GEOGRAPHY_PARAMETERS = geography\s*(?:\(\s*([^,]*?)\s*(?:,\s*(\w*)\s*)?\))?
```

so the CRS is read only up to the first `)` (geometry) or the first `,` / `)` (geography). Today the constructors accept any non-empty CRS, so a CRS containing one of those delimiters is written out by `toString()` but silently **truncated** when the type string is parsed back — the schema no longer round-trips.

For example:

```java
Types.GeometryType.of("foo)bar").toString()   // "geometry(foo)bar)"
Types.fromPrimitiveString("geometry(foo)bar)") // parses CRS as "foo" — wrong, silent
```

## Change

Validate the CRS at construction and fail fast with a clear message instead of allowing a value that cannot round-trip:

- `GeometryType` rejects a CRS containing `)`.
- `GeographyType` rejects a CRS containing `,` or `)` (its type string uses both as delimiters).

A geometry CRS may still contain `,` — geometry's type string has no comma delimiter, so `geometry(foo,bar)` round-trips fine; that case is covered by a positive assertion. Normal CRS values (`EPSG:4326`, `OGC:CRS84`, `srid:<n>`, `projjson:<id>`) are unaffected.

## Tests

Added `TestTypes.testGeospatialCrsRejectsUnrepresentableCharacters`:
- `GeometryType.of("foo)bar")` and `GeographyType.of("foo)bar")` / `of("foo,bar")` throw with a clear message.
- `GeometryType.of("foo,bar")` is accepted and round-trips through `fromPrimitiveString(toString())`.

`:iceberg-api:test`, `spotlessJavaCheck`, `checkstyleMain`, and `checkstyleTest` pass.

This pull request and its description were written by Isaac.
