### PR TITLE
REST: Add specific-name to UDF definition

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -1764,6 +1764,11 @@ class FunctionDefinition(BaseModel):
         alias='definition-id',
         description='A canonical string derived from the parameter types, formatted as a comma-separated list with no spaces.',
     )
+    specific_name: str | None = Field(
+        None,
+        alias='specific-name',
+        description='A user-assignable name for this definition that must be unique among all definitions within the UDF metadata.',
+    )
     parameters: list[FunctionParameter] = Field(
         ...,
         description='Ordered list of function parameters. Invocation order must match this list.',

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -4520,6 +4520,9 @@ components:
         definition-id:
           type: string
           description: A canonical string derived from the parameter types, formatted as a comma-separated list with no spaces.
+        specific-name:
+          type: string
+          description: A user-assignable name for this definition that must be unique among all definitions within the UDF metadata.
         parameters:
           type: array
           description: Ordered list of function parameters. Invocation order must match this list.


### PR DESCRIPTION
Adds the optional `specific-name` field to the `FunctionDefinition` schema in the REST catalog OpenAPI spec, aligning it with the UDF specification.

`specific-name` was added to the UDF spec in #16727 as an optional, user-assignable name for a single definition, analogous to the SQL standard's routine *specific name*. It gives a definition a stable handle that is independent of its signature, for statements such as `DROP SPECIFIC FUNCTION`. When present, it must be unique among all definitions within the UDF metadata.

The field is optional and is therefore not added to the `required` list. `rest-catalog-open-api.py` is regenerated accordingly.

