### PR TITLE
Build: Bump datamodel-code-generator from 0.67.0 to 0.68.1

### DIFF
--- a/open-api/requirements.txt
+++ b/open-api/requirements.txt
@@ -16,5 +16,5 @@
 # under the License.
 
 openapi-spec-validator==0.9.0
-datamodel-code-generator==0.67.0
+datamodel-code-generator==0.68.1
 yamllint==1.38.0

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -269,11 +269,10 @@ class Summary(BaseModel):
     model_config = ConfigDict(
         extra='allow',
     )
+    __annotations__ = {
+        '__pydantic_extra__': Dict[str, str],
+    }
     operation: Literal['append', 'replace', 'overwrite', 'delete']
-
-
-Summary.__annotations__['__pydantic_extra__'] = Dict[str, str]
-Summary.model_rebuild(force=True)
 
 
 class Snapshot(BaseModel):


### PR DESCRIPTION
- Closes #17221
