### PR TITLE
Aliyun: Add Aliyun auth type for REST catalog

### DIFF
--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/AliyunProperties.java
@@ -76,11 +76,28 @@ public class AliyunProperties implements Serializable {
    */
   public static final String OSS_STAGING_DIRECTORY = "oss.staging-dir";
 
+  public static final String REST_SIGNING_NAME = "aliyun.auth.signing-name";
+  public static final String REST_ACCESS_KEY_ID = "aliyun.auth.access-key-id";
+  public static final String REST_ACCESS_KEY_SECRET = "aliyun.auth.access-key-secret";
+  public static final String REST_STS_TOKEN = "aliyun.auth.sts-token";
+  public static final String REST_SIGNING_REGION = "aliyun.auth.region";
+
+  public static final String ENV_ACCESS_KEY_ID = "ALIBABA_CLOUD_ACCESS_KEY_ID";
+  public static final String ENV_ACCESS_KEY_SECRET = "ALIBABA_CLOUD_ACCESS_KEY_SECRET";
+  public static final String ENV_STS_TOKEN = "ALIBABA_CLOUD_SECURITY_TOKEN";
+  public static final String ENV_REGION = "ALIBABA_CLOUD_REGION_ID";
+
   private final String ossEndpoint;
   private final String accessKeyId;
   private final String accessKeySecret;
   private final String securityToken;
   private final String ossStagingDirectory;
+
+  private final String restSigningName;
+  private final String restAccessKeyId;
+  private final String restAccessKeySecret;
+  private final String restStsToken;
+  private final String restSigningRegion;
 
   public AliyunProperties() {
     this(ImmutableMap.of());
@@ -96,6 +113,13 @@ public class AliyunProperties implements Serializable {
     this.ossStagingDirectory =
         PropertyUtil.propertyAsString(
             properties, OSS_STAGING_DIRECTORY, System.getProperty("java.io.tmpdir"));
+
+    this.restSigningName = properties.getOrDefault(REST_SIGNING_NAME, "");
+    this.restAccessKeyId = resolveProperty(properties, REST_ACCESS_KEY_ID, ENV_ACCESS_KEY_ID);
+    this.restAccessKeySecret =
+        resolveProperty(properties, REST_ACCESS_KEY_SECRET, ENV_ACCESS_KEY_SECRET);
+    this.restStsToken = resolveProperty(properties, REST_STS_TOKEN, ENV_STS_TOKEN);
+    this.restSigningRegion = resolveProperty(properties, REST_SIGNING_REGION, ENV_REGION);
   }
 
   public String ossEndpoint() {
@@ -116,5 +140,34 @@ public class AliyunProperties implements Serializable {
 
   public String ossStagingDirectory() {
     return ossStagingDirectory;
+  }
+
+  public String restSigningName() {
+    return restSigningName;
+  }
+
+  public String restAccessKeyId() {
+    return restAccessKeyId;
+  }
+
+  public String restAccessKeySecret() {
+    return restAccessKeySecret;
+  }
+
+  public String restStsToken() {
+    return restStsToken;
+  }
+
+  public String restSigningRegion() {
+    return restSigningRegion;
+  }
+
+  private static String resolveProperty(
+      Map<String, String> properties, String propertyKey, String envVar) {
+    String value = properties.get(propertyKey);
+    if (value == null || value.isEmpty()) {
+      value = System.getenv(envVar);
+    }
+    return value;
   }
 }

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunAuthManager.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunAuthManager.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.auth;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.iceberg.aliyun.AliyunProperties;
+import org.apache.iceberg.catalog.SessionCatalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.rest.RESTClient;
+import org.apache.iceberg.rest.RESTUtil;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthSession;
+
+/**
+ * An {@link AuthManager} that signs every request using a product-specific signing protocol. The
+ * product is determined by the {@code aliyun.auth.signing-name} property.
+ */
+public final class AliyunAuthManager implements AuthManager {
+
+  private static final String SIGNING_NAME_ODPS = "odps";
+  private static final String SIGNER_IMPL_ODPS =
+      "org.apache.iceberg.aliyun.odps.auth.OdpsRequestSigner";
+
+  @SuppressWarnings("unused")
+  private final String name;
+
+  private Map<String, String> catalogProperties = Map.of();
+
+  public AliyunAuthManager(String name) {
+    this.name = name;
+  }
+
+  @Override
+  public AuthSession initSession(RESTClient initClient, Map<String, String> properties) {
+    return createSession(properties);
+  }
+
+  @Override
+  public AuthSession catalogSession(RESTClient sharedClient, Map<String, String> properties) {
+    this.catalogProperties = properties;
+    return createSession(properties);
+  }
+
+  @Override
+  public AuthSession contextualSession(SessionCatalog.SessionContext context, AuthSession parent) {
+    Map<String, String> contextProps =
+        RESTUtil.merge(
+            Optional.ofNullable(context.properties()).orElseGet(Map::of),
+            Optional.ofNullable(context.credentials()).orElseGet(Map::of));
+    Map<String, String> merged = RESTUtil.merge(catalogProperties, contextProps);
+    return createSession(merged);
+  }
+
+  @Override
+  public AuthSession tableSession(
+      TableIdentifier table, Map<String, String> properties, AuthSession parent) {
+    Map<String, String> tableProperties = RESTUtil.merge(catalogProperties, properties);
+    return createSession(tableProperties);
+  }
+
+  private AuthSession createSession(Map<String, String> properties) {
+    AliyunProperties aliyunProperties = new AliyunProperties(properties);
+    AliyunRequestSigner signer = createSigner(aliyunProperties, properties);
+    return new AliyunAuthSession(signer);
+  }
+
+  private static AliyunRequestSigner createSigner(
+      AliyunProperties aliyunProperties, Map<String, String> properties) {
+    String signingName = aliyunProperties.restSigningName();
+
+    String impl;
+    switch (signingName.toLowerCase(Locale.ROOT)) {
+      case SIGNING_NAME_ODPS:
+        impl = SIGNER_IMPL_ODPS;
+        break;
+      default:
+        impl = signingName;
+    }
+
+    return loadSigner(impl, aliyunProperties, properties);
+  }
+
+  private static AliyunRequestSigner loadSigner(
+      String impl, AliyunProperties aliyunProperties, Map<String, String> properties) {
+    DynConstructors.Ctor<AliyunRequestSigner> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(AliyunRequestSigner.class)
+              .loader(AliyunAuthManager.class.getClassLoader())
+              .impl(impl, AliyunProperties.class, Map.class)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot initialize AliyunRequestSigner implementation %s: %s", impl, e.getMessage()),
+          e);
+    }
+
+    try {
+      return ctor.newInstance(aliyunProperties, properties);
+    } catch (ClassCastException e) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "Cannot initialize signer, %s does not implement AliyunRequestSigner", impl),
+          e);
+    }
+  }
+
+  @Override
+  public void close() {}
+}

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunAuthSession.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunAuthSession.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.auth;
+
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.auth.AuthSession;
+
+final class AliyunAuthSession implements AuthSession {
+
+  private final AliyunRequestSigner signer;
+
+  AliyunAuthSession(AliyunRequestSigner signer) {
+    this.signer = Preconditions.checkNotNull(signer, "Invalid signer: null");
+  }
+
+  @Override
+  public HTTPRequest authenticate(HTTPRequest request) {
+    return signer.sign(request);
+  }
+
+  @Override
+  public void close() {}
+}

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunRequestSigner.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/auth/AliyunRequestSigner.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.auth;
+
+import org.apache.iceberg.rest.HTTPRequest;
+
+/**
+ * Signs an outgoing HTTP request for a specific Aliyun product.
+ *
+ * <p>Each Aliyun product has its own signing protocol with distinct Authorization format, header
+ * conventions, and algorithms. Implementations have full control over the request: they decide
+ * which headers to add, how to compute the signature, and how to format the Authorization value.
+ */
+public interface AliyunRequestSigner {
+  HTTPRequest sign(HTTPRequest request);
+}

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/odps/auth/OdpsAuthProperties.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/odps/auth/OdpsAuthProperties.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.odps.auth;
+
+public final class OdpsAuthProperties {
+
+  private OdpsAuthProperties() {}
+
+  public static final String CORPORATION = "odps.auth.corporation";
+  public static final String CORPORATION_DEFAULT = "aliyun";
+  public static final String STS_TOKEN_HEADER = "authorization-sts-token";
+}

--- a/aliyun/src/main/java/org/apache/iceberg/aliyun/odps/auth/OdpsRequestSigner.java
+++ b/aliyun/src/main/java/org/apache/iceberg/aliyun/odps/auth/OdpsRequestSigner.java
@@ -1,0 +1,315 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.odps.auth;
+
+// Signing logic ported from com.aliyun.odps:odps-sdk-core's AliyunRequestSigner /
+// SecurityUtils so this module can be used without pulling in the full ODPS SDK.
+
+import java.net.URI;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.time.Clock;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.iceberg.aliyun.AliyunProperties;
+import org.apache.iceberg.aliyun.auth.AliyunRequestSigner;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.apache.iceberg.rest.HTTPHeaders;
+import org.apache.iceberg.rest.HTTPHeaders.HTTPHeader;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPHeaders;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+
+/** Signs each outgoing request with the ODPS V2 or V4 protocol. */
+public final class OdpsRequestSigner implements AliyunRequestSigner {
+
+  static final String HEADER_PREFIX = "x-odps-";
+  static final String CONTENT_TYPE = "Content-Type";
+  static final String CONTENT_MD5 = "Content-MD5";
+  static final String DATE = "Date";
+
+  private static final String AUTHORIZATION = "Authorization";
+  private static final String NEW_LINE = "\n";
+  private static final DateTimeFormatter DATE_FMT =
+      DateTimeFormatter.ofPattern("yyyyMMdd", Locale.ROOT);
+  private static final DateTimeFormatter RFC1123 =
+      DateTimeFormatter.ofPattern("EEE, dd MMM yyyy HH:mm:ss 'GMT'", Locale.ENGLISH);
+
+  private final String accessId;
+  private final String accessKey;
+  private final String region;
+  private final String corporation;
+  private final String stsToken;
+  private final Clock clock;
+
+  public OdpsRequestSigner(AliyunProperties aliyunProperties, Map<String, String> properties) {
+    Preconditions.checkNotNull(aliyunProperties, "Invalid aliyunProperties: null");
+    Preconditions.checkArgument(
+        aliyunProperties.restAccessKeyId() != null && !aliyunProperties.restAccessKeyId().isEmpty(),
+        "accessKeyId should not be empty");
+    Preconditions.checkArgument(
+        aliyunProperties.restAccessKeySecret() != null
+            && !aliyunProperties.restAccessKeySecret().isEmpty(),
+        "accessKeySecret should not be empty");
+    this.accessId = aliyunProperties.restAccessKeyId();
+    this.accessKey = aliyunProperties.restAccessKeySecret();
+    this.region = aliyunProperties.restSigningRegion();
+    String corp =
+        properties.getOrDefault(
+            OdpsAuthProperties.CORPORATION, OdpsAuthProperties.CORPORATION_DEFAULT);
+    this.corporation = corp.isEmpty() ? OdpsAuthProperties.CORPORATION_DEFAULT : corp;
+    this.stsToken = aliyunProperties.restStsToken();
+    this.clock = Clock.systemUTC();
+  }
+
+  @Override
+  public HTTPRequest sign(HTTPRequest request) {
+    URI uri = request.requestUri();
+    String resource = resource(uri);
+
+    Map<String, String> headerMap = normalizeHeaders(request.headers());
+    String authValue =
+        authorization(request.method().name(), resource, headerMap, request.queryParameters());
+
+    ImmutableHTTPHeaders.Builder builder = ImmutableHTTPHeaders.builder();
+    headerMap.forEach((name, value) -> builder.addEntry(HTTPHeader.of(name, value)));
+    builder.addEntry(HTTPHeader.of(AUTHORIZATION, authValue));
+    if (stsToken != null && !stsToken.isEmpty()) {
+      builder.addEntry(HTTPHeader.of(OdpsAuthProperties.STS_TOKEN_HEADER, stsToken));
+    }
+
+    HTTPHeaders signedHeaders = builder.build();
+    return ImmutableHTTPRequest.builder().from(request).headers(signedHeaders).build();
+  }
+
+  private static String resource(URI uri) {
+    String rawPath = uri.getRawPath();
+    return rawPath == null || rawPath.isEmpty()
+        ? "/"
+        : URLDecoder.decode(rawPath, StandardCharsets.UTF_8);
+  }
+
+  String authorization(
+      String method,
+      String resource,
+      Map<String, String> headers,
+      Map<String, String> queryParams) {
+    ensureDateHeader(headers);
+    String canonical = canonicalString(method, resource, headers, queryParams);
+    if (region == null || region.isEmpty()) {
+      return signV2(canonical);
+    }
+    String scopeDate = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC)).format(DATE_FMT);
+    return signV4(canonical, scopeDate);
+  }
+
+  private void ensureDateHeader(Map<String, String> headers) {
+    if (headers.get(DATE) == null) {
+      ZonedDateTime now = ZonedDateTime.now(clock.withZone(ZoneOffset.UTC));
+      headers.put(DATE, RFC1123.format(now));
+    }
+  }
+
+  private String signV2(String stringToSign) {
+    byte[] sig =
+        hmacSha1(
+            stringToSign.getBytes(StandardCharsets.UTF_8),
+            accessKey.getBytes(StandardCharsets.UTF_8));
+    return "ODPS " + accessId + ":" + Base64.getEncoder().encodeToString(sig).trim();
+  }
+
+  private String signV4(String stringToSign, String date) {
+    String credential =
+        accessId + "/" + date + "/" + region + "/odps/" + corporation + "_v4_request";
+    byte[] derivedKey = derivedV4Key(date);
+    byte[] sig = hmacSha1(stringToSign.getBytes(StandardCharsets.UTF_8), derivedKey);
+    return "ODPS " + credential + ":" + Base64.getEncoder().encodeToString(sig);
+  }
+
+  private byte[] derivedV4Key(String date) {
+    byte[] kSecret = (corporation + "_v4" + accessKey).getBytes(StandardCharsets.UTF_8);
+    byte[] kDate = hmacSha256(date.getBytes(StandardCharsets.UTF_8), kSecret);
+    byte[] kRegion = hmacSha256(region.getBytes(StandardCharsets.UTF_8), kDate);
+    byte[] kService = hmacSha256("odps".getBytes(StandardCharsets.UTF_8), kRegion);
+    return hmacSha256((corporation + "_v4_request").getBytes(StandardCharsets.UTF_8), kService);
+  }
+
+  static String canonicalString(
+      String method,
+      String resource,
+      Map<String, String> headers,
+      Map<String, String> queryParams) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(method).append(NEW_LINE);
+
+    Map<String, String> headersToSign = Maps.newTreeMap();
+    addHeadersToSign(headersToSign, headers);
+    headersToSign.putIfAbsent(CONTENT_TYPE.toLowerCase(Locale.ROOT), "");
+    headersToSign.putIfAbsent(CONTENT_MD5.toLowerCase(Locale.ROOT), "");
+
+    if (queryParams != null) {
+      for (Map.Entry<String, String> e : queryParams.entrySet()) {
+        if (e.getKey() != null && e.getKey().startsWith(HEADER_PREFIX)) {
+          headersToSign.put(e.getKey(), e.getValue());
+        }
+      }
+    }
+
+    appendCanonicalHeaders(builder, headersToSign);
+    builder.append(canonicalResource(resource, queryParams));
+    return builder.toString();
+  }
+
+  private static void addHeadersToSign(
+      Map<String, String> headersToSign, Map<String, String> headers) {
+    if (headers == null) {
+      return;
+    }
+
+    for (Map.Entry<String, String> e : headers.entrySet()) {
+      if (e.getKey() == null) {
+        continue;
+      }
+
+      String lower = e.getKey().toLowerCase(Locale.ROOT);
+      if (shouldSignHeader(lower)) {
+        headersToSign.put(lower, e.getValue());
+      }
+    }
+  }
+
+  private static boolean shouldSignHeader(String headerName) {
+    return headerName.equals(CONTENT_TYPE.toLowerCase(Locale.ROOT))
+        || headerName.equals(CONTENT_MD5.toLowerCase(Locale.ROOT))
+        || headerName.equals(DATE.toLowerCase(Locale.ROOT))
+        || headerName.startsWith(HEADER_PREFIX);
+  }
+
+  private static void appendCanonicalHeaders(
+      StringBuilder builder, Map<String, String> headersToSign) {
+    for (Map.Entry<String, String> entry : headersToSign.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (key.startsWith(HEADER_PREFIX)) {
+        builder.append(key).append(':');
+        if (value != null) {
+          builder.append(value);
+        }
+      } else {
+        builder.append(value == null ? "" : value);
+      }
+      builder.append(NEW_LINE);
+    }
+  }
+
+  private static String canonicalResource(String resource, Map<String, String> params) {
+    StringBuilder builder = new StringBuilder();
+    builder.append(resource);
+    if (params != null && !params.isEmpty()) {
+      String[] names = params.keySet().toArray(new String[0]);
+      Arrays.sort(names);
+      char separator = '?';
+      for (String name : names) {
+        builder.append(separator).append(name);
+        String value = params.get(name);
+        if (value != null && !value.isEmpty()) {
+          builder.append('=').append(value);
+        }
+        separator = '&';
+      }
+    }
+    return builder.toString();
+  }
+
+  private static Map<String, String> normalizeHeaders(HTTPHeaders headers) {
+    Map<String, HTTPHeader> normalized = new LinkedHashMap<>();
+    headers
+        .entries()
+        .forEach(
+            header -> {
+              if (header.name().equalsIgnoreCase(AUTHORIZATION)) {
+                return;
+              }
+
+              String lowerCaseName = header.name().toLowerCase(Locale.ROOT);
+              HTTPHeader existing = normalized.get(lowerCaseName);
+              Preconditions.checkArgument(
+                  existing == null || existing.value().equals(header.value()),
+                  "ODPS auth does not support multiple values for header %s",
+                  header.name());
+              if (existing == null) {
+                normalized.put(
+                    lowerCaseName,
+                    HTTPHeader.of(canonicalHeaderName(header.name()), header.value()));
+              }
+            });
+
+    Map<String, String> normalizedValues = new LinkedHashMap<>();
+    normalized.values().forEach(header -> normalizedValues.put(header.name(), header.value()));
+    return normalizedValues;
+  }
+
+  private static String canonicalHeaderName(String name) {
+    String lowerCaseName = name.toLowerCase(Locale.ROOT);
+    if (CONTENT_TYPE.toLowerCase(Locale.ROOT).equals(lowerCaseName)) {
+      return CONTENT_TYPE;
+    }
+
+    if (CONTENT_MD5.toLowerCase(Locale.ROOT).equals(lowerCaseName)) {
+      return CONTENT_MD5;
+    }
+
+    if (DATE.toLowerCase(Locale.ROOT).equals(lowerCaseName)) {
+      return DATE;
+    }
+
+    return name;
+  }
+
+  private static byte[] hmacSha1(byte[] data, byte[] key) {
+    return hmac("HmacSHA1", data, key);
+  }
+
+  private static byte[] hmacSha256(byte[] data, byte[] key) {
+    return hmac("HmacSHA256", data, key);
+  }
+
+  private static byte[] hmac(String algo, byte[] data, byte[] key) {
+    try {
+      Mac mac = Mac.getInstance(algo);
+      mac.init(new SecretKeySpec(key, algo));
+      return mac.doFinal(data);
+    } catch (NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Algorithm not available: " + algo, e);
+    } catch (InvalidKeyException e) {
+      throw new IllegalStateException("Invalid key for " + algo, e);
+    }
+  }
+}

--- a/aliyun/src/test/java/org/apache/iceberg/aliyun/odps/auth/TestOdpsAuthManager.java
+++ b/aliyun/src/test/java/org/apache/iceberg/aliyun/odps/auth/TestOdpsAuthManager.java
@@ -1,0 +1,339 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.aliyun.odps.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.stream.Stream;
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.iceberg.aliyun.AliyunProperties;
+import org.apache.iceberg.aliyun.auth.AliyunAuthManager;
+import org.apache.iceberg.rest.HTTPHeaders;
+import org.apache.iceberg.rest.HTTPHeaders.HTTPHeader;
+import org.apache.iceberg.rest.HTTPRequest;
+import org.apache.iceberg.rest.ImmutableHTTPRequest;
+import org.apache.iceberg.rest.auth.AuthManager;
+import org.apache.iceberg.rest.auth.AuthManagers;
+import org.apache.iceberg.rest.auth.AuthProperties;
+import org.apache.iceberg.rest.auth.AuthSession;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class TestOdpsAuthManager {
+
+  private static final String AK = "LTAI-fake-id";
+  private static final String SK = "fake-secret";
+  private static final String STS = "fake-sts-token";
+  private static final String FIXED_DATE = "Thu, 28 May 2026 12:00:00 GMT";
+
+  @Test
+  void create() {
+    try (AuthManager manager =
+        AuthManagers.loadAuthManager(
+            "test",
+            Map.of(
+                AuthProperties.AUTH_TYPE,
+                AuthProperties.AUTH_TYPE_ALIYUN,
+                AliyunProperties.REST_SIGNING_NAME,
+                "odps",
+                AliyunProperties.REST_ACCESS_KEY_ID,
+                AK,
+                AliyunProperties.REST_ACCESS_KEY_SECRET,
+                SK))) {
+      assertThat(manager).isInstanceOf(AliyunAuthManager.class);
+    }
+  }
+
+  @ParameterizedTest
+  @MethodSource("missingCredentialCases")
+  void missingCredential(Map<String, String> properties, String missingProperty) {
+    try (AuthManager mgr = new AliyunAuthManager("aliyun")) {
+      assertThatThrownBy(() -> mgr.catalogSession(null, properties))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining(missingProperty);
+    }
+  }
+
+  @Test
+  void v2SignatureAddsAuthorizationAndDate() {
+    Map<String, String> properties =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME, "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID, AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET, SK);
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, properties)) {
+      HTTPRequest signed = session.authenticate(getRequest());
+
+      assertThat(signed.headers().firstEntry("Authorization"))
+          .isPresent()
+          .hasValueSatisfying(h -> assertThat(h.value()).startsWith("ODPS " + AK + ":"));
+      assertThat(signed.headers().firstEntry("Date")).isPresent();
+    }
+  }
+
+  @Test
+  void v4SignatureUsesCredentialScope() {
+    Map<String, String> properties =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME,
+            "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID,
+            AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET,
+            SK,
+            AliyunProperties.REST_SIGNING_REGION,
+            "cn-hangzhou");
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, properties)) {
+      HTTPRequest signed = session.authenticate(getRequest());
+
+      String auth = signed.headers().firstEntry("Authorization").orElseThrow().value();
+      assertThat(auth)
+          .startsWith("ODPS " + AK + "/")
+          .contains("/cn-hangzhou/odps/aliyun_v4_request:");
+    }
+  }
+
+  @Test
+  void stsTokenAddsHeaderWithoutAffectingSignature() {
+    Map<String, String> baseProps =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME, "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID, AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET, SK);
+    Map<String, String> stsProps =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME, "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID, AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET, SK,
+            AliyunProperties.REST_STS_TOKEN, STS);
+
+    HTTPRequest fixedRequest = getRequestWithDate("Thu, 28 May 2026 12:00:00 GMT");
+
+    HTTPRequest withoutSts;
+    HTTPRequest withSts;
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, baseProps)) {
+      withoutSts = session.authenticate(fixedRequest);
+    }
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, stsProps)) {
+      withSts = session.authenticate(fixedRequest);
+    }
+
+    // The Authorization signature must be byte-for-byte identical: STS token does not feed into
+    // the canonical string, mirroring com.aliyun.odps.account.StsRequestSigner.
+    assertThat(withSts.headers().firstEntry("Authorization").orElseThrow().value())
+        .isEqualTo(withoutSts.headers().firstEntry("Authorization").orElseThrow().value());
+
+    assertThat(withSts.headers().firstEntry(OdpsAuthProperties.STS_TOKEN_HEADER))
+        .isPresent()
+        .hasValueSatisfying(h -> assertThat(h.value()).isEqualTo(STS));
+
+    assertThat(withoutSts.headers().firstEntry(OdpsAuthProperties.STS_TOKEN_HEADER)).isEmpty();
+  }
+
+  @Test
+  void duplicateHeadersWithSameValueAreCollapsed() {
+    Map<String, String> properties =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME, "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID, AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET, SK);
+    HTTPRequest request =
+        ImmutableHTTPRequest.builder()
+            .baseUri(URI.create("https://service.cn-hangzhou.maxcompute.aliyun.com"))
+            .method(HTTPRequest.HTTPMethod.GET)
+            .path("api/v1/namespaces/test/tables/foo")
+            .headers(
+                HTTPHeaders.of(
+                    HTTPHeader.of("Content-Type", "application/json"),
+                    HTTPHeader.of("x-odps-user-agent", "iceberg-test"),
+                    HTTPHeader.of("X-ODPS-USER-AGENT", "iceberg-test"),
+                    HTTPHeader.of("date", "Thu, 28 May 2026 12:00:00 GMT")))
+            .queryParameters(Map.of())
+            .build();
+
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, properties)) {
+      HTTPRequest signed = session.authenticate(request);
+
+      assertThat(signed.headers().entries("x-odps-user-agent")).hasSize(1);
+      assertThat(signed.headers().entries("Date"))
+          .singleElement()
+          .satisfies(h -> assertThat(h.value()).isEqualTo("Thu, 28 May 2026 12:00:00 GMT"));
+    }
+  }
+
+  @Test
+  void duplicateHeadersWithDifferentValuesAreRejected() {
+    Map<String, String> properties =
+        Map.of(
+            AliyunProperties.REST_SIGNING_NAME, "odps",
+            AliyunProperties.REST_ACCESS_KEY_ID, AK,
+            AliyunProperties.REST_ACCESS_KEY_SECRET, SK);
+    HTTPRequest request =
+        ImmutableHTTPRequest.builder()
+            .baseUri(URI.create("https://service.cn-hangzhou.maxcompute.aliyun.com"))
+            .method(HTTPRequest.HTTPMethod.GET)
+            .path("api/v1/namespaces/test/tables/foo")
+            .headers(
+                HTTPHeaders.of(
+                    HTTPHeader.of("Content-Type", "application/json"),
+                    HTTPHeader.of("x-odps-user-agent", "iceberg-test"),
+                    HTTPHeader.of("X-ODPS-USER-AGENT", "other-test")))
+            .queryParameters(Map.of())
+            .build();
+
+    try (AuthManager mgr = new AliyunAuthManager("aliyun");
+        AuthSession session = mgr.catalogSession(null, properties)) {
+      assertThatThrownBy(() -> session.authenticate(request))
+          .isInstanceOf(IllegalArgumentException.class)
+          .hasMessageContaining("ODPS auth does not support multiple values for header");
+    }
+  }
+
+  @Test
+  void pathWithSpaceUsesOdpsSdkResourceDecoding() {
+    OdpsRequestSigner signer =
+        new OdpsRequestSigner(new AliyunProperties(credentialProperties()), credentialProperties());
+    HTTPRequest signed =
+        signer.sign(getRequestWithPathAndDate("api/v1/namespaces/a+b/tables/t", FIXED_DATE));
+
+    String expected =
+        signer.authorization(
+            "GET",
+            "/api/v1/namespaces/a b/tables/t",
+            Map.of("Content-Type", "application/json", "Date", FIXED_DATE),
+            Map.of());
+    assertThat(signed.headers().firstEntry("Authorization").orElseThrow().value())
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void pathWithEncodedPlusPreservesLiteralPlus() {
+    OdpsRequestSigner signer =
+        new OdpsRequestSigner(new AliyunProperties(credentialProperties()), credentialProperties());
+    HTTPRequest signed =
+        signer.sign(getRequestWithPathAndDate("api/v1/namespaces/a%2Bb/tables/t", FIXED_DATE));
+
+    String expected =
+        signer.authorization(
+            "GET",
+            "/api/v1/namespaces/a+b/tables/t",
+            Map.of("Content-Type", "application/json", "Date", FIXED_DATE),
+            Map.of());
+    assertThat(signed.headers().firstEntry("Authorization").orElseThrow().value())
+        .isEqualTo(expected);
+  }
+
+  @Test
+  void canonicalStringMatchesOdpsContract() throws Exception {
+    Map<String, String> headers =
+        Map.of(
+            "Content-Type", "application/json",
+            "Date", "Thu, 28 May 2026 12:00:00 GMT",
+            "x-odps-user-agent", "iceberg-test");
+    Map<String, String> params = Map.of("maxResults", "10");
+
+    String canonical =
+        OdpsRequestSigner.canonicalString("GET", "/api/v1/namespaces/ns/tables/t", headers, params);
+
+    String expected =
+        "GET\n"
+            + "\n"
+            + "application/json\n"
+            + "Thu, 28 May 2026 12:00:00 GMT\n"
+            + "x-odps-user-agent:iceberg-test\n"
+            + "/api/v1/namespaces/ns/tables/t?maxResults=10";
+    assertThat(canonical).isEqualTo(expected);
+
+    OdpsRequestSigner signer =
+        new OdpsRequestSigner(
+            new AliyunProperties(
+                Map.of(
+                    AliyunProperties.REST_ACCESS_KEY_ID, AK,
+                    AliyunProperties.REST_ACCESS_KEY_SECRET, SK)),
+            Map.of());
+    String authorization =
+        signer.authorization("GET", "/api/v1/namespaces/ns/tables/t", headers, params);
+
+    Mac mac = Mac.getInstance("HmacSHA1");
+    mac.init(new SecretKeySpec(SK.getBytes(), "HmacSHA1"));
+    String expectedSig =
+        java.util.Base64.getEncoder().encodeToString(mac.doFinal(expected.getBytes())).trim();
+    assertThat(authorization).isEqualTo("ODPS " + AK + ":" + expectedSig);
+  }
+
+  private static Stream<Arguments> missingCredentialCases() {
+    return Stream.of(
+        Arguments.of(
+            Map.of(AliyunProperties.REST_SIGNING_NAME, "odps"), "accessKeyId should not be empty"),
+        Arguments.of(
+            Map.of(
+                AliyunProperties.REST_SIGNING_NAME,
+                "odps",
+                AliyunProperties.REST_ACCESS_KEY_ID,
+                AK),
+            "accessKeySecret should not be empty"));
+  }
+
+  private static Map<String, String> credentialProperties() {
+    return Map.of(
+        AliyunProperties.REST_SIGNING_NAME,
+        "odps",
+        AliyunProperties.REST_ACCESS_KEY_ID,
+        AK,
+        AliyunProperties.REST_ACCESS_KEY_SECRET,
+        SK);
+  }
+
+  private static HTTPRequest getRequest() {
+    return ImmutableHTTPRequest.builder()
+        .baseUri(URI.create("https://service.cn-hangzhou.maxcompute.aliyun.com"))
+        .method(HTTPRequest.HTTPMethod.GET)
+        .path("api/v1/namespaces/test/tables/foo")
+        .headers(HTTPHeaders.of(HTTPHeader.of("Content-Type", "application/json")))
+        .queryParameters(Map.of())
+        .build();
+  }
+
+  private static HTTPRequest getRequestWithDate(String date) {
+    return getRequestWithPathAndDate("api/v1/namespaces/test/tables/foo", date);
+  }
+
+  private static HTTPRequest getRequestWithPathAndDate(String path, String date) {
+    return ImmutableHTTPRequest.builder()
+        .baseUri(URI.create("https://service.cn-hangzhou.maxcompute.aliyun.com"))
+        .method(HTTPRequest.HTTPMethod.GET)
+        .path(path)
+        .headers(
+            HTTPHeaders.of(
+                HTTPHeader.of("Content-Type", "application/json"), HTTPHeader.of("Date", date)))
+        .queryParameters(Map.of())
+        .build();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthManagers.java
@@ -101,6 +101,9 @@ public class AuthManagers {
       case AuthProperties.AUTH_TYPE_OAUTH2:
         impl = AuthProperties.AUTH_MANAGER_IMPL_OAUTH2;
         break;
+      case AuthProperties.AUTH_TYPE_ALIYUN:
+        impl = AuthProperties.AUTH_MANAGER_IMPL_ALIYUN;
+        break;
       default:
         impl = authType;
     }

--- a/core/src/main/java/org/apache/iceberg/rest/auth/AuthProperties.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/AuthProperties.java
@@ -29,6 +29,7 @@ public final class AuthProperties {
   public static final String AUTH_TYPE_OAUTH2 = "oauth2";
   public static final String AUTH_TYPE_SIGV4 = "sigv4";
   public static final String AUTH_TYPE_GOOGLE = "google";
+  public static final String AUTH_TYPE_ALIYUN = "aliyun";
 
   public static final String AUTH_MANAGER_IMPL_NONE =
       "org.apache.iceberg.rest.auth.NoopAuthManager";
@@ -38,6 +39,8 @@ public final class AuthProperties {
       "org.apache.iceberg.rest.auth.OAuth2Manager";
   public static final String AUTH_MANAGER_IMPL_SIGV4 =
       "org.apache.iceberg.aws.RESTSigV4AuthManager";
+  public static final String AUTH_MANAGER_IMPL_ALIYUN =
+      "org.apache.iceberg.aliyun.auth.AliyunAuthManager";
   public static final String AUTH_MANAGER_IMPL_GOOGLE =
       "org.apache.iceberg.gcp.auth.GoogleAuthManager";
 

--- a/docs/docs/catalog-properties.md
+++ b/docs/docs/catalog-properties.md
@@ -68,16 +68,16 @@ The following properties configure the table cache used for freshness-aware tabl
 ### Auth properties
 
 The following catalog properties configure authentication for the REST catalog.
-They support Basic, OAuth2, SigV4, and Google authentication.
+They support Basic, OAuth2, SigV4, Google, and Aliyun authentication.
 
 #### REST auth properties
 
-| Property                             | Default          | Description                                                                                                       |
-|--------------------------------------|------------------|-------------------------------------------------------------------------------------------------------------------|
-| `rest.auth.type`                     | `none`           | Authentication mechanism for REST catalog access. Supported values: `none`, `basic`, `oauth2`, `sigv4`, `google`. |
-| `rest.auth.basic.username`           | null             | Username for Basic authentication. Required if `rest.auth.type` = `basic`.                                        |
-| `rest.auth.basic.password`           | null             | Password for Basic authentication. Required if `rest.auth.type` = `basic`.                                        |
-| `rest.auth.sigv4.delegate-auth-type` | `oauth2`         | Auth type to delegate to after `sigv4` signing.                                                                   |
+| Property                             | Default          | Description                                                                                                                  |
+|--------------------------------------|------------------|------------------------------------------------------------------------------------------------------------------------------|
+| `rest.auth.type`                     | `none`           | Authentication mechanism for REST catalog access. Supported values: `none`, `basic`, `oauth2`, `sigv4`, `google`, `aliyun`. |
+| `rest.auth.basic.username`           | null             | Username for Basic authentication. Required if `rest.auth.type` = `basic`.                                                   |
+| `rest.auth.basic.password`           | null             | Password for Basic authentication. Required if `rest.auth.type` = `basic`.                                                   |
+| `rest.auth.sigv4.delegate-auth-type` | `oauth2`         | Auth type to delegate to after `sigv4` signing.                                                                              |
 
 #### OAuth2 auth properties
 Required and optional properties to include while using `oauth2` authentication
@@ -124,6 +124,24 @@ Required and optional properties to include while using `google` authentication
 | `gcp.auth.credentials-path`| Application Default Credentials (ADC)            | Path to a service account JSON key file.         |
 | `gcp.auth.credentials-json` | Application Default Credentials (ADC)            | JSON string of a service account credential.     |
 | `gcp.auth.scopes`          | `https://www.googleapis.com/auth/cloud-platform` | Comma-separated list of OAuth scopes to request. |
+
+#### Aliyun auth properties
+
+The `iceberg-aliyun` module must be present on the classpath when using `aliyun` authentication.
+The following properties configure Aliyun request signing:
+
+| Property                        | Default  | Description                                                                                                                                                             |
+|---------------------------------|----------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `aliyun.auth.signing-name`      | null     | Signing protocol to use. Set to `odps` for the built-in ODPS signer, or to the fully qualified class name of a custom signer.                                                      |
+| `aliyun.auth.access-key-id`     | null     | AccessKey ID used to sign requests. Falls back to the `ALIBABA_CLOUD_ACCESS_KEY_ID` environment variable.                                                               |
+| `aliyun.auth.access-key-secret` | null     | AccessKey secret used to sign requests. Falls back to the `ALIBABA_CLOUD_ACCESS_KEY_SECRET` environment variable.                                                       |
+| `aliyun.auth.sts-token`         | null     | Optional STS token for temporary credentials. Falls back to the `ALIBABA_CLOUD_SECURITY_TOKEN` environment variable.                                                    |
+| `aliyun.auth.region`            | null     | Signing region. Falls back to the `ALIBABA_CLOUD_REGION_ID` environment variable. For ODPS, setting a region enables V4 signing; otherwise, the signer uses V2 signing. |
+| `odps.auth.corporation`         | `aliyun` | Corporation identifier included in the ODPS V4 credential scope.                                                                                                       |
+
+Non-empty catalog properties take precedence over their corresponding environment variables.
+The AccessKey ID and AccessKey secret are required when using the built-in ODPS signer.
+A custom signer must implement `org.apache.iceberg.aliyun.auth.AliyunRequestSigner` and provide a public constructor that accepts `org.apache.iceberg.aliyun.AliyunProperties` and `Map<String, String>`.
 
 ## Lock catalog properties
 


### PR DESCRIPTION
## Backgroud

This PR adds built-in Alibaba Cloud authentication support for Iceberg REST
catalogs through `rest.auth.type=aliyun`.

It follows the dev-list discussion:

https://lists.apache.org/thread/2jrm755rzj3930wmgvcrtw73qzhnl44n

MaxCompute (ODPS) REST Catalog requests require Alibaba Cloud AK/SK signing.
Without built-in support, users must package and configure a custom
`AuthManager` JAR for each Spark, Flink, or other Iceberg deployment.

## Changes

- Register `aliyun` as a built-in REST auth type.
- Add `AliyunAuthManager` and `AliyunAuthSession`.
- Add a pluggable `AliyunRequestSigner` interface.
- Add the ODPS signer with V2 and V4 signing support.
- Support AK/SK credentials, optional STS tokens, and environment-variable fallback.
- Add unit tests for manager loading, credential validation, request
  canonicalization, V2/V4 signing, STS tokens, paths, and headers.

The change is additive: existing defaults remain unchanged, no REST
specification files are modified, and no new external runtime dependency is
introduced.

## Configuration

```properties
rest.auth.type=aliyun
aliyun.auth.signing-name=odps
aliyun.auth.access-key-id=<access-key-id>
aliyun.auth.access-key-secret=<access-key-secret>

# Optional: enable V4 signing
aliyun.auth.region=cn-hangzhou

# Optional: temporary credential
aliyun.auth.sts-token=<security-token>
```

## Signing implementation

The ODPS canonical request and signing logic is adapted from the Alibaba Cloud
ODPS Java SDK `release/0.58.x`:

- [AliyunRequestSigner.java](https://github.com/aliyun/aliyun-odps-java-sdk/blob/release/0.58.x/odps-sdk/odps-sdk-core/src/main/java/com/aliyun/odps/account/AliyunRequestSigner.java)
- [SecurityUtils.java](https://github.com/aliyun/aliyun-odps-java-sdk/blob/release/0.58.x/odps-sdk/odps-sdk-core/src/main/java/com/aliyun/odps/account/SecurityUtils.java)

Only the required signing logic is included to avoid depending on the full ODPS
SDK. The referenced sources are licensed under Apache License 2.0.

Feedback is especially welcome on the `aliyun` auth type name and the
provider-level signer abstraction.