### PR TITLE
Parquet: Fix nested initial default applied when ancestor struct is null

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/BaseFormatModelTests.java
@@ -842,6 +842,68 @@ public abstract class BaseFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testNestedDefaultValueWhenParentStructIsNull(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.NestedField nestedField =
+        Types.NestedField.optional("nested")
+            .withId(2)
+            .ofType(
+                Types.StructType.of(Types.NestedField.required(3, "inner", Types.StringType.get())))
+            .build();
+    Schema writeSchema = new Schema(idField, nestedField);
+
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    Record presentNested = GenericRecord.create(nestedField.type().asStructType());
+    presentNested.setField("inner", "a");
+    present.setField("nested", presentNested);
+
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 2L);
+    nullNested.setField("nested", null);
+
+    List<Record> genericRecords = List.of(present, nullNested);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // read schema drops "inner" entirely, projecting only the new defaulted field
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.optional("added")
+                            .withId(4)
+                            .ofType(Types.StringType.get())
+                            .withInitialDefault(Literal.of("US"))
+                            .build()))
+                .build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          if (record.getField("nested") != null) {
+            Record expectedNested =
+                GenericRecord.create(expectedSchema.findField("nested").type().asStructType());
+            expectedNested.setField("added", "US");
+            expected.setField("nested", expectedNested);
+          } else {
+            expected.setField("nested", null);
+          }
+
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testMapNestedDefaultValue(FileFormat fileFormat) throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 

--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -917,6 +917,291 @@ public abstract class ReadFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testNestedDefaultValueWhenParentStructIsNull(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    // write two leaves under the struct so the probe leaf is one of several, not the only column
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.StructType writeNested =
+        Types.StructType.of(
+            Types.NestedField.required(3, "a", Types.StringType.get()),
+            Types.NestedField.required(4, "b", Types.StringType.get()));
+    Types.NestedField nestedField =
+        Types.NestedField.optional("nested").withId(2).ofType(writeNested).build();
+    Schema writeSchema = new Schema(idField, nestedField);
+
+    Record presentNested = GenericRecord.create(writeNested);
+    presentNested.setField("a", "x");
+    presentNested.setField("b", "y");
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    present.setField("nested", presentNested);
+
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 2L);
+    nullNested.setField("nested", null);
+
+    List<Record> genericRecords = List.of(present, nullNested);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // read drops both a and b, projecting only the defaulted field
+    Types.StructType readNested =
+        Types.StructType.of(
+            Types.NestedField.optional("added")
+                .withId(5)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("US"))
+                .build());
+    Schema expectedSchema =
+        new Schema(
+            idField, Types.NestedField.optional("nested").withId(2).ofType(readNested).build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          // present struct reads the default, null struct stays null
+          if (record.getField("nested") != null) {
+            Record expectedNested = GenericRecord.create(readNested);
+            expectedNested.setField("added", "US");
+            expected.setField("nested", expectedNested);
+          } else {
+            expected.setField("nested", null);
+          }
+
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testArrayElementDefault(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.StructType writeElement =
+        Types.StructType.of(Types.NestedField.required(4, "inner", Types.StringType.get()));
+    Schema writeSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("arr")
+                .withId(2)
+                .ofType(Types.ListType.ofOptional(3, writeElement))
+                .build());
+
+    Record present = GenericRecord.create(writeElement);
+    present.setField("inner", "a");
+    Record row = GenericRecord.create(writeSchema);
+    row.setField("id", 1L);
+    row.setField("arr", Lists.newArrayList(present, null));
+    List<Record> genericRecords = List.of(row);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // element struct drops "inner" and projects only the added defaulted field
+    Types.StructType readElement =
+        Types.StructType.of(
+            Types.NestedField.optional("added")
+                .withId(5)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("US"))
+                .build());
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("arr")
+                .withId(2)
+                .ofType(Types.ListType.ofOptional(3, readElement))
+                .build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record withDefault = GenericRecord.create(readElement);
+          withDefault.setField("added", "US");
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          // present element reads the default, null element stays null
+          expected.setField("arr", Lists.newArrayList(withDefault, null));
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testArrayNullAndEmpty(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.StructType writeElement =
+        Types.StructType.of(Types.NestedField.required(4, "inner", Types.StringType.get()));
+    Schema writeSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("arr")
+                .withId(2)
+                .ofType(Types.ListType.ofOptional(3, writeElement))
+                .build());
+
+    Record nullList = GenericRecord.create(writeSchema);
+    nullList.setField("id", 1L);
+    nullList.setField("arr", null);
+    Record emptyList = GenericRecord.create(writeSchema);
+    emptyList.setField("id", 2L);
+    emptyList.setField("arr", Lists.newArrayList());
+    List<Record> genericRecords = List.of(nullList, emptyList);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // element struct projects only a default, so the list reads through the injected probe leaf
+    Types.StructType readElement =
+        Types.StructType.of(
+            Types.NestedField.optional("added")
+                .withId(5)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("US"))
+                .build());
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("arr")
+                .withId(2)
+                .ofType(Types.ListType.ofOptional(3, readElement))
+                .build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          // a null list stays null and an empty list stays empty
+          expected.setField("arr", record.getField("arr"));
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testMapValueDefault(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.StructType writeValue =
+        Types.StructType.of(Types.NestedField.required(5, "inner", Types.StringType.get()));
+    Schema writeSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("map")
+                .withId(2)
+                .ofType(Types.MapType.ofOptional(3, 4, Types.StringType.get(), writeValue))
+                .build());
+
+    Record present = GenericRecord.create(writeValue);
+    present.setField("inner", "a");
+    Map<String, Record> writtenMap = Maps.newLinkedHashMap();
+    writtenMap.put("k1", present);
+    writtenMap.put("k2", null);
+    Record row = GenericRecord.create(writeSchema);
+    row.setField("id", 1L);
+    row.setField("map", writtenMap);
+    List<Record> genericRecords = List.of(row);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // value struct drops "inner" and projects only the added defaulted field
+    Types.StructType readValue =
+        Types.StructType.of(
+            Types.NestedField.optional("added")
+                .withId(6)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("US"))
+                .build());
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("map")
+                .withId(2)
+                .ofType(Types.MapType.ofOptional(3, 4, Types.StringType.get(), readValue))
+                .build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record withDefault = GenericRecord.create(readValue);
+          withDefault.setField("added", "US");
+          Map<String, Record> expectedMap = Maps.newLinkedHashMap();
+          // present value reads the default, null value stays null
+          expectedMap.put("k1", withDefault);
+          expectedMap.put("k2", null);
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          expected.setField("map", expectedMap);
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
+  void testMapNullAndEmpty(FileFormat fileFormat) throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.StructType writeValue =
+        Types.StructType.of(Types.NestedField.required(5, "inner", Types.StringType.get()));
+    Schema writeSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("map")
+                .withId(2)
+                .ofType(Types.MapType.ofOptional(3, 4, Types.StringType.get(), writeValue))
+                .build());
+
+    Record nullMap = GenericRecord.create(writeSchema);
+    nullMap.setField("id", 1L);
+    nullMap.setField("map", null);
+    Record emptyMap = GenericRecord.create(writeSchema);
+    emptyMap.setField("id", 2L);
+    emptyMap.setField("map", Maps.newLinkedHashMap());
+    List<Record> genericRecords = List.of(nullMap, emptyMap);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // value struct projects only a default, so the map reads through the injected probe leaf
+    Types.StructType readValue =
+        Types.StructType.of(
+            Types.NestedField.optional("added")
+                .withId(6)
+                .ofType(Types.StringType.get())
+                .withInitialDefault(Literal.of("US"))
+                .build());
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional("map")
+                .withId(2)
+                .ofType(Types.MapType.ofOptional(3, 4, Types.StringType.get(), readValue))
+                .build());
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          // a null map stays null and an empty map stays empty
+          expected.setField("map", record.getField("map"));
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testMissingRequiredWithoutDefault(FileFormat fileFormat) throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 

--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -1054,6 +1054,45 @@ public abstract class ReadFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testNestedDefaultValueWhenParentStructWithOnlyListIsNull(FileFormat fileFormat)
+      throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.NestedField nestedField =
+        Types.NestedField.optional("nested")
+            .withId(2)
+            .ofType(
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        3, "tags", Types.ListType.ofRequired(4, Types.StringType.get()))))
+            .build();
+    Schema writeSchema = new Schema(idField, nestedField);
+    Types.StructType nestedType = nestedField.type().asStructType();
+
+    List<Record> genericRecords = Lists.newArrayList();
+    for (int i = 0; i < 5; i += 1) {
+      Record record = GenericRecord.create(writeSchema);
+      record.setField("id", (long) i);
+      if (i % 2 == 0) {
+        Record nested = GenericRecord.create(nestedType);
+        nested.setField("tags", IntStream.range(0, i).mapToObj(j -> "tag-" + j).toList());
+        record.setField("nested", nested);
+      }
+
+      genericRecords.add(record);
+    }
+
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    Schema expectedSchema = schemaWithOnlyDefaultedNestedField();
+
+    readAndAssertEngineRecords(
+        fileFormat, expectedSchema, genericRecords, defaultedNestedRecord(expectedSchema));
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testNestedProjectionWithoutDefaultWhenParentStructIsNull(FileFormat fileFormat)
       throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);

--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -978,6 +978,82 @@ public abstract class ReadFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testNestedDefaultValueWhenParentStructWithListIsNull(FileFormat fileFormat)
+      throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.NestedField nestedField =
+        Types.NestedField.optional("nested")
+            .withId(2)
+            .ofType(
+                Types.StructType.of(
+                    Types.NestedField.optional(
+                        3, "tags", Types.ListType.ofRequired(4, Types.StringType.get())),
+                    Types.NestedField.required(5, "inner", Types.StringType.get())))
+            .build();
+    Schema writeSchema = new Schema(idField, nestedField);
+    Types.StructType nestedType = nestedField.type().asStructType();
+
+    // alternate present and null structs, with a different number of list elements per row so
+    // that a reader tracking the list column would fall behind by more than one value per row
+    List<Record> genericRecords = Lists.newArrayList();
+    for (int i = 0; i < 5; i += 1) {
+      Record record = GenericRecord.create(writeSchema);
+      record.setField("id", (long) i);
+      if (i % 2 == 0) {
+        Record nested = GenericRecord.create(nestedType);
+        nested.setField("tags", IntStream.range(0, i).mapToObj(j -> "tag-" + j).toList());
+        nested.setField("inner", "inner-" + i);
+        record.setField("nested", nested);
+      }
+
+      genericRecords.add(record);
+    }
+
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    Schema expectedSchema = schemaWithOnlyDefaultedNestedField();
+
+    readAndAssertEngineRecords(
+        fileFormat, expectedSchema, genericRecords, defaultedNestedRecord(expectedSchema));
+  }
+
+  /**
+   * Projects "nested" with a single added field that is missing from the file but has a default.
+   */
+  private static Schema schemaWithOnlyDefaultedNestedField() {
+    return new Schema(
+        Types.NestedField.required(1, "id", Types.LongType.get()),
+        Types.NestedField.optional("nested")
+            .withId(2)
+            .ofType(
+                Types.StructType.of(
+                    Types.NestedField.optional("added")
+                        .withId(100)
+                        .ofType(Types.StringType.get())
+                        .withInitialDefault(Literal.of("US"))
+                        .build()))
+            .build());
+  }
+
+  private static Function<Record, Record> defaultedNestedRecord(Schema expectedSchema) {
+    Types.StructType nestedType = expectedSchema.findField("nested").type().asStructType();
+    return record -> {
+      Record expected = GenericRecord.create(expectedSchema);
+      expected.setField("id", record.getField("id"));
+      if (record.getField("nested") != null) {
+        Record expectedNested = GenericRecord.create(nestedType);
+        expectedNested.setField("added", "US");
+        expected.setField("nested", expectedNested);
+      }
+
+      return expected;
+    };
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testArrayElementDefault(FileFormat fileFormat) throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 

--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -920,7 +920,7 @@ public abstract class ReadFormatModelTests<T> {
   void testNestedDefaultValueWhenParentStructIsNull(FileFormat fileFormat) throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 
-    // write two leaves under the struct so the probe leaf is one of several, not the only column
+    // write two leaves under the struct so the presence column is one of several, not the only one
     Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
     Types.StructType writeNested =
         Types.StructType.of(
@@ -1054,6 +1054,61 @@ public abstract class ReadFormatModelTests<T> {
 
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
+  void testNestedProjectionWithoutDefaultWhenParentStructIsNull(FileFormat fileFormat)
+      throws IOException {
+    assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
+
+    Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
+    Types.NestedField nestedField =
+        Types.NestedField.optional(
+            2,
+            "nested",
+            Types.StructType.of(Types.NestedField.required(3, "inner", Types.StringType.get())));
+    Schema writeSchema = new Schema(idField, nestedField);
+
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    Record presentNested = GenericRecord.create(nestedField.type().asStructType());
+    presentNested.setField("inner", "a");
+    present.setField("nested", presentNested);
+
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 2L);
+    nullNested.setField("nested", null);
+
+    List<Record> genericRecords = List.of(present, nullNested);
+    writeGenericRecords(fileFormat, writeSchema, genericRecords);
+
+    // the only projected field of "nested" is missing from the file and has no initial default, so
+    // a present struct must still be read as a struct with a null field, not as a null struct
+    Schema expectedSchema =
+        new Schema(
+            idField,
+            Types.NestedField.optional(
+                2,
+                "nested",
+                Types.StructType.of(
+                    Types.NestedField.optional(4, "added", Types.StringType.get()))));
+
+    Types.StructType expectedNestedType = expectedSchema.findField("nested").type().asStructType();
+
+    readAndAssertEngineRecords(
+        fileFormat,
+        expectedSchema,
+        genericRecords,
+        record -> {
+          Record expected = GenericRecord.create(expectedSchema);
+          expected.setField("id", record.getField("id"));
+          if (record.getField("nested") != null) {
+            expected.setField("nested", GenericRecord.create(expectedNestedType));
+          }
+
+          return expected;
+        });
+  }
+
+  @ParameterizedTest
+  @FieldSource("FILE_FORMATS")
   void testArrayElementDefault(FileFormat fileFormat) throws IOException {
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 
@@ -1132,7 +1187,7 @@ public abstract class ReadFormatModelTests<T> {
     List<Record> genericRecords = List.of(nullList, emptyList);
     writeGenericRecords(fileFormat, writeSchema, genericRecords);
 
-    // element struct projects only a default, so the list reads through the injected probe leaf
+    // element struct projects only a default, so the list reads through the presence column
     Types.StructType readElement =
         Types.StructType.of(
             Types.NestedField.optional("added")
@@ -1247,7 +1302,7 @@ public abstract class ReadFormatModelTests<T> {
     List<Record> genericRecords = List.of(nullMap, emptyMap);
     writeGenericRecords(fileFormat, writeSchema, genericRecords);
 
-    // value struct projects only a default, so the map reads through the injected probe leaf
+    // value struct projects only a default, so the map reads through the presence column
     Types.StructType readValue =
         Types.StructType.of(
             Types.NestedField.optional("added")

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -33,8 +33,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.DataTestBase;
 import org.apache.iceberg.data.DataTestHelpers;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
@@ -180,6 +182,156 @@ public class TestGenericData extends DataTestBase {
       }
 
       assertThat(Lists.newArrayList(reader)).hasSize(1);
+    }
+  }
+
+  @Test
+  public void testNestedInitialDefaultWhenAncestorStructIsNull() throws IOException {
+    // one row has an inner value, the other has a null nested struct
+    Schema writeSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.required(3, "inner", Types.StringType.get())))
+                .build());
+
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    Record presentNested =
+        GenericRecord.create(writeSchema.findField("nested").type().asStructType());
+    presentNested.setField("inner", "a");
+    present.setField("nested", presentNested);
+
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 2L);
+    nullNested.setField("nested", null);
+
+    OutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> appender =
+        Parquet.write(output)
+            .schema(writeSchema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      appender.add(present);
+      appender.add(nullNested);
+    }
+
+    // project only the added field with the default; inner is not read
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.optional("added")
+                            .withId(4)
+                            .ofType(Types.StringType.get())
+                            .withInitialDefault(Literal.of("US"))
+                            .build()))
+                .build());
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader =
+        Parquet.read(output.toInputFile())
+            .project(readSchema)
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(readSchema, fileSchema))
+            .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    assertThat(rows).hasSize(2);
+
+    // present struct reads the default
+    Record row1Nested = (Record) rows.get(0).getField("nested");
+    assertThat(row1Nested).isNotNull();
+    assertThat(row1Nested.getField("added")).isEqualTo("US");
+
+    // null struct reads as null
+    assertThat(rows.get(1).getField("nested")).isNull();
+  }
+
+  @Test
+  public void testNestedInitialDefaultWithInterleavedNullStructs() throws IOException {
+    // alternate present and null nested structs across rows
+    Schema writeSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.required(3, "inner", Types.StringType.get())))
+                .build());
+
+    Types.StructType writeNestedType = writeSchema.findField("nested").type().asStructType();
+
+    // present, null, present, null, present
+    List<Record> records = Lists.newArrayList();
+    boolean[] present = {true, false, true, false, true};
+    for (int i = 0; i < present.length; i += 1) {
+      Record record = GenericRecord.create(writeSchema);
+      record.setField("id", (long) i);
+      if (present[i]) {
+        Record nested = GenericRecord.create(writeNestedType);
+        nested.setField("inner", "inner-" + i);
+        record.setField("nested", nested);
+      } else {
+        record.setField("nested", null);
+      }
+
+      records.add(record);
+    }
+
+    OutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> appender =
+        Parquet.write(output)
+            .schema(writeSchema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      appender.addAll(records);
+    }
+
+    // project only the added field with the default; inner is not read
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.optional("added")
+                            .withId(4)
+                            .ofType(Types.StringType.get())
+                            .withInitialDefault(Literal.of("US"))
+                            .build()))
+                .build());
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader =
+        Parquet.read(output.toInputFile())
+            .project(readSchema)
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(readSchema, fileSchema))
+            .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    assertThat(rows).hasSize(present.length);
+    for (int i = 0; i < present.length; i += 1) {
+      Record nested = (Record) rows.get(i).getField("nested");
+      if (present[i]) {
+        // present struct reads the default
+        assertThat(nested).as("row %s nested struct should be present", i).isNotNull();
+        assertThat(nested.getField("added")).isEqualTo("US");
+      } else {
+        // null struct reads as null
+        assertThat(nested).as("row %s nested struct should be null", i).isNull();
+      }
     }
   }
 }

--- a/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
+++ b/data/src/test/java/org/apache/iceberg/data/parquet/TestGenericData.java
@@ -33,8 +33,10 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.avro.AvroSchemaUtil;
 import org.apache.iceberg.data.DataTestBase;
 import org.apache.iceberg.data.DataTestHelpers;
+import org.apache.iceberg.data.GenericRecord;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
@@ -181,5 +183,75 @@ public class TestGenericData extends DataTestBase {
 
       assertThat(Lists.newArrayList(reader)).hasSize(1);
     }
+  }
+
+  @Test
+  public void testNestedInitialDefaultWhenAncestorStructIsNull() throws IOException {
+    // one row has an inner value, the other has a null nested struct
+    Schema writeSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.required(3, "inner", Types.StringType.get())))
+                .build());
+
+    Record present = GenericRecord.create(writeSchema);
+    present.setField("id", 1L);
+    Record presentNested =
+        GenericRecord.create(writeSchema.findField("nested").type().asStructType());
+    presentNested.setField("inner", "a");
+    present.setField("nested", presentNested);
+
+    Record nullNested = GenericRecord.create(writeSchema);
+    nullNested.setField("id", 2L);
+    nullNested.setField("nested", null);
+
+    OutputFile output = new InMemoryOutputFile();
+    try (FileAppender<Record> appender =
+        Parquet.write(output)
+            .schema(writeSchema)
+            .createWriterFunc(GenericParquetWriter::create)
+            .build()) {
+      appender.add(present);
+      appender.add(nullNested);
+    }
+
+    // project only the added field with the default; inner is not read
+    Schema readSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional("nested")
+                .withId(2)
+                .ofType(
+                    Types.StructType.of(
+                        Types.NestedField.optional("added")
+                            .withId(4)
+                            .ofType(Types.StringType.get())
+                            .withInitialDefault(Literal.of("US"))
+                            .build()))
+                .build());
+
+    List<Record> rows;
+    try (CloseableIterable<Record> reader =
+        Parquet.read(output.toInputFile())
+            .project(readSchema)
+            .createReaderFunc(
+                fileSchema -> GenericParquetReaders.buildReader(readSchema, fileSchema))
+            .build()) {
+      rows = Lists.newArrayList(reader);
+    }
+
+    assertThat(rows).hasSize(2);
+
+    // present struct reads the default
+    Record row1Nested = (Record) rows.get(0).getField("nested");
+    assertThat(row1Nested).isNotNull();
+    assertThat(row1Nested.getField("added")).isEqualTo("US");
+
+    // null struct reads as null
+    assertThat(rows.get(1).getField("nested")).isNull();
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -41,7 +41,6 @@ import org.apache.iceberg.parquet.ParquetValueReaders;
 import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -108,33 +107,16 @@ public class FlinkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              RowDataUtil::convertConstant);
 
       return new RowDataReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            RowDataUtil.convertConstant(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -107,16 +107,14 @@ public class FlinkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              RowDataUtil::convertConstant);
-
-      return new RowDataReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          RowDataUtil::convertConstant,
+          RowDataReader::new);
     }
 
     @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VariantReaderBuilder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -114,33 +113,16 @@ public class FlinkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              RowDataUtil::convertConstant);
 
       return new RowDataReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            RowDataUtil.convertConstant(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -113,16 +113,14 @@ public class FlinkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              RowDataUtil::convertConstant);
-
-      return new RowDataReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          RowDataUtil::convertConstant,
+          RowDataReader::new);
     }
 
     @Override

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VariantReaderBuilder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -114,33 +113,16 @@ public class FlinkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              RowDataUtil::convertConstant);
 
       return new RowDataReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            RowDataUtil.convertConstant(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -113,16 +113,14 @@ public class FlinkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              RowDataUtil::convertConstant);
-
-      return new RowDataReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          RowDataUtil::convertConstant,
+          RowDataReader::new);
     }
 
     @Override

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.parquet.TypeWithSchemaVisitor;
 import org.apache.iceberg.parquet.VariantReaderBuilder;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ArrayUtil;
@@ -114,33 +113,16 @@ public class FlinkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              RowDataUtil::convertConstant);
 
       return new RowDataReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            RowDataUtil.convertConstant(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/data/FlinkParquetReaders.java
@@ -113,16 +113,14 @@ public class FlinkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              RowDataUtil::convertConstant);
-
-      return new RowDataReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          RowDataUtil::convertConstant,
+          RowDataReader::new);
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -280,29 +280,91 @@ abstract class BaseParquetReaders<T> {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
+      String[] structPath = currentPath();
+      int constantDefinitionLevel = type.getMaxDefinitionLevel(structPath);
       List<Types.NestedField> expectedFields = expected.fields();
+
+      // When a nullable struct's projected fields are all constants (initial defaults, metadata
+      // columns, or partition values) with no real column read from the file, the struct has no
+      // per-row definition level to indicate whether an ancestor struct is null. In that case,
+      // borrow the definition level from a real leaf column that exists under the struct in the
+      // file so a null ancestor is not incorrectly materialized as a struct of default values.
+      boolean hasRealFieldReader =
+          expectedFields.stream().anyMatch(field -> readersById.containsKey(field.fieldId()));
+      ColumnDescriptor probe = null;
+      Integer probeHostId = null;
+      if (!hasRealFieldReader && constantDefinitionLevel > 0) {
+        probe = firstLeafUnder(structPath);
+        if (probe != null) {
+          probeHostId = probeHostFieldId(expectedFields);
+        }
+      }
+
       List<ParquetValueReader<?>> reorderedFields =
           Lists.newArrayListWithExpectedSize(expectedFields.size());
-
       for (Types.NestedField field : expectedFields) {
         int id = field.fieldId();
         ParquetValueReader<?> reader =
             ParquetValueReaders.replaceWithMetadataReader(
                 id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
+        boolean hostsProbe = probeHostId != null && id == probeHostId;
+        reorderedFields.add(
+            defaultReader(field, reader, constantDefinitionLevel, hostsProbe ? probe : null));
       }
 
       return createStructReader(reorderedFields, expected, fieldId(struct));
     }
 
+    /**
+     * Returns the descriptor for the first leaf column in the file that is nested under the given
+     * struct path, or null if the struct has no leaf columns in the file.
+     */
+    private ColumnDescriptor firstLeafUnder(String[] structPath) {
+      for (ColumnDescriptor descriptor : type.getColumns()) {
+        String[] columnPath = descriptor.getPath();
+        if (columnPath.length > structPath.length) {
+          boolean isUnderStruct = true;
+          for (int i = 0; i < structPath.length; i += 1) {
+            if (!structPath[i].equals(columnPath[i])) {
+              isUnderStruct = false;
+              break;
+            }
+          }
+
+          if (isUnderStruct) {
+            return descriptor;
+          }
+        }
+      }
+
+      return null;
+    }
+
+    /** Returns the id of the first field with an initial default that can host the probe column. */
+    private Integer probeHostFieldId(List<Types.NestedField> expectedFields) {
+      for (Types.NestedField field : expectedFields) {
+        if (field.initialDefault() != null) {
+          return field.fieldId();
+        }
+      }
+
+      return null;
+    }
+
     private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
+        Types.NestedField field,
+        ParquetValueReader<?> reader,
+        int constantDL,
+        ColumnDescriptor probe) {
       if (reader != null) {
         return reader;
       } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            convertConstant(field.type(), field.initialDefault()), constantDL);
+        Object value = convertConstant(field.type(), field.initialDefault());
+        if (probe != null) {
+          return ParquetValueReaders.constant(value, probe);
+        }
+
+        return ParquetValueReaders.constant(value, constantDL);
       } else if (field.isOptional()) {
         return ParquetValueReaders.nulls();
       }

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -262,34 +262,16 @@ abstract class BaseParquetReaders<T> {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              BaseParquetReaders.this::convertConstant);
 
       return createStructReader(reorderedFields, expected, fieldId(struct));
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            convertConstant(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -262,16 +262,14 @@ abstract class BaseParquetReaders<T> {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              BaseParquetReaders.this::convertConstant);
-
-      return createStructReader(reorderedFields, expected, fieldId(struct));
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          BaseParquetReaders.this::convertConstant,
+          readers -> createStructReader(readers, expected, fieldId(struct)));
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -24,11 +24,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.schema.GroupType;
+import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
@@ -129,10 +131,87 @@ public class ParquetSchemaUtil {
 
   public static MessageType pruneColumns(MessageType fileSchema, Schema expectedSchema) {
     // column order must match the incoming type, so it doesn't matter that the ids are unordered
-    Set<Integer> selectedIds = TypeUtil.getProjectedIds(expectedSchema);
+    Set<Integer> selectedIds = Sets.newHashSet(TypeUtil.getProjectedIds(expectedSchema));
+    // Retain one real leaf under each struct that projects only constants like default values,
+    // so its definition level still shows whether its parent struct is null.
+    collectDefinitionLevelProbeIds(expectedSchema.asStruct(), fileSchema, selectedIds);
     return (MessageType)
         TypeWithSchemaVisitor.visit(
             expectedSchema.asStruct(), fileSchema, new PruneColumns(selectedIds));
+  }
+
+  /**
+   * Walks the expected struct alongside the file schema. For each projected struct whose fields are
+   * all constants and would otherwise retain no file leaf, adds one leaf id under the matching file
+   * group so its definition level can signal whether the struct is null.
+   */
+  private static void collectDefinitionLevelProbeIds(
+      Types.StructType expectedStruct, GroupType fileGroup, Set<Integer> selectedIds) {
+    for (Types.NestedField field : expectedStruct.fields()) {
+      if (!field.type().isStructType()) {
+        continue;
+      }
+
+      Types.StructType expectedFieldStruct = field.type().asStructType();
+      if (expectedFieldStruct.fields().isEmpty()) {
+        // an explicitly empty struct projection has no fields to read and no default to apply,
+        // so there is no per-row null-ness to preserve
+        continue;
+      }
+
+      Type fileField = fieldById(fileGroup, field.fieldId());
+      if (fileField == null || fileField.isPrimitive()) {
+        continue;
+      }
+
+      GroupType fileFieldGroup = fileField.asGroupType();
+      if (isListOrMap(fileFieldGroup)) {
+        continue;
+      }
+
+      List<Integer> leafIds = leafIds(fileFieldGroup);
+      // recurse if a leaf is already selected here, else just add the first one below
+      if (leafIds.stream().anyMatch(selectedIds::contains)) {
+        collectDefinitionLevelProbeIds(field.type().asStructType(), fileFieldGroup, selectedIds);
+      } else if (!leafIds.isEmpty()) {
+        selectedIds.add(leafIds.get(0));
+      }
+    }
+  }
+
+  private static Type fieldById(GroupType group, int id) {
+    for (Type field : group.getFields()) {
+      if (field.getId() != null && field.getId().intValue() == id) {
+        return field;
+      }
+    }
+
+    return null;
+  }
+
+  private static boolean isListOrMap(GroupType group) {
+    LogicalTypeAnnotation annotation = group.getLogicalTypeAnnotation();
+    return LogicalTypeAnnotation.listType().equals(annotation)
+        || LogicalTypeAnnotation.mapType().equals(annotation);
+  }
+
+  /** Returns the ids of all leaf columns reachable under the given group. */
+  private static List<Integer> leafIds(GroupType group) {
+    List<Integer> ids = Lists.newArrayList();
+    collectLeafIds(group, ids);
+    return ids;
+  }
+
+  private static void collectLeafIds(GroupType group, List<Integer> ids) {
+    for (Type field : group.getFields()) {
+      if (field.isPrimitive()) {
+        if (field.getId() != null) {
+          ids.add(field.getId().intValue());
+        }
+      } else {
+        collectLeafIds(field.asGroupType(), ids);
+      }
+    }
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -24,9 +24,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
+import org.apache.parquet.column.ColumnDescriptor;
 import org.apache.parquet.io.InvalidRecordException;
 import org.apache.parquet.schema.GroupType;
 import org.apache.parquet.schema.MessageType;
@@ -129,10 +131,92 @@ public class ParquetSchemaUtil {
 
   public static MessageType pruneColumns(MessageType fileSchema, Schema expectedSchema) {
     // column order must match the incoming type, so it doesn't matter that the ids are unordered
-    Set<Integer> selectedIds = TypeUtil.getProjectedIds(expectedSchema);
+    Set<Integer> selectedIds = Sets.newHashSet(TypeUtil.getProjectedIds(expectedSchema));
+    // retain one real leaf under each struct that projects only constants like default values,
+    // so its definition level still shows whether the struct is null
+    TypeWithSchemaVisitor.visit(
+        expectedSchema.asStruct(),
+        fileSchema,
+        new DefinitionLevelProbeSelector(fileSchema, selectedIds));
     return (MessageType)
         TypeWithSchemaVisitor.visit(
             expectedSchema.asStruct(), fileSchema, new PruneColumns(selectedIds));
+  }
+
+  /**
+   * Adds one leaf id under each projected struct whose fields are all constants and would otherwise
+   * retain no file leaf. That leaf's definition level is what still shows whether the struct is
+   * null.
+   */
+  private static class DefinitionLevelProbeSelector extends TypeWithSchemaVisitor<Void> {
+    private final MessageType fileSchema;
+    private final Set<Integer> selectedIds;
+
+    private DefinitionLevelProbeSelector(MessageType fileSchema, Set<Integer> selectedIds) {
+      this.fileSchema = fileSchema;
+      this.selectedIds = selectedIds;
+    }
+
+    @Override
+    public Void struct(Types.StructType expected, GroupType struct, List<Void> fields) {
+      // nothing projected under this struct, so there is nothing to probe for
+      if (expected == null || expected.fields().isEmpty()) {
+        return null;
+      }
+
+      // a struct that can never be null needs no probe
+      if (fileSchema.getMaxDefinitionLevel(currentPath()) <= 0) {
+        return null;
+      }
+
+      List<ColumnDescriptor> leaves = leafColumns(fileSchema, currentPath());
+      // add a probe leaf only if no real leaf under the struct is already read
+      boolean readsRealLeaf = leaves.stream().anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
+      if (!readsRealLeaf && !leaves.isEmpty()) {
+        selectedIds.add(leafId(leaves.get(0)));
+      }
+
+      return null;
+    }
+
+    @Override
+    public Void variant(Types.VariantType expected, GroupType variantGroup, Void result) {
+      return null;
+    }
+  }
+
+  /** Returns the leaf columns with ids under the given path. */
+  static List<ColumnDescriptor> leafColumns(MessageType fileSchema, String[] path) {
+    List<ColumnDescriptor> columns = Lists.newArrayList();
+    for (ColumnDescriptor column : fileSchema.getColumns()) {
+      // a probe leaf is kept in the read set by id, so a leaf without one cannot be a probe
+      if (column.getPrimitiveType().getId() == null) {
+        continue;
+      }
+
+      String[] columnPath = column.getPath();
+      if (columnPath.length <= path.length) {
+        continue;
+      }
+
+      boolean under = true;
+      for (int i = 0; i < path.length; i += 1) {
+        if (!path[i].equals(columnPath[i])) {
+          under = false;
+          break;
+        }
+      }
+
+      if (under) {
+        columns.add(column);
+      }
+    }
+
+    return columns;
+  }
+
+  private static int leafId(ColumnDescriptor column) {
+    return column.getPrimitiveType().getId().intValue();
   }
 
   /**

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -196,7 +196,7 @@ public class ParquetSchemaUtil {
   }
 
   /** Returns the leaf columns with ids under the given path. */
-  static List<ColumnDescriptor> leafColumns(MessageType fileSchema, String[] path) {
+  private static List<ColumnDescriptor> leafColumns(MessageType fileSchema, String[] path) {
     List<ColumnDescriptor> columns = Lists.newArrayList();
     for (ColumnDescriptor column : fileSchema.getColumns()) {
       // a presence column is kept in the read set by id, so a leaf without one cannot be used

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -135,11 +135,9 @@ public class ParquetSchemaUtil {
     // column order must match the incoming type, so it doesn't matter that the ids are unordered
     Set<Integer> selectedIds = Sets.newHashSet(TypeUtil.getProjectedIds(expectedSchema));
     // retain one real leaf under each struct that projects only constants like default values,
-    // so its definition level still shows whether the struct is null
+    // so its definition level still shows whether the struct is present
     TypeWithSchemaVisitor.visit(
-        expectedSchema.asStruct(),
-        fileSchema,
-        new DefinitionLevelProbeSelector(fileSchema, selectedIds));
+        expectedSchema.asStruct(), fileSchema, new PresenceColumnSelector(fileSchema, selectedIds));
     return (MessageType)
         TypeWithSchemaVisitor.visit(
             expectedSchema.asStruct(), fileSchema, new PruneColumns(selectedIds));
@@ -148,33 +146,33 @@ public class ParquetSchemaUtil {
   /**
    * Adds one leaf id under each projected struct whose fields are all constants and would otherwise
    * retain no file leaf. That leaf's definition level is what still shows whether the struct is
-   * null.
+   * present.
    */
-  private static class DefinitionLevelProbeSelector extends TypeWithSchemaVisitor<Void> {
+  private static class PresenceColumnSelector extends TypeWithSchemaVisitor<Void> {
     private final MessageType fileSchema;
     private final Set<Integer> selectedIds;
 
-    private DefinitionLevelProbeSelector(MessageType fileSchema, Set<Integer> selectedIds) {
+    private PresenceColumnSelector(MessageType fileSchema, Set<Integer> selectedIds) {
       this.fileSchema = fileSchema;
       this.selectedIds = selectedIds;
     }
 
     @Override
     public Void struct(Types.StructType expected, GroupType struct, List<Void> fields) {
-      // nothing projected under this struct, so there is nothing to probe for
+      // nothing projected under this struct, so there is nothing to track
       if (expected == null || expected.fields().isEmpty()) {
         return null;
       }
 
       String[] path = currentPath();
-      // add a probe leaf only if no real leaf under the struct is already read
+      // add a presence column only if no real leaf under the struct is already read
       boolean readsRealLeaf =
           leafColumns(fileSchema, path).stream()
               .anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
       if (!readsRealLeaf) {
-        ColumnDescriptor probe = selectNullnessProbeLeaf(fileSchema, path);
-        if (probe != null) {
-          selectedIds.add(leafId(probe));
+        ColumnDescriptor presence = selectPresenceColumn(fileSchema, path);
+        if (presence != null) {
+          selectedIds.add(leafId(presence));
         }
       }
 
@@ -191,29 +189,29 @@ public class ParquetSchemaUtil {
    * First leaf under path with one value per occurrence of the struct at path (no LIST/MAP in
    * between).
    */
-  static ColumnDescriptor selectNullnessProbeLeaf(MessageType fileSchema, String[] path) {
+  static ColumnDescriptor selectPresenceColumn(MessageType fileSchema, String[] path) {
     if (fileSchema.getMaxDefinitionLevel(path) <= 0) {
       return null;
     }
 
     int structRepetitionLevel = fileSchema.getMaxRepetitionLevel(path);
-    ColumnDescriptor probe =
+    ColumnDescriptor presence =
         leafColumns(fileSchema, path).stream()
             .filter(leaf -> leaf.getMaxRepetitionLevel() == structRepetitionLevel)
             .findFirst()
             .orElse(null);
     Preconditions.checkArgument(
-        probe == null || probe.getMaxRepetitionLevel() == structRepetitionLevel,
-        "Invalid probe, repetition level does not match struct at %s",
+        presence == null || presence.getMaxRepetitionLevel() == structRepetitionLevel,
+        "Invalid presence column, repetition level does not match struct at %s",
         Arrays.toString(path));
-    return probe;
+    return presence;
   }
 
   /** Returns the leaf columns with ids under the given path. */
   static List<ColumnDescriptor> leafColumns(MessageType fileSchema, String[] path) {
     List<ColumnDescriptor> columns = Lists.newArrayList();
     for (ColumnDescriptor column : fileSchema.getColumns()) {
-      // a probe leaf is kept in the read set by id, so a leaf without one cannot be a probe
+      // a presence column is kept in the read set by id, so a leaf without one cannot be used
       if (column.getPrimitiveType().getId() == null) {
         continue;
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -18,12 +18,14 @@
  */
 package org.apache.iceberg.parquet;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -164,16 +166,16 @@ public class ParquetSchemaUtil {
         return null;
       }
 
-      // a struct that can never be null needs no probe
-      if (fileSchema.getMaxDefinitionLevel(currentPath()) <= 0) {
-        return null;
-      }
-
-      List<ColumnDescriptor> leaves = leafColumns(fileSchema, currentPath());
+      String[] path = currentPath();
       // add a probe leaf only if no real leaf under the struct is already read
-      boolean readsRealLeaf = leaves.stream().anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
-      if (!readsRealLeaf && !leaves.isEmpty()) {
-        selectedIds.add(leafId(leaves.get(0)));
+      boolean readsRealLeaf =
+          leafColumns(fileSchema, path).stream()
+              .anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
+      if (!readsRealLeaf) {
+        ColumnDescriptor probe = selectNullnessProbeLeaf(fileSchema, path);
+        if (probe != null) {
+          selectedIds.add(leafId(probe));
+        }
       }
 
       return null;
@@ -183,6 +185,28 @@ public class ParquetSchemaUtil {
     public Void variant(Types.VariantType expected, GroupType variantGroup, Void result) {
       return null;
     }
+  }
+
+  /**
+   * First leaf under path with one value per occurrence of the struct at path (no LIST/MAP in
+   * between).
+   */
+  static ColumnDescriptor selectNullnessProbeLeaf(MessageType fileSchema, String[] path) {
+    if (fileSchema.getMaxDefinitionLevel(path) <= 0) {
+      return null;
+    }
+
+    int structRepetitionLevel = fileSchema.getMaxRepetitionLevel(path);
+    ColumnDescriptor probe =
+        leafColumns(fileSchema, path).stream()
+            .filter(leaf -> leaf.getMaxRepetitionLevel() == structRepetitionLevel)
+            .findFirst()
+            .orElse(null);
+    Preconditions.checkArgument(
+        probe == null || probe.getMaxRepetitionLevel() == structRepetitionLevel,
+        "Invalid probe, repetition level does not match struct at %s",
+        Arrays.toString(path));
+    return probe;
   }
 
   /** Returns the leaf columns with ids under the given path. */

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -18,14 +18,13 @@
  */
 package org.apache.iceberg.parquet;
 
-import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.mapping.NameMapping;
-import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.TypeUtil;
@@ -185,26 +184,15 @@ public class ParquetSchemaUtil {
     }
   }
 
-  /**
-   * First leaf under path with one value per occurrence of the struct at path (no LIST/MAP in
-   * between).
-   */
+  /** Shallowest leaf under path; its definition level shows whether the struct is present. */
   static ColumnDescriptor selectPresenceColumn(MessageType fileSchema, String[] path) {
     if (fileSchema.getMaxDefinitionLevel(path) <= 0) {
       return null;
     }
 
-    int structRepetitionLevel = fileSchema.getMaxRepetitionLevel(path);
-    ColumnDescriptor presence =
-        leafColumns(fileSchema, path).stream()
-            .filter(leaf -> leaf.getMaxRepetitionLevel() == structRepetitionLevel)
-            .findFirst()
-            .orElse(null);
-    Preconditions.checkArgument(
-        presence == null || presence.getMaxRepetitionLevel() == structRepetitionLevel,
-        "Invalid presence column, repetition level does not match struct at %s",
-        Arrays.toString(path));
-    return presence;
+    return leafColumns(fileSchema, path).stream()
+        .min(Comparator.comparingInt(ColumnDescriptor::getMaxRepetitionLevel))
+        .orElse(null);
   }
 
   /** Returns the leaf columns with ids under the given path. */

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -164,12 +164,11 @@ public class ParquetSchemaUtil {
       }
 
       String[] path = currentPath();
+      List<ColumnDescriptor> leaves = leafColumns(fileSchema, path);
       // add a presence column only if no real leaf under the struct is already read
-      boolean readsRealLeaf =
-          leafColumns(fileSchema, path).stream()
-              .anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
+      boolean readsRealLeaf = leaves.stream().anyMatch(leaf -> selectedIds.contains(leafId(leaf)));
       if (!readsRealLeaf) {
-        ColumnDescriptor presence = selectPresenceColumn(fileSchema, path);
+        ColumnDescriptor presence = selectPresenceColumn(fileSchema, path, leaves);
         if (presence != null) {
           selectedIds.add(leafId(presence));
         }
@@ -186,11 +185,16 @@ public class ParquetSchemaUtil {
 
   /** Shallowest leaf under path; its definition level shows whether the struct is present. */
   static ColumnDescriptor selectPresenceColumn(MessageType fileSchema, String[] path) {
+    return selectPresenceColumn(fileSchema, path, leafColumns(fileSchema, path));
+  }
+
+  private static ColumnDescriptor selectPresenceColumn(
+      MessageType fileSchema, String[] path, List<ColumnDescriptor> leaves) {
     if (fileSchema.getMaxDefinitionLevel(path) <= 0) {
       return null;
     }
 
-    return leafColumns(fileSchema, path).stream()
+    return leaves.stream()
         .min(Comparator.comparingInt(ColumnDescriptor::getMaxRepetitionLevel))
         .orElse(null);
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -164,6 +164,24 @@ public class ParquetValueReaders {
     return new ConstantReader<>(value, definitionLevel);
   }
 
+  /**
+   * Returns a reader that always produces {@code value}, but derives its per-row definition level
+   * from a real leaf column in the file rather than a fixed constant.
+   *
+   * <p>This is used when every projected field of a struct is a constant (an initial default,
+   * metadata column, or partition value) that is absent from the file. In that case the struct has
+   * no real column to signal whether an ancestor struct is null on a given row, so a constant
+   * definition level would incorrectly report the struct as always present. This reader reads (and
+   * discards) the value of {@code probe}, exposing its real definition level so that an enclosing
+   * {@link #option(Type, int, ParquetValueReader) option} reader can detect a null ancestor.
+   *
+   * @param value the constant value to produce for every row where the ancestor struct is present
+   * @param probe a descriptor for a real leaf column that exists under the struct in the file
+   */
+  public static <C> ParquetValueReader<C> constant(C value, ColumnDescriptor probe) {
+    return new ConstantReader<>(value, probe);
+  }
+
   public static ParquetValueReader<Long> position() {
     return new PositionReader();
   }
@@ -287,21 +305,43 @@ public class ParquetValueReaders {
     private final C constantValue;
     private final TripleIterator<?> column;
     private final List<TripleIterator<?>> children;
+    // set only when the definition level is derived from a real leaf column (see constant(C,
+    // ColumnDescriptor)); the column is read and discarded to keep it advancing in lockstep
+    private final ColumnIterator<?> probe;
+    private final ColumnDescriptor probeDesc;
 
     ConstantReader(C constantValue) {
       this.constantValue = constantValue;
       this.column = NullReader.NULL_COLUMN;
       this.children = NullReader.COLUMNS;
+      this.probe = null;
+      this.probeDesc = null;
     }
 
     ConstantReader(C constantValue, int parentDl) {
       this.constantValue = constantValue;
       this.column = new ConstantDLColumn<>(parentDl);
       this.children = ImmutableList.of(column);
+      this.probe = null;
+      this.probeDesc = null;
+    }
+
+    ConstantReader(C constantValue, ColumnDescriptor probeColumn) {
+      this.constantValue = constantValue;
+      this.probeDesc = probeColumn;
+      this.probe = ColumnIterator.newIterator(probeColumn, "");
+      this.column = probe;
+      this.children = ImmutableList.of(column);
     }
 
     @Override
     public C read(C reuse) {
+      if (probe != null) {
+        // advance the probe column so its definition level tracks the current row; the value
+        // itself is unused because this reader always produces the constant
+        probe.nextNull();
+      }
+
       return constantValue;
     }
 
@@ -316,7 +356,11 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore) {}
+    public void setPageSource(PageReadStore pageStore) {
+      if (probe != null) {
+        probe.setPageSource(pageStore.getPageReader(probeDesc));
+      }
+    }
 
     private static class ConstantDLColumn<T> implements TripleIterator<T> {
       private final int definitionLevel;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.function.BiFunction;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.common.DynConstructors;
@@ -52,6 +53,7 @@ import org.apache.parquet.schema.LogicalTypeAnnotation.DecimalLogicalTypeAnnotat
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeLogicalTypeAnnotation;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimeUnit;
 import org.apache.parquet.schema.LogicalTypeAnnotation.TimestampLogicalTypeAnnotation;
+import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType;
 import org.apache.parquet.schema.Type;
 
@@ -164,6 +166,24 @@ public class ParquetValueReaders {
     return new ConstantReader<>(value, definitionLevel);
   }
 
+  /**
+   * Returns a reader that always produces {@code value}, but derives its per-row definition level
+   * from a real leaf column in the file rather than a fixed constant.
+   *
+   * <p>This is used when every projected field of a struct is a constant (an initial default,
+   * metadata column, or partition value) that is absent from the file. In that case the struct has
+   * no real column to signal whether an ancestor struct is null on a given row, so a constant
+   * definition level would incorrectly report the struct as always present. This reader reads (and
+   * discards) the value of {@code probe}, exposing its real definition level so that an enclosing
+   * {@link #option(Type, int, ParquetValueReader) option} reader can detect a null ancestor.
+   *
+   * @param value the constant value to produce for every row where the ancestor struct is present
+   * @param probe a descriptor for a real leaf column that exists under the struct in the file
+   */
+  public static <C> ParquetValueReader<C> constant(C value, ColumnDescriptor probe) {
+    return new ConstantReader<>(value, probe);
+  }
+
   public static ParquetValueReader<Long> position() {
     return new PositionReader();
   }
@@ -231,6 +251,87 @@ public class ParquetValueReaders {
     return reader;
   }
 
+  /**
+   * Builds readers for a struct's expected fields, in field order. A field present in the file uses
+   * its column reader; a field missing from the file uses a metadata or partition constant, or its
+   * initial default. When no expected field reads a file column, one default reader is given a
+   * probe column so its definition level tracks the struct's null-ness.
+   */
+  public static List<ParquetValueReader<?>> structFieldReaders(
+      MessageType fileSchema,
+      String[] structPath,
+      List<Types.NestedField> expectedFields,
+      Map<Integer, ParquetValueReader<?>> readersById,
+      Map<Integer, ?> idToConstant,
+      BiFunction<org.apache.iceberg.types.Type, Object, Object> convertConstant) {
+    int constantDefinitionLevel = fileSchema.getMaxDefinitionLevel(structPath);
+    ColumnDescriptor probe =
+        definitionLevelProbe(
+            fileSchema, structPath, constantDefinitionLevel, expectedFields, readersById);
+    Integer probeHostId = probe == null ? null : firstInitialDefaultFieldId(expectedFields);
+
+    List<ParquetValueReader<?>> readers = Lists.newArrayListWithExpectedSize(expectedFields.size());
+    for (Types.NestedField field : expectedFields) {
+      int id = field.fieldId();
+      ParquetValueReader<?> reader =
+          replaceWithMetadataReader(id, readersById.get(id), idToConstant, constantDefinitionLevel);
+      ColumnDescriptor fieldProbe = probeHostId != null && id == probeHostId ? probe : null;
+      readers.add(
+          defaultReader(field, reader, constantDefinitionLevel, fieldProbe, convertConstant));
+    }
+
+    return readers;
+  }
+
+  private static ParquetValueReader<?> defaultReader(
+      Types.NestedField field,
+      ParquetValueReader<?> reader,
+      int constantDefinitionLevel,
+      ColumnDescriptor probe,
+      BiFunction<org.apache.iceberg.types.Type, Object, Object> convertConstant) {
+    if (reader != null) {
+      return reader;
+    } else if (field.initialDefault() != null) {
+      Object value = convertConstant.apply(field.type(), field.initialDefault());
+      return probe != null ? constant(value, probe) : constant(value, constantDefinitionLevel);
+    } else if (field.isOptional()) {
+      return nulls();
+    }
+
+    throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
+  }
+
+  /**
+   * Returns the first leaf column under the struct, or null if an expected field already reads a
+   * file column or the struct has no leaf columns.
+   */
+  private static ColumnDescriptor definitionLevelProbe(
+      MessageType fileSchema,
+      String[] structPath,
+      int structDefinitionLevel,
+      List<Types.NestedField> expectedFields,
+      Map<Integer, ParquetValueReader<?>> readersById) {
+    boolean hasRealFieldReader =
+        expectedFields.stream().anyMatch(field -> readersById.containsKey(field.fieldId()));
+    if (hasRealFieldReader || structDefinitionLevel <= 0) {
+      return null;
+    }
+
+    List<ColumnDescriptor> leaves = ParquetSchemaUtil.leafColumns(fileSchema, structPath);
+    return leaves.isEmpty() ? null : leaves.get(0);
+  }
+
+  /** Returns the id of the first field with an initial default, or null if none has one. */
+  private static Integer firstInitialDefaultFieldId(List<Types.NestedField> fields) {
+    for (Types.NestedField field : fields) {
+      if (field.initialDefault() != null) {
+        return field.fieldId();
+      }
+    }
+
+    return null;
+  }
+
   private static class NullReader<T> implements ParquetValueReader<T> {
     private static final NullReader<Void> INSTANCE = new NullReader<>();
     private static final ImmutableList<TripleIterator<?>> COLUMNS = ImmutableList.of();
@@ -287,21 +388,42 @@ public class ParquetValueReaders {
     private final C constantValue;
     private final TripleIterator<?> column;
     private final List<TripleIterator<?>> children;
+    // non-null when the definition level comes from a real leaf column instead of a constant
+    private final ColumnIterator<?> probe;
+    private final ColumnDescriptor probeDesc;
 
     ConstantReader(C constantValue) {
       this.constantValue = constantValue;
       this.column = NullReader.NULL_COLUMN;
       this.children = NullReader.COLUMNS;
+      this.probe = null;
+      this.probeDesc = null;
     }
 
     ConstantReader(C constantValue, int parentDl) {
       this.constantValue = constantValue;
       this.column = new ConstantDLColumn<>(parentDl);
       this.children = ImmutableList.of(column);
+      this.probe = null;
+      this.probeDesc = null;
+    }
+
+    ConstantReader(C constantValue, ColumnDescriptor probeColumn) {
+      this.constantValue = constantValue;
+      this.probeDesc = probeColumn;
+      this.probe = ColumnIterator.newIterator(probeColumn, "");
+      this.column = probe;
+      this.children = ImmutableList.of(column);
     }
 
     @Override
     public C read(C reuse) {
+      if (probe != null) {
+        // advance the probe column so its definition level tracks the current row; the value
+        // itself is unused because this reader always produces the constant
+        probe.nextNull();
+      }
+
       return constantValue;
     }
 
@@ -316,7 +438,11 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore) {}
+    public void setPageSource(PageReadStore pageStore) {
+      if (probe != null) {
+        probe.setPageSource(pageStore.getPageReader(probeDesc));
+      }
+    }
 
     private static class ConstantDLColumn<T> implements TripleIterator<T> {
       private final int definitionLevel;
@@ -1142,19 +1268,22 @@ public class ParquetValueReaders {
       set(struct, pos, value);
     }
 
-    /**
-     * Find a non-null column or return NULL_COLUMN if one is not available.
-     *
-     * @param columns a collection of triple iterator columns
-     * @return the first non-null column in columns
-     */
     private TripleIterator<?> firstNonNullColumn(List<TripleIterator<?>> columns) {
+      // prefer a real file column over a constant reader's fixed definition level
+      TripleIterator<?> constantColumn = NullReader.NULL_COLUMN;
       for (TripleIterator<?> col : columns) {
-        if (col != NullReader.NULL_COLUMN) {
+        if (col == NullReader.NULL_COLUMN) {
+          continue;
+        } else if (col instanceof ConstantReader.ConstantDLColumn) {
+          if (constantColumn == NullReader.NULL_COLUMN) {
+            constantColumn = col;
+          }
+        } else {
           return col;
         }
       }
-      return NullReader.NULL_COLUMN;
+
+      return constantColumn;
     }
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -266,7 +266,7 @@ public class ParquetValueReaders {
 
     return presence == null
         ? reader
-        : withPresence(reader, presence, fileSchema.getMaxRepetitionLevel(structPath));
+        : new PresenceReader<>(reader, presence, fileSchema.getMaxRepetitionLevel(structPath));
   }
 
   private static ParquetValueReader<?> defaultReader(
@@ -312,11 +312,6 @@ public class ParquetValueReaders {
 
   private static boolean hasInitialDefault(List<Types.NestedField> fields) {
     return fields.stream().anyMatch(field -> field.initialDefault() != null);
-  }
-
-  private static <T> ParquetValueReader<T> withPresence(
-      ParquetValueReader<T> reader, ColumnDescriptor presence, int repetitionLevel) {
-    return new PresenceReader<>(reader, presence, repetitionLevel);
   }
 
   private static class NullReader<T> implements ParquetValueReader<T> {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.common.DynConstructors;
@@ -167,24 +168,6 @@ public class ParquetValueReaders {
     return new ConstantReader<>(value, definitionLevel);
   }
 
-  /**
-   * Returns a reader that always produces {@code value}, but derives its per-row definition level
-   * from a real leaf column in the file rather than a fixed constant.
-   *
-   * <p>This is used when every projected field of a struct is a constant (an initial default,
-   * metadata column, or partition value) that is absent from the file. In that case the struct has
-   * no real column to signal whether an ancestor struct is null on a given row, so a constant
-   * definition level would incorrectly report the struct as always present. This reader reads (and
-   * discards) the value of {@code probe}, exposing its real definition level so that an enclosing
-   * {@link #option(Type, int, ParquetValueReader) option} reader can detect a null ancestor.
-   *
-   * @param value the constant value to produce for every row where the ancestor struct is present
-   * @param probe a descriptor for a real leaf column that exists under the struct in the file
-   */
-  public static <C> ParquetValueReader<C> constant(C value, ColumnDescriptor probe) {
-    return new ConstantReader<>(value, probe);
-  }
-
   public static ParquetValueReader<Long> position() {
     return new PositionReader();
   }
@@ -253,48 +236,47 @@ public class ParquetValueReaders {
   }
 
   /**
-   * Builds readers for a struct's expected fields, in field order. A field present in the file uses
-   * its column reader; a field missing from the file uses a metadata or partition constant, or its
-   * initial default. When no expected field reads a file column, one default reader is given a
-   * probe column so its definition level tracks whether the struct is null.
+   * Builds a struct reader from the expected fields, in field order. A field present in the file
+   * uses its column reader; a field missing from the file uses a metadata or partition constant, or
+   * its initial default. When no expected field reads a file column, the struct reader is wrapped
+   * so a presence column supplies the definition level.
    */
-  public static List<ParquetValueReader<?>> structFieldReaders(
+  public static <T> ParquetValueReader<T> structReader(
       MessageType fileSchema,
       String[] structPath,
       List<Types.NestedField> expectedFields,
       Map<Integer, ParquetValueReader<?>> readersById,
       Map<Integer, ?> idToConstant,
-      BiFunction<org.apache.iceberg.types.Type, Object, Object> convertConstant) {
+      BiFunction<org.apache.iceberg.types.Type, Object, Object> convertConstant,
+      Function<List<ParquetValueReader<?>>, ParquetValueReader<T>> newStructReader) {
     int constantDefinitionLevel = fileSchema.getMaxDefinitionLevel(structPath);
-    ColumnDescriptor probe =
-        definitionLevelProbe(
-            fileSchema, structPath, constantDefinitionLevel, expectedFields, readersById);
-    Integer probeHostId = probe == null ? null : firstInitialDefaultFieldId(expectedFields);
 
     List<ParquetValueReader<?>> readers = Lists.newArrayListWithExpectedSize(expectedFields.size());
     for (Types.NestedField field : expectedFields) {
       int id = field.fieldId();
       ParquetValueReader<?> reader =
           replaceWithMetadataReader(id, readersById.get(id), idToConstant, constantDefinitionLevel);
-      ColumnDescriptor fieldProbe = probeHostId != null && id == probeHostId ? probe : null;
-      readers.add(
-          defaultReader(field, reader, constantDefinitionLevel, fieldProbe, convertConstant));
+      readers.add(defaultReader(field, reader, constantDefinitionLevel, convertConstant));
     }
 
-    return readers;
+    ParquetValueReader<T> reader = newStructReader.apply(readers);
+    ColumnDescriptor presence =
+        presenceColumn(
+            fileSchema, structPath, constantDefinitionLevel, expectedFields, readersById);
+
+    return presence == null ? reader : withPresence(reader, presence);
   }
 
   private static ParquetValueReader<?> defaultReader(
       Types.NestedField field,
       ParquetValueReader<?> reader,
       int constantDefinitionLevel,
-      ColumnDescriptor probe,
       BiFunction<org.apache.iceberg.types.Type, Object, Object> convertConstant) {
     if (reader != null) {
       return reader;
     } else if (field.initialDefault() != null) {
       Object value = convertConstant.apply(field.type(), field.initialDefault());
-      return probe != null ? constant(value, probe) : constant(value, constantDefinitionLevel);
+      return constant(value, constantDefinitionLevel);
     } else if (field.isOptional()) {
       return nulls();
     }
@@ -302,7 +284,11 @@ public class ParquetValueReaders {
     throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
   }
 
-  private static ColumnDescriptor definitionLevelProbe(
+  /**
+   * Returns the column whose definition level shows whether the struct is present on each row, or
+   * null if a field reader already reads one or the struct can never be null.
+   */
+  private static ColumnDescriptor presenceColumn(
       MessageType fileSchema,
       String[] structPath,
       int structDefinitionLevel,
@@ -314,23 +300,21 @@ public class ParquetValueReaders {
       return null;
     }
 
-    ColumnDescriptor probe = ParquetSchemaUtil.selectNullnessProbeLeaf(fileSchema, structPath);
+    ColumnDescriptor presence = ParquetSchemaUtil.selectPresenceColumn(fileSchema, structPath);
     Preconditions.checkState(
-        probe != null || firstInitialDefaultFieldId(expectedFields) == null,
-        "Cannot apply initial default, no leaf column tracks whether struct at %s is null",
+        presence != null || !hasInitialDefault(expectedFields),
+        "Cannot apply initial default, no leaf column tracks whether struct at %s is present",
         Arrays.toString(structPath));
-    return probe;
+    return presence;
   }
 
-  /** Returns the id of the first field with an initial default, or null if none has one. */
-  private static Integer firstInitialDefaultFieldId(List<Types.NestedField> fields) {
-    for (Types.NestedField field : fields) {
-      if (field.initialDefault() != null) {
-        return field.fieldId();
-      }
-    }
+  private static boolean hasInitialDefault(List<Types.NestedField> fields) {
+    return fields.stream().anyMatch(field -> field.initialDefault() != null);
+  }
 
-    return null;
+  private static <T> ParquetValueReader<T> withPresence(
+      ParquetValueReader<T> reader, ColumnDescriptor presence) {
+    return new PresenceReader<>(reader, presence);
   }
 
   private static class NullReader<T> implements ParquetValueReader<T> {
@@ -385,46 +369,67 @@ public class ParquetValueReaders {
     public void setPageSource(PageReadStore pageStore) {}
   }
 
+  /**
+   * Wraps a struct reader whose fields all read constants, so the struct still has a real column to
+   * report its definition level from. Values come from the wrapped reader.
+   */
+  private static class PresenceReader<T> implements ParquetValueReader<T> {
+    private final ParquetValueReader<T> reader;
+    private final ColumnDescriptor desc;
+    private final ColumnIterator<?> presence;
+    private final List<TripleIterator<?>> children;
+
+    private PresenceReader(ParquetValueReader<T> reader, ColumnDescriptor desc) {
+      this.reader = reader;
+      this.desc = desc;
+      this.presence = ColumnIterator.newIterator(desc, "");
+      this.children =
+          ImmutableList.<TripleIterator<?>>builder().add(presence).addAll(reader.columns()).build();
+    }
+
+    @Override
+    public T read(T reuse) {
+      // only the definition level is used, so the value is skipped
+      presence.nextNull();
+      return reader.read(reuse);
+    }
+
+    @Override
+    public TripleIterator<?> column() {
+      return presence;
+    }
+
+    @Override
+    public List<TripleIterator<?>> columns() {
+      return children;
+    }
+
+    @Override
+    public void setPageSource(PageReadStore pageStore) {
+      presence.setPageSource(pageStore.getPageReader(desc));
+      reader.setPageSource(pageStore);
+    }
+  }
+
   private static class ConstantReader<C> implements ParquetValueReader<C> {
     private final C constantValue;
     private final TripleIterator<?> column;
     private final List<TripleIterator<?>> children;
-    // non-null when the definition level comes from a real leaf column instead of a constant
-    private final ColumnIterator<?> probe;
-    private final ColumnDescriptor probeDesc;
 
     ConstantReader(C constantValue) {
       this.constantValue = constantValue;
       this.column = NullReader.NULL_COLUMN;
       this.children = NullReader.COLUMNS;
-      this.probe = null;
-      this.probeDesc = null;
     }
 
     ConstantReader(C constantValue, int parentDl) {
       this.constantValue = constantValue;
       this.column = new ConstantDLColumn<>(parentDl);
       this.children = ImmutableList.of(column);
-      this.probe = null;
-      this.probeDesc = null;
-    }
-
-    ConstantReader(C constantValue, ColumnDescriptor probeColumn) {
-      this.constantValue = constantValue;
-      this.probeDesc = probeColumn;
-      this.probe = ColumnIterator.newIterator(probeColumn, "");
-      this.column = probe;
-      this.children = ImmutableList.of(column);
     }
 
     @Override
     public C read(C reuse) {
-      if (probe != null) {
-        // advance the probe column so its definition level tracks the current row; the value
-        // itself is unused because this reader always produces the constant
-        probe.nextNull();
-      }
-
       return constantValue;
     }
 
@@ -439,11 +444,7 @@ public class ParquetValueReaders {
     }
 
     @Override
-    public void setPageSource(PageReadStore pageStore) {
-      if (probe != null) {
-        probe.setPageSource(pageStore.getPageReader(probeDesc));
-      }
-    }
+    public void setPageSource(PageReadStore pageStore) {}
 
     private static class ConstantDLColumn<T> implements TripleIterator<T> {
       private final int definitionLevel;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -26,6 +26,7 @@ import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -255,7 +256,7 @@ public class ParquetValueReaders {
    * Builds readers for a struct's expected fields, in field order. A field present in the file uses
    * its column reader; a field missing from the file uses a metadata or partition constant, or its
    * initial default. When no expected field reads a file column, one default reader is given a
-   * probe column so its definition level tracks the struct's null-ness.
+   * probe column so its definition level tracks whether the struct is null.
    */
   public static List<ParquetValueReader<?>> structFieldReaders(
       MessageType fileSchema,
@@ -301,10 +302,6 @@ public class ParquetValueReaders {
     throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
   }
 
-  /**
-   * Returns the first leaf column under the struct, or null if an expected field already reads a
-   * file column or the struct has no leaf columns.
-   */
   private static ColumnDescriptor definitionLevelProbe(
       MessageType fileSchema,
       String[] structPath,
@@ -317,8 +314,12 @@ public class ParquetValueReaders {
       return null;
     }
 
-    List<ColumnDescriptor> leaves = ParquetSchemaUtil.leafColumns(fileSchema, structPath);
-    return leaves.isEmpty() ? null : leaves.get(0);
+    ColumnDescriptor probe = ParquetSchemaUtil.selectNullnessProbeLeaf(fileSchema, structPath);
+    Preconditions.checkState(
+        probe != null || firstInitialDefaultFieldId(expectedFields) == null,
+        "Cannot apply initial default, no leaf column tracks whether struct at %s is null",
+        Arrays.toString(structPath));
+    return probe;
   }
 
   /** Returns the id of the first field with an initial default, or null if none has one. */

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -264,7 +264,9 @@ public class ParquetValueReaders {
         presenceColumn(
             fileSchema, structPath, constantDefinitionLevel, expectedFields, readersById);
 
-    return presence == null ? reader : withPresence(reader, presence);
+    return presence == null
+        ? reader
+        : withPresence(reader, presence, fileSchema.getMaxRepetitionLevel(structPath));
   }
 
   private static ParquetValueReader<?> defaultReader(
@@ -313,8 +315,8 @@ public class ParquetValueReaders {
   }
 
   private static <T> ParquetValueReader<T> withPresence(
-      ParquetValueReader<T> reader, ColumnDescriptor presence) {
-    return new PresenceReader<>(reader, presence);
+      ParquetValueReader<T> reader, ColumnDescriptor presence, int repetitionLevel) {
+    return new PresenceReader<>(reader, presence, repetitionLevel);
   }
 
   private static class NullReader<T> implements ParquetValueReader<T> {
@@ -377,11 +379,14 @@ public class ParquetValueReaders {
     private final ParquetValueReader<T> reader;
     private final ColumnDescriptor desc;
     private final ColumnIterator<?> presence;
+    private final int repetitionLevel;
     private final List<TripleIterator<?>> children;
 
-    private PresenceReader(ParquetValueReader<T> reader, ColumnDescriptor desc) {
+    private PresenceReader(
+        ParquetValueReader<T> reader, ColumnDescriptor desc, int repetitionLevel) {
       this.reader = reader;
       this.desc = desc;
+      this.repetitionLevel = repetitionLevel;
       this.presence = ColumnIterator.newIterator(desc, "");
       this.children =
           ImmutableList.<TripleIterator<?>>builder().add(presence).addAll(reader.columns()).build();
@@ -389,8 +394,10 @@ public class ParquetValueReaders {
 
     @Override
     public T read(T reuse) {
-      // only the definition level is used, so the value is skipped
-      presence.nextNull();
+      // drain the row's repeated values; only the definition level is used
+      do {
+        presence.nextNull();
+      } while (presence.currentRepetitionLevel() > repetitionLevel);
       return reader.read(reuse);
     }
 

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -150,34 +150,16 @@ public class SparkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              SparkUtil::internalToSpark);
 
       return new InternalRowReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            SparkUtil.internalToSpark(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -150,16 +150,14 @@ public class SparkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              SparkUtil::internalToSpark);
-
-      return new InternalRowReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          SparkUtil::internalToSpark,
+          InternalRowReader::new);
     }
 
     @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -156,34 +156,16 @@ public class SparkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              SparkUtil::internalToSpark);
 
       return new InternalRowReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            SparkUtil.internalToSpark(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -156,16 +156,14 @@ public class SparkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              SparkUtil::internalToSpark);
-
-      return new InternalRowReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          SparkUtil::internalToSpark,
+          InternalRowReader::new);
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -161,34 +161,16 @@ public class SparkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
       List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
+          ParquetValueReaders.structFieldReaders(
+              type,
+              currentPath(),
+              expected.fields(),
+              readersById,
+              idToConstant,
+              SparkUtil::internalToSpark);
 
       return new InternalRowReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            SparkUtil.internalToSpark(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
     }
 
     @Override

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -161,16 +161,14 @@ public class SparkParquetReaders {
         }
       }
 
-      List<ParquetValueReader<?>> reorderedFields =
-          ParquetValueReaders.structFieldReaders(
-              type,
-              currentPath(),
-              expected.fields(),
-              readersById,
-              idToConstant,
-              SparkUtil::internalToSpark);
-
-      return new InternalRowReader(reorderedFields);
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          SparkUtil::internalToSpark,
+          InternalRowReader::new);
     }
 
     @Override

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/data/SparkParquetReaders.java
@@ -161,34 +161,14 @@ public class SparkParquetReaders {
         }
       }
 
-      int constantDefinitionLevel = type.getMaxDefinitionLevel(currentPath());
-      List<Types.NestedField> expectedFields = expected.fields();
-      List<ParquetValueReader<?>> reorderedFields =
-          Lists.newArrayListWithExpectedSize(expectedFields.size());
-
-      for (Types.NestedField field : expectedFields) {
-        int id = field.fieldId();
-        ParquetValueReader<?> reader =
-            ParquetValueReaders.replaceWithMetadataReader(
-                id, readersById.get(id), idToConstant, constantDefinitionLevel);
-        reorderedFields.add(defaultReader(field, reader, constantDefinitionLevel));
-      }
-
-      return new InternalRowReader(reorderedFields);
-    }
-
-    private ParquetValueReader<?> defaultReader(
-        Types.NestedField field, ParquetValueReader<?> reader, int constantDL) {
-      if (reader != null) {
-        return reader;
-      } else if (field.initialDefault() != null) {
-        return ParquetValueReaders.constant(
-            SparkUtil.internalToSpark(field.type(), field.initialDefault()), constantDL);
-      } else if (field.isOptional()) {
-        return ParquetValueReaders.nulls();
-      }
-
-      throw new IllegalArgumentException(String.format("Missing required field: %s", field.name()));
+      return ParquetValueReaders.structReader(
+          type,
+          currentPath(),
+          expected.fields(),
+          readersById,
+          idToConstant,
+          SparkUtil::internalToSpark,
+          InternalRowReader::new);
     }
 
     @Override


### PR DESCRIPTION
When a query projects only a nested field that has an initial default and doesn't include the struct's real fields, PruneColumns reduces the struct to an empty group (which I think is correct, expected behavior for that abstraction). That discards the file leaf columns whose definition levels carry if the struct itself is null or not, so a null struct was incorrectly materialized as a struct of default values. in SQL

```
select struct.field from t1...
```

where struct is null but struct.field has a default value would surface the default value instead of null, which is not spec compliant. 

To address this we solve this in two parts:

1. Retain 1 leaf that we probe for (even if it's not being projected) just so we have a definition level to work with. I don't think there's any other way to get definition levels because those are carried at  the very leaf level of a struct.

2. The default value constant reader uses that real leafs definition level to derive if the parent struct is null or not so that we surface the spec compliant results.