### PR TITLE
docs: fix Delta Lake migration output method name

### DIFF
--- a/docs/docs/delta-lake-migration.md
+++ b/docs/docs/delta-lake-migration.md
@@ -84,7 +84,7 @@ For detailed usage and other optional configurations, please refer to the [Snaps
 #### Output
 | Output Name | Type | Description |
 | ------------|------|-------------|
-| `imported_files_count` | long | Number of files added to the new table |
+| `snapshotDataFilesCount()` | long | Number of files added to the new table |
 
 #### Added Table Properties
 The following table properties are added to the Iceberg table to be created by default:


### PR DESCRIPTION
## Summary

Fix incorrect output method name in Delta Lake migration documentation.

## Changes

- Updated the output table to show `snapshotDataFilesCount()` instead of `imported_files_count`
- The `SnapshotDeltaLakeTable.Result` interface uses `snapshotDataFilesCount()` as the actual method name

## Testing

N/A — documentation fix only.