### PR TITLE
Flink: Fix NPE in ExpireSnapshots config when retain-last is unset

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -109,16 +109,22 @@ public class ExpireSnapshots {
     }
 
     public Builder config(ExpireSnapshotsConfig expireSnapshotsConfig) {
-      return this.scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount())
+      this.scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount())
           .scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()))
           .deleteBatchSize(expireSnapshotsConfig.deleteBatchSize())
           .maxSnapshotAge(
               Optional.ofNullable(expireSnapshotsConfig.maxSnapshotAgeSeconds())
                   .map(Duration::ofSeconds)
                   .orElse(null))
-          .retainLast(expireSnapshotsConfig.retainLast())
           .cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata())
           .planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+
+      Integer retainLast = expireSnapshotsConfig.retainLast();
+      if (retainLast != null) {
+        retainLast(retainLast);
+      }
+
+      return this;
     }
 
     @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import java.time.Duration;
-import java.util.Optional;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -109,19 +108,20 @@ public class ExpireSnapshots {
     }
 
     public Builder config(ExpireSnapshotsConfig expireSnapshotsConfig) {
-      this.scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount())
-          .scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()))
-          .deleteBatchSize(expireSnapshotsConfig.deleteBatchSize())
-          .maxSnapshotAge(
-              Optional.ofNullable(expireSnapshotsConfig.maxSnapshotAgeSeconds())
-                  .map(Duration::ofSeconds)
-                  .orElse(null))
-          .cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata())
-          .planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+      scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount());
+      scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()));
+      deleteBatchSize(expireSnapshotsConfig.deleteBatchSize());
+      cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata());
+      planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
 
       Integer retainLast = expireSnapshotsConfig.retainLast();
       if (retainLast != null) {
         retainLast(retainLast);
+      }
+
+      Long maxSnapshotAgeSeconds = expireSnapshotsConfig.maxSnapshotAgeSeconds();
+      if (maxSnapshotAgeSeconds != null) {
+        maxSnapshotAge(Duration.ofSeconds(maxSnapshotAgeSeconds));
       }
 
       return this;

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.Map;
 import org.apache.flink.configuration.Configuration;
@@ -80,5 +81,13 @@ public class TestExpireSnapshotsConfig extends OperatorTestBase {
         .isEqualTo(ExpireSnapshotsConfig.DELETE_BATCH_SIZE_OPTION.defaultValue());
     assertThat(config.cleanExpiredMetadata()).isTrue();
     assertThat(config.planningWorkerPoolSize()).isEqualTo(ThreadPools.WORKER_THREAD_POOL_SIZE);
+  }
+
+  @Test
+  void configureBuilderWithoutRetainLast() {
+    ExpireSnapshotsConfig config =
+        new ExpireSnapshotsConfig(table, Maps.newHashMap(), new Configuration());
+
+    assertThatNoException().isThrownBy(() -> ExpireSnapshots.builder().config(config));
   }
 }


### PR DESCRIPTION

Closes #17275

## Summary

- `ExpireSnapshots.Builder.config()` passed the nullable `ExpireSnapshotsConfig.retainLast()` (`Integer`) to `retainLast(int)`; unboxing threw `NullPointerException` at `ExpireSnapshots.java:119`.
- `retain-last` has no default — `RETAIN_LAST_OPTION` is `.intType().noDefaultValue()` and no table property backs it. `TestExpireSnapshotsConfig` already asserts it is null by default.
- Not an edge case: `IcebergSink.java:813` calls `config()` unconditionally once `flink-maintenance.expire-snapshots.enabled` is on.
- The setter now runs only when the value is non-null, leaving `numSnapshots` (already a nullable `Integer`) unset otherwise. Same shape as the sibling `ConvertEqualityDeletes.Builder.config()` (`ConvertEqualityDeletes.java:136-144`), which guards its nullable `scheduleOnIntervalSecond()`.
- `Optional.ofNullable(...).orElse(null)`, used above for `maxSnapshotAge`, cannot work here: `retainLast` takes a primitive, so `orElse(null)` unboxes and throws anyway.
- Signatures unchanged; behavior when `retain-last` is set is identical.

```java
Integer retainLast = expireSnapshotsConfig.retainLast();
if (retainLast != null) {
  retainLast(retainLast);
}
```

## Testing done

- Added `TestExpireSnapshotsConfig#configureBuilderWithoutRetainLast`, feeding a default config into `ExpireSnapshots.builder().config(...)`. Fails with the NPE above without the fix, passes with it.
- `:iceberg-flink:iceberg-flink-2.1:test` over `TestExpireSnapshotsConfig`, `TestExpireSnapshots`, `TestConvertEqualityDeletesConfig` — 10 tests, 0 failures.
- `spotlessCheck`, `checkstyleMain`, `checkstyleTest` passed. Module-wide `:check` not run to completion locally (many MiniClusters); left to CI.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
