### PR TITLE
Core: Disallow adding and removing the same file in a rewrite files commit

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteFiles.java
@@ -152,5 +152,12 @@ class BaseRewriteFiles extends MergingSnapshotProducer<RewriteFiles> implements 
     Preconditions.checkArgument(
         deletesDeleteFiles() || !addsDeleteFiles(),
         "Delete files to add must be empty because there's no delete file to be rewritten");
+
+    for (DataFile added : addedDataFiles()) {
+      Preconditions.checkArgument(
+          !replacedDataFiles.contains(added),
+          "Cannot add and delete the same file in the same rewrite: %s",
+          added.location());
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteFiles.java
@@ -173,6 +173,22 @@ public class TestRewriteFiles extends TestBase {
   }
 
   @TestTemplate
+  public void addingAndDeletingSameFileDisallowed() {
+    assertThat(listManifestFiles()).isEmpty();
+
+    commit(table, table.newAppend().appendFile(FILE_A).appendFile(FILE_B), branch);
+
+    assertThatThrownBy(
+            () ->
+                apply(
+                    table.newRewrite().rewriteFiles(Sets.newSet(FILE_A), Sets.newSet(FILE_A)),
+                    branch))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot add and delete the same file in the same rewrite: " + FILE_A.location());
+  }
+
+  @TestTemplate
   public void testDeleteWithDuplicateEntriesInManifest() {
     assertThat(listManifestFiles()).isEmpty();
 

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -59,6 +60,7 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
+  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -310,10 +312,13 @@ class TestMonitorSource extends OperatorTestBase {
     // Create a DataOperations.REPLACE snapshot
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
+    // Replace the file with a new file to produce a REPLACE snapshot
+    DataFile replacement =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
+            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
-    // Replace the file with itself for testing purposes
     rewrite.deleteFile(dataFile);
-    rewrite.addFile(dataFile);
+    rewrite.addFile(replacement);
     rewrite.commit();
 
     // Check that the rewrite is ignored

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -39,13 +39,13 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -60,7 +60,6 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
-  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -313,9 +312,7 @@ class TestMonitorSource extends OperatorTestBase {
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
     // Replace the file with a new file to produce a REPLACE snapshot
-    DataFile replacement =
-        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
-            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
+    DataFile replacement = FileGenerationUtil.generateDataFile(table, null);
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
     rewrite.deleteFile(dataFile);
     rewrite.addFile(replacement);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -45,13 +45,13 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -66,7 +66,6 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
-  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -321,9 +320,7 @@ class TestMonitorSource extends OperatorTestBase {
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
     // Replace the file with a new file to produce a REPLACE snapshot
-    DataFile replacement =
-        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
-            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
+    DataFile replacement = FileGenerationUtil.generateDataFile(table, null);
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
     rewrite.deleteFile(dataFile);
     rewrite.addFile(replacement);

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -65,6 +66,7 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
+  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -318,10 +320,13 @@ class TestMonitorSource extends OperatorTestBase {
     // Create a DataOperations.REPLACE snapshot
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
+    // Replace the file with a new file to produce a REPLACE snapshot
+    DataFile replacement =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
+            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
-    // Replace the file with itself for testing purposes
     rewrite.deleteFile(dataFile);
-    rewrite.addFile(dataFile);
+    rewrite.addFile(replacement);
     rewrite.commit();
 
     // Check that the rewrite is ignored

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -45,13 +45,13 @@ import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileGenerationUtil;
 import org.apache.iceberg.RewriteFiles;
 import org.apache.iceberg.SnapshotChanges;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
-import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -66,7 +66,6 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
-  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -321,9 +320,7 @@ class TestMonitorSource extends OperatorTestBase {
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
     // Replace the file with a new file to produce a REPLACE snapshot
-    DataFile replacement =
-        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
-            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
+    DataFile replacement = FileGenerationUtil.generateDataFile(table, null);
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
     rewrite.deleteFile(dataFile);
     rewrite.addFile(replacement);

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/operator/TestMonitorSource.java
@@ -51,6 +51,7 @@ import org.apache.iceberg.Table;
 import org.apache.iceberg.data.GenericAppenderHelper;
 import org.apache.iceberg.data.RandomGenericData;
 import org.apache.iceberg.data.Record;
+import org.apache.iceberg.flink.SimpleDataUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.awaitility.Awaitility;
@@ -65,6 +66,7 @@ class TestMonitorSource extends OperatorTestBase {
   private static final RateLimiterStrategy LOW_RATE = RateLimiterStrategy.perSecond(1.0 / 10000.0);
 
   @TempDir private File checkpointDir;
+  @TempDir private java.nio.file.Path dataDir;
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
@@ -318,10 +320,13 @@ class TestMonitorSource extends OperatorTestBase {
     // Create a DataOperations.REPLACE snapshot
     DataFile dataFile =
         SnapshotChanges.builderFor(table).build().addedDataFiles().iterator().next();
+    // Replace the file with a new file to produce a REPLACE snapshot
+    DataFile replacement =
+        new GenericAppenderHelper(table, FileFormat.PARQUET, dataDir)
+            .writeFile(Lists.newArrayList(SimpleDataUtil.createRecord(2, "b")));
     RewriteFiles rewrite = tableLoader.loadTable().newRewrite();
-    // Replace the file with itself for testing purposes
     rewrite.deleteFile(dataFile);
-    rewrite.addFile(dataFile);
+    rewrite.addFile(replacement);
     rewrite.commit();
 
     // Check that the rewrite is ignored


### PR DESCRIPTION
Relates to https://github.com/apache/iceberg/pull/17198

Currently rewrite files allows us to add and remove the same file in a commit. Arguably this is incorrect, as it's an issue with change detection (whether the file was truly added or removed in that commit is ambiguous). It also can lead to ambiguity in file cleanup (though not in the reference implementation's file cleanup since it does a full a reachability analysis).