### PR TITLE
REST: Add presigned-URL access delegation method and presign endpoint

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1120,6 +1120,41 @@ class RemoteSignResult(BaseModel):
     headers: MultiValuedMap
 
 
+class PresignRequest(BaseModel):
+    """
+    A request to refresh pre-signed URLs for a set of files that were returned as part of a previous server-side scan planning result.
+
+    """
+
+    plan_id: str = Field(
+        ...,
+        alias='plan-id',
+        description='The plan-id of the scan planning result that produced the files being refreshed. The server uses this to authorize the request and resolve the query state needed to reissue signatures.',
+    )
+    file_paths: list[str] = Field(
+        ...,
+        alias='file-paths',
+        description='The logical file-paths for which fresh pre-signed URLs are requested.',
+    )
+
+
+class PresignResponse(BaseModel):
+    """
+    The response containing refreshed pre-signed URLs.
+    """
+
+    pre_signed_urls: dict[str, str] = Field(
+        ...,
+        alias='pre-signed-urls',
+        description="A map of file-path to a fresh pre-signed HTTP URL that can be used to read the file's contents directly.",
+    )
+    url_expiration_timestamp_ms: int = Field(
+        ...,
+        alias='url-expiration-timestamp-ms',
+        description='The timestamp, as milliseconds since the Unix epoch, when the refreshed URLs in `pre-signed-urls` expire.',
+    )
+
+
 class CreateNamespaceRequest(BaseModel):
     namespace: Namespace
     properties: dict[str, str] | None = Field(
@@ -2017,6 +2052,16 @@ class CompletedPlanningResult(ScanTasks):
         None,
         alias='storage-credentials',
         description='Storage credentials for accessing the files returned in the scan result.\nIf the server returns storage credentials as part of the completed scan planning response, the expectation is for the client to use these credentials to read the files returned in the FileScanTasks as part of the scan result.',
+    )
+    pre_signed_urls: dict[str, str] | None = Field(
+        None,
+        alias='pre-signed-urls',
+        description="A map of file-path (matching the `path` of a `ContentFile` referenced by a returned `FileScanTask` or `DeleteFile`) to a pre-signed HTTP URL that can be used to read the file's contents directly, without requiring cloud provider-specific credentials or request signing.\nThis is only returned when the client requests the `pre-signed-urls` access delegation mechanism via the `X-Iceberg-Access-Delegation` header. The underlying `path` values of the `DataFile` and `DeleteFile` objects returned in the scan result are unaffected and remain the immutable logical file locations.\n",
+    )
+    url_expiration_timestamp_ms: int | None = Field(
+        None,
+        alias='url-expiration-timestamp-ms',
+        description='The timestamp, as milliseconds since the Unix epoch, when the URLs in `pre-signed-urls` expire. Clients should request fresh URLs, for example via the presignFiles endpoint, before this timestamp elapses. Required when `pre-signed-urls` is present.\n',
     )
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1429,6 +1429,67 @@ paths:
         5XX:
           $ref: '#/components/responses/ServerErrorResponse'
 
+  /v1/{prefix}/namespaces/{namespace}/tables/{table}/presign:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+
+    post:
+      tags:
+        - Catalog API
+      summary: Refreshes pre-signed URLs for files from a completed scan planning result
+      description: >
+        Refreshes pre-signed URLs for a set of files that were returned as part of a
+        previous server-side scan planning result, identified by its plan-id.
+
+
+        This endpoint is intended for lightweight, proactive renewal of expiring URLs
+        (for example by a background caching daemon) and does not re-evaluate the
+        table's manifests or any pushed-down filters. It is only available when the
+        pre-signed-urls access delegation mechanism has been negotiated with the
+        planTableScan endpoint via the X-Iceberg-Access-Delegation header.
+      operationId: presignFiles
+      requestBody:
+        description: The plan-id and file-paths for which fresh pre-signed URLs are requested
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PresignRequest'
+        required: true
+      responses:
+        200:
+          $ref: '#/components/responses/PresignResponse'
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found
+            - NoSuchPlanIdException, the plan-id does not exist
+            - NoSuchTableException, the table does not exist
+            - NoSuchNamespaceException, the namespace does not exist
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                PlanIdDoesNotExist:
+                  $ref: '#/components/examples/NoSuchPlanIdError'
+                TableDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+                NamespaceDoesNotExist:
+                  $ref: '#/components/examples/NoSuchNamespaceError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
   /v1/{prefix}/tables/rename:
     parameters:
       - $ref: '#/components/parameters/prefix'
@@ -2149,6 +2210,8 @@ components:
 
         Specific properties and handling for `vended-credentials` and `remote-signing`
         are documented in the `LoadTableResult` schema section of this spec document.
+        Handling for `pre-signed-urls` is documented in the `CompletedPlanningResult`
+        schema section of this spec document.
 
       required: false
       schema:
@@ -2158,6 +2221,7 @@ components:
           enum:
             - vended-credentials
             - remote-signing
+            - pre-signed-urls
       style: simple
       explode: false
       example: "vended-credentials,remote-signing"
@@ -3791,6 +3855,29 @@ components:
                 to read the files returned in the FileScanTasks as part of the scan result.
               items:
                 $ref: '#/components/schemas/StorageCredential'
+            pre-signed-urls:
+              type: object
+              description: >
+                A map of file-path (matching the `path` of a `ContentFile` referenced by a
+                returned `FileScanTask` or `DeleteFile`) to a pre-signed HTTP URL that can be
+                used to read the file's contents directly, without requiring cloud
+                provider-specific credentials or request signing.
+
+                This is only returned when the client requests the `pre-signed-urls` access
+                delegation mechanism via the `X-Iceberg-Access-Delegation` header. The
+                underlying `path` values of the `DataFile` and `DeleteFile` objects returned
+                in the scan result are unaffected and remain the immutable logical file
+                locations.
+              additionalProperties:
+                type: string
+            url-expiration-timestamp-ms:
+              type: integer
+              format: int64
+              description: >
+                The timestamp, as milliseconds since the Unix epoch, when the URLs in
+                `pre-signed-urls` expire. Clients should request fresh URLs, for example via
+                the presignFiles endpoint, before this timestamp elapses. Required when
+                `pre-signed-urls` is present.
 
     CompletedPlanningWithIDResult:
       type: object
@@ -5280,6 +5367,48 @@ components:
         headers:
           $ref: '#/components/schemas/MultiValuedMap'
 
+    PresignRequest:
+      description: >
+        A request to refresh pre-signed URLs for a set of files that were returned as part
+        of a previous server-side scan planning result.
+      type: object
+      required:
+        - plan-id
+        - file-paths
+      properties:
+        plan-id:
+          type: string
+          description:
+            The plan-id of the scan planning result that produced the files being
+            refreshed. The server uses this to authorize the request and resolve the
+            query state needed to reissue signatures.
+        file-paths:
+          type: array
+          description: The logical file-paths for which fresh pre-signed URLs are requested.
+          items:
+            type: string
+
+    PresignResponse:
+      description: The response containing refreshed pre-signed URLs.
+      type: object
+      required:
+        - pre-signed-urls
+        - url-expiration-timestamp-ms
+      properties:
+        pre-signed-urls:
+          type: object
+          description:
+            A map of file-path to a fresh pre-signed HTTP URL that can be used to read the
+            file's contents directly.
+          additionalProperties:
+            type: string
+        url-expiration-timestamp-ms:
+          type: integer
+          format: int64
+          description:
+            The timestamp, as milliseconds since the Unix epoch, when the refreshed URLs
+            in `pre-signed-urls` expire.
+
   #############################
   # Reusable Response Objects #
   #############################
@@ -5595,6 +5724,13 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/RemoteSignResult'
+
+    PresignResponse:
+      description: The response containing refreshed pre-signed URLs for the requested files.
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PresignResponse'
 
   #######################################
   # Common examples of different values #


### PR DESCRIPTION
## Read tables via catalog-vended pre-signed URLs

Lets execution engines read Iceberg tables entirely through catalog-vended, ephemeral pre-signed HTTP(S) URLs — bypassing cloud-specific SDKs and credentials — and refreshes those URLs, both reactively (on a 403/401 mid-read) and proactively so long-running jobs don't fail partway through.

This PR makes additive REST spec changes mirroring the Delta Sharing model: pre-signed URLs travel as a `path -> URL` map at the root of the scan-planning response alongside an expiration hint, while `DataFile`/`FileScanTask` locations stay untouched as the immutable logical path — no manifest rewriting, no new fields on `DataFile`/`FileScanTask`.

### REST spec changes (`open-api/rest-catalog-open-api.yaml`)

- `X-Iceberg-Access-Delegation` gains a third option, `pre-signed-urls`, alongside `vended-credentials` and `remote-signing`.
- `CompletedPlanningResult` (and by inheritance `CompletedPlanningWithIDResult`) gains two fields, populated only when `pre-signed-urls` was negotiated:
  - `pre-signed-urls`: a map of a file's logical `path` (matching the `DataFile`/`DeleteFile` it belongs to) to a pre-signed HTTP URL.
  - `url-expiration-timestamp-ms`: when those URLs expire.
- New endpoint `POST /v1/{prefix}/namespaces/{namespace}/tables/{table}/presign` for lightweight, proactive renewal without re-evaluating manifests or filters: request is `PresignRequest {plan-id, file-paths}`, response is `PresignResponse {pre-signed-urls, url-expiration-timestamp-ms}`.
- The pre-existing `remote-signing` `/sign` endpoint and `RemoteSignRequest`/`RemoteSignResponse` schemas are untouched.

### Implementation 
- https://github.com/williamhyun/iceberg/pull/206

---
**AI Disclosure**
- Model: Claude Sonnet 5 (Thinking)
- Platform/Tool: Cursor
- Human Oversight: Fully Reviewed
- Prompt Summary: Implement and iterate on a POC for reading Iceberg tables via catalog-vended pre-signed URLs (server-side scan planning, `HTTPFileIO`, reactive and proactive URL refresh), then migrate it to a Delta-Sharing-style REST spec change.