### PR TITLE
[DO NOT REVIEW] REST: Preserve content file data sequence number

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -47,6 +47,7 @@ public class ContentFileParser {
   private static final String SPLIT_OFFSETS = "split-offsets";
   private static final String EQUALITY_IDS = "equality-ids";
   private static final String SORT_ORDER_ID = "sort-order-id";
+  private static final String DATA_SEQUENCE_NUMBER = "data-sequence-number";
   private static final String FIRST_ROW_ID = "first-row-id";
   private static final String REFERENCED_DATA_FILE = "referenced-data-file";
   private static final String CONTENT_OFFSET = "content-offset";
@@ -122,6 +123,8 @@ public class ContentFileParser {
       generator.writeNumberField(SORT_ORDER_ID, contentFile.sortOrderId());
     }
 
+    JsonUtil.writeLongFieldIfPresent(
+        DATA_SEQUENCE_NUMBER, contentFile.dataSequenceNumber(), generator);
     JsonUtil.writeLongFieldIfPresent(FIRST_ROW_ID, contentFile.firstRowId(), generator);
 
     if (contentFile instanceof DeleteFile) {
@@ -170,39 +173,46 @@ public class ContentFileParser {
     List<Long> splitOffsets = JsonUtil.getLongListOrNull(SPLIT_OFFSETS, jsonNode);
     int[] equalityFieldIds = JsonUtil.getIntArrayOrNull(EQUALITY_IDS, jsonNode);
     Integer sortOrderId = JsonUtil.getIntOrNull(SORT_ORDER_ID, jsonNode);
+    Long dataSequenceNumber = JsonUtil.getLongOrNull(DATA_SEQUENCE_NUMBER, jsonNode);
     Long firstRowId = JsonUtil.getLongOrNull(FIRST_ROW_ID, jsonNode);
     String referencedDataFile = JsonUtil.getStringOrNull(REFERENCED_DATA_FILE, jsonNode);
     Long contentOffset = JsonUtil.getLongOrNull(CONTENT_OFFSET, jsonNode);
     Long contentSizeInBytes = JsonUtil.getLongOrNull(CONTENT_SIZE, jsonNode);
 
     if (fileContent == FileContent.DATA) {
-      return new GenericDataFile(
-          specId,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          keyMetadata,
-          splitOffsets,
-          sortOrderId,
-          firstRowId);
+      GenericDataFile dataFile =
+          new GenericDataFile(
+              specId,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              keyMetadata,
+              splitOffsets,
+              sortOrderId,
+              firstRowId);
+      dataFile.setDataSequenceNumber(dataSequenceNumber);
+      return dataFile;
     } else {
-      return new GenericDeleteFile(
-          specId,
-          fileContent,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          equalityFieldIds,
-          sortOrderId,
-          splitOffsets,
-          keyMetadata,
-          referencedDataFile,
-          contentOffset,
-          contentSizeInBytes);
+      GenericDeleteFile deleteFile =
+          new GenericDeleteFile(
+              specId,
+              fileContent,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              equalityFieldIds,
+              sortOrderId,
+              splitOffsets,
+              keyMetadata,
+              referencedDataFile,
+              contentOffset,
+              contentSizeInBytes);
+      deleteFile.setDataSequenceNumber(dataSequenceNumber);
+      return deleteFile;
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
@@ -92,6 +92,21 @@ public class TestContentFileParser {
     assertContentFileEquals(dataFile, deserializedContentFile, spec);
   }
 
+  @Test
+  public void dataFileSequenceNumber() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    DataFile dataFile = dataFileWithRequiredOnly(spec);
+    ((BaseFile<?>) dataFile).setDataSequenceNumber(7L);
+
+    String jsonStr = ContentFileParser.toJson(dataFile, spec);
+    assertThat(jsonStr).contains("\"data-sequence-number\":7");
+
+    JsonNode jsonNode = JsonUtil.mapper().readTree(jsonStr);
+    ContentFile<?> deserializedContentFile =
+        ContentFileParser.fromJson(jsonNode, Map.of(spec.specId(), spec));
+    assertThat(deserializedContentFile.dataSequenceNumber()).isEqualTo(7L);
+  }
+
   @ParameterizedTest
   @MethodSource("provideSpecAndDeleteFile")
   public void testDeleteFile(PartitionSpec spec, DeleteFile deleteFile, String expectedJson)
@@ -611,5 +626,6 @@ public class TestContentFileParser {
     assertThat(actual.splitOffsets()).isEqualTo(expected.splitOffsets());
     assertThat(actual.equalityFieldIds()).isEqualTo(expected.equalityFieldIds());
     assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
+    assertThat(actual.dataSequenceNumber()).isEqualTo(expected.dataSequenceNumber());
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchScanTasksResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchScanTasksResponseParser.java
@@ -154,4 +154,22 @@ public class TestFetchScanTasksResponseParser {
 
     assertThat(FetchScanTasksResponseParser.toJson(copyResponse, false)).isEqualTo(expectedToJson);
   }
+
+  @Test
+  public void fileScanTaskDataSequenceNumber() {
+    String json =
+        "{"
+            + "\"file-scan-tasks\":["
+            + "{\"data-file\":{\"spec-id\":0,\"content\":\"data\",\"file-path\":\"/path/to/data-a.parquet\","
+            + "\"file-format\":\"parquet\",\"partition\":[0],\"file-size-in-bytes\":10,"
+            + "\"record-count\":1,\"sort-order-id\":0,\"data-sequence-number\":7},"
+            + "\"residual-filter\":true}]"
+            + "}";
+
+    FetchScanTasksResponse response =
+        FetchScanTasksResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+
+    assertThat(response.fileScanTasks().get(0).file().dataSequenceNumber()).isEqualTo(7L);
+    assertThat(FetchScanTasksResponseParser.toJson(response, false)).isEqualTo(json);
+  }
 }

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1047,6 +1047,11 @@ class ContentFile(BaseModel):
         None, alias='split-offsets', description='List of splittable offsets'
     )
     sort_order_id: int | None = Field(None, alias='sort-order-id')
+    data_sequence_number: int | None = Field(
+        None,
+        alias='data-sequence-number',
+        description="The data sequence number for the content file's manifest entry. Used to apply row-level metadata such as `_last_updated_sequence_number`.",
+    )
 
 
 class PositionDeleteFile(ContentFile):

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5036,6 +5036,13 @@ components:
           description: "List of splittable offsets"
         sort-order-id:
           type: integer
+        data-sequence-number:
+          type: integer
+          format: int64
+          description:
+            The data sequence number for the content file's manifest entry.
+            Used to apply row-level metadata such as
+            `_last_updated_sequence_number`.
 
     DataFile:
       allOf:


### PR DESCRIPTION
## Summary
- Preserve `data-sequence-number` when serializing and parsing REST content-file JSON.
- Add `data-sequence-number` to the REST OpenAPI `ContentFile` schema.
- Add focused parser coverage for content files and fetch-scan-task responses.

## Problem
REST scan-task payloads serialize scan task files through `ContentFileParser`. The payload preserved `first-row-id`, but dropped the data sequence number copied from the content file's manifest entry. Row-lineage readers need that sequence number to materialize `_last_updated_sequence_number` when the physical column is null or absent.

## Spec Basis
- The format spec says that when `_last_updated_sequence_number` is null, readers assign the `sequence_number` of the data file's manifest entry.
- The sequence number inheritance section defines the manifest-entry data sequence number that is inherited when it is not explicitly written.

## Testing
- `JAVA_HOME=/Users/gangwu/.sdkman/candidates/java/17.0.18-zulu ./gradlew spotlessApply :iceberg-core:test --tests org.apache.iceberg.TestContentFileParser.dataFileSequenceNumber --tests org.apache.iceberg.rest.responses.TestFetchScanTasksResponseParser.fileScanTaskDataSequenceNumber`

---
**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: OpenAI Codex
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix REST content-file data sequence number serialization for row lineage scan tasks.
