### PR TITLE
AWS: Allow setting more options for HTTP proxy

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/ApacheHttpClientConfigurations.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.aws;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
@@ -28,7 +27,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.http.SdkHttpClient;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
-import software.amazon.awssdk.http.apache.ProxyConfiguration;
 
 class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
   private Long connectionTimeoutMs;
@@ -40,9 +38,7 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
   private Integer maxConnections;
   private Boolean tcpKeepAliveEnabled;
   private Boolean useIdleConnectionReaperEnabled;
-  private String proxyEndpoint;
-  private Boolean proxyUseSystemPropertyValues;
-  private Boolean proxyUseEnvironmentVariableValues;
+  private ProxyConfiguration proxyConfiguration;
 
   private ApacheHttpClientConfigurations() {}
 
@@ -81,15 +77,7 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
     this.useIdleConnectionReaperEnabled =
         PropertyUtil.propertyAsNullableBoolean(
             httpClientProperties, HttpClientProperties.APACHE_USE_IDLE_CONNECTION_REAPER_ENABLED);
-    this.proxyEndpoint =
-        PropertyUtil.propertyAsString(
-            httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
-    this.proxyUseSystemPropertyValues =
-        PropertyUtil.propertyAsNullableBoolean(
-            httpClientProperties, HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES);
-    this.proxyUseEnvironmentVariableValues =
-        PropertyUtil.propertyAsNullableBoolean(
-            httpClientProperties, HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES);
+    this.proxyConfiguration = ProxyConfiguration.create(httpClientProperties);
   }
 
   @VisibleForTesting
@@ -125,22 +113,8 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
   }
 
   private void configureProxy(ApacheHttpClient.Builder apacheHttpClientBuilder) {
-    if (proxyEndpoint != null
-        || proxyUseSystemPropertyValues != null
-        || proxyUseEnvironmentVariableValues != null) {
-      ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder();
-
-      if (proxyEndpoint != null) {
-        proxyBuilder.endpoint(URI.create(proxyEndpoint));
-      }
-      if (proxyUseSystemPropertyValues != null) {
-        proxyBuilder.useSystemPropertyValues(proxyUseSystemPropertyValues);
-      }
-      if (proxyUseEnvironmentVariableValues != null) {
-        proxyBuilder.useEnvironmentVariableValues(proxyUseEnvironmentVariableValues);
-      }
-
-      apacheHttpClientBuilder.proxyConfiguration(proxyBuilder.build());
+    if (proxyConfiguration.isConfigured()) {
+      apacheHttpClientBuilder.proxyConfiguration(proxyConfiguration.toApache());
     }
   }
 
@@ -162,9 +136,7 @@ class ApacheHttpClientConfigurations extends BaseHttpClientConfigurations {
     keyComponents.put("maxConnections", maxConnections);
     keyComponents.put("tcpKeepAliveEnabled", tcpKeepAliveEnabled);
     keyComponents.put("useIdleConnectionReaperEnabled", useIdleConnectionReaperEnabled);
-    keyComponents.put("proxyEndpoint", proxyEndpoint);
-    keyComponents.put("proxyUseSystemPropertyValues", proxyUseSystemPropertyValues);
-    keyComponents.put("proxyUseEnvironmentVariableValues", proxyUseEnvironmentVariableValues);
+    proxyConfiguration.addToCacheKey(keyComponents);
 
     return keyComponents.entrySet().stream()
         .map(entry -> entry.getKey() + "=" + Objects.toString(entry.getValue(), "null"))

--- a/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/HttpClientProperties.java
@@ -62,6 +62,27 @@ public class HttpClientProperties implements Serializable {
   public static final String PROXY_ENDPOINT = "http-client.proxy-endpoint";
 
   /**
+   * Used to configure the proxy scheme. Used by both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}
+   */
+  public static final String PROXY_SCHEME = "http-client.proxy-scheme";
+
+  /**
+   * Used to configure the proxy username. Used by both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}
+   */
+  public static final String PROXY_USERNAME = "http-client.proxy-username";
+
+  /**
+   * Used to configure the proxy password. Used by both {@link
+   * software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient.Builder} and {@link
+   * software.amazon.awssdk.http.apache.ApacheHttpClient.Builder}
+   */
+  public static final String PROXY_PASSWORD = "http-client.proxy-password";
+
+  /**
    * Used to enable reading proxy configuration from Java system properties (http.proxyHost,
    * http.proxyPort, http.nonProxyHosts, etc.). Default is true.
    *

--- a/aws/src/main/java/org/apache/iceberg/aws/ProxyConfiguration.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/ProxyConfiguration.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aws;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.iceberg.util.PropertyUtil;
+
+record ProxyConfiguration(
+    String scheme,
+    String endpoint,
+    String username,
+    String password,
+    Boolean useSystemPropertyValues,
+    Boolean useEnvironmentVariableValues) {
+
+  private static final String DEFAULT_SCHEME = "http";
+
+  static ProxyConfiguration create(Map<String, String> properties) {
+    return new ProxyConfiguration(
+        PropertyUtil.propertyAsString(
+            properties, HttpClientProperties.PROXY_SCHEME, DEFAULT_SCHEME),
+        PropertyUtil.propertyAsString(properties, HttpClientProperties.PROXY_ENDPOINT, null),
+        PropertyUtil.propertyAsString(properties, HttpClientProperties.PROXY_USERNAME, null),
+        PropertyUtil.propertyAsString(properties, HttpClientProperties.PROXY_PASSWORD, null),
+        PropertyUtil.propertyAsNullableBoolean(
+            properties, HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES),
+        PropertyUtil.propertyAsNullableBoolean(
+            properties, HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES));
+  }
+
+  boolean isConfigured() {
+    return endpoint != null
+        || useSystemPropertyValues != null
+        || useEnvironmentVariableValues != null;
+  }
+
+  void addToCacheKey(Map<String, Object> keyComponents) {
+    keyComponents.put("proxyScheme", scheme);
+    keyComponents.put("proxyEndpoint", endpoint);
+    keyComponents.put("proxyUsername", username);
+    keyComponents.put("proxyPassword", password);
+    keyComponents.put("proxyUseSystemPropertyValues", useSystemPropertyValues);
+    keyComponents.put("proxyUseEnvironmentVariableValues", useEnvironmentVariableValues);
+  }
+
+  // for Apache client
+  software.amazon.awssdk.http.apache.ProxyConfiguration toApache() {
+    software.amazon.awssdk.http.apache.ProxyConfiguration.Builder builder =
+        software.amazon.awssdk.http.apache.ProxyConfiguration.builder();
+    if (endpoint != null) {
+      builder.scheme(scheme).endpoint(URI.create(endpoint)).username(username).password(password);
+    }
+    if (useSystemPropertyValues != null) {
+      builder.useSystemPropertyValues(useSystemPropertyValues);
+    }
+    if (useEnvironmentVariableValues != null) {
+      builder.useEnvironmentVariableValues(useEnvironmentVariableValues);
+    }
+    return builder.build();
+  }
+
+  // build for url client
+  software.amazon.awssdk.http.urlconnection.ProxyConfiguration toUrlConnection() {
+    software.amazon.awssdk.http.urlconnection.ProxyConfiguration.Builder builder =
+        software.amazon.awssdk.http.urlconnection.ProxyConfiguration.builder();
+    if (endpoint != null) {
+      builder.scheme(scheme).endpoint(URI.create(endpoint)).username(username).password(password);
+    }
+    if (useSystemPropertyValues != null) {
+      builder.useSystemPropertyValues(useSystemPropertyValues);
+    }
+    if (useEnvironmentVariableValues != null) {
+      builder.useEnvironmentVariablesValues(useEnvironmentVariableValues);
+    }
+    return builder.build();
+  }
+}

--- a/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/UrlConnectionHttpClientConfigurations.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.aws;
 
-import java.net.URI;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Objects;
@@ -27,16 +26,13 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
 import software.amazon.awssdk.http.SdkHttpClient;
-import software.amazon.awssdk.http.urlconnection.ProxyConfiguration;
 import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
 
 class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations {
 
   private Long httpClientUrlConnectionConnectionTimeoutMs;
   private Long httpClientUrlConnectionSocketTimeoutMs;
-  private String proxyEndpoint;
-  private Boolean proxyUseSystemPropertyValues;
-  private Boolean proxyUseEnvironmentVariableValues;
+  private ProxyConfiguration proxyConfiguration;
 
   private UrlConnectionHttpClientConfigurations() {}
 
@@ -55,15 +51,7 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
     this.httpClientUrlConnectionSocketTimeoutMs =
         PropertyUtil.propertyAsNullableLong(
             httpClientProperties, HttpClientProperties.URLCONNECTION_SOCKET_TIMEOUT_MS);
-    this.proxyEndpoint =
-        PropertyUtil.propertyAsString(
-            httpClientProperties, HttpClientProperties.PROXY_ENDPOINT, null);
-    this.proxyUseSystemPropertyValues =
-        PropertyUtil.propertyAsNullableBoolean(
-            httpClientProperties, HttpClientProperties.PROXY_USE_SYSTEM_PROPERTY_VALUES);
-    this.proxyUseEnvironmentVariableValues =
-        PropertyUtil.propertyAsNullableBoolean(
-            httpClientProperties, HttpClientProperties.PROXY_USE_ENVIRONMENT_VARIABLE_VALUES);
+    this.proxyConfiguration = ProxyConfiguration.create(httpClientProperties);
   }
 
   @VisibleForTesting
@@ -81,22 +69,8 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
   }
 
   private void configureProxy(UrlConnectionHttpClient.Builder urlConnectionHttpClientBuilder) {
-    if (proxyEndpoint != null
-        || proxyUseSystemPropertyValues != null
-        || proxyUseEnvironmentVariableValues != null) {
-      ProxyConfiguration.Builder proxyBuilder = ProxyConfiguration.builder();
-
-      if (proxyEndpoint != null) {
-        proxyBuilder.endpoint(URI.create(proxyEndpoint));
-      }
-      if (proxyUseSystemPropertyValues != null) {
-        proxyBuilder.useSystemPropertyValues(proxyUseSystemPropertyValues);
-      }
-      if (proxyUseEnvironmentVariableValues != null) {
-        proxyBuilder.useEnvironmentVariablesValues(proxyUseEnvironmentVariableValues);
-      }
-
-      urlConnectionHttpClientBuilder.proxyConfiguration(proxyBuilder.build());
+    if (proxyConfiguration.isConfigured()) {
+      urlConnectionHttpClientBuilder.proxyConfiguration(proxyConfiguration.toUrlConnection());
     }
   }
 
@@ -111,9 +85,7 @@ class UrlConnectionHttpClientConfigurations extends BaseHttpClientConfigurations
     keyComponents.put("type", "urlconnection");
     keyComponents.put("connectionTimeoutMs", httpClientUrlConnectionConnectionTimeoutMs);
     keyComponents.put("socketTimeoutMs", httpClientUrlConnectionSocketTimeoutMs);
-    keyComponents.put("proxyEndpoint", proxyEndpoint);
-    keyComponents.put("proxyUseSystemPropertyValues", proxyUseSystemPropertyValues);
-    keyComponents.put("proxyUseEnvironmentVariableValues", proxyUseEnvironmentVariableValues);
+    proxyConfiguration.addToCacheKey(keyComponents);
 
     return keyComponents.entrySet().stream()
         .map(entry -> entry.getKey() + "=" + Objects.toString(entry.getValue(), "null"))


### PR DESCRIPTION
I added three new properties: PROXY_SCHEME, PROXY_USERNAME and PROXY_PASSWORD. Need this to use an authenticated proxy.