### PR TITLE
Open-API: Close backend catalog when stopping RESTCatalogServer

### DIFF
--- a/open-api/src/test/java/org/apache/iceberg/rest/TestRESTCatalogServer.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/TestRESTCatalogServer.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Map;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.junit.jupiter.api.Test;
+
+class TestRESTCatalogServer {
+
+  @Test
+  void stopClosesBackendCatalog() throws Exception {
+    Map<String, String> config = Maps.newHashMap();
+    config.put(RESTCatalogServer.REST_PORT, String.valueOf(RCKUtils.findFreePort()));
+
+    RESTCatalogServer server = new RESTCatalogServer(config);
+    server.start(false);
+    Catalog backendCatalog = server.catalogContext().catalog();
+
+    server.stop();
+
+    // the backend catalog (JdbcCatalog by default) must be closed along with the server, so any
+    // subsequent use of its connection pool fails instead of leaking JDBC connections/FileIO
+    assertThatThrownBy(() -> backendCatalog.listTables(Namespace.of("ns")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("closed pool");
+  }
+}

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTCatalogServer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.rest;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.util.Map;
@@ -26,6 +27,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.jdbc.JdbcCatalog;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import org.eclipse.jetty.compression.gzip.GzipCompression;
@@ -48,6 +50,7 @@ public class RESTCatalogServer {
   static final String CATALOG_NAME_DEFAULT = "rest_backend";
 
   private Server httpServer;
+  private CatalogContext catalogContext;
   private final Map<String, String> config;
 
   RESTCatalogServer() {
@@ -108,7 +111,7 @@ public class RESTCatalogServer {
   }
 
   public void start(boolean join) throws Exception {
-    CatalogContext catalogContext = initializeBackendCatalog();
+    this.catalogContext = initializeBackendCatalog();
 
     RESTCatalogAdapter adapter = new RESTServerCatalogAdapter(catalogContext);
     RESTCatalogServlet servlet = new RESTCatalogServlet(adapter);
@@ -138,6 +141,14 @@ public class RESTCatalogServer {
     if (httpServer != null) {
       httpServer.stop();
     }
+    if (catalogContext != null && catalogContext.catalog() instanceof Closeable) {
+      ((Closeable) catalogContext.catalog()).close();
+    }
+  }
+
+  @VisibleForTesting
+  CatalogContext catalogContext() {
+    return catalogContext;
   }
 
   public static void main(String[] args) throws Exception {


### PR DESCRIPTION
Closes #17232

## Summary

- `RESTCatalogServer.stop()` only stopped the Jetty `httpServer`; the backend `Catalog` from `initializeBackendCatalog()` (a `Closeable` `JdbcCatalog` by default) was never closed, leaking its JDBC connection pool and `FileIO`.
- `RESTServerExtension` registers `RESTCatalogServer` as a class-level JUnit fixture (RCK suite, Spark 3.5/4.0/4.1 `TestBaseWithCatalog`), so the leak accumulated per test class.
- `stop()` now closes the backend catalog when `Closeable` — the "owner closes the backend" contract from `RESTCatalogAdapter.close()`, via the `instanceof Closeable` pattern in `ParallelIterable`.

## Testing done

- Added `TestRESTCatalogServer#stopClosesBackendCatalog`: starts a server on the default in-memory sqlite `JdbcCatalog`, stops it, and asserts the connection pool rejects further use (fails without the fix).
- `./gradlew :iceberg-open-api:check` — 1 test passed.
- Not a REVAPI module (no `src/main`); no public API change.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
