### PR TITLE
Docs: Centralize Slack invitation URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -25,7 +25,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Feel free to ask your question on [Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA) as well.
+        Feel free to ask your question on [Slack](https://s.apache.org/iceberg-slack) as well.
 
         Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/iceberg_question.yml
+++ b/.github/ISSUE_TEMPLATE/iceberg_question.yml
@@ -25,7 +25,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Feel free to ask your question on [Slack](https://s.apache.org/iceberg-slack) as well.
+        Feel free to ask your question on [Slack](https://iceberg.apache.org/community/#slack) as well.
 
         Do **NOT** share any sensitive information like passwords, security tokens, private URLs etc.
   - type: textarea

--- a/site/docs/blog/posts/2026-01-10-iceberg-summit.md
+++ b/site/docs/blog/posts/2026-01-10-iceberg-summit.md
@@ -80,7 +80,7 @@ We're accepting several types of submissions:
 
 What are you waiting for? Head over to [Sessionize](https://sessionize.com/iceberg-summit-2026/) to submit your proposal.
 
-**Need help crafting your submission?** Join us on the [Iceberg Community Slack](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA) #abstracts channel for feedback and advice.
+**Need help crafting your submission?** Join us on the [Iceberg Community Slack]({{ slackInviteUrl }}) #abstracts channel for feedback and advice.
 
 - ~~Session 1: Wednesday, December 17, 2025 @ 8:00 AM PT~~
 - ~~Session 2: Wednesday, January 7, 2026 @ 8:00 AM PT~~

--- a/site/docs/community.md
+++ b/site/docs/community.md
@@ -51,7 +51,7 @@ Apache Iceberg mailing lists:
 
 ### Slack
 
-We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link](https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA).
+We use the [Apache Iceberg workspace](https://apache-iceberg.slack.com/) on Slack. To be invited, follow [this invite link]({{ slackInviteUrl }}).
 
 Please note that this link may occasionally break when Slack does an upgrade. If you encounter problems using it, please let us know by sending an email to <dev@iceberg.apache.org>.
 

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -116,6 +116,7 @@ extra:
   flinkVersion: '2.1.0'
   flinkVersionMajor: '2.1'
   sparkVersionMajor: '4.1_2.13'
+  slackInviteUrl: &slackInviteUrl 'https://s.apache.org/iceberg-slack'
   social:
     - icon: fontawesome/regular/comments
       link: 'https://iceberg.apache.org/community/'
@@ -127,7 +128,7 @@ extra:
       link: 'https://www.youtube.com/@ApacheIceberg'
       title: youtube
     - icon: fontawesome/brands/slack
-      link: 'https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA'
+      link: *slackInviteUrl
       title: slack
 
 exclude_docs: |


### PR DESCRIPTION
Context: https://github.com/apache/iceberg/pull/17398#issuecomment-5110232590

Use the stable ASF redirect and share it through the MkDocs configuration to avoid repeated expiring invitation links.

Maps `https://s.apache.org/iceberg-slack` -> `https://join.slack.com/t/apache-iceberg/shared_invite/zt-4583kdp6p-ALpQGSa3O2tCYMtYwAMYNA`

From https://s.apache.org/s/private?action=list:
<img width="894" height="124" alt="Screenshot 2026-07-28 at 2 50 22 PM" src="https://github.com/user-attachments/assets/aec0f2a0-9992-49b4-a023-4454ccaf1a9f" />

Rendered and verified locally: `(cd site && make serve-dev)`
Generated-by: Codex

