### PR TITLE
Flink: Bump DynamicWriteResultSerializer version after format change

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -28,12 +28,14 @@ import org.apache.iceberg.io.WriteResult;
 
 class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicWriteResult> {
 
-  private static final int VERSION = 1;
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int JAVA_SERIALIZATION_MAGIC = 0xACED;
   private static final WriteResultSerializer WRITE_RESULT_SERIALIZER = new WriteResultSerializer();
 
   @Override
   public int getVersion() {
-    return VERSION;
+    return VERSION_2;
   }
 
   @Override
@@ -49,16 +51,59 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
 
   @Override
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
-    if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      TableKey key = TableKey.deserializeFrom(view);
-      int specId = view.readInt();
-      byte[] resultBuf = new byte[view.available()];
-      view.read(resultBuf);
-      WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);
-      return new DynamicWriteResult(key, specId, writeResult);
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
     }
 
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  /**
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout tagged as
+   * version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1 (the version was not bumped).
+   * This method distinguishes the two by sniffing for the Java serialization magic bytes ({@code 0xACED})
+   * at the expected position where the {@code WriteResult} payload would begin in the new format.
+   */
+  private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    view.readUTF();
+    view.readUTF();
+
+    if (isV1NewFormat(view)) {
+      return deserializeV2(serialized);
+    } else {
+      return deserializeV1WriteTarget(serialized);
+    }
+  }
+
+  private boolean isV1NewFormat(DataInputDeserializer view) throws IOException {
+    if (view.available() < 6) {
+      return false;
+    }
+    view.skipBytes(4);
+    int magic = view.readUnsignedShort();
+    return magic == JAVA_SERIALIZATION_MAGIC;
+  }
+
+  private DynamicWriteResult deserializeV1WriteTarget(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    WriteTarget key = WriteTarget.deserializeFrom(view);
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(
+        new TableKey(key.tableName(), key.branch()), key.specId(), writeResult);
+  }
+
+  private DynamicWriteResult deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    TableKey key = TableKey.deserializeFrom(view);
+    int specId = view.readInt();
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(key, specId, writeResult);
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -61,10 +61,10 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   }
 
   /**
-   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout tagged as
-   * version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1 (the version was not bumped).
-   * This method distinguishes the two by sniffing for the Java serialization magic bytes ({@code 0xACED})
-   * at the expected position where the {@code WriteResult} payload would begin in the new format.
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout tagged
+   * as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1. This method
+   * distinguishes the two by sniffing for the Java serialization magic bytes ({@code 0xACED}) at
+   * the expected position where the {@code WriteResult} payload would begin in the new format.
    */
   private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
     DataInputDeserializer view = new DataInputDeserializer(serialized);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.flink.sink.WriteResultSerializer;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
@@ -74,5 +77,95 @@ class TestDynamicWriteResultSerializer {
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))
         .hasMessage("Unrecognized version or corrupt state: -1")
         .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testDeserializeV1Format() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    // V1 format: WriteTarget serialization (tableName, branch, schemaId, specId, upsertMode,
+    // equalityFields) followed by WriteResult bytes
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(1); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that a checkpoint produced by the buggy 1.11.0 (new TableKey + specId format, tagged
+   * version 1) can be correctly restored on the fixed version. The fixed deserializer detects the
+   * format by sniffing for the Java serialization magic bytes (0xACED) 4 bytes after tableName and
+   * branch.
+   */
+  @Test
+  void testBuggyV1BytesRestoredWithFixedDeserializer() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int specId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(specId);
+    view.write(new WriteResultSerializer().serialize(writeResult));
+    byte[] buggyV1Bytes = out.toByteArray();
+
+    DynamicWriteResultSerializer fixedSerializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = fixedSerializer.deserialize(1, buggyV1Bytes);
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(specId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that the old V1 format (WriteTarget layout) with {@code specId=0} is not misidentified
+   * as the new format. When {@code specId=0}, the 4 bytes after tableName+branch are {@code
+   * 0x00000000} (schemaId=0), and the 2 bytes after that are the first 2 bytes of the actual specId
+   * — which must not match the Java serialization magic {@code 0xACED}.
+   */
+  @Test
+  void testOldV1FormatWithZeroSpecIdNotMisdetected() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 0;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(0); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -61,11 +61,10 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   }
 
   /**
-   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout
-   * tagged as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1.
-   * This method distinguishes the two by sniffing for the Java serialization magic bytes
-   * ({@code 0xACED}) at the expected position where the {@code WriteResult} payload would begin
-   * in the new format.
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout tagged
+   * as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1. This method
+   * distinguishes the two by sniffing for the Java serialization magic bytes ({@code 0xACED}) at
+   * the expected position where the {@code WriteResult} payload would begin in the new format.
    */
   private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
     DataInputDeserializer view = new DataInputDeserializer(serialized);

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -28,12 +28,14 @@ import org.apache.iceberg.io.WriteResult;
 
 class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicWriteResult> {
 
-  private static final int VERSION = 1;
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int JAVA_SERIALIZATION_MAGIC = 0xACED;
   private static final WriteResultSerializer WRITE_RESULT_SERIALIZER = new WriteResultSerializer();
 
   @Override
   public int getVersion() {
-    return VERSION;
+    return VERSION_2;
   }
 
   @Override
@@ -49,16 +51,60 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
 
   @Override
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
-    if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      TableKey key = TableKey.deserializeFrom(view);
-      int specId = view.readInt();
-      byte[] resultBuf = new byte[view.available()];
-      view.read(resultBuf);
-      WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);
-      return new DynamicWriteResult(key, specId, writeResult);
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
     }
 
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  /**
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout
+   * tagged as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1.
+   * This method distinguishes the two by sniffing for the Java serialization magic bytes
+   * ({@code 0xACED}) at the expected position where the {@code WriteResult} payload would begin
+   * in the new format.
+   */
+  private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    view.readUTF();
+    view.readUTF();
+
+    if (isV1NewFormat(view)) {
+      return deserializeV2(serialized);
+    } else {
+      return deserializeV1WriteTarget(serialized);
+    }
+  }
+
+  private boolean isV1NewFormat(DataInputDeserializer view) throws IOException {
+    if (view.available() < 6) {
+      return false;
+    }
+    view.skipBytes(4);
+    int magic = view.readUnsignedShort();
+    return magic == JAVA_SERIALIZATION_MAGIC;
+  }
+
+  private DynamicWriteResult deserializeV1WriteTarget(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    WriteTarget key = WriteTarget.deserializeFrom(view);
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(
+        new TableKey(key.tableName(), key.branch()), key.specId(), writeResult);
+  }
+
+  private DynamicWriteResult deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    TableKey key = TableKey.deserializeFrom(view);
+    int specId = view.readInt();
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(key, specId, writeResult);
   }
 }

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.flink.sink.WriteResultSerializer;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
@@ -74,5 +77,95 @@ class TestDynamicWriteResultSerializer {
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))
         .hasMessage("Unrecognized version or corrupt state: -1")
         .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testDeserializeV1Format() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    // V1 format: WriteTarget serialization (tableName, branch, schemaId, specId, upsertMode,
+    // equalityFields) followed by WriteResult bytes
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(1); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that a checkpoint produced by the buggy 1.11.0 (new TableKey + specId format, tagged
+   * version 1) can be correctly restored on the fixed version. The fixed deserializer detects the
+   * format by sniffing for the Java serialization magic bytes (0xACED) 4 bytes after tableName and
+   * branch.
+   */
+  @Test
+  void testBuggyV1BytesRestoredWithFixedDeserializer() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int specId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(specId);
+    view.write(new WriteResultSerializer().serialize(writeResult));
+    byte[] buggyV1Bytes = out.toByteArray();
+
+    DynamicWriteResultSerializer fixedSerializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = fixedSerializer.deserialize(1, buggyV1Bytes);
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(specId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that the old V1 format (WriteTarget layout) with {@code specId=0} is not misidentified
+   * as the new format. When {@code specId=0}, the 4 bytes after tableName+branch are {@code
+   * 0x00000000} (schemaId=0), and the 2 bytes after that are the first 2 bytes of the actual specId
+   * — which must not match the Java serialization magic {@code 0xACED}.
+   */
+  @Test
+  void testOldV1FormatWithZeroSpecIdNotMisdetected() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 0;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(0); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
   }
 }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -61,11 +61,10 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
   }
 
   /**
-   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout
-   * tagged as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1.
-   * This method distinguishes the two by sniffing for the Java serialization magic bytes
-   * ({@code 0xACED}) at the expected position where the {@code WriteResult} payload would begin
-   * in the new format.
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout tagged
+   * as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1. This method
+   * distinguishes the two by sniffing for the Java serialization magic bytes ({@code 0xACED}) at
+   * the expected position where the {@code WriteResult} payload would begin in the new format.
    */
   private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
     DataInputDeserializer view = new DataInputDeserializer(serialized);

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DynamicWriteResultSerializer.java
@@ -28,12 +28,14 @@ import org.apache.iceberg.io.WriteResult;
 
 class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicWriteResult> {
 
-  private static final int VERSION = 1;
+  private static final int VERSION_1 = 1;
+  private static final int VERSION_2 = 2;
+  private static final int JAVA_SERIALIZATION_MAGIC = 0xACED;
   private static final WriteResultSerializer WRITE_RESULT_SERIALIZER = new WriteResultSerializer();
 
   @Override
   public int getVersion() {
-    return VERSION;
+    return VERSION_2;
   }
 
   @Override
@@ -49,16 +51,60 @@ class DynamicWriteResultSerializer implements SimpleVersionedSerializer<DynamicW
 
   @Override
   public DynamicWriteResult deserialize(int version, byte[] serialized) throws IOException {
-    if (version == 1) {
-      DataInputDeserializer view = new DataInputDeserializer(serialized);
-      TableKey key = TableKey.deserializeFrom(view);
-      int specId = view.readInt();
-      byte[] resultBuf = new byte[view.available()];
-      view.read(resultBuf);
-      WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(version, resultBuf);
-      return new DynamicWriteResult(key, specId, writeResult);
+    if (version == VERSION_1) {
+      return deserializeV1(serialized);
+    } else if (version == VERSION_2) {
+      return deserializeV2(serialized);
     }
 
     throw new IOException("Unrecognized version or corrupt state: " + version);
+  }
+
+  /**
+   * Deserializes version-1 bytes, which are ambiguous: Iceberg 1.10.x wrote the old layout
+   * tagged as version 1, while the buggy 1.11.0 wrote the new layout also tagged as version 1.
+   * This method distinguishes the two by sniffing for the Java serialization magic bytes
+   * ({@code 0xACED}) at the expected position where the {@code WriteResult} payload would begin
+   * in the new format.
+   */
+  private DynamicWriteResult deserializeV1(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    view.readUTF();
+    view.readUTF();
+
+    if (isV1NewFormat(view)) {
+      return deserializeV2(serialized);
+    } else {
+      return deserializeV1WriteTarget(serialized);
+    }
+  }
+
+  private boolean isV1NewFormat(DataInputDeserializer view) throws IOException {
+    if (view.available() < 6) {
+      return false;
+    }
+    view.skipBytes(4);
+    int magic = view.readUnsignedShort();
+    return magic == JAVA_SERIALIZATION_MAGIC;
+  }
+
+  private DynamicWriteResult deserializeV1WriteTarget(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    WriteTarget key = WriteTarget.deserializeFrom(view);
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(
+        new TableKey(key.tableName(), key.branch()), key.specId(), writeResult);
+  }
+
+  private DynamicWriteResult deserializeV2(byte[] serialized) throws IOException {
+    DataInputDeserializer view = new DataInputDeserializer(serialized);
+    TableKey key = TableKey.deserializeFrom(view);
+    int specId = view.readInt();
+    byte[] resultBuf = new byte[view.available()];
+    view.read(resultBuf);
+    WriteResult writeResult = WRITE_RESULT_SERIALIZER.deserialize(VERSION_1, resultBuf);
+    return new DynamicWriteResult(key, specId, writeResult);
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestDynamicWriteResultSerializer.java
@@ -21,12 +21,15 @@ package org.apache.iceberg.flink.sink.dynamic;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.apache.flink.core.memory.DataOutputViewStreamWrapper;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.Metrics;
 import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.flink.sink.WriteResultSerializer;
 import org.apache.iceberg.io.WriteResult;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.Test;
@@ -74,5 +77,95 @@ class TestDynamicWriteResultSerializer {
     assertThatThrownBy(() -> serializer.deserialize(-1, serializer.serialize(dynamicWriteResult)))
         .hasMessage("Unrecognized version or corrupt state: -1")
         .isInstanceOf(IOException.class);
+  }
+
+  @Test
+  void testDeserializeV1Format() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    // V1 format: WriteTarget serialization (tableName, branch, schemaId, specId, upsertMode,
+    // equalityFields) followed by WriteResult bytes
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(1); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that a checkpoint produced by the buggy 1.11.0 (new TableKey + specId format, tagged
+   * version 1) can be correctly restored on the fixed version. The fixed deserializer detects the
+   * format by sniffing for the Java serialization magic bytes (0xACED) 4 bytes after tableName and
+   * branch.
+   */
+  @Test
+  void testBuggyV1BytesRestoredWithFixedDeserializer() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int specId = 3;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(specId);
+    view.write(new WriteResultSerializer().serialize(writeResult));
+    byte[] buggyV1Bytes = out.toByteArray();
+
+    DynamicWriteResultSerializer fixedSerializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = fixedSerializer.deserialize(1, buggyV1Bytes);
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(specId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
+  }
+
+  /**
+   * Verifies that the old V1 format (WriteTarget layout) with {@code specId=0} is not misidentified
+   * as the new format. When {@code specId=0}, the 4 bytes after tableName+branch are {@code
+   * 0x00000000} (schemaId=0), and the 2 bytes after that are the first 2 bytes of the actual specId
+   * — which must not match the Java serialization magic {@code 0xACED}.
+   */
+  @Test
+  void testOldV1FormatWithZeroSpecIdNotMisdetected() throws IOException {
+    WriteResult writeResult = WriteResult.builder().addDataFiles(DATA_FILE).build();
+    int expectedSpecId = 0;
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    DataOutputViewStreamWrapper view = new DataOutputViewStreamWrapper(out);
+    view.writeUTF(TABLE_KEY.tableName());
+    view.writeUTF(TABLE_KEY.branch());
+    view.writeInt(0); // schemaId
+    view.writeInt(expectedSpecId); // specId
+    view.writeBoolean(false); // upsertMode
+    view.writeInt(0); // equalityFields count
+    view.write(new WriteResultSerializer().serialize(writeResult));
+
+    DynamicWriteResultSerializer serializer = new DynamicWriteResultSerializer();
+    DynamicWriteResult deserialized = serializer.deserialize(1, out.toByteArray());
+
+    assertThat(deserialized.key()).isEqualTo(TABLE_KEY);
+    assertThat(deserialized.specId()).isEqualTo(expectedSpecId);
+    assertThat(deserialized.writeResult().dataFiles()).hasSize(1);
+    assertThat(deserialized.writeResult().dataFiles()[0].path())
+        .isEqualTo("/path/to/data-1.parquet");
+    assertThat(deserialized.writeResult().dataFiles()[0].recordCount()).isEqualTo(42L);
   }
 }


### PR DESCRIPTION

## Summary

[#14810](https://github.com/apache/iceberg/pull/14810) changed the serialized format of `DynamicWriteResultSerializer` by adding a `specId` field, but did not bump `getVersion()` from `1`. This breaks the `SimpleVersionedSerializer` versioning contract and makes version 1 ambiguous:

- **Iceberg 1.10.x** wrote the old `WriteTarget` layout (`tableName, branch, schemaId, specId, upsertMode, equalityFields`) tagged as version 1
- **Iceberg 1.11.0** (buggy) wrote the new `TableKey` + `specId` layout also tagged as version 1 (the version was not bumped)

This causes checkpoint/savepoint restore failures:

| Upgrade path | Result |
|---|---|
| 1.10.x → 1.11.0 | **Fails**: `StreamCorruptedException: invalid stream header: 00000000` |
| 1.11.0 → fixed version (apply this patch) | **Fails**: `OutOfMemoryError` (huge `equalityFields` count from misaligned bytes) |

The sibling `DynamicCommittableSerializer` was correctly versioned in the same commit (bumped to V2 with `deserializeV1`/`deserializeV2`). This was simply missed.

## Fix

1. **Bump `getVersion()` to 2** — new checkpoints are tagged V2, eliminating future ambiguity
2. **`deserializeV1WriteTarget`** — reads the old 1.10.x `WriteTarget` format
3. **`deserializeV2`** — reads the current `TableKey` + `specId` format (same body as the old `deserialize(1,...)`)
4. **`isV1NewFormat`** — sniffs V1 bytes to distinguish 1.10.x from 1.11.0, then delegates to the appropriate deserializer

### Heuristic: distinguishing the two V1 layouts

After `tableName` + `branch` (common to both layouts), the method skips 4 bytes and checks if the next 2 are `0xACED` (Java serialization magic):

- **New format (1.11.0):** the 4 skipped bytes are `specId`, the next 2 bytes are the start of the Java-serialized `WriteResult` stream (`0xACED`) → correctly identified as new format, delegates to `deserializeV2`
- **Old format (1.10.x):** the 4 skipped bytes are `schemaId`, the next 2 bytes are the upper 2 bytes of `specId`. Since spec IDs are sequentially assigned starting from 0, they are always < 65536, so the upper 2 bytes in big-endian are `0x0000` → correctly identified as old format, uses `deserializeV1WriteTarget`

A false positive would require `specId >= 0xACED0000` (~2.9 billion), which is impossible in practice.

### Upgrade paths after fix

| From → To | Path |
|---|---|
| 1.10.x → fixed | V1 → heuristic detects old format → `deserializeV1WriteTarget` |
| 1.11.0 → fixed | V1 → heuristic detects new format → `deserializeV2` |
| fixed → fixed | V2 → `deserializeV2` |

## Testing

- `testRoundtrip` — verifies V2 serialize → deserialize roundtrip (existing, uses `getVersion()` which now returns 2)
- `testUnsupportedVersion` — verifies unknown versions throw (existing, unchanged)
- `testDeserializeV1Format` — constructs old V1-format bytes (WriteTarget layout with `specId=3`) and verifies correct deserialization
- `testBuggyV1BytesRestoredWithFixedDeserializer` — constructs 1.11.0 V1-format bytes (TableKey + specId, tagged version 1) and verifies the fixed deserializer correctly restores them
- `testOldV1FormatWithZeroSpecIdNotMisdetected` — edge case: old V1 format with `specId=0` must not be misidentified as new format by the heuristic

All tests pass on `iceberg-flink-1.20`, `iceberg-flink-2.0`, and `iceberg-flink-2.1`.

Closes https://github.com/apache/iceberg/issues/17314

---
**AI Disclosure**
- Model: GLM 5.2
- Platform/Tool: opencode
- Human Oversight: fully reviewed
- Prompt Summary: Fix DynamicWriteResultSerializer version not bumped after format change; add heuristic to distinguish 1.10.x and 1.11.0 V1 byte layouts for backward-compatible deserialization.

