### PR TITLE
Flink: BackPort Fix TableMaintenance operator uid instability that breaks savepoint restore to 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -153,7 +152,7 @@ public class TableMaintenance {
     private final List<MaintenanceTaskBuilder<?>> taskBuilders;
     private final TriggerLockFactory lockFactory;
 
-    private String uidSuffix = "TableMaintenance-" + UUID.randomUUID();
+    private String uidSuffix = null;
     private String slotSharingGroup = null;
     private Duration rateLimit = Duration.ofSeconds(RATE_LIMIT_SECOND_DEFAULT);
     private Duration lockCheckDelay = Duration.ofSeconds(LOCK_CHECK_DELAY_SECOND_DEFAULT);
@@ -267,7 +266,6 @@ public class TableMaintenance {
     /** Builds the task graph for the maintenance tasks. */
     public void append() throws IOException {
       Preconditions.checkArgument(!taskBuilders.isEmpty(), "Provide at least one task");
-      Preconditions.checkNotNull(uidSuffix, "Uid suffix should no be null");
 
       List<String> taskNames = Lists.newArrayListWithCapacity(taskBuilders.size());
       List<TriggerEvaluator> evaluators = Lists.newArrayListWithCapacity(taskBuilders.size());
@@ -279,6 +277,10 @@ public class TableMaintenance {
       try (TableLoader loader = tableLoader.clone()) {
         loader.open();
         String tableName = loader.loadTable().name();
+        if (uidSuffix == null) {
+          this.uidSuffix = "TableMaintenance-" + tableName;
+        }
+
         DataStream<Trigger> triggers;
         if (lockFactory == null) {
           triggers =

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -351,6 +351,48 @@ class TestTableMaintenance extends OperatorTestBase {
   }
 
   @Test
+  void testUidSuffixUserProvidedIsUsedAsIs() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .uidSuffix(UID_SUFFIX)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .append();
+
+    String tableName = table.name();
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid())
+        .isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + UID_SUFFIX)
+        .doesNotContain(tableName);
+  }
+
+  @Test
+  void testUidSuffixDefaultContainsTableName() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .add(new MaintenanceTaskBuilderForTest(false).scheduleOnCommitCount(2))
+        .append();
+
+    String tableName = table.name();
+    String expectedSuffix = "TableMaintenance-" + tableName;
+
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid()).isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + expectedSuffix);
+  }
+
+  @Test
   void testMonitorRatePerSecond() {
     // Sub-second rate limits must not yield infinite (unthrottled) monitor rates.
     assertThat(TableMaintenance.Builder.monitorRatePerSecond(50)).isEqualTo(20.0);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/TableMaintenance.java
@@ -23,7 +23,6 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.annotation.VisibleForTesting;
@@ -153,7 +152,7 @@ public class TableMaintenance {
     private final List<MaintenanceTaskBuilder<?>> taskBuilders;
     private final TriggerLockFactory lockFactory;
 
-    private String uidSuffix = "TableMaintenance-" + UUID.randomUUID();
+    private String uidSuffix = null;
     private String slotSharingGroup = null;
     private Duration rateLimit = Duration.ofSeconds(RATE_LIMIT_SECOND_DEFAULT);
     private Duration lockCheckDelay = Duration.ofSeconds(LOCK_CHECK_DELAY_SECOND_DEFAULT);
@@ -267,7 +266,6 @@ public class TableMaintenance {
     /** Builds the task graph for the maintenance tasks. */
     public void append() throws IOException {
       Preconditions.checkArgument(!taskBuilders.isEmpty(), "Provide at least one task");
-      Preconditions.checkNotNull(uidSuffix, "Uid suffix should no be null");
 
       List<String> taskNames = Lists.newArrayListWithCapacity(taskBuilders.size());
       List<TriggerEvaluator> evaluators = Lists.newArrayListWithCapacity(taskBuilders.size());
@@ -279,6 +277,10 @@ public class TableMaintenance {
       try (TableLoader loader = tableLoader.clone()) {
         loader.open();
         String tableName = loader.loadTable().name();
+        if (uidSuffix == null) {
+          this.uidSuffix = "TableMaintenance-" + tableName;
+        }
+
         DataStream<Trigger> triggers;
         if (lockFactory == null) {
           triggers =

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestTableMaintenance.java
@@ -351,6 +351,48 @@ class TestTableMaintenance extends OperatorTestBase {
   }
 
   @Test
+  void testUidSuffixUserProvidedIsUsedAsIs() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .uidSuffix(UID_SUFFIX)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .append();
+
+    String tableName = table.name();
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid())
+        .isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + UID_SUFFIX)
+        .doesNotContain(tableName);
+  }
+
+  @Test
+  void testUidSuffixDefaultContainsTableName() throws IOException {
+    TableMaintenance.forChangeStream(
+            new ManualSource<>(env, TypeInformation.of(TableChange.class)).dataStream(),
+            tableLoader(),
+            LOCK_FACTORY)
+        .add(new MaintenanceTaskBuilderForTest(true).scheduleOnCommitCount(1))
+        .add(new MaintenanceTaskBuilderForTest(false).scheduleOnCommitCount(2))
+        .append();
+
+    String tableName = table.name();
+    String expectedSuffix = "TableMaintenance-" + tableName;
+
+    Transformation<?> triggerManager =
+        env.getTransformations().stream()
+            .filter(t -> t.getName().equals(TRIGGER_MANAGER_OPERATOR_NAME))
+            .findFirst()
+            .orElseThrow();
+    assertThat(triggerManager.getUid()).isEqualTo(TRIGGER_MANAGER_OPERATOR_NAME + expectedSuffix);
+  }
+
+  @Test
   void testMonitorRatePerSecond() {
     // Sub-second rate limits must not yield infinite (unthrottled) monitor rates.
     assertThat(TableMaintenance.Builder.monitorRatePerSecond(50)).isEqualTo(20.0);


### PR DESCRIPTION
Clean BackPort for https://github.com/apache/iceberg/pull/17210