### PR TITLE
API: Shorten dropped source type comment in PartitionSpec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/PartitionSpec.java
+++ b/api/src/main/java/org/apache/iceberg/PartitionSpec.java
@@ -191,9 +191,8 @@ public class PartitionSpec implements Serializable {
   private Type resultType(PartitionField field) {
     Type sourceType = schema.findType(field.sourceId());
     if (sourceType == null) {
-      // when the source field has been dropped, substitute unknown and let the transform derive
-      // its result type; transforms that return the source type (identity, truncate, void) yield
-      // unknown, while transforms with a fixed result type still resolve
+      // When the source field has been dropped, the source type has been lost
+      // Transforms with a fixed result type still work, so use unknown for source
       sourceType = Types.UnknownType.get();
     }
 


### PR DESCRIPTION
follow-up to #17262 