### PR TITLE
BigQuery: Use pattern-matching instanceof in BigQueryMetastoreClientImpl

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -92,8 +92,8 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
 
         @Override
         public RetryResult beforeEval(Exception exception) {
-          if (exception instanceof BaseServiceException) {
-            boolean retriable = ((BaseServiceException) exception).isRetryable();
+          if (exception instanceof BaseServiceException serviceException) {
+            boolean retriable = serviceException.isRetryable();
             return retriable
                 ? ExceptionHandler.Interceptor.RetryResult.RETRY
                 : ExceptionHandler.Interceptor.RetryResult.CONTINUE_EVALUATION;
@@ -672,8 +672,8 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
       BigQueryRetryHelper.BigQueryRetryHelperException retryException) {
     Throwable cause = retryException.getCause();
     String message = retryException.getMessage();
-    if (cause instanceof RuntimeException) {
-      throw (RuntimeException) cause;
+    if (cause instanceof RuntimeException runtimeException) {
+      throw runtimeException;
     } else {
       throw new RuntimeException(message, cause);
     }


### PR DESCRIPTION
Simplifies the two `instanceof`-followed-by-cast blocks in `BigQueryMetastoreClientImpl` to use pattern-matching `instanceof`, as flagged by the Error Prone `[PatternMatchingInstanceof]` check.
- `beforeEval(...)`: `((BaseServiceException) exception).isRetryable()` - binds `serviceException` in the `instanceof` and calls it directly.
- `handleBigQueryRetryException(...)`: `throw (RuntimeException) cause;` - binds `runtimeException` in the `instanceof` and rethrows it.

These are the only two occurrences in the file. Pure readability cleanup, no behavior change. Also, note that Java 17 (the project's release level) supports the syntax.