### PR TITLE
Core: harden puffin reader to malformed input

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DVUtil.java
+++ b/core/src/main/java/org/apache/iceberg/DVUtil.java
@@ -49,32 +49,12 @@ import org.apache.iceberg.util.Tasks;
 class DVUtil {
   private DVUtil() {}
 
-  /**
-   * Validate a DV. Based on the original from BaseDeleteLoader.
-   *
-   * @param dv deletion vector.
-   */
-  private static void validateDV(DeleteFile dv) {
-    Preconditions.checkArgument(
-        dv.contentOffset() != null,
-        "Invalid DV, offset cannot be null: %s",
-        ContentFileUtil.dvDesc(dv));
-    Preconditions.checkArgument(
-        dv.contentSizeInBytes() != null,
-        "Invalid DV, length is null: %s",
-        ContentFileUtil.dvDesc(dv));
-    Preconditions.checkArgument(
-        dv.contentSizeInBytes() <= Integer.MAX_VALUE,
-        "Can't read DV larger than 2GB: %s",
-        dv.contentSizeInBytes());
-  }
-
   static PositionDeleteIndex readDV(DeleteFile deleteFile, FileIO fileIO) {
     Preconditions.checkArgument(
         ContentFileUtil.isDV(deleteFile),
         "Cannot read, not a deletion vector: %s",
         deleteFile.location());
-    validateDV(deleteFile);
+    ContentFileUtil.validateDV(deleteFile);
     InputFile inputFile = fileIO.newInputFile(deleteFile);
     long offset = deleteFile.contentOffset();
     int length = deleteFile.contentSizeInBytes().intValue();

--- a/core/src/main/java/org/apache/iceberg/DVUtil.java
+++ b/core/src/main/java/org/apache/iceberg/DVUtil.java
@@ -49,11 +49,32 @@ import org.apache.iceberg.util.Tasks;
 class DVUtil {
   private DVUtil() {}
 
+  /**
+   * Validate a DV. Based on the original from BaseDeleteLoader.
+   *
+   * @param dv deletion vector.
+   */
+  private static void validateDV(DeleteFile dv) {
+    Preconditions.checkArgument(
+        dv.contentOffset() != null,
+        "Invalid DV, offset cannot be null: %s",
+        ContentFileUtil.dvDesc(dv));
+    Preconditions.checkArgument(
+        dv.contentSizeInBytes() != null,
+        "Invalid DV, length is null: %s",
+        ContentFileUtil.dvDesc(dv));
+    Preconditions.checkArgument(
+        dv.contentSizeInBytes() <= Integer.MAX_VALUE,
+        "Can't read DV larger than 2GB: %s",
+        dv.contentSizeInBytes());
+  }
+
   static PositionDeleteIndex readDV(DeleteFile deleteFile, FileIO fileIO) {
     Preconditions.checkArgument(
         ContentFileUtil.isDV(deleteFile),
         "Cannot read, not a deletion vector: %s",
         deleteFile.location());
+    validateDV(deleteFile);
     InputFile inputFile = fileIO.newInputFile(deleteFile);
     long offset = deleteFile.contentOffset();
     int length = deleteFile.contentSizeInBytes().intValue();

--- a/core/src/main/java/org/apache/iceberg/deletes/RoaringPositionBitmap.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/RoaringPositionBitmap.java
@@ -260,13 +260,15 @@ class RoaringPositionBitmap {
   public static RoaringPositionBitmap deserialize(ByteBuffer buffer) {
     validateByteOrder(buffer);
 
+    // Upper limit on the maximum possible number of bitmaps remaining.
+    int maxBitmaps = buffer.remaining();
     // the bitmap array may be sparse with more elements than the number of read bitmaps
-    int remainingBitmapCount = readBitmapCount(buffer);
+    int remainingBitmapCount = readBitmapCount(buffer, maxBitmaps);
     List<RoaringBitmap> bitmaps = Lists.newArrayListWithExpectedSize(remainingBitmapCount);
     int lastKey = -1;
 
     while (remainingBitmapCount > 0) {
-      int key = readKey(buffer, lastKey);
+      int key = readKey(buffer, lastKey, maxBitmaps);
 
       // fill gaps as the bitmap array may be sparse
       while (lastKey < key - 1) {
@@ -290,19 +292,36 @@ class RoaringPositionBitmap {
         "Roaring bitmap serialization requires little-endian byte order");
   }
 
-  private static int readBitmapCount(ByteBuffer buffer) {
+  /**
+   * Read the count of bitmaps from the buffer.
+   *
+   * @param buffer data buffer
+   * @param maxBitmaps the number of bitmaps possible
+   * @return the number of bitmaps in this position bitmap
+   * @throws IllegalArgumentException if it is invalid.
+   */
+  private static int readBitmapCount(ByteBuffer buffer, int maxBitmaps) {
     long bitmapCount = buffer.getLong();
     Preconditions.checkArgument(
-        bitmapCount >= 0 && bitmapCount <= Integer.MAX_VALUE,
-        "Invalid bitmap count: %s",
-        bitmapCount);
+        bitmapCount >= 0 && bitmapCount <= maxBitmaps, "Invalid bitmap count: %s", bitmapCount);
     return (int) bitmapCount;
   }
 
-  private static int readKey(ByteBuffer buffer, int lastKey) {
+  /**
+   * Read the next bitmap key from the buffer, validating it.
+   *
+   * @param buffer data buffer
+   * @param lastKey the last key read
+   * @param maxBitmaps the number of bitmaps possible
+   * @return the key
+   * @throws IllegalArgumentException if it is invalid.
+   */
+  private static int readKey(ByteBuffer buffer, int lastKey, int maxBitmaps) {
     int key = buffer.getInt();
     Preconditions.checkArgument(key >= 0, "Invalid unsigned key: %s", key);
     Preconditions.checkArgument(key <= Integer.MAX_VALUE - 1, "Key is too large: %s", key);
+    Preconditions.checkArgument(
+        key < maxBitmaps, "Key %s is out of range for %s remaining bytes", key, maxBitmaps);
     Preconditions.checkArgument(key > lastKey, "Keys must be sorted in ascending order");
     return key;
   }

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinFormat.java
@@ -156,10 +156,11 @@ final class PuffinFormat {
       inputLength = inputBytes.length;
     }
 
-    byte[] decompressed =
-        new byte
-            [Math.toIntExact(
-                ZstdDecompressor.getDecompressedSize(inputBytes, inputOffset, inputLength))];
+    long decompressedSize =
+        ZstdDecompressor.getDecompressedSize(inputBytes, inputOffset, inputLength);
+    Preconditions.checkArgument(
+        decompressedSize >= 0, "Invalid decompressed size: %s", decompressedSize);
+    byte[] decompressed = new byte[Math.toIntExact(decompressedSize)];
     int decompressedLength =
         new ZstdDecompressor()
             .decompress(inputBytes, inputOffset, inputLength, decompressed, 0, decompressed.length);

--- a/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
+++ b/core/src/main/java/org/apache/iceberg/puffin/PuffinReader.java
@@ -133,8 +133,18 @@ public class PuffinReader implements Closeable {
             .map(
                 (BlobMetadata blobMetadata) -> {
                   try {
-                    input.seek(blobMetadata.offset());
-                    byte[] bytes = new byte[Math.toIntExact(blobMetadata.length())];
+                    long offset = blobMetadata.offset();
+                    long length = blobMetadata.length();
+                    Preconditions.checkArgument(offset >= 0, "Invalid blob offset: %s", offset);
+                    Preconditions.checkArgument(length >= 0, "Invalid blob length: %s", length);
+                    Preconditions.checkArgument(
+                        offset <= fileSize && length <= fileSize - offset,
+                        "Blob offset %s and length %s are out of bounds for file size %s",
+                        offset,
+                        length,
+                        fileSize);
+                    input.seek(offset);
+                    byte[] bytes = new byte[Math.toIntExact(length)];
                     ByteStreams.readFully(input, bytes);
                     ByteBuffer rawData = ByteBuffer.wrap(bytes);
                     PuffinCompressionCodec codec =
@@ -173,10 +183,21 @@ public class PuffinReader implements Closeable {
       int footerPayloadSize =
           PuffinFormat.readIntegerLittleEndian(
               footerStruct, PuffinFormat.FOOTER_STRUCT_PAYLOAD_SIZE_OFFSET);
-      knownFooterSize =
-          PuffinFormat.FOOTER_START_MAGIC_LENGTH
+      // the payload size is read as a signed little-endian int; reject a negative value and keep
+      // the
+      // footer within the file so the footer buffer is never sized beyond the file itself
+      Preconditions.checkState(
+          footerPayloadSize >= 0, "Invalid footer payload size: %s", footerPayloadSize);
+      long footerSize =
+          (long) PuffinFormat.FOOTER_START_MAGIC_LENGTH
               + footerPayloadSize
               + PuffinFormat.FOOTER_STRUCT_LENGTH;
+      Preconditions.checkState(
+          footerSize <= fileSize,
+          "Invalid footer size %s is larger than the file size %s",
+          footerSize,
+          fileSize);
+      knownFooterSize = Math.toIntExact(footerSize);
     }
     return knownFooterSize;
   }

--- a/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/ContentFileUtil.java
@@ -156,6 +156,23 @@ public class ContentFileUtil {
         deleteFile.referencedDataFile());
   }
 
+  /**
+   * Validates that a deletion vector has a usable offset and length before it is read. The length
+   * must fit in an int so the bytes can be read into a single array.
+   *
+   * @param dv deletion vector to validate
+   */
+  public static void validateDV(DeleteFile dv) {
+    Preconditions.checkArgument(
+        dv.contentOffset() != null, "Invalid DV, offset cannot be null: %s", dvDesc(dv));
+    Preconditions.checkArgument(
+        dv.contentSizeInBytes() != null, "Invalid DV, length is null: %s", dvDesc(dv));
+    Preconditions.checkArgument(
+        dv.contentSizeInBytes() <= Integer.MAX_VALUE,
+        "Can't read DV larger than 2GB: %s",
+        dvDesc(dv));
+  }
+
   private static Metrics metricsWithoutPathBounds(DeleteFile file) {
     Map<Integer, ByteBuffer> lowerBounds =
         file.lowerBounds() == null ? null : Maps.newHashMap(file.lowerBounds());

--- a/core/src/test/java/org/apache/iceberg/deletes/TestRoaringPositionBitmap.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestRoaringPositionBitmap.java
@@ -36,6 +36,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.relocated.com.google.common.io.Resources;
 import org.apache.iceberg.util.Pair;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -543,6 +544,29 @@ public class TestRoaringPositionBitmap {
 
     assertEqual(bitmap, positions);
     assertRandomPositions(bitmap, positions);
+  }
+
+  @Test
+  public void testDeserializeBitmapCountLargerThanInput() {
+    ByteBuffer buffer = ByteBuffer.allocate(8);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putLong(1_000_000L); /* one million bitmaps in an 8 byte buffer. */
+    buffer.flip();
+    assertThatThrownBy(() -> RoaringPositionBitmap.deserialize(buffer))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid bitmap count");
+  }
+
+  @Test
+  public void testDeserializeRejectsKeyLargerThanInput() {
+    ByteBuffer buffer = ByteBuffer.allocate(12);
+    buffer.order(ByteOrder.LITTLE_ENDIAN);
+    buffer.putLong(1L);
+    buffer.putInt(1_000_000); /* key far beyond the 12 available bytes */
+    buffer.flip();
+    assertThatThrownBy(() -> RoaringPositionBitmap.deserialize(buffer))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("out of range");
   }
 
   private Pair<RoaringPositionBitmap, Set<Long>> generateSparseBitmap(

--- a/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
+++ b/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
@@ -154,4 +154,43 @@ public class TestPuffinReader {
           .isEqualTo(ImmutableMap.of("created-by", "Test 1234"));
     }
   }
+
+  @Test
+  public void testRejectsFooterPayloadSizeLargerThanFile() throws Exception {
+    byte[] footerStruct = footerStructWithPayloadSize(1_000_000);
+    InMemoryInputFile inputFile = new InMemoryInputFile(footerStruct);
+    try (PuffinReader reader = Puffin.read(inputFile).build()) {
+      assertThatThrownBy(reader::fileMetadata)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Invalid footer size");
+    }
+  }
+
+  @Test
+  public void testRejectsNegativeFooterPayloadSize() throws Exception {
+    byte[] footerStruct = footerStructWithPayloadSize(Integer.MIN_VALUE);
+    InMemoryInputFile inputFile = new InMemoryInputFile(footerStruct);
+    try (PuffinReader reader = Puffin.read(inputFile).build()) {
+      assertThatThrownBy(reader::fileMetadata)
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("Invalid footer payload size");
+    }
+  }
+
+  /**
+   * Build a bare 12-byte footer tail [payload size, flags, trailing magic].
+   *
+   * @param payloadSize declared payload size.
+   * @return the footer.
+   */
+  private static byte[] footerStructWithPayloadSize(int payloadSize) {
+    byte[] footerStruct = new byte[PuffinFormat.FOOTER_STRUCT_LENGTH];
+    footerStruct[0] = (byte) (payloadSize & 0xFF);
+    footerStruct[1] = (byte) ((payloadSize >> 8) & 0xFF);
+    footerStruct[2] = (byte) ((payloadSize >> 16) & 0xFF);
+    footerStruct[3] = (byte) ((payloadSize >> 24) & 0xFF);
+    byte[] magic = PuffinFormat.getMagic();
+    System.arraycopy(magic, 0, footerStruct, PuffinFormat.FOOTER_STRUCT_MAGIC_OFFSET, magic.length);
+    return footerStruct;
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
+++ b/core/src/test/java/org/apache/iceberg/puffin/TestPuffinReader.java
@@ -28,6 +28,7 @@ import static org.apache.iceberg.relocated.com.google.common.collect.ImmutableMa
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.iceberg.inmemory.InMemoryInputFile;
@@ -156,9 +157,59 @@ public class TestPuffinReader {
   }
 
   @Test
-  public void testRejectsFooterPayloadSizeLargerThanFile() throws Exception {
-    byte[] footerStruct = footerStructWithPayloadSize(1_000_000);
-    InMemoryInputFile inputFile = new InMemoryInputFile(footerStruct);
+  public void testReadAllRejectsBlobOffsetBeyondFile() throws Exception {
+    InMemoryInputFile inputFile =
+        new InMemoryInputFile(readTestResource("v1/empty-puffin-uncompressed.bin"));
+    assertBlobReadRejected(inputFile, blobAt(inputFile.getLength() + 1, 1), "out of bounds");
+  }
+
+  @Test
+  public void testReadAllRejectsBlobLengthBeyondFile() throws Exception {
+    InMemoryInputFile inputFile =
+        new InMemoryInputFile(readTestResource("v1/empty-puffin-uncompressed.bin"));
+    assertBlobReadRejected(inputFile, blobAt(0, inputFile.getLength() + 1), "out of bounds");
+  }
+
+  @Test
+  public void testReadAllRejectsNegativeBlobOffset() throws Exception {
+    InMemoryInputFile inputFile =
+        new InMemoryInputFile(readTestResource("v1/empty-puffin-uncompressed.bin"));
+    assertBlobReadRejected(inputFile, blobAt(-1, 1), "Invalid blob offset");
+  }
+
+  @Test
+  public void testReadAllRejectsNegativeBlobLength() throws Exception {
+    InMemoryInputFile inputFile =
+        new InMemoryInputFile(readTestResource("v1/empty-puffin-uncompressed.bin"));
+    assertBlobReadRejected(inputFile, blobAt(0, -1), "Invalid blob length");
+  }
+
+  private static BlobMetadata blobAt(long offset, long length) {
+    return new BlobMetadata(
+        "some-blob", ImmutableList.of(1), 0L, 0L, offset, length, null, ImmutableMap.of());
+  }
+
+  /**
+   * Assert that a blob read is rejected with an IllegalArgumentException.
+   *
+   * @param inputFile input file
+   * @param blob blob to read
+   * @param message content within the exception message
+   * @throws IOException any IOException raised during the read.
+   */
+  private static void assertBlobReadRejected(
+      final InMemoryInputFile inputFile, final BlobMetadata blob, final String message)
+      throws IOException {
+    try (PuffinReader reader = Puffin.read(inputFile).build()) {
+      assertThatThrownBy(() -> reader.readAll(ImmutableList.of(blob)).forEach(pair -> {}))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(message);
+    }
+  }
+
+  @Test
+  public void testReadRejectsFooterPayloadSizeLargerThanFile() throws Exception {
+    InMemoryInputFile inputFile = new InMemoryInputFile(footerStructWithPayloadSize(1_000_000));
     try (PuffinReader reader = Puffin.read(inputFile).build()) {
       assertThatThrownBy(reader::fileMetadata)
           .isInstanceOf(IllegalStateException.class)
@@ -167,9 +218,9 @@ public class TestPuffinReader {
   }
 
   @Test
-  public void testRejectsNegativeFooterPayloadSize() throws Exception {
-    byte[] footerStruct = footerStructWithPayloadSize(Integer.MIN_VALUE);
-    InMemoryInputFile inputFile = new InMemoryInputFile(footerStruct);
+  public void testReadRejectsNegativeFooterPayloadSize() throws Exception {
+    InMemoryInputFile inputFile =
+        new InMemoryInputFile(footerStructWithPayloadSize(Integer.MIN_VALUE));
     try (PuffinReader reader = Puffin.read(inputFile).build()) {
       assertThatThrownBy(reader::fileMetadata)
           .isInstanceOf(IllegalStateException.class)

--- a/core/src/test/java/org/apache/iceberg/util/TestContentFileUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestContentFileUtil.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.iceberg.DeleteFile;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+/** Test methods in {@link ContentFileUtil}. */
+public class TestContentFileUtil {
+  @Test
+  public void testValidateDVAcceptsUsableOffsetAndLength() {
+    // the happy path
+    ContentFileUtil.validateDV(mockDV(0L, 100L));
+  }
+
+  @Test
+  public void testValidateDVRejectsNullOffset() {
+    assertThatThrownBy(() -> ContentFileUtil.validateDV(mockDV(null, 100L)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("offset cannot be null");
+  }
+
+  @Test
+  public void testValidateDVRejectsNullLength() {
+    assertThatThrownBy(() -> ContentFileUtil.validateDV(mockDV(0L, null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("length is null");
+  }
+
+  @Test
+  public void testValidateDVRejectsLengthLargerThan2GB() {
+    assertThatThrownBy(() -> ContentFileUtil.validateDV(mockDV(0L, Integer.MAX_VALUE + 1L)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("larger than 2GB");
+  }
+
+  /**
+   * Create a mock Delete File with the supplied content offset and size; all other methods of the
+   * interface will be the default values or undefined.
+   *
+   * @param contentOffset offset; may be null.
+   * @param contentSize content size; may be null.
+   * @return a mock delete file.
+   */
+  private static DeleteFile mockDV(Long contentOffset, Long contentSize) {
+    DeleteFile mock = Mockito.mock(DeleteFile.class);
+    Mockito.when(mock.contentOffset()).thenReturn(contentOffset);
+    Mockito.when(mock.contentSizeInBytes()).thenReturn(contentSize);
+    return mock;
+  }
+}

--- a/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
+++ b/data/src/main/java/org/apache/iceberg/data/BaseDeleteLoader.java
@@ -264,18 +264,7 @@ public class BaseDeleteLoader implements DeleteLoader {
   }
 
   private void validateDV(DeleteFile dv, CharSequence filePath) {
-    Preconditions.checkArgument(
-        dv.contentOffset() != null,
-        "Invalid DV, offset cannot be null: %s",
-        ContentFileUtil.dvDesc(dv));
-    Preconditions.checkArgument(
-        dv.contentSizeInBytes() != null,
-        "Invalid DV, length is null: %s",
-        ContentFileUtil.dvDesc(dv));
-    Preconditions.checkArgument(
-        dv.contentSizeInBytes() <= Integer.MAX_VALUE,
-        "Can't read DV larger than 2GB: %s",
-        dv.contentSizeInBytes());
+    ContentFileUtil.validateDV(dv);
     Preconditions.checkArgument(
         filePath.toString().equals(dv.referencedDataFile()),
         "DV is expected to reference %s, not %s",


### PR DESCRIPTION

No serious issues found; the roaring bitmap overallocation is the big one in terms of memory consumption from small files. Fix
- limit allocation to the length of the data
- as the data is read, reduce that maximum size that can be allocated

Fix for #17214