### PR TITLE
BigQuery: Convert statement switch to arrow switch in BigQueryMetastoreClientImpl

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -631,10 +631,10 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
             + (exception.getContent() != null ? "\n" + exception.getContent() : "");
 
     switch (response.getStatusCode()) {
-      case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED:
-        throw new NotAuthorizedException(
-            "Not authorized to call the BigQuery API or access this resource: %s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_BAD_REQUEST:
+      case HttpStatusCodes.STATUS_CODE_UNAUTHORIZED ->
+          throw new NotAuthorizedException(
+              "Not authorized to call the BigQuery API or access this resource: %s", errorMessage);
+      case HttpStatusCodes.STATUS_CODE_BAD_REQUEST -> {
         GoogleJsonError errorDetails = exception.getDetails();
         if (errorDetails != null) {
           List<GoogleJsonError.ErrorInfo> errors = errorDetails.getErrors();
@@ -647,20 +647,20 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
           }
         }
         throw new BadRequestException("%s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_FORBIDDEN:
-        throw new ForbiddenException("%s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_PRECONDITION_FAILED:
-        throw new CommitFailedException("%s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_NOT_FOUND:
-        throw new IllegalArgumentException(errorMessage);
-      case HttpStatusCodes.STATUS_CODE_SERVER_ERROR:
-        throw new ServiceFailureException("%s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE:
-        throw new ServiceUnavailableException("%s", errorMessage);
-      case HttpStatusCodes.STATUS_CODE_CONFLICT:
-        throw new AlreadyExistsException("%s", errorMessage);
-      default:
-        throw new HttpResponseException(response);
+      }
+      case HttpStatusCodes.STATUS_CODE_FORBIDDEN ->
+          throw new ForbiddenException("%s", errorMessage);
+      case HttpStatusCodes.STATUS_CODE_PRECONDITION_FAILED ->
+          throw new CommitFailedException("%s", errorMessage);
+      case HttpStatusCodes.STATUS_CODE_NOT_FOUND ->
+          throw new IllegalArgumentException(errorMessage);
+      case HttpStatusCodes.STATUS_CODE_SERVER_ERROR ->
+          throw new ServiceFailureException("%s", errorMessage);
+      case HttpStatusCodes.STATUS_CODE_SERVICE_UNAVAILABLE ->
+          throw new ServiceUnavailableException("%s", errorMessage);
+      case HttpStatusCodes.STATUS_CODE_CONFLICT ->
+          throw new AlreadyExistsException("%s", errorMessage);
+      default -> throw new HttpResponseException(response);
     }
   }
 


### PR DESCRIPTION
Converts the `switch` in `BigQueryMetastoreClientImpl.convertExceptionIfUnsuccessful` from an old-style statement switch (colon labels with fall-through semantics) to a new-style arrow switch. This is a pure readability / lint cleanup with no behavioral change, every arm still throws the same exception on the same status code.