### PR TITLE
Build: Fix PR title check allowing backport prefixes

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -34,10 +34,10 @@ jobs:
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
-          PATTERN='^(Revert ")?[A-Za-z][A-Za-z0-9._+/&,-]*( [A-Za-z0-9][A-Za-z0-9._+/&,-]*)*: .+'
+          PATTERN='^(Revert ")?(\[[0-9]+\.[0-9]+\.x\] )?[A-Za-z][A-Za-z0-9._+/&,-]*( [A-Za-z0-9][A-Za-z0-9._+/&,-]*)*: .+'
           if ! echo "$PR_TITLE" | grep -Eq "$PATTERN"; then
-            echo "::error::PR title must follow 'Module: Description' format. Got: '$PR_TITLE'"
-            echo "Examples: 'Core: Fix ...', 'Spark: Add ...', 'Flink 2.1: Add ...', 'API, Core: Update ...'"
+            echo "::error::PR title must follow '[major.minor.x] Module: Description' or 'Module: Description' format. Got: '$PR_TITLE'"
+            echo "Examples: 'Core: Fix ...', '[1.10.x] Core, Spark: Fix ...', 'Revert \"[1.10.x] Core: Fix ...\"', 'API, Core: Update ...'"
             exit 1
           fi
 


### PR DESCRIPTION
## Summary

- Allows an optional `[major.minor.x]` prefix in PR titles, such as `[1.10.x] Core, Spark: Fix ...`.
- Preserves the existing module and description validation for unprefixed and revert titles.
- Updates the validation error and examples to document the accepted backport format.

The previous pattern required the first character to start a module name, causing release-branch backport titles to fail before their module list was evaluated.

---
**AI Disclosure**
- Model: OpenAI Codex
- Platform/Tool: Codex CLI
- Human Oversight: reviewed
- Prompt Summary: Update the PR title check to accept release-branch backport prefixes.
