### PR TITLE
API, Core: Only fall back to unknown partition type for source-dependent transforms

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -130,15 +130,8 @@ public class PartitionSpec implements Serializable {
           List<Types.NestedField> structFields = Lists.newArrayListWithExpectedSize(fields.length);
 
           for (PartitionField field : fields) {
-            Type sourceType = schema.findType(field.sourceId());
-            Type resultType = field.transform().getResultType(sourceType);
-
-            // When the source field has been dropped we cannot determine the type
-            if (sourceType == null) {
-              resultType = Types.UnknownType.get();
-            }
-
-            structFields.add(Types.NestedField.optional(field.fieldId(), field.name(), resultType));
+            structFields.add(
+                Types.NestedField.optional(field.fieldId(), field.name(), resultType(field)));
           }
 
           this.lazyPartitionType = Types.StructType.of(structFields);
@@ -183,14 +176,7 @@ public class PartitionSpec implements Serializable {
             if (field.transform() instanceof UnknownTransform) {
               classes[i] = Object.class;
             } else {
-              Type sourceType = schema.findType(field.sourceId());
-              if (null == sourceType) {
-                // When the source field has been dropped we cannot determine the type
-                sourceType = Types.UnknownType.get();
-              }
-
-              Type result = field.transform().getResultType(sourceType);
-              classes[i] = result.typeId().javaClass();
+              classes[i] = resultType(field).typeId().javaClass();
             }
           }
 
@@ -200,6 +186,18 @@ public class PartitionSpec implements Serializable {
     }
 
     return lazyJavaClasses;
+  }
+
+  private Type resultType(PartitionField field) {
+    Type sourceType = schema.findType(field.sourceId());
+    if (sourceType == null) {
+      // when the source field has been dropped, substitute unknown and let the transform derive
+      // its result type; transforms that return the source type (identity, truncate, void) yield
+      // unknown, while transforms with a fixed result type still resolve
+      sourceType = Types.UnknownType.get();
+    }
+
+    return field.transform().getResultType(sourceType);
   }
 
   @SuppressWarnings("unchecked")

--- a/core/src/test/java/org/apache/iceberg/TestPartitioning.java
+++ b/core/src/test/java/org/apache/iceberg/TestPartitioning.java
@@ -212,6 +212,52 @@ public class TestPartitioning {
   }
 
   @Test
+  public void testPartitionTypeWithDroppedSourceColumn() {
+    TestTables.TestTable table =
+        TestTables.create(
+            tableDir, "test", SCHEMA, BY_DATA_CATEGORY_BUCKET_SPEC, V2_FORMAT_VERSION);
+
+    table.updateSpec().removeField("category_bucket").commit();
+    table.updateSchema().deleteColumn("category").commit();
+
+    // bucket has a fixed result type that does not depend on the dropped source column
+    assertThat(table.specs().get(0).partitionType())
+        .isEqualTo(
+            StructType.of(
+                NestedField.optional(1000, "data", Types.StringType.get()),
+                NestedField.optional(1001, "category_bucket", Types.IntegerType.get())));
+
+    table.updateSpec().removeField("data").commit();
+    table.updateSchema().deleteColumn("data").commit();
+
+    // the identity result type cannot be determined without the source column
+    assertThat(table.specs().get(0).partitionType())
+        .isEqualTo(
+            StructType.of(
+                NestedField.optional(1000, "data", Types.UnknownType.get()),
+                NestedField.optional(1001, "category_bucket", Types.IntegerType.get())));
+  }
+
+  @Test
+  public void testPartitionTypeWithUnknownTransformAndDroppedSourceColumn() {
+    // a spec written by an engine with a transform this library does not implement parses as an
+    // UnknownTransform; if the source column is also dropped, the result type stays string
+    // (UnknownTransform's fixed result type) rather than falling back to unknown
+    Schema schemaWithoutCategory =
+        new Schema(
+            required(1, "id", Types.IntegerType.get()),
+            required(2, "data", Types.StringType.get()));
+    String specJson =
+        "{\"spec-id\": 1, \"fields\": [{\"name\": \"category_custom\", "
+            + "\"transform\": \"custom\", \"source-id\": 3, \"field-id\": 1000}]}";
+    PartitionSpec spec = PartitionSpecParser.fromJson(schemaWithoutCategory, specJson);
+
+    assertThat(spec.partitionType())
+        .isEqualTo(
+            StructType.of(NestedField.optional(1000, "category_custom", Types.StringType.get())));
+  }
+
+  @Test
   public void testGroupingKeyTypeWithSpecEvolutionInV1Tables() {
     TestTables.TestTable table =
         TestTables.create(tableDir, "test", SCHEMA, BY_DATA_SPEC, V1_FORMAT_VERSION);


### PR DESCRIPTION
`PartitionSpec.partitionType()` degrades a partition field's type to `unknown` whenever the source column has been dropped from the schema, even for transforms like bucket and the date/time transforms whose result type does not depend on the source type. Substitute unknown as the source type instead and let the transform derive its result type, matching the existing behavior of javaClasses(). Identity and truncate still fall back to unknown because their result type is the source type.

Follow-up to the discussion in https://github.com/apache/iceberg/pull/16958#discussion_r3555857111
