### PR TITLE
Kafka Connect: Use full table identifier to look up id-columns config

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
@@ -114,7 +114,7 @@ class RecordUtils {
     Set<Integer> identifierFieldIds = table.schema().identifierFieldIds();
 
     // override the identifier fields if the config is set
-    List<String> idCols = config.tableConfig(tableReference.identifier().name()).idColumns();
+    List<String> idCols = config.tableConfig(tableReference.identifier().toString()).idColumns();
     if (!idCols.isEmpty()) {
       identifierFieldIds =
           idCols.stream()

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
@@ -19,15 +19,20 @@
 package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Map;
+import java.util.UUID;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.connect.IcebergSinkConfig;
+import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 import org.junit.jupiter.api.Test;
 
-public class TestRecordUtils {
+public class TestRecordUtils extends WriterTestBase {
 
   @Test
   public void testExtractFromRecordValueStruct() {
@@ -89,5 +94,24 @@ public class TestRecordUtils {
 
     result = RecordUtils.extractFromRecordValue(val, "xkey");
     assertThat(result).isNull();
+  }
+
+  @Test
+  public void createTableWriterReadsIdColumnsForNamespacedTable() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            "iceberg.catalog.type", "rest",
+            "topics", "source-topic",
+            "iceberg.tables", "default.events",
+            "iceberg.table.default.events.id-columns", "missing_col");
+    IcebergSinkConfig config = new IcebergSinkConfig(props);
+    TableReference tableReference =
+        TableReference.of(
+            "test_catalog", TableIdentifier.of("default", "events"), UUID.randomUUID());
+
+    // the per-table id-columns config is only found when looked up by the full table identifier
+    assertThatThrownBy(() -> RecordUtils.createTableWriter(table, tableReference, config))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("ID column not found: missing_col");
   }
 }


### PR DESCRIPTION
Closes #17325

## Summary

- `RecordUtils.createTableWriter()` looked up the per-table config with `identifier().name()`, dropping the namespace.
- `IcebergSinkConfig.tableConfig(String)` builds the prefix `"iceberg.table." + tableName + "."`, so for `default.events` the lookup used `iceberg.table.events.` and never matched `iceberg.table.default.events.id-columns`.
- It silently fell back to `iceberg.tables.default-id-columns`. With no default set, an append writer was built instead of an equality delete writer, so upserts piled up duplicate rows with no error.
- Fixed by looking up with `identifier().toString()`, matching the three other call sites on this config map (`Coordinator.commitToTable()` line 260, `IcebergWriterFactory` line 101, `SinkWriter` line 111), left untouched.
- Backward compatible: `TableIdentifier.toString()` returns `name` when there is no namespace.
- `docs/docs/kafka-connect.md` line 76 documents this key as `iceberg.table.<table-name>.id-columns`, with namespaced examples.
- Regression from #14979 (`d85f8a87a`), which replaced `String tableName` with `TableReference`.

## Testing done

- Added `TestRecordUtils#createTableWriterReadsIdColumnsForNamespacedTable`: a real `IcebergSinkConfig` sets `iceberg.table.default.events.id-columns` to a column missing from the schema, so `createTableWriter` must throw `IllegalArgumentException`.
- Verified red→green: no exception on unfixed code, throws after the fix.
- `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect:check` — passed, 126 tests, 0 failures.
- REVAPI not applicable: kafka-connect is not published API.
