### PR TITLE
Core: Fix pruning for negated all_manifests filters

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -307,7 +307,7 @@ public class AllManifestsTable extends BaseMetadataTable {
     private final Expression boundExpr;
 
     private SnapshotEvaluator(Expression expr, Types.StructType structType, boolean caseSensitive) {
-      this.boundExpr = Binder.bind(structType, expr, caseSensitive);
+      this.boundExpr = Binder.bind(structType, Expressions.rewriteNot(expr), caseSensitive);
     }
 
     private boolean eval(Snapshot snapshot) {
@@ -333,11 +333,6 @@ public class AllManifestsTable extends BaseMetadataTable {
       @Override
       public Boolean alwaysFalse() {
         return ROWS_CANNOT_MATCH;
-      }
-
-      @Override
-      public Boolean not(Boolean result) {
-        return !result;
       }
 
       @Override

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -468,6 +468,129 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void testAllManifestsTableNegatedPredicateOnNonSnapshotColumn() {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(Expressions.not(Expressions.equal("content", ManifestContent.DATA.id())));
+
+    assertThat(scannedPaths(scan))
+        .as("A negated predicate on content must not prune snapshots")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L, 3L, 4L));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableNotEqualPredicateOnNonSnapshotColumn() {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(Expressions.notEqual("content", ManifestContent.DATA.id()));
+
+    assertThat(scannedPaths(scan))
+        .as("A not-equal predicate on content must not prune snapshots")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L, 3L, 4L));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableNegatedOrPredicate() {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    long firstSnapshotId = 1L;
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(
+                Expressions.not(
+                    Expressions.or(
+                        Expressions.equal("reference_snapshot_id", firstSnapshotId),
+                        Expressions.equal("content", ManifestContent.DELETES.id()))));
+
+    /*
+     * NOT(reference_snapshot_id = firstSnapshotId OR content = DELETES)
+     *
+     * is rewritten as:
+     *
+     * reference_snapshot_id != firstSnapshotId
+     *     AND content != DELETES
+     *
+     * The first snapshot can be pruned using reference_snapshot_id.
+     * The content predicate cannot prune the other snapshots because content
+     * is unknown while planning snapshot tasks.
+     */
+    assertThat(scannedPaths(scan))
+        .as("Only the explicitly excluded snapshot should be pruned")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L, 3L, 4L));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableNegatedAndPredicate() {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    long firstSnapshotId = 1L;
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(
+                Expressions.not(
+                    Expressions.and(
+                        Expressions.equal("reference_snapshot_id", firstSnapshotId),
+                        Expressions.equal("content", ManifestContent.DELETES.id()))));
+
+    /*
+     * NOT(reference_snapshot_id = firstSnapshotId AND content = DELETES)
+     *
+     * is rewritten as:
+     *
+     * reference_snapshot_id != firstSnapshotId
+     *     OR content != DELETES
+     *
+     * Even for firstSnapshotId, content != DELETES may match. Therefore,
+     * no snapshot can be safely pruned.
+     */
+    assertThat(scannedPaths(scan))
+        .as("A possibly matching content predicate must keep all snapshots")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 1L, 2L, 3L, 4L));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableNegatedSnapshotOnlyPredicate() {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(
+                Expressions.not(
+                    Expressions.or(
+                        Expressions.equal("reference_snapshot_id", 1L),
+                        Expressions.equal("reference_snapshot_id", 2L))));
+
+    /*
+     * This confirms that rewriteNot does not merely disable pruning.
+     * Both excluded snapshots must still be pruned.
+     */
+    assertThat(scannedPaths(scan))
+        .as("Negated snapshot-only predicates should still prune snapshots")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 3L, 4L));
+  }
+
+  @TestTemplate
   public void testPartitionsTableScanNoFilter() {
     preparePartitionedTable();
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
@@ -204,6 +205,78 @@ public class TestMetadataTables extends ExtensionsTestBase {
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableWithNegatedContentFilters() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    // Create a delete manifest.
+    sql("DELETE FROM %s WHERE id = 1", tableName);
+
+    List<Object[]> expectedDeleteManifests =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content = 1 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertThat(expectedDeleteManifests)
+        .as("Test setup should create at least one delete manifest")
+        .isNotEmpty();
+
+    List<Object[]> notEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content != 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content != 0 should return all delete manifests",
+        expectedDeleteManifests,
+        notEqualResults);
+
+    List<Object[]> alternativeNotEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content <> 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content <> 0 should return all delete manifests",
+        expectedDeleteManifests,
+        alternativeNotEqualResults);
+
+    List<Object[]> explicitNotResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE NOT(content = 0) "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "NOT(content = 0) should return all delete manifests",
+        expectedDeleteManifests,
+        explicitNotResults);
   }
 
   @TestTemplate

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
@@ -204,6 +205,78 @@ public class TestMetadataTables extends ExtensionsTestBase {
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableWithNegatedContentFilters() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    // Create a delete manifest.
+    sql("DELETE FROM %s WHERE id = 1", tableName);
+
+    List<Object[]> expectedDeleteManifests =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content = 1 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertThat(expectedDeleteManifests)
+        .as("Test setup should create at least one delete manifest")
+        .isNotEmpty();
+
+    List<Object[]> notEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content != 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content != 0 should return all delete manifests",
+        expectedDeleteManifests,
+        notEqualResults);
+
+    List<Object[]> alternativeNotEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content <> 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content <> 0 should return all delete manifests",
+        expectedDeleteManifests,
+        alternativeNotEqualResults);
+
+    List<Object[]> explicitNotResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE NOT(content = 0) "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "NOT(content = 0) should return all delete manifests",
+        expectedDeleteManifests,
+        explicitNotResults);
   }
 
   @TestTemplate

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestMetadataTables.java
@@ -65,6 +65,7 @@ import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
 import org.apache.spark.sql.catalyst.util.DateTimeUtils;
 import org.apache.spark.sql.types.StructType;
 import org.junit.jupiter.api.AfterEach;
@@ -204,6 +205,78 @@ public class TestMetadataTables extends ExtensionsTestBase {
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(0), actualFiles.get(0));
     TestHelpers.assertEqualsSafe(
         TestHelpers.nonDerivedSchema(actualFilesDs), expectedFiles.get(1), actualFiles.get(1));
+  }
+
+  @TestTemplate
+  public void testAllManifestsTableWithNegatedContentFilters() throws NoSuchTableException {
+    sql(
+        "CREATE TABLE %s (id bigint, data string) USING iceberg TBLPROPERTIES"
+            + "('format-version'='%s', 'write.delete.mode'='merge-on-read')",
+        tableName, formatVersion);
+
+    List<SimpleRecord> records =
+        Lists.newArrayList(
+            new SimpleRecord(1, "a"), new SimpleRecord(2, "b"), new SimpleRecord(3, "c"));
+
+    spark
+        .createDataset(records, Encoders.bean(SimpleRecord.class))
+        .coalesce(1)
+        .writeTo(tableName)
+        .append();
+
+    // Create a delete manifest.
+    sql("DELETE FROM %s WHERE id = 1", tableName);
+
+    List<Object[]> expectedDeleteManifests =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content = 1 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertThat(expectedDeleteManifests)
+        .as("Test setup should create at least one delete manifest")
+        .isNotEmpty();
+
+    List<Object[]> notEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content != 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content != 0 should return all delete manifests",
+        expectedDeleteManifests,
+        notEqualResults);
+
+    List<Object[]> alternativeNotEqualResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE content <> 0 "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "content <> 0 should return all delete manifests",
+        expectedDeleteManifests,
+        alternativeNotEqualResults);
+
+    List<Object[]> explicitNotResults =
+        sql(
+            "SELECT content, path, reference_snapshot_id "
+                + "FROM %s.all_manifests "
+                + "WHERE NOT(content = 0) "
+                + "ORDER BY path, reference_snapshot_id",
+            tableName);
+
+    assertEquals(
+        "NOT(content = 0) should return all delete manifests",
+        expectedDeleteManifests,
+        explicitNotResults);
   }
 
   @TestTemplate


### PR DESCRIPTION
## Summary

Fixes #17345

Queries against the `all_manifests` metadata table can return incorrect results when a filter contains a negated predicate on a column that cannot be evaluated during snapshot planning.

For example, although delete manifests are present, the following queries will incorrectly return no rows:

```sql
SELECT *
FROM catalog.db.table.all_manifests
WHERE content != 0;
```

```sql
SELECT *
FROM catalog.db.table.all_manifests
WHERE NOT(content = 0);
```

`AllManifestsTable.SnapshotEvaluator` is a may-match evaluator. Predicates on columns other than `reference_snapshot_id` conservatively return `true` because matching manifest rows may exist. Negating that result directly changes `true` to `false` and incorrectly prunes the snapshot.

## Changes

- Rewrite `NOT` expressions before binding filters in `AllManifestsTable.SnapshotEvaluator`.
- Preserve conservative evaluation for predicates that cannot be evaluated during snapshot planning.
- Preserve snapshot pruning for predicates on `reference_snapshot_id`.
- Add core regression tests for:
  - negated predicates on non-snapshot columns;
  - negated `OR` predicates containing known and unknown values;
  - negated `AND` predicates containing known and unknown values;
  - negated snapshot-only predicates.
- Add Spark 3.5, 4.0, 4.1 SQL regression coverage for:
  - `content != 0`;
  - `content <> 0`;
  - `NOT(content = 0)`.

## Why this fixes the issue

The evaluator previously handled an expression such as:

```text
NOT(content = 0)
```

as:

```text
content = 0        -> true because rows might match
NOT(content = 0)   -> false
```

The `false` result caused the snapshot to be incorrectly pruned.

Rewriting the expression first converts it to:

```text
noteq
```
then leverage the noteq evaluator to do the filter.

The evaluator then conservatively keeps the snapshot because `content` cannot be determined while planning snapshot tasks.

Rewriting also preserves valid pruning for predicates that only reference `reference_snapshot_id`.