### PR TITLE
MINOR: Update Slack invitation link

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -25,7 +25,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ) as well.
+        Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA) as well.
 
         Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea

--- a/site/docs/blog/posts/2026-01-10-iceberg-summit.md
+++ b/site/docs/blog/posts/2026-01-10-iceberg-summit.md
@@ -80,7 +80,7 @@ We're accepting several types of submissions:
 
 What are you waiting for? Head over to [Sessionize](https://sessionize.com/iceberg-summit-2026/) to submit your proposal.
 
-**Need help crafting your submission?** Join us on the [Iceberg Community Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ) #abstracts channel for feedback and advice.
+**Need help crafting your submission?** Join us on the [Iceberg Community Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA) #abstracts channel for feedback and advice.
 
 - ~~Session 1: Wednesday, December 17, 2025 @ 8:00 AM PT~~
 - ~~Session 2: Wednesday, January 7, 2026 @ 8:00 AM PT~~

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -51,7 +51,7 @@ Apache Iceberg mailing lists:
 
 ### Slack
 
-We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ).
+We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA).
 
 Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -127,7 +127,7 @@ extra:
       link: 'https://www.youtube.com/@ApacheIceberg'
       title: youtube
     - icon: fontawesome/brands/slack
-      link: 'https://join.slack.com/t/apache-iceberg/shared_invite/zt-3tkrk9gpf-1eFZ8ozS2In0~zM_BeZiRQ'
+      link: 'https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA'
       title: slack
 
 exclude_docs: |


### PR DESCRIPTION
The link seems to be outdated