### PR TITLE
Flink: Backport Avoid unnecessary TableLoader.loadTable() in IcebergCommitter subtasks > 0 to 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -79,6 +79,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   private ExecutorService workerPool;
   private int continuousEmptyCheckpoints = 0;
   private final boolean tableMaintenanceEnabled;
+  private final int subtaskId;
 
   IcebergCommitter(
       TableLoader tableLoader,
@@ -88,31 +89,45 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       int workerPoolSize,
       String sinkId,
       IcebergFilesCommitterMetrics committerMetrics,
-      boolean tableMaintenanceEnabled) {
+      boolean tableMaintenanceEnabled,
+      int subtaskId) {
     this.branch = branch;
     this.snapshotProperties = snapshotProperties;
     this.replacePartitions = replacePartitions;
     this.committerMetrics = committerMetrics;
     this.tableLoader = tableLoader;
-    if (!tableLoader.isOpen()) {
-      tableLoader.open();
+    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
+    this.subtaskId = subtaskId;
+
+    // IcebergSink#addPreCommitTopology routes all committables to subtask 0 via a .global()
+    // shuffle, so only subtask 0 needs to load the table and create the worker pool.
+    if (subtaskId == 0) {
+      if (!tableLoader.isOpen()) {
+        tableLoader.open();
+      }
+
+      this.table = tableLoader.loadTable();
+      this.maxContinuousEmptyCommits =
+          PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+      Preconditions.checkArgument(
+          maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+      this.workerPool =
+          ThreadPools.newFixedThreadPool(
+              "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     }
 
-    this.table = tableLoader.loadTable();
-    this.maxContinuousEmptyCommits =
-        PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
-    Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
-    this.workerPool =
-        ThreadPools.newFixedThreadPool(
-            "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
-    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
   }
 
   @Override
   public void commit(Collection<CommitRequest<IcebergCommittable>> commitRequests)
       throws IOException, InterruptedException {
+    Preconditions.checkState(
+        subtaskId == 0,
+        "IcebergCommitter received %s commit request(s) on subtask %s, but only subtask 0 is expected to commit.",
+        commitRequests.size(),
+        subtaskId);
+
     if (commitRequests.isEmpty()) {
       return;
     }
@@ -311,7 +326,12 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
 
   @Override
   public void close() throws IOException {
-    tableLoader.close();
-    workerPool.shutdown();
+    if (tableLoader.isOpen()) {
+      tableLoader.close();
+    }
+
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
   }
 }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -249,7 +249,8 @@ public class IcebergSink
         workerPoolSize,
         sinkId,
         metrics,
-        maintenanceEnabled);
+        maintenanceEnabled,
+        context.getTaskInfo().getIndexOfThisSubtask());
   }
 
   @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommitt
 import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
 import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -1166,6 +1167,48 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testCommitterSubtaskZeroCommits() throws Exception {
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 0)) {
+      testHarness.open();
+
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "subtask-zero");
+      DataFile dataFile = writeDataFile("data-subtask-zero", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
+
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+      // subtask 0 loaded the table and performed the commit end-to-end.
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(row), branch);
+      assertSnapshotSize(1);
+      assertMaxCommittedCheckpointId(jobId, checkpointId);
+    }
+  }
+
+  @TestTemplate
+  public void testCommitOnNonZeroSubtaskFailsFast() throws Exception {
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 1)) {
+      testHarness.open();
+
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "should-not-commit");
+      DataFile dataFile = writeDataFile("data-non-zero-subtask", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
+
+      assertThatThrownBy(() -> testHarness.notifyOfCompletedCheckpoint(checkpointId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("only subtask 0 is expected to commit");
+
+      // No snapshot should have been produced because the commit failed fast.
+      assertSnapshotSize(0);
+    }
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =
@@ -1293,6 +1336,12 @@ class TestIcebergCommitter extends TestBase {
   private OneInputStreamOperatorTestHarness<
           CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
       getTestHarness() throws Exception {
+    return getTestHarness(1, 0);
+  }
+
+  private OneInputStreamOperatorTestHarness<
+          CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+      getTestHarness(int parallelism, int subtaskIndex) throws Exception {
     IcebergSink sink =
         IcebergSink.forRowData(null).table(table).toBranch(branch).tableLoader(tableLoader).build();
 
@@ -1300,7 +1349,10 @@ class TestIcebergCommitter extends TestBase {
             CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
         testHarness =
             new OneInputStreamOperatorTestHarness<>(
-                new CommitterOperatorFactory<>(sink, !isStreamingMode, true));
+                new CommitterOperatorFactory<>(sink, !isStreamingMode, true),
+                parallelism,
+                parallelism,
+                subtaskIndex);
     testHarness.setup(committableMessageTypeSerializer);
     return testHarness;
   }
@@ -1317,7 +1369,8 @@ class TestIcebergCommitter extends TestBase {
         10,
         "sinkId",
         metric,
-        false);
+        false,
+        0);
   }
 
   private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergCommitter.java
@@ -79,6 +79,7 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
   private ExecutorService workerPool;
   private int continuousEmptyCheckpoints = 0;
   private final boolean tableMaintenanceEnabled;
+  private final int subtaskId;
 
   IcebergCommitter(
       TableLoader tableLoader,
@@ -88,31 +89,45 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
       int workerPoolSize,
       String sinkId,
       IcebergFilesCommitterMetrics committerMetrics,
-      boolean tableMaintenanceEnabled) {
+      boolean tableMaintenanceEnabled,
+      int subtaskId) {
     this.branch = branch;
     this.snapshotProperties = snapshotProperties;
     this.replacePartitions = replacePartitions;
     this.committerMetrics = committerMetrics;
     this.tableLoader = tableLoader;
-    if (!tableLoader.isOpen()) {
-      tableLoader.open();
+    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
+    this.subtaskId = subtaskId;
+
+    // IcebergSink#addPreCommitTopology routes all committables to subtask 0 via a .global()
+    // shuffle, so only subtask 0 needs to load the table and create the worker pool.
+    if (subtaskId == 0) {
+      if (!tableLoader.isOpen()) {
+        tableLoader.open();
+      }
+
+      this.table = tableLoader.loadTable();
+      this.maxContinuousEmptyCommits =
+          PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
+      Preconditions.checkArgument(
+          maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
+      this.workerPool =
+          ThreadPools.newFixedThreadPool(
+              "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     }
 
-    this.table = tableLoader.loadTable();
-    this.maxContinuousEmptyCommits =
-        PropertyUtil.propertyAsInt(table.properties(), MAX_CONTINUOUS_EMPTY_COMMITS, 10);
-    Preconditions.checkArgument(
-        maxContinuousEmptyCommits > 0, MAX_CONTINUOUS_EMPTY_COMMITS + " must be positive");
-    this.workerPool =
-        ThreadPools.newFixedThreadPool(
-            "iceberg-committer-pool-" + table.name() + "-" + sinkId, workerPoolSize);
     this.continuousEmptyCheckpoints = 0;
-    this.tableMaintenanceEnabled = tableMaintenanceEnabled;
   }
 
   @Override
   public void commit(Collection<CommitRequest<IcebergCommittable>> commitRequests)
       throws IOException, InterruptedException {
+    Preconditions.checkState(
+        subtaskId == 0,
+        "IcebergCommitter received %s commit request(s) on subtask %s, but only subtask 0 is expected to commit.",
+        commitRequests.size(),
+        subtaskId);
+
     if (commitRequests.isEmpty()) {
       return;
     }
@@ -311,7 +326,12 @@ class IcebergCommitter implements Committer<IcebergCommittable> {
 
   @Override
   public void close() throws IOException {
-    tableLoader.close();
-    workerPool.shutdown();
+    if (tableLoader.isOpen()) {
+      tableLoader.close();
+    }
+
+    if (workerPool != null) {
+      workerPool.shutdown();
+    }
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/IcebergSink.java
@@ -249,7 +249,8 @@ public class IcebergSink
         workerPoolSize,
         sinkId,
         metrics,
-        maintenanceEnabled);
+        maintenanceEnabled,
+        context.getTaskInfo().getIndexOfThisSubtask());
   }
 
   @Override

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -23,6 +23,7 @@ import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommitt
 import static org.apache.iceberg.flink.sink.SinkTestUtil.extractAndAssertCommittableWithLineage;
 import static org.apache.iceberg.flink.sink.SinkTestUtil.transformsToStreamElement;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
@@ -1156,6 +1157,48 @@ class TestIcebergCommitter extends TestBase {
     }
   }
 
+  @TestTemplate
+  public void testCommitterSubtaskZeroCommits() throws Exception {
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 0)) {
+      testHarness.open();
+
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "subtask-zero");
+      DataFile dataFile = writeDataFile("data-subtask-zero", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
+
+      testHarness.notifyOfCompletedCheckpoint(checkpointId);
+
+      // subtask 0 loaded the table and performed the commit end-to-end.
+      SimpleDataUtil.assertTableRows(table, ImmutableList.of(row), branch);
+      assertSnapshotSize(1);
+      assertMaxCommittedCheckpointId(jobId, checkpointId);
+    }
+  }
+
+  @TestTemplate
+  public void testCommitOnNonZeroSubtaskFailsFast() throws Exception {
+    try (OneInputStreamOperatorTestHarness<
+            CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+        testHarness = getTestHarness(2, 1)) {
+      testHarness.open();
+
+      long checkpointId = 1L;
+      RowData row = SimpleDataUtil.createRowData(1, "should-not-commit");
+      DataFile dataFile = writeDataFile("data-non-zero-subtask", ImmutableList.of(row));
+      processElement(jobId, checkpointId, testHarness, 1, OPERATOR_ID, dataFile);
+
+      assertThatThrownBy(() -> testHarness.notifyOfCompletedCheckpoint(checkpointId))
+          .isInstanceOf(IllegalStateException.class)
+          .hasMessageContaining("only subtask 0 is expected to commit");
+
+      // No snapshot should have been produced because the commit failed fast.
+      assertSnapshotSize(0);
+    }
+  }
+
   private ManifestFile createTestingManifestFile(Path manifestPath, DataFile dataFile)
       throws IOException {
     ManifestWriter<DataFile> writer =
@@ -1283,6 +1326,12 @@ class TestIcebergCommitter extends TestBase {
   private OneInputStreamOperatorTestHarness<
           CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
       getTestHarness() throws Exception {
+    return getTestHarness(1, 0);
+  }
+
+  private OneInputStreamOperatorTestHarness<
+          CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
+      getTestHarness(int parallelism, int subtaskIndex) throws Exception {
     IcebergSink sink =
         IcebergSink.forRowData(null).table(table).toBranch(branch).tableLoader(tableLoader).build();
 
@@ -1290,7 +1339,10 @@ class TestIcebergCommitter extends TestBase {
             CommittableMessage<IcebergCommittable>, CommittableMessage<IcebergCommittable>>
         testHarness =
             new OneInputStreamOperatorTestHarness<>(
-                new CommitterOperatorFactory<>(sink, !isStreamingMode, true));
+                new CommitterOperatorFactory<>(sink, !isStreamingMode, true),
+                parallelism,
+                parallelism,
+                subtaskIndex);
     testHarness.setup(committableMessageTypeSerializer);
     return testHarness;
   }
@@ -1307,7 +1359,8 @@ class TestIcebergCommitter extends TestBase {
         10,
         "sinkId",
         metric,
-        false);
+        false,
+        0);
   }
 
   private Committer.CommitRequest<IcebergCommittable> buildCommitRequestFor(


### PR DESCRIPTION
This is a clean backport for https://github.com/apache/iceberg/pull/17251