### PR TITLE
Arrow: Fix oversized vector allocations in vectorized reads

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -29,6 +29,7 @@ import org.apache.arrow.vector.BitVectorHelper;
 import org.apache.arrow.vector.DateDayVector;
 import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.FixedSizeBinaryVector;
+import org.apache.arrow.vector.FixedWidthVector;
 import org.apache.arrow.vector.Float4Vector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
@@ -335,7 +336,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         // and deprecated (see https://issues.apache.org/jira/browse/PARQUET-323)
         this.readType = ReadType.TIMESTAMP_INT96;
         this.vec = arrowField.createVector(rootAlloc);
-        ((BigIntVector) vec).allocateNew(batchSize);
+        ((FixedWidthVector) vec).allocateNew(batchSize);
         this.typeWidth = (int) BigIntVector.TYPE_WIDTH;
         break;
       case FLOAT:

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.Optional;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
+import org.apache.arrow.vector.BaseVariableWidthVector;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.arrow.vector.BitVector;
 import org.apache.arrow.vector.BitVectorHelper;
@@ -64,7 +65,7 @@ import org.apache.parquet.schema.PrimitiveType;
 public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
   public static final int DEFAULT_BATCH_SIZE = 5000;
   private static final Integer UNKNOWN_WIDTH = null;
-  private static final int AVERAGE_VARIABLE_WIDTH_RECORD_SIZE = 10;
+  private static final int AVERAGE_VARIABLE_WIDTH_RECORD_SIZE_BYTES = 10;
 
   private final ColumnDescriptor columnDescriptor;
   private final VectorizedColumnIterator vectorizedColumnIterator;
@@ -304,15 +305,15 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
           this.readType = ReadType.FIXED_WIDTH_BINARY;
         }
         this.vec = arrowField.createVector(rootAlloc);
-        vec.setInitialCapacity(batchSize * len);
-        vec.allocateNew();
+        ((FixedSizeBinaryVector) vec).allocateNew(batchSize);
         this.typeWidth = len;
         break;
       case BINARY:
         this.vec = arrowField.createVector(rootAlloc);
         // TODO: Possibly use the uncompressed page size info to set the initial capacity
-        vec.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
-        vec.allocateNewSafe();
+        ((BaseVariableWidthVector) vec)
+            .setInitialCapacity(batchSize, AVERAGE_VARIABLE_WIDTH_RECORD_SIZE_BYTES);
+        vec.allocateNew();
         this.readType = ReadType.VARBINARY;
         this.typeWidth = UNKNOWN_WIDTH;
         break;
@@ -332,12 +333,10 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         // Impala & Spark used to write timestamps as INT96 by default. For backwards
         // compatibility we try to read INT96 as timestamps. But INT96 is not recommended
         // and deprecated (see https://issues.apache.org/jira/browse/PARQUET-323)
-        int length = BigIntVector.TYPE_WIDTH;
         this.readType = ReadType.TIMESTAMP_INT96;
         this.vec = arrowField.createVector(rootAlloc);
-        vec.setInitialCapacity(batchSize * length);
-        vec.allocateNew();
-        this.typeWidth = length;
+        ((BigIntVector) vec).allocateNew(batchSize);
+        this.typeWidth = (int) BigIntVector.TYPE_WIDTH;
         break;
       case FLOAT:
         Field floatField =
@@ -631,8 +630,9 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     private Optional<LogicalTypeVisitorResult> allocateVectorForEnumJsonBsonString() {
       FieldVector vector = arrowField.createVector(rootAlloc);
       // TODO: Possibly use the uncompressed page size info to set the initial capacity
-      vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
-      vector.allocateNewSafe();
+      ((BaseVariableWidthVector) vector)
+          .setInitialCapacity(batchSize, AVERAGE_VARIABLE_WIDTH_RECORD_SIZE_BYTES);
+      vector.allocateNew();
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARCHAR, UNKNOWN_WIDTH));
     }
 

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestArrowReader.java
@@ -206,6 +206,31 @@ public class TestArrowReader {
     readAndCheckQueryResult(scan, 10, 12 * NUM_ROWS_PER_MONTH, ALL_COLUMNS);
   }
 
+  @Test
+  void vectorAllocationUsesBatchSizeAsValueCount() throws Exception {
+    writeTableWithIncrementalRecords();
+    Table table = tables.load(tableLocation);
+    int requestedBatchSize = 64;
+
+    try (VectorizedTableScanIterable itr =
+        new VectorizedTableScanIterable(table.newScan(), requestedBatchSize, false)) {
+      ColumnarBatch batch = itr.iterator().next();
+      VectorSchemaRoot root = batch.createVectorSchemaRootFromVectors();
+
+      assertVectorCapacity(root.getVector("string"), requestedBatchSize);
+      assertVectorCapacity(root.getVector("bytes"), requestedBatchSize);
+      assertVectorCapacity(root.getVector("uuid"), requestedBatchSize);
+      assertVectorCapacity(root.getVector("fixed"), requestedBatchSize);
+    }
+  }
+
+  private static void assertVectorCapacity(FieldVector vector, int requestedBatchSize) {
+    assertThat(vector.getValueCapacity())
+        .as("capacity for %s", vector.getName())
+        .isGreaterThanOrEqualTo(requestedBatchSize)
+        .isLessThan(requestedBatchSize * 2);
+  }
+
   /**
    * Read selected rows and all columns from the table using a time range row filter. The test
    * asserts that the Arrow {@link VectorSchemaRoot} contains the expected schema and expected


### PR DESCRIPTION
Fix Arrow vector capacity allocation in vectorized reads.

The batch size was incorrectly multiplied by the estimated or fixed type width, causing oversized allocations. This change allocates variable-width, fixed-size binary, and INT96 vectors using the requested batch row count. Added a new UT to verify this.
