### PR TITLE
[DO NOT REVIEW] Core, Parquet, ORC, Arrow: Fix row lineage readers

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -414,16 +414,16 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     if (baseRowId != null) {
       return new RowIdVectorReader(baseRowId, idReader);
     } else {
-      return nulls();
+      return idReader != null ? idReader : nulls();
     }
   }
 
   public static VectorizedArrowReader lastUpdated(
       Long baseRowId, Long fileLastUpdated, VectorizedArrowReader seqReader) {
-    if (fileLastUpdated != null && baseRowId != null) {
+    if (fileLastUpdated != null) {
       return new LastUpdatedSeqVectorReader(fileLastUpdated, seqReader);
     } else {
-      return nulls();
+      return seqReader != null ? seqReader : nulls();
     }
   }
 

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedArrowReader.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.arrow.vectorized;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.arrow.vector.BigIntVector;
+import org.junit.jupiter.api.Test;
+
+class TestVectorizedArrowReader {
+  @Test
+  void rowIdPreservesPhysicalReaderWithoutBase() {
+    VectorizedArrowReader physicalReader = VectorizedArrowReader.nulls();
+
+    assertThat(VectorizedArrowReader.rowIds(null, physicalReader)).isSameAs(physicalReader);
+  }
+
+  @Test
+  void lastUpdatedPreservesPhysicalReaderWithoutDataSequence() {
+    VectorizedArrowReader physicalReader = VectorizedArrowReader.nulls();
+
+    assertThat(VectorizedArrowReader.lastUpdated(10L, null, physicalReader))
+        .isSameAs(physicalReader);
+  }
+
+  @Test
+  void lastUpdatedInheritsWithoutBase() {
+    VectorizedArrowReader reader = VectorizedArrowReader.lastUpdated(null, 5L, null);
+    reader.setBatchSize(2);
+
+    VectorHolder holder = reader.read(null, 2);
+    try (BigIntVector vector = (BigIntVector) holder.vector()) {
+      assertThat(vector.getDataBuffer().getLong(0)).isEqualTo(5L);
+      assertThat(vector.getDataBuffer().getLong(Long.BYTES)).isEqualTo(5L);
+    }
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -329,16 +329,16 @@ public class ValueReaders {
     if (baseRowId != null) {
       return new RowIdReader(baseRowId, (ValueReader<Long>) idReader);
     } else {
-      return ValueReaders.constant(null);
+      return idReader != null ? (ValueReader<Long>) idReader : ValueReaders.constant(null);
     }
   }
 
   public static ValueReader<Long> lastUpdated(
       Long baseRowId, Long fileSeqNumber, ValueReader<?> seqReader) {
-    if (fileSeqNumber != null && baseRowId != null) {
+    if (fileSeqNumber != null) {
       return new LastUpdatedSeqReader(fileSeqNumber, (ValueReader<Long>) seqReader);
     } else {
-      return ValueReaders.constant(null);
+      return seqReader != null ? (ValueReader<Long>) seqReader : ValueReaders.constant(null);
     }
   }
 
@@ -1345,7 +1345,7 @@ public class ValueReaders {
 
     LastUpdatedSeqReader(long fileSeqNumber, ValueReader<Long> seqReader) {
       this.fileSeqNumber = fileSeqNumber;
-      this.seqReader = seqReader;
+      this.seqReader = seqReader != null ? seqReader : ValueReaders.constant(null);
     }
 
     @Override

--- a/core/src/test/java/org/apache/iceberg/avro/TestValueReaders.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestValueReaders.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import org.junit.jupiter.api.Test;
+
+class TestValueReaders {
+  @Test
+  void rowIdPreservesPhysicalValueWithoutBase() throws IOException {
+    ValueReader<Long> reader = ValueReaders.rowIds(null, ValueReaders.constant(34L));
+
+    assertThat(reader.read(null, null)).isEqualTo(34L);
+  }
+
+  @Test
+  void lastUpdatedPreservesPhysicalValueWithoutDataSequence() throws IOException {
+    ValueReader<Long> reader = ValueReaders.lastUpdated(10L, null, ValueReaders.constant(5L));
+
+    assertThat(reader.read(null, null)).isEqualTo(5L);
+  }
+
+  @Test
+  void lastUpdatedInheritsWithoutBase() throws IOException {
+    ValueReader<Long> reader = ValueReaders.lastUpdated(null, 5L, null);
+
+    assertThat(reader.read(null, null)).isEqualTo(5L);
+  }
+}

--- a/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java
@@ -268,6 +268,10 @@ public class OrcValueReaders {
         if (fileIdReader != null) {
           this.orcFieldIndex[pos] = orcIndex;
         }
+      } else if (fileReader != null) {
+        this.readers[pos] = fileReader;
+        this.isConstantOrMetadataField[pos] = false;
+        this.orcFieldIndex[pos] = orcIndex;
       } else {
         this.isConstantOrMetadataField[pos] = true;
         this.readers[pos] = constants(null);
@@ -282,14 +286,17 @@ public class OrcValueReaders {
         Map<Integer, ?> idToConstant,
         int orcIndex) {
       Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
-      Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
-      if (fileLastUpdated != null && firstRowId != null) {
+      if (fileLastUpdated != null) {
         OrcValueReader<Long> fileSeqReader = (OrcValueReader<Long>) fileReader;
         this.readers[pos] = new LastUpdatedSeqReader(fileLastUpdated, fileSeqReader);
         this.isConstantOrMetadataField[pos] = fileSeqReader == null;
         if (fileSeqReader != null) {
           this.orcFieldIndex[pos] = orcIndex;
         }
+      } else if (fileReader != null) {
+        this.readers[pos] = fileReader;
+        this.isConstantOrMetadataField[pos] = false;
+        this.orcFieldIndex[pos] = orcIndex;
       } else {
         this.isConstantOrMetadataField[pos] = true;
         this.readers[pos] = constants(null);

--- a/orc/src/test/java/org/apache/iceberg/orc/TestOrcValueReaders.java
+++ b/orc/src/test/java/org/apache/iceberg/orc/TestOrcValueReaders.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.orc;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+import org.apache.orc.TypeDescription;
+import org.junit.jupiter.api.Test;
+
+class TestOrcValueReaders {
+  @Test
+  void rowLineagePreservesPhysicalReadersWithoutConstants() {
+    Schema rowIdSchema = new Schema(MetadataColumns.ROW_ID);
+    OrcValueReader<Long> rowIdReader = OrcValueReaders.constants(34L);
+
+    TestStructReader rowIdStructReader = reader(rowIdSchema, List.of(rowIdReader), Map.of());
+
+    assertThat(rowIdStructReader.reader(0)).isSameAs(rowIdReader);
+
+    Schema lastUpdatedSchema = new Schema(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
+    OrcValueReader<Long> lastUpdatedReader = OrcValueReaders.constants(5L);
+
+    TestStructReader lastUpdatedStructReader =
+        reader(
+            lastUpdatedSchema,
+            List.of(lastUpdatedReader),
+            Map.of(MetadataColumns.ROW_ID.fieldId(), 10L));
+
+    assertThat(lastUpdatedStructReader.reader(0)).isSameAs(lastUpdatedReader);
+  }
+
+  @Test
+  void lastUpdatedInheritsWithoutBase() {
+    Schema schema = new Schema(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
+    TestStructReader reader =
+        reader(
+            schema,
+            Collections.singletonList(null),
+            Map.of(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), 5L));
+
+    assertThat(reader.reader(0).read(null, 0)).isEqualTo(5L);
+  }
+
+  private static TestStructReader reader(
+      Schema schema, List<OrcValueReader<?>> readers, Map<Integer, ?> idToConstant) {
+    TypeDescription orcType = ORCSchemaUtil.convert(schema);
+    return new TestStructReader(orcType, readers, schema.asStruct(), idToConstant);
+  }
+
+  private static class TestStructReader extends OrcValueReaders.StructReader<Object[]> {
+    TestStructReader(
+        TypeDescription orcType,
+        List<OrcValueReader<?>> readers,
+        Types.StructType struct,
+        Map<Integer, ?> idToConstant) {
+      super(orcType, readers, struct, idToConstant);
+    }
+
+    @Override
+    protected Object[] create() {
+      return new Object[2];
+    }
+
+    @Override
+    protected void set(Object[] struct, int pos, Object value) {
+      struct[pos] = value;
+    }
+  }
+}

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -173,17 +173,17 @@ public class ParquetValueReaders {
     if (baseRowId != null) {
       return new RowIdReader(baseRowId, (ParquetValueReader<Long>) idReader);
     } else {
-      return ParquetValueReaders.nulls();
+      return idReader != null ? (ParquetValueReader<Long>) idReader : ParquetValueReaders.nulls();
     }
   }
 
   @SuppressWarnings("unchecked")
   public static ParquetValueReader<Long> lastUpdated(
       Long baseRowId, Long fileLastUpdated, ParquetValueReader<?> seqReader) {
-    if (fileLastUpdated != null && baseRowId != null) {
+    if (fileLastUpdated != null) {
       return new LastUpdatedSeqReader(fileLastUpdated, (ParquetValueReader<Long>) seqReader);
     } else {
-      return ParquetValueReaders.nulls();
+      return seqReader != null ? (ParquetValueReader<Long>) seqReader : ParquetValueReaders.nulls();
     }
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetValueReaders.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetValueReaders.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class TestParquetValueReaders {
+  @Test
+  void rowIdPreservesPhysicalValueWithoutBase() {
+    ParquetValueReader<Long> reader =
+        ParquetValueReaders.rowIds(null, ParquetValueReaders.constant(34L));
+
+    assertThat(reader.read(null)).isEqualTo(34L);
+  }
+
+  @Test
+  void lastUpdatedPreservesPhysicalValueWithoutDataSequence() {
+    ParquetValueReader<Long> reader =
+        ParquetValueReaders.lastUpdated(10L, null, ParquetValueReaders.constant(5L));
+
+    assertThat(reader.read(null)).isEqualTo(5L);
+  }
+
+  @Test
+  void lastUpdatedInheritsWithoutBase() {
+    ParquetValueReader<Long> reader = ParquetValueReaders.lastUpdated(null, 5L, null);
+
+    assertThat(reader.read(null)).isEqualTo(5L);
+  }
+}


### PR DESCRIPTION
## Summary
- Preserve physical `_row_id` and `_last_updated_sequence_number` values when inheritance constants are missing.
- Inherit `_last_updated_sequence_number` from the file data sequence number without requiring a base row ID.
- Add focused Avro, Parquet, ORC, and Arrow reader tests.

## Problem
Row-lineage readers used null readers when fallback constants were missing. That could drop physical non-null lineage values already stored in files. The last-updated reader path also required a base row ID before applying the file data sequence number, even though `_last_updated_sequence_number` inheritance is based on the file sequence number, not row ID assignment.

## Spec Basis
- The format spec says missing row-lineage columns are read as null values.
- If `_last_updated_sequence_number` is null, readers assign the data file manifest-entry `sequence_number`.
- If `_row_id` is null, readers assign `first_row_id + _pos`; when `first_row_id` is null, inherited row IDs remain null, but existing rows still inherit `_last_updated_sequence_number` from their containing data file.

## Testing
- `JAVA_HOME=/Users/gangwu/.sdkman/candidates/java/17.0.18-zulu ./gradlew spotlessApply :iceberg-core:test --tests org.apache.iceberg.avro.TestValueReaders :iceberg-parquet:test --tests org.apache.iceberg.parquet.TestParquetValueReaders :iceberg-arrow:test --tests org.apache.iceberg.arrow.vectorized.TestVectorizedArrowReader :iceberg-orc:test --tests org.apache.iceberg.orc.TestOrcValueReaders`

---
**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: OpenAI Codex
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Fix row-lineage reader inheritance and physical value preservation.
