### PR TITLE
Build: Remove unused Jackson dependency from iceberg-delta-lake

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -664,8 +664,6 @@ project(':iceberg-delta-lake') {
     implementation project(':iceberg-common')
     implementation project(':iceberg-core')
     implementation project(':iceberg-parquet')
-    implementation platform(libs.jackson.bom)
-    implementation libs.jackson.databind
     annotationProcessor libs.immutables.value
     compileOnly libs.immutables.value
 


### PR DESCRIPTION
The `iceberg-delta-lake` module declared `jackson-bom` and `jackson-databind` as `implementation` dependencies, but no source in the module (main, test, or integration) imports Jackson. This removes the unused declarations. `iceberg-core` declares Jackson as `implementation` (not `api`), so it is not exposed transitively either.