### PR TITLE
Core, Spark: guard DeleteOrphanFiles against shared table locations

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -138,6 +138,38 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
         this.getClass().getName() + " does not implement equalAuthorities");
   }
 
+  /**
+   * Passes a location conflict mode that determines how this action should handle the situation
+   * when another Iceberg table appears to share the same table location.
+   *
+   * <p>The action detects this by inspecting the table's metadata directory: every {@code
+   * metadata.json} carries the creating table's immutable {@code table-uuid}. If the directory
+   * contains a {@code metadata.json} whose {@code table-uuid} differs from (or cannot be read for)
+   * the table being cleaned, it is strong evidence that another table shares this location and its
+   * files would be deleted as "orphans", corrupting that other table.
+   *
+   * <p>Possible values are {@link LocationConflictMode}: "ERROR" (default), "IGNORE", "DELETE".
+   *
+   * <ul>
+   *   <li>{@link LocationConflictMode#ERROR} - abort with a {@link
+   *       org.apache.iceberg.exceptions.ValidationException} when a location conflict is detected,
+   *       protecting the other table from data loss (recommended default).
+   *   <li>{@link LocationConflictMode#IGNORE} - no action. The cleanup is skipped entirely and the
+   *       other table's files are preserved.
+   *   <li>{@link LocationConflictMode#DELETE} - delete files. The shared-location check is skipped
+   *       entirely (legacy behavior); the cleanup proceeds and may delete files belonging to
+   *       another table. Use it only when you are absolutely certain no other table shares this
+   *       location, or when you intentionally accept the risk.
+   * </ul>
+   *
+   * @param newLocationConflictMode mode for handling location conflicts
+   * @return this for method chaining
+   */
+  default DeleteOrphanFiles locationConflictMode(LocationConflictMode newLocationConflictMode) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement locationConflictMode");
+  }
+
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns locations of orphan files. */
@@ -164,6 +196,30 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
       Preconditions.checkArgument(modeAsString != null, "Invalid mode: null");
       try {
         return PrefixMismatchMode.valueOf(modeAsString.toUpperCase(Locale.ENGLISH));
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException(String.format("Invalid mode: %s", modeAsString), e);
+      }
+    }
+  }
+
+  /**
+   * Defines the action behavior when another Iceberg table appears to share this table's location.
+   *
+   * <p>{@link #ERROR} - abort with a {@link org.apache.iceberg.exceptions.ValidationException} when
+   * a location conflict is detected, protecting the other table from data loss. {@link #IGNORE} -
+   * no action, the cleanup is skipped and the other table's files are preserved. {@link #DELETE} -
+   * delete files, the shared-location check is skipped entirely and the cleanup proceeds (legacy
+   * behavior); only use it when certain no other table shares this location.
+   */
+  enum LocationConflictMode {
+    ERROR,
+    IGNORE,
+    DELETE;
+
+    public static LocationConflictMode fromString(String modeAsString) {
+      Preconditions.checkArgument(modeAsString != null, "Invalid mode: null");
+      try {
+        return LocationConflictMode.valueOf(modeAsString.toUpperCase(Locale.ENGLISH));
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(String.format("Invalid mode: %s", modeAsString), e);
       }

--- a/core/src/main/java/org/apache/iceberg/util/OrphanFileUtils.java
+++ b/core/src/main/java/org/apache/iceberg/util/OrphanFileUtils.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.Set;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.SupportsPrefixOperations;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
+import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Helpers for orphan-file cleanup actions.
+ *
+ * <p>The key concern is that two independent Iceberg tables may point at the same underlying
+ * location. When orphan-file cleanup runs for one table it lists the whole location and deletes
+ * everything not referenced by that single table's metadata &mdash; including the other table's
+ * files, which corrupts it. This is especially easy to hit when a {@code SHOW CREATE TABLE} DDL is
+ * copied to a test table while forgetting to change the {@code LOCATION}.
+ *
+ * <p>Every Iceberg {@code metadata.json} carries the creating table's immutable {@code table-uuid}.
+ * By comparing the {@code table-uuid} of the metadata files found in a table's metadata directory
+ * we can detect whether another table shares the location, before any file is deleted.
+ */
+public class OrphanFileUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(OrphanFileUtils.class);
+
+  private static boolean isMetadataJson(String name) {
+    return name.endsWith(".metadata.json") || name.endsWith(".metadata.json.gz");
+  }
+
+  private OrphanFileUtils() {}
+
+  /**
+   * Returns {@code true} if another Iceberg table appears to share the same metadata location as
+   * the given table.
+   *
+   * <p>Lists the table's metadata directory via its own (storage-agnostic) {@link FileIO} and, for
+   * every {@code metadata.json} not in this table's own history (current + {@code
+   * previousFiles()}), reads its {@code table-uuid}:
+   *
+   * <ul>
+   *   <li>same uuid &rarr; older version of this table, ignored;
+   *   <li>different uuid &rarr; another table shares the location, returns {@code true};
+   *   <li>uuid missing/unreadable (legacy, corrupt, or compressed) &rarr; treated as a conflict,
+   *       returns {@code true} (fail-safe).
+   * </ul>
+   *
+   * <p>Requires {@link SupportsPrefixOperations} for FileIO; otherwise a {@link
+   * ValidationException} is thrown. The caller may choose to skip the check when the storage
+   * backend is known to be used by a single table. On the no-conflict path only a single listing is
+   * done and no metadata file is read.
+   *
+   * @param table the table whose location is about to be cleaned
+   * @throws ValidationException if the table's {@code FileIO} does not support prefix operations
+   */
+  public static boolean hasOtherTableInLocation(Table table) {
+    TableOperations ops = ((HasTableOperations) table).operations();
+    TableMetadata current = ops.current();
+
+    String myUuid = current.uuid();
+    Set<String> myMetadataFiles = Sets.newHashSet();
+    myMetadataFiles.add(new Path(current.metadataFileLocation()).getName());
+    for (TableMetadata.MetadataLogEntry entry : current.previousFiles()) {
+      myMetadataFiles.add(new Path(entry.file()).getName());
+    }
+
+    Path metadataDir = new Path(current.metadataFileLocation()).getParent();
+
+    FileIO io = table.io();
+    if (!(io instanceof SupportsPrefixOperations)) {
+      throw new ValidationException(
+          "Cannot detect location conflicts: the table's FileIO (%s) does not support prefix "
+              + "operations, which are required to inspect the metadata directory '%s'. Use a FileIO "
+              + "that implements SupportsPrefixOperations, or let the caller skip the check if the "
+              + "storage backend is known to be used by a single table.",
+          io.getClass().getName(), metadataDir);
+    }
+
+    String prefix = metadataDir.toString();
+    if (!prefix.endsWith("/")) {
+      prefix = prefix + "/";
+    }
+
+    SupportsPrefixOperations prefixIo = (SupportsPrefixOperations) io;
+    for (FileInfo info : prefixIo.listPrefix(prefix)) {
+      String name = new Path(info.location()).getName();
+      if (!isMetadataJson(name) || myMetadataFiles.contains(name)) {
+        continue;
+      }
+
+      String otherUuid = readTableUuid(table, info.location());
+      if (otherUuid == null || !otherUuid.equals(myUuid)) {
+        LOG.warn(
+            "Another table (uuid={}) belonging to metadata file {} shares the metadata location with this table (uuid={}); "
+                + "treating the location as conflicting",
+            otherUuid,
+            info.location(),
+            myUuid);
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Reads the {@code table-uuid} from a metadata file, transparently handling gzip-compressed
+   * metadata ({@code .metadata.json.gz}). Returns {@code null} if the uuid cannot be determined
+   * (legacy file without a uuid, corrupt file, or any read failure).
+   */
+  @VisibleForTesting
+  static String readTableUuid(Table table, String metadataLocation) {
+    try {
+      return TableMetadataParser.read(table.io(), metadataLocation).uuid();
+    } catch (Exception e) {
+      LOG.warn("Failed to read table-uuid from {}; treating as unreadable", metadataLocation, e);
+      return null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/util/TestOrphanFileUtils.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestOrphanFileUtils.java
@@ -1,0 +1,468 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DeleteFiles;
+import org.apache.iceberg.ExpireSnapshots;
+import org.apache.iceberg.HasTableOperations;
+import org.apache.iceberg.HistoryEntry;
+import org.apache.iceberg.ManageSnapshots;
+import org.apache.iceberg.OverwriteFiles;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.ReplacePartitions;
+import org.apache.iceberg.ReplaceSortOrder;
+import org.apache.iceberg.RewriteFiles;
+import org.apache.iceberg.RewriteManifests;
+import org.apache.iceberg.RowDelta;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SnapshotRef;
+import org.apache.iceberg.SortOrder;
+import org.apache.iceberg.StatisticsFile;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
+import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.Transaction;
+import org.apache.iceberg.UpdateLocation;
+import org.apache.iceberg.UpdatePartitionSpec;
+import org.apache.iceberg.UpdateProperties;
+import org.apache.iceberg.UpdateSchema;
+import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.hadoop.HadoopTables;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.LocationProvider;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.PositionOutputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class TestOrphanFileUtils {
+  private static final Schema SCHEMA = new Schema(required(1, "id", Types.LongType.get()));
+
+  private File tableDir;
+  private HadoopTables tables;
+
+  @BeforeEach
+  public void before() {
+    tableDir =
+        new File(System.getProperty("java.io.tmpdir"), "orphan-conflict-" + System.nanoTime());
+    tables = new HadoopTables(new Configuration());
+  }
+
+  @AfterEach
+  public void cleanup() {
+    try {
+      tables.dropTable(tableDir.getAbsolutePath());
+    } catch (Exception ignored) {
+      // best-effort cleanup
+    }
+  }
+
+  @Test
+  public void hasOtherTableInLocationReturnsTrueWhenForeignMetadataJsonPresent() {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // A metadata.json belonging to a different table (different, randomly generated table-uuid)
+    // written into this table's metadata directory must be detected as a conflict.
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), tableDir.getAbsolutePath(), Maps.newHashMap());
+    OutputFile foreignFile =
+        table
+            .io()
+            .newOutputFile(tableDir.getAbsolutePath() + "/metadata/00002-foreign.metadata.json");
+    TableMetadataParser.write(foreign, foreignFile);
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isTrue();
+  }
+
+  @Test
+  public void hasOtherTableInLocationReturnsFalseForSingleTable() {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isFalse();
+  }
+
+  @Test
+  public void hasOtherTableInLocationIgnoresOldVersionsOfSameTable() {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // An extra metadata.json that carries the SAME table-uuid (e.g. a truncated old version)
+    // must NOT be treated as a conflict.
+    String currentLocation =
+        ((HasTableOperations) table).operations().current().metadataFileLocation();
+    TableMetadata current = TableMetadataParser.read(table.io(), currentLocation);
+    OutputFile sameUuidFile =
+        table
+            .io()
+            .newOutputFile(tableDir.getAbsolutePath() + "/metadata/00002-sameuuid.metadata.json");
+    TableMetadataParser.write(current, sameUuidFile);
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isFalse();
+  }
+
+  @Test
+  public void hasOtherTableInLocationReturnsTrueWhenForeignMetadataHasNoUuid() throws IOException {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // Write a foreign metadata.json (its own random table-uuid), then strip the "uuid" field to
+    // simulate a legacy file without a uuid. readTableUuid must return null and the location must
+    // be treated as conflicting (fail-safe).
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), tableDir.getAbsolutePath(), Maps.newHashMap());
+    String foreignPath = tableDir.getAbsolutePath() + "/metadata/00002-foreign.metadata.json";
+    TableMetadataParser.write(foreign, table.io().newOutputFile(foreignPath));
+
+    String text =
+        readMetadataText(table, foreignPath).replaceFirst("\"uuid\"\\s*:\\s*\"[^\"]*\"\\s*,?", "");
+    writeMetadataBytes(table, foreignPath, text.getBytes(StandardCharsets.UTF_8));
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isTrue();
+  }
+
+  @Test
+  public void hasOtherTableInLocationReturnsTrueForCompressedForeignMetadata() throws IOException {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // A gzip-compressed metadata.json belonging to another table must also be detected.
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), tableDir.getAbsolutePath(), Maps.newHashMap());
+    String tmpPath = tableDir.getAbsolutePath() + "/metadata/00002-foreign.metadata.json";
+    TableMetadataParser.write(foreign, table.io().newOutputFile(tmpPath));
+    byte[] jsonBytes = readMetadataText(table, tmpPath).getBytes(StandardCharsets.UTF_8);
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (GZIPOutputStream gz = new GZIPOutputStream(baos)) {
+      gz.write(jsonBytes);
+    }
+    String gzPath = tableDir.getAbsolutePath() + "/metadata/00002-foreign.metadata.json.gz";
+    writeMetadataBytes(table, gzPath, baos.toByteArray());
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isTrue();
+  }
+
+  @Test
+  public void hasOtherTableInLocationReturnsTrueForUnreadableForeignMetadata() throws IOException {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // A file that looks like a metadata.json but is not valid JSON must be treated as a conflict
+    // (fail-safe), never silently ignored.
+    String corruptPath = tableDir.getAbsolutePath() + "/metadata/00002-corrupt.metadata.json";
+    writeMetadataBytes(
+        table, corruptPath, "this is not valid json".getBytes(StandardCharsets.UTF_8));
+
+    assertThat(OrphanFileUtils.hasOtherTableInLocation(table)).isTrue();
+  }
+
+  private String readMetadataText(Table table, String location) throws IOException {
+    try (InputStream is = table.io().newInputFile(location).newStream()) {
+      return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+    }
+  }
+
+  private void writeMetadataBytes(Table table, String location, byte[] bytes) throws IOException {
+    try (PositionOutputStream os = table.io().newOutputFile(location).createOrOverwrite()) {
+      os.write(bytes);
+    }
+  }
+
+  @Test
+  public void hasOtherTableInLocationThrowsWhenFileIoLacksPrefixSupport() {
+    Table table =
+        tables.create(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            SortOrder.unsorted(),
+            Maps.newHashMap(),
+            tableDir.getAbsolutePath());
+
+    // A FileIO that does NOT implement SupportsPrefixOperations cannot run the location-conflict
+    // check; the util must surface this as a ValidationException (so an ERROR-mode caller aborts)
+    // rather than silently skipping or deleting files.
+    Table wrapped = new DelegatingTable(table, new PlainFileIO());
+    assertThatThrownBy(() -> OrphanFileUtils.hasOtherTableInLocation(wrapped))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot detect location conflicts");
+  }
+
+  /** A {@link Table} wrapper that overrides {@link Table#io()} but delegates everything else. */
+  private static class DelegatingTable implements Table, HasTableOperations {
+    private final Table delegate;
+    private final FileIO io;
+
+    DelegatingTable(Table delegate, FileIO io) {
+      this.delegate = delegate;
+      this.io = io;
+    }
+
+    @Override
+    public FileIO io() {
+      return io;
+    }
+
+    @Override
+    public TableOperations operations() {
+      return ((HasTableOperations) delegate).operations();
+    }
+
+    @Override
+    public void refresh() {
+      delegate.refresh();
+    }
+
+    @Override
+    public TableScan newScan() {
+      return delegate.newScan();
+    }
+
+    @Override
+    public Schema schema() {
+      return delegate.schema();
+    }
+
+    @Override
+    public Map<Integer, Schema> schemas() {
+      return delegate.schemas();
+    }
+
+    @Override
+    public PartitionSpec spec() {
+      return delegate.spec();
+    }
+
+    @Override
+    public Map<Integer, PartitionSpec> specs() {
+      return delegate.specs();
+    }
+
+    @Override
+    public SortOrder sortOrder() {
+      return delegate.sortOrder();
+    }
+
+    @Override
+    public Map<Integer, SortOrder> sortOrders() {
+      return delegate.sortOrders();
+    }
+
+    @Override
+    public Map<String, String> properties() {
+      return delegate.properties();
+    }
+
+    @Override
+    public String location() {
+      return delegate.location();
+    }
+
+    @Override
+    public Snapshot currentSnapshot() {
+      return delegate.currentSnapshot();
+    }
+
+    @Override
+    public Snapshot snapshot(long snapshotId) {
+      return delegate.snapshot(snapshotId);
+    }
+
+    @Override
+    public Iterable<Snapshot> snapshots() {
+      return delegate.snapshots();
+    }
+
+    @Override
+    public List<HistoryEntry> history() {
+      return delegate.history();
+    }
+
+    @Override
+    public UpdateSchema updateSchema() {
+      return delegate.updateSchema();
+    }
+
+    @Override
+    public UpdatePartitionSpec updateSpec() {
+      return delegate.updateSpec();
+    }
+
+    @Override
+    public UpdateProperties updateProperties() {
+      return delegate.updateProperties();
+    }
+
+    @Override
+    public ReplaceSortOrder replaceSortOrder() {
+      return delegate.replaceSortOrder();
+    }
+
+    @Override
+    public UpdateLocation updateLocation() {
+      return delegate.updateLocation();
+    }
+
+    @Override
+    public AppendFiles newAppend() {
+      return delegate.newAppend();
+    }
+
+    @Override
+    public RewriteFiles newRewrite() {
+      return delegate.newRewrite();
+    }
+
+    @Override
+    public RewriteManifests rewriteManifests() {
+      return delegate.rewriteManifests();
+    }
+
+    @Override
+    public OverwriteFiles newOverwrite() {
+      return delegate.newOverwrite();
+    }
+
+    @Override
+    public RowDelta newRowDelta() {
+      return delegate.newRowDelta();
+    }
+
+    @Override
+    public ReplacePartitions newReplacePartitions() {
+      return delegate.newReplacePartitions();
+    }
+
+    @Override
+    public DeleteFiles newDelete() {
+      return delegate.newDelete();
+    }
+
+    @Override
+    public ExpireSnapshots expireSnapshots() {
+      return delegate.expireSnapshots();
+    }
+
+    @Override
+    public ManageSnapshots manageSnapshots() {
+      return delegate.manageSnapshots();
+    }
+
+    @Override
+    public Transaction newTransaction() {
+      return delegate.newTransaction();
+    }
+
+    @Override
+    public EncryptionManager encryption() {
+      return delegate.encryption();
+    }
+
+    @Override
+    public LocationProvider locationProvider() {
+      return delegate.locationProvider();
+    }
+
+    @Override
+    public List<StatisticsFile> statisticsFiles() {
+      return delegate.statisticsFiles();
+    }
+
+    @Override
+    public Map<String, SnapshotRef> refs() {
+      return delegate.refs();
+    }
+  }
+
+  /**
+   * A plain {@link FileIO} that deliberately does NOT implement {@link SupportsPrefixOperations}.
+   */
+  private static class PlainFileIO implements FileIO {
+    @Override
+    public InputFile newInputFile(String path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public OutputFile newOutputFile(String path) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deleteFile(String path) {
+      throw new UnsupportedOperationException();
+    }
+  }
+}

--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -306,19 +306,20 @@ Used to remove files which are not referenced in any metadata files of an Iceber
 
 #### Usage
 
-| Argument Name | Required? | Type | Description |
-|---------------|-----------|------|-------------|
-| `table`       | ✔️  | string | Name of the table to clean |
-| `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago) |
-| `location`    |    | string    | Directory to look for files in (defaults to the table's location) |
-| `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false) |
-| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used) |
-| `stream_results` |    | boolean       | When true, orphan files will be sent to Spark driver by RDD partition (by default, all the files will be sent to Spark driver). This option is recommended to set to `true` to prevent Spark driver OOM from large file size. When enabled, the output will contain a sample of up to 20,000 file paths |
-| `file_list_view` |    | string | Dataset to look for files in (skipping the directory listing) |
-| `equal_schemes` |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`). |
-| `equal_authorities` |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority. |
-| `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul> |  
-| `prefix_listing` |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false) |
+| Argument Name | Required? | Type | Description                                                                                                                                                                                                                                                                                                |
+|---------------|-----------|------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `table`       | ✔️  | string | Name of the table to clean                                                                                                                                                                                                                                                                                 |
+| `older_than`  | ️   | timestamp | Remove orphan files created before this timestamp (Defaults to 3 days ago)                                                                                                                                                                                                                                 |
+| `location`    |    | string    | Directory to look for files in (defaults to the table's location)                                                                                                                                                                                                                                          |
+| `dry_run`     |    | boolean   | When true, don't actually remove files (defaults to false)                                                                                                                                                                                                                                                 |
+| `max_concurrent_deletes` |    | int       | Size of the thread pool used for delete file actions (by default, no thread pool is used)                                                                                                                                                                                                                  |
+| `stream_results` |    | boolean       | When true, orphan files will be sent to Spark driver by RDD partition (by default, all the files will be sent to Spark driver). This option is recommended to set to `true` to prevent Spark driver OOM from large file size. When enabled, the output will contain a sample of up to 20,000 file paths    |
+| `file_list_view` |    | string | Dataset to look for files in (skipping the directory listing)                                                                                                                                                                                                                                              |
+| `equal_schemes` |    | map<string, string> | Mapping of file system schemes to be considered equal. Key is a comma-separated list of schemes and value is a scheme (defaults to `map('s3a,s3n','s3')`).                                                                                                                                                 |
+| `equal_authorities` |    | map<string, string> | Mapping of file system authorities to be considered equal. Key is a comma-separated list of authorities and value is an authority.                                                                                                                                                                         |
+| `prefix_mismatch_mode` |    | string | Action behavior when location prefixes (schemes/authorities) mismatch: <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files.</li></ul>                                                                                                                 |  
+| `location_conflict_mode` |    | string | Action behavior when another Iceberg table appears to share this table's metadata location (detected by comparing the immutable `table-uuid` stored in each `metadata.json`) : <ul><li>ERROR - throw an exception. (default) </li><li>IGNORE - no action.</li><li>DELETE - delete files; the shared-location check is skipped entirely (legacy behavior), so it never throws on a conflict.</li></ul> |  
+| `prefix_listing` |    | boolean   | When true, use prefix-based file listing via the `SupportsPrefixOperations` interface. The Table FileIO implementation must support `SupportsPrefixOperations` when this flag is enabled (defaults to false)                                                                                               |
 
 #### Output
 
@@ -361,6 +362,17 @@ CALL catalog_name.system.remove_orphan_files(table => 'db.sample', prefix_mismat
 The file can still be deleted by setting `prefix_mismatch_mode` to `DELETE`.
 ```sql
 CALL catalog_name.system.remove_orphan_files(table => 'db.sample', prefix_mismatch_mode => 'DELETE');
+```
+
+When another table (for example a test table created by copying `SHOW CREATE TABLE` but forgetting to change the `LOCATION`) shares this table's metadata location, the action aborts by default to avoid corrupting that other table.
+The cleanup can be skipped entirely &mdash; preserving the other table's files &mdash; by setting `location_conflict_mode` to `IGNORE`.
+```sql
+CALL catalog_name.system.remove_orphan_files(table => 'db.sample', location_conflict_mode => 'IGNORE');
+```
+
+The files can still be deleted (legacy behavior) by setting `location_conflict_mode` to `DELETE`. Note this mode skips the shared-location check entirely, so it never aborts on a conflict and is also safe for `FileIO` implementations that do not support prefix operations.
+```sql
+CALL catalog_name.system.remove_orphan_files(table => 'db.sample', location_conflict_mode => 'DELETE');
 ```
 
 The file can also be deleted by considering the mismatched prefixes equal.

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -47,8 +47,12 @@ import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinWriter;
@@ -749,5 +753,69 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Drop table in afterEach has purge and fails due to invalid authority "localhost"
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
+  }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesProcedureWithLocationConflictMode()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    Path metadataDir = new Path(table.location(), "metadata");
+
+    // Simulate another table sharing this table's metadata location: write a foreign
+    // metadata.json (its own random table-uuid) into the metadata directory.
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            table.schema(), table.spec(), table.location(), java.util.Collections.emptyMap());
+    OutputFile foreignFile =
+        table.io().newOutputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    TableMetadataParser.write(foreign, foreignFile);
+
+    // All three modes use an explicit older_than so the freshly-written foreign file is not
+    // filtered out by the default 3-day threshold (its modification time is "now", so it must be
+    // older than now). Wait so the timestamp is strictly after the foreign file was written.
+    waitUntilAfter(System.currentTimeMillis());
+    Timestamp conflictTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    // Default mode (ERROR) must abort when a location conflict is detected.
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s')",
+                    catalogName, tableIdent, conflictTimestamp))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot delete orphan files");
+
+    // IGNORE takes no action: the cleanup is skipped and the other table's files are preserved.
+    InputFile foreignInput =
+        table.io().newInputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    assertThat(foreignInput.exists()).isTrue();
+
+    List<Object[]> ignoreOutput =
+        sql(
+            "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s', location_conflict_mode => 'IGNORE')",
+            catalogName, tableIdent, conflictTimestamp);
+    assertThat(ignoreOutput).isEmpty(); // nothing was deleted
+    assertThat(foreignInput.exists()).isTrue(); // preserved
+
+    // DELETE proceeds with cleanup and removes the foreign metadata.json (reusing the same
+    // older_than so it is not filtered out by the default 3-day threshold).
+    sql(
+        "CALL %s.system.remove_orphan_files("
+            + "table => '%s',"
+            + "older_than => TIMESTAMP '%s',"
+            + "location_conflict_mode => 'DELETE')",
+        catalogName, tableIdent, conflictTimestamp);
+    // Verify deletion via a plain local file (not table.io(): Hadoop FileSystem may keep a stale
+    // cache entry for a file deleted moments ago and report it as still present).
+    File foreignFileLocal =
+        new File(new Path(metadataDir, "00002-foreign.metadata.json").toUri().getPath());
+    assertThat(foreignFileLocal.exists()).isFalse(); // deleted
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.OrphanFileUtils;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -125,6 +126,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Map<String, String> equalSchemes = flattenMap(EQUAL_SCHEMES_DEFAULT);
   private Map<String, String> equalAuthorities = Collections.emptyMap();
   private PrefixMismatchMode prefixMismatchMode = PrefixMismatchMode.ERROR;
+  private LocationConflictMode locationConflictMode = LocationConflictMode.ERROR;
   private String location;
   private long olderThanTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3);
   private Dataset<Row> compareToFileList;
@@ -160,6 +162,13 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @Override
   public DeleteOrphanFilesSparkAction prefixMismatchMode(PrefixMismatchMode newPrefixMismatchMode) {
     this.prefixMismatchMode = newPrefixMismatchMode;
+    return this;
+  }
+
+  @Override
+  public DeleteOrphanFilesSparkAction locationConflictMode(
+      LocationConflictMode newLocationConflictMode) {
+    this.locationConflictMode = newLocationConflictMode;
     return this;
   }
 
@@ -254,6 +263,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private DeleteOrphanFiles.Result doExecute() {
+    // ERROR aborts; IGNORE skips cleanup; DELETE proceeds with deletion.
+    if (!shouldProceedWithCleanup()) {
+      return emptyResult();
+    }
+
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
     Dataset<FileURI> validFileIdentDS = validFileIdentDS();
 
@@ -264,6 +278,73 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     } finally {
       orphanFileDS.unpersist();
     }
+  }
+
+  /**
+   * Determines whether the cleanup may proceed, given the configured location-conflict mode.
+   *
+   * <p>The shared-location detection runs only for {@code ERROR} and {@code IGNORE} modes, through
+   * the table's own {@link org.apache.iceberg.io.FileIO}. {@code DELETE} is an explicit escape
+   * hatch: the operator has confirmed the location is safe to clean (or accepts the risk), so the
+   * check is skipped entirely and cleanup proceeds without ever throwing a {@link
+   * ValidationException} (e.g. from a FileIO that lacks prefix support).
+   *
+   * @return {@code true} to proceed with cleanup; {@code false} to skip it (under {@code IGNORE}
+   *     mode with a confirmed conflict, or when the shared-location check cannot be performed)
+   */
+  private boolean shouldProceedWithCleanup() {
+    // DELETE is an explicit opt-in to skip the shared-location check entirely.
+    if (locationConflictMode == LocationConflictMode.DELETE) {
+      return true;
+    }
+
+    boolean conflict;
+    try {
+      conflict = OrphanFileUtils.hasOtherTableInLocation(table);
+    } catch (ValidationException e) {
+      // The shared-location check could not run (e.g. FileIO lacks prefix support). Fail closed:
+      // skip cleanup instead of risking another table's files. Use mode 'DELETE' only when the
+      // location is known to be exclusive.
+      LOG.error(
+          "Unable to determine whether another table shares location '{}': {}. "
+              + "Skipping cleanup to avoid deleting files that may belong to another table. "
+              + "If you are certain this location is not shared, set the location conflict mode to "
+              + "'DELETE' to skip this check and proceed with cleanup.",
+          table.location(),
+          e.getMessage());
+      return false;
+    }
+
+    if (!conflict) {
+      return true;
+    }
+
+    switch (locationConflictMode) {
+      case ERROR:
+        throw new ValidationException(
+            "Cannot delete orphan files: another Iceberg table shares the same location '%s' "
+                + "(detected via a metadata.json with a different table-uuid). Deleting orphan files "
+                + "from a shared location may corrupt the other table. Set the location conflict mode "
+                + "to 'IGNORE' to skip this table and preserve the other table's files (without failing), or to 'DELETE' "
+                + "only if you are absolutely certain no other table uses this location.",
+            table.location());
+      case IGNORE:
+        LOG.warn(
+            "Skipping orphan file cleanup for location '{}' (location_conflict_mode='IGNORE'): "
+                + "another table appears to share this location.",
+            table.location());
+        return false;
+      default:
+        throw new IllegalStateException(
+            "Unexpected location conflict mode: " + locationConflictMode);
+    }
+  }
+
+  private static DeleteOrphanFiles.Result emptyResult() {
+    return ImmutableDeleteOrphanFiles.Result.builder()
+        .orphanFileLocations(Lists.newArrayList())
+        .orphanFilesCount(0)
+        .build();
   }
 
   /**

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.DeleteOrphanFiles.LocationConflictMode;
 import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -68,6 +69,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       optionalInParameter("equal_authorities", STRING_MAP);
   private static final ProcedureParameter PREFIX_MISMATCH_MODE_PARAM =
       optionalInParameter("prefix_mismatch_mode", DataTypes.StringType);
+  private static final ProcedureParameter LOCATION_CONFLICT_MODE_PARAM =
+      optionalInParameter("location_conflict_mode", DataTypes.StringType);
   // List files with prefix operations. Default is false.
   private static final ProcedureParameter PREFIX_LISTING_PARAM =
       optionalInParameter("prefix_listing", DataTypes.BooleanType);
@@ -86,6 +89,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         EQUAL_SCHEMES_PARAM,
         EQUAL_AUTHORITIES_PARAM,
         PREFIX_MISMATCH_MODE_PARAM,
+        LOCATION_CONFLICT_MODE_PARAM,
         PREFIX_LISTING_PARAM,
         STREAM_RESULTS_PARAM
       };
@@ -140,6 +144,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         input.asStringMap(EQUAL_AUTHORITIES_PARAM, ImmutableMap.of());
 
     PrefixMismatchMode prefixMismatchMode = asPrefixMismatchMode(input, PREFIX_MISMATCH_MODE_PARAM);
+    LocationConflictMode locationConflictMode =
+        asLocationConflictMode(input, LOCATION_CONFLICT_MODE_PARAM);
 
     boolean prefixListing = input.asBoolean(PREFIX_LISTING_PARAM, false);
     boolean streamResults = input.asBoolean(STREAM_RESULTS_PARAM, false);
@@ -190,6 +196,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
             action.prefixMismatchMode(prefixMismatchMode);
           }
 
+          if (locationConflictMode != null) {
+            action.locationConflictMode(locationConflictMode);
+          }
+
           action.usePrefixListing(prefixListing);
 
           if (streamResults) {
@@ -237,5 +247,11 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   private PrefixMismatchMode asPrefixMismatchMode(ProcedureInput input, ProcedureParameter param) {
     String modeAsString = input.asString(param, null);
     return (modeAsString == null) ? null : PrefixMismatchMode.fromString(modeAsString);
+  }
+
+  private LocationConflictMode asLocationConflictMode(
+      ProcedureInput input, ProcedureParameter param) {
+    String modeAsString = input.asString(param, null);
+    return (modeAsString == null) ? null : LocationConflictMode.fromString(modeAsString);
   }
 }

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -47,8 +47,12 @@ import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinWriter;
@@ -748,5 +752,69 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Drop table in afterEach has purge and fails due to invalid authority "localhost"
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
+  }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesProcedureWithLocationConflictMode()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    Path metadataDir = new Path(table.location(), "metadata");
+
+    // Simulate another table sharing this table's metadata location: write a foreign
+    // metadata.json (its own random table-uuid) into the metadata directory.
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            table.schema(), table.spec(), table.location(), java.util.Collections.emptyMap());
+    OutputFile foreignFile =
+        table.io().newOutputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    TableMetadataParser.write(foreign, foreignFile);
+
+    // All three modes use an explicit older_than so the freshly-written foreign file is not
+    // filtered out by the default 3-day threshold (its modification time is "now", so it must be
+    // older than now). Wait so the timestamp is strictly after the foreign file was written.
+    waitUntilAfter(System.currentTimeMillis());
+    Timestamp conflictTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    // Default mode (ERROR) must abort when a location conflict is detected.
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s')",
+                    catalogName, tableIdent, conflictTimestamp))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot delete orphan files");
+
+    // IGNORE takes no action: the cleanup is skipped and the other table's files are preserved.
+    InputFile foreignInput =
+        table.io().newInputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    assertThat(foreignInput.exists()).isTrue();
+
+    List<Object[]> ignoreOutput =
+        sql(
+            "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s', location_conflict_mode => 'IGNORE')",
+            catalogName, tableIdent, conflictTimestamp);
+    assertThat(ignoreOutput).isEmpty(); // nothing was deleted
+    assertThat(foreignInput.exists()).isTrue(); // preserved
+
+    // DELETE proceeds with cleanup and removes the foreign metadata.json (reusing the same
+    // older_than so it is not filtered out by the default 3-day threshold).
+    sql(
+        "CALL %s.system.remove_orphan_files("
+            + "table => '%s',"
+            + "older_than => TIMESTAMP '%s',"
+            + "location_conflict_mode => 'DELETE')",
+        catalogName, tableIdent, conflictTimestamp);
+    // Verify deletion via a plain local file (not table.io(): Hadoop FileSystem may keep a stale
+    // cache entry for a file deleted moments ago and report it as still present).
+    File foreignFileLocal =
+        new File(new Path(metadataDir, "00002-foreign.metadata.json").toUri().getPath());
+    assertThat(foreignFileLocal.exists()).isFalse(); // deleted
   }
 }

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.OrphanFileUtils;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -125,6 +126,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Map<String, String> equalSchemes = flattenMap(EQUAL_SCHEMES_DEFAULT);
   private Map<String, String> equalAuthorities = Collections.emptyMap();
   private PrefixMismatchMode prefixMismatchMode = PrefixMismatchMode.ERROR;
+  private LocationConflictMode locationConflictMode = LocationConflictMode.ERROR;
   private String location;
   private long olderThanTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3);
   private Dataset<Row> compareToFileList;
@@ -160,6 +162,13 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @Override
   public DeleteOrphanFilesSparkAction prefixMismatchMode(PrefixMismatchMode newPrefixMismatchMode) {
     this.prefixMismatchMode = newPrefixMismatchMode;
+    return this;
+  }
+
+  @Override
+  public DeleteOrphanFilesSparkAction locationConflictMode(
+      LocationConflictMode newLocationConflictMode) {
+    this.locationConflictMode = newLocationConflictMode;
     return this;
   }
 
@@ -254,6 +263,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private DeleteOrphanFiles.Result doExecute() {
+    // ERROR aborts; IGNORE skips cleanup; DELETE proceeds with deletion.
+    if (!shouldProceedWithCleanup()) {
+      return emptyResult();
+    }
+
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
     Dataset<FileURI> validFileIdentDS = validFileIdentDS();
 
@@ -264,6 +278,73 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     } finally {
       orphanFileDS.unpersist();
     }
+  }
+
+  /**
+   * Determines whether the cleanup may proceed, given the configured location-conflict mode.
+   *
+   * <p>The shared-location detection runs only for {@code ERROR} and {@code IGNORE} modes, through
+   * the table's own {@link org.apache.iceberg.io.FileIO}. {@code DELETE} is an explicit escape
+   * hatch: the operator has confirmed the location is safe to clean (or accepts the risk), so the
+   * check is skipped entirely and cleanup proceeds without ever throwing a {@link
+   * ValidationException} (e.g. from a FileIO that lacks prefix support).
+   *
+   * @return {@code true} to proceed with cleanup; {@code false} to skip it (under {@code IGNORE}
+   *     mode with a confirmed conflict, or when the shared-location check cannot be performed)
+   */
+  private boolean shouldProceedWithCleanup() {
+    // DELETE is an explicit opt-in to skip the shared-location check entirely.
+    if (locationConflictMode == LocationConflictMode.DELETE) {
+      return true;
+    }
+
+    boolean conflict;
+    try {
+      conflict = OrphanFileUtils.hasOtherTableInLocation(table);
+    } catch (ValidationException e) {
+      // The shared-location check could not run (e.g. FileIO lacks prefix support). Fail closed:
+      // skip cleanup instead of risking another table's files. Use mode 'DELETE' only when the
+      // location is known to be exclusive.
+      LOG.error(
+          "Unable to determine whether another table shares location '{}': {}. "
+              + "Skipping cleanup to avoid deleting files that may belong to another table. "
+              + "If you are certain this location is not shared, set the location conflict mode to "
+              + "'DELETE' to skip this check and proceed with cleanup.",
+          table.location(),
+          e.getMessage());
+      return false;
+    }
+
+    if (!conflict) {
+      return true;
+    }
+
+    switch (locationConflictMode) {
+      case ERROR:
+        throw new ValidationException(
+            "Cannot delete orphan files: another Iceberg table shares the same location '%s' "
+                + "(detected via a metadata.json with a different table-uuid). Deleting orphan files "
+                + "from a shared location may corrupt the other table. Set the location conflict mode "
+                + "to 'IGNORE' to skip this table and preserve the other table's files (without failing), or to 'DELETE' "
+                + "only if you are absolutely certain no other table uses this location.",
+            table.location());
+      case IGNORE:
+        LOG.warn(
+            "Skipping orphan file cleanup for location '{}' (location_conflict_mode='IGNORE'): "
+                + "another table appears to share this location.",
+            table.location());
+        return false;
+      default:
+        throw new IllegalStateException(
+            "Unexpected location conflict mode: " + locationConflictMode);
+    }
+  }
+
+  private static DeleteOrphanFiles.Result emptyResult() {
+    return ImmutableDeleteOrphanFiles.Result.builder()
+        .orphanFileLocations(Lists.newArrayList())
+        .orphanFilesCount(0)
+        .build();
   }
 
   /**

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.DeleteOrphanFiles.LocationConflictMode;
 import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -74,6 +75,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       optionalInParameter("equal_authorities", STRING_MAP);
   private static final ProcedureParameter PREFIX_MISMATCH_MODE_PARAM =
       optionalInParameter("prefix_mismatch_mode", DataTypes.StringType);
+  private static final ProcedureParameter LOCATION_CONFLICT_MODE_PARAM =
+      optionalInParameter("location_conflict_mode", DataTypes.StringType);
   // List files with prefix operations. Default is false.
   private static final ProcedureParameter PREFIX_LISTING_PARAM =
       optionalInParameter("prefix_listing", DataTypes.BooleanType);
@@ -92,6 +95,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         EQUAL_SCHEMES_PARAM,
         EQUAL_AUTHORITIES_PARAM,
         PREFIX_MISMATCH_MODE_PARAM,
+        LOCATION_CONFLICT_MODE_PARAM,
         PREFIX_LISTING_PARAM,
         STREAM_RESULTS_PARAM
       };
@@ -146,6 +150,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         input.asStringMap(EQUAL_AUTHORITIES_PARAM, ImmutableMap.of());
 
     PrefixMismatchMode prefixMismatchMode = asPrefixMismatchMode(input, PREFIX_MISMATCH_MODE_PARAM);
+    LocationConflictMode locationConflictMode =
+        asLocationConflictMode(input, LOCATION_CONFLICT_MODE_PARAM);
 
     boolean prefixListing = input.asBoolean(PREFIX_LISTING_PARAM, false);
     boolean streamResults = input.asBoolean(STREAM_RESULTS_PARAM, false);
@@ -194,6 +200,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
           if (prefixMismatchMode != null) {
             action.prefixMismatchMode(prefixMismatchMode);
+          }
+
+          if (locationConflictMode != null) {
+            action.locationConflictMode(locationConflictMode);
           }
 
           action.usePrefixListing(prefixListing);
@@ -248,5 +258,11 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   private PrefixMismatchMode asPrefixMismatchMode(ProcedureInput input, ProcedureParameter param) {
     String modeAsString = input.asString(param, null);
     return (modeAsString == null) ? null : PrefixMismatchMode.fromString(modeAsString);
+  }
+
+  private LocationConflictMode asLocationConflictMode(
+      ProcedureInput input, ProcedureParameter param) {
+    String modeAsString = input.asString(param, null);
+    return (modeAsString == null) ? null : LocationConflictMode.fromString(modeAsString);
   }
 }

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestRemoveOrphanFilesProcedure.java
@@ -47,8 +47,12 @@ import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.ReachableFileUtil;
 import org.apache.iceberg.StatisticsFile;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.exceptions.ValidationException;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.puffin.Blob;
 import org.apache.iceberg.puffin.Puffin;
 import org.apache.iceberg.puffin.PuffinWriter;
@@ -748,5 +752,69 @@ public class TestRemoveOrphanFilesProcedure extends ExtensionsTestBase {
     // Drop table in afterEach has purge and fails due to invalid authority "localhost"
     // Dropping the table here
     sql("DROP TABLE %s", tableName);
+  }
+
+  @TestTemplate
+  public void testRemoveOrphanFilesProcedureWithLocationConflictMode()
+      throws NoSuchTableException, ParseException, IOException {
+    if (catalogName.equals("testhadoop")) {
+      sql("CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg", tableName);
+    } else {
+      sql(
+          "CREATE TABLE %s (id bigint NOT NULL, data string) USING iceberg LOCATION '%s'",
+          tableName, java.nio.file.Files.createTempDirectory(temp, "junit"));
+    }
+    Table table = Spark3Util.loadIcebergTable(spark, tableName);
+    Path metadataDir = new Path(table.location(), "metadata");
+
+    // Simulate another table sharing this table's metadata location: write a foreign
+    // metadata.json (its own random table-uuid) into the metadata directory.
+    TableMetadata foreign =
+        TableMetadata.newTableMetadata(
+            table.schema(), table.spec(), table.location(), java.util.Collections.emptyMap());
+    OutputFile foreignFile =
+        table.io().newOutputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    TableMetadataParser.write(foreign, foreignFile);
+
+    // All three modes use an explicit older_than so the freshly-written foreign file is not
+    // filtered out by the default 3-day threshold (its modification time is "now", so it must be
+    // older than now). Wait so the timestamp is strictly after the foreign file was written.
+    waitUntilAfter(System.currentTimeMillis());
+    Timestamp conflictTimestamp = Timestamp.from(Instant.ofEpochMilli(System.currentTimeMillis()));
+
+    // Default mode (ERROR) must abort when a location conflict is detected.
+    assertThatThrownBy(
+            () ->
+                sql(
+                    "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s')",
+                    catalogName, tableIdent, conflictTimestamp))
+        .isInstanceOf(ValidationException.class)
+        .hasMessageContaining("Cannot delete orphan files");
+
+    // IGNORE takes no action: the cleanup is skipped and the other table's files are preserved.
+    InputFile foreignInput =
+        table.io().newInputFile(new Path(metadataDir, "00002-foreign.metadata.json").toString());
+    assertThat(foreignInput.exists()).isTrue();
+
+    List<Object[]> ignoreOutput =
+        sql(
+            "CALL %s.system.remove_orphan_files(table => '%s', older_than => TIMESTAMP '%s', location_conflict_mode => 'IGNORE')",
+            catalogName, tableIdent, conflictTimestamp);
+    assertThat(ignoreOutput).isEmpty(); // nothing was deleted
+    assertThat(foreignInput.exists()).isTrue(); // preserved
+
+    // DELETE proceeds with cleanup and removes the foreign metadata.json (reusing the same
+    // older_than so it is not filtered out by the default 3-day threshold).
+    sql(
+        "CALL %s.system.remove_orphan_files("
+            + "table => '%s',"
+            + "older_than => TIMESTAMP '%s',"
+            + "location_conflict_mode => 'DELETE')",
+        catalogName, tableIdent, conflictTimestamp);
+    // Verify deletion via a plain local file (not table.io(): Hadoop FileSystem may keep a stale
+    // cache entry for a file deleted moments ago and report it as still present).
+    File foreignFileLocal =
+        new File(new Path(metadataDir, "00002-foreign.metadata.json").toUri().getPath());
+    assertThat(foreignFileLocal.exists()).isFalse(); // deleted
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -52,6 +52,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.JobGroupInfo;
 import org.apache.iceberg.util.FileSystemWalker;
+import org.apache.iceberg.util.OrphanFileUtils;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
@@ -125,6 +126,7 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Map<String, String> equalSchemes = flattenMap(EQUAL_SCHEMES_DEFAULT);
   private Map<String, String> equalAuthorities = Collections.emptyMap();
   private PrefixMismatchMode prefixMismatchMode = PrefixMismatchMode.ERROR;
+  private LocationConflictMode locationConflictMode = LocationConflictMode.ERROR;
   private String location;
   private long olderThanTimestamp = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(3);
   private Dataset<Row> compareToFileList;
@@ -160,6 +162,13 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   @Override
   public DeleteOrphanFilesSparkAction prefixMismatchMode(PrefixMismatchMode newPrefixMismatchMode) {
     this.prefixMismatchMode = newPrefixMismatchMode;
+    return this;
+  }
+
+  @Override
+  public DeleteOrphanFilesSparkAction locationConflictMode(
+      LocationConflictMode newLocationConflictMode) {
+    this.locationConflictMode = newLocationConflictMode;
     return this;
   }
 
@@ -254,6 +263,11 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   }
 
   private DeleteOrphanFiles.Result doExecute() {
+    // ERROR aborts; IGNORE skips cleanup; DELETE proceeds with deletion.
+    if (!shouldProceedWithCleanup()) {
+      return emptyResult();
+    }
+
     Dataset<FileURI> actualFileIdentDS = actualFileIdentDS();
     Dataset<FileURI> validFileIdentDS = validFileIdentDS();
 
@@ -264,6 +278,73 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
     } finally {
       orphanFileDS.unpersist();
     }
+  }
+
+  /**
+   * Determines whether the cleanup may proceed, given the configured location-conflict mode.
+   *
+   * <p>The shared-location detection runs only for {@code ERROR} and {@code IGNORE} modes, through
+   * the table's own {@link org.apache.iceberg.io.FileIO}. {@code DELETE} is an explicit escape
+   * hatch: the operator has confirmed the location is safe to clean (or accepts the risk), so the
+   * check is skipped entirely and cleanup proceeds without ever throwing a {@link
+   * ValidationException} (e.g. from a FileIO that lacks prefix support).
+   *
+   * @return {@code true} to proceed with cleanup; {@code false} to skip it (under {@code IGNORE}
+   *     mode with a confirmed conflict, or when the shared-location check cannot be performed)
+   */
+  private boolean shouldProceedWithCleanup() {
+    // DELETE is an explicit opt-in to skip the shared-location check entirely.
+    if (locationConflictMode == LocationConflictMode.DELETE) {
+      return true;
+    }
+
+    boolean conflict;
+    try {
+      conflict = OrphanFileUtils.hasOtherTableInLocation(table);
+    } catch (ValidationException e) {
+      // The shared-location check could not run (e.g. FileIO lacks prefix support). Fail closed:
+      // skip cleanup instead of risking another table's files. Use mode 'DELETE' only when the
+      // location is known to be exclusive.
+      LOG.error(
+          "Unable to determine whether another table shares location '{}': {}. "
+              + "Skipping cleanup to avoid deleting files that may belong to another table. "
+              + "If you are certain this location is not shared, set the location conflict mode to "
+              + "'DELETE' to skip this check and proceed with cleanup.",
+          table.location(),
+          e.getMessage());
+      return false;
+    }
+
+    if (!conflict) {
+      return true;
+    }
+
+    switch (locationConflictMode) {
+      case ERROR:
+        throw new ValidationException(
+            "Cannot delete orphan files: another Iceberg table shares the same location '%s' "
+                + "(detected via a metadata.json with a different table-uuid). Deleting orphan files "
+                + "from a shared location may corrupt the other table. Set the location conflict mode "
+                + "to 'IGNORE' to skip this table and preserve the other table's files (without failing), or to 'DELETE' "
+                + "only if you are absolutely certain no other table uses this location.",
+            table.location());
+      case IGNORE:
+        LOG.warn(
+            "Skipping orphan file cleanup for location '{}' (location_conflict_mode='IGNORE'): "
+                + "another table appears to share this location.",
+            table.location());
+        return false;
+      default:
+        throw new IllegalStateException(
+            "Unexpected location conflict mode: " + locationConflictMode);
+    }
+  }
+
+  private static DeleteOrphanFiles.Result emptyResult() {
+    return ImmutableDeleteOrphanFiles.Result.builder()
+        .orphanFileLocations(Lists.newArrayList())
+        .orphanFilesCount(0)
+        .build();
   }
 
   /**

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/procedures/RemoveOrphanFilesProcedure.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.actions.DeleteOrphanFiles;
+import org.apache.iceberg.actions.DeleteOrphanFiles.LocationConflictMode;
 import org.apache.iceberg.actions.DeleteOrphanFiles.PrefixMismatchMode;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -74,6 +75,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
       optionalInParameter("equal_authorities", STRING_MAP);
   private static final ProcedureParameter PREFIX_MISMATCH_MODE_PARAM =
       optionalInParameter("prefix_mismatch_mode", DataTypes.StringType);
+  private static final ProcedureParameter LOCATION_CONFLICT_MODE_PARAM =
+      optionalInParameter("location_conflict_mode", DataTypes.StringType);
   // List files with prefix operations. Default is false.
   private static final ProcedureParameter PREFIX_LISTING_PARAM =
       optionalInParameter("prefix_listing", DataTypes.BooleanType);
@@ -92,6 +95,7 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         EQUAL_SCHEMES_PARAM,
         EQUAL_AUTHORITIES_PARAM,
         PREFIX_MISMATCH_MODE_PARAM,
+        LOCATION_CONFLICT_MODE_PARAM,
         PREFIX_LISTING_PARAM,
         STREAM_RESULTS_PARAM
       };
@@ -146,6 +150,8 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
         input.asStringMap(EQUAL_AUTHORITIES_PARAM, ImmutableMap.of());
 
     PrefixMismatchMode prefixMismatchMode = asPrefixMismatchMode(input, PREFIX_MISMATCH_MODE_PARAM);
+    LocationConflictMode locationConflictMode =
+        asLocationConflictMode(input, LOCATION_CONFLICT_MODE_PARAM);
 
     boolean prefixListing = input.asBoolean(PREFIX_LISTING_PARAM, false);
     boolean streamResults = input.asBoolean(STREAM_RESULTS_PARAM, false);
@@ -194,6 +200,10 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
 
           if (prefixMismatchMode != null) {
             action.prefixMismatchMode(prefixMismatchMode);
+          }
+
+          if (locationConflictMode != null) {
+            action.locationConflictMode(locationConflictMode);
           }
 
           action.usePrefixListing(prefixListing);
@@ -248,5 +258,11 @@ public class RemoveOrphanFilesProcedure extends BaseProcedure {
   private PrefixMismatchMode asPrefixMismatchMode(ProcedureInput input, ProcedureParameter param) {
     String modeAsString = input.asString(param, null);
     return (modeAsString == null) ? null : PrefixMismatchMode.fromString(modeAsString);
+  }
+
+  private LocationConflictMode asLocationConflictMode(
+      ProcedureInput input, ProcedureParameter param) {
+    String modeAsString = input.asString(param, null);
+    return (modeAsString == null) ? null : LocationConflictMode.fromString(modeAsString);
   }
 }


### PR DESCRIPTION
Fix #17213

## Approach

Every Iceberg `metadata.json` (including `.metadata.json.gz`) carries the creating table's **immutable `table-uuid`**. So, **before deleting anything**, we inspect the table's metadata directory:

- if it contains a `metadata.json` that is not part of this table's own history (current + `previousFiles()`), and
- its `table-uuid` differs from, or cannot be read for, this table's uuid,

→ we conclude that another table shares the location and stop before any file is deleted.

**Constraint — requires `SupportsPrefixOperations`:** the detection relies on `table.io().listPrefix(...)` to walk the metadata directory. This means the table's `FileIO` must implement the `SupportsPrefixOperations` interface.

**Fail-safe bias:** a missing or unreadable uuid (legacy file without a uuid, corrupt file, or compressed file) is always treated as a conflict (preferring false positives over silently deleting another table's data).

## Changes

- **core**: new `OrphanFileUtils.hasOtherTableInLocation` + `readTableUuid` (the latter `@VisibleForTesting`, transparently handling gzip); new `TestOrphanFileUtils` covering conflict / no-conflict / null-uuid / compressed / corrupt / unsupported-FileIO cases.
- **api**: `DeleteOrphanFiles` interface extension (above).
- **spark 3.5 / 4.0 / 4.1**: `DeleteOrphanFilesSparkAction` extracts `shouldSkipDueToLocationConflict()` (called at the top of `doExecute`, keeping the main flow clean); `RemoveOrphanFilesProcedure` exposes a `location_conflict_mode` parameter and forwards it.
- **docs**: `docs/spark-procedures.md` documents the new parameter.

## API changes

In `api`'s `DeleteOrphanFiles` interface:

- New `enum LocationConflictMode { ERROR, IGNORE, DELETE }` plus `fromString(...)` (consistent with the existing `PrefixMismatchMode`).

Mode semantics:


| Condition | Mode | Behavior                                                                                                                                                                  |
|-----------|------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| Conflict | `ERROR` (default) | Abort with `ValidationException`; protects the other table (recommended default).                                                                                         |
| Conflict | `IGNORE` | Skip the cleanup entirely (returns success without deleting anything); preserve the other table's files without erroring.                                                 |
| Conflict | `DELETE` | Skip the shared-location check entirely and proceed with deletion (legacy behavior); use only when you are certain no other table shares the location. |
| No conflict | all modes | Cleanup proceeds normally; real orphans are deleted. |                                                                                                            
| Check cannot run (e.g. `FileIO` lacks `SupportsPrefixOperations`) | all modes | logged as "unable to determine" and skip the cleanup;  To force the cleanup, set the mode to `DELETE`.  |



## Tests

- core: `TestOrphanFileUtils` (foreign metadata with same/foreign uuid, missing uuid, compressed, corrupt, unsupported-FileIO throws).
- spark: `TestRemoveOrphanFilesProcedure` exercises all three modes across catalog variants.


## AI Disclosure
Model: hy3
Platform/Tool: CodeBuddy
Human Oversight: fully reviewed
Prompt Summary: Implement a shared-location guard for DeleteOrphanFiles (core detection helper + api LocationConflictMode enum + Spark 3.5/4.0/4.1 action/procedure wiring) and fix the resulting CI checkstyle/test failures.
