### PR TITLE
API, Core: Make variant classes serializable

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/SerializedArray.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedArray.java
@@ -18,13 +18,14 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
-class SerializedArray implements VariantArray, SerializedValue {
+class SerializedArray implements VariantArray, SerializedValue, Serializable {
   private static final int HEADER_SIZE = 1;
   private static final int OFFSET_SIZE_MASK = 0b1100;
   private static final int OFFSET_SIZE_SHIFT = 2;
@@ -90,5 +91,23 @@ class SerializedArray implements VariantArray, SerializedValue {
   @Override
   public String toString() {
     return VariantArray.asString(this);
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private final VariantMetadata metadata;
+    private final byte[] valueBytes;
+
+    private SerializationProxy(SerializedArray array) {
+      this.metadata = array.metadata;
+      this.valueBytes = ByteBuffers.toByteArray(array.buffer());
+    }
+
+    private Object readResolve() {
+      return SerializedArray.from(metadata, valueBytes);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedMetadata.java
@@ -18,13 +18,14 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 
-class SerializedMetadata implements VariantMetadata, Serialized {
+class SerializedMetadata implements VariantMetadata, Serialized, Serializable {
   private static final int HEADER_SIZE = 1;
   private static final int SUPPORTED_VERSION = 1;
   private static final int VERSION_MASK = 0b1111;
@@ -137,5 +138,21 @@ class SerializedMetadata implements VariantMetadata, Serialized {
   @Override
   public String toString() {
     return VariantMetadata.asString(this);
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private final byte[] metadataBytes;
+
+    private SerializationProxy(SerializedMetadata metadata) {
+      this.metadataBytes = ByteBuffers.toByteArray(metadata.buffer());
+    }
+
+    private Object readResolve() {
+      return SerializedMetadata.from(metadataBytes);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedObject.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Iterator;
@@ -29,7 +30,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ByteBuffers;
 
-class SerializedObject implements VariantObject, SerializedValue {
+class SerializedObject implements VariantObject, SerializedValue, Serializable {
   private static final int HEADER_SIZE = 1;
   private static final int OFFSET_SIZE_MASK = 0b1100;
   private static final int OFFSET_SIZE_SHIFT = 2;
@@ -237,5 +238,23 @@ class SerializedObject implements VariantObject, SerializedValue {
   @Override
   public String toString() {
     return VariantObject.asString(this);
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private final VariantMetadata metadata;
+    private final byte[] valueBytes;
+
+    private SerializationProxy(SerializedObject object) {
+      this.metadata = object.metadata;
+      this.valueBytes = ByteBuffers.toByteArray(object.buffer());
+    }
+
+    private Object readResolve() {
+      return SerializedObject.from(metadata, valueBytes);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
@@ -26,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.UUIDUtil;
 
-class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue {
+class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue, Serializable {
   private static final int PRIMITIVE_TYPE_SHIFT = 2;
   private static final int PRIMITIVE_OFFSET = 1;
 
@@ -149,5 +150,21 @@ class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue {
   @Override
   public String toString() {
     return VariantPrimitive.asString(this);
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private final byte[] valueBytes;
+
+    private SerializationProxy(SerializedPrimitive primitive) {
+      this.valueBytes = ByteBuffers.toByteArray(primitive.buffer());
+    }
+
+    private Object readResolve() {
+      return SerializedPrimitive.from(valueBytes);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedShortString.java
@@ -18,11 +18,13 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ByteBuffers;
 
-class SerializedShortString implements VariantPrimitive<String>, SerializedValue {
+class SerializedShortString implements VariantPrimitive<String>, SerializedValue, Serializable {
   private static final int HEADER_SIZE = 1;
   private static final int LENGTH_MASK = 0b11111100;
   private static final int LENGTH_SHIFT = 2;
@@ -80,5 +82,21 @@ class SerializedShortString implements VariantPrimitive<String>, SerializedValue
   @Override
   public String toString() {
     return VariantPrimitive.asString(this);
+  }
+
+  private Object writeReplace() {
+    return new SerializationProxy(this);
+  }
+
+  private static class SerializationProxy implements Serializable {
+    private final byte[] valueBytes;
+
+    private SerializationProxy(SerializedShortString string) {
+      this.valueBytes = ByteBuffers.toByteArray(string.buffer());
+    }
+
+    private Object readResolve() {
+      return SerializedShortString.from(valueBytes);
+    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/VariantData.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantData.java
@@ -18,9 +18,10 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
-class VariantData implements Variant {
+class VariantData implements Variant, Serializable {
   private final VariantMetadata metadata;
   private final VariantValue value;
 

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedArray.java
@@ -23,9 +23,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
 import java.util.Random;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestSerializedArray {
@@ -196,5 +198,14 @@ public class TestSerializedArray {
                     new byte[] {0b10011, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF}))
         .isInstanceOf(NegativeArraySizeException.class)
         .hasMessage("-1");
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<SerializedArray> serializer) throws Exception {
+    ByteBuffer buffer = VariantTestUtil.createArray(A, B, C, I34, I1234);
+    SerializedArray array = SerializedArray.from(EMPTY_METADATA, buffer, buffer.get(0));
+
+    VariantTestUtil.assertEqual(array, serializer.apply(array));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedMetadata.java
@@ -24,10 +24,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.nio.ByteBuffer;
 import java.util.Random;
 import java.util.Set;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestSerializedMetadata {
@@ -250,5 +252,15 @@ public class TestSerializedMetadata {
     assertThatThrownBy(
             () -> SerializedMetadata.from(new byte[] {(byte) 0b11010001, 0x00, 0x00, 0x00}))
         .isInstanceOf(IndexOutOfBoundsException.class);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<SerializedMetadata> serializer)
+      throws Exception {
+    SerializedMetadata metadata =
+        SerializedMetadata.from(VariantTestUtil.createMetadata(Set.of("a", "b", "c"), true));
+
+    VariantTestUtil.assertEqual(metadata, serializer.apply(metadata));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedObject.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.stream.Stream;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -338,5 +339,17 @@ public class TestSerializedObject {
     assertThat(object.get("AA").asPrimitive().get()).isEqualTo((byte) 2);
     assertThat(object.get("ZZ").type()).isEqualTo(PhysicalType.INT8);
     assertThat(object.get("ZZ").asPrimitive().get()).isEqualTo((byte) 3);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<SerializedObject> serializer) throws Exception {
+    Map<String, VariantValue> data = ImmutableMap.of("a", I1, "b", I2, "c", I3);
+    ByteBuffer meta = VariantTestUtil.createMetadata(data.keySet(), true /* sort names */);
+    ByteBuffer value = VariantTestUtil.createObject(meta, data);
+    SerializedObject object =
+        SerializedObject.from(SerializedMetadata.from(meta), value, value.get(0));
+
+    VariantTestUtil.assertEqual(object, serializer.apply(object));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestSerializedPrimitives.java
@@ -25,8 +25,11 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.UUID;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.util.DateTimeUtil;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 
 public class TestSerializedPrimitives {
   @Test
@@ -616,5 +619,26 @@ public class TestSerializedPrimitives {
 
   private static byte primitiveHeader(int primitiveType) {
     return (byte) (primitiveType << 2);
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testPrimitiveSerialization(RoundTripSerializer<SerializedPrimitive> serializer)
+      throws Exception {
+    // date value
+    SerializedPrimitive primitive =
+        SerializedPrimitive.from(new byte[] {primitiveHeader(11), (byte) 0xF4, 0x43, 0x00, 0x00});
+
+    VariantTestUtil.assertEqual(primitive, serializer.apply(primitive));
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testShortStringSerialization(RoundTripSerializer<SerializedShortString> serializer)
+      throws Exception {
+    SerializedShortString string =
+        SerializedShortString.from(new byte[] {0b11101, 'i', 'c', 'e', 'b', 'e', 'r', 'g'});
+
+    VariantTestUtil.assertEqual(string, serializer.apply(string));
   }
 }

--- a/api/src/test/java/org/apache/iceberg/variants/TestVariant.java
+++ b/api/src/test/java/org/apache/iceberg/variants/TestVariant.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.variants;
+
+import java.util.Map;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class TestVariant {
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<Variant> serializer) throws Exception {
+    Map<String, VariantValue> data =
+        ImmutableMap.of(
+            "a",
+            SerializedPrimitive.from(new byte[] {0b1100, 1}), // int8 = 1
+            "b",
+            VariantTestUtil.createShortString("iceberg"));
+    Variant variant = VariantTestUtil.variant(data);
+
+    Variant result = serializer.apply(variant);
+
+    VariantTestUtil.assertEqual(variant.metadata(), result.metadata());
+    VariantTestUtil.assertEqual(variant.value(), result.value());
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
+++ b/core/src/main/java/org/apache/iceberg/variants/PrimitiveWrapper.java
@@ -18,15 +18,17 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.UUIDUtil;
 
-class PrimitiveWrapper<T> implements VariantPrimitive<T> {
+class PrimitiveWrapper<T> implements VariantPrimitive<T>, Serializable {
   private static final byte NULL_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_NULL);
   private static final byte TRUE_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_TRUE);
   private static final byte FALSE_HEADER = VariantUtil.primitiveHeader(Primitives.TYPE_FALSE);
@@ -57,7 +59,9 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
 
   private final PhysicalType type;
   private final T value;
-  private ByteBuffer buffer = null;
+  // binary values are held as a serializable byte array rather than a non-serializable ByteBuffer
+  private final byte[] binary;
+  private transient ByteBuffer buffer = null;
 
   PrimitiveWrapper(PhysicalType type, T value) {
     if (value instanceof Boolean
@@ -67,7 +71,14 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
     } else {
       this.type = type;
     }
-    this.value = value;
+
+    if (this.type == PhysicalType.BINARY) {
+      this.binary = ByteBuffers.toByteArray((ByteBuffer) value);
+      this.value = null;
+    } else {
+      this.value = value;
+      this.binary = null;
+    }
   }
 
   @Override
@@ -76,7 +87,12 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
   }
 
   @Override
+  @SuppressWarnings("unchecked")
   public T get() {
+    if (type == PhysicalType.BINARY) {
+      return (T) ByteBuffer.wrap(binary);
+    }
+
     return value;
   }
 
@@ -110,7 +126,7 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
       case DECIMAL16:
         return 18; // 1 header + 1 scale + 16 unscaled value
       case BINARY:
-        return 5 + ((ByteBuffer) value).remaining(); // 1 header + 4 length + value length
+        return 5 + binary.length; // 1 header + 4 length + value length
       case STRING:
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));
@@ -205,11 +221,10 @@ class PrimitiveWrapper<T> implements VariantPrimitive<T> {
         }
         return 18;
       case BINARY:
-        ByteBuffer binary = (ByteBuffer) value;
         outBuffer.put(offset, BINARY_HEADER);
-        outBuffer.putInt(offset + 1, binary.remaining());
-        outBuffer.put(offset + 5, binary, binary.position(), binary.remaining());
-        return 5 + binary.remaining();
+        outBuffer.putInt(offset + 1, binary.length);
+        outBuffer.put(offset + 5, binary, 0, binary.length);
+        return 5 + binary.length;
       case STRING:
         if (null == buffer) {
           this.buffer = ByteBuffer.wrap(((String) value).getBytes(StandardCharsets.UTF_8));

--- a/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ShreddedObject.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Map;
@@ -39,12 +40,12 @@ import org.apache.iceberg.util.SortedMerge;
  * fields. This also does not allow updating or replacing the metadata for the unshredded object,
  * which could require recursively rewriting field IDs.
  */
-public class ShreddedObject implements VariantObject {
+public class ShreddedObject implements VariantObject, Serializable {
   private final VariantMetadata metadata;
   private final VariantObject unshredded;
   private final Map<String, VariantValue> shreddedFields = Maps.newHashMap();
   private final Set<String> removedFields = Sets.newHashSet();
-  private SerializationState serializationState = null;
+  private transient SerializationState serializationState = null;
 
   ShreddedObject(VariantMetadata metadata) {
     this(metadata, null);

--- a/core/src/main/java/org/apache/iceberg/variants/ValueArray.java
+++ b/core/src/main/java/org/apache/iceberg/variants/ValueArray.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.variants;
 
+import java.io.Serializable;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
@@ -25,8 +26,8 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.ByteBuffers;
 
-public class ValueArray implements VariantArray {
-  private SerializationState serializationState = null;
+public class ValueArray implements VariantArray, Serializable {
+  private transient SerializationState serializationState = null;
   private List<VariantValue> elements = Lists.newArrayList();
 
   ValueArray() {}

--- a/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestPrimitiveWrapper.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Random;
+import org.apache.iceberg.TestHelpers;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.RandomUtil;
@@ -97,5 +98,12 @@ public class TestPrimitiveWrapper {
 
     VariantTestUtil.assertEqual(expectedVariant.metadata(), readValue.metadata());
     VariantTestUtil.assertEqual(expectedVariant.value(), readValue.value());
+  }
+
+  @ParameterizedTest
+  @FieldSource("PRIMITIVES")
+  public void testSerialization(VariantPrimitive<?> primitive) throws Exception {
+    VariantTestUtil.assertEqual(primitive, TestHelpers.roundTripSerialize(primitive));
+    VariantTestUtil.assertEqual(primitive, TestHelpers.KryoHelpers.roundTripSerialize(primitive));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestShreddedObject.java
@@ -27,6 +27,7 @@ import java.nio.ByteOrder;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
@@ -36,6 +37,7 @@ import org.apache.iceberg.util.DateTimeUtil;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestShreddedObject {
@@ -451,5 +453,13 @@ public class TestShreddedObject {
         Variants.value(
             Variants.metadata(metadataBuffer),
             VariantTestUtil.createObject(metadataBuffer, fields));
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<ShreddedObject> serializer) throws Exception {
+    ShreddedObject object = createShreddedObject(FIELDS);
+
+    VariantTestUtil.assertEqual(object, serializer.apply(object));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
+++ b/core/src/test/java/org/apache/iceberg/variants/TestValueArray.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
 import java.util.Random;
+import org.apache.iceberg.TestHelpers.RoundTripSerializer;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Conversions;
@@ -32,6 +33,7 @@ import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.RandomUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestValueArray {
@@ -172,5 +174,14 @@ public class TestValueArray {
     }
 
     return arr;
+  }
+
+  @ParameterizedTest
+  @MethodSource("org.apache.iceberg.TestHelpers#serializers")
+  public void testSerialization(RoundTripSerializer<ValueArray> serializer) throws Exception {
+    ValueArray array = new ValueArray();
+    ELEMENTS.forEach(array::add);
+
+    VariantTestUtil.assertEqual(array, serializer.apply(array));
   }
 }


### PR DESCRIPTION
Testing `FieldStats` with all types for #17159 uncovered that variant instances are not `Serializable`. This makes all the variant classes serializable, so that stats can be serialized in tasks. Stats are not currently serialized in tasks because stats are discarded during planning (they're expensive) but I think it's a good idea to ensure that stats can be serialized.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>