### PR TITLE
Core: Drop test prefix from v4 struct test methods

### DIFF
--- a/core/src/test/java/org/apache/iceberg/TestContentStatsStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentStatsStruct.java
@@ -68,7 +68,7 @@ public class TestContentStatsStruct {
           null);
 
   @Test
-  public void testEmptyContentStats() {
+  public void emptyContentStats() {
     ContentStats stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
 
     assertThat(stats.statsFor(1)).isNull();
@@ -78,7 +78,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testSetStats() {
+  public void setStats() {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
 
     stats.setStats(1, ID_STATS);
@@ -90,7 +90,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testSetStatsWrongId() {
+  public void setStatsWrongId() {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
 
     assertThatThrownBy(() -> stats.setStats(2, ID_STATS))
@@ -99,7 +99,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testSetStatsUnknownField() {
+  public void setStatsUnknownField() {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
 
     FieldStats<Integer> fieldStats =
@@ -111,7 +111,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testGetByPosition() {
+  public void getByPosition() {
     // the content stats struct with a known field order
     Types.StructType contentStatsStruct =
         Types.StructType.of(
@@ -130,7 +130,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testSetByPosition() {
+  public void setByPosition() {
     // the content stats struct with a known field order
     Types.StructType statsStruct =
         Types.StructType.of(
@@ -150,7 +150,7 @@ public class TestContentStatsStruct {
   }
 
   @Test
-  public void testSize() {
+  public void size() {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
 
     assertThat(stats.size()).isEqualTo(3);
@@ -158,7 +158,7 @@ public class TestContentStatsStruct {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testCopy() {
+  public void copy() {
     FieldStats<Long> idStats = Mockito.mock(FieldStats.class);
     FieldStats<Long> idStatsCopy = Mockito.mock(FieldStats.class);
     Mockito.when(idStats.fieldId()).thenReturn(1);
@@ -186,7 +186,7 @@ public class TestContentStatsStruct {
 
   @Test
   @SuppressWarnings("unchecked")
-  public void testFilteredCopy() {
+  public void filteredCopy() {
     FieldStats<Long> idStats = Mockito.mock(FieldStats.class);
     FieldStats<Long> idStatsCopy = Mockito.mock(FieldStats.class);
     Mockito.when(idStats.fieldId()).thenReturn(1);
@@ -221,7 +221,7 @@ public class TestContentStatsStruct {
 
   @ParameterizedTest
   @FieldSource("SERIALIZERS")
-  public void testSerialization(RoundTripSerializer<ContentStatsStruct> serializer)
+  public void serialization(RoundTripSerializer<ContentStatsStruct> serializer)
       throws Exception {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
     stats.setStats(1, ID_STATS);

--- a/core/src/test/java/org/apache/iceberg/TestContentStatsStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentStatsStruct.java
@@ -221,8 +221,7 @@ public class TestContentStatsStruct {
 
   @ParameterizedTest
   @FieldSource("SERIALIZERS")
-  public void serialization(RoundTripSerializer<ContentStatsStruct> serializer)
-      throws Exception {
+  public void serialization(RoundTripSerializer<ContentStatsStruct> serializer) throws Exception {
     ContentStatsStruct stats = new ContentStatsStruct(CONTENT_STATS_STRUCT);
     stats.setStats(1, ID_STATS);
     stats.setStats(2, DATA_STATS);

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -28,7 +28,7 @@ import org.junit.jupiter.api.Test;
 class TestDeletionVectorStruct {
 
   @Test
-  void testFieldAccess() {
+  void fieldAccess() {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
@@ -44,7 +44,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testCopy() {
+  void copy() {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
@@ -62,13 +62,13 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testSize() {
+  void size() {
     DeletionVectorStruct dv = new DeletionVectorStruct(DeletionVector.schema());
     assertThat(dv.size()).isEqualTo(4);
   }
 
   @Test
-  void testProjectedStructLike() {
+  void projectedStructLike() {
     // project only location (field ID 155) and cardinality (field ID 156)
     Types.StructType projection =
         Types.StructType.of(DeletionVector.LOCATION, DeletionVector.CARDINALITY);
@@ -88,7 +88,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testInternalSetIgnoresUnknownOrdinal() {
+  void internalSetIgnoresUnknownOrdinal() {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
@@ -108,7 +108,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
@@ -126,7 +126,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testBuilderMissingRequiredFields() {
+  void builderMissingRequiredFields() {
     assertThatThrownBy(
             () -> DeletionVectorStruct.builder().offset(0).sizeInBytes(1).cardinality(1).build())
         .isInstanceOf(IllegalArgumentException.class)
@@ -164,7 +164,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testDvEquality() {
+  void dvEquality() {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")
@@ -222,7 +222,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testBuilderRejectsInvalidValuesAtSetter() {
+  void builderRejectsInvalidValuesAtSetter() {
     assertThatThrownBy(() -> DeletionVectorStruct.builder().location(null))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid location: null");
@@ -241,7 +241,7 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void testKryoSerializationRoundTrip() throws IOException {
+  void kryoSerializationRoundTrip() throws IOException {
     DeletionVectorStruct dv =
         DeletionVectorStruct.builder()
             .location("s3://bucket/data/dv.puffin")

--- a/core/src/test/java/org/apache/iceberg/TestFieldStatsStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestFieldStatsStruct.java
@@ -60,7 +60,7 @@ public class TestFieldStatsStruct {
       StatsUtil.fieldStatsStruct(true, Types.DoubleType.get(), BASE_ID, MetricsModes.Full.get());
 
   @Test
-  public void testFieldAccess() {
+  public void fieldAccess() {
     FieldStats<String> stats = new FieldStatsStruct<>(STRING_STATS, "a", "z", true, 28, 2, 0, 1);
 
     assertThat(stats.fieldId()).isEqualTo(100);
@@ -74,7 +74,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testStringGetByPosition() {
+  public void stringGetByPosition() {
     FieldStatsStruct<String> stats =
         new FieldStatsStruct<>(STRING_STATS, "a", "z", true, 28, 2, 0, 1);
 
@@ -87,7 +87,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testStringSetByPosition() {
+  public void stringSetByPosition() {
     FieldStatsStruct<String> stats = new FieldStatsStruct<>(STRING_STATS);
 
     stats.set(pos(STRING_STATS, "lower_bound"), "a");
@@ -106,7 +106,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testDoubleGetByPosition() {
+  public void doubleGetByPosition() {
     FieldStatsStruct<Double> stats =
         new FieldStatsStruct<>(DOUBLE_STATS, 0.0d, 25.0d, true, 34, 2, 6, 0);
 
@@ -119,7 +119,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testDoubleSetByPosition() {
+  public void doubleSetByPosition() {
     FieldStatsStruct<Double> stats = new FieldStatsStruct<>(DOUBLE_STATS);
 
     stats.set(pos(DOUBLE_STATS, "lower_bound"), 0.0d);
@@ -139,7 +139,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testFromFieldMetricsWrongField() {
+  public void fromFieldMetricsWrongField() {
     FieldStatsStruct<String> stats = new FieldStatsStruct<>(STRING_STATS);
     assertThatThrownBy(() -> stats.fromFieldMetrics(new FieldMetrics<>(21, 50, 0)))
         .isInstanceOf(IllegalArgumentException.class)
@@ -147,7 +147,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testFromFieldMetricsString() {
+  public void fromFieldMetricsString() {
     FieldStatsStruct<String> stats = new FieldStatsStruct<>(STRING_STATS);
 
     stats.fromFieldMetrics(new FieldMetrics<>(100, 28, 2, "a", "z"));
@@ -161,7 +161,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testFromFieldMetricsDouble() {
+  public void fromFieldMetricsDouble() {
     FieldStatsStruct<Double> stats = new FieldStatsStruct<>(DOUBLE_STATS);
 
     stats.fromFieldMetrics(new FieldMetrics<>(100, 34, 2, 6, 0.0d, 25.0d));
@@ -176,7 +176,7 @@ public class TestFieldStatsStruct {
   }
 
   @Test
-  public void testFieldStatsProjection() {
+  public void fieldStatsProjection() {
     Types.StructType projection =
         Types.StructType.of(
             optional(BASE_ID + StatsUtil.VALUE_COUNT_OFFSET, "count", Types.StringType.get()),
@@ -249,7 +249,7 @@ public class TestFieldStatsStruct {
 
   @ParameterizedTest
   @MethodSource("serializationCases")
-  public void testSerializationAndCopy(
+  public void serializationAndCopy(
       Type type,
       Object lowerBound,
       Object upperBound,
@@ -289,7 +289,7 @@ public class TestFieldStatsStruct {
 
   @ParameterizedTest
   @MethodSource("geoCases")
-  public void testGeoSerialization(
+  public void geoSerialization(
       Type geoType, RoundTripSerializer<FieldStatsStruct<?>> serializer) throws Exception {
     Types.StructType statsStruct =
         StatsUtil.fieldStatsStruct(true, geoType, BASE_ID, MetricsModes.Full.get());
@@ -328,7 +328,7 @@ public class TestFieldStatsStruct {
 
   @ParameterizedTest
   @FieldSource("VARIANT_SERIALIZERS")
-  public void testVariantSerialization(RoundTripSerializer<FieldStatsStruct<?>> serializer)
+  public void variantSerialization(RoundTripSerializer<FieldStatsStruct<?>> serializer)
       throws Exception {
     Types.StructType statsStruct =
         StatsUtil.fieldStatsStruct(true, Types.VariantType.get(), BASE_ID, MetricsModes.Full.get());

--- a/core/src/test/java/org/apache/iceberg/TestFieldStatsStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestFieldStatsStruct.java
@@ -289,8 +289,8 @@ public class TestFieldStatsStruct {
 
   @ParameterizedTest
   @MethodSource("geoCases")
-  public void geoSerialization(
-      Type geoType, RoundTripSerializer<FieldStatsStruct<?>> serializer) throws Exception {
+  public void geoSerialization(Type geoType, RoundTripSerializer<FieldStatsStruct<?>> serializer)
+      throws Exception {
     Types.StructType statsStruct =
         StatsUtil.fieldStatsStruct(true, geoType, BASE_ID, MetricsModes.Full.get());
 

--- a/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestInfoStruct.java
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 class TestManifestInfoStruct {
 
   @Test
-  void testFieldAccess() {
+  void fieldAccess() {
     ManifestInfoStruct info =
         new ManifestInfoStruct(10, 20, 3, 2, 1000L, 2000L, 300L, 200L, 5L, new byte[] {0xF}, 1L);
 
@@ -47,7 +47,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testCopy() {
+  void copy() {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(10)
@@ -81,7 +81,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testNullableFields() {
+  void nullableFields() {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(0)
@@ -100,7 +100,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testProjectedStructLike() {
+  void projectedStructLike() {
     // project only added_files_count (field ID 504) and min_sequence_number (field ID 516)
     Types.StructType projection =
         Types.StructType.of(ManifestInfo.ADDED_FILES_COUNT, ManifestInfo.MIN_SEQUENCE_NUMBER);
@@ -120,7 +120,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testInternalSetIgnoresUnknownOrdinal() {
+  void internalSetIgnoresUnknownOrdinal() {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(10)
@@ -154,7 +154,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testJavaSerializationRoundTrip() throws IOException, ClassNotFoundException {
+  void javaSerializationRoundTrip() throws IOException, ClassNotFoundException {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(10)
@@ -186,7 +186,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingAddedFilesCount() {
+  void builderMissingAddedFilesCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -204,7 +204,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingExistingFilesCount() {
+  void builderMissingExistingFilesCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -222,7 +222,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingDeletedFilesCount() {
+  void builderMissingDeletedFilesCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -240,7 +240,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingReplacedFilesCount() {
+  void builderMissingReplacedFilesCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -258,7 +258,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingAddedRowsCount() {
+  void builderMissingAddedRowsCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -276,7 +276,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingExistingRowsCount() {
+  void builderMissingExistingRowsCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -294,7 +294,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingDeletedRowsCount() {
+  void builderMissingDeletedRowsCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -312,7 +312,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingReplacedRowsCount() {
+  void builderMissingReplacedRowsCount() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -330,7 +330,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderMissingMinSequenceNumber() {
+  void builderMissingMinSequenceNumber() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -348,77 +348,77 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderRejectsNegativeAddedFilesCount() {
+  void builderRejectsNegativeAddedFilesCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().addedFilesCount(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid added files count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeExistingFilesCount() {
+  void builderRejectsNegativeExistingFilesCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().existingFilesCount(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid existing files count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeDeletedFilesCount() {
+  void builderRejectsNegativeDeletedFilesCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().deletedFilesCount(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid deleted files count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeReplacedFilesCount() {
+  void builderRejectsNegativeReplacedFilesCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().replacedFilesCount(-1))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid replaced files count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeAddedRowsCount() {
+  void builderRejectsNegativeAddedRowsCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().addedRowsCount(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid added rows count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeExistingRowsCount() {
+  void builderRejectsNegativeExistingRowsCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().existingRowsCount(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid existing rows count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeDeletedRowsCount() {
+  void builderRejectsNegativeDeletedRowsCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().deletedRowsCount(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid deleted rows count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeReplacedRowsCount() {
+  void builderRejectsNegativeReplacedRowsCount() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().replacedRowsCount(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid replaced rows count: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeMinSequenceNumber() {
+  void builderRejectsNegativeMinSequenceNumber() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().minSequenceNumber(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid min sequence number: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsNegativeDvCardinality() {
+  void builderRejectsNegativeDvCardinality() {
     assertThatThrownBy(() -> ManifestInfoStruct.builder().dvCardinality(-1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid DV cardinality: -1 (must be >= 0)");
   }
 
   @Test
-  void testBuilderRejectsRowsWithoutFiles() {
+  void builderRejectsRowsWithoutFiles() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -485,7 +485,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderAllowsFilesWithoutRows() {
+  void builderAllowsFilesWithoutRows() {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(5)
@@ -510,7 +510,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testBuilderDvPairingValidation() {
+  void builderDvPairingValidation() {
     assertThatThrownBy(
             () ->
                 ManifestInfoStruct.builder()
@@ -547,7 +547,7 @@ class TestManifestInfoStruct {
   }
 
   @Test
-  void testKryoSerializationRoundTrip() throws IOException {
+  void kryoSerializationRoundTrip() throws IOException {
     ManifestInfoStruct info =
         ManifestInfoStruct.builder()
             .addedFilesCount(10)

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -82,7 +82,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testDataFileAdapterDelegation() {
+  void dataFileAdapterDelegation() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.ADDED,
@@ -149,7 +149,7 @@ class TestTrackedFileAdapters {
 
   @ParameterizedTest
   @EnumSource(value = FileContent.class, mode = EnumSource.Mode.EXCLUDE, names = "DATA")
-  void testDataFileAdapterRejectsNonDataContent(FileContent contentType) {
+  void dataFileAdapterRejectsNonDataContent(FileContent contentType) {
     TrackedFileStruct file = dummyTrackedFile(contentType);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDataFile(file, UNPARTITIONED))
@@ -158,7 +158,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testEqualityDeleteFileAdapterDelegation() {
+  void equalityDeleteFileAdapterDelegation() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.ADDED,
@@ -226,7 +226,7 @@ class TestTrackedFileAdapters {
 
   @ParameterizedTest
   @EnumSource(value = FileContent.class, mode = EnumSource.Mode.EXCLUDE, names = "EQUALITY_DELETES")
-  void testEqualityDeleteFileAdapterRejectsNonEqualityContent(FileContent contentType) {
+  void equalityDeleteFileAdapterRejectsNonEqualityContent(FileContent contentType) {
     TrackedFileStruct file = dummyTrackedFile(contentType);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asEqualityDeleteFile(file, UNPARTITIONED))
@@ -235,7 +235,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testDVDeleteFileAdapterDelegation() {
+  void dVDeleteFileAdapterDelegation() {
     DeletionVector dv =
         DeletionVectorStruct.builder()
             .location(DV_LOCATION)
@@ -314,7 +314,7 @@ class TestTrackedFileAdapters {
 
   @ParameterizedTest
   @EnumSource(value = FileContent.class, mode = EnumSource.Mode.EXCLUDE, names = "DATA")
-  void testDVDeleteFileAdapterRejectsNonDataContent(FileContent contentType) {
+  void dVDeleteFileAdapterRejectsNonDataContent(FileContent contentType) {
     TrackedFileStruct file = dummyTrackedFile(contentType);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDVDeleteFile(file, UNPARTITIONED))
@@ -323,7 +323,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testDVDeleteFileAdapterRejectsNullDeletionVector() {
+  void dVDeleteFileAdapterRejectsNullDeletionVector() {
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDVDeleteFile(file, UNPARTITIONED))
@@ -332,7 +332,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testNullContentStatsReturnsNullStats() {
+  void nullContentStatsReturnsNullStats() {
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 
     DataFile dataFile = TrackedFileAdapters.asDataFile(file, UNPARTITIONED);
@@ -345,7 +345,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testNullTrackingReturnsNullTrackingFields() {
+  void nullTrackingReturnsNullTrackingFields() {
     // Files read before manifest inheritance have no tracking; tracking-derived fields must be
     // null rather than throwing.
     assertNullTrackingFields(
@@ -376,7 +376,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testUnpartitionedFilePartitionIsEmpty() {
+  void unpartitionedFilePartitionIsEmpty() {
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 
     DataFile dataFile = TrackedFileAdapters.asDataFile(file, UNPARTITIONED);
@@ -386,7 +386,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testNullSpecIdResolvesToUnpartitionedSpec() {
+  void nullSpecIdResolvesToUnpartitionedSpec() {
     PartitionSpec unpartitioned = PartitionSpec.builderFor(new Schema()).withSpecId(5).build();
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 
@@ -396,7 +396,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testNullSpecIdThrowsWhenNoUnpartitionedSpec() {
+  void nullSpecIdThrowsWhenNoUnpartitionedSpec() {
     Schema schema = new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
     PartitionSpec partitioned = PartitionSpec.builderFor(schema).identity("id").build();
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
@@ -407,7 +407,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testUnknownSpecIdThrows() {
+  void unknownSpecIdThrows() {
     TrackedFileStruct file =
         new TrackedFileStruct(
             null,
@@ -433,7 +433,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void testSpecIdMismatchThrows() {
+  void specIdMismatchThrows() {
     TrackedFileStruct file =
         new TrackedFileStruct(
             null,

--- a/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackedFileAdapters.java
@@ -235,7 +235,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void dVDeleteFileAdapterDelegation() {
+  void dvDeleteFileAdapterDelegation() {
     DeletionVector dv =
         DeletionVectorStruct.builder()
             .location(DV_LOCATION)
@@ -314,7 +314,7 @@ class TestTrackedFileAdapters {
 
   @ParameterizedTest
   @EnumSource(value = FileContent.class, mode = EnumSource.Mode.EXCLUDE, names = "DATA")
-  void dVDeleteFileAdapterRejectsNonDataContent(FileContent contentType) {
+  void dvDeleteFileAdapterRejectsNonDataContent(FileContent contentType) {
     TrackedFileStruct file = dummyTrackedFile(contentType);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDVDeleteFile(file, UNPARTITIONED))
@@ -323,7 +323,7 @@ class TestTrackedFileAdapters {
   }
 
   @Test
-  void dVDeleteFileAdapterRejectsNullDeletionVector() {
+  void dvDeleteFileAdapterRejectsNullDeletionVector() {
     TrackedFileStruct file = dummyTrackedFile(FileContent.DATA);
 
     assertThatThrownBy(() -> TrackedFileAdapters.asDVDeleteFile(file, UNPARTITIONED))

--- a/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingBuilder.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 class TestTrackingBuilder {
 
   @Test
-  void testAddedWithSameCommitDvStaysAdded() {
+  void addedWithSameCommitDvStaysAdded() {
     Tracking tracking = TrackingBuilder.added(42L).dvUpdated().build();
 
     assertThat(tracking.status()).isEqualTo(EntryStatus.ADDED);
@@ -47,7 +47,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testExistingBuilderPreservesSourceFields() {
+  void existingBuilderPreservesSourceFields() {
     Tracking source = sourceTracking();
 
     Tracking existing = TrackingBuilder.from(source, 1L).build();
@@ -61,7 +61,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testDeleteUpdatesSnapshotIdAndPreservesRest() {
+  void deleteUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
     Tracking deleted = TrackingBuilder.deleted(source, 999L);
@@ -75,7 +75,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testReplaceUpdatesSnapshotIdAndPreservesRest() {
+  void replaceUpdatesSnapshotIdAndPreservesRest() {
     Tracking source = sourceTracking();
 
     Tracking replaced = TrackingBuilder.replaced(source, 999L);
@@ -89,7 +89,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testSourceDvPositionsAreNotCarriedForward() {
+  void sourceDvPositionsAreNotCarriedForward() {
     Tracking source =
         new TrackingStruct(
             EntryStatus.ADDED, 42L, 10L, 10L, 43L, 1000L, new byte[] {1, 2}, new byte[] {3, 4});
@@ -108,7 +108,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testDvUpdatedProducesModifiedAndAdvancesDvSnapshotId() {
+  void dvUpdatedProducesModifiedAndAdvancesDvSnapshotId() {
     Tracking source = sourceTracking();
     Tracking modified = TrackingBuilder.from(source, 999L).dvUpdated().build();
 
@@ -120,7 +120,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testManifestDVMutatorsRejectedOnAdded() {
+  void manifestDVMutatorsRejectedOnAdded() {
     assertThatThrownBy(
             () -> TrackingBuilder.added(42L).deletedPositions(ByteBuffer.wrap(new byte[] {1})))
         .isInstanceOf(IllegalStateException.class)
@@ -133,7 +133,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testDvUpdatedRejectedWhenManifestPositionsSet() {
+  void dvUpdatedRejectedWhenManifestPositionsSet() {
     assertThatThrownBy(
             () ->
                 TrackingBuilder.from(manifestSourceTracking(), 999L)
@@ -154,14 +154,14 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testBuilderRejectsNullSource() {
+  void builderRejectsNullSource() {
     assertThatThrownBy(() -> TrackingBuilder.from(null, 1L))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("Invalid source tracking: null");
   }
 
   @Test
-  void testSourceBuildersRejectSourceWithoutSequenceNumbers() {
+  void sourceBuildersRejectSourceWithoutSequenceNumbers() {
     Tracking missingBoth = TrackingBuilder.added(42L).build();
 
     assertThatThrownBy(() -> TrackingBuilder.from(missingBoth, 1L))
@@ -207,7 +207,7 @@ class TestTrackingBuilder {
 
   @ParameterizedTest
   @MethodSource("terminalTransitionCases")
-  void testRejectsTransitionsFromTerminalStatus(
+  void rejectsTransitionsFromTerminalStatus(
       EntryStatus sourceStatus, Consumer<Tracking> factoryCall) {
     Tracking source = sourceTrackingWithStatus(sourceStatus);
     assertThatThrownBy(() -> factoryCall.accept(source))
@@ -216,7 +216,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testExistingToExistingIsAllowed() {
+  void existingToExistingIsAllowed() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
     Tracking existing = TrackingBuilder.from(existingSource, 1L).build();
@@ -226,7 +226,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testExistingToTerminalTransitions() {
+  void existingToTerminalTransitions() {
     Tracking existingSource = sourceTrackingWithStatus(EntryStatus.EXISTING);
 
     Tracking deleted = TrackingBuilder.deleted(existingSource, 999L);
@@ -239,7 +239,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testExistingPreservesSourceSnapshotId() {
+  void existingPreservesSourceSnapshotId() {
     Tracking source = sourceTracking();
     Tracking existing = TrackingBuilder.from(source, 999L).build();
     assertThat(existing.status()).isEqualTo(EntryStatus.EXISTING);
@@ -247,7 +247,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testCarryForwardFromModifiedSourceChangesToExisting() {
+  void carryForwardFromModifiedSourceChangesToExisting() {
     Tracking modifiedSource = sourceTrackingWithStatus(EntryStatus.MODIFIED);
     Tracking carried = TrackingBuilder.from(modifiedSource, 999L).build();
     assertThat(carried.status()).isEqualTo(EntryStatus.EXISTING);
@@ -259,7 +259,7 @@ class TestTrackingBuilder {
   }
 
   @Test
-  void testManifestDVPositionsProduceModified() {
+  void manifestDVPositionsProduceModified() {
     ByteBuffer deletedBytes = ByteBuffer.wrap(new byte[] {1, 2});
 
     Tracking addedSource = manifestSourceTracking();

--- a/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestTrackingStruct.java
@@ -37,7 +37,7 @@ class TestTrackingStruct {
   private static final int MANIFEST_POSITION_ORDINAL = Tracking.schema().fields().size();
 
   @Test
-  void testFieldAccess() {
+  void fieldAccess() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
@@ -57,7 +57,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testSetByPosition() {
+  void setByPosition() {
     TrackingStruct tracking = new TrackingStruct();
 
     tracking.set(pos("status"), EntryStatus.ADDED.id());
@@ -82,7 +82,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testGetByPosition() {
+  void getByPosition() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
@@ -103,7 +103,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testCopy() {
+  void copy() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.MODIFIED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
@@ -129,7 +129,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testInheritSnapshotId() {
+  void inheritSnapshotId() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
@@ -140,7 +140,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testInheritSequenceNumberForAddedEntries() {
+  void inheritSequenceNumberForAddedEntries() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
 
@@ -152,7 +152,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDoNotInheritSequenceNumberForExistingEntries() {
+  void doNotInheritSequenceNumberForExistingEntries() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.EXISTING, 42L, 5L, 6L, null, null, null, null);
 
@@ -164,7 +164,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testDoNotInheritSequenceNumberForModifiedEntries() {
+  void doNotInheritSequenceNumberForModifiedEntries() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.MODIFIED, 42L, 5L, 6L, null, null, null, null);
 
@@ -176,7 +176,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testExplicitValuesOverrideInheritance() {
+  void explicitValuesOverrideInheritance() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, 200L, 75L, 76L, null, null, null, null);
 
@@ -189,7 +189,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testInheritFromRejectsUnequalSequenceNumbers() {
+  void inheritFromRejectsUnequalSequenceNumbers() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, 42L, null, null, null, null, null, null);
 
@@ -202,7 +202,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testNoDefaultingWithoutInheritance() {
+  void noDefaultingWithoutInheritance() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
@@ -213,7 +213,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testInheritFromNullIsNoOp() {
+  void inheritFromNullIsNoOp() {
     TrackingStruct tracking =
         new TrackingStruct(EntryStatus.ADDED, null, null, null, null, null, null, null);
 
@@ -232,14 +232,14 @@ class TestTrackingStruct {
 
   @ParameterizedTest
   @EnumSource(EntryStatus.class)
-  void testIsLiveDelegatesToStatus(EntryStatus status) {
+  void isLiveDelegatesToStatus(EntryStatus status) {
     TrackingStruct tracking = new TrackingStruct(status, null, null, null, null, null, null, null);
 
     assertThat(tracking.isLive()).isEqualTo(status.isLive());
   }
 
   @Test
-  void testInternalSetIgnoresUnknownOrdinal() {
+  void internalSetIgnoresUnknownOrdinal() {
     TrackingStruct tracking =
         new TrackingStruct(
             EntryStatus.ADDED, 42L, 10L, 11L, 43L, 1000L, DELETED_POSITIONS, REPLACED_POSITIONS);
@@ -259,7 +259,7 @@ class TestTrackingStruct {
   }
 
   @Test
-  void testProjectedStructLike() {
+  void projectedStructLike() {
     // project only snapshot_id (field ID 1) and first_row_id (field ID 142)
     Types.StructType projection = Types.StructType.of(Tracking.SNAPSHOT_ID, Tracking.FIRST_ROW_ID);
 
@@ -279,7 +279,7 @@ class TestTrackingStruct {
 
   @ParameterizedTest
   @MethodSource("org.apache.iceberg.TestHelpers#serializers")
-  void testSerializationRoundTrip(TestHelpers.RoundTripSerializer<Tracking> roundTripSerializer)
+  void serializationRoundTrip(TestHelpers.RoundTripSerializer<Tracking> roundTripSerializer)
       throws IOException, ClassNotFoundException {
     TrackingStruct tracking =
         new TrackingStruct(


### PR DESCRIPTION
JUnit 5 does not require the test prefix on test methodsDrop the prefix from the v4 tracked-file struct tests, matching the convention used for newer tests.