### PR TITLE
AWS, GCP: Remove unused logger

### DIFF
--- a/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/s3/TestS3OutputStream.java
@@ -50,8 +50,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.MinIOContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
@@ -73,7 +71,6 @@ import software.amazon.awssdk.utils.BinaryUtils;
 
 @Testcontainers
 public class TestS3OutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(TestS3OutputStream.class);
   private static final String BUCKET = "test-bucket";
   private static final int FIVE_MBS = 5 * 1024 * 1024;
 

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSOutputStream.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGCSOutputStream.java
@@ -31,11 +31,8 @@ import java.util.stream.Stream;
 import org.apache.iceberg.gcp.GCPProperties;
 import org.apache.iceberg.metrics.MetricsContext;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class TestGCSOutputStream {
-  private static final Logger LOG = LoggerFactory.getLogger(TestGCSOutputStream.class);
   private static final String BUCKET = "test-bucket";
 
   private final GCPProperties properties = new GCPProperties();


### PR DESCRIPTION
Removes unused LOG fields (and their now-orphaned slf4j imports) from two test classes where the logger was declared but never invoked:

- aws/.../s3/TestS3OutputStream.java
- gcp/.../gcs/TestGCSOutputStream.java

Test-only change (behavior-preserving). The LOG fields had no references, so this also clears the corresponding unused org.slf4j.Logger / LoggerFactory imports.