### PR TITLE
REST: Add data sequence number to scan tasks

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -48,6 +48,7 @@ public class ContentFileParser {
   private static final String EQUALITY_IDS = "equality-ids";
   private static final String SORT_ORDER_ID = "sort-order-id";
   private static final String FIRST_ROW_ID = "first-row-id";
+  private static final String DATA_SEQUENCE_NUMBER = "data-sequence-number";
   private static final String REFERENCED_DATA_FILE = "referenced-data-file";
   private static final String CONTENT_OFFSET = "content-offset";
   private static final String CONTENT_SIZE = "content-size-in-bytes";
@@ -59,6 +60,12 @@ public class ContentFileParser {
 
   private static boolean hasPartitionData(StructLike partitionData) {
     return partitionData != null && partitionData.size() > 0;
+  }
+
+  private static Long dataSequenceNumber(ContentFile<?> contentFile) {
+    return contentFile instanceof DataFile && contentFile.firstRowId() != null
+        ? contentFile.dataSequenceNumber()
+        : null;
   }
 
   public static String toJson(ContentFile<?> contentFile, PartitionSpec spec) {
@@ -123,6 +130,8 @@ public class ContentFileParser {
     }
 
     JsonUtil.writeLongFieldIfPresent(FIRST_ROW_ID, contentFile.firstRowId(), generator);
+    JsonUtil.writeLongFieldIfPresent(
+        DATA_SEQUENCE_NUMBER, dataSequenceNumber(contentFile), generator);
 
     if (contentFile instanceof DeleteFile) {
       DeleteFile deleteFile = (DeleteFile) contentFile;
@@ -176,17 +185,20 @@ public class ContentFileParser {
     Long contentSizeInBytes = JsonUtil.getLongOrNull(CONTENT_SIZE, jsonNode);
 
     if (fileContent == FileContent.DATA) {
-      return new GenericDataFile(
-          specId,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          keyMetadata,
-          splitOffsets,
-          sortOrderId,
-          firstRowId);
+      GenericDataFile dataFile =
+          new GenericDataFile(
+              specId,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              keyMetadata,
+              splitOffsets,
+              sortOrderId,
+              firstRowId);
+      dataFile.setDataSequenceNumber(JsonUtil.getLongOrNull(DATA_SEQUENCE_NUMBER, jsonNode));
+      return dataFile;
     } else {
       return new GenericDeleteFile(
           specId,

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -48,6 +48,7 @@ public class ContentFileParser {
   private static final String EQUALITY_IDS = "equality-ids";
   private static final String SORT_ORDER_ID = "sort-order-id";
   private static final String FIRST_ROW_ID = "first-row-id";
+  private static final String DATA_SEQUENCE_NUMBER = "data-sequence-number";
   private static final String REFERENCED_DATA_FILE = "referenced-data-file";
   private static final String CONTENT_OFFSET = "content-offset";
   private static final String CONTENT_SIZE = "content-size-in-bytes";
@@ -59,6 +60,12 @@ public class ContentFileParser {
 
   private static boolean hasPartitionData(StructLike partitionData) {
     return partitionData != null && partitionData.size() > 0;
+  }
+
+  private static Long dataSequenceNumber(ContentFile<?> contentFile) {
+    return contentFile instanceof DataFile && contentFile.firstRowId() != null
+        ? contentFile.dataSequenceNumber()
+        : null;
   }
 
   public static String toJson(ContentFile<?> contentFile, PartitionSpec spec) {
@@ -122,6 +129,8 @@ public class ContentFileParser {
     }
 
     JsonUtil.writeLongFieldIfPresent(FIRST_ROW_ID, contentFile.firstRowId(), generator);
+    JsonUtil.writeLongFieldIfPresent(
+        DATA_SEQUENCE_NUMBER, dataSequenceNumber(contentFile), generator);
 
     if (contentFile instanceof DeleteFile) {
       DeleteFile deleteFile = (DeleteFile) contentFile;
@@ -175,17 +184,20 @@ public class ContentFileParser {
     Long contentSizeInBytes = JsonUtil.getLongOrNull(CONTENT_SIZE, jsonNode);
 
     if (fileContent == FileContent.DATA) {
-      return new GenericDataFile(
-          specId,
-          filePath,
-          fileFormat,
-          partitionData,
-          fileSizeInBytes,
-          metrics,
-          keyMetadata,
-          splitOffsets,
-          sortOrderId,
-          firstRowId);
+      GenericDataFile dataFile =
+          new GenericDataFile(
+              specId,
+              filePath,
+              fileFormat,
+              partitionData,
+              fileSizeInBytes,
+              metrics,
+              keyMetadata,
+              splitOffsets,
+              sortOrderId,
+              firstRowId);
+      dataFile.setDataSequenceNumber(JsonUtil.getLongOrNull(DATA_SEQUENCE_NUMBER, jsonNode));
+      return dataFile;
     } else {
       return new GenericDeleteFile(
           specId,

--- a/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
@@ -92,6 +92,78 @@ public class TestContentFileParser {
     assertContentFileEquals(dataFile, deserializedContentFile, spec);
   }
 
+  @Test
+  void dataFileSequenceNumberRoundTrip() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    DataFile dataFile =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .withFirstRowId(34L)
+            .build();
+    ((BaseFile<?>) dataFile).setDataSequenceNumber(17L);
+    ((BaseFile<?>) dataFile).setFileSequenceNumber(23L);
+
+    String json = ContentFileParser.toJson(dataFile, spec);
+    assertThat(json).contains("\"data-sequence-number\":17");
+    assertThat(json).doesNotContain("file-sequence-number");
+
+    ContentFile<?> deserialized =
+        ContentFileParser.fromJson(JsonUtil.mapper().readTree(json), Map.of(spec.specId(), spec));
+    assertThat(deserialized.dataSequenceNumber()).isEqualTo(17L);
+    assertThat(deserialized.fileSequenceNumber()).isNull();
+    assertContentFileEquals(dataFile, deserialized, spec);
+  }
+
+  @Test
+  void dataSequenceNumberOmittedForDeleteFiles() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    DeleteFile deleteFile = deleteFileWithRequiredOnly(spec);
+    ((BaseFile<?>) deleteFile).setDataSequenceNumber(17L);
+    ((BaseFile<?>) deleteFile).setFileSequenceNumber(23L);
+
+    String json = ContentFileParser.toJson(deleteFile, spec);
+    assertThat(json).isEqualTo(deleteFileJsonWithRequiredOnly(spec));
+    assertThat(json).doesNotContain("data-sequence-number");
+    assertThat(json).doesNotContain("file-sequence-number");
+
+    ContentFile<?> deserialized =
+        ContentFileParser.fromJson(JsonUtil.mapper().readTree(json), Map.of(spec.specId(), spec));
+    assertThat(deserialized.dataSequenceNumber()).isNull();
+    assertThat(deserialized.fileSequenceNumber()).isNull();
+    assertContentFileEquals(deleteFile, deserialized, spec);
+  }
+
+  @Test
+  void dataSequenceNumberOmittedWhenNull() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    DataFile dataFile = dataFileWithRequiredOnly(spec);
+    String dataFileJson = ContentFileParser.toJson(dataFile, spec);
+    assertThat(dataFileJson).doesNotContain("data-sequence-number");
+    assertThat(
+            ContentFileParser.fromJson(JsonUtil.mapper().readTree(dataFileJson), spec)
+                .dataSequenceNumber())
+        .isNull();
+  }
+
+  @Test
+  void dataSequenceNumberOmittedWithoutFirstRowId() throws Exception {
+    PartitionSpec spec = PartitionSpec.unpartitioned();
+    DataFile dataFile = dataFileWithRequiredOnly(spec);
+    ((BaseFile<?>) dataFile).setDataSequenceNumber(17L);
+    ((BaseFile<?>) dataFile).setFileSequenceNumber(23L);
+
+    String json = ContentFileParser.toJson(dataFile, spec);
+    assertThat(json).doesNotContain("data-sequence-number");
+    assertThat(json).doesNotContain("file-sequence-number");
+
+    ContentFile<?> deserialized =
+        ContentFileParser.fromJson(JsonUtil.mapper().readTree(json), Map.of(spec.specId(), spec));
+    assertThat(deserialized.dataSequenceNumber()).isNull();
+    assertThat(deserialized.fileSequenceNumber()).isNull();
+  }
+
   @ParameterizedTest
   @MethodSource("provideSpecAndDeleteFile")
   public void testDeleteFile(PartitionSpec spec, DeleteFile deleteFile, String expectedJson)
@@ -611,5 +683,9 @@ public class TestContentFileParser {
     assertThat(actual.splitOffsets()).isEqualTo(expected.splitOffsets());
     assertThat(actual.equalityFieldIds()).isEqualTo(expected.equalityFieldIds());
     assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
+    if (expected instanceof DataFile) {
+      assertThat(actual.dataSequenceNumber()).isEqualTo(expected.dataSequenceNumber());
+      assertThat(actual.firstRowId()).isEqualTo(expected.firstRowId());
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
@@ -82,8 +82,13 @@ public class TestFileScanTaskParser {
       residualEvaluator = ResidualEvaluator.of(spec, Expressions.equal("id", 1), caseSensitive);
     }
 
+    DataFile dataFile = TestBase.FILE_A.copy();
+    ((BaseFile<?>) dataFile).setDataSequenceNumber(17L);
+    ((BaseFile<?>) dataFile).setFileSequenceNumber(23L);
+    ((BaseFile<?>) dataFile).setFirstRowId(34L);
+
     return new BaseFileScanTask(
-        TestBase.FILE_A,
+        dataFile,
         new DeleteFile[] {TestBase.FILE_A_DELETES, TestBase.FILE_A2_DELETES},
         SchemaParser.toJson(TestBase.SCHEMA),
         PartitionSpecParser.toJson(spec),
@@ -98,7 +103,8 @@ public class TestFileScanTaskParser {
         + "\"transform\":\"bucket[16]\",\"source-id\":4,\"field-id\":1000}]},"
         + "\"data-file\":{\"spec-id\":0,\"content\":\"data\",\"file-path\":\"/path/to/data-a.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":[0],"
-        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
+        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0,\"first-row-id\":34,"
+        + "\"data-sequence-number\":17},"
         + "\"start\":0,\"length\":10,"
         + "\"delete-files\":[{\"spec-id\":0,\"content\":\"position-deletes\","
         + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"parquet\","
@@ -118,7 +124,8 @@ public class TestFileScanTaskParser {
         + "\"transform\":\"bucket[16]\",\"source-id\":4,\"field-id\":1000}]},"
         + "\"data-file\":{\"spec-id\":0,\"content\":\"data\",\"file-path\":\"/path/to/data-a.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":[0],"
-        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
+        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0,\"first-row-id\":34,"
+        + "\"data-sequence-number\":17},"
         + "\"start\":0,\"length\":10,"
         + "\"delete-files\":[{\"spec-id\":0,\"content\":\"position-deletes\","
         + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"parquet\","
@@ -138,7 +145,8 @@ public class TestFileScanTaskParser {
         + "\"transform\":\"bucket[16]\",\"source-id\":4,\"field-id\":1000}]},"
         + "\"data-file\":{\"spec-id\":0,\"content\":\"data\",\"file-path\":\"/path/to/data-a.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":{\"1000\":0},"
-        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
+        + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0,\"first-row-id\":34,"
+        + "\"data-sequence-number\":17},"
         + "\"start\":0,\"length\":10,"
         + "\"delete-files\":[{\"spec-id\":0,\"content\":\"position-deletes\","
         + "\"file-path\":\"/path/to/data-a-deletes.parquet\",\"file-format\":\"parquet\","

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -30,8 +30,11 @@ import static org.apache.iceberg.TestBase.SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.ContentFileParser;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpecParser;
@@ -43,6 +46,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.PlanStatus;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.util.JsonUtil;
 import org.junit.jupiter.api.Test;
 
 public class TestPlanTableScanResponseParser {
@@ -270,6 +274,39 @@ public class TestPlanTableScanResponseParser {
             .build();
 
     assertThat(PlanTableScanResponseParser.toJson(copyResponse)).isEqualTo(expectedToJson);
+  }
+
+  @Test
+  void roundTripSerdeWithDataSequenceNumber() throws Exception {
+    ObjectNode dataFileJson =
+        (ObjectNode) JsonUtil.mapper().readTree(ContentFileParser.toJson(FILE_A, SPEC));
+    dataFileJson.put("first-row-id", 34L);
+    dataFileJson.put("data-sequence-number", 17L);
+    DataFile dataFile = (DataFile) ContentFileParser.fromJson(dataFileJson, SPEC);
+    FileScanTask fileScanTask =
+        new BaseFileScanTask(
+            dataFile,
+            null,
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            ResidualEvaluator.of(SPEC, Expressions.alwaysTrue(), true));
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withFileScanTasks(List.of(fileScanTask))
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .build();
+
+    String json = PlanTableScanResponseParser.toJson(response);
+    assertThat(json).contains("\"first-row-id\":34");
+    assertThat(json).contains("\"data-sequence-number\":17");
+
+    PlanTableScanResponse deserialized =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(deserialized.fileScanTasks())
+        .singleElement()
+        .satisfies(task -> assertThat(task.file().dataSequenceNumber()).isEqualTo(17L));
+    assertThat(PlanTableScanResponseParser.toJson(deserialized)).isEqualTo(json);
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -30,8 +30,10 @@ import static org.apache.iceberg.TestBase.SPEC;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.ContentFileParser;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
@@ -46,6 +48,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.rest.PlanStatus;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
+import org.apache.iceberg.util.JsonUtil;
 import org.junit.jupiter.api.Test;
 
 public class TestPlanTableScanResponseParser {
@@ -261,6 +264,39 @@ public class TestPlanTableScanResponseParser {
             .build();
 
     assertThat(PlanTableScanResponseParser.toJson(copyResponse)).isEqualTo(expectedToJson);
+  }
+
+  @Test
+  void roundTripSerdeWithDataSequenceNumber() throws Exception {
+    ObjectNode dataFileJson =
+        (ObjectNode) JsonUtil.mapper().readTree(ContentFileParser.toJson(FILE_A, SPEC));
+    dataFileJson.put("first-row-id", 34L);
+    dataFileJson.put("data-sequence-number", 17L);
+    DataFile dataFile = (DataFile) ContentFileParser.fromJson(dataFileJson, SPEC);
+    FileScanTask fileScanTask =
+        new BaseFileScanTask(
+            dataFile,
+            null,
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            ResidualEvaluator.of(SPEC, Expressions.alwaysTrue(), true));
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withFileScanTasks(List.of(fileScanTask))
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .build();
+
+    String json = PlanTableScanResponseParser.toJson(response);
+    assertThat(json).contains("\"first-row-id\":34");
+    assertThat(json).contains("\"data-sequence-number\":17");
+
+    PlanTableScanResponse deserialized =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+    assertThat(deserialized.fileScanTasks())
+        .singleElement()
+        .satisfies(task -> assertThat(task.file().dataSequenceNumber()).isEqualTo(17L));
+    assertThat(PlanTableScanResponseParser.toJson(deserialized)).isEqualTo(json);
   }
 
   @Test

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1209,6 +1209,11 @@ class DataFile(ContentFile):
         alias='first-row-id',
         description='The first row ID assigned to the first row in the data file',
     )
+    data_sequence_number: int | None = Field(
+        None,
+        alias='data-sequence-number',
+        description='The inherited data sequence number of the manifest entry containing this data file. Servers SHOULD include this field when the data sequence number is known and first-row-id is non-null. For data files with a non-null first-row-id, clients use this value to replace a missing or null _last_updated_sequence_number. Clients MUST NOT substitute the file sequence number or snapshot sequence number when this field is absent.\n',
+    )
     column_sizes: CountMap | None = Field(
         None,
         alias='column-sizes',

--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1332,6 +1332,11 @@ class DataFile(ContentFile):
         alias='first-row-id',
         description='The first row ID assigned to the first row in the data file',
     )
+    data_sequence_number: int | None = Field(
+        None,
+        alias='data-sequence-number',
+        description='The inherited data sequence number of the manifest entry containing this data file. Servers SHOULD include this field when the data sequence number is known and first-row-id is non-null. For data files with a non-null first-row-id, clients use this value to replace a missing or null _last_updated_sequence_number. Clients MUST NOT substitute the file sequence number or snapshot sequence number when this field is absent.\n',
+    )
     column_sizes: CountMap | None = Field(
         None,
         alias='column-sizes',

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5051,6 +5051,16 @@ components:
           type: integer
           format: int64
           description: "The first row ID assigned to the first row in the data file"
+        data-sequence-number:
+          type: integer
+          format: int64
+          description: >
+            The inherited data sequence number of the manifest entry containing this data file.
+            Servers SHOULD include this field when the data sequence number is known and
+            first-row-id is non-null. For data files with a non-null first-row-id, clients use this
+            value to replace a missing or null _last_updated_sequence_number. Clients MUST NOT
+            substitute the file sequence number or snapshot sequence number when this field is
+            absent.
         column-sizes:
           allOf:
             - $ref: '#/components/schemas/CountMap'

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -5237,6 +5237,16 @@ components:
           type: integer
           format: int64
           description: "The first row ID assigned to the first row in the data file"
+        data-sequence-number:
+          type: integer
+          format: int64
+          description: >
+            The inherited data sequence number of the manifest entry containing this data file.
+            Servers SHOULD include this field when the data sequence number is known and
+            first-row-id is non-null. For data files with a non-null first-row-id, clients use this
+            value to replace a missing or null _last_updated_sequence_number. Clients MUST NOT
+            substitute the file sequence number or snapshot sequence number when this field is
+            absent.
         column-sizes:
           allOf:
             - $ref: '#/components/schemas/CountMap'


### PR DESCRIPTION
## Summary

- add optional `data-sequence-number` to REST-planned data files
- preserve manifest-entry data sequence numbers for Java data files while leaving delete-file JSON and file sequence numbers unchanged
- add content-file, scan-task, and REST scan-response regression coverage

## Motivation

REST-planned scan tasks currently omit manifest-entry data sequence numbers. Row-lineage clients need the data file value to inherit a missing or null `_last_updated_sequence_number` and must not substitute a file or snapshot sequence number.

The field remains optional for rolling compatibility. Servers SHOULD include it when known for data files with a non-null `first-row-id`, while clients MUST NOT substitute a file or snapshot sequence number when it is absent. Scoping and emitting the new field only for row-lineage data files avoids changing ordinary data-file and delete-file payloads that do not need it for lineage inheritance.

This incorporates feedback from the broader content-file approach in https://github.com/apache/iceberg/pull/17234 by @wgtmac.

## Compatibility

- New servers add an optional field only to row-lineage data-file payloads with non-null `first-row-id`; old clients are expected to ignore unknown fields.
- New clients continue to parse responses from old servers that omit the field and report unsupported lineage synthesis when the value is required.
- Delete-file JSON remains unchanged.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: reviewed
- Prompt Summary: Add backward-compatible REST data sequence number support for row-lineage data files.