### PR TITLE
Parquet: Backport variant BINARY upper bound fix (#16880) to 1.10.x

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetVariantUtil.java
@@ -367,7 +367,7 @@ class ParquetVariantUtil {
           return truncatedString != null ? Variants.of(PhysicalType.STRING, truncatedString) : null;
         case BINARY:
           ByteBuffer truncatedBuffer =
-              BinaryUtil.truncateBinaryMin((ByteBuffer) value.asPrimitive().get(), 16);
+              BinaryUtil.truncateBinaryMax((ByteBuffer) value.asPrimitive().get(), 16);
           return truncatedBuffer != null ? Variants.of(PhysicalType.BINARY, truncatedBuffer) : null;
         default:
           return value;

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantMetrics.java
@@ -217,6 +217,56 @@ public class TestVariantMetrics {
   }
 
   @Test
+  public void testShreddedBinaryBoundsTruncation() throws IOException {
+    // binary longer than the 16-byte truncation length so the bounds are truncated
+    byte[] bytes = new byte[20];
+    for (int i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (byte) (i + 1);
+    }
+    VariantValue value = Variants.of(ByteBuffer.wrap(bytes));
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMin(ByteBuffer.wrap(bytes), 16)));
+
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMax(ByteBuffer.wrap(bytes), 16)));
+  }
+
+  @Test
+  public void testShreddedBinaryUpperBoundOverflow() throws IOException {
+    // an all-0xFF binary cannot be truncated up so the upper bound is omitted
+    byte[] bytes = new byte[20];
+    for (int i = 0; i < bytes.length; i += 1) {
+      bytes[i] = (byte) 0xFF;
+    }
+    VariantValue value = Variants.of(ByteBuffer.wrap(bytes));
+
+    Metrics metrics =
+        writeParquet(
+            (id, name) -> ParquetVariantUtil.toParquetSchema(value),
+            Variant.of(EMPTY, value),
+            Variant.of(EMPTY, Variants.ofNull()),
+            null);
+
+    assertThat(metrics.lowerBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isEqualTo(Variants.of(BinaryUtil.truncateBinaryMin(ByteBuffer.wrap(bytes), 16)));
+
+    assertThat(metrics.upperBounds().get(2))
+        .extracting(b -> Variant.from(b).value().asObject().get(ROOT_FIELD))
+        .isNull();
+  }
+
+  @Test
   public void testVariantFloatNaN() throws IOException {
     // NaN values are not counted because there is no ID for FieldMetrics
     VariantValue floatValue = Variants.of(1.0F);


### PR DESCRIPTION
  Backports #16880 to the 1.10.x release branch.

  Fixes a silent wrong-results bug where the variant shredded BINARY upper
  bound truncated down instead of up, so file-skipping stats could exclude
  files that actually contain matching data.

  (cherry picked from commit 470f4642bdda336bac5372c79c762a2654dfe3f3)