### PR TITLE
Kafka Connect: Test DebeziumTransform in its null record test

### DIFF
--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestDebeziumTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestDebeziumTransform.java
@@ -60,11 +60,11 @@ public class TestDebeziumTransform {
           .build();
 
   @Test
-  public void testDmsTransformNull() {
-    try (DmsTransform<SinkRecord> smt = new DmsTransform<>()) {
+  public void testDebeziumTransformNull() {
+    try (DebeziumTransform<SinkRecord> smt = new DebeziumTransform<>()) {
       SinkRecord record = new SinkRecord("topic", 0, null, null, null, null, 0);
       SinkRecord result = smt.apply(record);
-      assertThat(result.value()).isNull();
+      assertThat(result).isSameAs(record);
     }
   }
 


### PR DESCRIPTION
Closes #17326

## Summary

- `TestDebeziumTransform.testDmsTransformNull()` instantiated `DmsTransform`, not `DebeziumTransform`, and `TestDmsTransform` (line 50-57) already holds that test verbatim — so the copy verified nothing new.
- The tombstone pass-through branch in `DebeziumTransform.apply()` (line 66-67) was therefore left uncovered by every test in the module.
- The other four SMT tests each cover their own null path (`TestDmsTransform` 51, `TestCopyValue` 35, `TestJsonToMapTransform` 54, `TestKafkaMetadataTransform` 48); `TestDebeziumTransform` was the only one that did not.
- This PR instantiates `DebeziumTransform` and asserts the record is returned as-is via `isSameAs`, matching `TestJsonToMapTransform` 68 and `TestKafkaMetadataTransform` 55. `TestDmsTransform` is untouched.
- Origin: 7d9e96f9f6 (#11936) added both SMTs in one commit; the null test was copied across without switching the class under test.

## Testing done

- `./gradlew :iceberg-kafka-connect:iceberg-kafka-connect-transforms:check` — 69 tests, 0 failures.
- `testDebeziumTransformNull` passes both before and after this change: it fills a coverage gap, not a red-to-green bug fix.
- Not vacuous — removing line 66-67 from `apply()` makes it fail with `DataException: Only Map objects supported in absence of schema`. That edit was reverted; no production code changed.



---
**AI Disclosure**
- Model: [unknown - human to fill in]
- Platform/Tool: Claude Code
- Human Oversight: [unknown - human to fill in]
- Prompt Summary: Audit the kafka-connect transforms tests for a case that verifies the wrong class, then correct it so `DebeziumTransform`'s tombstone pass-through branch is actually covered.
