### PR TITLE
AWS: Apply S3 access grants and user agent config in AssumeRole s3()

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AssumeRoleAwsClientFactory.java
@@ -47,6 +47,8 @@ public class AssumeRoleAwsClientFactory implements AwsClientFactory {
         .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
         .applyMutation(s3FileIOProperties::applyServiceConfigurations)
         .applyMutation(s3FileIOProperties::applySignerConfiguration)
+        .applyMutation(s3FileIOProperties::applyS3AccessGrantsConfigurations)
+        .applyMutation(s3FileIOProperties::applyUserAgentConfigurations)
         .applyMutation(s3FileIOProperties::applyRetryConfigurations)
         .build();
   }

--- a/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
+++ b/aws/src/test/java/org/apache/iceberg/aws/TestAwsClientFactories.java
@@ -40,6 +40,7 @@ import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentials;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.awscore.AwsClient;
+import software.amazon.awssdk.core.client.config.SdkAdvancedClientOption;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.retries.api.RetryStrategy;
 import software.amazon.awssdk.retries.internal.DefaultAdaptiveRetryStrategy;
@@ -173,6 +174,36 @@ public class TestAwsClientFactories {
     AwsClientFactory deserializedClientFactory =
         SerializationUtil.deserializeFromBytes(serializedFactoryBytes);
     assertThat(deserializedClientFactory).isInstanceOf(AssumeRoleAwsClientFactory.class);
+  }
+
+  @Test
+  public void testAssumeRoleAwsClientFactoryS3AppliesUserAgent() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+
+    Optional<String> userAgentPrefix =
+        factory
+            .s3()
+            .serviceClientConfiguration()
+            .overrideConfiguration()
+            .advancedOption(SdkAdvancedClientOption.USER_AGENT_PREFIX);
+    assertThat(userAgentPrefix).isPresent();
+    assertThat(userAgentPrefix.get()).startsWith("s3fileio/");
+  }
+
+  @Test
+  public void testAssumeRoleAwsClientFactoryS3AppliesS3AccessGrants() {
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(AwsProperties.CLIENT_FACTORY, AssumeRoleAwsClientFactory.class.getName());
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_ARN, "arn::test");
+    properties.put(AwsProperties.CLIENT_ASSUME_ROLE_REGION, "us-east-1");
+    properties.put(S3FileIOProperties.S3_ACCESS_GRANTS_ENABLED, "true");
+    AwsClientFactory factory = AwsClientFactories.from(properties);
+
+    assertThat(factory.s3()).isNotNull();
   }
 
   @ParameterizedTest


### PR DESCRIPTION
Closes #17245

## Summary

- `AssumeRoleAwsClientFactory.s3()` skipped `applyS3AccessGrantsConfigurations` and `applyUserAgentConfigurations`, so assume-role S3 clients ignored `s3.access-grants.enabled` and never set the `s3fileio/` user agent.
- This PR applies both in the same order as the sibling [`DefaultAwsClientFactory.s3()`](https://github.com/apache/iceberg/blob/main/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java#L108-L122): signer -> access grants -> user agent -> retry.
- Independent scope: this covers the s3 access-grants/user-agent parity gap only, separate from open PR #17049 by the same author, which changes the same files for glue/kms endpoint config.

## Testing done

- Added `TestAwsClientFactories#testAssumeRoleAwsClientFactoryS3AppliesUserAgent` (asserts the built S3 client's user agent prefix starts with `s3fileio/`) and `#testAssumeRoleAwsClientFactoryS3AppliesS3AccessGrants` (builds `s3()` with access grants enabled).
- `./gradlew :iceberg-aws:spotlessCheck :iceberg-aws:test --tests "org.apache.iceberg.aws.TestAwsClientFactories"` — 23 tests passed, 0 failed.
- Full `:iceberg-aws:check` was not run: it pulls in testcontainers/Docker integration tests that do not complete locally. aws is not a revapi module, so revapi is skipped.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
