### PR TITLE
Core: Delete orphaned merged DV files on cache invalidation and commit failure

### DIFF
--- a/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/MergingSnapshotProducer.java
@@ -91,6 +91,7 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   private final ManifestMergeManager<DeleteFile> deleteMergeManager;
   private final ManifestFilterManager<DeleteFile> deleteFilterManager;
   private final AtomicInteger dvMergeAttempt = new AtomicInteger(0);
+  private final List<String> cachedMergedDVLocations = Lists.newArrayList();
 
   // update data
   private final Map<Integer, DataFileSet> newDataFilesBySpec = Maps.newHashMap();
@@ -1076,6 +1077,10 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
   private void cleanUncommittedAppends(Set<ManifestFile> committed) {
     deleteUncommitted(cachedNewDataManifests, committed, true /* clear manifests */);
     deleteUncommitted(cachedNewDeleteManifests, committed, true /* clear manifests */);
+    if (cachedNewDeleteManifests.isEmpty()) {
+      cachedMergedDVLocations.forEach(this::deleteFile);
+      cachedMergedDVLocations.clear();
+    }
     // rewritten manifests are always owned by the table
     deleteUncommitted(rewrittenAppendManifests, committed, false);
 
@@ -1140,6 +1145,8 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
       // merge,
       // and the summary cannot be generated until after merging is complete.
       addedDeleteFilesSummary.clear();
+      cachedMergedDVLocations.forEach(this::deleteFile);
+      cachedMergedDVLocations.clear();
     }
 
     if (cachedNewDeleteManifests.isEmpty()) {
@@ -1183,12 +1190,22 @@ abstract class MergingSnapshotProducer<ThisT> extends SnapshotProducer<ThisT> {
                     String.format(
                         "merged-dvs-%s-%s", snapshotId(), dvMergeAttempt.incrementAndGet())));
 
-    return DVUtil.mergeAndWriteDVsIfRequired(
-        dvsByReferencedFile,
-        dvOutputLocation,
-        fileIO,
-        ops().current().specsById(),
-        ThreadPools.getDeleteWorkerPool());
+    List<DeleteFile> mergedDVs =
+        DVUtil.mergeAndWriteDVsIfRequired(
+            dvsByReferencedFile,
+            dvOutputLocation,
+            fileIO,
+            ops().current().specsById(),
+            ThreadPools.getDeleteWorkerPool());
+
+    // resolve the location through the FileIO so its scheme matches DeleteFile.location(),
+    // which may differ from the raw dvOutputLocation (e.g. stripping a "file:" URI scheme)
+    String puffinLocation = fileIO.newOutputFile(dvOutputLocation).location();
+    if (mergedDVs.stream().anyMatch(dv -> puffinLocation.equals(dv.location()))) {
+      cachedMergedDVLocations.add(puffinLocation);
+    }
+
+    return mergedDVs;
   }
 
   private class DataFileFilterManager extends ManifestFilterManager<DataFile> {

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -48,6 +48,7 @@ import org.apache.iceberg.deletes.PositionDeleteIndex;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionTestHelpers;
+import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
@@ -2235,6 +2236,78 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testMergedDVPuffinFileCleanedUpOnCacheInvalidation() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    DataFile dataFile = newDataFile("data_bucket=0");
+    commit(table, table.newRowDelta().addRows(dataFile), branch);
+
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
+
+    DeleteFile dv1 = dvWithPositions(dataFile, fileFactory, 0, 2);
+    DeleteFile dv2 = dvWithPositions(dataFile, fileFactory, 2, 4);
+
+    RowDelta rowDelta = table.newRowDelta().addDeletes(dv1).addDeletes(dv2);
+    Snapshot applied = apply(rowDelta, branch);
+
+    Set<String> mergedDVPuffinLocations = mergedDVPuffinLocations(applied);
+    assertThat(mergedDVPuffinLocations).hasSize(1);
+    String firstPuffinLocation = Iterables.getOnlyElement(mergedDVPuffinLocations);
+    assertThat(table.io().newInputFile(firstPuffinLocation).exists()).isTrue();
+
+    DeleteFile dv3 = dvWithPositions(dataFile, fileFactory, 4, 6);
+    rowDelta.addDeletes(dv3);
+
+    commit(table, rowDelta, branch);
+
+    assertThat(table.io().newInputFile(firstPuffinLocation).exists())
+        .as("Merged DV Puffin file should be deleted on cache invalidation")
+        .isFalse();
+
+    Iterable<DeleteFile> committedDeleteFiles =
+        SnapshotChanges.builderFor(table)
+            .snapshot(latestSnapshot(table, branch))
+            .build()
+            .addedDeleteFiles();
+    assertThat(committedDeleteFiles).hasSize(1);
+    DeleteFile committedDV = Iterables.getOnlyElement(committedDeleteFiles);
+    assertDVHasDeletedPositions(committedDV, LongStream.range(0, 6).boxed()::iterator);
+  }
+
+  @TestTemplate
+  public void testMergedDVPuffinFileCleanedUpOnCommitFailure() throws IOException {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    DataFile dataFile = newDataFile("data_bucket=0");
+    commit(table, table.newRowDelta().addRows(dataFile), branch);
+
+    OutputFileFactory fileFactory =
+        OutputFileFactory.builderFor(table, 1, 1).format(FileFormat.PUFFIN).build();
+
+    DeleteFile dv1 = dvWithPositions(dataFile, fileFactory, 0, 2);
+    DeleteFile dv2 = dvWithPositions(dataFile, fileFactory, 2, 4);
+
+    RowDelta rowDelta = table.newRowDelta().addDeletes(dv1).addDeletes(dv2);
+    Snapshot applied = apply(rowDelta, branch);
+
+    Set<String> mergedDVPuffinLocations = mergedDVPuffinLocations(applied);
+    assertThat(mergedDVPuffinLocations).hasSize(1);
+    String puffinLocation = Iterables.getOnlyElement(mergedDVPuffinLocations);
+    assertThat(table.io().newInputFile(puffinLocation).exists()).isTrue();
+
+    table.ops().failCommits(5);
+
+    assertThatThrownBy(() -> commit(table, rowDelta, branch))
+        .isInstanceOf(CommitFailedException.class)
+        .hasMessage("Injected failure");
+
+    assertThat(table.io().newInputFile(puffinLocation).exists())
+        .as("Merged DV Puffin file should be deleted on commit failure")
+        .isFalse();
+  }
+
+  @TestTemplate
   public void testConcurrentDVsInDifferentPartitionsWithFilter() {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
@@ -2600,6 +2673,22 @@ public class TestRowDelta extends TestBase {
       DataFile dataFile, OutputFileFactory fileFactory, int fromInclusive, int toExclusive)
       throws IOException {
     return dvWithPositions(table, dataFile, fileFactory, fromInclusive, toExclusive);
+  }
+
+  private Set<String> mergedDVPuffinLocations(Snapshot snapshot) throws IOException {
+    Set<String> locations = Sets.newHashSet();
+    for (ManifestFile manifest : snapshot.deleteManifests(table.io())) {
+      try (CloseableIterable<ManifestEntry<DeleteFile>> entries =
+          ManifestFiles.readDeleteManifest(manifest, table.io(), table.specs()).liveEntries()) {
+        for (ManifestEntry<DeleteFile> entry : entries) {
+          DeleteFile deleteFile = entry.file();
+          if (ContentFileUtil.isDV(deleteFile) && deleteFile.location().contains("merged-dvs-")) {
+            locations.add(deleteFile.location());
+          }
+        }
+      }
+    }
+    return locations;
   }
 
   private DeleteFile dvWithPositions(


### PR DESCRIPTION
## What

`MergingSnapshotProducer.mergeDVs()` writes a Puffin file each time duplicate DVs are merged. When the delete manifest cache is invalidated (by a subsequent `addDeletes` call) or the commit fails, only the manifest files were deleted — the Puffin files were left orphaned on disk.

## Why

After #15006, `mergeDVs()` writes a Puffin file (e.g. `merged-dvs-<snapshotId>-<n>.puffin`) and caches the resulting delete manifests. Two cleanup paths missed the Puffin files:

1. **Cache invalidation** (`newDeleteFilesAsManifests`): deleted the cached manifests but not the Puffin files they referenced.
2. **Commit failure** (`cleanUncommittedAppends`): deleted uncommitted delete manifests but not their Puffin files.

The orphaned files can only be removed by `remove_orphan_files`. No data corruption — read correctness is preserved.

## How

Track merged DV file locations in a `cachedMergedDVLocations` field (paralleling `cachedNewDeleteManifests`) and delete them in both cleanup paths. The location is resolved through the `FileIO` so its scheme matches `DeleteFile.location()` (e.g. stripping a `file:` URI scheme).

## Tests

- `testMergedDVPuffinFileCleanedUpOnCacheInvalidation` — verifies the Puffin file is deleted when a subsequent `addDeletes` invalidates the cache, and the committed snapshot has a correctly merged DV.
- `testMergedDVPuffinFileCleanedUpOnCommitFailure` — verifies the Puffin file is deleted when the commit fails (via injected `failCommits`).

Closes https://github.com/apache/iceberg/issues/17307

---

**AI Disclosure**
- Model: GLM 5.2
- Platform/Tool: opencode
- Human Oversight: fully reviewed
- Prompt Summary: Fix orphaned merged DV Puffin file on cache invalidation and commit failure, with tests covering both paths.