### PR TITLE
Hive: Use server-side filter to list Iceberg tables in HiveCatalog

### DIFF
--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.hive;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.metastore.api.UnknownDBException;
+import org.apache.hadoop.hive.metastore.api.hive_metastoreConstants;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
@@ -167,18 +169,19 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
     String database = namespace.level(0);
 
     try {
-      List<String> tableNames = clients.run(client -> client.getAllTables(database));
       List<TableIdentifier> tableIdentifiers;
 
       if (listAllTables) {
+        List<String> tableNames = clients.run(client -> client.getAllTables(database));
         tableIdentifiers =
             tableNames.stream()
                 .map(t -> TableIdentifier.of(namespace, t))
                 .collect(Collectors.toList());
       } else {
+        // Retrieving only the matching table names from HMS via server-side filter
         tableIdentifiers =
-            listIcebergTables(
-                tableNames, namespace, BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
+            listIcebergTablesByFilter(
+                namespace, BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE);
       }
 
       LOG.debug(
@@ -351,6 +354,43 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
                     && tableTypeProp.equalsIgnoreCase(
                         table.getParameters().get(BaseMetastoreTableOperations.TABLE_TYPE_PROP)))
         .map(table -> TableIdentifier.of(namespace, table.getTableName()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Lists the {@link TableIdentifier} of all Iceberg tables under the given database.
+   *
+   * <p>Implementation uses the HMS {@code get_table_names_by_filter} API, filtering on {@code
+   * parameters.table_type} on the server side so that only matching table names (rather than full
+   * Table objects) are returned.
+   *
+   * @param namespace the namespace corresponding to the database
+   * @param tableTypeValue the value of {@code parameters.table_type} to filter on, e.g. {@link
+   *     BaseMetastoreTableOperations#ICEBERG_TABLE_TYPE_VALUE} for tables. HMS normalizes this
+   *     value to upper case when persisting it, so the filter value is upper-cased to match.
+   */
+  private List<TableIdentifier> listIcebergTablesByFilter(
+      Namespace namespace, String tableTypeValue) throws TException, InterruptedException {
+    String database = namespace.level(0);
+    // HMS normalizes the `table_type` parameter value to upper case when persisting it
+    // (e.g. "iceberg" is stored as "ICEBERG"), so the filter value must be upper-cased to match.
+    // Note: `like` (rather than `=`) is used intentionally. Some HMS backends (e.g. Derby and
+    // Oracle, where PARAM_VALUE is a CLOB) do not support `=` comparison on property values and
+    // fail the filter query (see HIVE-21614); newer HMS versions internally rewrite `=` to `like`
+    // for this reason. As the value carries no `%`/`_` wildcards, `like` is equivalent to `=` here.
+    String filter =
+        hive_metastoreConstants.HIVE_FILTER_FIELD_PARAMS
+            + BaseMetastoreTableOperations.TABLE_TYPE_PROP
+            + " like \""
+            + tableTypeValue.toUpperCase(Locale.ROOT)
+            + "\"";
+
+    List<String> icebergTableNames =
+        clients.run(
+            client -> client.listTableNamesByFilter(database, filter, (short) -1 /* no limit */));
+
+    return icebergTableNames.stream()
+        .map(tableName -> TableIdentifier.of(namespace, tableName))
         .collect(Collectors.toList());
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveCatalog.java
@@ -360,14 +360,8 @@ public class HiveCatalog extends BaseMetastoreViewCatalog
   /**
    * Lists the {@link TableIdentifier} of all Iceberg tables under the given database.
    *
-   * <p>Implementation uses the HMS {@code get_table_names_by_filter} API, filtering on {@code
-   * parameters.table_type} on the server side so that only matching table names (rather than full
-   * Table objects) are returned.
-   *
    * @param namespace the namespace corresponding to the database
-   * @param tableTypeValue the value of {@code parameters.table_type} to filter on, e.g. {@link
-   *     BaseMetastoreTableOperations#ICEBERG_TABLE_TYPE_VALUE} for tables. HMS normalizes this
-   *     value to upper case when persisting it, so the filter value is upper-cased to match.
+   * @param tableTypeValue the value of {@code parameters.table_type} to filter on.
    */
   private List<TableIdentifier> listIcebergTablesByFilter(
       Namespace namespace, String tableTypeValue) throws TException, InterruptedException {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCatalog.java
@@ -45,8 +45,11 @@ import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.TableType;
 import org.apache.hadoop.hive.metastore.api.Database;
 import org.apache.hadoop.hive.metastore.api.PrincipalType;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.CachingCatalog;
@@ -78,6 +81,7 @@ import org.apache.iceberg.exceptions.NoSuchNamespaceException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
@@ -1265,5 +1269,72 @@ public class TestHiveCatalog extends CatalogTests<HiveCatalog> {
     } else {
       assertThat(base64EncodedHash).isNull();
     }
+  }
+
+  @Test
+  public void testListTablesFiltersOutNonIcebergTables() throws TException {
+    Namespace ns = Namespace.of(DB_NAME);
+    TableIdentifier icebergTable = TableIdentifier.of(ns, "iceberg_tbl");
+    TableIdentifier hiveTable = TableIdentifier.of(ns, "hive_tbl");
+
+    catalog.createTable(icebergTable, getTestSchema());
+    HIVE_METASTORE_EXTENSION
+        .metastoreClient()
+        .createTable(createNonIcebergTable(hiveTable.name(), TableType.EXTERNAL_TABLE));
+
+    try {
+      assertThat(catalog.listTables(ns)).containsExactly(icebergTable);
+    } finally {
+      catalog.dropTable(icebergTable);
+      HIVE_METASTORE_EXTENSION.metastoreClient().dropTable(DB_NAME, hiveTable.name());
+    }
+  }
+
+  @Test
+  public void testListTablesByFilterReturnsAllIcebergTables() throws Exception {
+    Namespace ns = Namespace.of(DB_NAME);
+    TableIdentifier t1 = TableIdentifier.of(ns, "t1");
+    TableIdentifier t2 = TableIdentifier.of(ns, "t2");
+
+    catalog.createTable(t1, getTestSchema());
+    catalog.createTable(t2, getTestSchema());
+
+    try {
+      assertThat(catalog.listTables(ns)).containsExactlyInAnyOrder(t1, t2);
+    } finally {
+      catalog.dropTable(t1);
+      catalog.dropTable(t2);
+    }
+  }
+
+  private org.apache.hadoop.hive.metastore.api.Table createNonIcebergTable(
+      String hiveTableName, TableType type) {
+    StorageDescriptor sd =
+        new StorageDescriptor(
+            Lists.newArrayList(),
+            temp.resolve(hiveTableName).toString(),
+            "org.apache.hadoop.mapred.TextInputFormat",
+            "org.apache.hadoop.mapred.TextOutputFormat",
+            false,
+            -1,
+            new SerDeInfo(
+                null, "org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe", Maps.newHashMap()),
+            Lists.newArrayList(),
+            Lists.newArrayList(),
+            Maps.newHashMap());
+
+    return new org.apache.hadoop.hive.metastore.api.Table(
+        hiveTableName,
+        DB_NAME,
+        "test_owner",
+        0,
+        0,
+        0,
+        sd,
+        Lists.newArrayList(),
+        Maps.newHashMap(),
+        null,
+        null,
+        type.name());
   }
 }


### PR DESCRIPTION
HiveCatalog.listTables previously called the HMS getTableObjectsByName API and loaded every Table object into the client to filter out non-Iceberg tables. For a namespace with many tables, this causes a timeout or an OutOfMemoryError on the client side.

Add listIcebergTablesByFilter, which uses HMS get_table_names_by_filter to filter on the `table_type` parameter server-side, so only the matching Iceberg table names are returned (not full Table objects). listTables uses this path by default; the existing list-iceberg-tables-legacy property opts back into the previous client-side behavior. 

Closes #17312