### PR TITLE
Flink: Nested projection pushdown

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/IcebergTableSource.java
@@ -18,16 +18,13 @@
  */
 package org.apache.iceberg.flink.source;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
-import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.connector.ChangelogMode;
 import org.apache.flink.table.connector.ProviderContext;
@@ -43,10 +40,12 @@ import org.apache.flink.table.expressions.ResolvedExpression;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.legacy.api.TableSchema;
 import org.apache.flink.table.types.DataType;
+import org.apache.flink.table.types.logical.RowType;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.flink.FlinkConfigOptions;
 import org.apache.iceberg.flink.FlinkFilters;
 import org.apache.iceberg.flink.FlinkReadOptions;
+import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.flink.source.assigner.SplitAssignerType;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -63,7 +62,7 @@ public class IcebergTableSource
         SupportsLimitPushDown,
         SupportsSourceWatermark {
 
-  private int[] projectedFields;
+  private Projector projector;
   private Long limit;
   private List<Expression> filters;
 
@@ -77,7 +76,7 @@ public class IcebergTableSource
     this.loader = toCopy.loader;
     this.schema = toCopy.schema;
     this.properties = toCopy.properties;
-    this.projectedFields = toCopy.projectedFields;
+    this.projector = toCopy.projector;
     this.isLimitPushDown = toCopy.isLimitPushDown;
     this.limit = toCopy.limit;
     this.filters = toCopy.filters;
@@ -96,7 +95,7 @@ public class IcebergTableSource
       TableLoader loader,
       ResolvedSchema schema,
       Map<String, String> properties,
-      int[] projectedFields,
+      Projector projector,
       boolean isLimitPushDown,
       Long limit,
       List<Expression> filters,
@@ -104,7 +103,7 @@ public class IcebergTableSource
     this.loader = loader;
     this.schema = schema;
     this.properties = properties;
-    this.projectedFields = projectedFields;
+    this.projector = projector;
     this.isLimitPushDown = isLimitPushDown;
     this.limit = limit;
     this.filters = filters;
@@ -112,13 +111,10 @@ public class IcebergTableSource
   }
 
   @Override
-  public void applyProjection(int[][] projectFields, DataType producedDataType) {
-    this.projectedFields = new int[projectFields.length];
-    for (int i = 0; i < projectFields.length; i++) {
-      Preconditions.checkArgument(
-          projectFields[i].length == 1, "Don't support nested projection in iceberg source now.");
-      this.projectedFields[i] = projectFields[i][0];
-    }
+  public void applyProjection(int[][] projectFields, DataType newProducedDataType) {
+    RowType originalRowType = (RowType) schema.toPhysicalRowDataType().getLogicalType();
+    RowType producedRowType = (RowType) newProducedDataType.getLogicalType();
+    this.projector = Projector.of(originalRowType, projectFields, producedRowType);
   }
 
   @SuppressWarnings("deprecation")
@@ -149,12 +145,10 @@ public class IcebergTableSource
   }
 
   private ResolvedSchema getProjectedSchema() {
-    if (projectedFields == null) {
+    if (projector == null) {
       return schema;
     } else {
-      List<Column> fullColumns = schema.getColumns();
-      return ResolvedSchema.of(
-          Arrays.stream(projectedFields).mapToObj(fullColumns::get).collect(Collectors.toList()));
+      return FlinkSchemaUtil.toResolvedSchema(projector.readSchema());
     }
   }
 
@@ -193,8 +187,7 @@ public class IcebergTableSource
 
   @Override
   public boolean supportsNestedProjection() {
-    // TODO: support nested projection
-    return false;
+    return true;
   }
 
   @Override
@@ -208,11 +201,18 @@ public class IcebergTableSource
       @Override
       public DataStream<RowData> produceDataStream(
           ProviderContext providerContext, StreamExecutionEnvironment execEnv) {
+        DataStream<RowData> stream;
         if (readableConfig.get(FlinkConfigOptions.TABLE_EXEC_ICEBERG_USE_FLIP27_SOURCE)) {
-          return createFLIP27Stream(execEnv);
+          stream = createFLIP27Stream(execEnv);
         } else {
-          return createDataStream(execEnv);
+          stream = createDataStream(execEnv);
         }
+
+        if (projector != null) {
+          stream = projector.project(stream);
+        }
+
+        return stream;
       }
 
       @Override

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/Projector.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/source/Projector.java
@@ -1,0 +1,206 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.List;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+import org.apache.flink.api.common.functions.MapFunction;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.iceberg.flink.FlinkRowData;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+
+/**
+ * Applies a Flink (possibly nested) projection pushed down into the Iceberg source.
+ *
+ * <p>A single projection has two sides, both derived here from the source {@link RowType} and
+ * Flink's {@code int[][]} projection paths:
+ *
+ * <ul>
+ *   <li>{@link #readSchema()} — the schema handed to the reader: pruned to the projected fields, in
+ *       table-schema order with nested structs left intact.
+ *   <li>{@link #project(DataStream)} — projects the reader's rows into the produced (SELECT-list)
+ *       order, extracting nested leaves into top-level columns, by adding a map step to the stream.
+ *       The map is added only when the projection is nested or reorders top-level fields; an
+ *       in-order projection is returned unchanged.
+ * </ul>
+ *
+ * <p>Projection paths descend only through structs ({@link RowType}); they never descend through
+ * the element of a list or the key/value of a map. Flink guarantees this: a subfield reference into
+ * a list/map element (for example {@code SELECT people[1].name}) reads the whole element struct
+ * rather than pushing a path into it, so a repeated type is always projected in full.
+ */
+final class Projector implements Serializable {
+
+  private final RowType readSchema;
+  private final boolean projectionNeeded;
+  private final RowType producedRowType;
+  private final RowProjection rowProjection;
+
+  static Projector of(RowType sourceRowType, int[][] projectedFields, RowType producedRowType) {
+    return new Projector(sourceRowType, projectedFields, producedRowType);
+  }
+
+  private Projector(RowType sourceRowType, int[][] projectedFields, RowType producedRowType) {
+    this.readSchema = prune(sourceRowType, projectedFields);
+    this.projectionNeeded = isProjectionNeeded(projectedFields);
+    this.producedRowType = producedRowType;
+
+    RowData.FieldGetter[] getters = new RowData.FieldGetter[projectedFields.length];
+    for (int col = 0; col < projectedFields.length; col++) {
+      getters[col] = getter(sourceRowType, readSchema, projectedFields[col]);
+    }
+    this.rowProjection = new RowProjection(getters);
+  }
+
+  /**
+   * The schema handed to the reader: pruned to the projected fields, preserving original field
+   * names, nesting, and table-schema order.
+   */
+  RowType readSchema() {
+    return readSchema;
+  }
+
+  /**
+   * Adds a map step projecting the reader's rows into the produced (SELECT-list) shape, or returns
+   * the stream unchanged when no projection is needed (a non-nested, in-order projection).
+   */
+  DataStream<RowData> project(DataStream<RowData> stream) {
+    if (!projectionNeeded) {
+      return stream;
+    }
+
+    return stream
+        .map(rowProjection)
+        .setParallelism(stream.getParallelism())
+        .returns(InternalTypeInfo.of(producedRowType));
+  }
+
+  private static boolean isProjectionNeeded(int[][] projectedFields) {
+    int previousFieldIndex = -1;
+    for (int[] path : projectedFields) {
+      if (path.length > 1 || path[0] <= previousFieldIndex) {
+        return true;
+      }
+      previousFieldIndex = path[0];
+    }
+
+    return false;
+  }
+
+  private static RowType prune(RowType rowType, int[][] projectedFields) {
+    List<RowType.RowField> fields =
+        Arrays.stream(projectedFields)
+            .collect(
+                Collectors.groupingBy(
+                    path -> path[0],
+                    TreeMap::new,
+                    Collectors.mapping(
+                        path -> Arrays.copyOfRange(path, 1, path.length), Collectors.toList())))
+            .entrySet()
+            .stream()
+            .map(
+                entry -> {
+                  int fieldIndex = entry.getKey();
+                  int[][] nestedFieldPaths = entry.getValue().toArray(new int[0][]);
+                  RowType.RowField field = rowType.getFields().get(fieldIndex);
+                  return prune(field, nestedFieldPaths);
+                })
+            .collect(Collectors.toList());
+
+    return new RowType(rowType.isNullable(), fields);
+  }
+
+  private static RowType.RowField prune(RowType.RowField field, int[][] projectedFields) {
+    boolean selectedWholeField =
+        Arrays.stream(projectedFields).anyMatch(nestedFieldPath -> nestedFieldPath.length == 0);
+
+    final LogicalType type;
+    if (selectedWholeField) {
+      type = field.getType();
+    } else {
+      Preconditions.checkArgument(
+          field.getType() instanceof RowType,
+          "Cannot project subfields of non-struct field <%s> of type <%s>",
+          field.getName(),
+          field.getType());
+      type = prune((RowType) field.getType(), projectedFields);
+    }
+
+    return new RowType.RowField(field.getName(), type, field.getDescription().orElse(null));
+  }
+
+  private static RowData.FieldGetter getter(
+      RowType originalRowType, RowType prunedRowType, int[] originalFieldPath) {
+    int originalFieldIndex = originalFieldPath[0];
+    String fieldName = originalRowType.getFieldNames().get(originalFieldIndex);
+    int prunedFieldIndex = prunedRowType.getFieldNames().indexOf(fieldName);
+    LogicalType prunedFieldType = prunedRowType.getTypeAt(prunedFieldIndex);
+
+    if (originalFieldPath.length == 1) {
+      return FlinkRowData.createFieldGetter(prunedFieldType, prunedFieldIndex);
+    } else {
+      LogicalType originalChildType = originalRowType.getTypeAt(originalFieldIndex);
+      Preconditions.checkArgument(
+          originalChildType instanceof RowType,
+          "Cannot descend into non-struct field <%s> of type <%s> for nested projection",
+          fieldName,
+          originalChildType);
+
+      RowType originalChildRowType = (RowType) originalChildType;
+      RowType prunedChildRowType = (RowType) prunedFieldType;
+      int childArity = prunedChildRowType.getFieldCount();
+      RowData.FieldGetter childGetter =
+          getter(
+              originalChildRowType,
+              prunedChildRowType,
+              Arrays.copyOfRange(originalFieldPath, 1, originalFieldPath.length));
+      return row ->
+          row.isNullAt(prunedFieldIndex)
+              ? null
+              : childGetter.getFieldOrNull(row.getRow(prunedFieldIndex, childArity));
+    }
+  }
+
+  private static final class RowProjection implements MapFunction<RowData, RowData> {
+
+    private final RowData.FieldGetter[] getters;
+
+    RowProjection(RowData.FieldGetter[] getters) {
+      this.getters = getters;
+    }
+
+    @Override
+    public RowData map(RowData row) {
+      GenericRowData output = new GenericRowData(getters.length);
+      for (int col = 0; col < getters.length; col++) {
+        output.setField(col, getters[col].getFieldOrNull(row));
+      }
+
+      return output;
+    }
+  }
+}

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TableSourceTestBase.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TableSourceTestBase.java
@@ -98,7 +98,9 @@ public abstract class TableSourceTestBase extends TestBase {
 
   @AfterEach
   public void clean() {
-    sql("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, TABLE_NAME);
+    for (String table : getTableEnv().listTables()) {
+      sql("DROP TABLE IF EXISTS %s.%s", DATABASE_NAME, table);
+    }
     dropDatabase(DATABASE_NAME, true);
     dropCatalog(CATALOG_NAME, true);
   }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestFlinkTableSource.java
@@ -30,6 +30,9 @@ import org.junit.jupiter.api.TestTemplate;
 
 public class TestFlinkTableSource extends TableSourceTestBase {
 
+  private static final String NESTED_TABLE_NAME = "nested_table";
+  private static final String MAP_TABLE_NAME = "map_table";
+
   @TestTemplate
   public void testLimitPushDown() {
 
@@ -557,5 +560,168 @@ public class TestFlinkTableSource extends TableSourceTestBase {
   @TestTemplate
   public void testSqlParseNaN() {
     // todo add some test case to test NaN
+  }
+
+  private void createNestedTable() {
+    createNestedTable("(1, ROW('a', 10), ROW('nyc', ROW(40, -74)), ARRAY[ROW('a', 10)])");
+  }
+
+  private void createNestedTable(String values) {
+    sql(
+        "CREATE TABLE %s ("
+            + "id INT, "
+            + "person ROW<name STRING, age INT>, "
+            + "address ROW<city STRING, geo ROW<lat INT, lng INT>>, "
+            + "people ARRAY<ROW<name STRING, age INT>>"
+            + ") WITH ('write.format.default'='%s')",
+        NESTED_TABLE_NAME, format.name());
+
+    sql("INSERT INTO %s VALUES %s", NESTED_TABLE_NAME, values);
+  }
+
+  private void createMapTable() {
+    sql(
+        "CREATE TABLE %s ("
+            + "id INT, "
+            + "attrs MAP<STRING, ROW<code STRING, label STRING>>"
+            + ") WITH ('write.format.default'='%s')",
+        MAP_TABLE_NAME, format.name());
+
+    sql("INSERT INTO %s VALUES (1, MAP['x', ROW('c1', 'l1')])", MAP_TABLE_NAME);
+  }
+
+  private void assertProjection(String expected) {
+    assertThat(scanEventCount).isEqualTo(1);
+    assertThat(lastScanEvent.projection().asStruct()).hasToString(expected);
+  }
+
+  @TestTemplate
+  public void testNestedFieldProjectionPushedDown() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT person.name FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of("a")), result);
+
+    assertProjection("struct<2: person: optional struct<5: name: optional string>>");
+  }
+
+  @TestTemplate
+  public void testMixedTopLevelAndNestedProjection() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT id, person.name FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of(1, "a")), result);
+
+    assertProjection(
+        "struct<1: id: optional int, 2: person: optional struct<5: name: optional string>>");
+  }
+
+  @TestTemplate
+  public void testWholeStructProjection() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT person FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of(Row.of("a", 10))), result);
+
+    assertProjection(
+        "struct<2: person: optional struct<5: name: optional string, 6: age: optional int>>");
+  }
+
+  @TestTemplate
+  public void testNullNestedStruct() {
+    createNestedTable(
+        "(1, ROW('a', 10), ROW('nyc', ROW(40, -74)), ARRAY[ROW('a', 10)]), "
+            + "(2, CAST(NULL AS ROW<name STRING, age INT>), ROW('sf', ROW(37, -122)), ARRAY[ROW('c', 30)])");
+
+    List<Row> result = sql("SELECT id, person.name FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of(1, "a"), Row.of(2, null)), result);
+
+    assertProjection(
+        "struct<1: id: optional int, 2: person: optional struct<5: name: optional string>>");
+  }
+
+  @TestTemplate
+  public void testNullIntermediateNestedStruct() {
+    createNestedTable(
+        "(1, ROW('a', 10), ROW('nyc', CAST(NULL AS ROW<lat INT, lng INT>)), ARRAY[ROW('a', 10)])");
+
+    // geo is null, so the leaf short-circuits to null one level deeper than testNullNestedStruct.
+    List<Row> result = sql("SELECT address.geo.lat FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of((Object) null)), result);
+
+    assertProjection(
+        "struct<3: address: optional struct<8: geo: optional struct<9: lat: optional int>>>");
+  }
+
+  @TestTemplate
+  public void testDeeplyNestedProjection() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT address.geo.lat FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of(40)), result);
+
+    assertProjection(
+        "struct<3: address: optional struct<8: geo: optional struct<9: lat: optional int>>>");
+  }
+
+  @TestTemplate
+  public void testSiblingLeavesShareIntermediateStruct() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT address.geo.lat, address.geo.lng FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of(40, -74)), result);
+
+    assertProjection(
+        "struct<3: address: optional struct<8: geo: optional struct<9: lat: optional int, 10: lng: optional int>>>");
+  }
+
+  @TestTemplate
+  public void testProjectionOutputOrderPreserved() {
+    createNestedTable();
+
+    // Output rows follow the SELECT list (name, id), while the pushed-down projection keeps table
+    // schema order (id, person).
+    List<Row> result = sql("SELECT person.name, id FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of("a", 1)), result);
+
+    assertProjection(
+        "struct<1: id: optional int, 2: person: optional struct<5: name: optional string>>");
+  }
+
+  @TestTemplate
+  public void testNestedLeavesFromDifferentStructs() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT person.name, address.city FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of("a", "nyc")), result);
+
+    assertProjection(
+        "struct<2: person: optional struct<5: name: optional string>, 3: address: optional struct<7: city: optional string>>");
+  }
+
+  @TestTemplate
+  public void testArrayElementSubfieldReadsWholeStruct() {
+    createNestedTable();
+
+    List<Row> result = sql("SELECT people[1].name FROM %s", NESTED_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of("a")), result);
+
+    // Flink does not support projection pushdown through arrays so age is still read despite only
+    // name being referenced: the element struct is not pruned. Other top-level fields are.
+    assertProjection(
+        "struct<4: people: optional list<struct<12: name: optional string, 13: age: optional int>>>");
+  }
+
+  @TestTemplate
+  public void testMapValueSubfieldReadsWholeStruct() {
+    createMapTable();
+
+    List<Row> result = sql("SELECT attrs['x'].code FROM %s", MAP_TABLE_NAME);
+    assertSameElements(Lists.newArrayList(Row.of("c1")), result);
+
+    // Flink does not support projection pushdown through maps so label is still read despite only
+    // code being referenced: the value struct is not pruned. Other top-level fields are.
+    assertProjection(
+        "struct<2: attrs: optional map<string, struct<5: code: optional string, 6: label: optional string>>>");
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestProjector.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/source/TestProjector.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.flink.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.table.connector.Projection;
+import org.apache.flink.table.data.GenericRowData;
+import org.apache.flink.table.data.RowData;
+import org.apache.flink.table.runtime.typeutils.InternalTypeInfo;
+import org.apache.flink.table.types.logical.IntType;
+import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.table.types.logical.NullType;
+import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VarCharType;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Projector} to cover behaviour that can't be tested in {@code
+ * TestFlinkTableSource}.
+ */
+public class TestProjector {
+
+  // id INT, person ROW<name STRING, age INT>, address ROW<city STRING, geo ROW<lat INT, lng INT>>
+  private static final RowType PERSON =
+      row(new String[] {"name", "age"}, VarCharType.STRING_TYPE, new IntType());
+  private static final RowType GEO = row(new String[] {"lat", "lng"}, new IntType(), new IntType());
+  private static final RowType ADDRESS =
+      row(new String[] {"city", "geo"}, VarCharType.STRING_TYPE, GEO);
+  private static final RowType ORIGINAL =
+      row(new String[] {"id", "person", "address"}, new IntType(), PERSON, ADDRESS);
+
+  private static RowType row(String[] names, LogicalType... types) {
+    return RowType.of(types, names);
+  }
+
+  private static Projector projector(int[][] projectedFields) {
+    RowType producedRowType = (RowType) Projection.of(projectedFields).project(ORIGINAL);
+    return Projector.of(ORIGINAL, projectedFields, producedRowType);
+  }
+
+  /** A source stream shaped like the reader output for the given projection (never executed). */
+  private static DataStream<RowData> readerStream(int[][] projectedFields) {
+    RowType readSchema = projector(projectedFields).readSchema();
+    return StreamExecutionEnvironment.getExecutionEnvironment()
+        .fromData(InternalTypeInfo.of(readSchema), new GenericRowData(readSchema.getFieldCount()));
+  }
+
+  @SuppressWarnings("unchecked")
+  private static <T> T roundTripSerialize(T instance) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(instance);
+    }
+    try (ObjectInputStream in =
+        new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (T) in.readObject();
+    }
+  }
+
+  @Test
+  public void addsNoMapForInOrderTopLevelProjection() {
+    // A non-nested, in-order projection already matches the produced shape, so the reader stream is
+    // returned unchanged (no map operator).
+    for (int[][] inOrder :
+        new int[][][] {
+          {{0}}, // select only first column
+          {{1}}, // select only second column
+          {{2}}, // select only third column
+          {{0}, {1}}, // select first two columns (in order)
+          {{1}, {2}}, // select last two columns (in order)
+          {{0}, {1}, {2}} // select all three columns (in order)
+        }) {
+      DataStream<RowData> source = readerStream(inOrder);
+      assertThat(projector(inOrder).project(source)).isSameAs(source);
+    }
+  }
+
+  @Test
+  public void buildsFieldGetterForUnknownTypeLeaf() {
+    // Iceberg `unknown` columns surface as Flink NullType. Building the projector builds a field
+    // getter for the NullType leaf, which must not fail on the NullType root. This is why
+    // Projector uses FlinkRowData.createFieldGetter (see FLINK-37245) instead of Flink's built-in
+    // RowData.createFieldGetter, which throws. A NullType column cannot be run through a real
+    // DataStream (Flink has no serializer for it), so this guards getter construction only.
+    RowType original = row(new String[] {"meta"}, row(new String[] {"note"}, new NullType()));
+    int[][] projection = {{0, 0}};
+    RowType produced = (RowType) Projection.of(projection).project(original);
+
+    Projector projector = Projector.of(original, projection, produced);
+
+    assertThat(projector.readSchema()).isEqualTo(original);
+  }
+
+  @Test
+  public void rejectsDescentIntoNonStruct() {
+    // Flink never pushes a path that descends into a scalar, so this guardrail is not reachable via
+    // SQL; assert it directly.
+    assertThatThrownBy(() -> Projector.of(ORIGINAL, new int[][] {{0, 0}}, ORIGINAL))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot project subfields of non-struct field <id>");
+  }
+
+  @Test
+  public void isSerializable() throws Exception {
+    // Flink ships the projection's map function to task managers, so it must survive Java
+    // serialization (in particular the nested field getters). A successful round-trip proves the
+    // whole projector -- including the shipped map -- serializes.
+    Projector projector = projector(new int[][] {{1, 0}, {0}});
+
+    Projector roundTripped = roundTripSerialize(projector);
+
+    assertThat(roundTripped.readSchema()).isEqualTo(projector.readSchema());
+  }
+}


### PR DESCRIPTION
Enables **_nested_** projection pushdown in the Flink v2.1 Iceberg source. Previously `supportsNestedProjection()` returned `false` so a query like `SELECT user.name FROM t` read the entire `user` struct. This PR pushes the nested field paths down to the reader so only the selected leaf columns are scanned.
