### PR TITLE
Build: make JMH harness JDK 17-clean (module opens, configurable heap, failOnError)

### DIFF
--- a/jmh.gradle
+++ b/jmh.gradle
@@ -62,11 +62,33 @@ configure(jmhProjects) {
 
   jmh {
     jmhVersion = '1.37'
-    failOnError = true
+    // Was hard-coded true; one failing param combination aborted the whole suite and discarded
+    // already-completed results. Make it configurable, default preserved.
+    failOnError = project.hasProperty('jmhFailOnError') ? project.property('jmhFailOnError').toBoolean() : true
     forceGC = true
     includeTests = true
     humanOutputFile = file(jmhOutputPath)
-    jvmArgs = ['-Xmx32g']
+    // Configurable heap (default preserved at 32g); full-scale PlanningBenchmark ...WithStats OOMs at 32g.
+    // Plus the JDK 17 module opens Spark 4.x needs (sun.util.calendar for date conversion, etc.).
+    jvmArgs = [
+      '-Xmx' + (project.findProperty('jmhHeap') ?: '32g'),
+      '-XX:+IgnoreUnrecognizedVMOptions',
+      '--add-opens=java.base/java.lang=ALL-UNNAMED',
+      '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
+      '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
+      '--add-opens=java.base/java.io=ALL-UNNAMED',
+      '--add-opens=java.base/java.net=ALL-UNNAMED',
+      '--add-opens=java.base/java.nio=ALL-UNNAMED',
+      '--add-opens=java.base/java.util=ALL-UNNAMED',
+      '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
+      '--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED',
+      '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED',
+      '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
+      '--add-opens=java.base/sun.nio.cs=ALL-UNNAMED',
+      '--add-opens=java.base/sun.security.action=ALL-UNNAMED',
+      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
+      '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
+    ]
     resultsFile = file(jmhJsonOutputPath)
     resultFormat = 'JSON'
     includes = [jmhIncludeRegex]

--- a/jmh.gradle
+++ b/jmh.gradle
@@ -68,27 +68,11 @@ configure(jmhProjects) {
     forceGC = true
     includeTests = true
     humanOutputFile = file(jmhOutputPath)
-    // Configurable heap (default preserved at 32g); full-scale PlanningBenchmark ...WithStats OOMs at 32g.
-    // Plus the JDK 17 module opens Spark 4.x needs (sun.util.calendar for date conversion, etc.).
-    jvmArgs = [
-      '-Xmx' + (project.findProperty('jmhHeap') ?: '32g'),
-      '-XX:+IgnoreUnrecognizedVMOptions',
-      '--add-opens=java.base/java.lang=ALL-UNNAMED',
-      '--add-opens=java.base/java.lang.invoke=ALL-UNNAMED',
-      '--add-opens=java.base/java.lang.reflect=ALL-UNNAMED',
-      '--add-opens=java.base/java.io=ALL-UNNAMED',
-      '--add-opens=java.base/java.net=ALL-UNNAMED',
-      '--add-opens=java.base/java.nio=ALL-UNNAMED',
-      '--add-opens=java.base/java.util=ALL-UNNAMED',
-      '--add-opens=java.base/java.util.concurrent=ALL-UNNAMED',
-      '--add-opens=java.base/java.util.concurrent.atomic=ALL-UNNAMED',
-      '--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED',
-      '--add-opens=java.base/sun.nio.ch=ALL-UNNAMED',
-      '--add-opens=java.base/sun.nio.cs=ALL-UNNAMED',
-      '--add-opens=java.base/sun.security.action=ALL-UNNAMED',
-      '--add-opens=java.base/sun.util.calendar=ALL-UNNAMED',
-      '--add-opens=java.security.jgss/sun.security.krb5=ALL-UNNAMED'
-    ]
+    // Reuse the shared module-opens list (single source of truth with the test tasks in build.gradle)
+    // and make the heap configurable (default preserved at 32g). The JMH task previously set jvmArgs
+    // directly, so unlike the test tasks it never inherited extraJvmArgs, which is why Spark 4.x reads
+    // failed on JDK 17 (sun.util.calendar). Full-scale PlanningBenchmark ...WithStats also OOMs at 32g.
+    jvmArgs = ['-Xmx' + (project.findProperty('jmhHeap') ?: '32g')] + project.property('extraJvmArgs')
     resultsFile = file(jmhJsonOutputPath)
     resultFormat = 'JSON'
     includes = [jmhIncludeRegex]


### PR DESCRIPTION
## What
Update `jmh.gradle` so the benchmark suite runs on a clean JDK 17 checkout:
- add the `--add-opens` set Spark 4.x needs (`sun.util.calendar`, nio, security, concurrent)
- make heap configurable: `-PjmhHeap` (default preserved at `32g`)
- make `failOnError` configurable: `-PjmhFailOnError` (default preserved at `true`)

## Why
On JDK 17 the read-path benchmarks throw `IllegalAccessException` (`sun.util.calendar`) at warm-up, and the full-scale `PlanningBenchmark` WithStats OOMs at 32g. Contributors currently cannot reproduce benchmarks without local edits. See #17330.

## Testing
- JDK 17: `./gradlew help`, `./gradlew spotlessApply`, `./gradlew :iceberg-core:jmhClasses` succeed with the updated harness
- Defaults unchanged for existing users: heap `32g`, `failOnError` true unless `-P` flags are passed
- JDK 21: `--add-opens` remain inert via `-XX:+IgnoreUnrecognizedVMOptions`

Closes #17330