### PR TITLE
Core: Update ExpressionParser to match new expressions spec

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.expressions;
 
+import java.util.List;
 import java.util.stream.Stream;
 import org.apache.iceberg.expressions.Expression.Operation;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -315,6 +316,49 @@ public class Expressions {
    */
   public static <T> UnboundTerm<T> transform(String name, Transform<?, T> transform) {
     return new UnboundTransform<>(ref(name), transform);
+  }
+
+  /**
+   * Create a reference to a function by name, in the catalog of the referencing object.
+   *
+   * @param name a function name
+   * @return a function reference
+   */
+  public static FunctionReference function(String name) {
+    return new FunctionReference(null, Lists.newArrayList(name));
+  }
+
+  /**
+   * Create a reference to a function by identifier, in the catalog of the referencing object.
+   *
+   * @param identifier namespace names followed by the function name
+   * @return a function reference
+   */
+  public static FunctionReference function(List<String> identifier) {
+    return new FunctionReference(null, identifier);
+  }
+
+  /**
+   * Create a reference to a function in a specific catalog.
+   *
+   * @param catalog a catalog name
+   * @param identifier namespace names followed by the function name
+   * @return a function reference
+   */
+  public static FunctionReference function(String catalog, List<String> identifier) {
+    return new FunctionReference(catalog, identifier);
+  }
+
+  /**
+   * Create an expression that applies a function to zero or more arguments.
+   *
+   * @param function a function reference
+   * @param arguments value expressions, predicates, or constants passed to the function
+   * @param <T> the Java type of this term
+   * @return an unbound apply expression
+   */
+  public static <T> UnboundApply<T> apply(FunctionReference function, List<Object> arguments) {
+    return new UnboundApply<>(function, arguments);
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expressions.java
@@ -319,13 +319,16 @@ public class Expressions {
   }
 
   /**
-   * Create a reference to a function by name, in the catalog of the referencing object.
+   * Create a reference to a function by identifier, in the catalog of the referencing object.
    *
-   * @param name a function name
+   * <p>Identifier parts are used as given and are never parsed or split. A part that contains dots
+   * is a single part, not a namespace followed by a function name.
+   *
+   * @param identifier namespace names followed by the function name
    * @return a function reference
    */
-  public static FunctionReference function(String name) {
-    return new FunctionReference(null, Lists.newArrayList(name));
+  public static FunctionReference function(String... identifier) {
+    return new FunctionReference(null, Lists.newArrayList(identifier));
   }
 
   /**
@@ -351,6 +354,9 @@ public class Expressions {
 
   /**
    * Create an expression that applies a function to zero or more arguments.
+   *
+   * <p>Each argument must be a value expression ({@link Term}), a predicate ({@link Expression}),
+   * or a constant. Constants are converted to {@link Literal}.
    *
    * @param function a function reference
    * @param arguments value expressions, predicates, or constants passed to the function

--- a/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
@@ -20,7 +20,6 @@ package org.apache.iceberg.expressions;
 
 import java.io.Serializable;
 import java.util.List;
-import java.util.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
@@ -28,7 +27,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
  * Represents a function reference in an expression. A function reference identifies a function by
  * name, optionally qualified with a catalog.
  *
- * <p>Use {@link Expressions#function(String)} and its overloads to create instances.
+ * <p>Use {@link Expressions#function(String...)} and its overloads to create instances.
  */
 public class FunctionReference implements Serializable {
   private final String catalog;
@@ -54,28 +53,9 @@ public class FunctionReference implements Serializable {
     return identifier;
   }
 
-  /** Returns the last element of the identifier (the function name). */
+  /** Returns the name of the function, without the catalog or namespace. */
   public String name() {
     return identifier.get(identifier.size() - 1);
-  }
-
-  @Override
-  public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (!(o instanceof FunctionReference)) {
-      return false;
-    }
-
-    FunctionReference that = (FunctionReference) o;
-    return Objects.equals(catalog, that.catalog) && Objects.equals(identifier, that.identifier);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(catalog, identifier);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Objects;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+
+/**
+ * Represents a function reference in an expression. A function reference identifies a function by
+ * name, optionally qualified with a catalog.
+ *
+ * <p>Use {@link Expressions#function(String)} and its overloads to create instances.
+ */
+public class FunctionReference implements Serializable {
+  private final String catalog;
+  private final List<String> identifier;
+
+  FunctionReference(String catalog, List<String> identifier) {
+    Preconditions.checkArgument(
+        identifier != null && !identifier.isEmpty(), "Function identifier cannot be null or empty");
+    Preconditions.checkArgument(
+        identifier.stream().noneMatch(part -> part == null || part.isEmpty()),
+        "Function identifier cannot contain empty parts: %s",
+        identifier);
+    this.catalog = catalog;
+    // not an immutable list so that Kryo can deserialize this class
+    this.identifier = Lists.newArrayList(identifier);
+  }
+
+  public String catalog() {
+    return catalog;
+  }
+
+  public List<String> identifier() {
+    return identifier;
+  }
+
+  /** Returns the last element of the identifier (the function name). */
+  public String name() {
+    return identifier.get(identifier.size() - 1);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof FunctionReference)) {
+      return false;
+    }
+    FunctionReference that = (FunctionReference) o;
+    return Objects.equals(catalog, that.catalog) && Objects.equals(identifier, that.identifier);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(catalog, identifier);
+  }
+
+  @Override
+  public String toString() {
+    if (catalog != null) {
+      return catalog + "." + String.join(".", identifier);
+    }
+    return String.join(".", identifier);
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/FunctionReference.java
@@ -36,10 +36,10 @@ public class FunctionReference implements Serializable {
 
   FunctionReference(String catalog, List<String> identifier) {
     Preconditions.checkArgument(
-        identifier != null && !identifier.isEmpty(), "Function identifier cannot be null or empty");
+        identifier != null && !identifier.isEmpty(), "Invalid function identifier: %s", identifier);
     Preconditions.checkArgument(
         identifier.stream().noneMatch(part -> part == null || part.isEmpty()),
-        "Function identifier cannot contain empty parts: %s",
+        "Invalid function identifier (empty or null part): %s",
         identifier);
     this.catalog = catalog;
     // not an immutable list so that Kryo can deserialize this class
@@ -64,9 +64,11 @@ public class FunctionReference implements Serializable {
     if (this == o) {
       return true;
     }
+
     if (!(o instanceof FunctionReference)) {
       return false;
     }
+
     FunctionReference that = (FunctionReference) o;
     return Objects.equals(catalog, that.catalog) && Objects.equals(identifier, that.identifier);
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
@@ -19,32 +19,17 @@
 package org.apache.iceberg.expressions;
 
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
-import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.transforms.Transforms;
-import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.Types;
 
 /**
  * Represents a function application expression. This is the general form for invoking functions on
- * value expressions. Known Iceberg partition transforms can be converted to {@link
- * UnboundTransform} via {@link #asTransform()}.
+ * value expressions.
  *
  * @param <T> the Java type of values produced by this expression
  */
 public class UnboundApply<T> implements UnboundTerm<T> {
-  // bucket and truncate take the transform parameter as their first argument, so they cannot be
-  // resolved from a name alone
-  private static final Set<String> PARAMETERIZED_TRANSFORMS = ImmutableSet.of("bucket", "truncate");
-
-  // the expressions spec defines partition transforms as functions, other than void
-  private static final String VOID = "void";
-
-  private static final String ICEBERG_FUNCTIONS_CATALOG = "iceberg_functions";
-
   private final FunctionReference function;
   private final List<Object> arguments;
 
@@ -52,95 +37,55 @@ public class UnboundApply<T> implements UnboundTerm<T> {
     Preconditions.checkArgument(function != null, "Invalid function: null");
     this.function = function;
     // not an immutable list so that Kryo can deserialize this class
-    this.arguments = arguments == null ? Lists.newArrayList() : Lists.newArrayList(arguments);
+    this.arguments =
+        arguments == null
+            ? Lists.newArrayList()
+            : Lists.newArrayList(Lists.transform(arguments, UnboundApply::toArgument));
+  }
+
+  /**
+   * Converts an argument to the type used to represent it, or throws if it cannot be an argument.
+   *
+   * <p>An argument is either a value expression or a predicate. Value expressions are {@link Term}
+   * (a reference or a nested apply) or a constant, which is converted to a {@link Literal}.
+   * Predicates are {@link Expression}.
+   */
+  private static Object toArgument(Object argument) {
+    Preconditions.checkArgument(argument != null, "Invalid function argument: null");
+    if (argument instanceof Term || argument instanceof Expression) {
+      return argument;
+    }
+
+    return Literals.from(argument);
   }
 
   public FunctionReference function() {
     return function;
   }
 
+  /**
+   * Returns the arguments passed to the function.
+   *
+   * <p>Each argument is a {@link Term} (a value expression), an {@link Expression} (a predicate),
+   * or a {@link Literal} (a constant value expression). Java has no union type, so the arguments
+   * are typed as {@link Object} and validated when this expression is created.
+   */
   public List<Object> arguments() {
     return arguments;
   }
 
-  public boolean isKnownTransform() {
-    String catalog = function.catalog();
-    if (catalog != null && !catalog.equalsIgnoreCase(ICEBERG_FUNCTIONS_CATALOG)) {
-      return false;
-    }
-
-    return isTransformName(function.name().toLowerCase(Locale.ROOT));
-  }
-
-  private static boolean isTransformName(String name) {
-    if (VOID.equals(name)) {
-      return false;
-    } else if (PARAMETERIZED_TRANSFORMS.contains(name)) {
-      return true;
-    }
-
-    return !(Transforms.fromString(name) instanceof UnknownTransform);
-  }
-
-  @SuppressWarnings({"unchecked", "rawtypes"})
-  public UnboundTransform asTransform() {
-    Preconditions.checkState(isKnownTransform(), "Not a known Iceberg transform: %s", function);
-
-    String transformName = function.name().toLowerCase(Locale.ROOT);
-    boolean parameterized = PARAMETERIZED_TRANSFORMS.contains(transformName);
-    int expectedArgs = parameterized ? 2 : 1;
-    Preconditions.checkArgument(
-        arguments.size() == expectedArgs,
-        "Cannot convert %s to a transform: expected %s argument(s), got %s",
-        function,
-        expectedArgs,
-        arguments.size());
-
-    String transformString = transformName;
-    if (parameterized) {
-      Object parameter = arguments.get(0);
-      Preconditions.checkArgument(
-          parameter instanceof Number,
-          "Cannot convert %s to a transform: first argument must be a number, got %s",
-          function,
-          parameter);
-      transformString = transformName + "[" + ((Number) parameter).intValue() + "]";
-    }
-
-    Object valueArg = arguments.get(expectedArgs - 1);
-    Preconditions.checkArgument(
-        valueArg instanceof NamedReference,
-        "Cannot convert %s to a transform: last argument must be a reference, got %s",
-        function,
-        valueArg);
-
-    return new UnboundTransform((NamedReference) valueArg, Transforms.fromString(transformString));
-  }
-
   @Override
-  @SuppressWarnings("unchecked")
   public NamedReference<T> ref() {
-    for (Object arg : arguments) {
-      if (arg instanceof NamedReference) {
-        return (NamedReference<T>) arg;
-      } else if (arg instanceof UnboundTerm) {
-        return (NamedReference<T>) ((UnboundTerm<?>) arg).ref();
-      }
-    }
-
+    // a function may be called with any number of references, so there is no single reference that
+    // this term produces values from
     throw new UnsupportedOperationException("Cannot determine reference for function: " + function);
   }
 
   @Override
   public BoundTerm<T> bind(Types.StructType struct, boolean caseSensitive) {
-    if (isKnownTransform()) {
-      return asTransform().bind(struct, caseSensitive);
-    }
-
-    throw new UnsupportedOperationException(
-        "Cannot bind unknown function: "
-            + function
-            + ". Only known Iceberg transforms are supported.");
+    // binding requires a function definition to determine the result type, and function definitions
+    // are not available in this API
+    throw new UnsupportedOperationException("Cannot bind function: " + function);
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.transforms.UnknownTransform;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Represents a function application expression. This is the general form for invoking functions on
+ * value expressions. Known Iceberg partition transforms can be converted to {@link
+ * UnboundTransform} via {@link #asTransform()}.
+ *
+ * @param <T> the Java type of values produced by this expression
+ */
+public class UnboundApply<T> implements UnboundTerm<T> {
+  // bucket and truncate take the transform parameter as their first argument, so they cannot be
+  // resolved from a name alone
+  private static final Set<String> PARAMETERIZED_TRANSFORMS = ImmutableSet.of("bucket", "truncate");
+
+  // the expressions spec defines partition transforms as functions, other than void
+  private static final String VOID = "void";
+
+  private static final String ICEBERG_FUNCTIONS_CATALOG = "iceberg_functions";
+
+  private final FunctionReference function;
+  private final List<Object> arguments;
+
+  UnboundApply(FunctionReference function, List<Object> arguments) {
+    Preconditions.checkArgument(function != null, "Function reference cannot be null");
+    this.function = function;
+    // not an immutable list so that Kryo can deserialize this class
+    this.arguments = arguments == null ? Lists.newArrayList() : Lists.newArrayList(arguments);
+  }
+
+  public FunctionReference function() {
+    return function;
+  }
+
+  public List<Object> arguments() {
+    return arguments;
+  }
+
+  public boolean isKnownTransform() {
+    String catalog = function.catalog();
+    if (catalog != null && !catalog.equalsIgnoreCase(ICEBERG_FUNCTIONS_CATALOG)) {
+      return false;
+    }
+
+    return isTransformName(function.name().toLowerCase(Locale.ROOT));
+  }
+
+  private static boolean isTransformName(String name) {
+    if (VOID.equals(name)) {
+      return false;
+    } else if (PARAMETERIZED_TRANSFORMS.contains(name)) {
+      return true;
+    }
+
+    return !(Transforms.fromString(name) instanceof UnknownTransform);
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public UnboundTransform asTransform() {
+    Preconditions.checkState(isKnownTransform(), "Not a known Iceberg transform: %s", function);
+
+    String transformName = function.name().toLowerCase(Locale.ROOT);
+    boolean parameterized = PARAMETERIZED_TRANSFORMS.contains(transformName);
+    int expectedArgs = parameterized ? 2 : 1;
+    Preconditions.checkArgument(
+        arguments.size() == expectedArgs,
+        "Cannot convert %s to a transform: expected %s argument(s), got %s",
+        function,
+        expectedArgs,
+        arguments.size());
+
+    String transformString = transformName;
+    if (parameterized) {
+      Object parameter = arguments.get(0);
+      Preconditions.checkArgument(
+          parameter instanceof Number,
+          "Cannot convert %s to a transform: first argument must be a number, got %s",
+          function,
+          parameter);
+      transformString = transformName + "[" + ((Number) parameter).intValue() + "]";
+    }
+
+    Object valueArg = arguments.get(expectedArgs - 1);
+    Preconditions.checkArgument(
+        valueArg instanceof NamedReference,
+        "Cannot convert %s to a transform: last argument must be a reference, got %s",
+        function,
+        valueArg);
+
+    return new UnboundTransform((NamedReference) valueArg, Transforms.fromString(transformString));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public NamedReference<T> ref() {
+    for (Object arg : arguments) {
+      if (arg instanceof NamedReference) {
+        return (NamedReference<T>) arg;
+      } else if (arg instanceof UnboundTerm) {
+        return (NamedReference<T>) ((UnboundTerm<?>) arg).ref();
+      }
+    }
+
+    throw new UnsupportedOperationException("Cannot determine reference for function: " + function);
+  }
+
+  @Override
+  public BoundTerm<T> bind(Types.StructType struct, boolean caseSensitive) {
+    if (isKnownTransform()) {
+      return asTransform().bind(struct, caseSensitive);
+    }
+
+    throw new UnsupportedOperationException(
+        "Cannot bind unknown function: "
+            + function
+            + ". Only known Iceberg transforms are supported.");
+  }
+
+  @Override
+  public String toString() {
+    return function + "(" + arguments + ")";
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundApply.java
@@ -49,7 +49,7 @@ public class UnboundApply<T> implements UnboundTerm<T> {
   private final List<Object> arguments;
 
   UnboundApply(FunctionReference function, List<Object> arguments) {
-    Preconditions.checkArgument(function != null, "Function reference cannot be null");
+    Preconditions.checkArgument(function != null, "Invalid function: null");
     this.function = function;
     // not an immutable list so that Kryo can deserialize this class
     this.arguments = arguments == null ? Lists.newArrayList() : Lists.newArrayList(arguments);

--- a/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
@@ -55,19 +55,19 @@ public class TestFunctionReference {
   public void testInvalidIdentifier() {
     assertThatThrownBy(() -> Expressions.function(ImmutableList.of()))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Function identifier cannot be null or empty");
+        .hasMessage("Invalid function identifier: []");
 
     assertThatThrownBy(() -> Expressions.function("cat", null))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Function identifier cannot be null or empty");
+        .hasMessage("Invalid function identifier: null");
 
     assertThatThrownBy(() -> Expressions.function(""))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Function identifier cannot contain empty parts: []");
+        .hasMessage("Invalid function identifier (empty or null part): []");
 
     assertThatThrownBy(() -> Expressions.function(ImmutableList.of("ns", "")))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage("Function identifier cannot contain empty parts: [ns, ]");
+        .hasMessage("Invalid function identifier (empty or null part): [ns, ]");
   }
 
   @Test

--- a/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
@@ -33,6 +33,14 @@ public class TestFunctionReference {
     assertThat(Expressions.function("bucket").name()).isEqualTo("bucket");
     assertThat(Expressions.function(ImmutableList.of("ns", "sub", "func")).name())
         .isEqualTo("func");
+    assertThat(Expressions.function("ns", "sub", "func").name()).isEqualTo("func");
+  }
+
+  @Test
+  public void testIdentifierPartsAreNotParsed() {
+    FunctionReference ref = Expressions.function("ns.func");
+    assertThat(ref.identifier()).containsExactly("ns.func");
+    assertThat(ref.name()).isEqualTo("ns.func");
   }
 
   @Test
@@ -74,7 +82,6 @@ public class TestFunctionReference {
   public void testJavaSerialization() throws Exception {
     for (FunctionReference ref : references()) {
       FunctionReference roundTripped = TestHelpers.roundTripSerialize(ref);
-      assertThat(roundTripped).isEqualTo(ref);
       assertThat(roundTripped.catalog()).isEqualTo(ref.catalog());
       assertThat(roundTripped.identifier()).isEqualTo(ref.identifier());
     }
@@ -84,7 +91,6 @@ public class TestFunctionReference {
   public void testKryoSerialization() throws Exception {
     for (FunctionReference ref : references()) {
       FunctionReference roundTripped = TestHelpers.KryoHelpers.roundTripSerialize(ref);
-      assertThat(roundTripped).isEqualTo(ref);
       assertThat(roundTripped.catalog()).isEqualTo(ref.catalog());
       assertThat(roundTripped.identifier()).isEqualTo(ref.identifier());
     }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestFunctionReference.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Arrays;
+import org.apache.iceberg.TestHelpers;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.junit.jupiter.api.Test;
+
+public class TestFunctionReference {
+
+  @Test
+  public void testName() {
+    assertThat(Expressions.function("bucket").name()).isEqualTo("bucket");
+    assertThat(Expressions.function(ImmutableList.of("ns", "sub", "func")).name())
+        .isEqualTo("func");
+  }
+
+  @Test
+  public void testIdentifier() {
+    FunctionReference ref = Expressions.function("cat", ImmutableList.of("ns", "func"));
+    assertThat(ref.catalog()).isEqualTo("cat");
+    assertThat(ref.identifier()).containsExactly("ns", "func");
+    assertThat(Expressions.function("func").catalog()).isNull();
+  }
+
+  @Test
+  public void testToString() {
+    assertThat(Expressions.function("func")).hasToString("func");
+    assertThat(Expressions.function(ImmutableList.of("ns", "func"))).hasToString("ns.func");
+    assertThat(Expressions.function("cat", ImmutableList.of("ns", "func")))
+        .hasToString("cat.ns.func");
+  }
+
+  @Test
+  public void testInvalidIdentifier() {
+    assertThatThrownBy(() -> Expressions.function(ImmutableList.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Function identifier cannot be null or empty");
+
+    assertThatThrownBy(() -> Expressions.function("cat", null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Function identifier cannot be null or empty");
+
+    assertThatThrownBy(() -> Expressions.function(""))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Function identifier cannot contain empty parts: []");
+
+    assertThatThrownBy(() -> Expressions.function(ImmutableList.of("ns", "")))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Function identifier cannot contain empty parts: [ns, ]");
+  }
+
+  @Test
+  public void testJavaSerialization() throws Exception {
+    for (FunctionReference ref : references()) {
+      FunctionReference roundTripped = TestHelpers.roundTripSerialize(ref);
+      assertThat(roundTripped).isEqualTo(ref);
+      assertThat(roundTripped.catalog()).isEqualTo(ref.catalog());
+      assertThat(roundTripped.identifier()).isEqualTo(ref.identifier());
+    }
+  }
+
+  @Test
+  public void testKryoSerialization() throws Exception {
+    for (FunctionReference ref : references()) {
+      FunctionReference roundTripped = TestHelpers.KryoHelpers.roundTripSerialize(ref);
+      assertThat(roundTripped).isEqualTo(ref);
+      assertThat(roundTripped.catalog()).isEqualTo(ref.catalog());
+      assertThat(roundTripped.identifier()).isEqualTo(ref.identifier());
+    }
+  }
+
+  private static Iterable<FunctionReference> references() {
+    return Arrays.asList(
+        Expressions.function("bucket"),
+        Expressions.function(ImmutableList.of("ns", "func")),
+        Expressions.function("iceberg_functions", ImmutableList.of("bucket")));
+  }
+}

--- a/api/src/test/java/org/apache/iceberg/expressions/TestUnboundApply.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestUnboundApply.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestUnboundApply {
+  private static final Types.StructType STRUCT =
+      Types.StructType.of(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  @Test
+  public void testConstantArgumentsAreConvertedToLiterals() {
+    UnboundTerm<?> ref = Expressions.ref("id");
+    UnboundApply<?> apply =
+        Expressions.apply(Expressions.function("bucket"), ImmutableList.of(16, ref));
+
+    assertThat(apply.arguments()).hasSize(2);
+    assertThat(apply.arguments().get(0)).isInstanceOf(Literal.class);
+    assertThat(((Literal<?>) apply.arguments().get(0)).value()).isEqualTo(16);
+    assertThat(apply.arguments().get(1)).isSameAs(ref);
+  }
+
+  @Test
+  public void testValueExpressionAndPredicateArgumentsArePreserved() {
+    UnboundTerm<?> nested =
+        Expressions.apply(Expressions.function("year"), ImmutableList.of(Expressions.ref("ts")));
+    Expression predicate = Expressions.isNull("id");
+    UnboundTerm<?> ref = Expressions.ref("id");
+    UnboundApply<?> apply =
+        Expressions.apply(
+            Expressions.function("if_else"), ImmutableList.of(predicate, nested, ref));
+
+    assertThat(apply.arguments()).containsExactly(predicate, nested, ref);
+  }
+
+  @Test
+  public void testLiteralArgumentsArePreserved() {
+    Literal<Integer> lit = Expressions.lit(16);
+    UnboundApply<?> apply =
+        Expressions.apply(Expressions.function("bucket"), ImmutableList.of(lit));
+
+    assertThat(apply.arguments()).containsExactly(lit);
+  }
+
+  @Test
+  public void testNullArgumentIsRejected() {
+    assertThatThrownBy(
+            () ->
+                Expressions.apply(
+                    Expressions.function("my_func"), Collections.singletonList((Object) null)))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid function argument: null");
+  }
+
+  @Test
+  public void testArgumentThatIsNotAnExpressionIsRejected() {
+    assertThatThrownBy(
+            () ->
+                Expressions.apply(
+                    Expressions.function("my_func"),
+                    Arrays.asList((Object) LocalDate.parse("2024-01-01"))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot create expression literal from java.time.LocalDate: 2024-01-01");
+  }
+
+  @Test
+  public void testNullFunctionIsRejected() {
+    assertThatThrownBy(() -> Expressions.apply(null, ImmutableList.of()))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid function: null");
+  }
+
+  @Test
+  public void testRefIsNotSupported() {
+    UnboundApply<?> apply =
+        Expressions.apply(Expressions.function("my_func"), ImmutableList.of(Expressions.ref("id")));
+
+    assertThatThrownBy(apply::ref)
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot determine reference for function: my_func");
+  }
+
+  @Test
+  public void testBindIsNotSupported() {
+    UnboundApply<?> apply =
+        Expressions.apply(
+            Expressions.function("iceberg_functions", ImmutableList.of("year")),
+            ImmutableList.of(Expressions.ref("id")));
+
+    assertThatThrownBy(() -> apply.bind(STRUCT, false))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot bind function: iceberg_functions.year");
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -25,16 +25,21 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SingleValueParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
 
@@ -50,6 +55,17 @@ public class ExpressionParser {
   private static final String CHILD = "child";
   private static final String REFERENCE = "reference";
   private static final String LITERAL = "literal";
+  private static final String LITERALS = "literals";
+  private static final String DATA_TYPE = "data-type";
+  private static final String APPLY = "apply";
+  private static final String FUNCTION = "function";
+  private static final String ARGUMENTS = "arguments";
+  private static final String NAME = "name";
+  private static final String ID = "id";
+  private static final String IDENTIFIER = "identifier";
+  private static final String CATALOG = "catalog";
+
+  private static final Pattern HAS_WIDTH = Pattern.compile("(\\w+)\\[(\\d+)]");
 
   private ExpressionParser() {}
 
@@ -74,10 +90,6 @@ public class ExpressionParser {
       this.gen = gen;
     }
 
-    /**
-     * A convenience method to make code more readable by calling {@code toJson} instead of {@code
-     * get()}
-     */
     private void toJson(Supplier<Void> child) {
       child.get();
     }
@@ -152,16 +164,20 @@ public class ExpressionParser {
       return generate(
           () -> {
             gen.writeStartObject();
-
             gen.writeStringField(TYPE, operationType(pred.op()));
-            gen.writeFieldName(TERM);
-            term(pred.term());
 
-            if (pred.isLiteralPredicate()) {
-              gen.writeFieldName(VALUE);
+            if (pred.isUnaryPredicate()) {
+              gen.writeFieldName(CHILD);
+              writeValueExpr(pred.term());
+            } else if (pred.isLiteralPredicate()) {
+              gen.writeFieldName(LEFT);
+              writeValueExpr(pred.term());
+              gen.writeFieldName(RIGHT);
               SingleValueParser.toJson(
                   pred.term().type(), pred.asLiteralPredicate().literal().value(), gen);
             } else if (pred.isSetPredicate()) {
+              gen.writeFieldName(CHILD);
+              writeValueExpr(pred.term());
               gen.writeArrayFieldStart(VALUES);
               for (T value : pred.asSetPredicate().literalSet()) {
                 SingleValueParser.toJson(pred.term().type(), value, gen);
@@ -178,24 +194,26 @@ public class ExpressionParser {
       return generate(
           () -> {
             gen.writeStartObject();
-
             gen.writeStringField(TYPE, operationType(pred.op()));
-            gen.writeFieldName(TERM);
-            term(pred.term());
 
-            if (pred.literals() != null) {
-              if (pred.op() == Expression.Operation.IN
-                  || pred.op() == Expression.Operation.NOT_IN) {
-                gen.writeArrayFieldStart(VALUES);
+            if (pred.op() == Expression.Operation.IN || pred.op() == Expression.Operation.NOT_IN) {
+              gen.writeFieldName(CHILD);
+              writeValueExpr(pred.term());
+              gen.writeArrayFieldStart(VALUES);
+              if (pred.literals() != null) {
                 for (Literal<T> lit : pred.literals()) {
                   unboundLiteral(lit.value());
                 }
-                gen.writeEndArray();
-
-              } else {
-                gen.writeFieldName(VALUE);
-                unboundLiteral(pred.literal().value());
               }
+              gen.writeEndArray();
+            } else if (pred.literals() == null || pred.literals().isEmpty()) {
+              gen.writeFieldName(CHILD);
+              writeValueExpr(pred.term());
+            } else {
+              gen.writeFieldName(LEFT);
+              writeValueExpr(pred.term());
+              gen.writeFieldName(RIGHT);
+              unboundLiteral(pred.literal().value());
             }
 
             gen.writeEndObject();
@@ -203,7 +221,6 @@ public class ExpressionParser {
     }
 
     private void unboundLiteral(Object object) throws IOException {
-      // this handles each type supported in Literals.from
       if (object instanceof Integer) {
         SingleValueParser.toJson(Types.IntegerType.get(), object, gen);
       } else if (object instanceof Long) {
@@ -226,6 +243,9 @@ public class ExpressionParser {
         BigDecimal decimal = (BigDecimal) object;
         SingleValueParser.toJson(
             Types.DecimalType.of(decimal.precision(), decimal.scale()), decimal, gen);
+      } else {
+        throw new UnsupportedOperationException(
+            "Cannot write literal of unsupported type: " + object.getClass().getName());
       }
     }
 
@@ -233,29 +253,97 @@ public class ExpressionParser {
       return op.toString().replaceAll("_", "-").toLowerCase(Locale.ENGLISH);
     }
 
-    private void term(Term term) throws IOException {
-      if (term instanceof UnboundTransform) {
+    private void writeValueExpr(Term term) throws IOException {
+      if (term instanceof UnboundApply) {
+        writeApply((UnboundApply<?>) term);
+      } else if (term instanceof UnboundTransform) {
         UnboundTransform<?, ?> transform = (UnboundTransform<?, ?>) term;
-        transform(transform.transform().toString(), transform.ref().name());
-        return;
+        writeTransformAsApply(transform.transform().toString(), transform.ref());
       } else if (term instanceof BoundTransform) {
         BoundTransform<?, ?> transform = (BoundTransform<?, ?>) term;
-        transform(transform.transform().toString(), transform.ref().name());
-        return;
+        writeTransformAsApply(transform.transform().toString(), transform.ref());
+      } else if (term instanceof BoundReference) {
+        BoundReference<?> ref = (BoundReference<?>) term;
+        gen.writeStartObject();
+        gen.writeStringField(TYPE, REFERENCE);
+        gen.writeNumberField(ID, ref.fieldId());
+        gen.writeEndObject();
       } else if (term instanceof Reference) {
-        gen.writeString(((Reference<?>) term).name());
-        return;
+        gen.writeStartObject();
+        gen.writeStringField(TYPE, REFERENCE);
+        gen.writeStringField(NAME, ((Reference<?>) term).name());
+        gen.writeEndObject();
+      } else {
+        throw new UnsupportedOperationException("Cannot write unsupported term: " + term);
       }
-
-      throw new UnsupportedOperationException("Cannot write unsupported term: " + term);
     }
 
-    private void transform(String transform, String name) throws IOException {
+    /**
+     * Writes a transform as an apply expression. Parameterized transforms are written as
+     * two-argument functions with the parameter first, like {@code bucket(16, ref)}.
+     */
+    private void writeTransformAsApply(String transformStr, Term ref) throws IOException {
       gen.writeStartObject();
-      gen.writeStringField(TYPE, TRANSFORM);
-      gen.writeStringField(TRANSFORM, transform);
-      gen.writeStringField(TERM, name);
+      gen.writeStringField(TYPE, APPLY);
+
+      Matcher matcher = HAS_WIDTH.matcher(transformStr);
+      boolean parameterized = matcher.matches();
+      gen.writeStringField(FUNCTION, parameterized ? matcher.group(1) : transformStr);
+
+      gen.writeArrayFieldStart(ARGUMENTS);
+      if (parameterized) {
+        gen.writeNumber(Integer.parseInt(matcher.group(2)));
+      }
+      writeValueExpr(ref);
+      gen.writeEndArray();
+
       gen.writeEndObject();
+    }
+
+    private void writeApply(UnboundApply<?> apply) throws IOException {
+      gen.writeStartObject();
+      gen.writeStringField(TYPE, APPLY);
+
+      writeFunctionRef(apply.function());
+
+      gen.writeArrayFieldStart(ARGUMENTS);
+      for (Object arg : apply.arguments()) {
+        if (arg instanceof UnboundTerm) {
+          writeValueExpr((Term) arg);
+        } else if (arg instanceof Expression) {
+          ExpressionParser.toJson((Expression) arg, gen);
+        } else {
+          // remaining arguments are constants, written as bare literal values
+          unboundLiteral(arg);
+        }
+      }
+      gen.writeEndArray();
+
+      gen.writeEndObject();
+    }
+
+    private void writeFunctionRef(FunctionReference ref) throws IOException {
+      if (ref.catalog() == null && ref.identifier().size() == 1) {
+        gen.writeStringField(FUNCTION, ref.name());
+      } else if (ref.catalog() == null) {
+        gen.writeFieldName(FUNCTION);
+        gen.writeStartArray();
+        for (String part : ref.identifier()) {
+          gen.writeString(part);
+        }
+        gen.writeEndArray();
+      } else {
+        gen.writeFieldName(FUNCTION);
+        gen.writeStartObject();
+        gen.writeStringField(CATALOG, ref.catalog());
+        gen.writeFieldName(IDENTIFIER);
+        gen.writeStartArray();
+        for (String part : ref.identifier()) {
+          gen.writeString(part);
+        }
+        gen.writeEndArray();
+        gen.writeEndObject();
+      }
     }
   }
 
@@ -273,7 +361,6 @@ public class ExpressionParser {
 
   static Expression fromJson(JsonNode json, Schema schema) {
     Preconditions.checkArgument(null != json, "Cannot parse expression from null object");
-    // check for constant expressions
     if (json.isBoolean()) {
       if (json.asBoolean()) {
         return Expressions.alwaysTrue();
@@ -296,6 +383,12 @@ public class ExpressionParser {
 
     Expression.Operation op = fromType(type);
     switch (op) {
+      case TRUE:
+        // deprecated: the constant true predicate is written as a bare boolean
+        return Expressions.alwaysTrue();
+      case FALSE:
+        // deprecated: the constant false predicate is written as a bare boolean
+        return Expressions.alwaysFalse();
       case NOT:
         return Expressions.not(fromJson(JsonUtil.get(CHILD, json), schema));
       case AND:
@@ -308,7 +401,11 @@ public class ExpressionParser {
             fromJson(JsonUtil.get(RIGHT, json), schema));
     }
 
-    return predicateFromJson(op, json, schema);
+    if (json.has(TERM)) {
+      return deprecatedPredicateFromJson(op, json, schema);
+    } else {
+      return predicateFromJson(op, json, schema);
+    }
   }
 
   private static Expression.Operation fromType(String type) {
@@ -318,22 +415,55 @@ public class ExpressionParser {
   @SuppressWarnings("unchecked")
   private static <T> UnboundPredicate<T> predicateFromJson(
       Expression.Operation op, JsonNode node, Schema schema) {
-    UnboundTerm<T> term = term(JsonUtil.get(TERM, node));
-
-    Function<JsonNode, T> convertValue;
-    if (schema != null) {
-      BoundTerm<?> bound = term.bind(schema.asStruct(), false);
-      convertValue = valueNode -> (T) SingleValueParser.fromJson(bound.type(), valueNode);
-    } else {
-      convertValue = valueNode -> (T) ExpressionParser.asObject(valueNode);
+    switch (op) {
+      case IS_NULL:
+      case NOT_NULL:
+      case IS_NAN:
+      case NOT_NAN:
+        {
+          UnboundTerm<T> child = valueExprFromJson(JsonUtil.get(CHILD, node), schema);
+          return Expressions.predicate(op, child);
+        }
+      case LT:
+      case LT_EQ:
+      case GT:
+      case GT_EQ:
+      case EQ:
+      case NOT_EQ:
+      case STARTS_WITH:
+      case NOT_STARTS_WITH:
+        {
+          UnboundTerm<T> left = valueExprFromJson(JsonUtil.get(LEFT, node), schema);
+          Function<JsonNode, T> convertValue = valueConverter(left, schema);
+          T value = literalFromJson(JsonUtil.get(RIGHT, node), convertValue);
+          return Expressions.predicate(op, left, ImmutableList.of(value));
+        }
+      case IN:
+      case NOT_IN:
+        {
+          UnboundTerm<T> child = valueExprFromJson(JsonUtil.get(CHILD, node), schema);
+          Function<JsonNode, T> convertValue = valueConverter(child, schema);
+          JsonNode valuesNode = JsonUtil.get(VALUES, node);
+          Iterable<T> values = literalsFromJson(valuesNode, convertValue);
+          return Expressions.predicate(op, child, values);
+        }
+      default:
+        throw new UnsupportedOperationException("Unsupported operation: " + op);
     }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> UnboundPredicate<T> deprecatedPredicateFromJson(
+      Expression.Operation op, JsonNode node, Schema schema) {
+    UnboundTerm<T> term = deprecatedTermFromJson(JsonUtil.get(TERM, node));
+
+    Function<JsonNode, T> convertValue = valueConverter(term, schema);
 
     switch (op) {
       case IS_NULL:
       case NOT_NULL:
       case IS_NAN:
       case NOT_NAN:
-        // unary predicates
         Preconditions.checkArgument(
             !node.has(VALUE), "Cannot parse %s predicate: has invalid value field", op);
         Preconditions.checkArgument(
@@ -347,16 +477,14 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
-        // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);
         Preconditions.checkArgument(
             !node.has(VALUES), "Cannot parse %s predicate: has invalid values field", op);
-        T value = literal(JsonUtil.get(VALUE, node), convertValue);
+        T value = literalFromJson(JsonUtil.get(VALUE, node), convertValue);
         return Expressions.predicate(op, term, ImmutableList.of(value));
       case IN:
       case NOT_IN:
-        // literal set predicates
         Preconditions.checkArgument(
             node.has(VALUES), "Cannot parse %s predicate: missing values", op);
         Preconditions.checkArgument(
@@ -368,22 +496,189 @@ public class ExpressionParser {
             op,
             term,
             Iterables.transform(
-                ((ArrayNode) valuesNode)::elements, valueNode -> literal(valueNode, convertValue)));
+                ((ArrayNode) valuesNode)::elements,
+                valueNode -> literalFromJson(valueNode, convertValue)));
       default:
         throw new UnsupportedOperationException("Unsupported operation: " + op);
     }
   }
 
-  private static <T> T literal(JsonNode valueNode, Function<JsonNode, T> toValue) {
+  @SuppressWarnings("unchecked")
+  private static <T> Function<JsonNode, T> valueConverter(UnboundTerm<T> term, Schema schema) {
+    if (schema != null) {
+      BoundTerm<?> bound = term.bind(schema.asStruct(), false);
+      return valueNode -> (T) SingleValueParser.fromJson(bound.type(), valueNode);
+    } else {
+      return valueNode -> (T) ExpressionParser.asObject(valueNode);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> UnboundTerm<T> valueExprFromJson(JsonNode node, Schema schema) {
+    if (node.isObject()) {
+      String type = JsonUtil.getString(TYPE, node);
+      switch (type) {
+        case REFERENCE:
+          return referenceFromJson(node, schema);
+        case APPLY:
+          return applyFromJson(node, schema);
+        default:
+          throw new IllegalArgumentException("Unknown value expression type: " + type);
+      }
+    }
+
+    // a bare string is a literal value, which cannot be a predicate operand
+    throw new IllegalArgumentException(
+        "Cannot parse value expression, expected a reference or apply: " + node);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> UnboundTerm<T> referenceFromJson(JsonNode node, Schema schema) {
+    if (node.has(NAME)) {
+      return Expressions.ref(JsonUtil.getString(NAME, node));
+    } else if (node.has(ID)) {
+      int fieldId = JsonUtil.getInt(ID, node);
+      Preconditions.checkArgument(
+          schema != null, "Cannot parse reference by field ID %s without a schema", fieldId);
+      String name = schema.findColumnName(fieldId);
+      Preconditions.checkArgument(name != null, "Cannot find field with ID %s in schema", fieldId);
+      return Expressions.ref(name);
+    } else if (node.has(TERM)) {
+      return Expressions.ref(JsonUtil.getString(TERM, node));
+    }
+
+    throw new IllegalArgumentException(
+        "Cannot parse reference (requires 'name', 'id', or 'term' field): " + node);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> UnboundTerm<T> applyFromJson(JsonNode node, Schema schema) {
+    FunctionReference funcRef = functionRefFromJson(JsonUtil.get(FUNCTION, node));
+    List<Object> arguments = Lists.newArrayList();
+
+    if (node.has(ARGUMENTS)) {
+      JsonNode argsNode = JsonUtil.get(ARGUMENTS, node);
+      Preconditions.checkArgument(
+          argsNode.isArray(), "Apply arguments must be an array: %s", argsNode);
+      for (JsonNode argNode : argsNode) {
+        arguments.add(parseApplyArgument(argNode, schema));
+      }
+    }
+
+    UnboundApply<T> apply = Expressions.apply(funcRef, arguments);
+
+    if (apply.isKnownTransform()) {
+      return apply.asTransform();
+    }
+
+    return apply;
+  }
+
+  private static Object parseApplyArgument(JsonNode node, Schema schema) {
+    if (node.isIntegralNumber()) {
+      return node.canConvertToInt() ? (Object) node.asInt() : (Object) node.asLong();
+    } else if (node.isFloatingPointNumber()) {
+      return node.asDouble();
+    } else if (node.isTextual()) {
+      // a bare string is a literal value, not a reference
+      return node.asText();
+    } else if (node.isBoolean()) {
+      return node.asBoolean() ? Expressions.alwaysTrue() : Expressions.alwaysFalse();
+    } else if (node.isObject()) {
+      String type = JsonUtil.getString(TYPE, node);
+      switch (type) {
+        case REFERENCE:
+          return referenceFromJson(node, schema);
+        case APPLY:
+          return applyFromJson(node, schema);
+        case LITERAL:
+          return literalFromJson(node, ExpressionParser::asObject);
+        default:
+          return fromJson(node, schema);
+      }
+    }
+
+    throw new IllegalArgumentException("Cannot parse apply argument: " + node);
+  }
+
+  private static FunctionReference functionRefFromJson(JsonNode node) {
+    if (node.isTextual()) {
+      return Expressions.function(node.asText());
+    } else if (node.isArray()) {
+      return Expressions.function(namesFromJson(node));
+    } else if (node.isObject()) {
+      String catalog = node.hasNonNull(CATALOG) ? JsonUtil.getString(CATALOG, node) : null;
+      List<String> identifier = namesFromJson(JsonUtil.get(IDENTIFIER, node));
+      return catalog != null
+          ? Expressions.function(catalog, identifier)
+          : Expressions.function(identifier);
+    }
+
+    throw new IllegalArgumentException("Cannot parse function reference: " + node);
+  }
+
+  private static List<String> namesFromJson(JsonNode node) {
+    Preconditions.checkArgument(
+        node.isArray(), "Cannot parse function identifier from non-array: %s", node);
+    List<String> names = Lists.newArrayList();
+    for (JsonNode name : node) {
+      names.add(name.asText());
+    }
+
+    return names;
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T literalFromJson(JsonNode valueNode, Function<JsonNode, T> toValue) {
     if (valueNode.isObject() && valueNode.has(TYPE)) {
       String type = JsonUtil.getString(TYPE, valueNode);
       Preconditions.checkArgument(
           type.equalsIgnoreCase(LITERAL), "Cannot parse type as a literal: %s", type);
-      return toValue.apply(JsonUtil.get(VALUE, valueNode));
+      JsonNode value = JsonUtil.get(VALUE, valueNode);
+      if (valueNode.hasNonNull(DATA_TYPE)) {
+        return (T) typedValueFromJson(dataTypeFromJson(valueNode), value);
+      }
+
+      return toValue.apply(value);
     }
 
-    // the node is a directly embedded literal value
     return toValue.apply(valueNode);
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> Iterable<T> literalsFromJson(
+      JsonNode node, Function<JsonNode, T> convertValue) {
+    if (node.isArray()) {
+      return Iterables.transform(
+          ((ArrayNode) node)::elements, valueNode -> literalFromJson(valueNode, convertValue));
+    } else if (node.isObject() && node.has(TYPE)) {
+      String type = JsonUtil.getString(TYPE, node);
+      Preconditions.checkArgument(
+          type.equalsIgnoreCase(LITERALS), "Cannot parse type as literals: %s", type);
+      JsonNode valuesNode = JsonUtil.get(VALUES, node);
+      Preconditions.checkArgument(
+          valuesNode.isArray(), "Cannot parse literals values from non-array: %s", valuesNode);
+      if (node.hasNonNull(DATA_TYPE)) {
+        Type dataType = dataTypeFromJson(node);
+        return Iterables.transform(
+            ((ArrayNode) valuesNode)::elements,
+            valueNode -> (T) typedValueFromJson(dataType, valueNode));
+      }
+
+      return Iterables.transform(((ArrayNode) valuesNode)::elements, convertValue::apply);
+    }
+
+    throw new IllegalArgumentException("Cannot parse literals: " + node);
+  }
+
+  private static Type dataTypeFromJson(JsonNode node) {
+    return Types.fromPrimitiveString(JsonUtil.getString(DATA_TYPE, node));
+  }
+
+  private static Object typedValueFromJson(Type dataType, JsonNode valueNode) {
+    Object value = SingleValueParser.fromJson(dataType, valueNode);
+    Preconditions.checkArgument(value != null, "Cannot parse %s literal from null value", dataType);
+    return value;
   }
 
   private static Object asObject(JsonNode node) {
@@ -401,16 +696,19 @@ public class ExpressionParser {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> UnboundTerm<T> term(JsonNode node) {
+  private static <T> UnboundTerm<T> deprecatedTermFromJson(JsonNode node) {
     if (node.isTextual()) {
       return Expressions.ref(node.asText());
     } else if (node.isObject()) {
       String type = JsonUtil.getString(TYPE, node);
       switch (type) {
         case REFERENCE:
+          if (node.has(NAME)) {
+            return Expressions.ref(JsonUtil.getString(NAME, node));
+          }
           return Expressions.ref(JsonUtil.getString(TERM, node));
         case TRANSFORM:
-          UnboundTerm<T> child = term(JsonUtil.get(TERM, node));
+          UnboundTerm<T> child = deprecatedTermFromJson(JsonUtil.get(TERM, node));
           String transform = JsonUtil.getString(TRANSFORM, node);
           return (UnboundTerm<T>)
               Expressions.transform(child.ref().name(), Transforms.fromString(transform));

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -27,6 +27,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -36,9 +37,11 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.SingleValueParser;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.transforms.Transforms;
+import org.apache.iceberg.transforms.UnknownTransform;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.JsonUtil;
@@ -67,6 +70,13 @@ public class ExpressionParser {
 
   private static final Pattern HAS_WIDTH = Pattern.compile("(\\w+)\\[(\\d+)]");
 
+  private static final String ICEBERG_FUNCTIONS = "iceberg_functions";
+  // the expressions spec defines partition transforms as functions, other than void
+  private static final String VOID = "void";
+  // bucket and truncate take the transform parameter as their first argument, so they cannot be
+  // resolved from a name alone
+  private static final Set<String> PARAMETERIZED_TRANSFORMS = ImmutableSet.of("bucket", "truncate");
+
   private ExpressionParser() {}
 
   public static String toJson(Expression expression) {
@@ -90,6 +100,10 @@ public class ExpressionParser {
       this.gen = gen;
     }
 
+    /**
+     * A convenience method to make code more readable by calling {@code toJson} instead of {@code
+     * get()}
+     */
     private void toJson(Supplier<Void> child) {
       child.get();
     }
@@ -221,6 +235,7 @@ public class ExpressionParser {
     }
 
     private void unboundLiteral(Object object) throws IOException {
+      // this handles each type supported in Literals.from
       if (object instanceof Integer) {
         SingleValueParser.toJson(Types.IntegerType.get(), object, gen);
       } else if (object instanceof Long) {
@@ -308,13 +323,13 @@ public class ExpressionParser {
 
       gen.writeArrayFieldStart(ARGUMENTS);
       for (Object arg : apply.arguments()) {
-        if (arg instanceof UnboundTerm) {
+        if (arg instanceof Term) {
           writeValueExpr((Term) arg);
         } else if (arg instanceof Expression) {
           ExpressionParser.toJson((Expression) arg, gen);
         } else {
           // remaining arguments are constants, written as bare literal values
-          unboundLiteral(arg);
+          unboundLiteral(((Literal<?>) arg).value());
         }
       }
       gen.writeEndArray();
@@ -361,6 +376,7 @@ public class ExpressionParser {
 
   static Expression fromJson(JsonNode json, Schema schema) {
     Preconditions.checkArgument(null != json, "Cannot parse expression from null object");
+    // check for constant expressions
     if (json.isBoolean()) {
       if (json.asBoolean()) {
         return Expressions.alwaysTrue();
@@ -464,6 +480,7 @@ public class ExpressionParser {
       case NOT_NULL:
       case IS_NAN:
       case NOT_NAN:
+        // unary predicates
         Preconditions.checkArgument(
             !node.has(VALUE), "Cannot parse %s predicate: has invalid value field", op);
         Preconditions.checkArgument(
@@ -477,6 +494,7 @@ public class ExpressionParser {
       case NOT_EQ:
       case STARTS_WITH:
       case NOT_STARTS_WITH:
+        // literal predicates
         Preconditions.checkArgument(
             node.has(VALUE), "Cannot parse %s predicate: missing value", op);
         Preconditions.checkArgument(
@@ -485,6 +503,7 @@ public class ExpressionParser {
         return Expressions.predicate(op, term, ImmutableList.of(value));
       case IN:
       case NOT_IN:
+        // literal set predicates
         Preconditions.checkArgument(
             node.has(VALUES), "Cannot parse %s predicate: missing values", op);
         Preconditions.checkArgument(
@@ -567,11 +586,77 @@ public class ExpressionParser {
 
     UnboundApply<T> apply = Expressions.apply(funcRef, arguments);
 
-    if (apply.isKnownTransform()) {
-      return apply.asTransform();
+    if (isTransformFunction(funcRef)) {
+      return transformFromApply(apply);
     }
 
     return apply;
+  }
+
+  /**
+   * Returns whether a function reference is an Iceberg partition transform.
+   *
+   * <p>The expressions spec defines Iceberg partition transforms as functions in the {@code
+   * iceberg_functions} catalog, other than {@code void}.
+   */
+  private static boolean isTransformFunction(FunctionReference function) {
+    if (function.catalog() != null && !function.catalog().equalsIgnoreCase(ICEBERG_FUNCTIONS)) {
+      return false;
+    }
+
+    String name = function.name().toLowerCase(Locale.ROOT);
+    if (VOID.equals(name)) {
+      return false;
+    } else if (PARAMETERIZED_TRANSFORMS.contains(name)) {
+      return true;
+    }
+
+    return !(Transforms.fromString(name) instanceof UnknownTransform);
+  }
+
+  /**
+   * Converts an apply expression that calls an Iceberg partition transform to an {@link
+   * UnboundTransform}.
+   *
+   * <p>Parameterized transforms are called as two-argument functions with the transform parameter
+   * first, like {@code bucket(16, ref)}.
+   */
+  @SuppressWarnings("unchecked")
+  private static <T> UnboundTerm<T> transformFromApply(UnboundApply<T> apply) {
+    FunctionReference function = apply.function();
+    String name = function.name().toLowerCase(Locale.ROOT);
+    boolean parameterized = PARAMETERIZED_TRANSFORMS.contains(name);
+
+    List<Object> arguments = apply.arguments();
+    int expectedArgs = parameterized ? 2 : 1;
+    Preconditions.checkArgument(
+        arguments.size() == expectedArgs,
+        "Cannot convert %s to a transform: expected %s argument(s), got %s",
+        function,
+        expectedArgs,
+        arguments.size());
+
+    String transform = name;
+    if (parameterized) {
+      Object parameter = arguments.get(0);
+      Preconditions.checkArgument(
+          parameter instanceof Literal && ((Literal<?>) parameter).value() instanceof Number,
+          "Cannot convert %s to a transform: first argument must be a number, got %s",
+          function,
+          parameter);
+      transform = name + "[" + ((Number) ((Literal<?>) parameter).value()).intValue() + "]";
+    }
+
+    Object valueArg = arguments.get(expectedArgs - 1);
+    Preconditions.checkArgument(
+        valueArg instanceof NamedReference,
+        "Cannot convert %s to a transform: last argument must be a reference, got %s",
+        function,
+        valueArg);
+
+    return (UnboundTerm<T>)
+        Expressions.transform(
+            ((NamedReference<?>) valueArg).name(), Transforms.fromString(transform));
   }
 
   private static Object parseApplyArgument(JsonNode node, Schema schema) {
@@ -642,6 +727,7 @@ public class ExpressionParser {
       return toValue.apply(value);
     }
 
+    // the node is a directly embedded literal value
     return toValue.apply(valueNode);
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
@@ -127,7 +127,7 @@ public class TestAllManifestsTableTaskParser {
         + "\"transform\":\"bucket[16]\",\"source-id\":4,\"field-id\":1000}]}],"
         + "\"manifest-list-Location\":\"/path/manifest-list-file.avro\","
         + "\"manifest-list-key-id\":\"a\","
-        + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1},"
+        + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1},"
         + "\"reference-snapshot-id\":1}";
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileScanTaskParser.java
@@ -106,7 +106,7 @@ public class TestFileScanTaskParser {
         + "{\"spec-id\":0,\"content\":\"equality-deletes\",\"file-path\":\"/path/to/data-a2-deletes.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":[0],\"file-size-in-bytes\":10,"
         + "\"record-count\":1,\"equality-ids\":[1],\"sort-order-id\":0}],"
-        + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}";
+        + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}";
   }
 
   private String fileScanTaskJson() {
@@ -126,7 +126,7 @@ public class TestFileScanTaskParser {
         + "{\"spec-id\":0,\"content\":\"equality-deletes\",\"file-path\":\"/path/to/data-a2-deletes.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":[0],\"file-size-in-bytes\":10,"
         + "\"record-count\":1,\"equality-ids\":[1],\"sort-order-id\":0}],"
-        + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}";
+        + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}";
   }
 
   private String fileScanTaskFieldIdPartitionMapJson() {
@@ -146,7 +146,7 @@ public class TestFileScanTaskParser {
         + "{\"spec-id\":0,\"content\":\"equality-deletes\",\"file-path\":\"/path/to/data-a2-deletes.parquet\","
         + "\"file-format\":\"parquet\",\"partition\":{\"1000\":0},\"file-size-in-bytes\":10,"
         + "\"record-count\":1,\"equality-ids\":[1],\"sort-order-id\":0}],"
-        + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}";
+        + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}";
   }
 
   private static void assertFileScanTaskEquals(

--- a/core/src/test/java/org/apache/iceberg/TestFilesTableTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestFilesTableTaskParser.java
@@ -102,7 +102,7 @@ public class TestFilesTableTaskParser {
         + "\"properties\":{\"k1\":\"v1\",\"k2\":\"v2\"}},"
         + "\"partition-specs\":[{\"spec-id\":0,\"fields\":[{"
         + "\"name\":\"data_bucket\",\"transform\":\"bucket[16]\",\"source-id\":4,\"field-id\":1000}]}],"
-        + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1},"
+        + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1},"
         + "\"manifest-file\":{\"path\":\"/path/input.m0.avro\","
         + "\"length\":5878,\"partition-spec-id\":0,\"content\":0,\"sequence-number\":1,\"min-sequence-number\":2,"
         + "\"added-snapshot-id\":12345678901234567,"

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -26,8 +26,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
+import java.time.LocalDate;
+import java.util.Comparator;
 import java.util.UUID;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
@@ -98,15 +102,9 @@ public class TestExpressionParser {
         };
 
     for (Expression expr : expressions) {
-      Expression bound = Binder.bind(SUPPORTED_PRIMITIVES, expr);
-      String boundJson = ExpressionParser.toJson(bound, true);
       String unboundJson = ExpressionParser.toJson(expr, true);
 
-      assertThat(boundJson)
-          .as("Bound and unbound should produce identical json")
-          .isEqualTo(unboundJson);
-
-      Expression parsed = ExpressionParser.fromJson(boundJson, SCHEMA);
+      Expression parsed = ExpressionParser.fromJson(unboundJson, SCHEMA);
       assertThat(ExpressionUtil.equivalent(expr, parsed, SUPPORTED_PRIMITIVES, true))
           .as("Round-trip value should be equivalent")
           .isTrue();
@@ -132,6 +130,10 @@ public class TestExpressionParser {
     // type=literal is also supported
     String longJson = "{\n  \"type\" : \"literal\",\n  \"value\" : true\n}";
     assertThat(ExpressionParser.fromJson(longJson)).isEqualTo(Expressions.alwaysTrue());
+
+    // deprecated: the object form used by older clients
+    assertThat(ExpressionParser.fromJson("{\n  \"type\" : \"true\"\n}"))
+        .isEqualTo(Expressions.alwaysTrue());
   }
 
   @Test
@@ -142,12 +144,23 @@ public class TestExpressionParser {
     // type=literal is also supported
     String longJson = "{\n  \"type\" : \"literal\",\n  \"value\" : false\n}";
     assertThat(ExpressionParser.fromJson(longJson)).isEqualTo(Expressions.alwaysFalse());
+
+    // deprecated: the object form used by older clients
+    assertThat(ExpressionParser.fromJson("{\n  \"type\" : \"false\"\n}"))
+        .isEqualTo(Expressions.alwaysFalse());
   }
 
   @Test
   public void eqExpression() {
     String expected =
-        "{\n" + "  \"type\" : \"eq\",\n" + "  \"term\" : \"name\",\n" + "  \"value\" : 25\n" + "}";
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"name\"\n"
+            + "  },\n"
+            + "  \"right\" : 25\n"
+            + "}";
     assertThat(ExpressionParser.toJson(Expressions.equal("name", 25), true)).isEqualTo(expected);
     Expression expression = ExpressionParser.fromJson(expected);
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
@@ -158,42 +171,49 @@ public class TestExpressionParser {
     String expected =
         "{\n"
             + "  \"type\" : \"lt-eq\",\n"
-            + "  \"term\" : {\n"
-            + "    \"type\" : \"transform\",\n"
-            + "    \"transform\" : \"bucket[100]\",\n"
-            + "    \"term\" : \"id\"\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"apply\",\n"
+            + "    \"function\" : \"bucket\",\n"
+            + "    \"arguments\" : [ 100, {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"id\"\n"
+            + "    } ]\n"
             + "  },\n"
-            + "  \"value\" : 50\n"
+            + "  \"right\" : 50\n"
             + "}";
 
     assertThat(
             ExpressionParser.toJson(
                 Expressions.lessThanOrEqual(Expressions.bucket("id", 100), 50), true))
         .isEqualTo(expected);
-    // schema is required to parse transform expressions
-    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected, SCHEMA), true))
-        .isEqualTo(expected);
+    Expression parsed = ExpressionParser.fromJson(expected, SCHEMA);
+    assertThat(ExpressionParser.toJson(parsed, true)).isEqualTo(expected);
   }
 
   @Test
   public void extraFields() {
-    assertThat(
-            ExpressionParser.toJson(
-                ExpressionParser.fromJson(
-                    "{\n"
-                        + "  \"type\" : \"in\",\n"
-                        + "  \"term\" : \"column-name\",\n"
-                        + "  \"extra-one\" : \"x\",\n"
-                        + "  \"extra-twp\" : \"y\",\n"
-                        + "  \"values\" : [ 1, 2, 3 ]\n"
-                        + "}"),
-                true))
-        .isEqualTo(
-            "{\n"
-                + "  \"type\" : \"in\",\n"
-                + "  \"term\" : \"column-name\",\n"
-                + "  \"values\" : [ 1, 2, 3 ]\n"
-                + "}");
+    // deprecated format input with extra fields should still parse
+    String deprecatedInput =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"term\" : \"column-name\",\n"
+            + "  \"extra-one\" : \"x\",\n"
+            + "  \"extra-twp\" : \"y\",\n"
+            + "  \"values\" : [ 1, 2, 3 ]\n"
+            + "}";
+
+    String expected =
+        "{\n"
+            + "  \"type\" : \"in\",\n"
+            + "  \"child\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"values\" : [ 1, 2, 3 ]\n"
+            + "}";
+
+    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(deprecatedInput), true))
+        .isEqualTo(expected);
   }
 
   @Test
@@ -337,8 +357,11 @@ public class TestExpressionParser {
     String expected =
         "{\n"
             + "  \"type\" : \"lt-eq\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"value\" : 50\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"right\" : 50\n"
             + "}";
 
     assertThat(ExpressionParser.toJson(Expressions.lessThanOrEqual("column-name", 50), true))
@@ -349,13 +372,7 @@ public class TestExpressionParser {
 
   @Test
   public void testPredicateWithObjectLiteral() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"lt-eq\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"value\" : 50\n"
-            + "}";
-
+    // deprecated format input with object literal should still parse
     String json =
         "{\n"
             + "  \"type\" : \"lt-eq\",\n"
@@ -366,18 +383,22 @@ public class TestExpressionParser {
             + "  }\n"
             + "}";
 
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"right\" : 50\n"
+            + "}";
+
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json), true)).isEqualTo(expected);
   }
 
   @Test
   public void testPredicateWithObjectReference() {
-    String expected =
-        "{\n"
-            + "  \"type\" : \"lt-eq\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"value\" : 50\n"
-            + "}";
-
+    // deprecated format input with object reference should still parse
     String json =
         "{\n"
             + "  \"type\" : \"lt-eq\",\n"
@@ -386,6 +407,16 @@ public class TestExpressionParser {
             + "    \"term\" : \"column-name\"\n"
             + "  },\n"
             + "  \"value\" : 50\n"
+            + "}";
+
+    String expected =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"right\" : 50\n"
             + "}";
 
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json), true)).isEqualTo(expected);
@@ -398,12 +429,18 @@ public class TestExpressionParser {
             + "  \"type\" : \"and\",\n"
             + "  \"left\" : {\n"
             + "    \"type\" : \"gt-eq\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"value\" : 50\n"
+            + "    \"left\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-1\"\n"
+            + "    },\n"
+            + "    \"right\" : 50\n"
             + "  },\n"
             + "  \"right\" : {\n"
             + "    \"type\" : \"in\",\n"
-            + "    \"term\" : \"column-name-2\",\n"
+            + "    \"child\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-2\"\n"
+            + "    },\n"
             + "    \"values\" : [ \"one\", \"two\" ]\n"
             + "  }\n"
             + "}";
@@ -425,12 +462,18 @@ public class TestExpressionParser {
             + "  \"type\" : \"or\",\n"
             + "  \"left\" : {\n"
             + "    \"type\" : \"lt\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"value\" : 50\n"
+            + "    \"left\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-1\"\n"
+            + "    },\n"
+            + "    \"right\" : 50\n"
             + "  },\n"
             + "  \"right\" : {\n"
             + "    \"type\" : \"not-null\",\n"
-            + "    \"term\" : \"column-name-2\"\n"
+            + "    \"child\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-2\"\n"
+            + "    }\n"
             + "  }\n"
             + "}";
 
@@ -449,8 +492,11 @@ public class TestExpressionParser {
             + "  \"type\" : \"not\",\n"
             + "  \"child\" : {\n"
             + "    \"type\" : \"gt-eq\",\n"
-            + "    \"term\" : \"column-name-1\",\n"
-            + "    \"value\" : 50\n"
+            + "    \"left\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-1\"\n"
+            + "    },\n"
+            + "    \"right\" : 50\n"
             + "  }\n"
             + "}";
 
@@ -470,18 +516,27 @@ public class TestExpressionParser {
             + "    \"type\" : \"and\",\n"
             + "    \"left\" : {\n"
             + "      \"type\" : \"in\",\n"
-            + "      \"term\" : \"column-name-1\",\n"
+            + "      \"child\" : {\n"
+            + "        \"type\" : \"reference\",\n"
+            + "        \"name\" : \"column-name-1\"\n"
+            + "      },\n"
             + "      \"values\" : [ 50, 51, 52 ]\n"
             + "    },\n"
             + "    \"right\" : {\n"
             + "      \"type\" : \"eq\",\n"
-            + "      \"term\" : \"column-name-2\",\n"
-            + "      \"value\" : \"test\"\n"
+            + "      \"left\" : {\n"
+            + "        \"type\" : \"reference\",\n"
+            + "        \"name\" : \"column-name-2\"\n"
+            + "      },\n"
+            + "      \"right\" : \"test\"\n"
             + "    }\n"
             + "  },\n"
             + "  \"right\" : {\n"
             + "    \"type\" : \"is-nan\",\n"
-            + "    \"term\" : \"column-name-3\"\n"
+            + "    \"child\" : {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"column-name-3\"\n"
+            + "    }\n"
             + "  }\n"
             + "}";
 
@@ -501,8 +556,11 @@ public class TestExpressionParser {
     String expected =
         "{\n"
             + "  \"type\" : \"eq\",\n"
-            + "  \"term\" : \"column-name\",\n"
-            + "  \"value\" : \"010203\"\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
+            + "  \"right\" : \"010203\"\n"
             + "}";
 
     ByteBuffer byteBuffer = ByteBuffer.wrap(new byte[] {1, 2, 3});
@@ -518,7 +576,10 @@ public class TestExpressionParser {
     String expected =
         "{\n"
             + "  \"type\" : \"in\",\n"
-            + "  \"term\" : \"column-name\",\n"
+            + "  \"child\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
             + "  \"values\" : [ \"3.14\" ]\n"
             + "}";
 
@@ -534,7 +595,10 @@ public class TestExpressionParser {
     String expected =
         "{\n"
             + "  \"type\" : \"in\",\n"
-            + "  \"term\" : \"column-name\",\n"
+            + "  \"child\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"column-name\"\n"
+            + "  },\n"
             + "  \"values\" : [ \"3.14E+4\" ]\n"
             + "}";
 
@@ -543,5 +607,428 @@ public class TestExpressionParser {
     assertThat(ExpressionParser.toJson(expression, true)).isEqualTo(expected);
     assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(expected), true))
         .isEqualTo(expected);
+  }
+
+  // Backward compatibility: deprecated format should still parse correctly
+
+  @Test
+  public void testReadDeprecatedUnaryPredicate() {
+    String deprecated = "{\n  \"type\" : \"is-null\",\n  \"term\" : \"data\"\n}";
+    Expression parsed = ExpressionParser.fromJson(deprecated);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.isNull("data"), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testReadDeprecatedComparisonPredicate() {
+    String deprecated = "{\n  \"type\" : \"eq\",\n  \"term\" : \"id\",\n  \"value\" : 5\n}";
+    Expression parsed = ExpressionParser.fromJson(deprecated);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.equal("id", 5), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testReadDeprecatedSetPredicate() {
+    String deprecated =
+        "{\n  \"type\" : \"in\",\n  \"term\" : \"id\",\n  \"values\" : [ 1, 2, 3 ]\n}";
+    Expression parsed = ExpressionParser.fromJson(deprecated);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.in("id", 1, 2, 3), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testReadDeprecatedTransformPredicate() {
+    String deprecated =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"term\" : {\n"
+            + "    \"type\" : \"transform\",\n"
+            + "    \"transform\" : \"bucket[100]\",\n"
+            + "    \"term\" : \"id\"\n"
+            + "  },\n"
+            + "  \"value\" : 50\n"
+            + "}";
+    Expression parsed = ExpressionParser.fromJson(deprecated, SCHEMA);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed,
+                Expressions.lessThanOrEqual(Expressions.bucket("id", 100), 50),
+                SUPPORTED_PRIMITIVES,
+                true))
+        .isTrue();
+  }
+
+  @Test
+  public void testReadDeprecatedObjectReference() {
+    String deprecated =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"term\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"term\" : \"id\"\n"
+            + "  },\n"
+            + "  \"value\" : 42\n"
+            + "}";
+    Expression parsed = ExpressionParser.fromJson(deprecated);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.equal("id", 42), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  // New format specific tests
+
+  @Test
+  public void testNewFormatRoundTrip() {
+    Expression[] expressions =
+        new Expression[] {
+          Expressions.isNull("data"),
+          Expressions.equal("id", 100),
+          Expressions.in("id", 1, 2, 3),
+          Expressions.lessThanOrEqual(Expressions.bucket("id", 100), 50),
+          Expressions.and(Expressions.equal("id", 1), Expressions.notNull("data")),
+          Expressions.not(Expressions.isNaN("d")),
+        };
+
+    for (Expression expr : expressions) {
+      String json = ExpressionParser.toJson(expr, true);
+      Expression parsed = ExpressionParser.fromJson(json, SCHEMA);
+      String roundTripped = ExpressionParser.toJson(parsed, true);
+      assertThat(roundTripped).as("Round-trip JSON should be stable").isEqualTo(json);
+    }
+  }
+
+  @Test
+  public void testApplySimpleFunctionName() {
+    // Apply with simple string function name
+    String json =
+        "{\n"
+            + "  \"type\" : \"lt-eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"apply\",\n"
+            + "    \"function\" : \"year\",\n"
+            + "    \"arguments\" : [ {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"ts\"\n"
+            + "    } ]\n"
+            + "  },\n"
+            + "  \"right\" : 50\n"
+            + "}";
+
+    Expression parsed = ExpressionParser.fromJson(json, SCHEMA);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed,
+                Expressions.lessThanOrEqual(Expressions.year("ts"), 50),
+                SUPPORTED_PRIMITIVES,
+                true))
+        .isTrue();
+  }
+
+  @Test
+  public void testApplyWithCatalogFunction() {
+    // Apply with catalog-qualified function reference
+    String json =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"apply\",\n"
+            + "    \"function\" : {\n"
+            + "      \"catalog\" : \"iceberg_functions\",\n"
+            + "      \"identifier\" : [ \"bucket\" ]\n"
+            + "    },\n"
+            + "    \"arguments\" : [ 100, {\n"
+            + "      \"type\" : \"reference\",\n"
+            + "      \"name\" : \"id\"\n"
+            + "    } ]\n"
+            + "  },\n"
+            + "  \"right\" : 5\n"
+            + "}";
+
+    Expression parsed = ExpressionParser.fromJson(json, SCHEMA);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed,
+                Expressions.equal(Expressions.bucket("id", 100), 5),
+                SUPPORTED_PRIMITIVES,
+                true))
+        .isTrue();
+  }
+
+  @Test
+  public void testNewFormatNamedReference() {
+    String json =
+        "{\n"
+            + "  \"type\" : \"is-null\",\n"
+            + "  \"child\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"data\"\n"
+            + "  }\n"
+            + "}";
+    Expression parsed = ExpressionParser.fromJson(json);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.isNull("data"), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testNewFormatTypedLiteral() {
+    // Typed literal object form
+    String json =
+        "{\n"
+            + "  \"type\" : \"eq\",\n"
+            + "  \"left\" : {\n"
+            + "    \"type\" : \"reference\",\n"
+            + "    \"name\" : \"id\"\n"
+            + "  },\n"
+            + "  \"right\" : {\n"
+            + "    \"type\" : \"literal\",\n"
+            + "    \"value\" : 42\n"
+            + "  }\n"
+            + "}";
+    Expression parsed = ExpressionParser.fromJson(json);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.equal("id", 42), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testBoundReferenceRoundTrip() {
+    Expression bound = Expressions.equal("id", 34L).bind(SUPPORTED_PRIMITIVES, true);
+    String json = ExpressionParser.toJson(bound, true);
+    assertThat(json)
+        .isEqualTo(
+            "{\n"
+                + "  \"type\" : \"eq\",\n"
+                + "  \"left\" : {\n"
+                + "    \"type\" : \"reference\",\n"
+                + "    \"id\" : 100\n"
+                + "  },\n"
+                + "  \"right\" : 34\n"
+                + "}");
+
+    Expression parsed = ExpressionParser.fromJson(json, SCHEMA);
+    assertThat(
+            ExpressionUtil.equivalent(
+                parsed, Expressions.equal("id", 34L), SUPPORTED_PRIMITIVES, true))
+        .isTrue();
+  }
+
+  @Test
+  public void testReferenceByIdRequiresSchema() {
+    String json = "{\"type\":\"is-null\",\"child\":{\"type\":\"reference\",\"id\":101}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse reference by field ID 101 without a schema");
+  }
+
+  @Test
+  public void testReferenceByUnknownId() {
+    String json = "{\"type\":\"is-null\",\"child\":{\"type\":\"reference\",\"id\":999}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json, SCHEMA))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot find field with ID 999 in schema");
+  }
+
+  @Test
+  public void testReferenceWithoutNameOrId() {
+    String json = "{\"type\":\"is-null\",\"child\":{\"type\":\"reference\"}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json, SCHEMA))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("Cannot parse reference (requires 'name', 'id', or 'term' field)");
+  }
+
+  @Test
+  public void testTypedLiteralUsesDataType() {
+    String json =
+        "{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"date\"},"
+            + "\"right\":{\"type\":\"literal\",\"value\":\"2024-01-01\",\"data-type\":\"date\"}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    assertThat(parsed.literal().value())
+        .isEqualTo((int) LocalDate.parse("2024-01-01").toEpochDay());
+  }
+
+  @Test
+  public void testTypedLiteralsUseDataType() {
+    String json =
+        "{\"type\":\"in\",\"child\":{\"type\":\"reference\",\"name\":\"date\"},"
+            + "\"values\":{\"type\":\"literals\",\"values\":[\"2024-01-01\",\"2024-01-02\"],"
+            + "\"data-type\":\"date\"}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    assertThat(parsed.literals()).hasSize(2);
+    assertThat(parsed.literals().get(0).value())
+        .isEqualTo((int) LocalDate.parse("2024-01-01").toEpochDay());
+    assertThat(parsed.literals().get(1).value())
+        .isEqualTo((int) LocalDate.parse("2024-01-02").toEpochDay());
+  }
+
+  @Test
+  public void testTypedLiteralWithDecimalDataType() {
+    String json =
+        "{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"dec_11_2\"},"
+            + "\"right\":{\"type\":\"literal\",\"value\":\"12.34\",\"data-type\":\"decimal(11, 2)\"}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    assertThat(parsed.literal().value()).isEqualTo(new BigDecimal("12.34"));
+  }
+
+  @Test
+  public void testEmptyInKeepsValuesField() {
+    assertThat(ExpressionParser.toJson(Expressions.in("data", ImmutableList.of()), true))
+        .isEqualTo(
+            "{\n"
+                + "  \"type\" : \"in\",\n"
+                + "  \"child\" : {\n"
+                + "    \"type\" : \"reference\",\n"
+                + "    \"name\" : \"data\"\n"
+                + "  },\n"
+                + "  \"values\" : [ ]\n"
+                + "}");
+  }
+
+  @Test
+  public void testApplyPreservesNumericArgumentTypes() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"my_func\","
+            + "\"arguments\":[1.5,9999999999,{\"type\":\"reference\",\"name\":\"data\"}]}}";
+    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json)))
+        .isEqualTo(
+            "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"my_func\","
+                + "\"arguments\":[1.5,9999999999,{\"type\":\"reference\",\"name\":\"data\"}]}}");
+  }
+
+  @Test
+  public void testApplyPreservesBooleanArgument() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"my_func\","
+            + "\"arguments\":[true,{\"type\":\"reference\",\"name\":\"data\"}]}}";
+    assertThat(ExpressionParser.toJson(ExpressionParser.fromJson(json))).isEqualTo(json);
+  }
+
+  @Test
+  public void testApplyStringArgumentIsALiteral() {
+    // a bare string argument is a literal value, not a reference
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"date_format\","
+            + "\"arguments\":[{\"type\":\"reference\",\"name\":\"ts\"},\"yyyy-MM-dd\"]}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    UnboundApply<?> apply = (UnboundApply<?>) parsed.term();
+    assertThat(apply.arguments()).element(1).isEqualTo("yyyy-MM-dd");
+    assertThat(ExpressionParser.toJson(parsed)).isEqualTo(json);
+  }
+
+  @Test
+  public void testBareStringIsNotAValidOperand() {
+    assertThatThrownBy(
+            () -> ExpressionParser.fromJson("{\"type\":\"eq\",\"left\":\"x\",\"right\":\"y\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse value expression, expected a reference or apply: \"x\"");
+
+    assertThatThrownBy(() -> ExpressionParser.fromJson("{\"type\":\"is-null\",\"child\":\"x\"}"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot parse value expression, expected a reference or apply: \"x\"");
+  }
+
+  @Test
+  public void testVoidIsNotAnIcebergFunction() {
+    // the expressions spec defines partition transforms as functions, other than void
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"void\","
+            + "\"arguments\":[{\"type\":\"reference\",\"name\":\"data\"}]}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    assertThat(parsed.term()).isInstanceOf(UnboundApply.class);
+    assertThat(((UnboundApply<?>) parsed.term()).isKnownTransform()).isFalse();
+  }
+
+  @Test
+  public void testFunctionReferenceWithNullCatalog() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\","
+            + "\"function\":{\"catalog\":null,\"identifier\":[\"my_func\"]},"
+            + "\"arguments\":[{\"type\":\"reference\",\"name\":\"data\"}]}}";
+    UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
+    UnboundApply<?> apply = (UnboundApply<?>) parsed.term();
+    assertThat(apply.function().catalog()).isNull();
+    assertThat(apply.function().identifier()).containsExactly("my_func");
+  }
+
+  @Test
+  public void testTransformRejectsReversedArguments() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"bucket\","
+            + "\"arguments\":[{\"type\":\"reference\",\"name\":\"id\"},16]}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot convert bucket to a transform: first argument must be a number, "
+                + "got ref(name=\"id\")");
+  }
+
+  @Test
+  public void testTransformRejectsNestedTransform() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"bucket\","
+            + "\"arguments\":[16,{\"type\":\"apply\",\"function\":\"year\","
+            + "\"arguments\":[{\"type\":\"reference\",\"name\":\"ts\"}]}]}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith(
+            "Cannot convert bucket to a transform: last argument must be a reference");
+  }
+
+  @Test
+  public void testTransformRejectsExtraArguments() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"bucket\","
+            + "\"arguments\":[16,{\"type\":\"reference\",\"name\":\"id\"},"
+            + "{\"type\":\"reference\",\"name\":\"data\"}]}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot convert bucket to a transform: expected 2 argument(s), got 3");
+  }
+
+  @Test
+  public void testTransformRejectsMissingArguments() {
+    String json =
+        "{\"type\":\"is-null\",\"child\":{\"type\":\"apply\",\"function\":\"year\","
+            + "\"arguments\":[]}}";
+    assertThatThrownBy(() -> ExpressionParser.fromJson(json))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Cannot convert year to a transform: expected 1 argument(s), got 0");
+  }
+
+  @Test
+  public void testUnsupportedLiteralTypeFailsToWrite() {
+    UnboundPredicate<Object> pred =
+        new UnboundPredicate<Object>(
+            Expression.Operation.EQ, Expressions.ref("date"), new LocalDateLiteral());
+    assertThatThrownBy(() -> ExpressionParser.toJson(pred))
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage("Cannot write literal of unsupported type: java.time.LocalDate");
+  }
+
+  /** A literal whose value type is not supported by the JSON writer. */
+  private static class LocalDateLiteral implements Literal<Object> {
+    @Override
+    public Object value() {
+      return LocalDate.parse("2024-01-01");
+    }
+
+    @Override
+    public <X> Literal<X> to(Type type) {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
+
+    @Override
+    public Comparator<Object> comparator() {
+      throw new UnsupportedOperationException("Not used in this test");
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
+++ b/core/src/test/java/org/apache/iceberg/expressions/TestExpressionParser.java
@@ -920,7 +920,7 @@ public class TestExpressionParser {
             + "\"arguments\":[{\"type\":\"reference\",\"name\":\"ts\"},\"yyyy-MM-dd\"]}}";
     UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
     UnboundApply<?> apply = (UnboundApply<?>) parsed.term();
-    assertThat(apply.arguments()).element(1).isEqualTo("yyyy-MM-dd");
+    assertThat(((Literal<?>) apply.arguments().get(1)).value()).isEqualTo("yyyy-MM-dd");
     assertThat(ExpressionParser.toJson(parsed)).isEqualTo(json);
   }
 
@@ -944,7 +944,22 @@ public class TestExpressionParser {
             + "\"arguments\":[{\"type\":\"reference\",\"name\":\"data\"}]}}";
     UnboundPredicate<?> parsed = (UnboundPredicate<?>) ExpressionParser.fromJson(json);
     assertThat(parsed.term()).isInstanceOf(UnboundApply.class);
-    assertThat(((UnboundApply<?>) parsed.term()).isKnownTransform()).isFalse();
+    assertThat(((UnboundApply<?>) parsed.term()).function().name()).isEqualTo("void");
+    assertThat(ExpressionParser.toJson(parsed)).isEqualTo(json);
+  }
+
+  @Test
+  public void testApplyWithBoundReferenceArgument() {
+    Schema schema = new Schema(Types.NestedField.required(1, "data", Types.StringType.get()));
+    UnboundApply<?> apply =
+        Expressions.apply(
+            Expressions.function("my_func"),
+            ImmutableList.of(Expressions.ref("data").bind(schema.asStruct(), false)));
+
+    assertThat(ExpressionParser.toJson(Expressions.notNull(apply)))
+        .isEqualTo(
+            "{\"type\":\"not-null\",\"child\":{\"type\":\"apply\",\"function\":\"my_func\","
+                + "\"arguments\":[{\"type\":\"reference\",\"id\":1}]}}");
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/requests/TestPlanTableScanRequestParser.java
@@ -265,7 +265,7 @@ public class TestPlanTableScanRequestParser {
 
     String expectedJson =
         "{\"snapshot-id\":1,"
-            + "\"filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1},"
+            + "\"filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1},"
             + "\"case-sensitive\":true,"
             + "\"use-snapshot-schema\":false}";
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchPlanningResultResponseParser.java
@@ -203,7 +203,7 @@ public class TestFetchPlanningResultResponseParser {
             + "\"file-format\":\"parquet\",\"partition\":[0],"
             + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
             + "\"delete-file-references\":[0],"
-            + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}]"
+            + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}]"
             + "}";
 
     String json = FetchPlanningResultResponseParser.toJson(response, false);

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchScanTasksResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestFetchScanTasksResponseParser.java
@@ -136,7 +136,7 @@ public class TestFetchScanTasksResponseParser {
             + "\"file-format\":\"parquet\",\"partition\":[0],"
             + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
             + "\"delete-file-references\":[0],"
-            + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}]"
+            + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}]"
             + "}";
 
     String json = FetchScanTasksResponseParser.toJson(response, false);

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -251,7 +251,7 @@ public class TestPlanTableScanResponseParser {
             + "\"file-format\":\"parquet\",\"partition\":[0],"
             + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
             + "\"delete-file-references\":[0],"
-            + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}]"
+            + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}]"
             + "}";
 
     String json = PlanTableScanResponseParser.toJson(response);
@@ -410,7 +410,7 @@ public class TestPlanTableScanResponseParser {
             + "{\"data-file\":{\"spec-id\":0,\"content\":\"data\",\"file-path\":\"/path/to/data-a.parquet\","
             + "\"file-format\":\"parquet\",\"partition\":[0],"
             + "\"file-size-in-bytes\":10,\"record-count\":1,\"sort-order-id\":0},"
-            + "\"residual-filter\":{\"type\":\"eq\",\"term\":\"id\",\"value\":1}}]"
+            + "\"residual-filter\":{\"type\":\"eq\",\"left\":{\"type\":\"reference\",\"name\":\"id\"},\"right\":1}}]"
             + "}";
 
     String json = PlanTableScanResponseParser.toJson(response);
@@ -625,8 +625,11 @@ public class TestPlanTableScanResponseParser {
             + "    \"delete-file-references\" : [ 0 ],\n"
             + "    \"residual-filter\" : {\n"
             + "      \"type\" : \"eq\",\n"
-            + "      \"term\" : \"id\",\n"
-            + "      \"value\" : 1\n"
+            + "      \"left\" : {\n"
+            + "        \"type\" : \"reference\",\n"
+            + "        \"name\" : \"id\"\n"
+            + "      },\n"
+            + "      \"right\" : 1\n"
             + "    }\n"
             + "  } ]\n"
             + "}";


### PR DESCRIPTION
PR Description

## Summary

Updates the Java `ExpressionParser` to serialize predicates in the new
form defined in [`format/expressions-spec.md`](https://github.com/apache/iceberg/blob/main/format/expressions-spec.md#appendix-b-json-serialization),
while continuing to accept the deprecated term-based form for backward
compatibility.

This is the Java-side counterpart to #17138, which updates the REST
OpenAPI spec to the new `Predicate` / `ValueExpression` model.

## Changes

### New model classes (`api` module)
- `FunctionReference` — value class for function references, supporting
  the four spec forms: bare name, name array, `{identifier}`, and
  `{catalog, identifier}`.
- `UnboundApply<T>` — implements `UnboundTerm<T>` to represent general
  function applications. `bind()` delegates to `UnboundTransform` for
  known Iceberg transforms (identity, year, month, day, hour, bucket,
  truncate, void); other functions currently throw at bind time.

### Parser changes (`core` module)
- **Writer** now emits the new form only:
  - Predicates use `child` / `left` / `right` instead of `term` / `value`
  - References serialize as `{"type": "reference", "name": ...}` for
    unbound and `{"type": "reference", "id": N}` for bound
  - Transforms serialize as `apply` with the
    arguments (e.g. `bucket[100](id)` → `{"type": "apply",
    "function": "bucket", "arguments": [100, {"type": "reference",
    "name": "id"}]}`)
- **Reader** detects the format from the payload and accepts both:
  - If a predicate has a `term` field, the deprecated path parses it
    (existing behavior)
  - Otherwise the new path parses `child` / `left` / `right`,
    references (`name` or deprecated `term`), and `apply` expressions
  - Known Iceberg transforms parsed from `apply` are converted back to
    `UnboundTransform` so downstream binding paths are unchanged

### Tests
- Updated existing round-trip and expected-JSON assertions in
  `TestExpressionParser`, `TestPlanTableScanRequestParser`,
  `TestFileScanTaskParser`, `TestPlanTableScanResponseParser`,
  `TestFetchPlanningResultResponseParser`,
  `TestFetchScanTasksResponseParser`,
  `TestAllManifestsTableTaskParser`, and `TestFilesTableTaskParser` to
  the new writer output.
- Added backward-compatibility reader tests for each deprecated
  predicate form (`testReadDeprecatedUnaryPredicate`,
  `testReadDeprecatedComparisonPredicate`,
  `testReadDeprecatedSetPredicate`,
  `testReadDeprecatedTransformPredicate`,
  `testReadDeprecatedObjectReference`).
- Added new-format tests: `testNewFormatRoundTrip`,
  `testApplySimpleFunctionName`, `testApplyWithCatalogFunction`,
  `testNewFormatNamedReference`, `testNewFormatTypedLiteral`.

## Test plan

- [x] `./gradlew :iceberg-api:test`
- [x] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.expressions.*"`
- [x] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.rest.*"`
- [x] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.metrics.*"`
- [x] `./gradlew :iceberg-core:test --tests "org.apache.iceberg.TestFileScanTaskParser"`
- [x] `./gradlew spotlessApply`
