### PR TITLE
Arrow: Document NullabilityHolder.reset() null-marker contract

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
@@ -76,15 +76,13 @@ public class NullabilityHolder {
   }
 
   /**
-   * Resets this holder so it can be reused for the next batch.
-   *
-   * <p>Only the null count is cleared. The per-index markers returned by {@link #isNullAt(int)} are
-   * deliberately left untouched: for every batch, writers set the marker of each index through
-   * {@link #setNull(int)}/{@link #setNotNull(int)} (or their bulk variants {@link #setNulls(int,
-   * int)}/{@link #setNotNulls(int, int)}) before the markers are read, so values carried over from
-   * a previous batch are overwritten rather than observed.
+   * Resets this holder so it can be reused for the next batch. Only the null count is cleared; the
+   * per-index markers returned by {@link #isNullAt(int)} are left as they are.
    */
   public void reset() {
+    // the markers are not cleared because every index is set through setNull/setNotNull (or their
+    // bulk variants) before it is read back, so a value carried over from the previous batch is
+    // always overwritten rather than observed
     numNulls = 0;
   }
 }

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/NullabilityHolder.java
@@ -75,6 +75,15 @@ public class NullabilityHolder {
     return numNulls;
   }
 
+  /**
+   * Resets this holder so it can be reused for the next batch.
+   *
+   * <p>Only the null count is cleared. The per-index markers returned by {@link #isNullAt(int)} are
+   * deliberately left untouched: for every batch, writers set the marker of each index through
+   * {@link #setNull(int)}/{@link #setNotNull(int)} (or their bulk variants {@link #setNulls(int,
+   * int)}/{@link #setNotNulls(int, int)}) before the markers are read, so values carried over from
+   * a previous batch are overwritten rather than observed.
+   */
   public void reset() {
     numNulls = 0;
   }


### PR DESCRIPTION
Documents the behavior reported in #15808

## Summary

- `NullabilityHolder.reset()` clears only `numNulls`; the `isNull` marker array read by `isNullAt(int)` is left as-is.
- This is intentional, not a bug: for every batch, `VectorizedParquetDefinitionLevelReader` sets the marker of each index via `setNull`/`setNotNull` (or the bulk `setNulls`/`setNotNulls`) before any marker is read, so values from a previous batch are overwritten rather than observed.
- Add Javadoc on `reset()` stating this contract, so the behavior is not mistaken for a stale-state bug.
- On closed PR #16264, the reviewer noted writers set all values explicitly and suggested documenting this instead of changing `reset()`.

## Testing done

- Javadoc-only change, no behavior change — no test added.
- `./gradlew :iceberg-arrow:spotlessCheck` — passed.
- `./gradlew :iceberg-arrow:checkstyleMain` — passed.

---

**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Document the `NullabilityHolder.reset()` null-marker contract.
