### PR TITLE
Core: Invalidate cached table on commit to prevent stale reads

### DIFF
--- a/core/src/main/java/org/apache/iceberg/CachingCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/CachingCatalog.java
@@ -31,7 +31,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
+import org.apache.iceberg.exceptions.CommitStateUnknownException;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.slf4j.Logger;
@@ -144,13 +148,13 @@ public class CachingCatalog implements Catalog {
       return cached;
     }
 
-    Table table = tableCache.get(canonicalized, catalog::loadTable);
+    Table table = tableCache.get(canonicalized, this::loadTableAndWrap);
 
     if (table instanceof BaseMetadataTable) {
       // Cache underlying table
       TableIdentifier originTableIdentifier =
           TableIdentifier.of(canonicalized.namespace().levels());
-      Table originTable = tableCache.get(originTableIdentifier, catalog::loadTable);
+      Table originTable = tableCache.get(originTableIdentifier, this::loadTableAndWrap);
 
       // Share TableOperations instance of origin table for all metadata tables, so that metadata
       // table instances are refreshed as well when origin table instance is refreshed.
@@ -169,6 +173,119 @@ public class CachingCatalog implements Catalog {
     return table;
   }
 
+  private Table loadTableAndWrap(TableIdentifier canonicalized) {
+    return wrapTable(canonicalized, catalog.loadTable(canonicalized));
+  }
+
+  /**
+   * Installs commit-invalidating operations on a table handed out by this cache, so that a commit
+   * performed through the table invalidates its cache entry (and its metadata tables). Otherwise a
+   * commit does not update the cache, and a table that was (re)loaded during an in-flight write
+   * keeps serving the pre-commit snapshot until the entry expires. See
+   * https://github.com/apache/iceberg/issues/10493.
+   *
+   * <p>The concrete table type is preserved. A plain {@link BaseTable} is re-created directly. A
+   * subclass opts in by implementing {@link SupportsOperationsReplacement} (for example {@code
+   * RESTTable}, which keeps its server-side scan planning). Any other {@link BaseTable} subclass is
+   * returned unchanged rather than downgraded to a plain {@link BaseTable}, so it keeps its
+   * behavior but does not get commit-based invalidation. Non-{@link BaseTable} tables such as
+   * metadata tables are also returned unchanged; metadata tables share the origin table's
+   * operations and are invalidated together with it.
+   */
+  private Table wrapTable(TableIdentifier canonicalized, Table table) {
+    if (!(table instanceof BaseTable)) {
+      return table;
+    }
+
+    BaseTable baseTable = (BaseTable) table;
+    TableOperations notifyingOps =
+        new CacheInvalidatingTableOperations(baseTable.operations(), canonicalized);
+
+    if (table instanceof SupportsOperationsReplacement) {
+      return ((SupportsOperationsReplacement) table).withOperations(notifyingOps);
+    } else if (table.getClass() == BaseTable.class) {
+      return new BaseTable(notifyingOps, baseTable.name(), baseTable.reporter());
+    }
+
+    return table;
+  }
+
+  /**
+   * A {@link TableOperations} wrapper that invalidates the cached table entry after a commit, so
+   * that a subsequent {@link #loadTable(TableIdentifier)} observes the committed metadata. This
+   * closes a race where another thread reloads and re-caches a table during an in-flight write and
+   * the commit would otherwise leave the stale entry in the cache until it expires (see <a
+   * href="https://github.com/apache/iceberg/issues/10493">#10493</a>).
+   */
+  private class CacheInvalidatingTableOperations implements TableOperations {
+    private final TableOperations delegate;
+    private final TableIdentifier identifier;
+
+    private CacheInvalidatingTableOperations(TableOperations delegate, TableIdentifier identifier) {
+      this.delegate = delegate;
+      this.identifier = identifier;
+    }
+
+    @Override
+    public TableMetadata current() {
+      return delegate.current();
+    }
+
+    @Override
+    public TableMetadata refresh() {
+      return delegate.refresh();
+    }
+
+    @Override
+    public void commit(TableMetadata base, TableMetadata metadata) {
+      try {
+        delegate.commit(base, metadata);
+      } catch (CommitStateUnknownException e) {
+        // The commit may have succeeded, so the cached table may be stale. Invalidate before
+        // rethrowing so that a subsequent load re-reads the table metadata.
+        invalidateLocalCache(identifier);
+        throw e;
+      }
+
+      invalidateLocalCache(identifier);
+    }
+
+    @Override
+    public FileIO io() {
+      return delegate.io();
+    }
+
+    @Override
+    public EncryptionManager encryption() {
+      return delegate.encryption();
+    }
+
+    @Override
+    public String metadataFileLocation(String fileName) {
+      return delegate.metadataFileLocation(fileName);
+    }
+
+    @Override
+    public LocationProvider locationProvider() {
+      return delegate.locationProvider();
+    }
+
+    @Override
+    public TableOperations temp(TableMetadata uncommittedMetadata) {
+      return delegate.temp(uncommittedMetadata);
+    }
+
+    @Override
+    public long newSnapshotId() {
+      return delegate.newSnapshotId();
+    }
+
+    @Override
+    public boolean requireStrictCleanup() {
+      return delegate.requireStrictCleanup();
+    }
+  }
+
   @Override
   public boolean dropTable(TableIdentifier ident, boolean purge) {
     boolean dropped = catalog.dropTable(ident, purge);
@@ -185,14 +302,20 @@ public class CachingCatalog implements Catalog {
   @Override
   public void invalidateTable(TableIdentifier ident) {
     catalog.invalidateTable(ident);
-    TableIdentifier canonicalized = canonicalizeIdentifier(ident);
+    invalidateLocalCache(canonicalizeIdentifier(ident));
+  }
+
+  private void invalidateLocalCache(TableIdentifier canonicalized) {
     tableCache.invalidate(canonicalized);
     tableCache.invalidateAll(metadataTableIdentifiers(canonicalized));
   }
 
   @Override
   public Table registerTable(TableIdentifier identifier, String metadataFileLocation) {
-    Table table = catalog.registerTable(identifier, metadataFileLocation);
+    Table table =
+        wrapTable(
+            canonicalizeIdentifier(identifier),
+            catalog.registerTable(identifier, metadataFileLocation));
     invalidateTable(identifier);
     return table;
   }
@@ -200,7 +323,10 @@ public class CachingCatalog implements Catalog {
   @Override
   public Table registerTable(
       TableIdentifier identifier, String metadataFileLocation, boolean overwrite) {
-    Table table = catalog.registerTable(identifier, metadataFileLocation, overwrite);
+    Table table =
+        wrapTable(
+            canonicalizeIdentifier(identifier),
+            catalog.registerTable(identifier, metadataFileLocation, overwrite));
     invalidateTable(identifier);
     return table;
   }
@@ -269,7 +395,7 @@ public class CachingCatalog implements Catalog {
               canonicalizeIdentifier(ident),
               identifier -> {
                 created.set(true);
-                return innerBuilder.create();
+                return wrapTable(identifier, innerBuilder.create());
               });
 
       if (!created.get()) {

--- a/core/src/main/java/org/apache/iceberg/SupportsOperationsReplacement.java
+++ b/core/src/main/java/org/apache/iceberg/SupportsOperationsReplacement.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+/**
+ * A {@link Table} that can produce a copy of itself backed by a different {@link TableOperations},
+ * preserving its concrete type.
+ *
+ * <p>{@link CachingCatalog} uses this to hand out tables whose operations invalidate the cache
+ * entry on commit. A table type must opt in by implementing this interface; a table that does not
+ * is left unchanged by the cache (it is not re-created, so a commit through it does not invalidate
+ * the cache entry). Plain {@link BaseTable} instances are re-created directly by the cache and do
+ * not need to implement this interface.
+ */
+public interface SupportsOperationsReplacement {
+  /**
+   * Returns a copy of this table backed by the given operations, with the same concrete type.
+   *
+   * @param newOps the operations the returned table should use
+   * @return a copy of this table backed by {@code newOps}
+   */
+  Table withOperations(TableOperations newOps);
+}

--- a/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTTable.java
@@ -26,12 +26,15 @@ import org.apache.iceberg.BatchScan;
 import org.apache.iceberg.BatchScanAdapter;
 import org.apache.iceberg.ImmutableTableScanContext;
 import org.apache.iceberg.SupportsDistributedScanPlanning;
+import org.apache.iceberg.SupportsOperationsReplacement;
+import org.apache.iceberg.Table;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableScan;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.metrics.MetricsReporter;
 
-class RESTTable extends BaseTable implements SupportsDistributedScanPlanning {
+class RESTTable extends BaseTable
+    implements SupportsDistributedScanPlanning, SupportsOperationsReplacement {
   private final RESTClient client;
   private final Supplier<Map<String, String>> headers;
   private final MetricsReporter reporter;
@@ -87,5 +90,20 @@ class RESTTable extends BaseTable implements SupportsDistributedScanPlanning {
   @Override
   public boolean allowDistributedPlanning() {
     return false;
+  }
+
+  @Override
+  public Table withOperations(TableOperations newOps) {
+    return new RESTTable(
+        newOps,
+        name(),
+        reporter,
+        client,
+        headers,
+        tableIdentifier,
+        resourcePaths,
+        supportedEndpoints,
+        catalogProperties,
+        hadoopConf);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCachingCatalog.java
@@ -31,13 +31,18 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseMetadataTable;
+import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CachingCatalog;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.MetadataTableType;
 import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.SupportsOperationsReplacement;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TestableCachingCatalog;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.Namespace;
@@ -89,14 +94,14 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     Table filesMetaTable2 = catalog.loadTable(filesMetaTableIdent);
     Table manifestsMetaTable2 = catalog.loadTable(manifestsMetaTableIdent);
 
-    // metadata tables are cached
-    assertThat(filesMetaTable2).isEqualTo(filesMetaTable);
-    assertThat(manifestsMetaTable2).isEqualTo(manifestsMetaTable);
+    // committing through the origin table invalidates its metadata tables, so they are reloaded
+    assertThat(filesMetaTable2).isNotEqualTo(filesMetaTable);
+    assertThat(manifestsMetaTable2).isNotEqualTo(manifestsMetaTable);
 
     // the current snapshot of origin table is updated after committing
     assertThat(table.currentSnapshot()).isNotEqualTo(oldSnapshot);
 
-    // underlying table operation in metadata tables are shared with the origin table
+    // reloaded metadata tables observe the origin table's new snapshot
     assertThat(filesMetaTable2.currentSnapshot()).isEqualTo(table.currentSnapshot());
     assertThat(manifestsMetaTable2.currentSnapshot()).isEqualTo(table.currentSnapshot());
   }
@@ -270,9 +275,154 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
     assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
 
+    // Committing through a table obtained from the catalog invalidates its cache entry so that a
+    // subsequent load observes the commit (https://github.com/apache/iceberg/issues/10493).
     table.newAppend().appendFile(FILE_A).commit();
-    assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
-    assertThat(catalog.remainingAgeFor(tableIdent)).get().isEqualTo(HALF_OF_EXPIRATION);
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+  }
+
+  @Test
+  public void testLoadTableObservesCommitAfterConcurrentReloadDuringWrite() throws IOException {
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Start from a clean cache so the writer is loaded fresh from the underlying catalog.
+    catalog.cache().invalidateAll();
+
+    // A writer loads the table and establishes an initial snapshot.
+    Table writer = catalog.loadTable(tableIdent);
+    writer.newAppend().appendFile(FILE_A).commit();
+    Snapshot committedBeforeWrite = writer.currentSnapshot();
+    assertThat(committedBeforeWrite).isNotNull();
+
+    // The writer begins a long-running write that will outlive the cache TTL.
+    AppendFiles pendingWrite = writer.newAppend().appendFile(FILE_B);
+
+    // The cache entry expires while the write is still in progress.
+    ticker.advance(EXPIRATION_TTL.plus(Duration.ofSeconds(1)));
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+
+    // A concurrent loader (e.g. an OpenLineage listener thread) reloads the table before the
+    // write commits, re-caching the pre-commit table with a fresh TTL.
+    Table concurrentlyReloaded = catalog.loadTable(tableIdent);
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(concurrentlyReloaded.currentSnapshot()).isEqualTo(committedBeforeWrite);
+
+    // The writer commits the in-flight write through its own table reference.
+    pendingWrite.commit();
+    Snapshot committedAfterWrite = writer.currentSnapshot();
+    assertThat(committedAfterWrite).isNotEqualTo(committedBeforeWrite);
+
+    // A subsequent load must observe the committed snapshot, not the stale table that was
+    // re-cached during the write (https://github.com/apache/iceberg/issues/10493).
+    assertThat(catalog.loadTable(tableIdent).currentSnapshot())
+        .as("loadTable after commit must not return a snapshot re-cached during the write")
+        .isEqualTo(committedAfterWrite);
+  }
+
+  @Test
+  public void testCreatedTableObservesCommitAfterConcurrentReloadDuringWrite() throws IOException {
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(hadoopCatalog(), EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+
+    // The writer keeps the table reference returned by createTable.
+    Table writer = catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+    writer.newAppend().appendFile(FILE_A).commit();
+    Snapshot committedBeforeWrite = writer.currentSnapshot();
+    assertThat(committedBeforeWrite).isNotNull();
+
+    // The writer begins a long-running write that will outlive the cache TTL.
+    AppendFiles pendingWrite = writer.newAppend().appendFile(FILE_B);
+
+    // The cache entry is not present while the write is in progress.
+    ticker.advance(EXPIRATION_TTL.plus(Duration.ofSeconds(1)));
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+
+    // A concurrent loader reloads the table before the write commits, re-caching the pre-commit
+    // table with a fresh TTL.
+    Table concurrentlyReloaded = catalog.loadTable(tableIdent);
+    assertThat(catalog.cache().asMap()).containsKey(tableIdent);
+    assertThat(concurrentlyReloaded.currentSnapshot()).isEqualTo(committedBeforeWrite);
+
+    // The writer commits the in-flight write through the created-table reference.
+    pendingWrite.commit();
+    Snapshot committedAfterWrite = writer.currentSnapshot();
+    assertThat(committedAfterWrite).isNotEqualTo(committedBeforeWrite);
+
+    // A subsequent load must observe the committed snapshot, not the stale re-cached table.
+    assertThat(catalog.loadTable(tableIdent).currentSnapshot())
+        .as("loadTable after a commit through a created table must not return a stale snapshot")
+        .isEqualTo(committedAfterWrite);
+  }
+
+  @Test
+  public void testCachingCatalogPreservesTableSubtypeAndInvalidatesOnCommit() throws IOException {
+    // A delegate catalog that returns a BaseTable subclass (like RESTTable) from loadTable.
+    HadoopCatalog subtypeReturningCatalog =
+        new HadoopCatalog() {
+          @Override
+          public Table loadTable(TableIdentifier ident) {
+            Table loaded = super.loadTable(ident);
+            return new CustomBaseTable(((HasTableOperations) loaded).operations(), loaded.name());
+          }
+        };
+    subtypeReturningCatalog.setConf(new Configuration());
+    subtypeReturningCatalog.initialize(
+        "hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, tempDir.getAbsolutePath()));
+
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(subtypeReturningCatalog, EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Load fresh from the delegate so the cache wraps the delegate's subtype.
+    catalog.cache().invalidateAll();
+    Table loaded = catalog.loadTable(tableIdent);
+
+    // The cache preserves the delegate's concrete table type via SupportsOperationsReplacement,
+    // rather than downgrading it to a plain BaseTable (which would discard specialized behavior).
+    assertThat(loaded).isInstanceOf(CustomBaseTable.class);
+
+    // A commit through the subtype still invalidates the cache entry.
+    loaded.newAppend().appendFile(FILE_A).commit();
+    assertThat(catalog.cache().asMap()).doesNotContainKey(tableIdent);
+  }
+
+  @Test
+  public void testCachingCatalogLeavesUnknownSubclassUnchanged() throws IOException {
+    // A delegate that returns a BaseTable subclass which does NOT opt in to operations replacement.
+    HadoopCatalog subtypeReturningCatalog =
+        new HadoopCatalog() {
+          @Override
+          public Table loadTable(TableIdentifier ident) {
+            Table loaded = super.loadTable(ident);
+            return new NonReplaceableBaseTable(
+                ((HasTableOperations) loaded).operations(), loaded.name());
+          }
+        };
+    subtypeReturningCatalog.setConf(new Configuration());
+    subtypeReturningCatalog.initialize(
+        "hadoop", ImmutableMap.of(CatalogProperties.WAREHOUSE_LOCATION, tempDir.getAbsolutePath()));
+
+    TestableCachingCatalog catalog =
+        TestableCachingCatalog.wrap(subtypeReturningCatalog, EXPIRATION_TTL, ticker);
+    Namespace namespace = Namespace.of("db", "ns1", "ns2");
+    TableIdentifier tableIdent = TableIdentifier.of(namespace, "tbl");
+    catalog.createTable(tableIdent, SCHEMA, SPEC, ImmutableMap.of("key", "value"));
+
+    // Load fresh from the delegate so the cache processes the subtype.
+    catalog.cache().invalidateAll();
+    Table loaded = catalog.loadTable(tableIdent);
+
+    // A subclass that does not opt in must be returned unchanged, not downgraded to a plain
+    // BaseTable (which would discard its overridden behavior).
+    assertThat(loaded).isInstanceOf(NonReplaceableBaseTable.class);
   }
 
   @Test
@@ -285,6 +435,9 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     assertThat(catalog.cache().asMap()).containsKey(tableIdent);
 
     table.newAppend().appendFile(FILE_A).commit();
+
+    // The commit invalidates the cached entry; reload so the data table is cached again.
+    catalog.loadTable(tableIdent);
     assertThat(catalog.cache().asMap()).containsKey(tableIdent);
     assertThat(catalog.ageOf(tableIdent)).get().isEqualTo(Duration.ZERO);
 
@@ -440,5 +593,27 @@ public class TestCachingCatalog extends HadoopTableTestBase {
     return Arrays.stream(MetadataTableType.values())
         .map(type -> TableIdentifier.parse(tableIdent + "." + type.name().toLowerCase(Locale.ROOT)))
         .toArray(TableIdentifier[]::new);
+  }
+
+  /**
+   * A {@link BaseTable} subclass that opts in to operations replacement, preserving its type when
+   * re-created with new operations.
+   */
+  private static class CustomBaseTable extends BaseTable implements SupportsOperationsReplacement {
+    private CustomBaseTable(TableOperations ops, String name) {
+      super(ops, name);
+    }
+
+    @Override
+    public Table withOperations(TableOperations newOps) {
+      return new CustomBaseTable(newOps, name());
+    }
+  }
+
+  /** A {@link BaseTable} subclass that does not opt in to operations replacement. */
+  private static class NonReplaceableBaseTable extends BaseTable {
+    private NonReplaceableBaseTable(TableOperations ops, String name) {
+      super(ops, name);
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTScanPlanning.java
@@ -36,10 +36,12 @@ import static org.mockito.Mockito.atLeastOnce;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import java.util.function.Function;
+import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.DataFile;
@@ -52,8 +54,10 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Scan;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableScan;
+import org.apache.iceberg.TestableCachingCatalog;
 import org.apache.iceberg.catalog.SessionCatalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.expressions.Expressions;
@@ -71,6 +75,7 @@ import org.apache.iceberg.rest.responses.FetchPlanningResultResponse;
 import org.apache.iceberg.rest.responses.LoadTableResponse;
 import org.apache.iceberg.rest.responses.PlanTableScanResponse;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.FakeTicker;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -1648,6 +1653,52 @@ public class TestRESTScanPlanning extends TestBaseWithRESTServer {
             .create();
 
     verifyTableTypeForPlanningMode(serverMode, table);
+  }
+
+  @Test
+  public void testCachingCatalogObservesCommitAfterConcurrentReloadWithServerSidePlanning()
+      throws IOException {
+    Duration expiration = Duration.ofMinutes(5);
+    FakeTicker ticker = new FakeTicker();
+    TestableCachingCatalog cachingCatalog =
+        TestableCachingCatalog.wrap(restCatalog, expiration, ticker);
+
+    String tableName = "caching_stale_read";
+    TableIdentifier ident = TableIdentifier.of(NS, tableName);
+    createTableWithScanPlanning(restCatalog, tableName);
+
+    // The writer loads the table through the caching catalog. With server-side scan planning the
+    // catalog returns a RESTTable. Establish an initial snapshot.
+    Table writer = cachingCatalog.loadTable(ident);
+    assertThat(writer).isInstanceOf(RESTTable.class);
+    writer.newAppend().appendFile(FILE_A).commit();
+    Snapshot committedBeforeWrite = writer.currentSnapshot();
+    assertThat(committedBeforeWrite).isNotNull();
+
+    // The writer begins a long-running write that will outlive the cache TTL.
+    AppendFiles pendingWrite = writer.newAppend().appendFile(FILE_B);
+
+    // The cache entry is not present while the write is in progress.
+    ticker.advance(expiration.plus(Duration.ofSeconds(1)));
+    assertThat(cachingCatalog.cache().asMap()).doesNotContainKey(ident);
+
+    // A concurrent loader reloads the table before the write commits, re-caching the pre-commit
+    // RESTTable with a fresh TTL.
+    Table concurrentlyReloaded = cachingCatalog.loadTable(ident);
+    assertThat(concurrentlyReloaded).isInstanceOf(RESTTable.class);
+    assertThat(concurrentlyReloaded.currentSnapshot()).isEqualTo(committedBeforeWrite);
+
+    // The writer commits the in-flight write.
+    pendingWrite.commit();
+    Snapshot committedAfterWrite = writer.currentSnapshot();
+    assertThat(committedAfterWrite).isNotEqualTo(committedBeforeWrite);
+
+    // A subsequent load observes the committed snapshot, and the cached table is still a RESTTable
+    // whose newScan() plans server-side, so wrapping the operations preserved neither a stale
+    // snapshot nor downgraded the concrete type or scan planning.
+    Table reloaded = cachingCatalog.loadTable(ident);
+    assertThat(reloaded.currentSnapshot()).isEqualTo(committedAfterWrite);
+    assertThat(restTableScanFor(reloaded)).isInstanceOf(RESTTableScan.class);
   }
 
   private void verifyTableTypeForPlanningMode(String planingMode, Table table) {


### PR DESCRIPTION
## Problem

`CachingCatalog` hands out `Table` instances pinned to the snapshot that was
current when the table was loaded, and a commit performed through such a table
is invisible to the cache. The cached entry is therefore never updated on
commit, which allows a stale snapshot to be served after a commit:

1. A writer loads a table (snapshot N) and begins a long-running write.
2. The cache entry expires mid-write (the default TTL is 30s).
3. Another thread (for example an OpenLineage Spark listener) calls `loadTable`,
   reloads snapshot N (pre-commit), and re-caches it with a fresh TTL.
4. The writer commits snapshot N+1 through its own reference. Nothing
   invalidates the cache.
5. A subsequent `loadTable` returns the re-cached snapshot N, a stale read.

This is the race reported in #10493. It caused a production stale-read incident
for us after an OpenLineage listener began issuing background `loadTable` calls
during writes.

## Fix

Establish a single invariant: every writable table handed out by
`CachingCatalog` carries commit-invalidating operations, regardless of how it
was obtained. On the cache-miss load path, and on the create and register
paths, the returned table is given a `TableOperations` wrapper that invalidates
the table's cache entry (and its metadata tables) after a successful `commit`.
All write paths, including direct operations (`newAppend()`, `newOverwrite()`,
and so on), `newTransaction()`, and metadata-table operations that share the
origin table's ops, funnel through `TableOperations.commit`, so a single
interception point covers them.

To install the wrapper without discarding the concrete table type, a table opts
in by implementing the new `SupportsOperationsReplacement` interface (a copy
hook that returns the table backed by different operations). `RESTTable`
implements it, so REST server-side scan planning is preserved when a REST
catalog is wrapped by `CachingCatalog`. A plain `BaseTable` is re-created
directly. Any other `BaseTable` subclass that does not opt in is returned
unchanged rather than downgraded to a plain `BaseTable`, so existing extensions
keep their behavior (they simply do not get commit-based invalidation).

### Race safety

The load path uses Caffeine's atomic `Cache.get(key, loader)`, where the value
is loaded and stored under the per-key compute lock, and the wrapper invalidates
only after the commit is durable. Across all interleavings, a concurrent reload
either has its stored entry invalidated by the commit, or (if it runs after the
invalidation) reads the post-commit snapshot. A `CommitStateUnknownException`
also triggers invalidation, since the commit may have succeeded.

### Behavior change

A commit through a table obtained from `CachingCatalog` now invalidates that
table's cache entry and its metadata-table entries; previously the cache was
untouched on commit. Three existing `TestCachingCatalog` tests that asserted the
old behavior are updated accordingly
(`testCatalogExpirationTtlRefreshesAfterAccessViaCatalog`,
`testInvalidateMetadataTablesIfBaseTableIsModified`, and
`testCacheExpirationEagerlyRemovesMetadataTables`). This touches the "table
entry vs metadata-table entry consistency" area raised on the issue, so it is
called out here for reviewer input.

## Tests

- `testLoadTableObservesCommitAfterConcurrentReloadDuringWrite` and
  `testCreatedTableObservesCommitAfterConcurrentReloadDuringWrite`:
  deterministic regressions reproducing the expire / concurrent-reload / commit
  interleaving for the load and create paths. Both assert the post-commit
  `loadTable` observes the committed snapshot, and both fail without the fix.
- `testCachingCatalogPreservesTableSubtypeAndInvalidatesOnCommit` and
  `testCachingCatalogLeavesUnknownSubclassUnchanged`: a delegate that returns a
  `BaseTable` subclass verifies that an opted-in subtype is preserved and still
  invalidates on commit, and that a subtype which does not opt in is returned
  unchanged (not downgraded to a plain `BaseTable`).
- Existing `TestCachingCatalog` tests pass, with the behavior-change updates
  noted above.

Closes #10493
