### PR TITLE
Hive: Do not drop an Iceberg view via dropTable

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -242,6 +242,11 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
       return false;
     }
 
+    // a view with the same name is not a table, so there is nothing to drop
+    if (viewExists(identifier)) {
+      return false;
+    }
+
     String database = identifier.namespace().level(0);
 
     TableOperations ops = newTableOps(identifier);

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCatalog.java
@@ -350,6 +350,28 @@ public class TestHiveViewCatalog extends ViewCatalogTests<HiveCatalog> {
     assertThat(catalog.viewExists(identifier)).isFalse();
   }
 
+  @Test
+  void dropTableShouldNotDropIcebergView() {
+    String dbName = "hivedb";
+    Namespace ns = Namespace.of(dbName);
+    TableIdentifier identifier = TableIdentifier.of(ns, "test_iceberg_view_drop_table");
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(identifier.namespace());
+    }
+
+    catalog
+        .buildView(identifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(ns)
+        .withQuery("hive", "select * from hivedb.tbl")
+        .create();
+
+    assertThat(catalog.dropTable(identifier, false))
+        .as("Should not drop a view via dropTable")
+        .isFalse();
+    assertThat(catalog.viewExists(identifier)).as("View should still exist").isTrue();
+  }
+
   private Table createHiveTableWithType(
       String hiveTableName, String dbName, String location, TableType type) {
     Map<String, String> parameters = Maps.newHashMap();


### PR DESCRIPTION
Closes #17278

## Summary

- `HiveCatalog.dropTable(identifier, false)` silently drops an Iceberg view and returns `true`: the only view check (`ops.current()`) is inside the `if (purge)` branch, and HMS `drop_table` does not distinguish tables from views. This breaks the `Catalog.dropTable` contract ("false if the table did not exist") and contradicts `tableExists(viewId)`.
- Adds a `viewExists` guard at the entry point, reusing `registerTable`'s check (line 943-949); `dropTable` was the only path missing it.
- **`purge=true` also changes**: returns `false` instead of propagating `NoSuchTableException`. Intentional — the guard is outside the `purge` branch, and the method already maps that exception to `false` (line 278-280).
- **Iceberg views only** — non-Iceberg `VIRTUAL_VIEW`s are still dropped (out of scope).
- **Costs one extra HMS `getTable`**, a tradeoff `registerTable` accepts.
- `InMemoryCatalog`, `JdbcCatalog`, and REST already return `false` here; Hive diverges only because HMS keeps tables and views in one namespace. `NoSuchTableException` is the alternative, but `false` matches the Javadoc and every sibling.

## Testing done

- Added `TestHiveViewCatalog#dropTableShouldNotDropIcebergView`, asserting the view survives. Fails on `main` (returns `true`, view dropped), passes here.
- `./gradlew :iceberg-hive-metastore:check` — 309 tests passed.
- Not a REVAPI module; signatures unchanged.

---

**AI Disclosure**
- Tool: Claude Code — used to analyze the code, implement the fix, and write the test.
