### PR TITLE
Core: Include CRC values in DV deserialization error message

### DIFF
--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -150,7 +150,8 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
     int crc = computeChecksum(bytes, bitmapDataLength);
     int crcOffset = LENGTH_SIZE_BYTES + bitmapDataLength;
     int expectedCrc = buffer.getInt(crcOffset);
-    Preconditions.checkArgument(crc == expectedCrc, "Invalid CRC");
+    Preconditions.checkArgument(
+        crc == expectedCrc, "Invalid CRC: %s, expected %s", crc, expectedCrc);
     return new BitmapPositionDeleteIndex(bitmap, deleteFile);
   }
 

--- a/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
+++ b/core/src/main/java/org/apache/iceberg/deletes/BitmapPositionDeleteIndex.java
@@ -151,7 +151,11 @@ class BitmapPositionDeleteIndex implements PositionDeleteIndex {
     int crcOffset = LENGTH_SIZE_BYTES + bitmapDataLength;
     int expectedCrc = buffer.getInt(crcOffset);
     Preconditions.checkArgument(
-        crc == expectedCrc, "Invalid CRC: %s, expected %s", crc, expectedCrc);
+        crc == expectedCrc,
+        "Invalid CRC for deletion vector %s: 0x%s, expected 0x%s",
+        deleteFile.location(),
+        Integer.toHexString(crc),
+        Integer.toHexString(expectedCrc));
     return new BitmapPositionDeleteIndex(bitmap, deleteFile);
   }
 

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -192,7 +192,8 @@ public class TestBitmapPositionDeleteIndex {
 
     assertThatThrownBy(() -> PositionDeleteIndex.deserialize(bytes, dv))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Invalid CRC for deletion vector s3://bucket/dv.puffin");
+        .hasMessage(
+            "Invalid CRC for deletion vector s3://bucket/dv.puffin: 0x712fa6e8, expected 0x712fa6e9");
   }
 
   private static void validate(PositionDeleteIndex index, String goldenFile) throws Exception {

--- a/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
+++ b/core/src/test/java/org/apache/iceberg/deletes/TestBitmapPositionDeleteIndex.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.deletes;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.IOException;
 import java.net.URL;
@@ -174,6 +175,24 @@ public class TestBitmapPositionDeleteIndex {
         position(1 /* bitmap */, 2 /* container */, CONTAINER_OFFSET - 1));
 
     validate(index, "all-container-types-position-index.bin");
+  }
+
+  @Test
+  public void testDeserializeInvalidCrc() {
+    PositionDeleteIndex index = new BitmapPositionDeleteIndex();
+    index.delete(1L);
+    index.delete(2L);
+    byte[] bytes = index.serialize().array();
+
+    // corrupt the last CRC byte so the computed checksum no longer matches
+    bytes[bytes.length - 1] ^= 0x01;
+
+    DeleteFile dv = mockDV(bytes.length, index.cardinality());
+    Mockito.when(dv.location()).thenReturn("s3://bucket/dv.puffin");
+
+    assertThatThrownBy(() -> PositionDeleteIndex.deserialize(bytes, dv))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid CRC for deletion vector s3://bucket/dv.puffin");
   }
 
   private static void validate(PositionDeleteIndex index, String goldenFile) throws Exception {


### PR DESCRIPTION
When a deletion vector fails CRC validation, the error message was a static "Invalid CRC". This includes the actual and expected CRC values to make the failure actionable, matching the sibling validation messages in the same class (`Invalid magic number/cardinality/bitmap data length: %s, expected %s`).