### PR TITLE
Data: Fix bounds assertions in testMaxColumnsWithDefaultOverride

### DIFF
--- a/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
+++ b/data/src/test/java/org/apache/iceberg/io/TestWriterMetrics.java
@@ -341,13 +341,17 @@ public abstract class TestWriterMetrics<T> {
     dataWriter.close();
     DataFile dataFile = dataWriter.toDataFile();
 
-    // Field should have metrics because the user set the default explicitly
+    // All fields should have metrics because the user set the default explicitly
     Map<Integer, ByteBuffer> upperBounds = dataFile.upperBounds();
-    Map<Integer, ByteBuffer> lowerBounds = dataFile.upperBounds();
-    for (int i = 0; i < numColumns; i++) {
-      assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(1)))
+    Map<Integer, ByteBuffer> lowerBounds = dataFile.lowerBounds();
+    assertThat(upperBounds).hasSize(numColumns);
+    assertThat(lowerBounds).hasSize(numColumns);
+
+    // start at 1 because IDs were reassigned in the table
+    for (int id = 1; id <= numColumns; id += 1) {
+      assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), upperBounds.get(id)))
           .isEqualTo(1);
-      assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(1)))
+      assertThat((int) Conversions.fromByteBuffer(Types.IntegerType.get(), lowerBounds.get(id)))
           .isEqualTo(1);
     }
   }


### PR DESCRIPTION

Closes #17268

## Summary

`testMaxColumnsWithDefaultOverride` claims that setting the default metrics mode explicitly bypasses the max-inferred-column limit, so all 101 columns keep metrics. It never checked that.

- Lower bounds were read from `dataFile.upperBounds()`, so `lowerBounds()` was never called.
- The loop variable was unused: both assertions hardcoded `get(1)`, so only column 1 was checked, 101 times. The other 100 could lose metrics and the test would stay green.

Fix: read lower bounds from `lowerBounds()`, assert both maps hold every column, and use the loop variable. IDs start at 1 because the table reassigns them, as in the sibling `testMaxColumns`. The size assertion mirrors `testMaxColumnsBounded`.

Test-only; unchanged since #3959.

## Testing done

`TestWriterMetrics` is abstract with no subclass in `data/`, so `:iceberg-data:test` never runs it. Verified through two of its six subclasses, covering ORC and Parquet:

- `-DflinkVersions=1.20 :iceberg-flink:iceberg-flink-1.20:test --tests "*TestFlinkWriterMetrics"` — 12 tests, 0 failures.
- `:iceberg-spark:iceberg-spark-4.1_2.13:test --tests "*TestSparkWriterMetrics"` — 12 tests, 0 failures.
- `:iceberg-data:spotlessCheck` — passed.

Suppressing the bypass in `MetricsConfig.from()` makes the new assertions fail (`Expected size: 101 but was: 100`); the old ones passed. That edit was reverted.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code and fix the test.
