### PR TITLE
GCP: Fix GCSInputStream Javadoc describing streaming uploads

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GCSInputStream.java
@@ -42,8 +42,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * The GCSInputStream leverages native streaming channels from the GCS API for streaming uploads.
- * See <a href="https://cloud.google.com/storage/docs/streaming">Streaming Transfers</a>
+ * The GCSInputStream leverages native streaming channels from the GCS API for streaming downloads.
+ * See <a href="https://cloud.google.com/storage/docs/streaming-downloads">Streaming downloads</a>
  */
 class GCSInputStream extends SeekableInputStream implements RangeReadable {
   private static final Logger LOG = LoggerFactory.getLogger(GCSInputStream.class);


### PR DESCRIPTION
## Summary

- `GCSInputStream` is read-only: it extends `SeekableInputStream`, implements `RangeReadable`, and only opens a `ReadChannel` via `storage.reader()`. Its class Javadoc described it as being for "streaming uploads", and the old link resolves to the upload docs (`/storage/docs/uploads`).
- The wording was copied from `GCSOutputStream`, added in the same commit (#3711), where "uploads" is correct — so `GCSOutputStream` is left untouched.
- Changed the text to "streaming downloads" and the link to `https://cloud.google.com/storage/docs/streaming-downloads`, whose title matches the anchor text.

## Testing done

- Javadoc wording only, no behavior change — no test added. `./gradlew :iceberg-gcp:spotlessCheck` passed.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code and correct the documentation.
