### PR TITLE
API: Close encryption manager after FileIO close failure

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -159,14 +159,10 @@ public class EncryptingFileIO implements FileIO, Serializable {
 
   @Override
   public void close() {
-    if (em instanceof Closeable) {
-      try (Closeable closeableManager = (Closeable) em) {
-        io.close();
-      } catch (IOException e) {
-        throw new UncheckedIOException("Failed to close encryption manager", e);
-      }
-    } else {
+    try (Closeable closeableManager = em instanceof Closeable ? (Closeable) em : null) {
       io.close();
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to close encryption manager", e);
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -159,14 +159,14 @@ public class EncryptingFileIO implements FileIO, Serializable {
 
   @Override
   public void close() {
-    io.close();
-
     if (em instanceof Closeable) {
-      try {
-        ((Closeable) em).close();
+      try (Closeable closeableManager = (Closeable) em) {
+        io.close();
       } catch (IOException e) {
         throw new UncheckedIOException("Failed to close encryption manager", e);
       }
+    } else {
+      io.close();
     }
   }
 

--- a/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
+++ b/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
@@ -19,12 +19,15 @@
 package org.apache.iceberg.encryption;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.io.DelegateFileIO;
@@ -149,6 +152,39 @@ public class TestEncryptingFileIO {
 
     verify(delegate).close();
     verify((Closeable) em).close();
+  }
+
+  @Test
+  public void closeClosesEncryptionManagerWhenFileIOCloseFails() throws Exception {
+    RuntimeException fileIOFailure = new RuntimeException("FileIO close failure");
+    EncryptionManager em =
+        mock(EncryptionManager.class, withSettings().extraInterfaces(Closeable.class));
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+    doThrow(fileIOFailure).when(delegate).close();
+
+    EncryptingFileIO fileIO = EncryptingFileIO.combine(delegate, em);
+
+    assertThatThrownBy(fileIO::close).isSameAs(fileIOFailure);
+    verify((Closeable) em).close();
+  }
+
+  @Test
+  public void closeSuppressesEncryptionManagerFailureWhenFileIOCloseFails() throws Exception {
+    RuntimeException fileIOFailure = new RuntimeException("FileIO close failure");
+    IOException managerFailure = new IOException("Encryption manager close failure");
+    EncryptionManager em =
+        mock(EncryptionManager.class, withSettings().extraInterfaces(Closeable.class));
+    Closeable closeableManager = (Closeable) em;
+    DelegateFileIO delegate = mock(DelegateFileIO.class);
+    doThrow(fileIOFailure).when(delegate).close();
+    doThrow(managerFailure).when(closeableManager).close();
+
+    EncryptingFileIO fileIO = EncryptingFileIO.combine(delegate, em);
+
+    assertThatThrownBy(fileIO::close)
+        .isSameAs(fileIOFailure)
+        .satisfies(failure -> assertThat(failure.getSuppressed()).containsExactly(managerFailure));
+    verify(closeableManager).close();
   }
 
   @Test


### PR DESCRIPTION
## Summary

- close a closeable encryption manager even when the delegate `FileIO` fails to close
- retain the delegate failure as the primary exception and suppress a subsequent encryption-manager close failure
- add regression coverage for both failure paths

## Motivation

`EncryptingFileIO.close()` currently closes its delegate before closing a closeable encryption
manager. If the delegate throws, the encryption manager is never closed. This can leak resources
owned by the encryption manager, such as a KMS client.

The updated implementation uses try-with-resources to preserve the existing close order while
ensuring both resources are closed with standard suppressed-exception behavior.

This was identified while reviewing the KMS client lifecycle for Apache Polaris:

https://github.com/apache/polaris/pull/5060#discussion_r3625705099

## Testing

- `./gradlew :iceberg-api:test --tests org.apache.iceberg.encryption.TestEncryptingFileIO --no-daemon --console=plain`
- `./gradlew :iceberg-api:spotlessCheck --no-daemon --console=plain`
- `./gradlew :iceberg-api:check --no-daemon --console=plain`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Fix `EncryptingFileIO.close()` so all owned resources are closed safely when the delegate close fails, and add regression tests.
