### PR TITLE
Core, Hive: source encryption keys from table metadata to prevent key…

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -565,6 +565,10 @@ acceptedBreaks:
       old: "field org.apache.iceberg.PartitionStatsHandler.PARTITION_FIELD_NAME"
       justification: "Removed deprecated functionality for partition stats"
     - code: "java.method.removed"
+      old: "method java.lang.String org.apache.iceberg.encryption.StandardEncryptionManager::addManifestListKeyMetadata(org.apache.iceberg.encryption.NativeEncryptionKeyMetadata)"
+      justification: "Replaced by pure StandardEncryptionManager.mintManifestListKey;\
+        \ the immutable, metadata-sourced manager no longer stores minted keys"
+    - code: "java.method.removed"
       old: "method org.apache.iceberg.MetricsConfig org.apache.iceberg.MetricsConfig::forPositionDelete(org.apache.iceberg.Table)"
       justification: "Deprecated for removal in 1.12.0"
     - code: "java.method.removed"

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -66,7 +66,7 @@ public class BaseTransaction implements Transaction {
   private final String tableName;
   private final TableOperations ops;
   private final TransactionTable transactionTable;
-  private final TableOperations transactionOps;
+  private final TransactionTableOperations transactionOps;
   private final List<PendingUpdate> updates;
   private final Set<String> deletedFiles =
       Sets.newHashSet(); // keep track of files deleted in the most recent commit
@@ -445,6 +445,9 @@ public class BaseTransaction implements Transaction {
       // use refreshed the metadata
       this.base = underlyingOps.current();
       this.current = underlyingOps.current();
+      // Re-point temp ops at the refreshed metadata so a metadata-sourced encryption manager can
+      // resolve keys for the concurrently-committed snapshots the refresh pulled in.
+      transactionOps.useMetadata(current);
       for (PendingUpdate update : updates) {
         // re-commit each update in the chain to apply it and update current
         try {
@@ -482,6 +485,10 @@ public class BaseTransaction implements Transaction {
 
   public class TransactionTableOperations implements TableOperations {
     private TableOperations tempOps = ops.temp(current);
+
+    private void useMetadata(TableMetadata metadata) {
+      this.tempOps = ops.temp(metadata);
+    }
 
     @Override
     public TableMetadata current() {

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -36,6 +36,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
   private final StandardEncryptionManager standardEncryptionManager;
   private final NativeEncryptionKeyMetadata manifestListKeyMetadata;
   private final OutputFile outputFile;
+  private StandardEncryptionManager.MintedKeys lazyManifestListKeys = null;
 
   private ManifestListWriter(
       OutputFile file, EncryptionManager encryptionManager, Map<String, String> meta) {
@@ -95,13 +96,23 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
 
   public ManifestListFile toManifestListFile() {
     if (manifestListKeyMetadata != null && manifestListKeyMetadata.encryptionKey() != null) {
-      String manifestListKeyID =
-          standardEncryptionManager.addManifestListKeyMetadata(
-              manifestListKeyMetadata.copyWithLength(writer.length()));
-      return new BaseManifestListFile(outputFile.location(), manifestListKeyID);
+      // Mint once so repeated calls return the same key id.
+      if (lazyManifestListKeys == null) {
+        this.lazyManifestListKeys =
+            standardEncryptionManager.mintManifestListKey(
+                manifestListKeyMetadata.copyWithLength(writer.length()));
+      }
+
+      return new BaseManifestListFile(
+          outputFile.location(), lazyManifestListKeys.manifestListKey().keyId());
     } else {
       return new BaseManifestListFile(outputFile.location(), null);
     }
+  }
+
+  /** Keys minted while writing this manifest list, or {@code null} if unencrypted. */
+  public StandardEncryptionManager.MintedKeys manifestListKeys() {
+    return lazyManifestListKeys;
   }
 
   static class V4Writer extends ManifestListWriter {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -46,8 +46,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptedOutputFile;
 import org.apache.iceberg.encryption.EncryptingFileIO;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.events.CreateSnapshotEvent;
 import org.apache.iceberg.events.Listeners;
 import org.apache.iceberg.exceptions.CleanableFailure;
@@ -113,6 +115,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private final Map<String, String> manifestWriterProps;
   private MetricsReporter reporter = LoggingMetricsReporter.instance();
   private volatile Long snapshotId = null;
+  // Keys minted while writing the manifest list in apply(), persisted in commit(). apply() and
+  // commit() run on the same thread, so no volatile is needed.
+  private StandardEncryptionManager.MintedKeys applyManifestListKeys;
   private TableMetadata base;
   private boolean stageOnly = false;
   private Consumer<String> deleteFunc = defaultDelete;
@@ -292,6 +297,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   @Override
   public Snapshot apply() {
     refresh();
+    this.applyManifestListKeys = null;
     Snapshot parentSnapshot = SnapshotUtil.latestSnapshot(base, targetBranch);
 
     long sequenceNumber = base.nextSequenceNumber();
@@ -354,6 +360,9 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
           replacedRecords);
     }
 
+    ManifestListFile manifestListFile = writer.toManifestListFile();
+    this.applyManifestListKeys = writer.manifestListKeys();
+
     return new BaseSnapshot(
         sequenceNumber,
         snapshotId(),
@@ -365,7 +374,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         manifestList.location(),
         nextRowId,
         assignedRows,
-        writer.toManifestListFile().encryptionKeyID());
+        manifestListFile.encryptionKeyID());
   }
 
   private void runValidations(Snapshot parentSnapshot) {
@@ -500,8 +509,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
                     // this is a rollback operation
                     update.setBranchSnapshot(newSnapshot.snapshotId(), targetBranch);
                   } else if (stageOnly) {
+                    addEncryptionKeys(update, newSnapshot);
                     update.addSnapshot(newSnapshot);
                   } else {
+                    addEncryptionKeys(update, newSnapshot);
                     update.setBranchSnapshot(newSnapshot, targetBranch);
                   }
 
@@ -567,6 +578,25 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
       notifyListeners();
     } catch (Throwable e) {
       LOG.warn("Failed to notify event listeners", e);
+    }
+  }
+
+  private void addEncryptionKeys(TableMetadata.Builder update, Snapshot snapshot) {
+    if (applyManifestListKeys == null) {
+      return;
+    }
+
+    EncryptedKey manifestListKey = applyManifestListKeys.manifestListKey();
+    Preconditions.checkState(
+        manifestListKey.keyId().equals(snapshot.keyId()),
+        "Snapshot key id %s does not match minted manifest list key id %s",
+        snapshot.keyId(),
+        manifestListKey.keyId());
+    update.addEncryptionKey(manifestListKey);
+
+    EncryptedKey newKeyEncryptionKey = applyManifestListKeys.newKeyEncryptionKey();
+    if (newKeyEncryptionKey != null) {
+      update.addEncryptionKey(newKeyEncryptionKey);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -353,7 +353,9 @@ public class TableMetadata implements Serializable {
     this.snapshotsLoaded = snapshotsSupplier == null;
     this.snapshotLog = snapshotLog;
     this.previousFiles = previousFiles;
-    this.encryptionKeys = encryptionKeys;
+    // Immutable so a built instance's key set is stable, which HiveTableOperations relies on to
+    // memoize its metadata-sourced encryption manager by metadata identity.
+    this.encryptionKeys = ImmutableList.copyOf(encryptionKeys);
 
     // changes are carried through until metadata is read from a file
     this.changes = changes;

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -23,6 +23,7 @@ import com.github.benmanes.caffeine.cache.LoadingCache;
 import java.nio.ByteBuffer;
 import java.security.SecureRandom;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -36,6 +37,12 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.SerializableMap;
 
+/**
+ * An immutable {@link EncryptionManager} for standard (envelope) encryption whose keys are sourced
+ * from table metadata. Minting a manifest-list key is a pure operation ({@link
+ * #mintManifestListKey}) that returns the new key(s) for the caller to persist into metadata rather
+ * than storing them, so instances are safe to share across concurrent commits and to serialize.
+ */
 public class StandardEncryptionManager implements EncryptionManager {
   // Maximal lifespan of key encryption keys is 2 years according to NIST SP 800-57 (PART 1 REV. 5,
   // section 5.3.6.7.b)
@@ -84,15 +91,17 @@ public class StandardEncryptionManager implements EncryptionManager {
     this.dataKeyLength = dataKeyLength;
     this.testTimeShift = 0;
 
-    this.encryptionKeys = SerializableMap.copyOf(Maps.newLinkedHashMap());
+    Map<String, EncryptedKey> keyMap = Maps.newLinkedHashMap();
     if (keys != null) {
       for (EncryptedKey key : keys) {
-        this.encryptionKeys.put(
+        keyMap.put(
             key.keyId(),
             new BaseEncryptedKey(
                 key.keyId(), key.encryptedKeyMetadata(), key.encryptedById(), key.properties()));
       }
     }
+
+    this.encryptionKeys = Collections.unmodifiableMap(SerializableMap.copyOf(keyMap));
   }
 
   @Override
@@ -129,7 +138,7 @@ public class StandardEncryptionManager implements EncryptionManager {
     return unwrappedKeyCache;
   }
 
-  private SecureRandom workerRNG() {
+  private synchronized SecureRandom workerRNG() {
     if (this.lazyRNG == null) {
       this.lazyRNG = new SecureRandom();
     }
@@ -157,33 +166,6 @@ public class StandardEncryptionManager implements EncryptionManager {
     return encryptionKeys;
   }
 
-  String keyEncryptionKeyID() {
-    // Find unexpired key encryption key
-    for (String keyID : encryptionKeys.keySet()) {
-      EncryptedKey key = encryptionKeys.get(keyID);
-      if (key.encryptedById().equals(tableKeyId)) { // this is a key encryption key
-        String timestampProperty = key.properties().get(KEY_TIMESTAMP);
-        long keyTimestamp = Long.parseLong(timestampProperty);
-        if (currentTimeMillis() - keyTimestamp < KEY_ENCRYPTION_KEY_LIFESPAN_MS) {
-          return keyID;
-        }
-      }
-    }
-
-    // No unexpired key encryption keys; create one
-    ByteBuffer unwrapped = newKey();
-    ByteBuffer wrapped = kmsClient.wrapKey(unwrapped, tableKeyId);
-    Map<String, String> properties = Maps.newHashMap();
-    properties.put(KEY_TIMESTAMP, "" + currentTimeMillis());
-    EncryptedKey key = new BaseEncryptedKey(generateKeyId(), wrapped, tableKeyId, properties);
-
-    // update internal tracking
-    unwrappedKeyCache().put(key.keyId(), unwrapped);
-    encryptionKeys.put(key.keyId(), key);
-
-    return key.keyId();
-  }
-
   // For key rotation tests
   void setTestTimeShift(long shift) {
     testTimeShift = shift;
@@ -209,20 +191,39 @@ public class StandardEncryptionManager implements EncryptionManager {
     return unwrappedKeyCache().get(encryptedKeyMetadata.encryptedById());
   }
 
-  public String addManifestListKeyMetadata(NativeEncryptionKeyMetadata keyMetadata) {
-    String manifestListKeyID = generateKeyId();
-    String keyEncryptionKeyID = keyEncryptionKeyID();
-    String keyEncryptionKeyTimestamp =
-        encryptionKeys.get(keyEncryptionKeyID).properties().get(KEY_TIMESTAMP);
+  /**
+   * Mints a manifest-list key for the given key metadata without storing it. The returned {@link
+   * MintedKeys} must be persisted into table metadata by the caller to stay decryptable.
+   */
+  public MintedKeys mintManifestListKey(NativeEncryptionKeyMetadata keyMetadata) {
+    KeyEncryptionKey kek = keyEncryptionKey();
+    String kekTimestamp = kek.key().properties().get(KEY_TIMESTAMP);
     ByteBuffer encryptedKeyMetadata =
-        EncryptionUtil.encryptManifestListKeyMetadata(
-            unwrappedKeyCache().get(keyEncryptionKeyID), keyEncryptionKeyTimestamp, keyMetadata);
-    BaseEncryptedKey key =
-        new BaseEncryptedKey(manifestListKeyID, encryptedKeyMetadata, keyEncryptionKeyID, null);
+        EncryptionUtil.encryptManifestListKeyMetadata(kek.unwrapped(), kekTimestamp, keyMetadata);
+    EncryptedKey manifestListKey =
+        new BaseEncryptedKey(generateKeyId(), encryptedKeyMetadata, kek.key().keyId(), null);
+    return new MintedKeys(manifestListKey, kek.minted() ? kek.key() : null);
+  }
 
-    encryptionKeys.put(key.keyId(), key);
+  /**
+   * Returns an unexpired key encryption key from the metadata-sourced keys, or mints a fresh one.
+   */
+  private KeyEncryptionKey keyEncryptionKey() {
+    for (EncryptedKey key : encryptionKeys.values()) {
+      if (key.encryptedById().equals(tableKeyId)) { // this is a key encryption key
+        long keyTimestamp = Long.parseLong(key.properties().get(KEY_TIMESTAMP));
+        if (currentTimeMillis() - keyTimestamp < KEY_ENCRYPTION_KEY_LIFESPAN_MS) {
+          return new KeyEncryptionKey(key, unwrappedKeyCache().get(key.keyId()), false);
+        }
+      }
+    }
 
-    return manifestListKeyID;
+    ByteBuffer unwrapped = newKey();
+    ByteBuffer wrapped = kmsClient.wrapKey(unwrapped, tableKeyId);
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(KEY_TIMESTAMP, "" + currentTimeMillis());
+    EncryptedKey key = new BaseEncryptedKey(generateKeyId(), wrapped, tableKeyId, properties);
+    return new KeyEncryptionKey(key, unwrapped, true);
   }
 
   private String generateKeyId() {
@@ -235,6 +236,50 @@ public class StandardEncryptionManager implements EncryptionManager {
     byte[] newKey = new byte[dataKeyLength];
     workerRNG().nextBytes(newKey);
     return ByteBuffer.wrap(newKey);
+  }
+
+  /** The keys minted by a single {@link #mintManifestListKey} call, for the caller to persist. */
+  public static class MintedKeys {
+    private final EncryptedKey manifestListKey;
+    private final EncryptedKey newKeyEncryptionKey;
+
+    private MintedKeys(EncryptedKey manifestListKey, EncryptedKey newKeyEncryptionKey) {
+      this.manifestListKey = manifestListKey;
+      this.newKeyEncryptionKey = newKeyEncryptionKey;
+    }
+
+    public EncryptedKey manifestListKey() {
+      return manifestListKey;
+    }
+
+    /** The wrapping key encryption key if newly minted (not yet in metadata), else {@code null}. */
+    public EncryptedKey newKeyEncryptionKey() {
+      return newKeyEncryptionKey;
+    }
+  }
+
+  private static class KeyEncryptionKey {
+    private final EncryptedKey key;
+    private final ByteBuffer unwrapped;
+    private final boolean minted;
+
+    private KeyEncryptionKey(EncryptedKey key, ByteBuffer unwrapped, boolean minted) {
+      this.key = key;
+      this.unwrapped = unwrapped;
+      this.minted = minted;
+    }
+
+    private EncryptedKey key() {
+      return key;
+    }
+
+    private ByteBuffer unwrapped() {
+      return unwrapped;
+    }
+
+    private boolean minted() {
+      return minted;
+    }
   }
 
   private class StandardEncryptedOutputFile implements NativeEncryptionOutputFile {

--- a/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
@@ -24,8 +24,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.avro.InvalidAvroMagicException;
@@ -33,14 +31,13 @@ import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionTestHelpers;
-import org.apache.iceberg.encryption.EncryptionUtil;
+import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.encryption.UnitestKMS;
 import org.apache.iceberg.exceptions.RuntimeIOException;
 import org.apache.iceberg.inmemory.InMemoryFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
-import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -99,9 +96,7 @@ public class TestManifestListEncryption {
 
   @Test
   public void testEncryption() throws IOException {
-    EncryptionManager em = EncryptionTestHelpers.createEncryptionManager();
-
-    ManifestFile manifest = writeAndReadEncryptedManifestList(em);
+    ManifestFile manifest = writeAndReadEncryptedManifestList(Lists.newArrayList(), 0).manifest;
 
     assertThat(manifest.path()).isEqualTo(PATH);
     assertThat(manifest.length()).isEqualTo(LENGTH);
@@ -116,104 +111,71 @@ public class TestManifestListEncryption {
     assertThat((long) manifest.existingRowsCount()).isEqualTo(EXISTING_ROWS);
     assertThat((int) manifest.deletedFilesCount()).isEqualTo(DELETED_FILES);
     assertThat((long) manifest.deletedRowsCount()).isEqualTo(DELETED_ROWS);
-    assertThat(manifest.content()).isEqualTo(ManifestContent.DATA);
   }
 
   @Test
-  public void testKeyWrappingAndRotation() throws IOException {
-    EncryptionManager em = EncryptionTestHelpers.createEncryptionManager();
-    // This manager uses UnitestKMS.MASTER_KEY_NAME1 as the table master key
-    String tableMasterKeyID = UnitestKMS.MASTER_KEY_NAME1;
+  public void testFirstMintCreatesKeyEncryptionKey() throws IOException {
+    StandardEncryptionManager.MintedKeys minted =
+        writeAndReadEncryptedManifestList(Lists.newArrayList(), 0).minted;
 
-    // Initial write/read
-    writeAndReadEncryptedManifestList(em);
-    Map<String, EncryptedKey> keyList = EncryptionUtil.encryptionKeys(em);
-    // Two keys: manifest list key (metadata), and its key encryption key
-    assertThat(keyList.size()).isEqualTo(2);
-    String initialKekID = EncryptionTestHelpers.keyEncryptionKeyID(em);
-    int kekCount = 0;
-    int mlkmCount = 0;
-
-    for (String keyID : keyList.keySet()) {
-      EncryptedKey key = keyList.get(keyID);
-      if (key.encryptedById().equals(tableMasterKeyID)) { // key encryption key
-        kekCount++;
-        assertThat(keyID).isEqualTo(initialKekID);
-      } else { // manifest list key metadata
-        mlkmCount++;
-        assertThat(key.encryptedById()).isEqualTo(initialKekID);
-      }
-    }
-
-    assertThat(kekCount).isEqualTo(1);
-    assertThat(mlkmCount).isEqualTo(1);
-
-    // Write/read after 30 days
-    EncryptionTestHelpers.shiftEncryptionManagerTime(em, TimeUnit.DAYS.toMillis(30));
-    writeAndReadEncryptedManifestList(em);
-    // below rotation time, key encryption key must be the same
-    assertThat(EncryptionTestHelpers.keyEncryptionKeyID(em)).isEqualTo(initialKekID);
-    keyList = EncryptionUtil.encryptionKeys(em);
-    // three keys: two manifest list keys (metadata), and their key encryption key
-    assertThat(keyList.size()).isEqualTo(3);
-    Set<String> intermediateKeySet = Sets.newHashSet((keyList.keySet()));
-    kekCount = 0;
-    mlkmCount = 0;
-
-    for (String keyID : intermediateKeySet) {
-      EncryptedKey key = keyList.get(keyID);
-      if (key.encryptedById().equals(tableMasterKeyID)) { // key encryption key
-        kekCount++;
-        assertThat(keyID).isEqualTo(initialKekID);
-      } else { // manifest list key metadata
-        mlkmCount++;
-        assertThat(key.encryptedById()).isEqualTo(initialKekID);
-      }
-    }
-
-    assertThat(kekCount).isEqualTo(1);
-    assertThat(mlkmCount).isEqualTo(2);
-
-    // Write/read after 800 days
-    EncryptionTestHelpers.shiftEncryptionManagerTime(em, TimeUnit.DAYS.toMillis(800));
-    writeAndReadEncryptedManifestList(em);
-    String newKekID = EncryptionTestHelpers.keyEncryptionKeyID(em);
-    // above rotation time, key encryption key must be different
-    assertThat(newKekID).isNotEqualTo(initialKekID);
-    keyList = EncryptionUtil.encryptionKeys(em);
-    // five keys: three manifest list keys (metadata), and two key encryption keys (old and new)
-    assertThat(keyList.size()).isEqualTo(5);
-    kekCount = 0;
-    mlkmCount = 0;
-
-    for (String keyID : keyList.keySet()) {
-      if (!intermediateKeySet.contains(keyID)) { // new keys
-        EncryptedKey key = keyList.get(keyID);
-        if (key.encryptedById().equals(tableMasterKeyID)) { // key encryption key
-          kekCount++;
-          assertThat(keyID).isEqualTo(newKekID);
-        } else { // manifest list key metadata
-          mlkmCount++;
-          assertThat(key.encryptedById()).isEqualTo(newKekID); // wrapped by new kek
-        }
-      }
-    }
-
-    // new keys
-    assertThat(kekCount).isEqualTo(1);
-    assertThat(mlkmCount).isEqualTo(1);
+    assertThat(minted.newKeyEncryptionKey()).isNotNull();
+    assertThat(minted.manifestListKey().encryptedById())
+        .isEqualTo(minted.newKeyEncryptionKey().keyId());
+    assertThat(minted.newKeyEncryptionKey().encryptedById()).isEqualTo(UnitestKMS.MASTER_KEY_NAME1);
   }
 
-  private ManifestFile writeAndReadEncryptedManifestList(EncryptionManager em) throws IOException {
+  @Test
+  public void testKeyEncryptionKeyReusedBeforeRotation() throws IOException {
+    List<EncryptedKey> metadataKeys = Lists.newArrayList();
+    String initialKekId =
+        writeAndReadEncryptedManifestList(metadataKeys, 0).minted.newKeyEncryptionKey().keyId();
+
+    // 30 days is well within the 2-year lifespan, so the existing KEK must be reused.
+    StandardEncryptionManager.MintedKeys second =
+        writeAndReadEncryptedManifestList(metadataKeys, TimeUnit.DAYS.toMillis(30)).minted;
+
+    assertThat(second.newKeyEncryptionKey()).isNull();
+    assertThat(second.manifestListKey().encryptedById()).isEqualTo(initialKekId);
+  }
+
+  @Test
+  public void testKeyEncryptionKeyRotatesAfterLifespan() throws IOException {
+    List<EncryptedKey> metadataKeys = Lists.newArrayList();
+    String initialKekId =
+        writeAndReadEncryptedManifestList(metadataKeys, 0).minted.newKeyEncryptionKey().keyId();
+
+    // 800 days exceeds the 2-year (730-day) lifespan, forcing rotation.
+    StandardEncryptionManager.MintedKeys rotated =
+        writeAndReadEncryptedManifestList(metadataKeys, TimeUnit.DAYS.toMillis(800)).minted;
+
+    assertThat(rotated.newKeyEncryptionKey()).isNotNull();
+    assertThat(rotated.newKeyEncryptionKey().keyId()).isNotEqualTo(initialKekId);
+    assertThat(rotated.manifestListKey().encryptedById())
+        .isEqualTo(rotated.newKeyEncryptionKey().keyId());
+  }
+
+  /**
+   * Writes an encrypted manifest list with a manager built from {@code metadataKeys}, persists the
+   * minted keys into {@code metadataKeys} (as SnapshotProducer would), then reads it back through a
+   * fresh manager built from the updated keys, mirroring a reader loading keys from refreshed
+   * metadata.
+   */
+  private WriteResult writeAndReadEncryptedManifestList(
+      List<EncryptedKey> metadataKeys, long timeShiftMillis) throws IOException {
     FileIO io = new InMemoryFileIO();
-    EncryptingFileIO encryptingFileIO = EncryptingFileIO.combine(io, em);
     OutputFile outputFile = io.newOutputFile("memory:" + UUID.randomUUID());
+
+    EncryptionManager writeManager =
+        EncryptionTestHelpers.createEncryptionManager(Lists.newArrayList(metadataKeys));
+    if (timeShiftMillis != 0) {
+      EncryptionTestHelpers.shiftEncryptionManagerTime(writeManager, timeShiftMillis);
+    }
 
     ManifestListWriter writer =
         ManifestLists.write(
             3,
             outputFile,
-            encryptingFileIO.encryptionManager(),
+            writeManager,
             SNAPSHOT_ID,
             SNAPSHOT_ID - 1,
             SEQ_NUM,
@@ -222,16 +184,34 @@ public class TestManifestListEncryption {
     writer.close();
     ManifestListFile manifestListFile = writer.toManifestListFile();
 
-    // First try to read without decryption
+    StandardEncryptionManager.MintedKeys minted = writer.manifestListKeys();
+    metadataKeys.add(minted.manifestListKey());
+    if (minted.newKeyEncryptionKey() != null) {
+      metadataKeys.add(minted.newKeyEncryptionKey());
+    }
+
+    // The manifest list is unreadable without decryption.
     assertThatThrownBy(() -> ManifestLists.read(outputFile.toInputFile()))
         .isInstanceOf(RuntimeIOException.class)
         .hasMessageContaining("Failed to open file")
         .hasCauseInstanceOf(InvalidAvroMagicException.class);
 
-    List<ManifestFile> manifests =
-        ManifestLists.read(encryptingFileIO.newInputFile(manifestListFile));
-    assertThat(manifests.size()).isEqualTo(1);
+    EncryptionManager readManager =
+        EncryptionTestHelpers.createEncryptionManager(Lists.newArrayList(metadataKeys));
+    EncryptingFileIO readIO = EncryptingFileIO.combine(io, readManager);
+    List<ManifestFile> manifests = ManifestLists.read(readIO.newInputFile(manifestListFile));
+    assertThat(manifests).hasSize(1);
 
-    return manifests.get(0);
+    return new WriteResult(manifests.get(0), minted);
+  }
+
+  private static final class WriteResult {
+    private final ManifestFile manifest;
+    private final StandardEncryptionManager.MintedKeys minted;
+
+    private WriteResult(ManifestFile manifest, StandardEncryptionManager.MintedKeys minted) {
+      this.manifest = manifest;
+      this.minted = minted;
+    }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestRowDelta.java
+++ b/core/src/test/java/org/apache/iceberg/TestRowDelta.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.deletes.BaseDVFileWriter;
 import org.apache.iceberg.deletes.DVFileWriter;
 import org.apache.iceberg.deletes.PositionDelete;
 import org.apache.iceberg.deletes.PositionDeleteIndex;
+import org.apache.iceberg.encryption.EncryptedKey;
 import org.apache.iceberg.encryption.EncryptingFileIO;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionTestHelpers;
@@ -1991,6 +1992,21 @@ public class TestRowDelta extends TestBase {
   }
 
   @TestTemplate
+  public void testStagedSnapshotKeysArePersistedWithEncryption() {
+    assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
+
+    TestTables.TestTable encryptedTable = createEncryptedTable();
+    AppendFiles stagedAppend =
+        encryptedTable.newAppend().appendFile(newDataFile("data_bucket=0")).stageOnly();
+    stagedAppend.commit();
+
+    Snapshot staged = Iterables.getOnlyElement(encryptedTable.snapshots());
+    // Reading the staged snapshot's manifest list decrypts it, proving its key was persisted into
+    // metadata even though the snapshot is not a branch head.
+    assertThat(staged.allManifests(encryptedTable.io())).hasSize(1);
+  }
+
+  @TestTemplate
   public void testDuplicateDVsMergedMultipleSpecs() throws IOException {
     assumeThat(formatVersion).isGreaterThanOrEqualTo(3);
 
@@ -2654,17 +2670,20 @@ public class TestRowDelta extends TestBase {
   }
 
   private TestTables.TestTable createEncryptedTable() {
-    EncryptionManager encryptionManager = EncryptionTestHelpers.createEncryptionManager();
     String tableName = "encrypted-" + branch;
     java.io.File encryptedTableDir = temp.resolve(tableName).toFile();
     TestTables.TestTableOperations ops =
-        new TestTables.TestTableOperations(
-            tableName,
-            encryptedTableDir,
-            EncryptingFileIO.combine(new TestTables.LocalFileIO(), encryptionManager)) {
+        new TestTables.TestTableOperations(tableName, encryptedTableDir) {
           @Override
           public EncryptionManager encryption() {
-            return encryptionManager;
+            // Metadata-sourced: keys live in metadata, persisted by SnapshotProducer at commit.
+            List<EncryptedKey> keys = current() == null ? List.of() : current().encryptionKeys();
+            return EncryptionTestHelpers.createEncryptionManager(keys);
+          }
+
+          @Override
+          public EncryptingFileIO io() {
+            return EncryptingFileIO.combine(super.io(), encryption());
           }
         };
 

--- a/core/src/test/java/org/apache/iceberg/encryption/EncryptionTestHelpers.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/EncryptionTestHelpers.java
@@ -30,6 +30,13 @@ public class EncryptionTestHelpers {
   private EncryptionTestHelpers() {}
 
   public static EncryptionManager createEncryptionManager() {
+    return createEncryptionManager(List.of());
+  }
+
+  /**
+   * Creates a manager whose immutable key set is exactly {@code keys}, as if sourced from metadata.
+   */
+  public static EncryptionManager createEncryptionManager(List<EncryptedKey> keys) {
     Map<String, String> catalogProperties = Maps.newHashMap();
     catalogProperties.put(
         CatalogProperties.ENCRYPTION_KMS_IMPL, UnitestKMS.class.getCanonicalName());
@@ -37,14 +44,7 @@ public class EncryptionTestHelpers {
     tableProperties.put(TableProperties.ENCRYPTION_TABLE_KEY, UnitestKMS.MASTER_KEY_NAME1);
 
     return EncryptionUtil.createEncryptionManager(
-        List.of(), tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
-  }
-
-  public static String keyEncryptionKeyID(EncryptionManager em) {
-    Preconditions.checkState(
-        em instanceof StandardEncryptionManager,
-        "Retrieving key encryption key requires a StandardEncryptionManager");
-    return ((StandardEncryptionManager) em).keyEncryptionKeyID();
+        keys, tableProperties, EncryptionUtil.createKmsClient(catalogProperties));
   }
 
   public static void shiftEncryptionManagerTime(EncryptionManager em, long shiftMillis) {

--- a/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManager.java
+++ b/core/src/test/java/org/apache/iceberg/encryption/TestStandardEncryptionManager.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.encryption;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.junit.jupiter.api.Test;
+
+public class TestStandardEncryptionManager {
+
+  @Test
+  public void testKeysAreSourcedFromConstruction() {
+    StandardEncryptionManager manager =
+        (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager();
+    StandardEncryptionManager.MintedKeys minted = manager.mintManifestListKey(keyMetadata());
+
+    // A manager built from the minted keys resolves them; the original (empty) manager does not.
+    List<EncryptedKey> metadataKeys =
+        Lists.newArrayList(minted.manifestListKey(), minted.newKeyEncryptionKey());
+    StandardEncryptionManager rebuilt =
+        (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager(metadataKeys);
+
+    assertThat(rebuilt.encryptionKeys())
+        .containsKeys(minted.manifestListKey().keyId(), minted.newKeyEncryptionKey().keyId());
+    assertThat(manager.encryptionKeys()).isEmpty();
+  }
+
+  @Test
+  public void testConcurrentMintingIsSafeAndDoesNotMutateKeys() throws InterruptedException {
+    int threads = 8;
+    int keysPerThread = 200;
+    StandardEncryptionManager manager =
+        (StandardEncryptionManager) EncryptionTestHelpers.createEncryptionManager();
+
+    List<StandardEncryptionManager.MintedKeys> minted = new CopyOnWriteArrayList<>();
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    CountDownLatch start = new CountDownLatch(1);
+    CountDownLatch done = new CountDownLatch(threads);
+    ExecutorService pool = Executors.newFixedThreadPool(threads);
+
+    for (int t = 0; t < threads; t++) {
+      pool.submit(
+          () -> {
+            try {
+              start.await();
+              for (int i = 0; i < keysPerThread; i++) {
+                minted.add(manager.mintManifestListKey(keyMetadata()));
+                // Reading the immutable key set concurrently with minting must never throw.
+                manager.encryptionKeys().forEach((id, key) -> {});
+              }
+            } catch (Throwable e) {
+              failure.compareAndSet(null, e);
+            } finally {
+              done.countDown();
+            }
+          });
+    }
+
+    start.countDown();
+    assertThat(done.await(60, TimeUnit.SECONDS)).isTrue();
+    pool.shutdownNow();
+
+    assertThat(failure.get()).isNull();
+    assertThat(minted).hasSize(threads * keysPerThread);
+
+    Set<String> manifestListKeyIds =
+        minted.stream().map(keys -> keys.manifestListKey().keyId()).collect(Collectors.toSet());
+    assertThat(manifestListKeyIds).hasSize(minted.size());
+
+    // Minting never mutates the manager's immutable key set.
+    assertThat(manager.encryptionKeys()).isEmpty();
+  }
+
+  private static NativeEncryptionKeyMetadata keyMetadata() {
+    return new StandardKeyMetadata(new byte[16], new byte[12]);
+  }
+}

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveTableOperations.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +38,7 @@ import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ClientPool;
 import org.apache.iceberg.LocationProviders;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableMetadataParser;
 import org.apache.iceberg.TableOperations;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.encryption.EncryptedKey;
@@ -47,7 +47,6 @@ import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 import org.apache.iceberg.encryption.KeyManagementClient;
 import org.apache.iceberg.encryption.PlaintextEncryptionManager;
-import org.apache.iceberg.encryption.StandardEncryptionManager;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.CommitStateUnknownException;
@@ -59,7 +58,6 @@ import org.apache.iceberg.io.LocationProvider;
 import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTesting;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.thrift.TException;
 import org.slf4j.Logger;
@@ -88,12 +86,13 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   private final KeyManagementClient keyManagementClient;
   private final ClientPool<IMetaStoreClient, TException> metaClients;
 
-  private EncryptionManager encryptionManager;
-  private EncryptingFileIO encryptingFileIO;
-  private String tableKeyId;
-  private int encryptionDekLength;
-
-  private List<EncryptedKey> encryptedKeys = List.of();
+  // Keys live only in table metadata; the manager is immutable, built on demand from a metadata's
+  // keys and memoized by identity. tableKeyId (volatile) gates the plaintext fast path.
+  private volatile String tableKeyId;
+  private volatile int encryptionDekLength;
+  private final Object managerCacheLock = new Object();
+  private TableMetadata cachedManagerMetadata;
+  private EncryptionManager cachedManager;
 
   protected HiveTableOperations(
       Configuration conf,
@@ -126,44 +125,59 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
 
   @Override
   public FileIO io() {
-    if (tableKeyId == null) {
-      return fileIO;
-    }
-
-    if (encryptingFileIO == null) {
-      encryptingFileIO = EncryptingFileIO.combine(fileIO, encryption());
-    }
-
-    return encryptingFileIO;
+    // Avoid current() (which may refresh) on the unencrypted fast path.
+    return tableKeyId == null ? fileIO : io(current());
   }
 
   @Override
   public EncryptionManager encryption() {
-    if (encryptionManager != null) {
-      return encryptionManager;
+    return tableKeyId == null ? PlaintextEncryptionManager.instance() : encryption(current());
+  }
+
+  private FileIO io(TableMetadata metadata) {
+    if (tableKeyId == null) {
+      return fileIO;
     }
 
-    if (tableKeyId != null) {
-      Preconditions.checkArgument(
-          keyManagementClient != null,
-          "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
-          CatalogProperties.ENCRYPTION_KMS_IMPL);
+    return EncryptingFileIO.combine(fileIO, encryption(metadata));
+  }
 
-      Map<String, String> encryptionProperties =
-          ImmutableMap.of(
-              TableProperties.ENCRYPTION_TABLE_KEY,
-              tableKeyId,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              String.valueOf(encryptionDekLength));
-
-      encryptionManager =
-          EncryptionUtil.createEncryptionManager(
-              encryptedKeys, encryptionProperties, keyManagementClient);
-    } else {
+  /**
+   * Returns an {@link EncryptionManager} sourced from the given metadata's keys. Callers pass the
+   * metadata whose keys the manager must resolve: {@code current()} for a committed table, or the
+   * uncommitted metadata for staged transaction operations. Memoized by metadata identity so
+   * repeated calls with the same metadata reuse one manager.
+   */
+  private EncryptionManager encryption(TableMetadata metadata) {
+    if (tableKeyId == null) {
       return PlaintextEncryptionManager.instance();
     }
 
-    return encryptionManager;
+    synchronized (managerCacheLock) {
+      if (cachedManager == null || cachedManagerMetadata != metadata) {
+        cachedManager = createEncryptionManager(metadata);
+        cachedManagerMetadata = metadata;
+      }
+
+      return cachedManager;
+    }
+  }
+
+  private EncryptionManager createEncryptionManager(TableMetadata metadata) {
+    Preconditions.checkArgument(
+        keyManagementClient != null,
+        "Cannot create encryption manager without a key management client. Consider setting the '%s' catalog property",
+        CatalogProperties.ENCRYPTION_KMS_IMPL);
+
+    Map<String, String> encryptionProperties =
+        ImmutableMap.of(
+            TableProperties.ENCRYPTION_TABLE_KEY,
+            tableKeyId,
+            TableProperties.ENCRYPTION_DEK_LENGTH,
+            String.valueOf(encryptionDekLength));
+
+    List<EncryptedKey> keys = metadata == null ? List.of() : metadata.encryptionKeys();
+    return EncryptionUtil.createEncryptionManager(keys, encryptionProperties, keyManagementClient);
   }
 
   @Override
@@ -203,36 +217,23 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       throw new RuntimeException("Interrupted during refresh", e);
     }
 
-    refreshFromMetadataLocation(metadataLocation, metadataRefreshMaxRetries);
+    // Use plain fileIO, not io(): metadata isn't envelope-encrypted and io() would re-enter
+    // refresh.
+    refreshFromMetadataLocation(
+        metadataLocation,
+        null,
+        metadataRefreshMaxRetries,
+        location -> TableMetadataParser.read(fileIO, location));
 
     if (tableKeyIdFromHMS != null) {
       checkIntegrityForEncryption(tableKeyIdFromHMS, dekLengthFromHMS, metadataHashFromHMS);
 
-      tableKeyId = tableKeyIdFromHMS;
-      encryptionDekLength =
+      // Keys aren't cached here; encryption() rebuilds the manager from metadata on demand.
+      this.encryptionDekLength =
           (dekLengthFromHMS != null)
               ? Integer.parseInt(dekLengthFromHMS)
               : TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT;
-
-      encryptedKeys =
-          Optional.ofNullable(current().encryptionKeys())
-              .map(Lists::newLinkedList)
-              .orElseGet(Lists::newLinkedList);
-
-      if (encryptionManager != null) {
-        Set<String> keyIdsFromMetadata =
-            encryptedKeys.stream().map(EncryptedKey::keyId).collect(Collectors.toSet());
-
-        for (EncryptedKey keyFromEM : EncryptionUtil.encryptionKeys(encryptionManager).values()) {
-          if (!keyIdsFromMetadata.contains(keyFromEM.keyId())) {
-            encryptedKeys.add(keyFromEM);
-          }
-        }
-      }
-
-      // Force re-creation of encryption manager with updated keys
-      encryptingFileIO = null;
-      encryptionManager = null;
+      this.tableKeyId = tableKeyIdFromHMS;
     }
   }
 
@@ -240,25 +241,11 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   @Override
   protected void doCommit(TableMetadata base, TableMetadata metadata) {
     boolean newTable = base == null;
-    final TableMetadata tableMetadata;
     encryptionPropsFromMetadata(metadata.properties());
 
-    String newMetadataLocation;
-    EncryptionManager encrManager = encryption();
-    if (encrManager instanceof StandardEncryptionManager) {
-      // Add new encryption keys to the metadata
-      TableMetadata.Builder builder = TableMetadata.buildFrom(metadata);
-      for (Map.Entry<String, EncryptedKey> entry :
-          EncryptionUtil.encryptionKeys(encrManager).entrySet()) {
-        builder.addEncryptionKey(entry.getValue());
-      }
-
-      tableMetadata = builder.build();
-    } else {
-      tableMetadata = metadata;
-    }
-
-    newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
+    // Encryption keys are already persisted into the metadata by SnapshotProducer.
+    TableMetadata tableMetadata = metadata;
+    String newMetadataLocation = writeNewMetadataIfRequired(newTable, tableMetadata);
 
     boolean hiveEngineEnabled = hiveEngineEnabled(tableMetadata, conf);
     boolean keepHiveStats = conf.getBoolean(ConfigProperties.KEEP_HIVE_STATS, false);
@@ -488,12 +475,15 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
       @Override
       public FileIO io() {
         HiveTableOperations.this.encryptionPropsFromMetadata(uncommittedMetadata.properties());
-        return HiveTableOperations.this.io();
+        // Source keys from the uncommitted metadata so staged transaction operations can read
+        // snapshots produced by earlier operations before the transaction commits.
+        return HiveTableOperations.this.io(uncommittedMetadata);
       }
 
       @Override
       public EncryptionManager encryption() {
-        return HiveTableOperations.this.encryption();
+        HiveTableOperations.this.encryptionPropsFromMetadata(uncommittedMetadata.properties());
+        return HiveTableOperations.this.encryption(uncommittedMetadata);
       }
 
       @Override
@@ -558,16 +548,19 @@ public class HiveTableOperations extends BaseMetastoreTableOperations
   }
 
   private void encryptionPropsFromMetadata(Map<String, String> tableProperties) {
+    // Write-once from null/unset; the manager always re-sources keys from metadata, so a benign
+    // race at worst has two threads compute the same value.
     if (tableKeyId == null) {
-      tableKeyId = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
-    }
-
-    if (tableKeyId != null && encryptionDekLength <= 0) {
-      encryptionDekLength =
-          PropertyUtil.propertyAsInt(
-              tableProperties,
-              TableProperties.ENCRYPTION_DEK_LENGTH,
-              TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+      String tableKeyIdFromProps = tableProperties.get(TableProperties.ENCRYPTION_TABLE_KEY);
+      if (tableKeyIdFromProps != null) {
+        this.encryptionDekLength =
+            PropertyUtil.propertyAsInt(
+                tableProperties,
+                TableProperties.ENCRYPTION_DEK_LENGTH,
+                TableProperties.ENCRYPTION_DEK_LENGTH_DEFAULT);
+        // Set last: it gates the plaintext fast path, so DEK length must be visible first.
+        this.tableKeyId = tableKeyIdFromProps;
+      }
     }
   }
 

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestTableEncryption.java
@@ -162,6 +162,29 @@ public class TestTableEncryption extends CatalogTestBase {
     assertThat(currentDataFiles(table)).hasSize(dataFiles.size() + 2);
   }
 
+  @TestTemplate
+  public void testSharedTableTransactionInterleavedWithDirectCommit() {
+    validationCatalog.initialize(catalogName, catalogConfig);
+    // A single shared Table (and its EncryptionManager) drives both a staged transaction and a
+    // direct commit. With a mutable shared manager, the direct commit's key could be dropped from
+    // metadata, leaving its snapshot undecryptable. The metadata-sourced manager keeps every key.
+    Table table = validationCatalog.loadTable(tableIdent);
+    List<DataFile> dataFiles = currentDataFiles(table);
+    DataFile dataFile = dataFiles.get(0);
+
+    Transaction transaction = table.newTransaction();
+    transaction.newAppend().appendFile(dataFile).commit();
+
+    // Direct commit on the same shared Table, interleaved before the transaction commits.
+    table.newFastAppend().appendFile(dataFile).commit();
+
+    transaction.commitTransaction();
+
+    // Reading forces decryption of every snapshot's manifest list, including the direct commit's.
+    Table reloaded = validationCatalog.loadTable(tableIdent);
+    assertThat(currentDataFiles(reloaded)).hasSize(dataFiles.size() + 2);
+  }
+
   // See CatalogTests#testConcurrentReplaceTransactions
   @TestTemplate
   public void testConcurrentReplaceTransactions() {


### PR DESCRIPTION
… loss under concurrent commits

A single Table (and its shared TableOperations + EncryptionManager, e.g. via a caching catalog) can be used concurrently. On encrypted tables the mutable, shared StandardEncryptionManager could drop a snapshot's manifest-list key from encryption-keys, leaving a committed snapshot undecryptable.

Make encryption keys live only in table metadata and the manager immutable and metadata-sourced:

- StandardEncryptionManager holds an immutable key snapshot. Minting a manifest-list key is a pure operation (mintManifestListKey) that returns the new key(s) instead of storing them; removes the mutating key methods.
- SnapshotProducer captures the keys minted while writing the manifest list and persists them into the metadata it commits.
- HiveTableOperations builds the manager on demand from a metadata's keys (memoized by metadata identity); drops the doCommit/doRefresh key merges and the mutable manager/key fields. temp(uncommittedMetadata) sources keys from the uncommitted metadata, and BaseTransaction re-points temp ops after a rebase, so staged operations resolve earlier ops' (and concurrently committed) keys.

The immutable manager serializes to Spark executors with no concurrent-mutation hazard.