### PR TITLE
Kafka Connect: Harden commit coordinator (fencing, recovery, dedup, retryable commits)

### DIFF
--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/IntegrationTestBase.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/IntegrationTestBase.java
@@ -225,7 +225,7 @@ public abstract class IntegrationTestBase {
     flush();
 
     Awaitility.await()
-        .atMost(Duration.ofSeconds(30))
+        .atMost(Duration.ofSeconds(60))
         .pollInterval(Duration.ofSeconds(1))
         .untilAsserted(() -> assertSnapshotAdded(tableIdentifiers));
   }

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestIntegrationDynamicTable.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/TestIntegrationDynamicTable.java
@@ -99,7 +99,7 @@ public class TestIntegrationDynamicTable extends IntegrationTestBase {
       flush();
 
       Awaitility.await()
-          .atMost(Duration.ofSeconds(30))
+          .atMost(Duration.ofSeconds(60))
           .pollInterval(Duration.ofSeconds(1))
           .untilAsserted(() -> assertSnapshotAdded(List.of(smtTableId)));
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -22,7 +22,6 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.data.Offset;
 import org.apache.iceberg.connect.events.AvroUtil;
@@ -32,11 +31,13 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Utils;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,6 +54,7 @@ abstract class Channel {
   private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
   private final String producerId;
+  private final String channelId;
 
   Channel(
       String name,
@@ -60,13 +62,21 @@ abstract class Channel {
       IcebergSinkConfig config,
       KafkaClientFactory clientFactory,
       SinkTaskContext context) {
+    this.channelId = config.connectorName() + "-" + config.taskId() + "-" + name;
     this.controlTopic = config.controlTopic();
     this.connectGroupId = config.connectGroupId();
     this.context = context;
 
-    String transactionalId = config.transactionalPrefix() + name + config.transactionalSuffix();
+    String transactionalId =
+        "worker".equalsIgnoreCase(name)
+            ? config.transactionalPrefix() + name + config.transactionalSuffix()
+            : connectGroupId + "-" + config.connectorName() + "-coord";
+
     this.producer = clientFactory.createProducer(transactionalId);
-    this.consumer = clientFactory.createConsumer(consumerGroupId);
+    this.consumer =
+        "coordinator".equalsIgnoreCase(name)
+            ? clientFactory.createConsumer(consumerGroupId, "earliest")
+            : clientFactory.createConsumer(consumerGroupId);
     this.admin = clientFactory.createAdmin();
 
     this.producerId = UUID.randomUUID().toString();
@@ -85,12 +95,12 @@ abstract class Channel {
         events.stream()
             .map(
                 event -> {
-                  LOG.info("Sending event of type: {}", event.type().name());
+                  LOG.info("Channel {} sending event of type: {}", channelId, event.type().name());
                   byte[] data = AvroUtil.encode(event);
                   // key by producer ID to keep event order
                   return new ProducerRecord<>(controlTopic, producerId, data);
                 })
-            .collect(Collectors.toList());
+            .toList();
 
     synchronized (producer) {
       producer.beginTransaction();
@@ -107,7 +117,7 @@ abstract class Channel {
         try {
           producer.abortTransaction();
         } catch (Exception ex) {
-          LOG.warn("Error aborting producer transaction", ex);
+          LOG.warn("Channel {} got error while aborting producer transaction", channelId, ex);
         }
         throw e;
       }
@@ -119,21 +129,27 @@ abstract class Channel {
   protected void consumeAvailable(Duration pollDuration) {
     ConsumerRecords<String, byte[]> records = consumer.poll(pollDuration);
     while (!records.isEmpty()) {
-      records.forEach(
-          record -> {
-            // the consumer stores the offsets that corresponds to the next record to consume,
-            // so increment the record offset by one
-            controlTopicOffsets.put(record.partition(), record.offset() + 1);
+      for (ConsumerRecord<String, byte[]> record : records) {
+        if (record.offset() < controlTopicOffsets.getOrDefault(record.partition(), 0L)) {
+          LOG.debug(
+              "Channel {} skipping already-consumed control-topic record at offset {} for partition {}",
+              channelId,
+              record.offset(),
+              record.partition());
+          continue;
+        }
+        // the consumer stores the offset of the next record to consume, so increment by one
+        controlTopicOffsets.put(record.partition(), record.offset() + 1);
 
-            Event event = AvroUtil.decode(record.value());
+        Event event = AvroUtil.decode(record.value());
 
-            if (event.groupId().equals(connectGroupId)) {
-              LOG.debug("Received event of type: {}", event.type().name());
-              if (receive(new Envelope(event, record.partition(), record.offset()))) {
-                LOG.info("Handled event of type: {}", event.type().name());
-              }
-            }
-          });
+        if (event.groupId().equals(connectGroupId)) {
+          LOG.debug("Channel {} received event of type: {}", channelId, event.type().name());
+          if (receive(new Envelope(event, record.partition(), record.offset()))) {
+            LOG.info("Channel {} handled event of type: {}", channelId, event.type().name());
+          }
+        }
+      }
       records = consumer.poll(pollDuration);
     }
   }
@@ -159,9 +175,9 @@ abstract class Channel {
   }
 
   void stop() {
-    LOG.info("Channel stopping");
-    producer.close();
-    consumer.close();
-    admin.close();
+    LOG.info("Channel {} stopping", channelId);
+    Utils.closeQuietly(producer, channelId + "-producer");
+    Utils.closeQuietly(consumer, channelId + "-consumer");
+    Utils.closeQuietly(admin, channelId + "-admin");
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.connect.channel;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.connect.Committer;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -30,6 +31,9 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberDescription;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InvalidProducerEpochException;
+import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.errors.UnknownProducerIdException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.slf4j.Logger;
@@ -39,6 +43,10 @@ public class CommitterImpl implements Committer {
 
   private static final Logger LOG = LoggerFactory.getLogger(CommitterImpl.class);
 
+  // Bounded wait for a coordinator thread to fully exit (release its producer/consumer/admin) when
+  // stopping it, so a newly elected coordinator does not overlap the old one's clients.
+  private static final long COORDINATOR_STOP_TIMEOUT_MS = 60_000L;
+
   private CoordinatorThread coordinatorThread;
   private Worker worker;
   private Catalog catalog;
@@ -46,6 +54,7 @@ public class CommitterImpl implements Committer {
   private SinkTaskContext context;
   private KafkaClientFactory clientFactory;
   private Collection<MemberDescription> membersWhenWorkerIsCoordinator;
+  private final AtomicReference<TopicPartition> leaderTopicPartition = new AtomicReference<>(null);
   private final AtomicBoolean isInitialized = new AtomicBoolean(false);
   private String taskId;
 
@@ -109,6 +118,7 @@ public class CommitterImpl implements Committer {
           "Committer {} contains the first partition {}, this task is the leader",
           taskId,
           firstTopicPartition);
+      leaderTopicPartition.set(firstTopicPartition);
     } else {
       LOG.debug(
           "Committer {} does not contain the first partition {}, not the leader",
@@ -176,8 +186,11 @@ public class CommitterImpl implements Committer {
     }
 
     // Normal close: if leader partition is lost, stop coordinator.
-    if (hasLeaderPartition(closedPartitions)) {
-      LOG.info("Committer {} lost leader partition. Stopping coordinator.", taskId);
+    if (closedPartitions.contains(leaderTopicPartition.get())) {
+      LOG.info(
+          "Committer {} lost leader partition {}. Stopping coordinator.",
+          taskId,
+          leaderTopicPartition.get());
       stopCoordinator();
     }
 
@@ -197,8 +210,15 @@ public class CommitterImpl implements Committer {
 
   private void processControlEvents() {
     if (coordinatorThread != null && coordinatorThread.isTerminated()) {
-      throw new NotRunningException(
-          String.format("Coordinator unexpectedly terminated on committer %s", taskId));
+      if (isProducerFenced(coordinatorThread.exception())) {
+        // Lost the coordinator race (fenced by a newer coordinator). Clear it so
+        // commit thread pool are released.
+        LOG.warn("Committer {} coordinator was fenced by a newer coordinator; clearing it", taskId);
+        stopCoordinator();
+      } else {
+        throw new NotRunningException(
+            String.format("Coordinator unexpectedly terminated on committer %s", taskId));
+      }
     }
     if (worker != null) {
       worker.process();
@@ -216,7 +236,10 @@ public class CommitterImpl implements Committer {
 
   private void startCoordinator() {
     if (null == this.coordinatorThread) {
-      LOG.info("Task {} elected leader, starting commit coordinator", taskId);
+      LOG.info(
+          "Task {} elected leader (owns {}), starting commit coordinator.",
+          taskId,
+          leaderTopicPartition);
       Coordinator coordinator =
           new Coordinator(catalog, config, membersWhenWorkerIsCoordinator, clientFactory, context);
       coordinatorThread = new CoordinatorThread(coordinator);
@@ -232,9 +255,48 @@ public class CommitterImpl implements Committer {
   }
 
   private void stopCoordinator() {
-    if (coordinatorThread != null) {
-      coordinatorThread.terminate();
-      coordinatorThread = null;
+    CoordinatorThread thread = coordinatorThread;
+    if (thread == null) {
+      return;
     }
+    coordinatorThread = null;
+
+    try {
+      if (!thread.isTerminated()) {
+        thread.terminate();
+      }
+    } catch (RuntimeException e) {
+      LOG.warn(
+          "Committer {}: error signalling coordinator termination, continuing shutdown", taskId, e);
+    }
+
+    try {
+      thread.join(COORDINATOR_STOP_TIMEOUT_MS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn(
+          "Committer {}: interrupted while waiting for the coordinator thread to stop", taskId, e);
+      return;
+    }
+
+    if (thread.isAlive()) {
+      LOG.warn(
+          "Committer {}: coordinator thread did not stop within {} ms; it will keep shutting down "
+              + "in the background (a newer coordinator fences its producer)",
+          taskId,
+          COORDINATOR_STOP_TIMEOUT_MS);
+    }
+  }
+
+  private static boolean isProducerFenced(Throwable cause) {
+    Throwable current = cause;
+    for (int depth = 0; current != null && depth < 20; depth++, current = current.getCause()) {
+      if (current instanceof ProducerFencedException
+          || current instanceof InvalidProducerEpochException
+          || current instanceof UnknownProducerIdException) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Coordinator.java
@@ -56,6 +56,7 @@ import org.apache.iceberg.connect.events.StartCommit;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.NoSuchTableException;
+import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Streams;
 import org.apache.iceberg.relocated.com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -168,8 +169,8 @@ class Coordinator extends Channel {
         return;
       }
 
-      if (!(e instanceof CommitFailedException)) {
-        // CommitStateUnknownException, ValidationException, ForbiddenException,
+      if (!isRetryable(e)) {
+        // CommitStateUnknownException, ValidationException, ForbiddenException, ProducerFenced,
         // NPE, anything else -- not retryable, terminate immediately
         throw e;
       }
@@ -193,6 +194,14 @@ class Coordinator extends Channel {
     } finally {
       commitState.endCurrentCommit();
     }
+  }
+
+  @VisibleForTesting
+  static boolean isRetryable(RuntimeException exception) {
+    return exception instanceof CommitFailedException
+        || exception instanceof org.apache.kafka.clients.consumer.CommitFailedException
+        || exception instanceof org.apache.kafka.common.errors.RebalanceInProgressException
+        || exception instanceof org.apache.kafka.common.errors.RetriableException;
   }
 
   private void doCommit(boolean partialCommit) {
@@ -277,7 +286,7 @@ class Coordinator extends Channel {
                   return minOffset == null || envelope.offset() >= minOffset;
                 })
             .map(envelope -> (DataWritten) envelope.event().payload())
-            .collect(Collectors.toList());
+            .toList();
 
     List<DataFile> dataFiles =
         payloads.stream()
@@ -285,7 +294,7 @@ class Coordinator extends Channel {
             .flatMap(payload -> payload.dataFiles().stream())
             .filter(dataFile -> dataFile.recordCount() > 0)
             .filter(distinctByKey(ContentFile::location))
-            .collect(Collectors.toList());
+            .toList();
 
     List<DeleteFile> deleteFiles =
         payloads.stream()
@@ -293,7 +302,7 @@ class Coordinator extends Channel {
             .flatMap(payload -> payload.deleteFiles().stream())
             .filter(deleteFile -> deleteFile.recordCount() > 0)
             .filter(distinctByKey(ContentFile::location))
-            .collect(Collectors.toList());
+            .toList();
 
     if (terminated) {
       throw new ConnectException(
@@ -437,6 +446,7 @@ class Coordinator extends Channel {
         throw new ConnectException("Timed out waiting for coordinator shutdown");
       }
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new ConnectException("Interrupted while waiting for coordinator shutdown", e);
     }
   }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CoordinatorThread.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +28,7 @@ class CoordinatorThread extends Thread {
 
   private final Coordinator coordinator;
   private volatile boolean terminated;
+  private final AtomicReference<Throwable> exception = new AtomicReference<>();
 
   CoordinatorThread(Coordinator coordinator) {
     super(THREAD_NAME);
@@ -39,6 +41,7 @@ class CoordinatorThread extends Thread {
       coordinator.start();
     } catch (Exception e) {
       LOG.error("Coordinator error during start, exiting thread", e);
+      exception.set(e);
       this.terminated = true;
     }
 
@@ -47,6 +50,7 @@ class CoordinatorThread extends Thread {
         coordinator.process();
       } catch (Exception e) {
         LOG.error("Coordinator error during process, exiting thread", e);
+        exception.set(e);
         this.terminated = true;
       }
     }
@@ -65,5 +69,9 @@ class CoordinatorThread extends Thread {
   void terminate() {
     this.terminated = true;
     coordinator.terminate();
+  }
+
+  Throwable exception() {
+    return exception.get();
   }
 }

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/KafkaClientFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.connect.channel;
 
+import java.time.Duration;
 import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
@@ -46,13 +47,22 @@ class KafkaClientFactory {
     producerProps.put(ProducerConfig.TRANSACTIONAL_ID_CONFIG, transactionalId);
     KafkaProducer<String, byte[]> result =
         new KafkaProducer<>(producerProps, new StringSerializer(), new ByteArraySerializer());
-    result.initTransactions();
+    try {
+      result.initTransactions();
+    } catch (RuntimeException e) {
+      result.close(Duration.ZERO);
+      throw e;
+    }
     return result;
   }
 
   Consumer<String, byte[]> createConsumer(String consumerGroupId) {
+    return createConsumer(consumerGroupId, "latest");
+  }
+
+  Consumer<String, byte[]> createConsumer(String consumerGroupId, String defaultAutoOffsetReset) {
     Map<String, Object> consumerProps = Maps.newHashMap(kafkaProps);
-    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, defaultAutoOffsetReset);
     consumerProps.putIfAbsent(ConsumerConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
     consumerProps.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
     consumerProps.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/NotRunningException.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/NotRunningException.java
@@ -22,4 +22,8 @@ public class NotRunningException extends RuntimeException {
   public NotRunningException(String msg) {
     super(msg);
   }
+
+  public NotRunningException(String msg, Throwable cause) {
+    super(msg, cause);
+  }
 }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/ChannelTestBase.java
@@ -124,6 +124,7 @@ public class ChannelTestBase {
     clientFactory = mock(KafkaClientFactory.class);
     when(clientFactory.createProducer(any())).thenReturn(producer);
     when(clientFactory.createConsumer(any())).thenReturn(consumer);
+    when(clientFactory.createConsumer(any(), any())).thenReturn(consumer);
     when(clientFactory.createAdmin()).thenReturn(admin);
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -284,6 +284,62 @@ public class TestCoordinator extends ChannelTestBase {
         .hasMessageContaining("concurrent update");
   }
 
+  @Test
+  public void testIsRetryableClassifiesCommitAndTransientKafkaErrors() {
+    // Iceberg optimistic-concurrency failure -> retry
+    assertThat(Coordinator.isRetryable(new CommitFailedException("occ"))).isTrue();
+    // Kafka consumer-commit failures from commitConsumerOffsets() -> retry (must NOT be confused
+    // with the Iceberg CommitFailedException, which was the original bug)
+    assertThat(
+            Coordinator.isRetryable(
+                new org.apache.kafka.clients.consumer.CommitFailedException("evicted")))
+        .isTrue();
+    assertThat(
+            Coordinator.isRetryable(
+                new org.apache.kafka.common.errors.RebalanceInProgressException()))
+        .isTrue();
+    assertThat(Coordinator.isRetryable(new org.apache.kafka.common.errors.TimeoutException()))
+        .isTrue();
+    // Fencing and unknown errors -> fatal (terminate)
+    assertThat(
+            Coordinator.isRetryable(
+                new org.apache.kafka.common.errors.ProducerFencedException("fenced")))
+        .isFalse();
+    assertThat(Coordinator.isRetryable(new ValidationException("stale"))).isFalse();
+    assertThat(Coordinator.isRetryable(new RuntimeException("boom"))).isFalse();
+  }
+
+  @Test
+  public void testConsumeAvailableSkipsAlreadyConsumedOffsets() {
+    when(config.commitIntervalMs()).thenReturn(Integer.MAX_VALUE);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+    TopicPartition tp = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+    addControlRecord(0);
+    addControlRecord(1);
+    coordinator.process();
+    assertThat(coordinator.controlTopicOffsets().get(0)).isEqualTo(2L);
+
+    // An eager -coord rebalance can rewind the fetch position and re-deliver already-consumed
+    // records; consumeAvailable must skip them (offset < tracked), so the tracked offset never
+    // regresses and the records are not re-processed.
+    consumer.seek(tp, 0L);
+    coordinator.process();
+    assertThat(coordinator.controlTopicOffsets().get(0)).isEqualTo(2L);
+  }
+
+  private void addControlRecord(long offset) {
+    Event event = new Event(config.connectGroupId(), new StartCommit(UUID.randomUUID()));
+    consumer.addRecord(
+        new ConsumerRecord<>(CTL_TOPIC_NAME, 0, offset, "key", AvroUtil.encode(event)));
+  }
+
   private long nextOffset = 1;
 
   private void triggerCommitCycle(Coordinator coordinator) {


### PR DESCRIPTION
## What
  
  Hardens the Iceberg Kafka Connect sink's commit `Coordinator` — its zombie-fencing,
  recovery, control-topic consumption, and shutdown paths. 

  ## Coordinator hardening

  - **Zombie fencing via a fixed `transactional.id`.** The coordinator producer id is now
    `<connectGroupId>-<connectorName>-coord` — identical across a connector's tasks and stable
    across restarts/reconfigurations — so a newly elected coordinator's `initTransactions()`
    epoch-bumps and fences a prior (zombie) coordinator's control-plane writes. Worker ids are
    unchanged (`<prefix>worker<suffix>`), so sibling workers never fence each other. Solves https://github.com/apache/iceberg/issues/13593#issuecomment-4796667015

  - **Fenced ≠ fatal.** A coordinator that terminates because it was fenced
    (`ProducerFencedException` / `InvalidProducerEpochException` / `UnknownProducerIdException`,
    matched across the cause chain up to a bounded depth) is cleared without failing the task
    (Connect does not auto-restart FAILED tasks); any other coordinator termination still fails
    the task loudly.

  - **Recovery reads from `earliest`.** The coordinator's `-coord` consumer group now defaults
    to `auto.offset.reset=earliest`, so a fresh or expired group re-reads uncommitted control
    events instead of skipping to the log end and dropping their data. Replay is idempotent via
    the snapshot offset floor + `distinctByKey(location)` dedup + the offsets compare-and-swap.

  - **Idempotency filter in `Channel.consumeAvailable`.** Control-topic records at or below the
    already-consumed per-partition offset are skipped, so a re-delivered or rewound record is
    never re-buffered or re-counted. The per-partition offset is only ever advanced. This solves [#16282](https://github.com/apache/iceberg/issues/16282)

  - **Transient Kafka commit errors are retryable.** A consumer-offset commit hiccup from
    `commitConsumerOffsets()` (Iceberg `CommitFailedException`, Kafka `CommitFailedException`,
    `RebalanceInProgressException`, `RetriableException` — e.g. the `-coord` consumer briefly
    evicted when a catalog commit exceeds `max.poll.interval.ms`) no longer fails the task: the
    table commit already succeeded and the watermark re-advances on the next cycle. Non-retryable
    errors still terminate the coordinator.

  - **Bounded, interrupt-safe shutdown.** `stopCoordinator` clears state first, then signals
    termination and waits (bounded, 60s) for the thread to release its producer/consumer/admin
    before returning; a `terminate()` failure is best-effort (logged, not fatal) and interrupts
    are preserved.

  - **No producer leak on failed init.** `KafkaClientFactory.createProducer` closes the producer
    if `initTransactions()` throws.

  ## Testing

  - Unit tests for the retryable-commit classification (including Iceberg vs. Kafka
    `CommitFailedException`, `RebalanceInProgressException`, `RetriableException`) and for the
    `consumeAvailable` skip-already-consumed-offsets guard.
  - Existing coordinator/committer tests cover fenced-vs-fatal termination and the transactional-id
    format.
  - Raised the integration-test commit-wait from 30s to 60s to reduce flakiness under CI load.