### PR TITLE
API: Fix null/Nan counts in evaluator test

### DIFF
--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -1060,14 +1060,14 @@ public class TestInclusiveMetricsEvaluator {
             "single_value_nulls.avro",
             Row.of(),
             10,
-            ImmutableMap.of(3, 10L),
-            ImmutableMap.of(3, 2L),
+            ImmutableMap.of(14, 10L),
+            ImmutableMap.of(14, 2L),
             null,
-            ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")),
-            ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")));
+            ImmutableMap.of(14, toByteBuffer(StringType.get(), "abc")),
+            ImmutableMap.of(14, toByteBuffer(StringType.get(), "abc")));
 
     shouldRead =
-        new InclusiveMetricsEvaluator(SCHEMA, notEqual("required", "abc"))
+        new InclusiveMetricsEvaluator(SCHEMA, notEqual("some_empty", "abc"))
             .eval(singleValueWithNulls);
     assertThat(shouldRead).as("Should read: file has nulls which match != predicate").isTrue();
 
@@ -1151,14 +1151,14 @@ public class TestInclusiveMetricsEvaluator {
             "single_value_nulls.avro",
             Row.of(),
             10,
-            ImmutableMap.of(3, 10L),
-            ImmutableMap.of(3, 2L),
-            ImmutableMap.of(3, 0L),
-            ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")),
-            ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")));
+            ImmutableMap.of(14, 10L),
+            ImmutableMap.of(14, 2L),
+            null,
+            ImmutableMap.of(14, toByteBuffer(StringType.get(), "abc")),
+            ImmutableMap.of(14, toByteBuffer(StringType.get(), "abc")));
 
     shouldRead =
-        new InclusiveMetricsEvaluator(SCHEMA, notIn("required", "abc", "def"))
+        new InclusiveMetricsEvaluator(SCHEMA, notIn("some_empty", "abc", "def"))
             .eval(singleValueWithNulls);
     assertThat(shouldRead).as("Should read: file has nulls which match NOT IN predicate").isTrue();
 

--- a/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestInclusiveMetricsEvaluator.java
@@ -1022,7 +1022,7 @@ public class TestInclusiveMetricsEvaluator {
             10,
             ImmutableMap.of(3, 10L),
             ImmutableMap.of(3, 0L),
-            ImmutableMap.of(3, 0L),
+            null,
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "aaa")),
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "zzz")));
 
@@ -1111,7 +1111,7 @@ public class TestInclusiveMetricsEvaluator {
             10,
             ImmutableMap.of(3, 10L),
             ImmutableMap.of(3, 0L),
-            ImmutableMap.of(3, 0L),
+            null,
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "aaa")),
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "zzz")));
 
@@ -1128,7 +1128,7 @@ public class TestInclusiveMetricsEvaluator {
             10,
             ImmutableMap.of(3, 10L),
             ImmutableMap.of(3, 0L),
-            ImmutableMap.of(3, 0L),
+            null,
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")),
             ImmutableMap.of(3, toByteBuffer(StringType.get(), "abc")));
 


### PR DESCRIPTION
The single_value_nulls fixtures in testNotEqWithSingleValue and testNotInWithSingleValue reported 2 nulls for field 3, the "required" column. A required column cannot contain nulls, so no writer produces those metrics. Move both to the optional "some_empty" column, which keeps the case the tests cover: a file whose bounds hold a single value still has to be read when the column also contains nulls, because those nulls match != and NOT IN.

The NOT IN fixture also reported a NaN count for a string column, which only float and double columns track.


- Model: Claude Opus 5
- Platform/Tool: Cursor
- Human Oversight: fully reviewed
- Prompt Summary: While reviewing #17413, identify a test fixture that reports
  metrics no writer can produce, and fix it on a separate branch off main.