### PR TITLE
API: Reject non-null defaults for geometry, geography, and variant with a clear error

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Types.java
+++ b/api/src/main/java/org/apache/iceberg/types/Types.java
@@ -893,17 +893,37 @@ public class Types {
     }
 
     private static Literal<?> castDefault(Literal<?> defaultValue, Type type) {
-      if (type.isNestedType() && defaultValue != null) {
-        throw new IllegalArgumentException(
-            String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
-      } else if (defaultValue != null) {
-        Literal<?> typedDefault = defaultValue.to(type);
-        Preconditions.checkArgument(
-            typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
-        return typedDefault;
+      if (defaultValue == null) {
+        return null;
       }
 
-      return null;
+      // Nested types and the unknown, variant, geometry, and geography types have no single-value
+      // representation for a default, so the spec requires their columns to default to null.
+      if (!supportsDefaultValue(type)) {
+        throw new IllegalArgumentException(
+            String.format("Invalid default value for %s: %s (must be null)", type, defaultValue));
+      }
+
+      Literal<?> typedDefault = defaultValue.to(type);
+      Preconditions.checkArgument(
+          typedDefault != null, "Cannot cast default value to %s: %s", type, defaultValue);
+      return typedDefault;
+    }
+
+    private static boolean supportsDefaultValue(Type type) {
+      if (type.isNestedType()) {
+        return false;
+      }
+
+      switch (type.typeId()) {
+        case UNKNOWN:
+        case VARIANT:
+        case GEOMETRY:
+        case GEOGRAPHY:
+          return false;
+        default:
+          return true;
+      }
     }
 
     public boolean isOptional() {

--- a/api/src/test/java/org/apache/iceberg/TestSchema.java
+++ b/api/src/test/java/org/apache/iceberg/TestSchema.java
@@ -221,6 +221,71 @@ public class TestSchema {
   }
 
   @Test
+  public void testGeospatialTypesRejectNonNullDefault() {
+    // The spec requires geometry and geography columns to default to null. Neither type has a
+    // single-value encoding for a default, so building a field with a non-null default is rejected
+    // in the field constructor -- i.e. on the CREATE TABLE / Schema construction path, not only via
+    // schema evolution.
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.optional("geom")
+                    .withId(2)
+                    .ofType(Types.GeometryType.crs84())
+                    .withInitialDefault(Literal.of("POINT(0 0)"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid default value for geometry(OGC:CRS84): \"POINT(0 0)\" (must be null)");
+
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.optional("geom")
+                    .withId(2)
+                    .ofType(Types.GeometryType.crs84())
+                    .withWriteDefault(Literal.of("POINT(0 0)"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid default value for geometry(OGC:CRS84): \"POINT(0 0)\" (must be null)");
+
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.optional("geog")
+                    .withId(2)
+                    .ofType(Types.GeographyType.crs84())
+                    .withInitialDefault(Literal.of("POINT(0 0)"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid default value for geography(OGC:CRS84, spherical): \"POINT(0 0)\" "
+                + "(must be null)");
+
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.optional("geog")
+                    .withId(2)
+                    .ofType(Types.GeographyType.crs84())
+                    .withWriteDefault(Literal.of("POINT(0 0)"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid default value for geography(OGC:CRS84, spherical): \"POINT(0 0)\" "
+                + "(must be null)");
+  }
+
+  @Test
+  public void testVariantTypeRejectsNonNullDefault() {
+    // Like the geospatial types, the spec requires variant columns to default to null.
+    assertThatThrownBy(
+            () ->
+                Types.NestedField.optional("var")
+                    .withId(2)
+                    .ofType(Types.VariantType.get())
+                    .withInitialDefault(Literal.of("v1"))
+                    .build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid default value for variant: \"v1\" (must be null)");
+  }
+
+  @Test
   public void testIndexFieldsSingleSchema() {
     Schema schema =
         new Schema(

--- a/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
+++ b/core/src/test/java/org/apache/iceberg/TestSchemaUpdate.java
@@ -2498,7 +2498,7 @@ public class TestSchemaUpdate {
                     .addColumn("unk", Types.UnknownType.get(), Literal.of("string!"))
                     .apply())
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Cannot cast default value to unknown: \"string!\"");
+        .hasMessage("Invalid default value for unknown: \"string!\" (must be null)");
   }
 
   @Test
@@ -2513,6 +2513,38 @@ public class TestSchemaUpdate {
                     .apply())
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Cannot create required field with unknown type: unk");
+  }
+
+  @Test
+  public void testAddGeometryNonNullDefault() {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()));
+
+    // The spec requires geometry columns to default to null; a non-null default is rejected.
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(schema, schema.highestFieldId())
+                    .allowIncompatibleChanges()
+                    .addColumn("geom", Types.GeometryType.crs84(), Literal.of("POINT(0 0)"))
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid default value for geometry(OGC:CRS84): \"POINT(0 0)\" (must be null)");
+  }
+
+  @Test
+  public void testAddGeographyNonNullDefault() {
+    Schema schema = new Schema(required(1, "id", Types.LongType.get()));
+
+    // The spec requires geography columns to default to null; a non-null default is rejected.
+    assertThatThrownBy(
+            () ->
+                new SchemaUpdate(schema, schema.highestFieldId())
+                    .allowIncompatibleChanges()
+                    .addColumn("geog", Types.GeographyType.crs84(), Literal.of("POINT(0 0)"))
+                    .apply())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Invalid default value for geography(OGC:CRS84, spherical): \"POINT(0 0)\" "
+                + "(must be null)");
   }
 
   @Test


### PR DESCRIPTION
The spec requires columns of `unknown`, `variant`, `geometry`, and `geography` types to default to null: "All columns of `unknown`, `variant`, `geometry`, and `geography` types must default to null. Non-null values for `initial-default` or `write-default` are invalid."

`NestedField.castDefault` handled this inconsistently across those four types:

- `unknown`, `geometry`, and `geography` fell through to `Literal.to(type)`, which returns `null` for these types, so a non-null default was rejected with the misleading message `Cannot cast default value to <type>: <value>`. That reads like a value-conversion failure rather than "this type cannot carry a default at all."
- `variant`'s `Literal.to(VARIANT)` returns the literal itself, so a non-null variant default was **not rejected**. It is only unreachable today because there is no public variant `Literal` factory and `SingleValueParser` rejects variant defaults on the JSON path — but the constructor-level guard was missing.

This routes all four types (plus nested types, which were already rejected) through a single `supportsDefaultValue` check that throws the clearer, spec-aligned message `Invalid default value for <type>: <value> (must be null)`, reusing the wording already used for nested types. Valid defaults on all other primitive types are unaffected — they still go through `Literal.to(type)`.

There is no behavior change for the types that were already rejected, other than a clearer message; the only behavioral fix is closing the variant gap at the field constructor.

## Testing

- `TestSchema.testGeospatialTypesRejectNonNullDefault` — the `CREATE TABLE` / field-constructor path, covering both `initial-default` and `write-default` for geometry and geography.
- `TestSchema.testVariantTypeRejectsNonNullDefault` — variant default rejected at the constructor.
- `TestSchemaUpdate.testAddGeometryNonNullDefault` / `testAddGeographyNonNullDefault` — the `addColumn` (schema evolution) path.
- `TestSchemaUpdate.testAddUnknownNonNullDefault` — existing test updated to the new message.

All pass locally (`iceberg-api` and `iceberg-core` test suites, spotless clean).
