### PR TITLE
Build: Fix empty tarball name in source-release.sh log message

### DIFF
--- a/dev/source-release.sh
+++ b/dev/source-release.sh
@@ -108,8 +108,8 @@ cp $projectdir/build/iceberg-build.properties $projectdir/iceberg-build.properti
 
 # be conservative and use the release hash, even though git produces the same
 # archive (identical hashes) using the scm tag
-echo "Creating tarball ${tarball} using commit $release_hash"
 tarball=$tag.tar.gz
+echo "Creating tarball ${tarball} using commit $release_hash"
 git archive $release_hash --worktree-attributes --prefix $tag/ --add-file $projectdir/version.txt --add-file $projectdir/iceberg-build.properties -o $projectdir/$tarball
 
 # remove the uncommitted build files so they don't affect the current working copy


### PR DESCRIPTION
The "Creating tarball ..." message in `dev/source-release.sh` referenced `${tarball}` before it was assigned, printing an empty name. This assigns the variable before logging it. Pure reorder of two adjacent lines.