### PR TITLE
Spark: fix flaky testReadingStreamFromFutureTimestamp by switching to Awaitility.await

### DIFF
--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,7 @@ import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.Trigger;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -602,7 +604,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testReadingStreamFromFutureTimetsamp() throws Exception {
+  public void testReadingStreamFromFutureTimestamp() throws Exception {
     long futureTimestamp = System.currentTimeMillis() + 10000;
 
     StreamingQuery query =
@@ -627,12 +629,14 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     waitUntilAfter(futureTimestamp);
 
-    // Data appended after the timestamp should appear
+    // With async planning the new snapshot is discovered by a background thread, so poll until
+    // the appended data becomes visible.
     appendData(data);
-    // Allow async background thread to refresh, else test sometimes fails
-    Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    Awaitility.await("data appended after fromTimestamp becomes visible")
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(
+            () -> assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data));
   }
 
   @TestTemplate

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -75,6 +76,7 @@ import org.apache.spark.sql.streaming.DataStreamWriter;
 import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.Trigger;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -609,7 +611,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testReadingStreamFromFutureTimetsamp() throws Exception {
+  public void testReadingStreamFromFutureTimestamp() throws Exception {
     long futureTimestamp = System.currentTimeMillis() + 10000;
 
     StreamingQuery query =
@@ -634,12 +636,14 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     waitUntilAfter(futureTimestamp);
 
-    // Data appended after the timestamp should appear
+    // With async planning the new snapshot is discovered by a background thread, so poll until
+    // the appended data becomes visible.
     appendData(data);
-    // Allow async background thread to refresh, else test sometimes fails
-    Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    Awaitility.await("data appended after fromTimestamp becomes visible")
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(
+            () -> assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data));
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructuredStreamingRead3.java
@@ -24,6 +24,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.io.File;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -76,6 +77,7 @@ import org.apache.spark.sql.streaming.OutputMode;
 import org.apache.spark.sql.streaming.StreamingQuery;
 import org.apache.spark.sql.streaming.Trigger;
 import org.apache.spark.sql.util.CaseInsensitiveStringMap;
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -610,7 +612,7 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
   }
 
   @TestTemplate
-  public void testReadingStreamFromFutureTimetsamp() throws Exception {
+  public void testReadingStreamFromFutureTimestamp() throws Exception {
     long futureTimestamp = System.currentTimeMillis() + 10000;
 
     StreamingQuery query =
@@ -635,12 +637,14 @@ public final class TestStructuredStreamingRead3 extends CatalogTestBase {
 
     waitUntilAfter(futureTimestamp);
 
-    // Data appended after the timestamp should appear
+    // With async planning the new snapshot is discovered by a background thread, so poll until
+    // the appended data becomes visible.
     appendData(data);
-    // Allow async background thread to refresh, else test sometimes fails
-    Thread.sleep(50);
-    actual = rowsAvailable(query);
-    assertThat(actual).containsExactlyInAnyOrderElementsOf(data);
+    Awaitility.await("data appended after fromTimestamp becomes visible")
+        .atMost(Duration.ofSeconds(10))
+        .pollInterval(Duration.ofMillis(10))
+        .untilAsserted(
+            () -> assertThat(rowsAvailable(query)).containsExactlyInAnyOrderElementsOf(data));
   }
 
   @TestTemplate


### PR DESCRIPTION
Fix the flaky test in 
https://github.com/apache/iceberg/actions/runs/30405288650/job/90429251920#step:6:11506

```
TestStructuredStreamingRead3 > testReadingStreamFromFutureTimetsamp() > catalogName = testhive, implementation = org.apache.iceberg.spark.SparkCatalog, config = {type=hive, default-namespace=default}, async = true FAILED
    java.lang.AssertionError: 
    Expecting actual:
      []
    to contain exactly in any order:
      [{"id"=-2,"data"="minustwo"},
        {"id"=-1,"data"="minusone"},
        {"id"=0,"data"="zero"}]
    but could not find the following elements:
      [{"id"=-2,"data"="minustwo"},
        {"id"=-1,"data"="minusone"},
        {"id"=0,"data"="zero"}]
        at org.apache.iceberg.spark.source.TestStructuredStreamingRead3.testReadingStreamFromFutureTimetsamp(TestStructuredStreamingRead3.java:635)
```

switch to Awaitility.await for better polling. Verified 5 times locally on all spark 3.5/4.0/4.1  