### PR TITLE
REST: add table encryption without breaking catalog extensions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -52,6 +52,8 @@ import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
@@ -174,6 +176,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private CloseableGroup closeables = null;
   private Set<Endpoint> endpoints;
   private Supplier<Map<String, String>> mutationHeaders = Map::of;
+  private KeyManagementClient keyManagementClient = null;
   private String namespaceSeparator = null;
   private ScanPlanningMode clientScanPlanningMode = null;
 
@@ -285,6 +288,12 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     if (reportingViaRestEnabled) {
       this.metricsExecutor = ThreadPools.newFixedThreadPool("rest-metrics-reporter", 1);
       this.closeables.addCloseable(metricsExecutor::shutdown);
+    }
+
+    if (mergedProps.containsKey(CatalogProperties.ENCRYPTION_KMS_TYPE)
+        || mergedProps.containsKey(CatalogProperties.ENCRYPTION_KMS_IMPL)) {
+      this.keyManagementClient = EncryptionUtil.createKmsClient(mergedProps);
+      this.closeables.addCloseable(this.keyManagementClient);
     }
 
     this.namespaceSeparator =
@@ -1263,7 +1272,14 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       TableMetadata current,
       Set<Endpoint> supportedEndpoints) {
     return new RESTTableOperations(
-        restClient, path, readHeaders, mutationHeaderSupplier, fileIO, current, supportedEndpoints);
+        restClient,
+        path,
+        readHeaders,
+        mutationHeaderSupplier,
+        fileIO,
+        keyManagementClient,
+        current,
+        supportedEndpoints);
   }
 
   /**
@@ -1302,6 +1318,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
         readHeaders,
         mutationHeaderSupplier,
         fileIO,
+        keyManagementClient,
         updateType,
         createChanges,
         current,

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTableOperations.java
@@ -21,9 +21,12 @@ package org.apache.iceberg.rest;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.MetadataUpdate;
 import org.apache.iceberg.SnapshotRef;
@@ -32,17 +35,25 @@ import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.UpdateRequirement;
 import org.apache.iceberg.UpdateRequirements;
+import org.apache.iceberg.encryption.EncryptedKey;
+import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.encryption.EncryptionManager;
+import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.KeyManagementClient;
+import org.apache.iceberg.encryption.PlaintextEncryptionManager;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.util.LocationUtil;
+import org.apache.iceberg.util.PropertyUtil;
 
 class RESTTableOperations implements TableOperations {
   private static final String METADATA_FOLDER_NAME = "metadata";
@@ -58,17 +69,26 @@ class RESTTableOperations implements TableOperations {
   private final Supplier<Map<String, String>> readHeaders;
   private final Supplier<Map<String, String>> mutationHeaders;
   private final FileIO io;
+  private final KeyManagementClient keyManagementClient;
   private final List<MetadataUpdate> createChanges;
   private final TableMetadata replaceBase;
   private final Set<Endpoint> endpoints;
   private UpdateType updateType;
   private TableMetadata current;
 
+  private EncryptionManager encryptionManager;
+  private EncryptingFileIO encryptingFileIO;
+  private String tableKeyId;
+  private int encryptionDekLength;
+
+  private List<EncryptedKey> encryptedKeys = List.of();
+
   RESTTableOperations(
       RESTClient client,
       String path,
       Supplier<Map<String, String>> headers,
       FileIO io,
+      KeyManagementClient keyManagementClient,
       TableMetadata current,
       Set<Endpoint> endpoints) {
     this(
@@ -77,6 +97,7 @@ class RESTTableOperations implements TableOperations {
         headers,
         headers,
         io,
+        keyManagementClient,
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
@@ -88,11 +109,22 @@ class RESTTableOperations implements TableOperations {
       String path,
       Supplier<Map<String, String>> headers,
       FileIO io,
+      KeyManagementClient keyManagementClient,
       UpdateType updateType,
       List<MetadataUpdate> createChanges,
       TableMetadata current,
       Set<Endpoint> endpoints) {
-    this(client, path, headers, headers, io, updateType, createChanges, current, endpoints);
+    this(
+        client,
+        path,
+        headers,
+        headers,
+        io,
+        keyManagementClient,
+        updateType,
+        createChanges,
+        current,
+        endpoints);
   }
 
   RESTTableOperations(
@@ -101,6 +133,7 @@ class RESTTableOperations implements TableOperations {
       Supplier<Map<String, String>> readHeaders,
       Supplier<Map<String, String>> mutationHeaders,
       FileIO io,
+      KeyManagementClient keyManagementClient,
       TableMetadata current,
       Set<Endpoint> endpoints) {
     this(
@@ -109,6 +142,7 @@ class RESTTableOperations implements TableOperations {
         readHeaders,
         mutationHeaders,
         io,
+        keyManagementClient,
         UpdateType.SIMPLE,
         Lists.newArrayList(),
         current,
@@ -121,6 +155,7 @@ class RESTTableOperations implements TableOperations {
       Supplier<Map<String, String>> readHeaders,
       Supplier<Map<String, String>> mutationHeaders,
       FileIO io,
+      KeyManagementClient keyManagementClient,
       UpdateType updateType,
       List<MetadataUpdate> createChanges,
       TableMetadata current,
@@ -130,6 +165,7 @@ class RESTTableOperations implements TableOperations {
     this.readHeaders = readHeaders;
     this.mutationHeaders = mutationHeaders;
     this.io = io;
+    this.keyManagementClient = keyManagementClient;
     this.updateType = updateType;
     this.createChanges = createChanges;
     this.replaceBase = current;
@@ -139,6 +175,10 @@ class RESTTableOperations implements TableOperations {
       this.current = current;
     }
     this.endpoints = endpoints;
+
+    // N.B. We don't use this.current due to it being null for the CREATE update type; we still
+    // want encryption configured for this case.
+    encryptionPropsFromMetadata(current);
   }
 
   @Override
@@ -156,6 +196,19 @@ class RESTTableOperations implements TableOperations {
   @Override
   public void commit(TableMetadata base, TableMetadata metadata) {
     Endpoint.check(endpoints, Endpoint.V1_UPDATE_TABLE);
+
+    EncryptionManager encryption = encryption();
+    if (encryption instanceof StandardEncryptionManager) {
+      // Add encryption keys to the to-be-committed metadata
+      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
+      EncryptionUtil.encryptionKeys(encryption).values().forEach(builder::addEncryptionKey);
+      commitInternal(base, builder.build());
+    } else {
+      commitInternal(base, metadata);
+    }
+  }
+
+  private void commitInternal(TableMetadata base, TableMetadata metadata) {
     Consumer<ErrorResponse> errorHandler;
     List<UpdateRequirement> requirements;
     List<MetadataUpdate> updates;
@@ -194,6 +247,21 @@ class RESTTableOperations implements TableOperations {
       default:
         throw new UnsupportedOperationException(
             String.format("Update type %s is not supported", updateType));
+    }
+
+    if (base != null) {
+      boolean encryptionKeyRemoved =
+          base.properties().containsKey(TableProperties.ENCRYPTION_TABLE_KEY)
+              && !metadata.properties().containsKey(TableProperties.ENCRYPTION_TABLE_KEY);
+      Preconditions.checkArgument(
+          !encryptionKeyRemoved, "Cannot remove key ID from an encrypted table");
+
+      boolean encryptionKeyUnchanged =
+          Objects.equals(
+              base.properties().get(TableProperties.ENCRYPTION_TABLE_KEY),
+              metadata.properties().get(TableProperties.ENCRYPTION_TABLE_KEY));
+      Preconditions.checkArgument(
+          encryptionKeyUnchanged, "Cannot modify key ID of an encrypted table");
     }
 
     UpdateTableRequest request = new UpdateTableRequest(requirements, updates);
@@ -243,9 +311,47 @@ class RESTTableOperations implements TableOperations {
     }
   }
 
+  // TODO: Integrate and test encryption with REST scan planning
   @Override
   public FileIO io() {
-    return io;
+    if (tableKeyId == null) {
+      return io;
+    }
+
+    if (encryptingFileIO == null) {
+      encryptingFileIO = EncryptingFileIO.combine(io, encryption());
+    }
+
+    return encryptingFileIO;
+  }
+
+  @Override
+  public EncryptionManager encryption() {
+    if (encryptionManager != null) {
+      return encryptionManager;
+    }
+
+    if (tableKeyId != null) {
+      Preconditions.checkArgument(
+          keyManagementClient != null,
+          "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
+          CatalogProperties.ENCRYPTION_KMS_IMPL);
+
+      Map<String, String> encryptionProperties =
+          ImmutableMap.of(
+              TableProperties.ENCRYPTION_TABLE_KEY,
+              tableKeyId,
+              TableProperties.ENCRYPTION_DEK_LENGTH,
+              String.valueOf(encryptionDekLength));
+
+      encryptionManager =
+          EncryptionUtil.createEncryptionManager(
+              encryptedKeys, encryptionProperties, keyManagementClient);
+    } else {
+      return PlaintextEncryptionManager.instance();
+    }
+
+    return encryptionManager;
   }
 
   private static Long expectedSnapshotIdIfSnapshotAddOnly(List<MetadataUpdate> updates) {
@@ -285,6 +391,45 @@ class RESTTableOperations implements TableOperations {
     return addedSnapshotId;
   }
 
+  private void encryptionPropsFromMetadata(TableMetadata metadata) {
+    if (metadata == null || metadata.properties() == null) {
+      return;
+    }
+
+    // Refresh encryption-related properties and keys on new/refreshed metadata
+    Map<String, String> tableProperties = metadata.properties();
+    tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
+
+    if (tableKeyId != null) {
+      encryptionDekLength =
+          PropertyUtil.propertyAsInt(
+              tableProperties,
+              TableProperties.ENCRYPTION_DEK_LENGTH,
+              TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+
+      encryptedKeys =
+          Optional.ofNullable(metadata.encryptionKeys())
+              .map(Lists::newLinkedList)
+              .orElseGet(Lists::newLinkedList);
+
+      // Include pending encryption keys from the encryption manager
+      if (encryptionManager != null) {
+        Set<String> keyIdsFromMetadata =
+            encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
+
+        for (EncryptedKey keyFromEM : EncryptionUtil.encryptionKeys(encryptionManager).values()) {
+          if (!keyIdsFromMetadata.contains(keyFromEM.keyId())) {
+            encryptedKeys.add(keyFromEM);
+          }
+        }
+      }
+    }
+
+    // Force re-creation of encryption manager
+    encryptingFileIO = null;
+    encryptionManager = null;
+  }
+
   private TableMetadata updateCurrentMetadata(LoadTableResponse response) {
     // LoadTableResponse is used to deserialize the response, but config is not allowed by the REST
     // spec so it can be
@@ -292,6 +437,7 @@ class RESTTableOperations implements TableOperations {
     if (current == null
         || !Objects.equals(current.metadataFileLocation(), response.metadataLocation())) {
       this.current = checkUUID(current, response.tableMetadata());
+      encryptionPropsFromMetadata(current);
     }
 
     return current;

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -750,7 +750,7 @@ public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
           FileIO io,
           TableMetadata current,
           Set<Endpoint> endpoints) {
-        super(client, path, readHeaders, mutationHeaders, io, current, endpoints);
+        super(client, path, readHeaders, mutationHeaders, io, null, current, endpoints);
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -80,6 +80,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableCommit;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -3150,6 +3151,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   @Test
+  @SuppressWarnings("MethodLength")
   public void testCustomTableOperationsInjection() throws IOException {
     AtomicBoolean customTableOpsCalled = new AtomicBoolean();
     AtomicBoolean customTransactionTableOpsCalled = new AtomicBoolean();
@@ -3165,9 +3167,17 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           String path,
           Supplier<Map<String, String>> headers,
           FileIO fileIO,
+          KeyManagementClient keyManagementClient,
           TableMetadata current,
           Set<Endpoint> supportedEndpoints) {
-        super(client, path, () -> customHeaders, fileIO, current, supportedEndpoints);
+        super(
+            client,
+            path,
+            () -> customHeaders,
+            fileIO,
+            keyManagementClient,
+            current,
+            supportedEndpoints);
         customTableOpsCalled.set(true);
       }
 
@@ -3176,6 +3186,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           String path,
           Supplier<Map<String, String>> headers,
           FileIO fileIO,
+          KeyManagementClient keyManagementClient,
           RESTTableOperations.UpdateType updateType,
           List<MetadataUpdate> createChanges,
           TableMetadata current,
@@ -3185,6 +3196,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
             path,
             () -> customHeaders,
             fileIO,
+            keyManagementClient,
             updateType,
             createChanges,
             current,
@@ -3212,7 +3224,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
           Set<Endpoint> supportedEndpoints) {
         RESTTableOperations ops =
             new CustomRESTTableOperations(
-                restClient, path, mutationHeaders, fileIO, current, supportedEndpoints);
+                restClient, path, mutationHeaders, fileIO, null, current, supportedEndpoints);
         RESTTableOperations spy = Mockito.spy(ops);
         capturedOps.set(spy);
         return spy;
@@ -3235,6 +3247,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
                 path,
                 mutationHeaders,
                 fileIO,
+                null,
                 updateType,
                 createChanges,
                 current,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCTASEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestCTASEncryption.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.spark.CatalogTestBase;
@@ -57,6 +58,15 @@ public class TestCTASEncryption extends CatalogTestBase {
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
         appendCatalogEncryptionProperties(SparkCatalogConfig.HIVE.properties())
+      },
+      {
+        SparkCatalogConfig.REST.catalogName(),
+        SparkCatalogConfig.REST.implementation(),
+        appendCatalogEncryptionProperties(
+            ImmutableMap.<String, String>builder()
+                .putAll(SparkCatalogConfig.REST.properties())
+                .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
+                .build())
       }
     };
   }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.Files.localInput;
 import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 import java.io.File;
 import java.io.IOException;
@@ -50,8 +51,10 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.parquet.Parquet;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
+import org.apache.iceberg.rest.RESTCatalog;
 import org.apache.iceberg.spark.CatalogTestBase;
 import org.apache.iceberg.spark.SparkCatalogConfig;
 import org.apache.iceberg.types.Types;
@@ -77,6 +80,15 @@ public class TestTableEncryption extends CatalogTestBase {
         SparkCatalogConfig.HIVE.catalogName(),
         SparkCatalogConfig.HIVE.implementation(),
         appendCatalogEncryptionProperties(SparkCatalogConfig.HIVE.properties())
+      },
+      {
+        SparkCatalogConfig.REST.catalogName(),
+        SparkCatalogConfig.REST.implementation(),
+        appendCatalogEncryptionProperties(
+            ImmutableMap.<String, String>builder()
+                .putAll(SparkCatalogConfig.REST.properties())
+                .put(CatalogProperties.URI, restCatalog.properties().get(CatalogProperties.URI))
+                .build())
       }
     };
   }
@@ -162,7 +174,6 @@ public class TestTableEncryption extends CatalogTestBase {
     assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 2);
   }
 
-  // See CatalogTests#testConcurrentReplaceTransactions
   @TestTemplate
   public void testConcurrentReplaceTransactions() {
     validationCatalog.initialize(catalogName, catalogConfig);
@@ -171,7 +182,7 @@ public class TestTableEncryption extends CatalogTestBase {
     DataFile file = currentDataFiles(table).get(0);
     Schema schema = table.schema();
 
-    // Write data for a replace transaction that will be committed later
+    // Begin a replace transaction that will be committed second
     Transaction secondReplace =
         validationCatalog
             .buildTable(tableIdent, schema)
@@ -185,12 +196,15 @@ public class TestTableEncryption extends CatalogTestBase {
             .buildTable(tableIdent, schema)
             .withProperty("encryption.key-id", UnitestKMS.MASTER_KEY_NAME1)
             .replaceTransaction();
-    firstReplace.newFastAppend().appendFile(file).commit();
     firstReplace.commitTransaction();
 
+    // This second replace transaction fails but then retries after refreshing latest metadata.
     secondReplace.commitTransaction();
 
     Table afterSecondReplace = validationCatalog.loadTable(tableIdent);
+
+    // This tests that encryption keys are maintained on refreshing different metadata - if
+    // they are not, the table will be unreadable and this will fail.
     assertThat(currentDataFiles(afterSecondReplace)).hasSize(1);
   }
 
@@ -224,10 +238,14 @@ public class TestTableEncryption extends CatalogTestBase {
 
   @TestTemplate
   public void testMetadataTamperproofing() throws IOException {
-    ChecksumFileSystem fs = ((ChecksumFileSystem) FileSystem.newInstance(new Configuration()));
-    catalog.initialize(catalogName, catalogConfig);
+    assumeThat(validationCatalog)
+        .as("RESTCatalog does not store metadata file hashes")
+        .isNotInstanceOf(RESTCatalog.class);
 
-    Table table = catalog.loadTable(tableIdent);
+    ChecksumFileSystem fs = ((ChecksumFileSystem) FileSystem.newInstance(new Configuration()));
+    validationCatalog.initialize(catalogName, catalogConfig);
+
+    Table table = validationCatalog.loadTable(tableIdent);
     TableMetadata currentMetadata = ((HasTableOperations) table).operations().current();
     Path metadataFile = new Path(currentMetadata.metadataFileLocation());
     Path previousMetadataFile = new Path(Iterables.firstOf(currentMetadata.previousFiles()).file());
@@ -238,7 +256,7 @@ public class TestTableEncryption extends CatalogTestBase {
     fs.delete(metadataFile, false);
     fs.rename(previousMetadataFile, metadataFile);
 
-    assertThatThrownBy(() -> catalog.loadTable(tableIdent))
+    assertThatThrownBy(() -> validationCatalog.loadTable(tableIdent))
         .hasMessageContaining(
             String.format(
                 "The current metadata file %s might have been modified. Hash of metadata loaded from storage differs from HMS-stored metadata hash.",


### PR DESCRIPTION
This draft adds REST Catalog table encryption support while preserving the existing protected RESTSessionCatalog.newTableOps extension points. PR #13225 changes both protected hook signatures by adding KeyManagementClient, which breaks source compatibility for existing RESTSessionCatalog subclasses. This patch keeps both signatures unchanged, initializes the KMS client privately, and passes it from the default implementations to RESTTableOperations. Tests: spotlessCheck; targeted REST Catalog tests; targeted Spark 4.1 table and CTAS encryption tests. REST scan planning with vended credentials remains outside this patch. Related to #13225.