### PR TITLE
Azure: Return fully-qualified locations from ADLSFileIO.listPrefix

### DIFF
--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
@@ -169,7 +169,8 @@ public class TestADLSFileIO extends AzuriteTestBase {
 
     // assert that only files were returned and not directories
     FileInfo fileInfo = result.next();
-    assertThat(fileInfo.location()).isEqualTo("dir/file");
+    assertThat(fileInfo.location())
+        .isEqualTo("abfs://container@account.dfs.core.windows.net/dir/file");
     assertThat(fileInfo.size()).isEqualTo(123L);
     assertThat(fileInfo.createdAtMillis()).isEqualTo(now.toInstant().toEpochMilli());
 

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -227,7 +227,12 @@ public class ADLSFileIO implements DelegateFileIO {
             .map(
                 pathItem ->
                     new FileInfo(
-                        pathItem.getName(),
+                        String.format(
+                            "%s://%s%s/%s",
+                            location.scheme(),
+                            location.container().map(c -> c + "@").orElse(""),
+                            location.host(),
+                            pathItem.getName()),
                         pathItem.getContentLength(),
                         pathItem.getCreationTime().toInstant().toEpochMilli()))
             .iterator();

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 class ADLSLocation {
   private static final Pattern URI_PATTERN = Pattern.compile("^(abfss?|wasbs?)://([^/?#]+)(.*)?$");
 
+  private final String scheme;
   private final String storageAccount;
   private final String container;
   private final String path;
@@ -63,6 +64,8 @@ class ADLSLocation {
 
     ValidationException.check(matcher.matches(), "Invalid ADLS URI: %s", location);
 
+    this.scheme = matcher.group(1);
+
     String authority = matcher.group(2);
     String[] parts = authority.split("@", -1);
     if (parts.length > 1) {
@@ -77,6 +80,11 @@ class ADLSLocation {
 
     String uriPath = matcher.group(3);
     this.path = uriPath == null ? "" : uriPath.startsWith("/") ? uriPath.substring(1) : uriPath;
+  }
+
+  /** Returns the URI scheme, e.g. abfs, abfss, wasb, or wasbs. */
+  public String scheme() {
+    return scheme;
   }
 
   /** Returns Azure storage account. */

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
@@ -19,16 +19,25 @@
 package org.apache.iceberg.azure.adlsv2;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import com.azure.core.http.rest.PagedIterable;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
+import com.azure.storage.file.datalake.models.PathItem;
 import java.io.IOException;
+import java.time.OffsetDateTime;
+import java.util.Iterator;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
 import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableFunction;
 import org.junit.jupiter.api.Test;
@@ -292,5 +301,35 @@ public class TestADLSFileIO {
     for (DataLakeFileSystemClient result : results) {
       assertThat(result).isSameAs(mockClient);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  void listPrefixReturnsFullyQualifiedLocation() {
+    String prefix = "abfss://container@account.dfs.core.windows.net/dir";
+
+    OffsetDateTime now = OffsetDateTime.now();
+    PathItem file =
+        new PathItem(
+            "tag", now, 123L, "group", false, "dir/file", "owner", "permissions", now, null);
+
+    PagedIterable<PathItem> response = mock(PagedIterable.class);
+    when(response.stream()).thenReturn(ImmutableList.of(file).stream());
+
+    DataLakeFileSystemClient client = mock(DataLakeFileSystemClient.class);
+    when(client.listPaths(any(), any())).thenReturn(response);
+
+    ADLSFileIO io = spy(new ADLSFileIO());
+    io.initialize(ImmutableMap.of());
+    doReturn(client).when(io).client(any(ADLSLocation.class));
+
+    Iterator<FileInfo> result = io.listPrefix(prefix).iterator();
+
+    // the returned location must be a fully-qualified URI that preserves the scheme,
+    // container, and host of the prefix, matching S3FileIO and GCSFileIO
+    FileInfo fileInfo = result.next();
+    assertThat(fileInfo.location())
+        .isEqualTo("abfss://container@account.dfs.core.windows.net/dir/file");
+    assertThat(result.hasNext()).isFalse();
   }
 }


### PR DESCRIPTION

Closes #17247

## Summary

- `ADLSFileIO.listPrefix()` returned each file's location as a container-relative path (`dir/file`) instead of a fully-qualified URI.
- Siblings return full URIs: `S3FileIO` builds `s3://bucket/key` (S3FileIO.java:348), `GCSFileIO` builds `gs://bucket/name` (GCSFileIO.java:302).
- `ADLSLocation` cannot parse a relative path, so it throws `ValidationException` when `FileSystemWalker` round-trips it (opt-in Spark `usePrefixListing`, Flink maintenance orphan cleanup).
- Reconstruct the full URI from the prefix location, preserving its scheme, container, and host; add `ADLSLocation.scheme()` to expose the captured scheme.

## Testing done

- Added `TestADLSFileIO#listPrefixReturnsFullyQualifiedLocation` (unit, Mockito) asserting the location is `abfss://container@account.dfs.core.windows.net/dir/file`.
- `./gradlew :iceberg-azure:test --tests "...TestADLSFileIO"` — 13 tests passed. `:iceberg-azure:spotlessCheck :iceberg-azure:checkstyleMain :iceberg-azure:checkstyleTest` — passed.
- Updated the existing `src/integration/.../TestADLSFileIO#testListPrefixOperations` assertion to the full URI. Not run locally, along with `:iceberg-azure:check`, since both need Docker/Azurite.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
