### PR TITLE
Flink: Avoid unnecessary TableLoader.loadTable() in IcebergCommitter subtasks > 0

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -79,6 +79,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   private ExecutorService workerPool;
   private int continuousEmptyCheckpoints = 0;
   private final boolean tableMaintenanceEnabled;
+  private final int subtaskId;
 
   IcebergCommitter(
       TableLoader tableLoader,
@@ -88,31 +89,43 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       int workerPoolSize,
       String sinkId,
       IcebergFilesCommitterMetrics committerMetrics,
-      boolean tableMaintenanceEnabled) {
+      boolean tableMaintenanceEnabled,
+      int subtaskId) {
     this.branch = branch;
     this.snapshotProperties = snapshotProperties;
     this.replacePartitions = replacePartitions;
     this.committerMetrics = committerMetrics;
     this.tableLoader = tableLoader;
-    if (!tableLoader.isOpen()) {
-      tableLoader.open();
+    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
+    this.subtaskId = subtaskId;
+
+    if (subtaskId == 0) {
+      if (!tableLoader.isOpen()) {
+        tableLoader.open();
+      }
+
+      this.table = tableLoader.loadTable();
+      this.maxContinuousEmptyCommits =
+          PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+      Preconditions.checkArgument(
+          maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+      this.workerPool =
+          ThreadPools.newFixedThreadPool(
+              "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     }
 
-    this.table = tableLoader.loadTable();
-    this.maxContinuousEmptyCommits =
-        PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
-    Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
-    this.workerPool =
-        ThreadPools.newFixedThreadPool(
-            "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
-    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
   }
 
   @Override
   public void commit(Collection<CommitRequest<IcebergCommittable>> commitRequests)
       throws IOException, InterruptedException {
+    Preconditions.checkState(
+        subtaskId == 0,
+        "IcebergCommitter received %s commit request(s) on subtask %s, but only subtask 0 is expected to commit.",
+        commitRequests.size(),
+        subtaskId);
+
     if (commitRequests.isEmpty()) {
       return;
     }
@@ -311,7 +324,12 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
 
   @Override
   public void close() throws IOException {
-    tableLoader.close();
-    workerPool.shutdown();
+    if (tableLoader.isOpen()) {
+      tableLoader.close();
+    }
+
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -99,6 +99,8 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
     this.tableMaintenanceEnabled = tableMaintenanceEnabled;
     this.subtaskId = subtaskId;
 
+    // IcebergSink#addPreCommitTopology routes all committables to subtask 0 via a .global()
+    // shuffle, so only subtask 0 needs to load the table and create the worker pool.
     if (subtaskId == 0) {
       if (!tableLoader.isOpen()) {
         tableLoader.open();

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -249,7 +249,8 @@ public class IcebergSink
         workerPoolSize,
         sinkId,
         metrics,
-        maintenanceEnabled);
+        maintenanceEnabled,
+        context.getTaskInfo().getIndexOfThisSubtask());
   }
 
   @Override

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -23,10 +23,13 @@ import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommitt
 import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
 import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -1156,6 +1159,54 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testCommitterOnSubtaskZeroLoadsTable() throws Exception {
+    TableLoader spyLoader = spy(tableLoader);
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            spyLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 0);
+
+    verify(spyLoader).open();
+    verify(spyLoader).loadTable();
+
+    committer.close();
+  }
+
+  @TestTemplate
+  public void testCommitterOnNonZeroSubtaskSkipsTableLoad() throws Exception {
+    TableLoader spyLoader = spy(tableLoader);
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            spyLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 1);
+
+    verify(spyLoader, never()).open();
+    verify(spyLoader, never()).loadTable();
+
+    committer.close();
+  }
+
+  @TestTemplate
+  public void testCommitOnNonZeroSubtaskFailsFast() throws Exception {
+    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
+    IcebergCommitter committer =
+        new IcebergCommitter(
+            tableLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 1);
+
+    Committer.CommitRequest<IcebergCommittable> commitRequest =
+        buildCommitRequestFor(jobId, 1L, Lists.newArrayList());
+    assertThatThrownBy(() -> committer.commit(Lists.newArrayList(commitRequest)))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("only subtask 0 is expected to commit");
+
+    assertThatThrownBy(() -> committer.commit(Lists.newArrayList()))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("only subtask 0 is expected to commit");
+
+    committer.close();
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =
@@ -1307,7 +1358,8 @@ class TestIcebergCommitter extends TestBase {
         10,
         "sinkId",
         metric,
-        false);
+        false,
+        0);
   }
 
   private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -27,9 +27,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
@@ -1160,51 +1158,45 @@ class TestIcebergCommitter extends TestBase {
   }
 
   @TestTemplate
-  public void testCommitterOnSubtaskZeroLoadsTable() throws Exception {
-    TableLoader spyLoader = spy(tableLoader);
-    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
-    IcebergCommitter committer =
-        new IcebergCommitter(
-            spyLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 0);
+  public void testCommitterSubtaskZeroCommits() throws Exception {
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 0)) {
+      testHarness.open();
 
-    verify(spyLoader).open();
-    verify(spyLoader).loadTable();
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "subtask-zero");
+      DataFile dataFile = writeDataFile("data-subtask-zero", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
 
-    committer.close();
-  }
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
 
-  @TestTemplate
-  public void testCommitterOnNonZeroSubtaskSkipsTableLoad() throws Exception {
-    TableLoader spyLoader = spy(tableLoader);
-    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
-    IcebergCommitter committer =
-        new IcebergCommitter(
-            spyLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 1);
-
-    verify(spyLoader, never()).open();
-    verify(spyLoader, never()).loadTable();
-
-    committer.close();
+      // subtask 0 loaded the table and performed the commit end-to-end.
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(row), branch);
+      assertSnapshotSize(1);
+      assertMaxCommittedCheckpointId(jobId, checkpointId);
+    }
   }
 
   @TestTemplate
   public void testCommitOnNonZeroSubtaskFailsFast() throws Exception {
-    IcebergFilesCommitterMetrics metric = mock(IcebergFilesCommitterMetrics.class);
-    IcebergCommitter committer =
-        new IcebergCommitter(
-            tableLoader, branch, Collections.emptyMap(), false, 10, "sinkId", metric, false, 1);
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 1)) {
+      testHarness.open();
 
-    Committer.CommitRequest<IcebergCommittable> commitRequest =
-        buildCommitRequestFor(jobId, 1L, Lists.newArrayList());
-    assertThatThrownBy(() -> committer.commit(Lists.newArrayList(commitRequest)))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("only subtask 0 is expected to commit");
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "should-not-commit");
+      DataFile dataFile = writeDataFile("data-non-zero-subtask", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
 
-    assertThatThrownBy(() -> committer.commit(Lists.newArrayList()))
-        .isInstanceOf(IllegalStateException.class)
-        .hasMessageContaining("only subtask 0 is expected to commit");
+      assertThatThrownBy(() -> testHarness.notifyOfCompletedCheckpoint(checkpointId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("only subtask 0 is expected to commit");
 
-    committer.close();
+      // No snapshot should have been produced because the commit failed fast.
+      assertSnapshotSize(0);
+    }
   }
 
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
@@ -1334,6 +1326,12 @@ class TestIcebergCommitter extends TestBase {
   private OneInputStreamOperatorTestHarness<
           CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
       getTestHarness() throws Exception {
+    return getTestHarness(1, 0);
+  }
+
+  private OneInputStreamOperatorTestHarness<
+          CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+      getTestHarness(int parallelism, int subtaskIndex) throws Exception {
     IcebergSink sink =
         IcebergSink.forRowData(null).table(table).toBranch(branch).tableLoader(tableLoader).build();
 
@@ -1341,7 +1339,10 @@ class TestIcebergCommitter extends TestBase {
             CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
         testHarness =
             new OneInputStreamOperatorTestHarness<>(
-                new CommitterOperatorFactory<>(sink, !isStreamingMode, true));
+                new CommitterOperatorFactory<>(sink, !isStreamingMode, true),
+                parallelism,
+                parallelism,
+                subtaskIndex);
     testHarness.setup(committableMessageTypeSerializer);
     return testHarness;
   }


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/17140

`IcebergSink#addPreCommitTopology` uses a `.global()` shuffle to force all committables to subtask 0 of the downstream committer operator, so that commits only happen on a single subtask.

Even though only subtask 0 will ever receive a `CommitRequest`, every committer subtask still eagerly loads the Iceberg table and creates a worker thread pool in its constructor.

This pr add code to avoid unnecessary TableLoader.loadTable() in IcebergCommitter subtasks > 0 . 