### PR TITLE
Parquet: Handle notNaN for columns absent from files

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -175,12 +175,12 @@ public class ParquetDictionaryRowGroupFilter {
     public <T> Boolean notNaN(BoundReference<T> ref) {
       int id = ref.fieldId();
 
-      if (mayContainNulls.get(id)) {
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
         return ROWS_MIGHT_MATCH;
       }
 
-      Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
+      if (mayContainNulls.get(id)) {
         return ROWS_MIGHT_MATCH;
       }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -484,10 +484,15 @@ public class TestDictionaryRowGroupFilter {
   public void testColumnNotInFile() {
     Expression[] exprs =
         new Expression[] {
-          lessThan("not_in_file", 1.0f), lessThanOrEqual("not_in_file", 1.0f),
-          equal("not_in_file", 1.0f), greaterThan("not_in_file", 1.0f),
-          greaterThanOrEqual("not_in_file", 1.0f), notNull("not_in_file"),
-          isNull("not_in_file"), notEqual("not_in_file", 1.0f)
+          lessThan("not_in_file", 1.0f),
+          lessThanOrEqual("not_in_file", 1.0f),
+          equal("not_in_file", 1.0f),
+          greaterThan("not_in_file", 1.0f),
+          greaterThanOrEqual("not_in_file", 1.0f),
+          notNull("not_in_file"),
+          isNull("not_in_file"),
+          notEqual("not_in_file", 1.0f),
+          notNaN("not_in_file")
         };
 
     for (Expression expr : exprs) {


### PR DESCRIPTION
## What

Check for absent Parquet column metadata before consulting nullability in
`ParquetDictionaryRowGroupFilter#notNaN`. This keeps row groups readable when a
float or double column was added after an older file was written.

Add `notNaN` to the existing missing-column dictionary-filter regression
coverage.

## Why

`mayContainNulls.get(id)` was unboxed before the existing missing-column guard.
For an evolved column absent from an older file, the map has no entry and reader
initialization fails with a `NullPointerException`.

## Testing

Passed locally on commit `c2730baf84401925c54bf9dd5d91cd417b73848c`:

- `./gradlew --no-build-cache :iceberg-parquet:test --tests 'org.apache.iceberg.parquet.TestDictionaryRowGroupFilter.testColumnNotInFile' --no-daemon` — targeted regression
- `./gradlew --no-build-cache :iceberg-parquet:test --no-daemon` — full Parquet module
- `./gradlew --no-build-cache spotlessCheck --no-daemon` — repository-wide formatting
- `./gradlew --no-build-cache build -x integrationTest --no-daemon` — repository-wide locally runnable build (475 tasks, 59m 7s)

The production `Parquet.read(...)` reproduction described in #17301 was also
repeated successfully after the fix. Docker-backed integration tests were not
runnable because Docker is not installed. The repository-wide build was run
from a byte-identical checkout without spaces because the OpenAPI validator
cannot parse the original checkout path as a URI.

Closes #17301

---
**AI Disclosure**
- Model: GPT-5.6 Sol (Extra High)
- Platform/Tool: OpenAI Codex
- Human Oversight: fully reviewed
- Prompt Summary: Diagnose and fix issue #17301 with a minimal regression test, run local validation, and prepare a contribution-ready PR.
