### PR TITLE
Spark 4.1: Add streaming-merge-append-enabled write config

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -268,6 +268,7 @@ df.writeTo("catalog.db.table")
 | delete-granularity | file | Override this table's delete granularity for this write |
 | shred-variants | false | Overrides this table's write.parquet.shred-variants for this write |
 | variant-inference-buffer-size | 100 | Overrides this table's write.parquet.variant-inference-buffer-size for this write |
+| streaming-merge-append-enabled | false | Use a merge append instead of a fast append for streaming appends, so manifests are merged on commit rather than accumulating as small manifests |
 
 CommitMetadata provides an interface to add custom metadata to a snapshot summary during a SQL execution, which can be beneficial for purposes such as auditing or change tracking. If properties start with `snapshot-property.`, then that prefix will be removed from each property. Here is an example:
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -244,6 +244,14 @@ public class SparkWriteConf {
         .parse();
   }
 
+  public boolean streamingMergeAppendEnabled() {
+    return confParser
+        .booleanConf()
+        .option(SparkWriteOptions.STREAMING_MERGE_APPEND_ENABLED)
+        .defaultValue(SparkWriteOptions.STREAMING_MERGE_APPEND_ENABLED_DEFAULT)
+        .parse();
+  }
+
   public FileFormat deleteFileFormat() {
     if (!(table instanceof BaseMetadataTable) && TableUtil.formatVersion(table) >= 3) {
       return FileFormat.PUFFIN;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteOptions.java
@@ -92,4 +92,8 @@ public class SparkWriteOptions {
 
   // Controls the buffer size for variant schema inference during writes
   public static final String VARIANT_INFERENCE_BUFFER_SIZE = "variant-inference-buffer-size";
+
+  // Uses the merge append instead of fast append for streaming appends
+  public static final String STREAMING_MERGE_APPEND_ENABLED = "streaming-merge-append-enabled";
+  public static final boolean STREAMING_MERGE_APPEND_ENABLED_DEFAULT = false;
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -110,6 +110,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
   private final StructType dsSchema;
   private final Map<String, String> extraSnapshotMetadata;
   private final boolean useFanoutWriter;
+  private final boolean streamingMergeAppendEnabled;
   private final SparkWriteRequirements writeRequirements;
   private final Map<String, String> writeProperties;
 
@@ -140,6 +141,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
     this.dsSchema = dsSchema;
     this.extraSnapshotMetadata = writeConf.extraSnapshotMetadata();
     this.useFanoutWriter = writeConf.useFanoutWriter(writeRequirements);
+    this.streamingMergeAppendEnabled = writeConf.streamingMergeAppendEnabled();
     this.writeRequirements = writeRequirements;
     this.outputSpecId = writeConf.outputSpecId();
     this.writeProperties = writeConf.writeProperties();
@@ -634,7 +636,8 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     protected void doCommit(long epochId, WriterCommitMessage[] messages) {
-      AppendFiles append = table.newFastAppend();
+      AppendFiles append =
+          streamingMergeAppendEnabled ? table.newAppend() : table.newFastAppend();
       int numFiles = 0;
       for (DataFile file : files(messages)) {
         append.appendFile(file);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkWrite.java
@@ -636,8 +636,7 @@ abstract class SparkWrite extends BaseSparkWrite implements Write, RequiresDistr
 
     @Override
     protected void doCommit(long epochId, WriterCommitMessage[] messages) {
-      AppendFiles append =
-          streamingMergeAppendEnabled ? table.newAppend() : table.newFastAppend();
+      AppendFiles append = streamingMergeAppendEnabled ? table.newAppend() : table.newFastAppend();
       int numFiles = 0;
       for (DataFile file : files(messages)) {
         append.appendFile(file);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -34,10 +34,12 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.hadoop.HadoopTables;
 import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkWriteOptions;
 import org.apache.iceberg.spark.TestBase;
 import org.apache.iceberg.types.Types;
 import org.apache.spark.sql.Dataset;
@@ -139,6 +141,71 @@ public class TestStructuredStreaming {
 
       assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
       assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
+    } finally {
+      for (StreamingQuery query : spark.streams().active()) {
+        query.stop();
+      }
+    }
+  }
+
+  @Test
+  public void testStreamingWriteAppendModeWithMergeAppend() throws Exception {
+    File parent = temp.resolve("parquet").toFile();
+    File location = new File(parent, "test-table");
+    File checkpoint = new File(parent, "checkpoint");
+
+    HadoopTables tables = new HadoopTables(CONF);
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    // set a low min-count-to-merge so the merge append visibly consolidates manifests
+    Table table =
+        tables.create(
+            SCHEMA,
+            spec,
+            ImmutableMap.of(TableProperties.MANIFEST_MIN_MERGE_COUNT, "2"),
+            location.toString());
+
+    List<SimpleRecord> expected =
+        Lists.newArrayList(
+            new SimpleRecord(1, "1"),
+            new SimpleRecord(2, "2"),
+            new SimpleRecord(3, "3"),
+            new SimpleRecord(4, "4"));
+
+    MemoryStream<Integer> inputStream = newMemoryStream(1, spark, Encoders.INT());
+    DataStreamWriter<Row> streamWriter =
+        inputStream
+            .toDF()
+            .selectExpr("value AS id", "CAST (value AS STRING) AS data")
+            .writeStream()
+            .outputMode("append")
+            .format("iceberg")
+            .option("checkpointLocation", checkpoint.toString())
+            .option("path", location.toString())
+            .option(SparkWriteOptions.STREAMING_MERGE_APPEND_ENABLED, "true");
+
+    try {
+      StreamingQuery query = streamWriter.start();
+      List<Integer> batch1 = Lists.newArrayList(1, 2);
+      send(batch1, inputStream);
+      query.processAllAvailable();
+      List<Integer> batch2 = Lists.newArrayList(3, 4);
+      send(batch2, inputStream);
+      query.processAllAvailable();
+      query.stop();
+
+      Dataset<Row> result = spark.read().format("iceberg").load(location.toString());
+      List<SimpleRecord> actual =
+          result.orderBy("id").as(Encoders.bean(SimpleRecord.class)).collectAsList();
+
+      assertThat(actual).hasSameSizeAs(expected).isEqualTo(expected);
+      assertThat(table.snapshots()).as("Number of snapshots should match").hasSize(2);
+
+      // the second streaming append uses the regular append, which merges the two data manifests
+      // into a single manifest; a fast append would have left two separate manifests
+      table.refresh();
+      assertThat(table.currentSnapshot().dataManifests(table.io()))
+          .as("Merge append should consolidate data manifests")
+          .hasSize(1);
     } finally {
       for (StreamingQuery query : spark.streams().active()) {
         query.stop();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreaming.java
@@ -202,7 +202,6 @@ public class TestStructuredStreaming {
 
       // the second streaming append uses the regular append, which merges the two data manifests
       // into a single manifest; a fast append would have left two separate manifests
-      table.refresh();
       assertThat(table.currentSnapshot().dataManifests(table.io()))
           .as("Merge append should consolidate data manifests")
           .hasSize(1);


### PR DESCRIPTION
Add a Spark write configuration that makes streaming appends use the regular merge append instead of fast append when enabled. Defaults to false, preserving existing fast-append behavior.

The rationale here is that as of today fast appends produces many tiny manifests, and there are Spark Streaming commit intervals where the latency of merging manifests is a negligible cost compared to the maintenance and read burden (and metadata bloat/footprint). This is a metadata equivalent to a lot of the read/write tradeoff analysis we did for DVs and equality deletes, where the notion of a "cheap write" ends up being compromised when there isn't very aggressive maintenance (which oftentimes there isn't).

Furthermore streaming engine integrations like Flink and Kafka Connect today use merge appends so I think there's general precedent that this is probably good enough for the streaming workloads Spark Streaming and Iceberg is capable of handling today, especially if it's opt in. 

Especially since going forward in V4, we're addressing these cases in a much better way at the table format level (achieving fast appends without all the metadata bloat of small manifests)

I do think at some point we should flip this default (a future release version), but in the interim to prevent any unforseen regressions on upgrade, I think it makes sense to default to false.