### PR TITLE
Docs: Fix invalid StructType.of call in Java API example

### DIFF
--- a/docs/docs/api.md
+++ b/docs/docs/api.md
@@ -170,7 +170,7 @@ Struct fields are created using `NestedField.optional` or `NestedField.required`
 
 ```java
 // struct<1 id: int, 2 data: optional string>
-StructType struct = Struct.of(
+StructType struct = StructType.of(
     Types.NestedField.required(1, "id", Types.IntegerType.get()),
     Types.NestedField.optional(2, "data", Types.StringType.get())
   )


### PR DESCRIPTION
The type-creation example in the Java API docs called `Struct.of(...)`, but no such type exists; the factory method is `StructType.of(...)`. This fixes the example to use the actual API, matching the sibling `MapType`/`ListType` examples. Docs-only.