### PR TITLE
API: Fix Identity projection for mismatched transform types

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Identity.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Identity.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.transforms;
 import java.io.ObjectStreamException;
 import java.util.Set;
 import org.apache.iceberg.expressions.BoundPredicate;
+import org.apache.iceberg.expressions.BoundReference;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.UnboundPredicate;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -146,6 +147,10 @@ class Identity<T> implements Transform<T, T> {
 
   @Override
   public UnboundPredicate<T> projectStrict(String name, BoundPredicate<T> predicate) {
+    if (!(predicate.term() instanceof BoundReference)) {
+      return null;
+    }
+
     if (predicate.isUnaryPredicate()) {
       return Expressions.predicate(predicate.op(), name);
     } else if (predicate.isLiteralPredicate()) {

--- a/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
+++ b/api/src/test/java/org/apache/iceberg/transforms/TestProjection.java
@@ -394,4 +394,34 @@ public class TestProjection {
             Projections.inclusive(partitionSpec).project(equal(truncate("string", 10), "abc"));
     assertThat(predicate.ref().name()).isEqualTo("string_trunc");
   }
+
+  @Test
+  public void testIdentityProjectionWithTransformPredicate() {
+    // Regression test for https://github.com/apache/iceberg/issues/15502
+    // When an identity-partitioned timestamptz field is filtered with hours(), the
+    // projection must return alwaysTrue (inclusive) or alwaysFalse (strict) because
+    // the identity transform cannot project a transform-based predicate.
+    //
+    // Without the fix, projectStrict() returns an invalid UnboundPredicate with an
+    // integer literal (490674) for a timestamptz field. This test fails because the
+    // result is neither alwaysTrue nor alwaysFalse -- it is the invalid predicate
+    // "ts == 490674" which causes a downstream ValidationException when evaluated.
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            required(2, "ts", Types.TimestampType.withZone()));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("ts").build();
+
+    // hours(ts) = 490674 produces an integer literal that cannot bind to timestamptz.
+    Expression hourFilter = equal(hour("ts"), 490674);
+
+    // Inclusive projection: cannot project, falls back to alwaysTrue
+    Expression projected = Projections.inclusive(spec).project(hourFilter);
+    assertThat(projected).isEqualTo(Expressions.alwaysTrue());
+
+    // Strict projection: cannot project, falls back to alwaysFalse
+    Expression strictProjected = Projections.strict(spec).project(hourFilter);
+    assertThat(strictProjected).isEqualTo(Expressions.alwaysFalse());
+  }
 }


### PR DESCRIPTION
This continues #16074, which was auto-closed by the stale bot and can no longer be reopened (GitHub blocks reopening because the branch was force-pushed/recreated). Same fix, rebased onto current `main`.

## What

`Identity.projectStrict()` currently produces a predicate even when the predicate term is a transform expression rather than a `BoundReference`, which yields an invalid cross-type predicate during partition projection. This adds a guard so that a non-`BoundReference` term makes `projectStrict()` return `null`, letting the projection framework fall back to `alwaysTrue`/`alwaysFalse`. `project()` delegates to `projectStrict()`, so both paths are covered.

## Why

Fixes #15502 - Identity partition projection returns incorrect results when the source and projected transform types differ.

## Tests

Adds a regression test in `TestProjection` that exercises the mismatched-transform case; it fails on the pre-fix code (producing an invalid `ref(...) == ...` predicate instead of `alwaysTrue`) and passes with the fix.
