### PR TITLE
Flink: BackPort Add plannedGroups counter metric and log for DataFileRewritePlanner to 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -63,6 +63,7 @@ public class DataFileRewritePlanner
   private final long maxRewriteBytes;
   private final Map<String, String> rewriterOptions;
   private transient Counter errorCounter;
+  private transient Counter plannedGroupsCounter;
   private final String branch;
   private final SerializableSupplier<Expression> filterSupplier;
 
@@ -100,6 +101,9 @@ public class DataFileRewritePlanner
     this.errorCounter =
         TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, taskIndex)
             .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.plannedGroupsCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.PLANNED_GROUPS_COUNTER);
   }
 
   @Override
@@ -157,12 +161,14 @@ public class DataFileRewritePlanner
           IntMath.divide(groups.size(), partialProgressMaxCommits, RoundingMode.CEILING);
 
       LOG.info(
-          DataFileRewritePlanner.MESSAGE_PREFIX + "Rewrite plan created {}",
+          DataFileRewritePlanner.MESSAGE_PREFIX + "Rewrite plan created, {} groups: {}",
           tableName,
           taskName,
           taskIndex,
           ctx.timestamp(),
+          groups.size(),
           groups);
+      plannedGroupsCounter.inc(groups.size());
 
       for (RewriteFileGroup group : groups) {
         LOG.info(

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableMaintenanceMetrics.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableMaintenanceMetrics.java
@@ -51,6 +51,9 @@ public class TableMaintenanceMetrics {
   public static final String REMOVED_DATA_FILE_NUM_METRIC = "removedDataFileNum";
   public static final String REMOVED_DATA_FILE_SIZE_METRIC = "removedDataFileSize";
 
+  // DataFileRewritePlanner metrics
+  public static final String PLANNED_GROUPS_COUNTER = "plannedGroups";
+
   static MetricGroup groupFor(
       RuntimeContext context, String tableName, String taskName, int taskIndex) {
     return groupFor(groupFor(context, tableName), taskName, taskIndex);

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.flink.maintenance.api.RewriteDataFiles.REWRITE_
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ADDED_DATA_FILE_NUM_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ADDED_DATA_FILE_SIZE_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ERROR_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.PLANNED_GROUPS_COUNTER;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.REMOVED_DATA_FILE_NUM_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.REMOVED_DATA_FILE_SIZE_METRIC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -257,6 +258,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                 1L)
             .put(
                 ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",
                     DUMMY_TABLE_NAME,
                     DUMMY_TASK_NAME,
@@ -373,6 +382,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                 0L)
             .put(
                 ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",
                     DUMMY_TABLE_NAME,
                     DUMMY_TASK_NAME,
@@ -450,6 +467,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                     "0",
                     ERROR_COUNTER),
                 0L)
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
             .put(
                 ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/DataFileRewritePlanner.java
@@ -63,6 +63,7 @@ public class DataFileRewritePlanner
   private final long maxRewriteBytes;
   private final Map<String, String> rewriterOptions;
   private transient Counter errorCounter;
+  private transient Counter plannedGroupsCounter;
   private final String branch;
   private final SerializableSupplier<Expression> filterSupplier;
 
@@ -100,6 +101,9 @@ public class DataFileRewritePlanner
     this.errorCounter =
         TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, taskIndex)
             .counter(TableMaintenanceMetrics.ERROR_COUNTER);
+    this.plannedGroupsCounter =
+        TableMaintenanceMetrics.groupFor(getRuntimeContext(), tableName, taskName, taskIndex)
+            .counter(TableMaintenanceMetrics.PLANNED_GROUPS_COUNTER);
   }
 
   @Override
@@ -157,12 +161,14 @@ public class DataFileRewritePlanner
           IntMath.divide(groups.size(), partialProgressMaxCommits, RoundingMode.CEILING);
 
       LOG.info(
-          DataFileRewritePlanner.MESSAGE_PREFIX + "Rewrite plan created {}",
+          DataFileRewritePlanner.MESSAGE_PREFIX + "Rewrite plan created, {} groups: {}",
           tableName,
           taskName,
           taskIndex,
           ctx.timestamp(),
+          groups.size(),
           groups);
+      plannedGroupsCounter.inc(groups.size());
 
       for (RewriteFileGroup group : groups) {
         LOG.info(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableMaintenanceMetrics.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/TableMaintenanceMetrics.java
@@ -51,6 +51,9 @@ public class TableMaintenanceMetrics {
   public static final String REMOVED_DATA_FILE_NUM_METRIC = "removedDataFileNum";
   public static final String REMOVED_DATA_FILE_SIZE_METRIC = "removedDataFileSize";
 
+  // DataFileRewritePlanner metrics
+  public static final String PLANNED_GROUPS_COUNTER = "plannedGroups";
+
   static MetricGroup groupFor(
       RuntimeContext context, String tableName, String taskName, int taskIndex) {
     return groupFor(groupFor(context, tableName), taskName, taskIndex);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -25,6 +25,7 @@ import static org.apache.iceberg.flink.maintenance.api.RewriteDataFiles.REWRITE_
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ADDED_DATA_FILE_NUM_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ADDED_DATA_FILE_SIZE_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.ERROR_COUNTER;
+import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.PLANNED_GROUPS_COUNTER;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.REMOVED_DATA_FILE_NUM_METRIC;
 import static org.apache.iceberg.flink.maintenance.operator.TableMaintenanceMetrics.REMOVED_DATA_FILE_SIZE_METRIC;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -257,6 +258,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                 1L)
             .put(
                 ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",
                     DUMMY_TABLE_NAME,
                     DUMMY_TASK_NAME,
@@ -373,6 +382,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                 0L)
             .put(
                 ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
+            .put(
+                ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",
                     DUMMY_TABLE_NAME,
                     DUMMY_TASK_NAME,
@@ -450,6 +467,14 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
                     "0",
                     ERROR_COUNTER),
                 0L)
+            .put(
+                ImmutableList.of(
+                    PLANNER_TASK_NAME + "[0]",
+                    DUMMY_TABLE_NAME,
+                    DUMMY_TASK_NAME,
+                    "0",
+                    PLANNED_GROUPS_COUNTER),
+                1L)
             .put(
                 ImmutableList.of(
                     REWRITE_TASK_NAME + "[0]",


### PR DESCRIPTION
This is a clean backport for https://github.com/apache/iceberg/pull/17316