### PR TITLE
Spark 4.1: Vectorize geometry and geography Parquet reads

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/ArrowSchemaUtil.java
@@ -131,6 +131,8 @@ public class ArrowSchemaUtil {
 
       switch (primitive.typeId()) {
         case BINARY:
+        case GEOMETRY:
+        case GEOGRAPHY:
           arrowType = ArrowType.Binary.INSTANCE;
           break;
         case FIXED:

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -636,6 +636,14 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARCHAR, UNKNOWN_WIDTH));
     }
 
+    private Optional<LogicalTypeVisitorResult> allocateVectorForBinaryLogicalType() {
+      FieldVector vector = arrowField.createVector(rootAlloc);
+      // TODO: Possibly use the uncompressed page size info to set the initial capacity
+      vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
+      vector.allocateNewSafe();
+      return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARBINARY, UNKNOWN_WIDTH));
+    }
+
     @Override
     public Optional<LogicalTypeVisitorResult> visit(
         LogicalTypeAnnotation.JsonLogicalTypeAnnotation jsonLogicalType) {
@@ -646,6 +654,18 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
     public Optional<LogicalTypeVisitorResult> visit(
         LogicalTypeAnnotation.BsonLogicalTypeAnnotation bsonLogicalType) {
       return allocateVectorForEnumJsonBsonString();
+    }
+
+    @Override
+    public Optional<LogicalTypeVisitorResult> visit(
+        LogicalTypeAnnotation.GeometryLogicalTypeAnnotation geometryLogicalType) {
+      return allocateVectorForBinaryLogicalType();
+    }
+
+    @Override
+    public Optional<LogicalTypeVisitorResult> visit(
+        LogicalTypeAnnotation.GeographyLogicalTypeAnnotation geographyLogicalType) {
+      return allocateVectorForBinaryLogicalType();
     }
   }
 

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -310,8 +310,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         break;
       case BINARY:
         this.vec = arrowField.createVector(rootAlloc);
-        // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata
-        // to set the initial capacity.
+        // TODO(apache/iceberg#17305): Use uncompressed size metadata to set the initial capacity.
         vec.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
         vec.allocateNewSafe();
         this.readType = ReadType.VARBINARY;
@@ -631,8 +630,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     private Optional<LogicalTypeVisitorResult> allocateVectorForEnumJsonBsonString() {
       FieldVector vector = arrowField.createVector(rootAlloc);
-      // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata to
-      // set the initial capacity.
+      // TODO(apache/iceberg#17305): Use uncompressed size metadata to set the initial capacity.
       vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
       vector.allocateNewSafe();
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARCHAR, UNKNOWN_WIDTH));
@@ -640,8 +638,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     private Optional<LogicalTypeVisitorResult> allocateVectorForBinaryLogicalType() {
       FieldVector vector = arrowField.createVector(rootAlloc);
-      // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata to
-      // set the initial capacity.
+      // TODO(apache/iceberg#17305): Use uncompressed size metadata to set the initial capacity.
       vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
       vector.allocateNewSafe();
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARBINARY, UNKNOWN_WIDTH));

--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -310,7 +310,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         break;
       case BINARY:
         this.vec = arrowField.createVector(rootAlloc);
-        // TODO: Possibly use the uncompressed page size info to set the initial capacity
+        // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata
+        // to set the initial capacity.
         vec.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
         vec.allocateNewSafe();
         this.readType = ReadType.VARBINARY;
@@ -630,7 +631,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     private Optional<LogicalTypeVisitorResult> allocateVectorForEnumJsonBsonString() {
       FieldVector vector = arrowField.createVector(rootAlloc);
-      // TODO: Possibly use the uncompressed page size info to set the initial capacity
+      // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata to
+      // set the initial capacity.
       vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
       vector.allocateNewSafe();
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARCHAR, UNKNOWN_WIDTH));
@@ -638,7 +640,8 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
 
     private Optional<LogicalTypeVisitorResult> allocateVectorForBinaryLogicalType() {
       FieldVector vector = arrowField.createVector(rootAlloc);
-      // TODO: Possibly use the uncompressed page size info to set the initial capacity
+      // TODO(https://github.com/apache/iceberg/issues/17305): Use uncompressed size metadata to
+      // set the initial capacity.
       vector.setInitialCapacity(batchSize * AVERAGE_VARIABLE_WIDTH_RECORD_SIZE);
       vector.allocateNewSafe();
       return Optional.of(new LogicalTypeVisitorResult(vector, ReadType.VARBINARY, UNKNOWN_WIDTH));

--- a/arrow/src/test/java/org/apache/iceberg/arrow/TestArrowSchemaUtil.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/TestArrowSchemaUtil.java
@@ -59,6 +59,8 @@ public class TestArrowSchemaUtil {
   private static final String LIST_FIELD = "lt";
   private static final String MAP_FIELD = "mt";
   private static final String UUID_FIELD = "uu";
+  private static final String GEOMETRY_FIELD = "geom";
+  private static final String GEOGRAPHY_FIELD = "geog";
 
   @Test
   public void convertPrimitive() {
@@ -84,7 +86,9 @@ public class TestArrowSchemaUtil {
             Types.NestedField.optional(17, FIXED_WIDTH_BINARY_FIELD, Types.FixedType.ofLength(10)),
             Types.NestedField.optional(18, UUID_FIELD, Types.UUIDType.get()),
             Types.NestedField.optional(
-                19, TIMESTAMP_NANO_FIELD, Types.TimestampNanoType.withZone()));
+                19, TIMESTAMP_NANO_FIELD, Types.TimestampNanoType.withZone()),
+            Types.NestedField.optional(20, GEOMETRY_FIELD, Types.GeometryType.of("EPSG:3857")),
+            Types.NestedField.optional(21, GEOGRAPHY_FIELD, Types.GeographyType.crs84()));
 
     org.apache.arrow.vector.types.pojo.Schema arrow = ArrowSchemaUtil.convert(iceberg);
 
@@ -245,6 +249,14 @@ public class TestArrowSchemaUtil {
         break;
       case BINARY:
         assertThat(field.getName()).isEqualTo(BINARY_FIELD);
+        assertThat(arrowType.getTypeID()).isEqualTo(ArrowType.Binary.TYPE_TYPE);
+        break;
+      case GEOMETRY:
+        assertThat(field.getName()).isEqualTo(GEOMETRY_FIELD);
+        assertThat(arrowType.getTypeID()).isEqualTo(ArrowType.Binary.TYPE_TYPE);
+        break;
+      case GEOGRAPHY:
+        assertThat(field.getName()).isEqualTo(GEOGRAPHY_FIELD);
         assertThat(arrowType.getTypeID()).isEqualTo(ArrowType.Binary.TYPE_TYPE);
         break;
       case DECIMAL:

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorBuilder.java
@@ -40,6 +40,10 @@ class ColumnVectorBuilder {
       } else {
         throw new IllegalStateException("Unknown dummy vector holder: " + holder);
       }
+    } else if (holder.icebergType().typeId() == Type.TypeID.GEOMETRY) {
+      return new GeometryArrowColumnVector(holder);
+    } else if (holder.icebergType().typeId() == Type.TypeID.GEOGRAPHY) {
+      return new GeographyArrowColumnVector(holder);
     } else {
       return new IcebergArrowColumnVector(holder);
     }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/ColumnVectorWithFilter.java
@@ -24,6 +24,8 @@ import org.apache.spark.sql.types.VariantType;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -131,6 +133,16 @@ public class ColumnVectorWithFilter extends ColumnVector {
   @Override
   public byte[] getBinary(int rowId) {
     return delegate.getBinary(rowIdMapping[rowId]);
+  }
+
+  @Override
+  public GeographyVal getGeography(int rowId) {
+    return delegate.getGeography(rowIdMapping[rowId]);
+  }
+
+  @Override
+  public GeometryVal getGeometry(int rowId) {
+    return delegate.getGeometry(rowIdMapping[rowId]);
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/GeographyArrowColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/GeographyArrowColumnVector.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.arrow.vectorized.VectorHolder;
+import org.apache.spark.sql.catalyst.util.STUtils;
+import org.apache.spark.unsafe.types.GeographyVal;
+
+class GeographyArrowColumnVector extends IcebergArrowColumnVector {
+
+  GeographyArrowColumnVector(VectorHolder holder) {
+    super(holder);
+  }
+
+  @Override
+  public GeographyVal getGeography(int rowId) {
+    byte[] wkb = getBinary(rowId);
+    return wkb == null ? null : STUtils.stGeogFromWKB(wkb);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/GeometryArrowColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/GeometryArrowColumnVector.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.arrow.vectorized.VectorHolder;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.util.STUtils;
+import org.apache.spark.sql.types.GeometryType$;
+import org.apache.spark.unsafe.types.GeometryVal;
+
+class GeometryArrowColumnVector extends IcebergArrowColumnVector {
+  private final int srid;
+
+  GeometryArrowColumnVector(VectorHolder holder) {
+    super(holder);
+    Types.GeometryType geometryType = (Types.GeometryType) holder.icebergType();
+    this.srid = GeometryType$.MODULE$.apply(geometryType.crs()).srid();
+  }
+
+  @Override
+  public GeometryVal getGeometry(int rowId) {
+    byte[] wkb = getBinary(rowId);
+    return wkb == null ? null : STUtils.stGeomFromWKB(wkb, srid);
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
@@ -22,11 +22,17 @@ import org.apache.iceberg.arrow.vectorized.ArrowVectorAccessor;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.iceberg.arrow.vectorized.VectorHolder;
 import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.vectorized.ArrowColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -39,11 +45,13 @@ public class IcebergArrowColumnVector extends ColumnVector {
 
   private final ArrowVectorAccessor<Decimal, UTF8String, ColumnarArray, ArrowColumnVector> accessor;
   private final NullabilityHolder nullabilityHolder;
+  private final Integer geometrySrid;
 
   public IcebergArrowColumnVector(VectorHolder holder) {
     super(SparkSchemaUtil.convert(holder.icebergType()));
     this.nullabilityHolder = holder.nullabilityHolder();
     this.accessor = ArrowVectorAccessors.getVectorAccessor(holder);
+    this.geometrySrid = geometrySrid(holder.icebergType());
   }
 
   protected ArrowVectorAccessor<Decimal, UTF8String, ColumnarArray, ArrowColumnVector> accessor() {
@@ -150,6 +158,33 @@ public class IcebergArrowColumnVector extends ColumnVector {
       return null;
     }
     return accessor.getBinary(rowId);
+  }
+
+  @Override
+  public GeographyVal getGeography(int rowId) {
+    if (isNullAt(rowId)) {
+      return null;
+    }
+
+    return STUtils.stGeogFromWKB(accessor.getBinary(rowId));
+  }
+
+  @Override
+  public GeometryVal getGeometry(int rowId) {
+    if (isNullAt(rowId)) {
+      return null;
+    }
+
+    return STUtils.stGeomFromWKB(accessor.getBinary(rowId), geometrySrid);
+  }
+
+  private static Integer geometrySrid(Type type) {
+    if (type.typeId() != Type.TypeID.GEOMETRY) {
+      return null;
+    }
+
+    Types.GeometryType geometryType = (Types.GeometryType) type;
+    return GeometryType$.MODULE$.apply(geometryType.crs()).srid();
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/IcebergArrowColumnVector.java
@@ -22,17 +22,11 @@ import org.apache.iceberg.arrow.vectorized.ArrowVectorAccessor;
 import org.apache.iceberg.arrow.vectorized.NullabilityHolder;
 import org.apache.iceberg.arrow.vectorized.VectorHolder;
 import org.apache.iceberg.spark.SparkSchemaUtil;
-import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
-import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.Decimal;
-import org.apache.spark.sql.types.GeometryType$;
 import org.apache.spark.sql.vectorized.ArrowColumnVector;
 import org.apache.spark.sql.vectorized.ColumnVector;
 import org.apache.spark.sql.vectorized.ColumnarArray;
 import org.apache.spark.sql.vectorized.ColumnarMap;
-import org.apache.spark.unsafe.types.GeographyVal;
-import org.apache.spark.unsafe.types.GeometryVal;
 import org.apache.spark.unsafe.types.UTF8String;
 
 /**
@@ -45,13 +39,11 @@ public class IcebergArrowColumnVector extends ColumnVector {
 
   private final ArrowVectorAccessor<Decimal, UTF8String, ColumnarArray, ArrowColumnVector> accessor;
   private final NullabilityHolder nullabilityHolder;
-  private final Integer geometrySrid;
 
   public IcebergArrowColumnVector(VectorHolder holder) {
     super(SparkSchemaUtil.convert(holder.icebergType()));
     this.nullabilityHolder = holder.nullabilityHolder();
     this.accessor = ArrowVectorAccessors.getVectorAccessor(holder);
-    this.geometrySrid = geometrySrid(holder.icebergType());
   }
 
   protected ArrowVectorAccessor<Decimal, UTF8String, ColumnarArray, ArrowColumnVector> accessor() {
@@ -158,33 +150,6 @@ public class IcebergArrowColumnVector extends ColumnVector {
       return null;
     }
     return accessor.getBinary(rowId);
-  }
-
-  @Override
-  public GeographyVal getGeography(int rowId) {
-    if (isNullAt(rowId)) {
-      return null;
-    }
-
-    return STUtils.stGeogFromWKB(accessor.getBinary(rowId));
-  }
-
-  @Override
-  public GeometryVal getGeometry(int rowId) {
-    if (isNullAt(rowId)) {
-      return null;
-    }
-
-    return STUtils.stGeomFromWKB(accessor.getBinary(rowId), geometrySrid);
-  }
-
-  private static Integer geometrySrid(Type type) {
-    if (type.typeId() != Type.TypeID.GEOMETRY) {
-      return null;
-    }
-
-    Types.GeometryType geometryType = (Types.GeometryType) type;
-    return GeometryType$.MODULE$.apply(geometryType.crs()).srid();
   }
 
   @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -154,8 +154,7 @@ class SparkBatch implements Batch {
 
   // conditions for using Parquet batch reads:
   // - Parquet vectorization is enabled
-  // - only primitives, unshredded variant, or metadata columns are projected, excluding geometry
-  //   and geography which are primitives with no Arrow vector yet
+  // - only primitives, unshredded variant, or metadata columns are projected
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()
@@ -194,12 +193,6 @@ class SparkBatch implements Batch {
     }
 
     Type type = field.type();
-    // Geometry and geography are primitive types but have no Arrow vector yet, so they must be
-    // read through the non-vectorized reader.
-    if (type.typeId() == Type.TypeID.GEOMETRY || type.typeId() == Type.TypeID.GEOGRAPHY) {
-      return false;
-    }
-
     if (type.isVariantType()) {
       boolean shredVariants =
           PropertyUtil.propertyAsBoolean(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/TestColumnVectorWithFilter.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.spark.sql.types.DataTypes;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.junit.jupiter.api.Test;
+
+public class TestColumnVectorWithFilter {
+
+  @Test
+  public void testGeospatialAccessorsUseMappedRowId() {
+    ColumnVector delegate = mock(ColumnVector.class);
+    when(delegate.dataType()).thenReturn(DataTypes.BinaryType);
+
+    ColumnVector filtered = new ColumnVectorWithFilter(delegate, new int[] {2, 0});
+    filtered.getGeometry(0);
+    filtered.getGeography(1);
+
+    verify(delegate).getGeometry(2);
+    verify(delegate).getGeography(0);
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -31,6 +31,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Iterator;
@@ -42,6 +43,7 @@ import org.apache.arrow.memory.BufferAllocator;
 import org.apache.iceberg.Files;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.arrow.ArrowAllocation;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.data.parquet.GenericParquetReaders;
@@ -66,17 +68,22 @@ import org.apache.iceberg.spark.data.vectorized.VectorizedSparkParquetReaders;
 import org.apache.iceberg.types.Type.PrimitiveType;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.RandomUtil;
 import org.apache.parquet.column.ParquetProperties;
 import org.apache.parquet.hadoop.ParquetOutputFormat;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.Type;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestParquetVectorizedReads extends AvroDataTestBase {
   private static final int NUM_ROWS = 200_000;
@@ -362,6 +369,78 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
         0L,
         RandomData.DEFAULT_NULL_PERCENTAGE,
         false);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testGeospatialTypes(boolean dictionaryEnabled) throws IOException {
+    Schema schema =
+        new Schema(
+            required(1, "id", Types.LongType.get()),
+            optional(2, "geom", Types.GeometryType.of("EPSG:3857")),
+            optional(3, "geog", Types.GeographyType.crs84()));
+
+    ByteBuffer geometryWkb = ByteBuffer.wrap(RandomUtil.wkbPoint(30, 10));
+    ByteBuffer geographyWkb = ByteBuffer.wrap(RandomUtil.wkbPoint(-71, 42));
+    GenericRecord first = GenericRecord.create(schema);
+    first.setField("id", 1L);
+    first.setField("geom", geometryWkb);
+    first.setField("geog", geographyWkb);
+    GenericRecord nulls = GenericRecord.create(schema);
+    nulls.setField("id", 2L);
+    GenericRecord repeated = GenericRecord.create(schema);
+    repeated.setField("id", 3L);
+    repeated.setField("geom", geometryWkb);
+    repeated.setField("geog", geographyWkb);
+
+    File dataFile = temp.resolve("geo-" + dictionaryEnabled + ".parquet").toFile();
+    try (FileAppender<Record> writer =
+        Parquet.write(Files.localOutput(dataFile))
+            .schema(schema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(ParquetOutputFormat.ENABLE_DICTIONARY, String.valueOf(dictionaryEnabled))
+            .build()) {
+      writer.add(first);
+      writer.add(nulls);
+      writer.add(repeated);
+    }
+
+    assertNoLeak(
+        dataFile.getName(),
+        allocator -> {
+          try (CloseableIterable<ColumnarBatch> reader =
+              Parquet.read(Files.localInput(dataFile))
+                  .project(schema)
+                  .recordsPerBatch(BATCH_SIZE)
+                  .createBatchedReaderFunc(
+                      type ->
+                          VectorizedSparkParquetReaders.buildReader(
+                              schema, type, ImmutableMap.of(), allocator))
+                  .build()) {
+            Iterator<ColumnarBatch> batches = reader.iterator();
+            assertThat(batches).hasNext();
+            ColumnarBatch batch = batches.next();
+            assertThat(batch.numRows()).isEqualTo(3);
+
+            GeometryVal geometry = batch.column(1).getGeometry(0);
+            assertThat(STUtils.stAsBinary(geometry)).isEqualTo(geometryWkb.array());
+            assertThat(STUtils.stSrid(geometry)).isEqualTo(3857);
+
+            GeographyVal geography = batch.column(2).getGeography(0);
+            assertThat(STUtils.stAsBinary(geography)).isEqualTo(geographyWkb.array());
+            assertThat(STUtils.stSrid(geography)).isEqualTo(4326);
+
+            assertThat(batch.column(1).isNullAt(1)).isTrue();
+            assertThat(batch.column(2).isNullAt(1)).isTrue();
+            assertThat(STUtils.stAsBinary(batch.column(1).getGeometry(2)))
+                .isEqualTo(geometryWkb.array());
+            assertThat(STUtils.stAsBinary(batch.column(2).getGeography(2)))
+                .isEqualTo(geographyWkb.array());
+            assertThat(batches).isExhausted();
+          } catch (IOException e) {
+            throw new RuntimeException(e);
+          }
+        });
   }
 
   @Test

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/vectorized/parquet/TestParquetVectorizedReads.java
@@ -83,7 +83,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestParquetVectorizedReads extends AvroDataTestBase {
   private static final int NUM_ROWS = 200_000;
@@ -371,13 +370,24 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
         false);
   }
 
-  @ParameterizedTest
-  @ValueSource(booleans = {false, true})
-  public void testGeospatialTypes(boolean dictionaryEnabled) throws IOException {
+  static Stream<Arguments> geospatialTypes() {
+    return Stream.of(false, true)
+        .flatMap(
+            dictionaryEnabled ->
+                Stream.of(
+                    Arguments.of(dictionaryEnabled, "SRID:0", 0),
+                    Arguments.of(dictionaryEnabled, "EPSG:3857", 3857),
+                    Arguments.of(dictionaryEnabled, "OGC:CRS84", 4326)));
+  }
+
+  @ParameterizedTest(name = "dictionary = {0}, geometry CRS = {1}")
+  @MethodSource("geospatialTypes")
+  public void testGeospatialTypes(
+      boolean dictionaryEnabled, String geometryCrs, int expectedGeometrySrid) throws IOException {
     Schema schema =
         new Schema(
             required(1, "id", Types.LongType.get()),
-            optional(2, "geom", Types.GeometryType.of("EPSG:3857")),
+            optional(2, "geom", Types.GeometryType.of(geometryCrs)),
             optional(3, "geog", Types.GeographyType.crs84()));
 
     ByteBuffer geometryWkb = ByteBuffer.wrap(RandomUtil.wkbPoint(30, 10));
@@ -393,7 +403,9 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
     repeated.setField("geom", geometryWkb);
     repeated.setField("geog", geographyWkb);
 
-    File dataFile = temp.resolve("geo-" + dictionaryEnabled + ".parquet").toFile();
+    File dataFile =
+        temp.resolve(String.format("geo-%s-%s.parquet", dictionaryEnabled, expectedGeometrySrid))
+            .toFile();
     try (FileAppender<Record> writer =
         Parquet.write(Files.localOutput(dataFile))
             .schema(schema)
@@ -424,7 +436,7 @@ public class TestParquetVectorizedReads extends AvroDataTestBase {
 
             GeometryVal geometry = batch.column(1).getGeometry(0);
             assertThat(STUtils.stAsBinary(geometry)).isEqualTo(geometryWkb.array());
-            assertThat(STUtils.stSrid(geometry)).isEqualTo(3857);
+            assertThat(STUtils.stSrid(geometry)).isEqualTo(expectedGeometrySrid);
 
             GeographyVal geography = batch.column(2).getGeography(0);
             assertThat(STUtils.stAsBinary(geography)).isEqualTo(geographyWkb.array());

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -80,8 +80,7 @@ public class TestSparkGeospatial extends TestBase {
   @ParameterizedTest
   @ValueSource(booleans = {false, true})
   public void testGeospatialWkbReadBack(boolean vectorized) {
-    // Even with vectorization enabled, geo columns fall back to the non-vectorized reader (there is
-    // no Arrow geo vector yet), so both settings read back correctly.
+    // Exercise both row and vectorized readers; both attach the schema SRID to the stored WKB.
     setVectorization(vectorized);
 
     // st_asbinary strips the SRID header back to pure WKB, matching what was inserted.
@@ -105,10 +104,9 @@ public class TestSparkGeospatial extends TestBase {
   public void testDeleteGeospatial(String mode, boolean vectorized) {
     // Exercise both row-level modes: copy-on-write (the default) rewrites the surviving rows into a
     // new data file, while merge-on-read writes a deletion vector. Both must read the geo values
-    // back out correctly, whether or not vectorized reads are requested (geo falls back to the
-    // non-vectorized reader either way). Write both rows into one data file (COALESCE(1)) so the
-    // merge-on-read delete leaves a survivor in that file, forcing a deletion vector rather than a
-    // whole-file removal. Filter on id since Spark has no spatial predicate.
+    // back out correctly through row and vectorized readers. Write both rows into one data file
+    // (COALESCE(1)) so the merge-on-read delete leaves a survivor in that file, forcing a deletion
+    // vector rather than a whole-file removal. Filter on id since Spark has no spatial predicate.
     String deleteTable = CATALOG + ".default.geo_delete";
     sql("DROP TABLE IF EXISTS %s", deleteTable);
     sql(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkGeospatial.java
@@ -110,27 +110,34 @@ public class TestSparkGeospatial extends TestBase {
     String deleteTable = CATALOG + ".default.geo_delete";
     sql("DROP TABLE IF EXISTS %s", deleteTable);
     sql(
-        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(4326), geog GEOGRAPHY(4326)) USING iceberg "
+        "CREATE TABLE %s (id BIGINT, geom GEOMETRY(3857), geog GEOGRAPHY(4326)) USING iceberg "
             + "TBLPROPERTIES ('format-version'='3', 'write.delete.mode'='%s', "
             + "'read.parquet.vectorization.enabled'='%s')",
         deleteTable, mode, vectorized);
     sql(
         "INSERT INTO %s SELECT /*+ COALESCE(1) */ id, "
             + "CASE WHEN geom_wkb IS NULL THEN NULL "
-            + "ELSE st_setsrid(st_geomfromwkb(geom_wkb), 4326) END, "
+            + "ELSE st_setsrid(st_geomfromwkb(geom_wkb), 3857) END, "
             + "CASE WHEN geog_wkb IS NULL THEN NULL "
             + "ELSE st_setsrid(st_geogfromwkb(geog_wkb), 4326) END "
-            + "FROM VALUES (1, X'%s', X'%s'), (2, CAST(NULL AS BINARY), CAST(NULL AS BINARY)) "
+            + "FROM VALUES (1, CAST(NULL AS BINARY), CAST(NULL AS BINARY)), (2, X'%s', X'%s') "
             + "AS v(id, geom_wkb, geog_wkb)",
         deleteTable, GEOM_WKB, GEOG_WKB);
 
     sql("DELETE FROM %s WHERE id = 1", deleteTable);
 
     assertEquals(
-        "Only the null-geo row should remain after the delete",
-        ImmutableList.of(row(2L, null, null)),
+        "The surviving geo row should retain its WKB and SRIDs after the delete",
+        ImmutableList.of(
+            row(
+                2L,
+                GEOM_WKB.toUpperCase(Locale.ROOT),
+                3857,
+                GEOG_WKB.toUpperCase(Locale.ROOT),
+                4326)),
         sql(
-            "SELECT id, hex(st_asbinary(geom)), hex(st_asbinary(geog)) FROM %s ORDER BY id",
+            "SELECT id, hex(st_asbinary(geom)), st_srid(geom), "
+                + "hex(st_asbinary(geog)), st_srid(geog) FROM %s ORDER BY id",
             deleteTable));
 
     // A merge-on-read delete of a row from a multi-row file writes a deletion vector (format v3),


### PR DESCRIPTION
## Summary

Spark 4.1 currently falls back to the row reader whenever a projection contains a geometry or geography column, even when Parquet vectorization is enabled. This adds vectorized Geo reads without introducing a GeoArrow representation: Iceberg continues to store pure WKB, Arrow carries it in variable-width binary vectors, and the Spark column-vector boundary reconstructs `GeometryVal`/`GeographyVal`. Geometry values receive the SRID derived from the Iceberg schema CRS.

- Map Iceberg geometry and geography primitives to Arrow binary fields and read their Parquet logical annotations through the existing `VARBINARY` batch path.
- Restore typed Spark Geo values through dedicated geometry/geography column vectors, including non-default geometry SRIDs, while keeping `IcebergArrowColumnVector` type-agnostic.
- Forward typed Geo accessors through `ColumnVectorWithFilter`, so deletion-vector row remapping preserves WKB and SRID.
- Allow `SparkBatch` to select columnar Parquet reads for top-level Geo primitives.
- Cover dictionary-enabled and plain pages, null values, WKB round trips, geometry CRS/SRID mappings for SRID:0, EPSG:3857, and OGC:CRS84, CRS84 geography, and a format-v3 deletion-vector scan with a non-null EPSG:3857 survivor.

Nested structs remain on the existing row-reader fallback because nested vectorized reads are outside this change. The Parquet representation remains byte-identical WKB, and this does not add spatial parsing or bbox behavior to the reader.

## Test Plan

- [x] Arrow schema conversion test for geometry and geography
- [x] Direct Spark batched-reader test with dictionary enabled and disabled
- [x] Deletion-filter row-ID remapping test for typed Geo accessors
- [x] Full Spark Geo SQL/DML suite with vectorization on and off, including a real v3 deletion vector
- [x] Arrow and Spark 4.1 Spotless checks

## Verification Commands

```bash
./gradlew :iceberg-arrow:test --tests org.apache.iceberg.arrow.TestArrowSchemaUtil
./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:test \
  --tests org.apache.iceberg.spark.data.vectorized.parquet.TestParquetVectorizedReads.testGeospatialTypes \
  --tests org.apache.iceberg.spark.data.vectorized.TestColumnVectorWithFilter \
  --tests org.apache.iceberg.spark.sql.TestSparkGeospatial
./gradlew :iceberg-arrow:spotlessCheck \
  :iceberg-spark:iceberg-spark-4.1_2.13:spotlessCheck
```
