### PR TITLE
Core: Add pruneColumnStats to RewriteManifests

### DIFF
--- a/api/src/main/java/org/apache/iceberg/RewriteManifests.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteManifests.java
@@ -86,4 +86,26 @@ public interface RewriteManifests extends SnapshotUpdate<RewriteManifests> {
    * @return this for method chaining
    */
   RewriteManifests addManifest(ManifestFile manifest);
+
+  /**
+   * Prunes column-level stats from rewritten data files that exceed the table's current {@code
+   * write.metadata.metrics.*} configuration.
+   *
+   * <p>Rewriting manifests normally copies each data file's stats verbatim, so tightening the
+   * metrics configuration does not shrink existing manifests. When this is enabled, stats are
+   * dropped to match the configured modes as files are rewritten: columns configured as {@code
+   * none} lose all stats and columns configured as {@code counts} lose their bounds. Existing
+   * bounds are never re-truncated, so columns configured as {@code truncate(n)} or {@code full}
+   * keep their stats unchanged.
+   *
+   * <p>Pruning only applies to files in manifests that are actually rewritten. If no clustering
+   * function is set via {@link #clusterBy(Function)}, enabling this triggers a full rewrite that
+   * groups all data files together.
+   *
+   * @return this for method chaining
+   */
+  default RewriteManifests pruneColumnStats() {
+    throw new UnsupportedOperationException(
+        getClass().getName() + " doesn't implement pruneColumnStats");
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -48,6 +48,8 @@ import org.apache.iceberg.util.Tasks;
 
 public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
     implements RewriteManifests {
+  private static final Object SINGLE_CLUSTER_KEY = new Object();
+
   private final String tableName;
   private final Map<Integer, PartitionSpec> specsById;
   private final long manifestTargetSizeBytes;
@@ -65,6 +67,10 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   private Function<DataFile, Object> clusterByFunc;
   private Predicate<ManifestFile> predicate;
+
+  private boolean pruneColumnStats = false;
+  private Schema tableSchema;
+  private MetricsConfig metricsConfig;
 
   private final SnapshotSummary.Builder summaryBuilder = SnapshotSummary.builder();
 
@@ -120,6 +126,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   @Override
   public RewriteManifests rewriteIf(Predicate<ManifestFile> pred) {
     this.predicate = pred;
+    return this;
+  }
+
+  @Override
+  public RewriteManifests pruneColumnStats() {
+    this.pruneColumnStats = true;
     return this;
   }
 
@@ -204,7 +216,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   }
 
   private boolean requiresRewrite(Set<ManifestFile> currentManifests) {
-    if (clusterByFunc == null) {
+    if (clusterByFunc == null && !pruneColumnStats) {
       // manifests are deleted and added directly so don't perform a rewrite
       return false;
     }
@@ -238,6 +250,9 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   private void performRewrite(List<ManifestFile> currentManifests) {
     reset();
+    initColumnStatsPruning();
+
+    Function<DataFile, Object> clusterBy = effectiveClusterByFunc();
 
     List<ManifestFile> remainingManifests =
         currentManifests.stream()
@@ -262,7 +277,7 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
                             entry ->
                                 appendEntry(
                                     entry,
-                                    clusterByFunc.apply(entry.file()),
+                                    clusterBy.apply(entry.file()),
                                     manifest.partitionSpecId()));
 
                   } catch (IOException x) {
@@ -342,6 +357,38 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
         Pair.of(key, partitionSpecId), k -> new WriterWrapper(specsById.get(partitionSpecId)));
   }
 
+  private Function<DataFile, Object> effectiveClusterByFunc() {
+    return clusterByFunc != null ? clusterByFunc : file -> SINGLE_CLUSTER_KEY;
+  }
+
+  private void initColumnStatsPruning() {
+    if (!pruneColumnStats) {
+      return;
+    }
+
+    TableMetadata current = ops().current();
+    this.tableSchema = current.schema();
+    this.metricsConfig =
+        MetricsConfig.from(current.properties(), current.schema(), current.sortOrder());
+  }
+
+  private DataFile prunedFile(DataFile file) {
+    Metrics fileMetrics =
+        new Metrics(
+            file.recordCount(),
+            file.columnSizes(),
+            file.valueCounts(),
+            file.nullValueCounts(),
+            file.nanValueCounts(),
+            file.lowerBounds(),
+            file.upperBounds());
+    Metrics prunedMetrics = MetricsUtil.pruneColumnStats(tableSchema, metricsConfig, fileMetrics);
+    return DataFiles.builder(specsById.get(file.specId()))
+        .copy(file)
+        .withMetrics(prunedMetrics)
+        .build();
+  }
+
   @Override
   protected void cleanUncommitted(Set<ManifestFile> committed) {
     deleteUncommitted(newManifests, committed, false);
@@ -369,7 +416,16 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
         close();
         writer = newManifestWriter(spec);
       }
-      writer.existing(entry);
+
+      if (pruneColumnStats) {
+        writer.existing(
+            prunedFile(entry.file()),
+            entry.snapshotId(),
+            entry.dataSequenceNumber(),
+            entry.fileSequenceNumber());
+      } else {
+        writer.existing(entry);
+      }
     }
 
     synchronized void close() {

--- a/core/src/main/java/org/apache/iceberg/MetricsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsUtil.java
@@ -80,6 +80,67 @@ public class MetricsUtil {
         copyWithoutKeys(metrics.originalTypes(), excludedFieldIds));
   }
 
+  /**
+   * Copies a metrics object, dropping stats that exceed the metrics modes configured for the table.
+   *
+   * <p>Stats are only removed, never re-truncated: columns configured as {@link MetricsModes.None}
+   * lose all stats, columns configured as {@link MetricsModes.Counts} lose their bounds, and
+   * columns configured as {@link MetricsModes.Truncate} or {@link MetricsModes.Full} keep their
+   * stats unchanged. Stats for fields that are not present in the schema are left untouched.
+   *
+   * @param schema the table schema the metrics are bound against
+   * @param metricsConfig the table's metrics configuration
+   * @param metrics the metrics to prune
+   * @return a new metrics object retaining only the stats permitted by the metrics configuration
+   */
+  public static Metrics pruneColumnStats(
+      Schema schema, MetricsConfig metricsConfig, Metrics metrics) {
+    Set<Integer> allStatsExcludedIds = Sets.newHashSet();
+    Set<Integer> boundsExcludedIds = Sets.newHashSet();
+
+    for (int fieldId : fieldIdsWithStats(metrics)) {
+      String columnName = schema.findColumnName(fieldId);
+      if (columnName == null) {
+        continue;
+      }
+
+      MetricsModes.MetricsMode mode = metricsConfig.columnMode(columnName);
+      if (mode == MetricsModes.None.get()) {
+        allStatsExcludedIds.add(fieldId);
+        boundsExcludedIds.add(fieldId);
+      } else if (mode == MetricsModes.Counts.get()) {
+        boundsExcludedIds.add(fieldId);
+      }
+    }
+
+    return new Metrics(
+        metrics.recordCount(),
+        copyWithoutKeys(metrics.columnSizes(), allStatsExcludedIds),
+        copyWithoutKeys(metrics.valueCounts(), allStatsExcludedIds),
+        copyWithoutKeys(metrics.nullValueCounts(), allStatsExcludedIds),
+        copyWithoutKeys(metrics.nanValueCounts(), allStatsExcludedIds),
+        copyWithoutKeys(metrics.lowerBounds(), boundsExcludedIds),
+        copyWithoutKeys(metrics.upperBounds(), boundsExcludedIds),
+        copyWithoutKeys(metrics.originalTypes(), boundsExcludedIds));
+  }
+
+  private static Set<Integer> fieldIdsWithStats(Metrics metrics) {
+    Set<Integer> fieldIds = Sets.newHashSet();
+    addKeys(fieldIds, metrics.columnSizes());
+    addKeys(fieldIds, metrics.valueCounts());
+    addKeys(fieldIds, metrics.nullValueCounts());
+    addKeys(fieldIds, metrics.nanValueCounts());
+    addKeys(fieldIds, metrics.lowerBounds());
+    addKeys(fieldIds, metrics.upperBounds());
+    return fieldIds;
+  }
+
+  private static void addKeys(Set<Integer> fieldIds, Map<Integer, ?> map) {
+    if (map != null) {
+      fieldIds.addAll(map.keySet());
+    }
+  }
+
   private static <K, V> Map<K, V> copyWithoutKeys(Map<K, V> map, Set<K> keys) {
     if (map == null) {
       return null;

--- a/core/src/test/java/org/apache/iceberg/TestMetricsUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetricsUtil.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.apache.iceberg.types.Types.NestedField.required;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestMetricsUtil {
+  private static final Schema SCHEMA =
+      new Schema(
+          required(1, "id", Types.IntegerType.get()),
+          optional(2, "data", Types.StringType.get()),
+          optional(3, "measurement", Types.DoubleType.get()));
+
+  private static final int DROPPED_FIELD_ID = 99;
+
+  @Test
+  public void testPruneColumnStatsRespectsPerColumnModes() {
+    Metrics metrics = metricsForAllColumns();
+    MetricsConfig config =
+        MetricsConfig.from(
+            ImmutableMap.of(
+                "write.metadata.metrics.column.id", "full",
+                "write.metadata.metrics.column.data", "counts",
+                "write.metadata.metrics.column.measurement", "none"),
+            SCHEMA,
+            SortOrder.unsorted());
+
+    Metrics pruned = MetricsUtil.pruneColumnStats(SCHEMA, config, metrics);
+
+    assertThat(pruned.valueCounts()).containsKeys(1, 2).doesNotContainKey(3);
+    assertThat(pruned.columnSizes()).containsKeys(1, 2).doesNotContainKey(3);
+    assertThat(pruned.lowerBounds()).containsKey(1).doesNotContainKeys(2, 3);
+    assertThat(pruned.upperBounds()).containsKey(1).doesNotContainKeys(2, 3);
+  }
+
+  @Test
+  public void testPruneColumnStatsKeepsStatsForFieldsMissingFromSchema() {
+    Metrics metrics = metricsForAllColumns();
+    MetricsConfig config =
+        MetricsConfig.from(
+            ImmutableMap.of("write.metadata.metrics.default", "none"),
+            SCHEMA,
+            SortOrder.unsorted());
+
+    Metrics pruned = MetricsUtil.pruneColumnStats(SCHEMA, config, metrics);
+
+    assertThat(pruned.valueCounts()).containsOnlyKeys(DROPPED_FIELD_ID);
+    assertThat(pruned.lowerBounds()).containsOnlyKeys(DROPPED_FIELD_ID);
+  }
+
+  @Test
+  public void testPruneColumnStatsDoesNotReTruncateBounds() {
+    ByteBuffer lowerBound = stringBuffer("aaaaaaaa");
+    ByteBuffer upperBound = stringBuffer("zzzzzzzz");
+    Metrics metrics =
+        new Metrics(
+            10L,
+            ImmutableMap.of(2, 200L),
+            ImmutableMap.of(2, 20L),
+            ImmutableMap.of(2, 0L),
+            null,
+            ImmutableMap.of(2, lowerBound),
+            ImmutableMap.of(2, upperBound));
+    MetricsConfig config =
+        MetricsConfig.from(
+            ImmutableMap.of("write.metadata.metrics.column.data", "truncate(2)"),
+            SCHEMA,
+            SortOrder.unsorted());
+
+    Metrics pruned = MetricsUtil.pruneColumnStats(SCHEMA, config, metrics);
+
+    assertThat(pruned.lowerBounds().get(2)).isEqualTo(lowerBound);
+    assertThat(pruned.upperBounds().get(2)).isEqualTo(upperBound);
+  }
+
+  private static Metrics metricsForAllColumns() {
+    return new Metrics(
+        10L,
+        ImmutableMap.of(1, 100L, 2, 200L, 3, 300L, DROPPED_FIELD_ID, 400L),
+        ImmutableMap.of(1, 10L, 2, 20L, 3, 30L, DROPPED_FIELD_ID, 40L),
+        ImmutableMap.of(1, 0L, 2, 0L, 3, 0L, DROPPED_FIELD_ID, 0L),
+        ImmutableMap.of(3, 1L),
+        ImmutableMap.of(
+            1, intBuffer(1), 2, intBuffer(2), 3, intBuffer(3), DROPPED_FIELD_ID, intBuffer(4)),
+        ImmutableMap.of(
+            1, intBuffer(5), 2, intBuffer(6), 3, intBuffer(7), DROPPED_FIELD_ID, intBuffer(8)));
+  }
+
+  private static ByteBuffer intBuffer(int value) {
+    return Conversions.toByteBuffer(Types.IntegerType.get(), value);
+  }
+
+  private static ByteBuffer stringBuffer(String value) {
+    return Conversions.toByteBuffer(Types.StringType.get(), value);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -32,15 +32,22 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Conversions;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -70,6 +77,186 @@ public class TestRewriteManifests extends TestBase {
 
     validateManifestEntries(
         manifests.get(0), ids(appendId), files(FILE_A), statuses(ManifestEntry.Status.EXISTING));
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsPrunesColumnStats() throws IOException {
+    Table table = load();
+
+    table
+        .updateProperties()
+        .set("write.metadata.metrics.column.id", "counts")
+        .set("write.metadata.metrics.column.data", "none")
+        .commit();
+
+    int idFieldId = table.schema().findField("id").fieldId();
+    int dataFieldId = table.schema().findField("data").fieldId();
+    table.newFastAppend().appendFile(fileWithStats(idFieldId, dataFieldId)).commit();
+
+    table.rewriteManifests().pruneColumnStats().commit();
+
+    List<ManifestFile> manifests = table.currentSnapshot().dataManifests(table.io());
+    assertThat(manifests).hasSize(1);
+
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifests.get(0), table.io(), table.specs())) {
+      DataFile file = reader.iterator().next();
+
+      // id is configured as counts: counts and sizes are kept, bounds are dropped
+      // data is configured as none: all of its stats are dropped
+      assertThat(file.columnSizes()).containsOnlyKeys(idFieldId);
+      assertThat(file.valueCounts()).containsOnlyKeys(idFieldId);
+      assertThat(file.nullValueCounts()).containsOnlyKeys(idFieldId);
+      assertThat(file.nanValueCounts()).containsOnlyKeys(idFieldId);
+      assertThat(file.lowerBounds()).isNullOrEmpty();
+      assertThat(file.upperBounds()).isNullOrEmpty();
+    }
+  }
+
+  private static DataFile fileWithStats(int idFieldId, int dataFieldId) {
+    return DataFiles.builder(SPEC)
+        .withPath("/path/to/data-to-prune.parquet")
+        .withPartitionPath("data_bucket=0")
+        .withFileSizeInBytes(350)
+        .withMetrics(
+            new Metrics(
+                10L,
+                ImmutableMap.of(idFieldId, 100L, dataFieldId, 200L),
+                ImmutableMap.of(idFieldId, 90L, dataFieldId, 180L),
+                ImmutableMap.of(idFieldId, 10L, dataFieldId, 20L),
+                ImmutableMap.of(idFieldId, 0L, dataFieldId, 0L),
+                ImmutableMap.of(
+                    idFieldId, Conversions.toByteBuffer(Types.IntegerType.get(), 1),
+                    dataFieldId, Conversions.toByteBuffer(Types.StringType.get(), "a")),
+                ImmutableMap.of(
+                    idFieldId, Conversions.toByteBuffer(Types.IntegerType.get(), 5),
+                    dataFieldId, Conversions.toByteBuffer(Types.StringType.get(), "z"))))
+        .build();
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsWithoutClusterByPrunesStatsAcrossManifests() throws IOException {
+    Table table = load();
+
+    table
+        .updateProperties()
+        .set("write.metadata.metrics.column.id", "counts")
+        .set("write.metadata.metrics.column.data", "none")
+        .commit();
+
+    int idFieldId = table.schema().findField("id").fieldId();
+    int dataFieldId = table.schema().findField("data").fieldId();
+    table
+        .newFastAppend()
+        .appendFile(
+            fileWithStats("/path/to/data-prune-1.parquet", "data_bucket=0", idFieldId, dataFieldId))
+        .commit();
+    table
+        .newFastAppend()
+        .appendFile(
+            fileWithStats("/path/to/data-prune-2.parquet", "data_bucket=1", idFieldId, dataFieldId))
+        .commit();
+    assertThat(table.currentSnapshot().dataManifests(table.io())).hasSize(2);
+
+    table.rewriteManifests().pruneColumnStats().commit();
+
+    List<ManifestFile> manifests = table.currentSnapshot().dataManifests(table.io());
+    assertThat(manifests).hasSize(1);
+    int fileCount = 0;
+    try (ManifestReader<DataFile> reader =
+        ManifestFiles.read(manifests.get(0), table.io(), table.specs())) {
+      for (DataFile file : reader) {
+        fileCount += 1;
+        assertThat(file.columnSizes()).containsOnlyKeys(idFieldId);
+        assertThat(file.valueCounts()).containsOnlyKeys(idFieldId);
+        assertThat(file.nullValueCounts()).containsOnlyKeys(idFieldId);
+        assertThat(file.nanValueCounts()).containsOnlyKeys(idFieldId);
+        assertThat(file.lowerBounds()).isNullOrEmpty();
+        assertThat(file.upperBounds()).isNullOrEmpty();
+      }
+    }
+
+    assertThat(fileCount).isEqualTo(2);
+  }
+
+  @TestTemplate
+  public void testPruneColumnStatsIsUnsupportedByDefault() {
+    RewriteManifests rewriteManifests =
+        new RewriteManifests() {
+          @Override
+          public RewriteManifests clusterBy(Function<DataFile, Object> func) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests rewriteIf(Predicate<ManifestFile> predicate) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests deleteManifest(ManifestFile manifest) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests addManifest(ManifestFile manifest) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests set(String property, String value) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests deleteWith(Consumer<String> deleteFunc) {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests stageOnly() {
+            return this;
+          }
+
+          @Override
+          public RewriteManifests scanManifestsWith(ExecutorService executorService) {
+            return this;
+          }
+
+          @Override
+          public Snapshot apply() {
+            return null;
+          }
+
+          @Override
+          public void commit() {}
+        };
+
+    assertThatThrownBy(rewriteManifests::pruneColumnStats)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessageContaining("doesn't implement pruneColumnStats");
+  }
+
+  private static DataFile fileWithStats(
+      String path, String partition, int idFieldId, int dataFieldId) {
+    return DataFiles.builder(SPEC)
+        .withPath(path)
+        .withPartitionPath(partition)
+        .withFileSizeInBytes(350)
+        .withMetrics(
+            new Metrics(
+                10L,
+                ImmutableMap.of(idFieldId, 100L, dataFieldId, 200L),
+                ImmutableMap.of(idFieldId, 90L, dataFieldId, 180L),
+                ImmutableMap.of(idFieldId, 10L, dataFieldId, 20L),
+                ImmutableMap.of(idFieldId, 0L, dataFieldId, 0L),
+                ImmutableMap.of(
+                    idFieldId, Conversions.toByteBuffer(Types.IntegerType.get(), 1),
+                    dataFieldId, Conversions.toByteBuffer(Types.StringType.get(), "a")),
+                ImmutableMap.of(
+                    idFieldId, Conversions.toByteBuffer(Types.IntegerType.get(), 5),
+                    dataFieldId, Conversions.toByteBuffer(Types.StringType.get(), "z"))))
+        .build();
   }
 
   @TestTemplate


### PR DESCRIPTION
Closes #17257.

Adds a `pruneColumnStats()` option to `RewriteManifests`. When enabled, column
stats that exceed the table's current `write.metadata.metrics.*` configuration
are dropped as manifests are rewritten: columns configured `none` lose all
stats, `counts` columns lose their bounds, and `truncate(n)`/`full` columns are
left unchanged (existing bounds are never re-truncated).

Iceberg infers metrics for up to 100 columns by default, which bloats manifests
and slows planning on wide tables. Tightening the metrics config doesn't shrink
existing manifests today because `RewriteManifests` copies each data file's
stats verbatim. This option lets users reclaim that space during a manifest
rewrite without rewriting the data files.

Pruning applies only to manifests that are actually rewritten. With no
`clusterBy(...)` set, enabling it triggers a full rewrite so all data files are
regrouped. The new `default` interface method throws
`UnsupportedOperationException`, keeping existing implementors compatible.
