### PR TITLE
API: Define RepairManifests action interface

### DIFF
--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -94,4 +94,10 @@ public interface ActionsProvider {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement removeDanglingDeleteFiles");
   }
+
+  /** Instantiates an action to repair manifests */
+  default RepairManifests repairManifests(Table table) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not implement repairManifests");
+  }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -95,9 +95,9 @@ public interface ActionsProvider {
         this.getClass().getName() + " does not implement removeDanglingDeleteFiles");
   }
 
-  /** Instantiates an action to repair the manifests of a table. */
-  default RepairManifests repairManifests(Table table) {
+  /** Instantiates an action to repair a table. */
+  default RepairTable repairTable(Table table) {
     throw new UnsupportedOperationException(
-        this.getClass().getName() + " does not implement repairManifests");
+        this.getClass().getName() + " does not implement repairTable");
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
+++ b/api/src/main/java/org/apache/iceberg/actions/ActionsProvider.java
@@ -95,7 +95,7 @@ public interface ActionsProvider {
         this.getClass().getName() + " does not implement removeDanglingDeleteFiles");
   }
 
-  /** Instantiates an action to repair manifests */
+  /** Instantiates an action to repair the manifests of a table. */
   default RepairManifests repairManifests(Table table) {
     throw new UnsupportedOperationException(
         this.getClass().getName() + " does not implement repairManifests");

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.actions;
+
+import org.apache.iceberg.ManifestFile;
+
+/** An action that will repair manifests. Implementations should produce a new set of manifests. */
+public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairManifests.Result> {
+
+  /** Configuration method for repairing manifest entry statistics */
+  RepairManifests repairEntryStats();
+
+  /**
+   * Configuration method for removing duplicate file entries and removing files which no longer
+   * exist in storage
+   */
+  RepairManifests repairFileEntries();
+
+  /**
+   * Configuration option for determining the rewritten and added manifests without actually
+   * committing the operation to the table
+   *
+   * @return this for method chaining
+   */
+  RepairManifests dryRun();
+
+  interface Result {
+    /** Returns rewritten manifests. */
+    Iterable<ManifestFile> rewrittenManifests();
+
+    /** Returns the duplicate file paths removed */
+    Iterable<String> duplicateFilesRemoved();
+
+    /** Returns the paths of the missing files which were removed */
+    Iterable<String> missingFilesRemoved();
+
+    /** Returns the paths of the missing files which were recovered */
+    Iterable<String> missingFilesRecovered();
+
+    /** Returns the number of manifest entries for which stats were incorrect */
+    long entryStatsIncorrectCount();
+
+    /** Returns the number of manifest entries for which stats were corrected */
+    long entryStatsRepairedCount();
+  }
+}

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -49,10 +49,7 @@ public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairM
     /** Returns the repaired manifests. */
     Iterable<ManifestFile> repairedManifests();
 
-    /** Returns the number of manifest entries for which stats were incorrect. */
-    long incorrectEntryCount();
-
-    /** Returns the number of manifest entries for which stats were corrected. */
+    /** Returns the number of manifest entries whose stats were repaired. */
     long repairedEntryCount();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -46,13 +46,13 @@ public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairM
 
   /** The action result that contains a summary of the execution. */
   interface Result {
-    /** Returns rewritten manifests. */
-    Iterable<ManifestFile> rewrittenManifests();
+    /** Returns the repaired manifests. */
+    Iterable<ManifestFile> repairedManifests();
 
     /** Returns the number of manifest entries for which stats were incorrect. */
-    long entryStatsIncorrectCount();
+    long incorrectEntryCount();
 
     /** Returns the number of manifest entries for which stats were corrected. */
-    long entryStatsRepairedCount();
+    long repairedEntryCount();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairManifests.java
@@ -20,43 +20,39 @@ package org.apache.iceberg.actions;
 
 import org.apache.iceberg.ManifestFile;
 
-/** An action that will repair manifests. Implementations should produce a new set of manifests. */
+/**
+ * An action that repairs incorrect statistics in the manifests of a table.
+ *
+ * <p>Implementations rewrite the manifests of the table, producing a new set of manifests in which
+ * the statistics of the entries are corrected to match the underlying data and delete files.
+ */
 public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairManifests.Result> {
 
-  /** Configuration method for repairing manifest entry statistics */
+  /**
+   * Repairs incorrect statistics of manifest entries, such as record counts, file sizes and column
+   * level statistics.
+   *
+   * @return this for method chaining
+   */
   RepairManifests repairEntryStats();
 
   /**
-   * Configuration method for removing duplicate file entries and removing files which no longer
-   * exist in storage
-   */
-  RepairManifests repairFileEntries();
-
-  /**
-   * Configuration option for determining the rewritten and added manifests without actually
-   * committing the operation to the table
+   * Determines the repairs that would be performed without actually committing the operation to the
+   * table.
    *
    * @return this for method chaining
    */
   RepairManifests dryRun();
 
+  /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns rewritten manifests. */
     Iterable<ManifestFile> rewrittenManifests();
 
-    /** Returns the duplicate file paths removed */
-    Iterable<String> duplicateFilesRemoved();
-
-    /** Returns the paths of the missing files which were removed */
-    Iterable<String> missingFilesRemoved();
-
-    /** Returns the paths of the missing files which were recovered */
-    Iterable<String> missingFilesRecovered();
-
-    /** Returns the number of manifest entries for which stats were incorrect */
+    /** Returns the number of manifest entries for which stats were incorrect. */
     long entryStatsIncorrectCount();
 
-    /** Returns the number of manifest entries for which stats were corrected */
+    /** Returns the number of manifest entries for which stats were corrected. */
     long entryStatsRepairedCount();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/actions/RepairTable.java
+++ b/api/src/main/java/org/apache/iceberg/actions/RepairTable.java
@@ -21,20 +21,21 @@ package org.apache.iceberg.actions;
 import org.apache.iceberg.ManifestFile;
 
 /**
- * An action that repairs incorrect statistics in the manifests of a table.
+ * An action that repairs a table.
  *
- * <p>Implementations rewrite the manifests of the table, producing a new set of manifests in which
- * the statistics of the entries are corrected to match the underlying data and delete files.
+ * <p>The repairs to perform are selected through the configuration methods of this action.
+ * Implementations rewrite the affected metadata, producing a new set of manifests in which the
+ * repaired entries replace the corrupt ones.
  */
-public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairManifests.Result> {
+public interface RepairTable extends SnapshotUpdate<RepairTable, RepairTable.Result> {
 
   /**
-   * Repairs incorrect statistics of manifest entries, such as record counts, file sizes and column
-   * level statistics.
+   * Repairs incorrect metrics of manifest entries, such as record counts, file sizes and column
+   * level statistics, by comparing them against the underlying data and delete files.
    *
    * @return this for method chaining
    */
-  RepairManifests repairEntryStats();
+  RepairTable repairFileMetrics();
 
   /**
    * Determines the repairs that would be performed without actually committing the operation to the
@@ -42,14 +43,14 @@ public interface RepairManifests extends SnapshotUpdate<RepairManifests, RepairM
    *
    * @return this for method chaining
    */
-  RepairManifests dryRun();
+  RepairTable dryRun();
 
   /** The action result that contains a summary of the execution. */
   interface Result {
     /** Returns the repaired manifests. */
     Iterable<ManifestFile> repairedManifests();
 
-    /** Returns the number of manifest entries whose stats were repaired. */
+    /** Returns the number of manifest entries that were repaired. */
     long repairedEntryCount();
   }
 }


### PR DESCRIPTION
## Summary

Reviving #10784 by @amogh-jahagirdar (co-authored with @tabmatfournier). See #10445 for motivation. Scoped down to just repairing stats for now

Problem: manifest entry stats can disagree with the files they describe — `record_count`, `file_size_in_bytes`, column bounds and null counts written wrong by a non-reference writer. Data files are fine, only the metadata is wrong, so you get bad pruning or read failures on wrong sizes. `RewriteManifests` doesn't help, it carries over whatever entries it finds. Finding the bad entries means stat-ing or reading the footer of every file in a live manifest entry, so this needs to be a distributed action.

This defines the action interface only. Spark implementation and procedure to follow.
