### PR TITLE
Core: Remove redundant toString() in NoSuchTableException message

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -537,7 +537,7 @@ public class CatalogHandlers {
       return LoadTableResponse.builder().withTableMetadata(metadata).build();
     } else if (table instanceof BaseMetadataTable) {
       // metadata tables are loaded on the client side, return NoSuchTableException for now
-      throw new NoSuchTableException("Table does not exist: %s", ident.toString());
+      throw new NoSuchTableException("Table does not exist: %s", ident);
     }
 
     throw new IllegalStateException("Cannot wrap catalog that does not produce BaseTable");


### PR DESCRIPTION
"`NoSuchTableException` formats its message with `%s`, so passing `ident.toString()` is redundant. The three sibling call sites in `CatalogHandlers` (`dropTable`, `purgeTable`, `tableExists`) already pass the identifier directly; this aligns the remaining one for consistency. Byte-identical output; behavior-preserving.