### PR TITLE
Parquet: Extract nested/variant type check in ParquetMetricsRowGroupFilter

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -189,8 +189,7 @@ public class ParquetMetricsRowGroupFilter {
       // When filtering nested types or variant types, notNull() is an implicit filter passed
       // even though complex filters aren't pushed down in Parquet. Leave these type filters
       // to be evaluated post scan.
-      Type type = schema.findType(id);
-      if (type instanceof Type.NestedType || type.isVariantType()) {
+      if (isNestedOrVariantType(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -359,8 +358,7 @@ public class ParquetMetricsRowGroupFilter {
 
       // Leave all nested column type and variant type filters to be
       // evaluated post scan.
-      Type type = schema.findType(id);
-      if (type instanceof Type.NestedType || type.isVariantType()) {
+      if (isNestedOrVariantType(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -409,8 +407,7 @@ public class ParquetMetricsRowGroupFilter {
 
       // Leave all nested column type and variant type filters to be
       // evaluated post scan.
-      Type type = schema.findType(id);
-      if (type instanceof Type.NestedType || type.isVariantType()) {
+      if (isNestedOrVariantType(id)) {
         return ROWS_MIGHT_MATCH;
       }
 
@@ -589,6 +586,11 @@ public class ParquetMetricsRowGroupFilter {
     @SuppressWarnings("unchecked")
     private <T> T max(Statistics<?> statistics, int id) {
       return (T) conversions.get(id).apply(statistics.genericGetMax());
+    }
+
+    private boolean isNestedOrVariantType(int id) {
+      Type type = schema.findType(id);
+      return type instanceof Type.NestedType || type.isVariantType();
     }
 
     @Override

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -588,14 +588,14 @@ public class ParquetMetricsRowGroupFilter {
       return (T) conversions.get(id).apply(statistics.genericGetMax());
     }
 
-    private boolean isNestedOrVariantType(int id) {
-      Type type = schema.findType(id);
-      return type instanceof Type.NestedType || type.isVariantType();
-    }
-
     @Override
     public <T> Boolean handleNonReference(Bound<T> term) {
       return ROWS_MIGHT_MATCH;
+    }
+
+    private boolean isNestedOrVariantType(int id) {
+      Type type = schema.findType(id);
+      return type instanceof Type.NestedType || type.isVariantType();
     }
   }
 


### PR DESCRIPTION
The same nested-or-variant type check was duplicated verbatim across `notNull()`, `eq()`, and `in()` in `ParquetMetricsRowGroupFilter`. This extracts it into a private `isNestedOrVariantType(int id)` helper (placed alongside the existing `min`/`max` helpers) to remove the duplication. Behavior-preserving; the three call sites were byte-identical.