### PR TITLE
Infra: Fix labeler.yml indentation for actions/labeler v7

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -20,165 +20,140 @@
 
 INFRA:
   - changed-files:
-    - any-glob-to-any-file: [
-      '.asf.yaml',
-      '.gitattributes',
-      '.gitignore',
-      'baseline.gradle',
-      'deploy.gradle',
-      '.baseline/**/*',
-      '.github/**/*',
-      'dev/**/*'
-    ]
+    - any-glob-to-any-file:
+      - '.asf.yaml'
+      - '.gitattributes'
+      - '.gitignore'
+      - 'baseline.gradle'
+      - 'deploy.gradle'
+      - '.baseline/**/*'
+      - '.github/**/*'
+      - 'dev/**/*'
 
 BUILD:
   - changed-files:
-    - any-glob-to-any-file: [
-      '**/*gradle*'
-    ]
+    - any-glob-to-any-file:
+      - '**/*gradle*'
 
 DOCS:
   - changed-files:
-    - any-glob-to-any-file: [
-      'docs/**/*',
-      'site/**/*',
-      '**/*CHANGELOG.md',
-      '**/*README.md',
-      '**/*CONTRIBUTING.md'
-    ]
+    - any-glob-to-any-file:
+      - 'docs/**/*'
+      - 'site/**/*'
+      - '**/*CHANGELOG.md'
+      - '**/*README.md'
+      - '**/*CONTRIBUTING.md'
 
 SPECIFICATION:
   - changed-files:
-    - any-glob-to-any-file: [
-      'format/*'
-    ]
+    - any-glob-to-any-file:
+      - 'format/*'
 
 EXAMPLES:
   - changed-files:
-    - any-glob-to-any-file: [
-      'examples/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'examples/**/*'
 
 COMMON:
   - changed-files:
-    - any-glob-to-any-file: [
-      'common/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'common/**/*'
 
 API:
   - changed-files:
-    - any-glob-to-any-file: [
-      'api/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'api/**/*'
 
 CORE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'core/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'core/**/*'
 
 PARQUET:
   - changed-files:
-    - any-glob-to-any-file: [
-      'parquet/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'parquet/**/*'
 
 ARROW:
   - changed-files:
-    - any-glob-to-any-file: [
-      'arrow/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'arrow/**/*'
 
 ORC:
   - changed-files:
-    - any-glob-to-any-file: [
-      'orc/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'orc/**/*'
 
 HIVE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'hive-metastore/**/*',
-    ]
+    - any-glob-to-any-file:
+      - 'hive-metastore/**/*'
 
 DATA:
   - changed-files:
-    - any-glob-to-any-file: [
-      'data/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'data/**/*'
 
 SPARK:
   - changed-files:
-    - any-glob-to-any-file: [
-      'spark/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'spark/**/*'
 
 FLINK:
   - changed-files:
-    - any-glob-to-any-file: [
-      'flink/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'flink/**/*'
 
 MR:
   - changed-files:
-    - any-glob-to-any-file: [
-      'mr/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'mr/**/*'
 
 AWS:
   - changed-files:
-    - any-glob-to-any-file: [
-      'aws/**/*',
-      'aws-bundle/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'aws/**/*'
+      - 'aws-bundle/**/*'
 
 NESSIE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'nessie/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'nessie/**/*'
 
 ALIYUN:
   - changed-files:
-    - any-glob-to-any-file: [
-      'aliyun/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'aliyun/**/*'
 
 GCP:
   - changed-files:
-    - any-glob-to-any-file: [
-      'gcp/**/*',
-      'gcp-bundle/**/*',
-      'bigquery/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'gcp/**/*'
+      - 'gcp-bundle/**/*'
+      - 'bigquery/**/*'
 
 DELL:
   - changed-files:
-    - any-glob-to-any-file: [
-      'dell/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'dell/**/*'
 
 SNOWFLAKE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'snowflake/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'snowflake/**/*'
 
 OPENAPI:
   - changed-files:
-    - any-glob-to-any-file: [
-      'open-api/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'open-api/**/*'
 
 AZURE:
   - changed-files:
-    - any-glob-to-any-file: [
-      'azure/**/*',
-      'azure-bundle/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'azure/**/*'
+      - 'azure-bundle/**/*'
 
 KAFKACONNECT:
   - changed-files:
-    - any-glob-to-any-file: [
-      'kafka-connect/**/*'
-    ]
+    - any-glob-to-any-file:
+      - 'kafka-connect/**/*'


### PR DESCRIPTION
## What / Why

The `triage` job (`.github/workflows/labeler.yml`) is currently **failing on every PR** with:

```
##[error]YAMLException: deficient indentation (24:7)
 23 |     - any-glob-to-any-file: [
 24 |       '.asf.yaml',
------------^
```

### Root cause

#17371 bumped `actions/labeler` from **v6.2.0 → v7.0.0**. That release upgraded the action's bundled `js-yaml` dependency from `^4.2.0` to `^5.1.0`. The js-yaml **5.0.0** major release expanded YAML 1.2 conformance and tightened block/flow parsing.

Under the stricter parser, the multi-line **flow sequences** (`[ ... ]`) in `labeler.yml` are now rejected: the list entries were indented to the *same* column as their parent `any-glob-to-any-file:` key rather than deeper, which the new parser flags as "deficient indentation". The action reads this config from the base branch, so the error appears on all PRs regardless of their contents. `labeler.yml` itself has not changed since May 2025 — the parser under it got stricter.

### Fix

Convert the multi-line flow sequences to **block sequences**, which parse cleanly under the new parser and are the idiomatic labeler syntax. This is a **pure syntax change** — the parsed configuration is equivalent (same labels, same globs), verified by parsing both the old and new file and confirming the loaded structures are deep-equal. Also drops a stray trailing comma in the `HIVE` block.

Before:
```yaml
INFRA:
  - changed-files:
    - any-glob-to-any-file: [
      '.asf.yaml',
      '.gitattributes',
    ]
```

After:
```yaml
INFRA:
  - changed-files:
    - any-glob-to-any-file:
      - '.asf.yaml'
      - '.gitattributes'
```

### Testing

Parsed the updated file with js-yaml 5.x semantics (warnings-as-errors): **0 warnings**, and the loaded config is deep-equal to the original across all 25 labels.