### PR TITLE
API: Fix incorrect Javadoc on ManageSnapshots tag methods

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
+++ b/api/src/main/java/org/apache/iceberg/ManageSnapshots.java
@@ -110,7 +110,7 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
    * Create a new tag pointing to the given snapshot id
    *
    * @param name tag name
-   * @param snapshotId snapshotId for the head of the new branch.
+   * @param snapshotId snapshotId for the head of the new tag.
    * @return this for method chaining
    * @throws IllegalArgumentException if a tag with the given name already exists
    */
@@ -140,7 +140,7 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
    *
    * @param name tag name
    * @return this for method chaining
-   * @throws IllegalArgumentException if the branch does not exist
+   * @throws IllegalArgumentException if the tag does not exist
    */
   ManageSnapshots removeTag(String name);
 


### PR DESCRIPTION
## Summary

- `createTag(String, long)`: `@param snapshotId` said "head of the new branch"; corrected to "tag".
- `removeTag(String)`: `@throws IllegalArgumentException` said "if the branch does not exist"; corrected to "tag".
- Both are copy-paste leftovers from the sibling `createBranch(String, long)` and `removeBranch(String)` Javadoc, which are the correct anchors.

## Testing done

- Typo/wording fix, no behavior change — no test added. `./gradlew :iceberg-api:spotlessCheck` passed.

