### PR TITLE
BigQuery: Use imported Map instead of fully-qualified name

### DIFF
--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -568,8 +568,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
       return false;
     }
 
-    java.util.Map<String, String> parameters =
-        table.getExternalCatalogTableOptions().getParameters();
+    Map<String, String> parameters = table.getExternalCatalogTableOptions().getParameters();
 
     if (!parameters.containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP)
         || !parameters.containsKey(BaseMetastoreTableOperations.TABLE_TYPE_PROP)) {


### PR DESCRIPTION
`java.util.Map` is already imported and used with its simple name throughout `BigQueryMetastoreClientImpl`. This uses the simple name at the one remaining fully-qualified usage for consistency.