### PR TITLE
Docs: Fix invalid API in sort order evolution example

### DIFF
--- a/docs/docs/evolution.md
+++ b/docs/docs/evolution.md
@@ -93,7 +93,7 @@ and `category` column sorted in descending order with nulls first:
 Table sampleTable = ...;
 sampleTable.replaceSortOrder()
    .asc("id", NullOrder.NULLS_LAST)
-   .dec("category", NullOrder.NULL_FIRST)
+   .desc("category", NullOrder.NULLS_FIRST)
    .commit();
 ```
 


### PR DESCRIPTION
The `replaceSortOrder` example in the evolution docs used `.dec(...)` and `NullOrder.NULL_FIRST`, neither of which exists in the API (the method is `.desc(...)` and the enum value is `NULLS_FIRST`). This corrects the example to compile against the real API and match the surrounding prose (""descending order with nulls first""). Docs-only.