### PR TITLE
Docs: Fix Delta Lake migration output name

### DIFF
--- a/docs/docs/delta-lake-migration.md
+++ b/docs/docs/delta-lake-migration.md
@@ -84,7 +84,7 @@ For detailed usage and other optional configurations, please refer to the [Snaps
 #### Output
 | Output Name | Type | Description |
 | ------------|------|-------------|
-| `imported_files_count` | long | Number of files added to the new table |
+| `snapshotDataFilesCount` | long | Number of files added to the new table |
 
 #### Added Table Properties
 The following table properties are added to the Iceberg table to be created by default:


### PR DESCRIPTION
Closes #17266

## Summary

- The Output table on the Delta Lake migration page named the `snapshotDeltaLakeTable` result `imported_files_count`, a name that does not exist in the `delta-lake` module.
- `SnapshotDeltaLakeTable.Result` declares one method, `long snapshotDataFilesCount()` (`delta-lake/src/main/java/org/apache/iceberg/delta/SnapshotDeltaLakeTable.java` lines 85-91). The docs now use that name.
- `imported_files_count` is the output column of the Spark `snapshot` procedure; the row was character-identical to `docs/docs/spark-procedures.md` line 618.
- The page documents the Java API only — Usage lists Java configuration methods, Examples calls `DeltaLakeToIcebergMigrationActionsProvider` — so no SQL procedure output belongs in this table.
- The `Type` (`long`) and `Description` columns are unchanged.

## Testing done

- Docs-only change, no behavior change — no test added, no Gradle module affected.
- Verified the new name against the `SnapshotDeltaLakeTable.Result` declaration and against `BaseSnapshotDeltaLakeTableAction`, which builds the result via `snapshotDataFilesCount(totalDataFiles)`.

---

**AI Disclosure**
- Tool: Claude Code — used to review the docs and draft the fix.
