### PR TITLE
Flink: Fix RANGE distribution ignoring user-specified equality fields

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/HashKeyGenerator.java
@@ -173,7 +173,7 @@ class HashKeyGenerator {
         }
 
       case RANGE:
-        if (schema.identifierFieldIds().isEmpty()) {
+        if (equalityFields.isEmpty()) {
           LOG.warn(
               "{}: Fallback to use 'none' distribution mode, because there are no equality fields set "
                   + "and {}='range' is not supported yet in flink",

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -165,6 +165,48 @@ class TestHashKeyGenerator {
   }
 
   @Test
+  void rangeModeWithEqualityFields() throws Exception {
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    GenericRowData row1 = GenericRowData.of(1, StringData.fromString("foo"));
+    GenericRowData row2 = GenericRowData.of(1, StringData.fromString("bar"));
+    GenericRowData row3 = GenericRowData.of(2, StringData.fromString("baz"));
+    // SCHEMA has no identifier fields, so the equality fields only come from the record
+    Set<String> equalityColumns = Collections.singleton("id");
+
+    int writeKey1 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.RANGE,
+            writeParallelism,
+            equalityColumns,
+            row1);
+    int writeKey2 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.RANGE,
+            writeParallelism,
+            equalityColumns,
+            row2);
+    int writeKey3 =
+        getWriteKey(
+            generator,
+            unpartitioned,
+            DistributionMode.RANGE,
+            writeParallelism,
+            equalityColumns,
+            row3);
+
+    assertThat(writeKey1).isEqualTo(writeKey2);
+    assertThat(writeKey2).isNotEqualTo(writeKey3);
+  }
+
+  @Test
   void testHashModeWithPartitionFieldAndEqualityField() throws Exception {
     int writeParallelism = 2;
     int maxWriteParallelism = 8;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestHashKeyGenerator.java
@@ -165,7 +165,7 @@ class TestHashKeyGenerator {
   }
 
   @Test
-  void rangeModeWithEqualityFields() throws Exception {
+  void testRangeModeWithEqualityFields() throws Exception {
     int writeParallelism = 2;
     int maxWriteParallelism = 8;
     HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
@@ -204,6 +204,35 @@ class TestHashKeyGenerator {
 
     assertThat(writeKey1).isEqualTo(writeKey2);
     assertThat(writeKey2).isNotEqualTo(writeKey3);
+  }
+
+  @Test
+  void testRangeModeFallsBackToDistributionModeNone() throws Exception {
+    int writeParallelism = 2;
+    int maxWriteParallelism = 8;
+    HashKeyGenerator generator = new HashKeyGenerator(16, maxWriteParallelism);
+    Schema noIdSchema = new Schema(Types.NestedField.required(1, "x", Types.StringType.get()));
+    PartitionSpec unpartitioned = PartitionSpec.unpartitioned();
+
+    DynamicRecord record =
+        new DynamicRecord(
+            TABLE_IDENTIFIER,
+            BRANCH,
+            noIdSchema,
+            GenericRowData.of(StringData.fromString("v")),
+            unpartitioned,
+            DistributionMode.RANGE,
+            writeParallelism);
+
+    int writeKey1 = generator.generateKey(record);
+    int writeKey2 = generator.generateKey(record);
+    int writeKey3 = generator.generateKey(record);
+    assertThat(writeKey1).isNotEqualTo(writeKey2);
+    assertThat(writeKey3).isEqualTo(writeKey1);
+
+    assertThat(getSubTaskId(writeKey1, writeParallelism, maxWriteParallelism)).isEqualTo(1);
+    assertThat(getSubTaskId(writeKey2, writeParallelism, maxWriteParallelism)).isEqualTo(0);
+    assertThat(getSubTaskId(writeKey3, writeParallelism, maxWriteParallelism)).isEqualTo(1);
   }
 
   @Test


### PR DESCRIPTION

Closes #17274

## Summary

- `case RANGE` in `HashKeyGenerator.getKeySelector()` tested `schema.identifierFieldIds().isEmpty()` but passed the `equalityFields` parameter to `equalityFieldKeySelector`. Siblings `case NONE` and `case HASH` test `equalityFields.isEmpty()`; RANGE now matches.
- Previously, equality fields on a schema without identifier fields fell back to round-robin while `DynamicWriter` still emitted equality deletes for them; the `"because there are no equality fields set"` warning, left unchanged, now matches the condition.
- Backward compatible: `equalityFields` comes from `DynamicSinkUtil.resolveEqualityFieldNames(record.equalityFields(), schema)`, which falls back to `schema.identifierFieldNames()` when unset, so `equalityFields.isEmpty()` implies `schema.identifierFieldIds().isEmpty()`. `getKeySelector` is private with one caller, so only the user-specified case changes behavior.
- #16243 lifted that fallback into the caller, making the RANGE schema check redundant.

## Testing done

- Added `TestHashKeyGenerator#rangeModeWithEqualityFields` (RANGE, equality fields `{"id"}`, schema without identifier fields). Fails before the change, passes after.
- `:iceberg-flink:iceberg-flink-2.1:test --tests "*TestHashKeyGenerator*"` — 17 tests passed.
- Same task for `*TestDynamicRecordProcessor*`, `*TestDynamicWriter*`, `*TestDynamicRecordWithConfig*`, `*TestTableUpdater*` — 30 tests passed.
- `spotlessCheck`, `checkstyleMain`, `checkstyleTest` passed. The full module `:check` was not run — its MiniCluster suites do not complete here. Flink is not a REVAPI module.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
