### PR TITLE
Core: add labels to the load table/view read path

### DIFF
--- a/core/src/main/java/org/apache/iceberg/FieldLabels.java
+++ b/core/src/main/java/org/apache/iceberg/FieldLabels.java
@@ -16,29 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.rest.responses;
+package org.apache.iceberg;
 
 import java.util.Map;
-import org.apache.iceberg.Labels;
-import org.apache.iceberg.rest.RESTResponse;
-import org.apache.iceberg.view.ViewMetadata;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.immutables.value.Value;
 
+/** Labels attached to a single field, identified by its field id. See {@link Labels}. */
 @Value.Immutable
-public interface LoadViewResponse extends RESTResponse {
-  String metadataLocation();
+public interface FieldLabels {
+  int fieldId();
 
-  ViewMetadata metadata();
+  Map<String, String> labels();
 
-  Map<String, String> config();
-
-  @Value.Default
-  default Labels labels() {
-    return Labels.EMPTY;
-  }
-
-  @Override
+  @Value.Check
   default void validate() {
-    // nothing to validate as it's not possible to create an invalid instance
+    Preconditions.checkArgument(fieldId() >= 1, "Invalid field id: must be >= 1");
   }
 }

--- a/core/src/main/java/org/apache/iceberg/FieldLabelsParser.java
+++ b/core/src/main/java/org/apache/iceberg/FieldLabelsParser.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class FieldLabelsParser {
+  private static final String FIELD_ID = "field-id";
+  private static final String LABELS = "labels";
+
+  private FieldLabelsParser() {}
+
+  public static String toJson(FieldLabels fieldLabels) {
+    return toJson(fieldLabels, false);
+  }
+
+  public static String toJson(FieldLabels fieldLabels, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(fieldLabels, gen), pretty);
+  }
+
+  public static void toJson(FieldLabels fieldLabels, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != fieldLabels, "Invalid field labels: null");
+
+    gen.writeStartObject();
+
+    gen.writeNumberField(FIELD_ID, fieldLabels.fieldId());
+    JsonUtil.writeStringMap(LABELS, fieldLabels.labels(), gen);
+
+    gen.writeEndObject();
+  }
+
+  public static FieldLabels fromJson(String json) {
+    return JsonUtil.parse(json, FieldLabelsParser::fromJson);
+  }
+
+  public static FieldLabels fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse field labels from null object");
+
+    return ImmutableFieldLabels.builder()
+        .fieldId(JsonUtil.getInt(FIELD_ID, json))
+        .labels(JsonUtil.getStringMap(LABELS, json))
+        .build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/Labels.java
+++ b/core/src/main/java/org/apache/iceberg/Labels.java
@@ -16,29 +16,25 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.iceberg.rest.responses;
+package org.apache.iceberg;
 
+import java.util.List;
 import java.util.Map;
-import org.apache.iceberg.Labels;
-import org.apache.iceberg.rest.RESTResponse;
-import org.apache.iceberg.view.ViewMetadata;
 import org.immutables.value.Value;
 
+/** Optional catalog-provided labels returned on a load response. */
 @Value.Immutable
-public interface LoadViewResponse extends RESTResponse {
-  String metadataLocation();
+public interface Labels {
+  Labels EMPTY = ImmutableLabels.builder().build();
 
-  ViewMetadata metadata();
+  /** Object-level labels. */
+  Map<String, String> objectLabels();
 
-  Map<String, String> config();
+  /** Field-level labels */
+  List<FieldLabels> fields();
 
-  @Value.Default
-  default Labels labels() {
-    return Labels.EMPTY;
-  }
-
-  @Override
-  default void validate() {
-    // nothing to validate as it's not possible to create an invalid instance
+  /** Returns true when there are neither object-level nor field-level labels. */
+  default boolean isEmpty() {
+    return objectLabels().isEmpty() && fields().isEmpty();
   }
 }

--- a/core/src/main/java/org/apache/iceberg/LabelsParser.java
+++ b/core/src/main/java/org/apache/iceberg/LabelsParser.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.util.JsonUtil;
+
+public class LabelsParser {
+  private static final String OBJECT_LABELS = "object-labels";
+  private static final String FIELDS = "fields";
+
+  private LabelsParser() {}
+
+  public static String toJson(Labels labels) {
+    return toJson(labels, false);
+  }
+
+  public static String toJson(Labels labels, boolean pretty) {
+    return JsonUtil.generate(gen -> toJson(labels, gen), pretty);
+  }
+
+  public static void toJson(Labels labels, JsonGenerator gen) throws IOException {
+    Preconditions.checkArgument(null != labels, "Invalid labels: null");
+
+    gen.writeStartObject();
+
+    if (!labels.objectLabels().isEmpty()) {
+      JsonUtil.writeStringMap(OBJECT_LABELS, labels.objectLabels(), gen);
+    }
+
+    if (!labels.fields().isEmpty()) {
+      gen.writeArrayFieldStart(FIELDS);
+      for (FieldLabels fieldLabels : labels.fields()) {
+        FieldLabelsParser.toJson(fieldLabels, gen);
+      }
+
+      gen.writeEndArray();
+    }
+
+    gen.writeEndObject();
+  }
+
+  public static Labels fromJson(String json) {
+    return JsonUtil.parse(json, LabelsParser::fromJson);
+  }
+
+  public static Labels fromJson(JsonNode json) {
+    Preconditions.checkArgument(null != json, "Cannot parse labels from null object");
+
+    ImmutableLabels.Builder builder = ImmutableLabels.builder();
+
+    if (json.hasNonNull(OBJECT_LABELS)) {
+      builder.objectLabels(JsonUtil.getStringMap(OBJECT_LABELS, json));
+    }
+
+    if (json.hasNonNull(FIELDS)) {
+      builder.fields(JsonUtil.getObjectList(FIELDS, json, FieldLabelsParser::fromJson));
+    }
+
+    return builder.build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponse.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest.responses;
 
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.Labels;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -45,6 +46,7 @@ public class LoadTableResponse implements RESTResponse {
   private Map<String, String> config;
   private TableMetadata metadataWithLocation;
   private List<Credential> credentials;
+  private Labels labels;
 
   public LoadTableResponse() {
     // Required for Jackson deserialization
@@ -54,11 +56,13 @@ public class LoadTableResponse implements RESTResponse {
       String metadataLocation,
       TableMetadata metadata,
       Map<String, String> config,
-      List<Credential> credentials) {
+      List<Credential> credentials,
+      Labels labels) {
     this.metadataLocation = metadataLocation;
     this.metadata = metadata;
     this.config = config;
     this.credentials = credentials;
+    this.labels = labels;
   }
 
   @Override
@@ -87,12 +91,17 @@ public class LoadTableResponse implements RESTResponse {
     return credentials != null ? credentials : ImmutableList.of();
   }
 
+  public Labels labels() {
+    return labels != null ? labels : Labels.EMPTY;
+  }
+
   @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("metadataLocation", metadataLocation)
         .add("metadata", metadata)
         .add("config", config)
+        .add("labels", labels)
         .toString();
   }
 
@@ -105,6 +114,7 @@ public class LoadTableResponse implements RESTResponse {
     private TableMetadata metadata;
     private final Map<String, String> config = Maps.newHashMap();
     private final List<Credential> credentials = Lists.newArrayList();
+    private Labels labels;
 
     private Builder() {}
 
@@ -134,9 +144,14 @@ public class LoadTableResponse implements RESTResponse {
       return this;
     }
 
+    public Builder withLabels(Labels tableLabels) {
+      this.labels = tableLabels;
+      return this;
+    }
+
     public LoadTableResponse build() {
       Preconditions.checkNotNull(metadata, "Invalid metadata: null");
-      return new LoadTableResponse(metadataLocation, metadata, config, credentials);
+      return new LoadTableResponse(metadataLocation, metadata, config, credentials, labels);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadTableResponseParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest.responses;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import org.apache.iceberg.LabelsParser;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -34,6 +35,7 @@ public class LoadTableResponseParser {
   private static final String METADATA = "metadata";
   private static final String CONFIG = "config";
   private static final String STORAGE_CREDENTIALS = "storage-credentials";
+  private static final String LABELS = "labels";
 
   private LoadTableResponseParser() {}
 
@@ -70,6 +72,11 @@ public class LoadTableResponseParser {
       gen.writeEndArray();
     }
 
+    if (!response.labels().isEmpty()) {
+      gen.writeFieldName(LABELS);
+      LabelsParser.toJson(response.labels(), gen);
+    }
+
     gen.writeEndObject();
   }
 
@@ -99,6 +106,10 @@ public class LoadTableResponseParser {
 
     if (json.hasNonNull(STORAGE_CREDENTIALS)) {
       builder.addAllCredentials(LoadCredentialsResponseParser.fromJson(json).credentials());
+    }
+
+    if (json.hasNonNull(LABELS)) {
+      builder.withLabels(LabelsParser.fromJson(JsonUtil.get(LABELS, json)));
     }
 
     return builder.build();

--- a/core/src/main/java/org/apache/iceberg/rest/responses/LoadViewResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/responses/LoadViewResponseParser.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.rest.responses;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import org.apache.iceberg.LabelsParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.JsonUtil;
 import org.apache.iceberg.view.ViewMetadata;
@@ -31,6 +32,7 @@ public class LoadViewResponseParser {
   private static final String METADATA_LOCATION = "metadata-location";
   private static final String METADATA = "metadata";
   private static final String CONFIG = "config";
+  private static final String LABELS = "labels";
 
   private LoadViewResponseParser() {}
 
@@ -56,6 +58,11 @@ public class LoadViewResponseParser {
       JsonUtil.writeStringMap(CONFIG, response.config(), gen);
     }
 
+    if (!response.labels().isEmpty()) {
+      gen.writeFieldName(LABELS);
+      LabelsParser.toJson(response.labels(), gen);
+    }
+
     gen.writeEndObject();
   }
 
@@ -78,6 +85,10 @@ public class LoadViewResponseParser {
 
     if (json.hasNonNull(CONFIG)) {
       builder.config(JsonUtil.getStringMap(CONFIG, json));
+    }
+
+    if (json.hasNonNull(LABELS)) {
+      builder.labels(LabelsParser.fromJson(JsonUtil.get(LABELS, json)));
     }
 
     return builder.build();

--- a/core/src/test/java/org/apache/iceberg/TestFieldLabelsParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFieldLabelsParser.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestFieldLabelsParser {
+
+  @Test
+  public void nullCheck() {
+    assertThatThrownBy(() -> FieldLabelsParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field labels: null");
+
+    assertThatThrownBy(() -> FieldLabelsParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse field labels from null object");
+  }
+
+  @Test
+  public void roundTrip() {
+    FieldLabels fieldLabels =
+        ImmutableFieldLabels.builder().fieldId(3).labels(ImmutableMap.of("pii", "true")).build();
+
+    String expectedJson =
+        """
+        {
+          "field-id" : 3,
+          "labels" : {
+            "pii" : "true"
+          }
+        }""";
+
+    assertThat(FieldLabelsParser.toJson(fieldLabels, true)).isEqualTo(expectedJson);
+    assertThat(FieldLabelsParser.fromJson(expectedJson)).isEqualTo(fieldLabels);
+  }
+
+  @Test
+  public void invalidFieldId() {
+    assertThatThrownBy(
+            () ->
+                ImmutableFieldLabels.builder().fieldId(0).labels(ImmutableMap.of("k", "v")).build())
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field id: must be >= 1");
+  }
+
+  @Test
+  public void invalidFieldIdFromJson() {
+    assertThatThrownBy(
+            () -> FieldLabelsParser.fromJson("{\"field-id\": 0, \"labels\": {\"k\": \"v\"}}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid field id: must be >= 1");
+  }
+
+  @Test
+  public void emptyLabels() {
+    FieldLabels fieldLabels = ImmutableFieldLabels.builder().fieldId(1).build();
+
+    assertThat(fieldLabels.labels()).isEmpty();
+  }
+
+  @Test
+  public void emptyLabelsFromJson() {
+    FieldLabels fieldLabels = FieldLabelsParser.fromJson("{\"field-id\": 1, \"labels\": {}}");
+
+    assertThat(fieldLabels.fieldId()).isEqualTo(1);
+    assertThat(fieldLabels.labels()).isEmpty();
+  }
+
+  @Test
+  public void missingLabelsFromJson() {
+    assertThatThrownBy(() -> FieldLabelsParser.fromJson("{\"field-id\": 1}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse missing map: labels");
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestLabelsParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestLabelsParser.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestLabelsParser {
+
+  @Test
+  public void nullCheck() {
+    assertThatThrownBy(() -> LabelsParser.toJson(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid labels: null");
+
+    assertThatThrownBy(() -> LabelsParser.fromJson((JsonNode) null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse labels from null object");
+  }
+
+  @Test
+  public void emptyLabels() {
+    Labels labels = ImmutableLabels.builder().build();
+    assertThat(labels.isEmpty()).isTrue();
+
+    String expectedJson = "{ }";
+    assertThat(LabelsParser.toJson(labels, true)).isEqualTo(expectedJson);
+
+    Labels roundTrip = LabelsParser.fromJson(expectedJson);
+    assertThat(roundTrip.objectLabels()).isEmpty();
+    assertThat(roundTrip.fields()).isEmpty();
+
+    Labels nonEmpty = ImmutableLabels.builder().objectLabels(ImmutableMap.of("k", "v")).build();
+    assertThat(nonEmpty.isEmpty()).isFalse();
+  }
+
+  @Test
+  public void objectLabelsOnly() {
+    Labels labels =
+        ImmutableLabels.builder()
+            .objectLabels(ImmutableMap.of("owner", "team-a", "sensitivity", "high"))
+            .build();
+
+    String expectedJson =
+        """
+        {
+          "object-labels" : {
+            "owner" : "team-a",
+            "sensitivity" : "high"
+          }
+        }""";
+
+    assertThat(LabelsParser.toJson(labels, true)).isEqualTo(expectedJson);
+    assertThat(LabelsParser.fromJson(expectedJson)).isEqualTo(labels);
+  }
+
+  @Test
+  public void fieldLabelsOnly() {
+    Labels labels =
+        ImmutableLabels.builder()
+            .addFields(
+                ImmutableFieldLabels.builder()
+                    .fieldId(3)
+                    .labels(ImmutableMap.of("pii", "true"))
+                    .build())
+            .build();
+
+    String expectedJson =
+        """
+        {
+          "fields" : [ {
+            "field-id" : 3,
+            "labels" : {
+              "pii" : "true"
+            }
+          } ]
+        }""";
+
+    assertThat(LabelsParser.toJson(labels, true)).isEqualTo(expectedJson);
+    assertThat(LabelsParser.fromJson(expectedJson)).isEqualTo(labels);
+  }
+
+  @Test
+  public void objectAndFieldLabels() {
+    Labels labels =
+        ImmutableLabels.builder()
+            .objectLabels(ImmutableMap.of("owner", "team-a"))
+            .addFields(
+                ImmutableFieldLabels.builder()
+                    .fieldId(1)
+                    .labels(ImmutableMap.of("classification", "pii"))
+                    .build())
+            .addFields(
+                ImmutableFieldLabels.builder()
+                    .fieldId(2)
+                    .labels(ImmutableMap.of("classification", "public"))
+                    .build())
+            .build();
+
+    String expectedJson =
+        """
+        {
+          "object-labels" : {
+            "owner" : "team-a"
+          },
+          "fields" : [ {
+            "field-id" : 1,
+            "labels" : {
+              "classification" : "pii"
+            }
+          }, {
+            "field-id" : 2,
+            "labels" : {
+              "classification" : "public"
+            }
+          } ]
+        }""";
+
+    assertThat(LabelsParser.toJson(labels, true)).isEqualTo(expectedJson);
+    assertThat(LabelsParser.fromJson(expectedJson)).isEqualTo(labels);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponse.java
@@ -26,6 +26,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Map;
+import org.apache.iceberg.ImmutableFieldLabels;
+import org.apache.iceberg.ImmutableLabels;
+import org.apache.iceberg.Labels;
 import org.apache.iceberg.NullOrder;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
@@ -163,6 +166,48 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
   }
 
   @Test
+  public void testRoundTripSerdeWithLabels() throws Exception {
+    String tableMetadataJson = readTableMetadataInputFile("TableMetadataV2Valid.json");
+    TableMetadata metadata =
+        TableMetadataParser.fromJson(TEST_METADATA_LOCATION, tableMetadataJson);
+    Labels labels =
+        ImmutableLabels.builder()
+            .objectLabels(ImmutableMap.of("owner", "team-a"))
+            .addFields(
+                ImmutableFieldLabels.builder()
+                    .fieldId(1)
+                    .labels(ImmutableMap.of("classification", "pii"))
+                    .build())
+            .build();
+    String json =
+        String.format(
+            """
+            {
+              "metadata-location":"%s",
+              "metadata":%s,
+              "config":{"foo":"bar"},
+              "labels":{
+                "object-labels":{"owner":"team-a"},
+                "fields":[{"field-id":1,"labels":{"classification":"pii"}}]
+              }
+            }""",
+            TEST_METADATA_LOCATION, TableMetadataParser.toJson(metadata));
+
+    // exercise the full RESTObjectMapper (Jackson) path, not just the parser
+    LoadTableResponse actual = deserialize(json);
+    assertThat(actual.labels()).isEqualTo(labels);
+
+    LoadTableResponse resp =
+        LoadTableResponse.builder()
+            .withTableMetadata(metadata)
+            .addAllConfig(CONFIG)
+            .withLabels(labels)
+            .build();
+    // compare as JSON trees so the readable (pretty) input above is whitespace-insensitive
+    assertThat(mapper().readTree(serialize(resp))).isEqualTo(mapper().readTree(json));
+  }
+
+  @Test
   public void testCanDeserializeWithoutDefaultValues() throws Exception {
     String metadataJson = readTableMetadataInputFile("TableMetadataV1Valid.json");
     // `config` is missing in the JSON
@@ -187,6 +232,7 @@ public class TestLoadTableResponse extends RequestResponseTestBase<LoadTableResp
     assertThat(actual.metadataLocation())
         .as("Should have the same metadata location")
         .isEqualTo(expected.metadataLocation());
+    assertThat(actual.labels()).as("Should have the same labels").isEqualTo(expected.labels());
   }
 
   private void assertEqualTableMetadata(TableMetadata actual, TableMetadata expected) {

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadTableResponseParser.java
@@ -23,6 +23,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.ImmutableFieldLabels;
+import org.apache.iceberg.ImmutableLabels;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
@@ -477,5 +479,120 @@ public class TestLoadTableResponseParser {
     // can't do an equality comparison because Schema doesn't implement equals/hashCode
     assertThat(LoadTableResponseParser.toJson(LoadTableResponseParser.fromJson(json), true))
         .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void roundTripSerdeWithLabels() {
+    String uuid = "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b";
+    TableMetadata metadata =
+        TableMetadata.buildFromEmpty()
+            .assignUUID(uuid)
+            .setLocation("location")
+            .setCurrentSchema(
+                new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
+            .addPartitionSpec(PartitionSpec.unpartitioned())
+            .addSortOrder(SortOrder.unsorted())
+            .discardChanges()
+            .withMetadataLocation("metadata-location")
+            .build();
+
+    LoadTableResponse response =
+        LoadTableResponse.builder()
+            .withTableMetadata(metadata)
+            .withLabels(
+                ImmutableLabels.builder()
+                    .objectLabels(ImmutableMap.of("owner", "team-a"))
+                    .addFields(
+                        ImmutableFieldLabels.builder()
+                            .fieldId(1)
+                            .labels(ImmutableMap.of("classification", "pii"))
+                            .build())
+                    .build())
+            .build();
+
+    String expectedJson =
+        String.format(
+            """
+            {
+              "metadata-location" : "metadata-location",
+              "metadata" : {
+                "format-version" : 2,
+                "table-uuid" : "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b",
+                "location" : "location",
+                "last-sequence-number" : 0,
+                "last-updated-ms" : %d,
+                "last-column-id" : 1,
+                "current-schema-id" : 0,
+                "schemas" : [ {
+                  "type" : "struct",
+                  "schema-id" : 0,
+                  "fields" : [ {
+                    "id" : 1,
+                    "name" : "x",
+                    "required" : true,
+                    "type" : "long"
+                  } ]
+                } ],
+                "default-spec-id" : 0,
+                "partition-specs" : [ {
+                  "spec-id" : 0,
+                  "fields" : [ ]
+                } ],
+                "last-partition-id" : 999,
+                "default-sort-order-id" : 0,
+                "sort-orders" : [ {
+                  "order-id" : 0,
+                  "fields" : [ ]
+                } ],
+                "properties" : { },
+                "current-snapshot-id" : -1,
+                "refs" : { },
+                "snapshots" : [ ],
+                "statistics" : [ ],
+                "partition-statistics" : [ ],
+                "snapshot-log" : [ ],
+                "metadata-log" : [ ]
+              },
+              "labels" : {
+                "object-labels" : {
+                  "owner" : "team-a"
+                },
+                "fields" : [ {
+                  "field-id" : 1,
+                  "labels" : {
+                    "classification" : "pii"
+                  }
+                } ]
+              }
+            }""",
+            metadata.lastUpdatedMillis());
+
+    String json = LoadTableResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    // can't do an equality comparison because Schema doesn't implement equals/hashCode
+    assertThat(LoadTableResponseParser.toJson(LoadTableResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void labelsAreOptional() {
+    String uuid = "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b";
+    TableMetadata metadata =
+        TableMetadata.buildFromEmpty()
+            .assignUUID(uuid)
+            .setLocation("location")
+            .setCurrentSchema(
+                new Schema(Types.NestedField.required(1, "x", Types.LongType.get())), 1)
+            .addPartitionSpec(PartitionSpec.unpartitioned())
+            .addSortOrder(SortOrder.unsorted())
+            .discardChanges()
+            .withMetadataLocation("metadata-location")
+            .build();
+
+    LoadTableResponse response = LoadTableResponse.builder().withTableMetadata(metadata).build();
+
+    String json = LoadTableResponseParser.toJson(response, true);
+    assertThat(json).doesNotContain("labels");
+    assertThat(LoadTableResponseParser.fromJson(json).labels().isEmpty()).isTrue();
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadViewResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestLoadViewResponseParser.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.iceberg.ImmutableFieldLabels;
+import org.apache.iceberg.ImmutableLabels;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -278,5 +280,119 @@ public class TestLoadViewResponseParser {
     LoadViewResponse parsed = LoadViewResponseParser.fromJson(jsonWithNullConfig);
     assertThat(parsed.config()).isEmpty();
     assertThat(LoadViewResponseParser.toJson(parsed, true)).isEqualTo(jsonWithoutConfig);
+  }
+
+  @Test
+  public void roundTripSerdeWithLabels() {
+    String uuid = "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b";
+    ViewMetadata viewMetadata =
+        ViewMetadata.builder()
+            .assignUUID(uuid)
+            .setLocation("location")
+            .addSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())))
+            .addVersion(
+                ImmutableViewVersion.builder()
+                    .schemaId(0)
+                    .versionId(1)
+                    .timestampMillis(23L)
+                    .defaultNamespace(Namespace.of("ns1"))
+                    .build())
+            .setCurrentVersionId(1)
+            .build();
+
+    LoadViewResponse response =
+        ImmutableLoadViewResponse.builder()
+            .metadata(viewMetadata)
+            .metadataLocation("custom-location")
+            .labels(
+                ImmutableLabels.builder()
+                    .objectLabels(ImmutableMap.of("owner", "team-a"))
+                    .addFields(
+                        ImmutableFieldLabels.builder()
+                            .fieldId(1)
+                            .labels(ImmutableMap.of("classification", "pii"))
+                            .build())
+                    .build())
+            .build();
+
+    String expectedJson =
+        """
+        {
+          "metadata-location" : "custom-location",
+          "metadata" : {
+            "view-uuid" : "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b",
+            "format-version" : 1,
+            "location" : "location",
+            "schemas" : [ {
+              "type" : "struct",
+              "schema-id" : 0,
+              "fields" : [ {
+                "id" : 1,
+                "name" : "x",
+                "required" : true,
+                "type" : "long"
+              } ]
+            } ],
+            "current-version-id" : 1,
+            "versions" : [ {
+              "version-id" : 1,
+              "timestamp-ms" : 23,
+              "schema-id" : 0,
+              "summary" : { },
+              "default-namespace" : [ "ns1" ],
+              "representations" : [ ]
+            } ],
+            "version-log" : [ {
+              "timestamp-ms" : 23,
+              "version-id" : 1
+            } ]
+          },
+          "labels" : {
+            "object-labels" : {
+              "owner" : "team-a"
+            },
+            "fields" : [ {
+              "field-id" : 1,
+              "labels" : {
+                "classification" : "pii"
+              }
+            } ]
+          }
+        }""";
+
+    String json = LoadViewResponseParser.toJson(response, true);
+    assertThat(json).isEqualTo(expectedJson);
+    // can't do an equality comparison because Schema doesn't implement equals/hashCode
+    assertThat(LoadViewResponseParser.toJson(LoadViewResponseParser.fromJson(json), true))
+        .isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void labelsAreOptional() {
+    String uuid = "386b9f01-002b-4d8c-b77f-42c3fd3b7c9b";
+    ViewMetadata viewMetadata =
+        ViewMetadata.builder()
+            .assignUUID(uuid)
+            .setLocation("location")
+            .addSchema(new Schema(Types.NestedField.required(1, "x", Types.LongType.get())))
+            .addVersion(
+                ImmutableViewVersion.builder()
+                    .schemaId(0)
+                    .versionId(1)
+                    .timestampMillis(23L)
+                    .defaultNamespace(Namespace.of("ns1"))
+                    .build())
+            .setCurrentVersionId(1)
+            .build();
+
+    LoadViewResponse response =
+        ImmutableLoadViewResponse.builder()
+            .metadata(viewMetadata)
+            .metadataLocation("custom-location")
+            .build();
+
+    String json = LoadViewResponseParser.toJson(response, true);
+    assertThat(json).doesNotContain("labels");
+    assertThat(LoadViewResponseParser.fromJson(json).labels().isEmpty()).isTrue();
   }
 }

--- a/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerLabels.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerLabels.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+import java.util.Map;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.FieldLabels;
+import org.apache.iceberg.Labels;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.catalog.Namespace;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
+import org.apache.iceberg.types.Types;
+import org.apache.iceberg.view.View;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Verifies that labels injected by the REST server fixture reach the client over the wire.
+ *
+ * <p>The labels are read from the raw load responses rather than from the loaded table so that this
+ * covers the response payload itself, which is what other client implementations parse.
+ */
+public class TestRESTServerLabels {
+
+  private static final Namespace NAMESPACE = Namespace.of("ns");
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "data", Types.StringType.get()));
+
+  @RegisterExtension
+  private static final RESTServerExtension REST_SERVER_EXTENSION =
+      new RESTServerExtension(
+          Map.of(
+              RESTCatalogServer.REST_PORT,
+              RESTServerExtension.FREE_PORT,
+              RESTCatalogServer.CATALOG_NAME,
+              "labels_backend",
+              CatalogProperties.CLIENT_POOL_SIZE,
+              "1",
+              "include-labels",
+              "true"));
+
+  private static RESTCatalog restCatalog;
+  private static RESTClient client;
+  private static ResourcePaths paths;
+
+  @BeforeAll
+  static void beforeAll() {
+    // labels here are injected by the local fixture, so there is nothing to assert when the tests
+    // are pointed at an external REST server
+    assumeThat(REST_SERVER_EXTENSION.client())
+        .as("requires the local REST server fixture")
+        .isNotNull();
+
+    restCatalog = REST_SERVER_EXTENSION.client();
+    restCatalog.createNamespace(NAMESPACE);
+
+    paths = ResourcePaths.forCatalogProperties(ImmutableMap.of());
+    client =
+        HTTPClient.builder(ImmutableMap.of())
+            .uri(
+                String.format(
+                    "http://localhost:%s/",
+                    REST_SERVER_EXTENSION.config().get(RESTCatalogServer.REST_PORT)))
+            .build();
+  }
+
+  @AfterAll
+  static void afterAll() throws Exception {
+    if (client != null) {
+      client.close();
+    }
+  }
+
+  @Test
+  public void tableLabelsAreReturnedOnLoad() {
+    TableIdentifier ident = TableIdentifier.of(NAMESPACE, "tbl");
+    restCatalog.createTable(ident, SCHEMA);
+
+    LoadTableResponse response =
+        client.get(
+            paths.table(ident),
+            LoadTableResponse.class,
+            ImmutableMap.of(),
+            ErrorHandlers.tableErrorHandler());
+
+    assertLabels(response.labels());
+    // the response must remain usable, so injecting labels cannot drop the metadata
+    assertThat(response.tableMetadata().schema().asStruct()).isEqualTo(SCHEMA.asStruct());
+  }
+
+  @Test
+  public void viewLabelsAreReturnedOnLoad() {
+    TableIdentifier ident = TableIdentifier.of(NAMESPACE, "v");
+    View view =
+        restCatalog
+            .buildView(ident)
+            .withSchema(SCHEMA)
+            .withDefaultNamespace(NAMESPACE)
+            .withQuery("spark", "SELECT id, data FROM tbl")
+            .create();
+
+    LoadViewResponse response =
+        client.get(
+            paths.view(ident),
+            LoadViewResponse.class,
+            ImmutableMap.of(),
+            ErrorHandlers.viewErrorHandler());
+
+    assertLabels(response.labels());
+    assertThat(response.metadata().schema().asStruct()).isEqualTo(view.schema().asStruct());
+  }
+
+  private void assertLabels(Labels labels) {
+    assertThat(labels.isEmpty()).isFalse();
+    assertThat(labels.objectLabels()).containsEntry("catalog-name", "labels_backend");
+
+    assertThat(labels.fields()).hasSize(1);
+    FieldLabels fieldLabels = labels.fields().get(0);
+    assertThat(fieldLabels.fieldId()).isEqualTo(1);
+    assertThat(fieldLabels.labels()).containsEntry("classification", "public");
+  }
+}

--- a/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerLabels.java
+++ b/open-api/src/test/java/org/apache/iceberg/rest/TestRESTServerLabels.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.types.Types;
@@ -88,6 +89,8 @@ public class TestRESTServerLabels {
                 String.format(
                     "http://localhost:%s/",
                     REST_SERVER_EXTENSION.config().get(RESTCatalogServer.REST_PORT)))
+            // the local fixture does not authenticate requests
+            .withAuthSession(AuthSession.EMPTY)
             .build();
   }
 

--- a/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerCatalogAdapter.java
+++ b/open-api/src/testFixtures/java/org/apache/iceberg/rest/RESTServerCatalogAdapter.java
@@ -18,9 +18,15 @@
  */
 package org.apache.iceberg.rest;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import org.apache.iceberg.ImmutableFieldLabels;
+import org.apache.iceberg.ImmutableLabels;
+import org.apache.iceberg.Labels;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.aws.s3.S3FileIOProperties;
 import org.apache.iceberg.azure.AzureProperties;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -29,12 +35,21 @@ import org.apache.iceberg.rest.RESTCatalogServer.CatalogContext;
 import org.apache.iceberg.rest.credentials.Credential;
 import org.apache.iceberg.rest.credentials.ImmutableCredential;
 import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
+import org.apache.iceberg.rest.responses.ImmutableLoadViewResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
+import org.apache.iceberg.rest.responses.LoadViewResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.util.PropertyUtil;
 
 class RESTServerCatalogAdapter extends RESTCatalogAdapter {
   private static final String INCLUDE_CREDENTIALS = "include-credentials";
+  private static final String INCLUDE_LABELS = "include-labels";
+
+  private static final String CATALOG_NAME_LABEL = "catalog-name";
+  private static final String CATALOG_HOST_LABEL = "catalog-host";
+  private static final String CLASSIFICATION_LABEL = "classification";
+
+  private static final String HOSTNAME = hostname();
 
   private final CatalogContext catalogContext;
 
@@ -80,7 +95,68 @@ class RESTServerCatalogAdapter extends RESTCatalogAdapter {
       }
     }
 
+    if (PropertyUtil.propertyAsBoolean(catalogContext.configuration(), INCLUDE_LABELS, false)) {
+      if (restResponse instanceof LoadTableResponse response) {
+        // rebuild because labels can only be set through the builder. this preserves the metadata
+        // as it was produced by the handler, including any snapshot suppression already applied.
+        return (T)
+            LoadTableResponse.builder()
+                .withTableMetadata(response.tableMetadata())
+                .addAllConfig(response.config())
+                .addAllCredentials(response.credentials())
+                .withLabels(labels(response.tableMetadata().schema()))
+                .build();
+      } else if (restResponse instanceof LoadViewResponse response) {
+        return (T)
+            ImmutableLoadViewResponse.builder()
+                .from(response)
+                .labels(labels(response.metadata().schema()))
+                .build();
+      }
+    }
+
     return restResponse;
+  }
+
+  /**
+   * Produces labels derived from the catalog and the server environment.
+   *
+   * <p>These values carry no meaning beyond exercising the labels read path end-to-end: they let
+   * clients verify that object-level and field-level labels survive a round trip over the wire.
+   */
+  private Labels labels(Schema schema) {
+    ImmutableLabels.Builder labels =
+        ImmutableLabels.builder()
+            .putObjectLabels(
+                CATALOG_NAME_LABEL,
+                PropertyUtil.propertyAsString(
+                    catalogContext.configuration(),
+                    RESTCatalogServer.CATALOG_NAME,
+                    RESTCatalogServer.CATALOG_NAME_DEFAULT));
+
+    if (null != HOSTNAME) {
+      labels.putObjectLabels(CATALOG_HOST_LABEL, HOSTNAME);
+    }
+
+    // label the first column so that field-level labels are covered without assuming a schema
+    if (!schema.columns().isEmpty()) {
+      labels.addFields(
+          ImmutableFieldLabels.builder()
+              .fieldId(schema.columns().get(0).fieldId())
+              .putLabels(CLASSIFICATION_LABEL, "public")
+              .build());
+    }
+
+    return labels.build();
+  }
+
+  private static String hostname() {
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      // the hostname is not resolvable in all environments, so it is simply omitted
+      return null;
+    }
   }
 
   private void applyCredentials(


### PR DESCRIPTION
Reference client implementation for the IRC labels read path, the Java-side counterpart to the spec change in #15750.

## Why

The spec PR (#15750) adds an optional `labels` field to `LoadTableResult` and `LoadViewResult`. Without a corresponding client change, `RESTObjectMapper` (which sets `FAIL_ON_UNKNOWN_PROPERTIES = false`) silently drops the field on deserialization, so labels returned by a catalog are invisible to the Java client. This PR makes the reference client able to read and round-trip them.

## What changed

New `org.apache.iceberg.rest.labels` package (laid out like `rest.credentials`):

- `Labels` — `object` (catalog-object-level, flat string map) and `fields` (per-field labels).
- `FieldLabels` — a single field's labels, identified by `field-id`.
- `LabelsParser` / `FieldLabelsParser` — JSON serialization, symmetric with the spec schemas.

Wired an optional `labels` field into `LoadTableResponse` and `LoadViewResponse` and their parsers. Labels are omitted from the wire when absent, so the change is backward compatible — existing responses serialize identically.

## Tests

- `TestLabelsParser`: round-trips (object-only, fields-only, both), empty labels, and `field-id` validation.
- `roundTripSerdeWithLabels` and `labelsAreOptional` added to `TestLoadTableResponseParser` and `TestLoadViewResponseParser`.

## Notes

- Draft, opened primarily to exercise CI.
- Depends on the wire shape in #15750; the `object` / `fields` naming follows the structure agreed on that PR.
- Scope is the read path only. The write path (`UpdateLabels`) is a separate follow-up, consistent with the spec PR.
