### PR TITLE
Build: bump Jackson to fix CVE GHSA-r7wm-3cxj-wff9

### DIFF
--- a/.github/trivyignore/kafka-connect-runtime.trivyignore
+++ b/.github/trivyignore/kafka-connect-runtime.trivyignore
@@ -17,14 +17,17 @@
 #
 # Trivy ignore file for the Kafka Connect runtime distribution.
 #
-# The Kafka Connect runtime's own jackson-databind is already aligned to the
-# project version (2.22.x). The remaining finding comes from parquet-jackson,
-# which ships its own shaded copy of jackson-databind (relocated under
-# shaded.parquet.*). That copy cannot be upgraded independently of Apache
-# Parquet, and 1.17.1 still bundles a vulnerable version.
+# The Kafka Connect runtime's own jackson-core / jackson-databind are already
+# aligned to the project version (2.22.x). The remaining findings come from
+# parquet-jackson, which ships its own shaded copy of jackson-core /
+# jackson-databind (relocated under shaded.parquet.*). That copy cannot be
+# upgraded independently of Apache Parquet, and 1.17.1 still bundles
+# vulnerable versions.
 #
 # jackson-databind CVEs shaded into parquet-jackson, only fixed in jackson
 # >= 2.21.4 / 2.18.8.
 CVE-2026-54512
 CVE-2026-54513
+# jackson-core CVE shaded into parquet-jackson, only fixed in jackson
+# >= 2.18.8 / 2.21.4 / 2.22.1.
 GHSA-r7wm-3cxj-wff9

--- a/.github/trivyignore/spark-runtime-3.5.trivyignore
+++ b/.github/trivyignore/spark-runtime-3.5.trivyignore
@@ -25,4 +25,3 @@
 # jackson-databind CVEs that are only fixed in jackson >= 2.18.8.
 CVE-2026-54512
 CVE-2026-54513
-GHSA-r7wm-3cxj-wff9

--- a/.github/trivyignore/spark-runtime-3.5.trivyignore
+++ b/.github/trivyignore/spark-runtime-3.5.trivyignore
@@ -22,6 +22,3 @@
 # compatibility with Spark 3.5. Newer Spark lines (4.0, 4.1) align Jackson to a
 # fixed version instead of ignoring the finding.
 #
-# jackson-databind CVEs that are only fixed in jackson >= 2.18.8.
-CVE-2026-54512
-CVE-2026-54513

--- a/.github/trivyignore/spark-runtime-3.5.trivyignore
+++ b/.github/trivyignore/spark-runtime-3.5.trivyignore
@@ -16,9 +16,3 @@
 # under the License.
 #
 # Trivy ignore file for the Spark 3.5 runtime bundle.
-#
-# The Spark 3.5 runtime bundles the Jackson version provided by Spark 3.5
-# (jackson 2.15.x), which cannot be safely upgraded without breaking
-# compatibility with Spark 3.5. Newer Spark lines (4.0, 4.1) align Jackson to a
-# fixed version instead of ignoring the finding.
-#

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,7 +60,6 @@ hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 immutables-value = "2.12.2"
 jackson-annotations = "2.22"
 jackson-bom = "2.22.1"
-jackson215 = { strictly = "2.15.2"} # see rich version usage explanation above
 jackson218 = { strictly = "2.18.8"}
 jackson221 = { strictly = "2.21.4"}
 jakarta-el-api = "3.0.3"

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -30,9 +30,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson218.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson218.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson221.get()}"
+        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson221.get()}"
+        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson221.get()}"
       }
     }
   }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -30,9 +30,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson221.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson221.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson221.get()}"
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson218.get()}"
       }
     }
   }

--- a/spark/v3.5/build.gradle
+++ b/spark/v3.5/build.gradle
@@ -30,9 +30,9 @@ configure(sparkProjects) {
   configurations {
     all {
       resolutionStrategy {
-        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson215.get()}"
-        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson215.get()}"
+        force "com.fasterxml.jackson.module:jackson-module-scala_${scalaVersion}:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-databind:${libs.versions.jackson218.get()}"
+        force "com.fasterxml.jackson.core:jackson-core:${libs.versions.jackson218.get()}"
       }
     }
   }

--- a/spark/v3.5/spark-runtime/runtime-deps.txt
+++ b/spark/v3.5/spark-runtime/runtime-deps.txt
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.22
-com.fasterxml.jackson.core:jackson-core:2.15
-com.fasterxml.jackson.core:jackson-databind:2.15
+com.fasterxml.jackson.core:jackson-core:2.18
+com.fasterxml.jackson.core:jackson-databind:2.18
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.github.ben-manes.caffeine:caffeine:2.9
 com.google.errorprone:error_prone_annotations:2.10

--- a/spark/v3.5/spark-runtime/runtime-deps.txt
+++ b/spark/v3.5/spark-runtime/runtime-deps.txt
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.22
-com.fasterxml.jackson.core:jackson-core:2.21
-com.fasterxml.jackson.core:jackson-databind:2.21
+com.fasterxml.jackson.core:jackson-core:2.18
+com.fasterxml.jackson.core:jackson-databind:2.18
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.github.ben-manes.caffeine:caffeine:2.9
 com.google.errorprone:error_prone_annotations:2.10

--- a/spark/v3.5/spark-runtime/runtime-deps.txt
+++ b/spark/v3.5/spark-runtime/runtime-deps.txt
@@ -1,6 +1,6 @@
 com.fasterxml.jackson.core:jackson-annotations:2.22
-com.fasterxml.jackson.core:jackson-core:2.18
-com.fasterxml.jackson.core:jackson-databind:2.18
+com.fasterxml.jackson.core:jackson-core:2.21
+com.fasterxml.jackson.core:jackson-databind:2.21
 com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.22
 com.github.ben-manes.caffeine:caffeine:2.9
 com.google.errorprone:error_prone_annotations:2.10


### PR DESCRIPTION

This PR updates the Spark 3.5 runtime Jackson dependency alignment to address `GHSA-r7wm-3cxj-wff9`.

- Bumps Spark 3.5 forced Jackson dependencies from the `jackson215` version set to `jackson218`.
- Updates the Spark 3.5 runtime dependency baseline for `jackson-core` and `jackson-databind`.
- Documents the remaining Kafka Connect runtime vulnerability finding as coming from the shaded Jackson copy embedded in `parquet-jackson`, which cannot be upgraded independently of Apache Parquet.


