### PR TITLE
Core: Add streaming reader for snapshots in table metadata

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -19,10 +19,16 @@
 package org.apache.iceberg;
 
 import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.NoSuchElementException;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
@@ -54,6 +60,7 @@ public class SnapshotParser {
   private static final String FIRST_ROW_ID = "first-row-id";
   private static final String ADDED_ROWS = "added-rows";
   private static final String KEY_ID = "key-id";
+  private static final String SNAPSHOTS = "snapshots";
 
   static void toJson(Snapshot snapshot, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
@@ -209,6 +216,134 @@ public class SnapshotParser {
 
   public static Snapshot fromJson(String json) {
     return JsonUtil.parse(json, SnapshotParser::fromJson);
+  }
+
+  /**
+   * Streams snapshots from a table metadata JSON file one at a time.
+   *
+   * <p>{@link TableMetadataParser} reads the whole document into memory and materializes every
+   * entry of the {@code snapshots} array. For tables with very large snapshot histories that can
+   * dominate heap usage even when only a few snapshots are needed. This method walks the document
+   * with a streaming parser and holds only one {@link Snapshot} in memory at a time.
+   *
+   * <p>The returned iterable opens a fresh stream on each iteration and must be closed by the
+   * caller. It yields an empty iterable if the file has no {@code snapshots} array.
+   */
+  public static CloseableIterable<Snapshot> fromJson(InputFile file) {
+    Preconditions.checkArgument(file != null, "Invalid metadata file: null");
+    return new CloseableIterable<Snapshot>() {
+      @Override
+      public CloseableIterator<Snapshot> iterator() {
+        return new SnapshotIterator(file);
+      }
+
+      @Override
+      public void close() {}
+    };
+  }
+
+  private static class SnapshotIterator implements CloseableIterator<Snapshot> {
+    private final JsonParser parser;
+    private Snapshot next;
+    private boolean closed;
+
+    private SnapshotIterator(InputFile file) {
+      SeekableInputStream input = file.newStream();
+      JsonParser jsonParser;
+      try {
+        jsonParser = JsonUtil.factory().createParser(input);
+        jsonParser.setCodec(JsonUtil.mapper());
+      } catch (IOException e) {
+        try {
+          input.close();
+        } catch (IOException ignored) {
+          // suppress so the original failure is reported
+        }
+        throw new UncheckedIOException("Failed to open metadata file: " + file.location(), e);
+      }
+
+      this.parser = jsonParser;
+      if (!seekToSnapshots(parser)) {
+        close();
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      if (closed) {
+        return false;
+      }
+
+      if (next == null) {
+        next = advance();
+        if (next == null) {
+          close();
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    @Override
+    public Snapshot next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException();
+      }
+
+      Snapshot result = next;
+      this.next = null;
+      return result;
+    }
+
+    @Override
+    public void close() {
+      if (!closed) {
+        this.closed = true;
+        try {
+          parser.close();
+        } catch (IOException e) {
+          throw new UncheckedIOException("Failed to close metadata parser", e);
+        }
+      }
+    }
+
+    private Snapshot advance() {
+      try {
+        if (parser.nextToken() == JsonToken.START_OBJECT) {
+          JsonNode node = parser.readValueAsTree();
+          return fromJson(node);
+        }
+
+        // END_ARRAY or end of input: no more snapshots
+        return null;
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to read snapshot from table metadata", e);
+      }
+    }
+
+    /** Advances the parser to the start of the {@code snapshots} array, if present. */
+    private static boolean seekToSnapshots(JsonParser parser) {
+      try {
+        if (parser.nextToken() != JsonToken.START_OBJECT) {
+          return false;
+        }
+
+        while (parser.nextToken() == JsonToken.FIELD_NAME) {
+          String field = parser.currentName();
+          parser.nextToken();
+          if (SNAPSHOTS.equals(field)) {
+            return parser.currentToken() == JsonToken.START_ARRAY;
+          }
+
+          parser.skipChildren();
+        }
+
+        return false;
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to read table metadata", e);
+      }
+    }
   }
 
   /**

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotStreamParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotStreamParser.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.Files.localInput;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestSnapshotStreamParser {
+  @TempDir private Path temp;
+
+  @Test
+  public void testStreamsAllSnapshotsInOrder() throws IOException {
+    List<Snapshot> snapshots =
+        Lists.newArrayList(snapshot(1, null), snapshot(2, 1L), snapshot(3, 2L));
+    File metadata = writeMetadata(snapshots);
+
+    try (CloseableIterable<Snapshot> stream = SnapshotParser.fromJson(localInput(metadata))) {
+      List<Long> ids = Lists.newArrayList();
+      for (Snapshot snapshot : stream) {
+        ids.add(snapshot.snapshotId());
+      }
+
+      assertThat(ids).containsExactly(1L, 2L, 3L);
+    }
+  }
+
+  @Test
+  public void testStreamPreservesSnapshotFields() throws IOException {
+    File metadata = writeMetadata(Lists.newArrayList(snapshot(5, 4L)));
+
+    try (CloseableIterable<Snapshot> stream = SnapshotParser.fromJson(localInput(metadata))) {
+      Snapshot snapshot = Lists.newArrayList(stream).get(0);
+
+      assertThat(snapshot.snapshotId()).isEqualTo(5L);
+      assertThat(snapshot.parentId()).isEqualTo(4L);
+      assertThat(snapshot.timestampMillis()).isEqualTo(5000L);
+      assertThat(snapshot.manifestListLocation()).isEqualTo("s3://bucket/snap-5.avro");
+    }
+  }
+
+  @Test
+  public void testStreamIsReiterable() throws IOException {
+    File metadata = writeMetadata(Lists.newArrayList(snapshot(1, null), snapshot(2, 1L)));
+
+    try (CloseableIterable<Snapshot> stream = SnapshotParser.fromJson(localInput(metadata))) {
+      assertThat(collectIds(stream)).containsExactly(1L, 2L);
+      assertThat(collectIds(stream)).containsExactly(1L, 2L);
+    }
+  }
+
+  @Test
+  public void testMetadataWithoutSnapshotsArray() throws IOException {
+    File metadata = write("{\"format-version\":2,\"table-uuid\":\"uuid\"}");
+
+    try (CloseableIterable<Snapshot> stream = SnapshotParser.fromJson(localInput(metadata))) {
+      assertThat(stream).isEmpty();
+    }
+  }
+
+  @Test
+  public void testEmptySnapshotsArray() throws IOException {
+    File metadata = writeMetadata(Lists.newArrayList());
+
+    try (CloseableIterable<Snapshot> stream = SnapshotParser.fromJson(localInput(metadata))) {
+      assertThat(stream).isEmpty();
+    }
+  }
+
+  private List<Long> collectIds(CloseableIterable<Snapshot> stream) {
+    List<Long> ids = Lists.newArrayList();
+    for (Snapshot snapshot : stream) {
+      ids.add(snapshot.snapshotId());
+    }
+
+    return ids;
+  }
+
+  private Snapshot snapshot(long id, Long parentId) {
+    return new BaseSnapshot(
+        0,
+        id,
+        parentId,
+        id * 1000,
+        null,
+        null,
+        1,
+        "s3://bucket/snap-" + id + ".avro",
+        null,
+        null,
+        null);
+  }
+
+  /** Writes a metadata document with fields both before and after the {@code snapshots} array. */
+  private File writeMetadata(List<Snapshot> snapshots) throws IOException {
+    StringBuilder json = new StringBuilder();
+    json.append("{\"format-version\":2,\"table-uuid\":\"uuid\",\"properties\":{\"k\":\"v\"},");
+    json.append("\"snapshots\":[");
+    for (int i = 0; i < snapshots.size(); i += 1) {
+      if (i > 0) {
+        json.append(",");
+      }
+
+      json.append(SnapshotParser.toJson(snapshots.get(i)));
+    }
+
+    json.append("],\"current-snapshot-id\":-1}");
+    return write(json.toString());
+  }
+
+  private File write(String json) throws IOException {
+    File file = File.createTempFile("metadata", ".json", temp.toFile());
+    Files.write(file.toPath(), json.getBytes(StandardCharsets.UTF_8));
+    return file;
+  }
+}


### PR DESCRIPTION
### What
Adds `SnapshotParser.fromJson(InputFile)`, which streams the `snapshots` array of a table metadata JSON document and yields one `Snapshot` at a time instead of materializing the whole list.

### Why
`TableMetadataParser` parses the entire document into memory and builds every `Snapshot` in the `snapshots` array. For tables with very large snapshot histories this dominates heap usage even when a consumer only needs to walk snapshots (e.g. by id, timestamp, or manifest-list location). The streaming reader keeps a single snapshot in memory at a time.

### Notes
- The returned `CloseableIterable` opens a fresh stream on each iteration and must be closed by the caller.
- Returns an empty iterable when the document has no `snapshots` array.
- No spec or public-type changes; reuses the existing snapshot parsing.

### Testing
- Adds `TestSnapshotStreamParser` covering ordering, snapshot-field fidelity, re-iteration, and the missing/empty `snapshots` array cases.
