### PR TITLE
Build: Make JMH benchmark configuration flexible for JDK 17+

### DIFF
--- a/jmh.gradle
+++ b/jmh.gradle
@@ -62,11 +62,12 @@ configure(jmhProjects) {
 
   jmh {
     jmhVersion = '1.37'
-    failOnError = true
+    failOnError = project.findProperty('jmhFailOnError')?.toBoolean() ?: true
     forceGC = true
     includeTests = true
     humanOutputFile = file(jmhOutputPath)
-    jvmArgs = ['-Xmx32g']
+    jvmArgs = ["-Xmx${project.findProperty('jmhHeapSize') ?: '32g'}",
+               '--add-opens=java.base/java.nio=ALL-UNNAMED']
     resultsFile = file(jmhJsonOutputPath)
     resultFormat = 'JSON'
     includes = [jmhIncludeRegex]


### PR DESCRIPTION
## Summary

Make JMH benchmark configuration more flexible by allowing heap size and failure behavior to be overridden via Gradle properties. This helps developers who cannot allocate the default 32GB heap or run on JDK 17+ which requires module opens.

## Changes

- Make `maxHeapSize` configurable via `-PjmhHeapSize=` (default: 32g)
- Make `failOnError` configurable via `-PjmhFailOnError=` (default: true)
- Add JDK 17+ module opens for java.nio access

## Testing

Verified builds with `./gradlew jmh -PjmhHeapSize=4g` locally.