### PR TITLE
Docs: Add Table Spec V3 breakdown to implementation status page

### DIFF
--- a/site/docs/status.md
+++ b/site/docs/status.md
@@ -110,6 +110,20 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Expire snapshots            | Y    | N         | N    | Y  | N   |
 | Manage snapshots            | Y    | N         | N    | Y  | N   |
 
+### Table Spec V3
+
+| Operation                   | Java | PyIceberg | Rust | Go | C++ |
+|-----------------------------|------|-----------|------|----|-----|
+| Update schema               | Y    | Y         | Y    | Y  | Y   |
+| Update partition spec       | Y    | Y         | N    | Y  | Y   |
+| Update table properties     | Y    | Y         | Y    | Y  | Y   |
+| Replace sort order          | Y    | Y         | Y    | Y  | Y   |
+| Update table location       | Y    | Y         | Y    | Y  | Y   |
+| Update statistics           | Y    | Y         | Y    | Y  | Y   |
+| Update partition statistics | Y    | N         | N    | Y  | Y   |
+| Expire snapshots            | Y    | Y         | Y    | Y  | Y   |
+| Manage snapshots            | Y    | Y         | N    | Y  | Y   |
+
 ## Table Update Operations
 
 ### Table Spec V1
@@ -133,6 +147,17 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Row delta         | Y    | N         | N    | Y  | N   |
 | Delete files      | Y    | Y         | N    | Y  | N   |
 
+### Table Spec V3
+
+| Operation         | Java | PyIceberg | Rust | Go | C++ |
+|-------------------|------|-----------|------|----|-----|
+| Append data files | Y    | N         | Y    | Y  | Y   |
+| Rewrite files     | Y    | N         | N    | Y  | Y   |
+| Rewrite manifests | Y    | N         | N    | Y  | N   |
+| Overwrite files   | Y    | N         | N    | Y  | Y   |
+| Row delta         | Y    | N         | N    | Y  | Y   |
+| Delete files      | Y    | N         | N    | Y  | Y   |
+
 ## Table Read Operations
 
 ### Table Spec V1
@@ -155,6 +180,18 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Read with position deletes  | Y    | Y         | Y    | Y  | N   |
 | Read with equality deletes  | Y    | N         | Y    | Y  | N   |
 
+### Table Spec V3
+
+| Operation                    | Java | PyIceberg | Rust | Go | C++ |
+|------------------------------|------|-----------|------|----|-----|
+| Plan with data file          | Y    | Y         | Y    | Y  | Y   |
+| Plan with deletion vectors   | Y    | Y         | N    | Y  | Y   |
+| Plan with equality deletes   | Y    | N         | Y    | Y  | Y   |
+| Plan with puffin statistics  | Y    | N         | N    | N  | N   |
+| Read data file               | Y    | Y         | Y    | Y  | Y   |
+| Read with deletion vectors   | Y    | Y         | N    | Y  | Y   |
+| Read with equality deletes   | Y    | N         | Y    | Y  | Y   |
+
 ## Table Write Operations
 
 ### Table Spec V1
@@ -170,6 +207,14 @@ This section lists the libraries that implement the Apache Iceberg specification
 | Append data            | Y    | Y         | Y    | Y  | N   |
 | Write position deletes | Y    | N         | N    | Y  | N   |
 | Write equality deletes | Y    | N         | Y    | Y  | N   |
+
+### Table Spec V3
+
+| Operation              | Java | PyIceberg | Rust | Go | C++ |
+|------------------------|------|-----------|------|----|-----|
+| Append data            | Y    | N         | Y    | Y  | Y   |
+| Write deletion vectors | Y    | N         | N    | Y  | Y   |
+| Write equality deletes | Y    | N         | Y    | Y  | Y   |
 
 ## Catalogs
 
@@ -188,6 +233,18 @@ This section lists the libraries that implement the Apache Iceberg specification
 | tableExists     | Y    | Y         | Y    | Y  | Y   |
 
 #### Table Spec V2
+
+| Table Operation | Java | PyIceberg | Rust | Go | C++ |
+|-----------------|------|-----------|------|----|-----|
+| listTable       | Y    | Y         | Y    | Y  | Y   |
+| createTable     | Y    | Y         | Y    | Y  | Y   |
+| dropTable       | Y    | Y         | Y    | Y  | Y   |
+| loadTable       | Y    | Y         | Y    | Y  | Y   |
+| updateTable     | Y    | Y         | Y    | Y  | Y   |
+| renameTable     | Y    | Y         | Y    | Y  | Y   |
+| tableExists     | Y    | Y         | Y    | Y  | Y   |
+
+#### Table Spec V3
 
 | Table Operation | Java | PyIceberg | Rust | Go | C++ |
 |-----------------|------|-----------|------|----|-----|
@@ -255,6 +312,18 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 | renameTable     | Y    | Y         | Y    | Y  | N   |
 | tableExists     | Y    | Y         | Y    | Y  | N   |
 
+#### Table Spec V3
+
+| Table Operation | Java | PyIceberg | Rust | Go | C++ |
+|-----------------|------|-----------|------|----|-----|
+| listTable       | Y    | Y         | Y    | Y  | N   |
+| createTable     | Y    | Y         | Y    | Y  | N   |
+| dropTable       | Y    | Y         | Y    | Y  | N   |
+| loadTable       | Y    | Y         | Y    | Y  | N   |
+| updateTable     | Y    | Y         | Y    | Y  | N   |
+| renameTable     | Y    | Y         | Y    | Y  | N   |
+| tableExists     | Y    | Y         | Y    | Y  | N   |
+
 #### View Spec V1
 
 | View Operation | Java | PyIceberg | Rust | Go | C++ |
@@ -303,6 +372,18 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 | renameTable     | Y    | Y         | Y    | Y  | N   |
 | tableExists     | Y    | Y         | Y    | Y  | N   |
 
+#### Table Spec V3
+
+| Table Operation | Java | PyIceberg | Rust | Go | C++ |
+|-----------------|------|-----------|------|----|-----|
+| listTable       | Y    | Y         | Y    | Y  | N   |
+| createTable     | Y    | Y         | Y    | Y  | N   |
+| dropTable       | Y    | Y         | Y    | Y  | N   |
+| loadTable       | Y    | Y         | Y    | Y  | N   |
+| updateTable     | Y    | Y         | Y    | Y  | N   |
+| renameTable     | Y    | Y         | Y    | Y  | N   |
+| tableExists     | Y    | Y         | Y    | Y  | N   |
+
 #### View Spec V1
 
 | View Operation | Java | PyIceberg | Rust | Go | C++ |
@@ -340,6 +421,18 @@ The sql catalog is a catalog backed by a sql database, which is called jdbc cata
 | tableExists     | Y    | Y         | Y    | Y  | N   |
 
 #### Table Spec V2
+
+| Table Operation | Java | PyIceberg | Rust | Go | C++ |
+|-----------------|------|-----------|------|----|-----|
+| listTable       | Y    | Y         | Y    | Y  | N   |
+| createTable     | Y    | Y         | Y    | Y  | N   |
+| dropTable       | Y    | Y         | Y    | Y  | N   |
+| loadTable       | Y    | Y         | Y    | Y  | N   |
+| updateTable     | Y    | Y         | Y    | Y  | N   |
+| renameTable     | Y    | Y         | Y    | Y  | N   |
+| tableExists     | Y    | Y         | Y    | Y  | N   |
+
+#### Table Spec V3
 
 | Table Operation | Java | PyIceberg | Rust | Go | C++ |
 |-----------------|------|-----------|------|----|-----|


### PR DESCRIPTION
## What changes were proposed in this pull request?

The [Implementation Status](https://iceberg.apache.org/status/) page (`site/docs/status.md`) only broke down **Table Maintenance / Update / Read / Write Operations** and **Catalog operations** into `Table Spec V1` and `Table Spec V2` sections. There was no `V3` section anywhere, even though Table Spec V3 (deletion vectors, row lineage, etc.) is ratified.

This PR adds the missing `Table Spec V3` subsections. Closes #17308.

## How were the values determined?

Per-language V3 values were verified against the **current `main` HEAD of each implementation repository**, not carried over blindly from V2:

| Column | Source repo |
|--------|-------------|
| Java | `apache/iceberg` (this repo) |
| PyIceberg | `apache/iceberg-python` |
| Rust | `apache/iceberg-rust` |
| Go | `apache/iceberg-go` |
| C++ | `apache/iceberg-cpp` |

Notable V3-specific findings from the source:

- **Deletion vectors** (the defining V3 read/write change, replacing position delete files):
  - **Java** — full read + write (`core/.../deletes/BaseDVFileWriter.java`).
  - **Go** — read + write (`table/dv/`, `arrow_scanner.go` DV read path; partitioned DV write is in progress).
  - **C++** — read + write (`data/deletion_vector_writer.cc`, `data/delete_loader.cc`, `table_scan.cc`).
  - **Rust** — **not yet implemented** (explicit TODOs in `delete_file_index.rs` / `caching_delete_file_loader.rs`; no DV writer). V2 position/equality deletes exist, but DVs do not.
  - **PyIceberg** — **reads** DVs (`io/pyarrow.py` Puffin branch) but **cannot write** to v3 tables (the manifest writer rejects format version 3 in `manifest.py`), so all V3 write/update rows are `N`.
- **Maintenance / Update / Catalog** rows reflect each library's actual operation + format-v3 support. Catalog V3 tables mirror V2 because all four libraries treat catalogs as format-version-agnostic (they serialize v3-capable metadata and pass it through).

## Note

Some pre-existing V1/V2 cells appear stale relative to current code (e.g., a few Rust maintenance ops and the C++ column). This PR scopes the audit to the new V3 tables; the V1/V2 cells are left unchanged and can be refreshed separately.

## Documentation change only

No code changes; this only edits `site/docs/status.md`.
