### PR TITLE
Doc: Fix incorrect weight value description for range-distribution-sort-key-base-weight in Flink

### DIFF
--- a/docs/docs/flink-configuration.md
+++ b/docs/docs/flink-configuration.md
@@ -181,7 +181,7 @@ than a threshold (currently 10,000), statistics are automatically switched to Sk
 
 If sort order contains partition columns, each sort key would map to one partition and data
 file. This relative weight can avoid placing too many small files for sort keys with low
-traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
 each key has a base weight of `2%` of the targeted traffic weight per writer task.
 
 E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream
@@ -193,7 +193,7 @@ task would be `1,000`. Assume the weight sum for the oldest 150 days is `1,000`.
 the range partitioner would put all the oldest 150 days in one writer task. That writer task
 would write to 150 small files (one per day). Keeping 150 open files can potentially consume
 large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
 base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
 avoid placing more than `50` data files (one per day) on one writer task no matter how small
 they are.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -309,7 +309,7 @@ public class FlinkSink {
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream
@@ -321,7 +321,7 @@ public class FlinkSink {
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -531,7 +531,7 @@ public class IcebergSink
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream
@@ -543,7 +543,7 @@ public class IcebergSink
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -310,7 +310,7 @@ public class FlinkSink {
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream
@@ -322,7 +322,7 @@ public class FlinkSink {
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -531,7 +531,7 @@ public class IcebergSink
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream
@@ -543,7 +543,7 @@ public class IcebergSink
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -310,7 +310,7 @@ public class FlinkSink {
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/FlinkSink.java
@@ -322,7 +322,7 @@ public class FlinkSink {
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -543,7 +543,7 @@ public class IcebergSink
      * the range partitioner would put all the oldest 150 days in one writer task. That writer task
      * would write to 150 small files (one per day). Keeping 150 open files can potentially consume
      * large amount of memory. Flushing and uploading 150 files (however small) at checkpoint time
-     * can also be potentially slow. If this config is set to `0.02`. It means every sort key has a
+     * can also be potentially slow. If this config is set to `2.0`. It means every sort key has a
      * base weight of `2%` of targeted weight of `1,000` for every write task. It would essentially
      * avoid placing more than `50` data files (one per day) on one writer task no matter how small
      * they are.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -531,7 +531,7 @@ public class IcebergSink
     /**
      * If sort order contains partition columns, each sort key would map to one partition and data
      * file. This relative weight can avoid placing too many small files for sort keys with low
-     * traffic. It is a double value that defines the minimal weight for each sort key. `0.02` means
+     * traffic. It is a double value that defines the minimal weight for each sort key. `2.0` means
      * each key has a base weight of `2%` of the targeted traffic weight per writer task.
      *
      * <p>E.g. the sink Iceberg table is partitioned daily by event time. Assume the data stream


### PR DESCRIPTION
The documented value `0.02` is inconsistent with the actual weighting logic in MapAssignment, where the value is divided by 100 (`closeFileCostWeightPercentage / 100`). `rangeDistributionSortKeyBaseWeight` will be directly assigned to `closeFileCostWeightPercentage`.

https://github.com/apache/iceberg/blob/8de28da314ec2f13251dac8b7dc0c7de1f899d2e/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/shuffle/MapAssignment.java#L129-133



To represent 2%, users should set `2.0`, not `0.02`. This fixes the incorrect weight value in the documentation.
