### PR TITLE
Dell: Throw NoSuchNamespaceException when updating missing namespace

### DIFF
--- a/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
+++ b/dell/src/main/java/org/apache/iceberg/dell/ecs/EcsCatalog.java
@@ -362,6 +362,9 @@ public class EcsCatalog extends BaseMetastoreCatalog
 
   public boolean updateProperties(Namespace namespace, Consumer<Map<String, String>> propertiesFn)
       throws NoSuchNamespaceException {
+    if (!namespaceExists(namespace)) {
+      throw new NoSuchNamespaceException("Namespace %s does not exist", namespace);
+    }
 
     // Load old properties
     Properties oldProperties = loadProperties(namespaceURI(namespace));

--- a/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
+++ b/dell/src/test/java/org/apache/iceberg/dell/ecs/TestEcsCatalog.java
@@ -112,6 +112,19 @@ public class TestEcsCatalog {
   }
 
   @Test
+  public void namespacePropertiesOfMissingNamespace() {
+    assertThatThrownBy(
+            () -> ecsCatalog.setProperties(Namespace.of("unknown"), ImmutableMap.of("a", "a")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace unknown does not exist");
+
+    assertThatThrownBy(
+            () -> ecsCatalog.removeProperties(Namespace.of("unknown"), ImmutableSet.of("a")))
+        .isInstanceOf(NoSuchNamespaceException.class)
+        .hasMessage("Namespace unknown does not exist");
+  }
+
+  @Test
   public void testDropNamespace() {
     ecsCatalog.createNamespace(Namespace.of("a"));
     ecsCatalog.createNamespace(Namespace.of("a", "b1"));


### PR DESCRIPTION

Closes #17270

## Summary

- `EcsCatalog.setProperties()` and `removeProperties()` leaked the vendor exception `com.emc.object.s3.S3Exception` (404 `NoSuchKey`) for a missing namespace.
- Both delegate to `updateProperties()`, which called `loadProperties()` with no existence check; `loadProperties()` does not translate 404, unlike `objectMetadata()`.
- Every sibling catalog supporting namespace properties checks first — `InMemoryCatalog`, `JdbcCatalog`, `GlueCatalog` — as does `loadNamespaceMetadata()` here. `EcsCatalog` was the only leak.
- Both signatures already declare `throws NoSuchNamespaceException`. `SupportsNamespaces` marks that `@throws` `(optional)`, which permits not throwing — not leaking a vendor exception.
- `Namespace.empty()` (root) has no properties object, so it now raises `NoSuchNamespaceException` rather than `S3Exception`; only the exception type changes.

The check follows the dominant idiom in this class (`listNamespaces()`, `dropNamespace()`):

```java
if (!namespaceExists(namespace)) {
  throw new NoSuchNamespaceException("Namespace %s does not exist", namespace);
}
```

## Testing done

- Added `TestEcsCatalog#namespacePropertiesOfMissingNamespace` covering both methods; it fails on `main` with `S3Exception`.
- `./gradlew :iceberg-dell:check` — 26 tests passed.
- `dell/` is outside the published REVAPI modules, so no revapi run.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
