### PR TITLE
API: Add test for DateTimeUtil.formatTimestampMillis

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestDateTimeUtil.java
@@ -123,4 +123,15 @@ public class TestDateTimeUtil {
     assertThat(DateTimeUtil.millisFromTimestamp(LocalDateTime.parse("1970-01-01T00:00")))
         .isEqualTo(0L);
   }
+
+  @Test
+  public void formatTimestampMillis() {
+    assertThat(DateTimeUtil.formatTimestampMillis(1510871468000L))
+        .isEqualTo("2017-11-16T22:31:08+00:00");
+    assertThat(DateTimeUtil.formatTimestampMillis(1510871468123L))
+        .isEqualTo("2017-11-16T22:31:08.123+00:00");
+    assertThat(DateTimeUtil.formatTimestampMillis(0L)).isEqualTo("1970-01-01T00:00:00+00:00");
+    assertThat(DateTimeUtil.formatTimestampMillis(-1510871468000L))
+        .isEqualTo("1922-02-15T01:28:52+00:00");
+  }
 }


### PR DESCRIPTION
`DateTimeUtil.formatTimestampMillis` is a public helper used to build user-facing timestamps in error messages (e.g. in `RemoveSnapshots`), but it had no direct unit test. This adds a focused JUnit5 + AssertJ test covering whole-second, fractional-millisecond, epoch, and pre-epoch (negative) values. Expected strings were verified against the actual implementation on a JVM. Test-only; no production code changed.