### PR TITLE
[WIP] Core: Fix testLoadTableWithMissingMetadataFile for object storage

### DIFF
--- a/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/catalog/CatalogTests.java
@@ -203,8 +203,25 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     return false;
   }
 
+  @TempDir private Path tempDir;
+
   protected String baseTableLocation(TableIdentifier identifier) {
     return BASE_TABLE_LOCATION + "/" + identifier.namespace() + "/" + identifier.name();
+  }
+
+  protected URI resolveStorageLocation(String location) {
+    return URI.create(location);
+  }
+
+  protected URI createStorageFile(String filename, String content) throws IOException {
+    Path path = tempDir.resolve(filename);
+    path.toFile().deleteOnExit();
+    Files.writeString(path, content);
+    return path.toUri();
+  }
+
+  protected void moveStorageFile(URI source, URI target) throws IOException {
+    Files.move(Paths.get(source), Paths.get(target), StandardCopyOption.REPLACE_EXISTING);
   }
 
   @Test
@@ -1009,7 +1026,7 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
   }
 
   @Test
-  public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) throws IOException {
+  public void testLoadTableWithMissingMetadataFile() throws IOException {
     C catalog = catalog();
 
     if (requiresNamespaceCreate()) {
@@ -1020,22 +1037,17 @@ public abstract class CatalogTests<C extends Catalog & SupportsNamespaces> {
     assertThat(catalog.tableExists(TBL)).as("Table should exist").isTrue();
 
     Table table = catalog.loadTable(TBL);
-    String metadataFileLocation =
-        ((HasTableOperations) table).operations().current().metadataFileLocation();
-    Path renamedMetadataFile = tempDir.resolve("tmp.json");
-    renamedMetadataFile.toFile().deleteOnExit();
-    Files.writeString(renamedMetadataFile, "metadata");
-    Path metadataFilePath =
-        metadataFileLocation.startsWith("file:")
-            ? Paths.get(URI.create(metadataFileLocation))
-            : Paths.get(metadataFileLocation);
+    URI metadataFileLocation =
+        resolveStorageLocation(
+            ((HasTableOperations) table).operations().current().metadataFileLocation());
+    URI renamedMetadataFileLocation = createStorageFile("tmp.json", "metadata");
     try {
-      Files.move(metadataFilePath, renamedMetadataFile, StandardCopyOption.REPLACE_EXISTING);
+      moveStorageFile(metadataFileLocation, renamedMetadataFileLocation);
       assertThatThrownBy(() -> catalog.loadTable(TBL))
           .isInstanceOf(NotFoundException.class)
           .hasMessageContaining("Failed to open input stream for file: " + metadataFileLocation);
     } finally {
-      Files.move(renamedMetadataFile, metadataFilePath, StandardCopyOption.REPLACE_EXISTING);
+      moveStorageFile(renamedMetadataFileLocation, metadataFileLocation);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/inmemory/TestInMemoryCatalog.java
@@ -21,8 +21,6 @@ package org.apache.iceberg.inmemory;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.Map;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.HasTableOperations;
@@ -32,7 +30,6 @@ import org.apache.iceberg.exceptions.NotFoundException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.io.TempDir;
 
 public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
   private InMemoryCatalog catalog;
@@ -89,7 +86,7 @@ public class TestInMemoryCatalog extends CatalogTests<InMemoryCatalog> {
 
   @Test
   @Override
-  public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) throws IOException {
+  public void testLoadTableWithMissingMetadataFile() {
 
     if (requiresNamespaceCreate()) {
       catalog.createNamespace(TBL.namespace());

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -3678,7 +3678,7 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
 
   @Test
   @Override
-  public void testLoadTableWithMissingMetadataFile(@TempDir Path tempDir) {
+  public void testLoadTableWithMissingMetadataFile() {
 
     if (requiresNamespaceCreate()) {
       restCatalog.createNamespace(TBL.namespace());


### PR DESCRIPTION
`CatalogTests#testLoadTableWithMissingMetadataFile` tries to swap a file in the default storage location with that in a local filesystem via `java.nio.file.Files`. Therefore, it works only when the default storage location is a local filesystem.

Apache Hive runs RCK against the full cluster setup of Hive Metastore and Apache Ozone with S3 Gateway. We would like `testLoadTableWithMissingMetadataFile` to work with S3A.
https://github.com/apache/hive/pull/6660