### PR TITLE
Core: Support metrics with nested field in AppendBenchmark and FileGenerationUtil

### DIFF
--- a/core/src/jmh/java/org/apache/iceberg/AppendBenchmark.java
+++ b/core/src/jmh/java/org/apache/iceberg/AppendBenchmark.java
@@ -71,7 +71,19 @@ public class AppendBenchmark {
           required(10, "str_col4", Types.StringType.get()),
           required(11, "str_col5", Types.StringType.get()),
           required(12, "str_col6", Types.StringType.get()),
-          required(13, "str_col7", Types.StringType.get()));
+          required(13, "str_col7", Types.StringType.get()),
+          required(14, "time_col", Types.TimeType.get()),
+          required(
+              15,
+              "struct_col",
+              Types.StructType.of(
+                  required(16, "nested_int", Types.IntegerType.get()),
+                  required(17, "nested_str", Types.StringType.get()))),
+          required(
+              18,
+              "map_col",
+              Types.MapType.ofRequired(19, 20, Types.StringType.get(), Types.LongType.get())),
+          required(21, "list_col", Types.ListType.ofRequired(22, Types.StringType.get())));
   private static final PartitionSpec SPEC = PartitionSpec.unpartitioned();
   private static final HadoopTables TABLES = new HadoopTables();
 

--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -20,6 +20,7 @@ package org.apache.iceberg;
 
 import java.nio.ByteBuffer;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
@@ -31,6 +32,7 @@ import org.apache.iceberg.MetricsModes.Truncate;
 import org.apache.iceberg.io.DeleteSchemaUtil;
 import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.transforms.Transforms;
@@ -38,6 +40,7 @@ import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Type.PrimitiveType;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.RandomUtil;
@@ -177,19 +180,20 @@ public class FileGenerationUtil {
     Map<Integer, ByteBuffer> upperBounds = Maps.newHashMap();
     Map<Integer, Type> originalTypes = Maps.newHashMap();
 
-    for (Types.NestedField column : schema.columns()) {
-      int fieldId = column.fieldId();
+    for (Types.NestedField field : leafFields(schema)) {
+      int fieldId = field.fieldId();
       columnSizes.put(fieldId, generateColumnSize());
       valueCounts.put(fieldId, generateValueCount());
       nullValueCounts.put(fieldId, (long) random().nextInt(5));
       nanValueCounts.put(fieldId, (long) random().nextInt(5));
-      originalTypes.put(fieldId, column.type());
+      originalTypes.put(fieldId, field.type());
+
       if (knownLowerBounds.containsKey(fieldId) && knownUpperBounds.containsKey(fieldId)) {
         lowerBounds.put(fieldId, knownLowerBounds.get(fieldId));
         upperBounds.put(fieldId, knownUpperBounds.get(fieldId));
-      } else if (column.type().isPrimitiveType()) {
-        PrimitiveType type = column.type().asPrimitiveType();
-        MetricsMode metricsMode = metricsConfig.columnMode(column.name());
+      } else {
+        PrimitiveType type = field.type().asPrimitiveType();
+        MetricsMode metricsMode = metricsConfig.columnMode(schema.findColumnName(fieldId));
         Pair<ByteBuffer, ByteBuffer> bounds = generateBounds(type, metricsMode);
         lowerBounds.put(fieldId, bounds.first());
         upperBounds.put(fieldId, bounds.second());
@@ -205,6 +209,44 @@ public class FileGenerationUtil {
         lowerBounds,
         upperBounds,
         originalTypes);
+  }
+
+  // collects leaf primitive fields, recursing through struct/list/map
+  static List<Types.NestedField> leafFields(Schema schema) {
+    List<Types.NestedField> leaves = Lists.newArrayList();
+    TypeUtil.visit(
+        schema,
+        new TypeUtil.SchemaVisitor<Void>() {
+          @Override
+          public Void struct(Types.StructType struct, List<Void> fieldResults) {
+            for (Types.NestedField field : struct.fields()) {
+              if (field.type().isPrimitiveType()) {
+                leaves.add(field);
+              }
+            }
+            return null;
+          }
+
+          @Override
+          public Void list(Types.ListType list, Void elementResult) {
+            if (list.elementType().isPrimitiveType()) {
+              leaves.add(list.field(list.elementId()));
+            }
+            return null;
+          }
+
+          @Override
+          public Void map(Types.MapType map, Void keyResult, Void valueResult) {
+            if (map.keyType().isPrimitiveType()) {
+              leaves.add(map.field(map.keyId()));
+            }
+            if (map.valueType().isPrimitiveType()) {
+              leaves.add(map.field(map.valueId()));
+            }
+            return null;
+          }
+        });
+    return leaves;
   }
 
   private static Metrics generatePositionDeleteMetrics(DataFile dataFile) {

--- a/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/FileGenerationUtil.java
@@ -193,7 +193,7 @@ public class FileGenerationUtil {
         upperBounds.put(fieldId, knownUpperBounds.get(fieldId));
       } else {
         PrimitiveType type = field.type().asPrimitiveType();
-        MetricsMode metricsMode = metricsConfig.columnMode(schema.findColumnName(fieldId));
+        MetricsMode metricsMode = metricsConfig.columnMode(fieldId);
         Pair<ByteBuffer, ByteBuffer> bounds = generateBounds(type, metricsMode);
         lowerBounds.put(fieldId, bounds.first());
         upperBounds.put(fieldId, bounds.second());
@@ -211,41 +211,14 @@ public class FileGenerationUtil {
         originalTypes);
   }
 
-  // collects leaf primitive fields, recursing through struct/list/map
+  // collects all primitive (leaf) fields, including those nested within structs, lists, and maps
   static List<Types.NestedField> leafFields(Schema schema) {
     List<Types.NestedField> leaves = Lists.newArrayList();
-    TypeUtil.visit(
-        schema,
-        new TypeUtil.SchemaVisitor<Void>() {
-          @Override
-          public Void struct(Types.StructType struct, List<Void> fieldResults) {
-            for (Types.NestedField field : struct.fields()) {
-              if (field.type().isPrimitiveType()) {
-                leaves.add(field);
-              }
-            }
-            return null;
-          }
-
-          @Override
-          public Void list(Types.ListType list, Void elementResult) {
-            if (list.elementType().isPrimitiveType()) {
-              leaves.add(list.field(list.elementId()));
-            }
-            return null;
-          }
-
-          @Override
-          public Void map(Types.MapType map, Void keyResult, Void valueResult) {
-            if (map.keyType().isPrimitiveType()) {
-              leaves.add(map.field(map.keyId()));
-            }
-            if (map.valueType().isPrimitiveType()) {
-              leaves.add(map.field(map.valueId()));
-            }
-            return null;
-          }
-        });
+    for (Types.NestedField field : TypeUtil.indexById(schema.asStruct()).values()) {
+      if (field.type().isPrimitiveType()) {
+        leaves.add(field);
+      }
+    }
     return leaves;
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -123,7 +123,9 @@ public class TestFileGenerationUtil {
   public void testBoundsForNestedTypes(String metricsMode) {
     MetricsConfig metricsConfig =
         MetricsConfig.from(
-            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode), SCHEMA, null);
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode),
+            NESTED_SCHEMA,
+            null);
     Metrics metrics =
         FileGenerationUtil.generateRandomMetrics(
             NESTED_SCHEMA,

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -143,7 +143,7 @@ public class TestFileGenerationUtil {
 
   private void checkBounds(Schema schema, Metrics metrics, MetricsConfig metricsConfig) {
     for (NestedField field : FileGenerationUtil.leafFields(schema)) {
-      MetricsMode mode = metricsConfig.columnMode(schema.findColumnName(field.fieldId()));
+      MetricsMode mode = metricsConfig.columnMode(field.fieldId());
       ByteBuffer lowerBuffer = metrics.lowerBounds().get(field.fieldId());
       ByteBuffer upperBuffer = metrics.upperBounds().get(field.fieldId());
       if (mode.equals(MetricsModes.None.get()) || mode.equals(MetricsModes.Counts.get())) {

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -46,6 +46,21 @@ public class TestFileGenerationUtil {
           required(6, "timestamp_tz_col", Types.TimestampType.withZone()),
           required(7, "str_col", Types.StringType.get()));
 
+  public static final Schema NESTED_SCHEMA =
+      new Schema(
+          required(1, "int_col", Types.IntegerType.get()),
+          required(
+              2,
+              "struct_col",
+              Types.StructType.of(
+                  required(3, "nested_int", Types.IntegerType.get()),
+                  required(4, "nested_str", Types.StringType.get()))),
+          required(
+              5,
+              "map_col",
+              Types.MapType.ofRequired(6, 7, Types.StringType.get(), Types.LongType.get())),
+          required(8, "list_col", Types.ListType.ofRequired(9, Types.IntegerType.get())));
+
   @Test
   public void testBoundsWithDefaultMetricsConfig() {
     MetricsConfig metricsConfig = MetricsConfig.getDefault();
@@ -59,7 +74,7 @@ public class TestFileGenerationUtil {
     assertThat(metrics.lowerBounds()).hasSize(SCHEMA.columns().size());
     assertThat(metrics.upperBounds()).hasSize(SCHEMA.columns().size());
 
-    checkBounds(metrics, metricsConfig);
+    checkBounds(SCHEMA, metrics, metricsConfig);
   }
 
   @Test
@@ -79,7 +94,7 @@ public class TestFileGenerationUtil {
     assertThat(metrics.lowerBounds()).hasSize(SCHEMA.columns().size());
     assertThat(metrics.upperBounds()).hasSize(SCHEMA.columns().size());
 
-    checkBounds(metrics, metricsConfig);
+    checkBounds(SCHEMA, metrics, metricsConfig);
 
     ByteBuffer actualIntLower = metrics.lowerBounds().get(intField.fieldId());
     ByteBuffer actualIntUpper = metrics.upperBounds().get(intField.fieldId());
@@ -89,7 +104,6 @@ public class TestFileGenerationUtil {
 
   @ParameterizedTest
   @ValueSource(strings = {"none", "counts", "truncate(16)", "full"})
-  @SuppressWarnings("deprecation")
   void testBoundsForAllMetricsModes(String metricsMode) {
     MetricsConfig metricsConfig =
         MetricsConfig.from(
@@ -101,12 +115,32 @@ public class TestFileGenerationUtil {
             ImmutableMap.of() /* no lower bounds */,
             ImmutableMap.of() /* no upper bounds */);
 
-    checkBounds(metrics, metricsConfig);
+    checkBounds(SCHEMA, metrics, metricsConfig);
   }
 
-  private void checkBounds(Metrics metrics, MetricsConfig metricsConfig) {
-    for (NestedField field : SCHEMA.columns()) {
-      MetricsMode mode = metricsConfig.columnMode(field.name());
+  @Test
+  public void testBoundsForNestedTypes() {
+    MetricsConfig metricsConfig = MetricsConfig.getDefault();
+    Metrics metrics =
+        FileGenerationUtil.generateRandomMetrics(
+            NESTED_SCHEMA,
+            metricsConfig,
+            ImmutableMap.of() /* no known lower bounds */,
+            ImmutableMap.of() /* no known upper bounds */);
+
+    assertThat(metrics.lowerBounds())
+        .as("only leaf primitive fields have lower bound")
+        .containsOnlyKeys(1, 3, 4, 6, 7, 9);
+    assertThat(metrics.upperBounds())
+        .as("only leaf primitive fields have upper bound")
+        .containsOnlyKeys(1, 3, 4, 6, 7, 9);
+
+    checkBounds(NESTED_SCHEMA, metrics, metricsConfig);
+  }
+
+  private void checkBounds(Schema schema, Metrics metrics, MetricsConfig metricsConfig) {
+    for (NestedField field : FileGenerationUtil.leafFields(schema)) {
+      MetricsMode mode = metricsConfig.columnMode(schema.findColumnName(field.fieldId()));
       ByteBuffer lowerBuffer = metrics.lowerBounds().get(field.fieldId());
       ByteBuffer upperBuffer = metrics.upperBounds().get(field.fieldId());
       if (mode.equals(MetricsModes.None.get()) || mode.equals(MetricsModes.Counts.get())) {

--- a/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestFileGenerationUtil.java
@@ -118,9 +118,12 @@ public class TestFileGenerationUtil {
     checkBounds(SCHEMA, metrics, metricsConfig);
   }
 
-  @Test
-  public void testBoundsForNestedTypes() {
-    MetricsConfig metricsConfig = MetricsConfig.getDefault();
+  @ParameterizedTest
+  @ValueSource(strings = {"none", "counts", "truncate(16)", "full"})
+  public void testBoundsForNestedTypes(String metricsMode) {
+    MetricsConfig metricsConfig =
+        MetricsConfig.from(
+            ImmutableMap.of(TableProperties.DEFAULT_WRITE_METRICS_MODE, metricsMode), SCHEMA, null);
     Metrics metrics =
         FileGenerationUtil.generateRandomMetrics(
             NESTED_SCHEMA,


### PR DESCRIPTION
Adding schema support for nested fields in AppendBenchmark and FileGenerationUtil. Previous it will only handle the primitive type but real production workload often involves complex type. 


fast | numFiles | Score (ms/op)
-- | -- | --
true (FastAppend) | 50,000 | 519.3 ± 676.1
true (FastAppend) | 100,000 | 876.3 ± 3311.6
false (MergeAppend) | 50,000 | 484.0 ± 247.3
false (MergeAppend) | 100,000 | 739.2 ± 395.2

---
Model: Claude Opus 4.8
Platform/Tool: Claude CLI
Human Oversight: fully reviewed
Prompt Summary: Spin a new branch to fix pre-existing bug in FileGenerationUtil where default metrics generation for nested binary field crashes