### PR TITLE
Core: Align ByteBufferInputStream read behavior

### DIFF
--- a/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
+++ b/core/src/main/java/org/apache/iceberg/io/SingleBufferInputStream.java
@@ -115,6 +115,14 @@ class SingleBufferInputStream extends ByteBufferInputStream {
 
   @Override
   public int read(ByteBuffer out) {
+    if (!out.hasRemaining()) {
+      return 0;
+    }
+
+    if (!buffer.hasRemaining()) {
+      return -1;
+    }
+
     int bytesToCopy;
     ByteBuffer copyBuffer;
     if (buffer.remaining() <= out.remaining()) {
@@ -130,7 +138,6 @@ class SingleBufferInputStream extends ByteBufferInputStream {
     }
 
     out.put(copyBuffer);
-    out.flip();
 
     return bytesToCopy;
   }

--- a/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
+++ b/core/src/test/java/org/apache/iceberg/io/TestByteBufferInputStreams.java
@@ -173,6 +173,32 @@ public abstract class TestByteBufferInputStreams {
   }
 
   @Test
+  public void testReadByteBuffer() throws Exception {
+    ByteBufferInputStream stream = newStream();
+    ByteBuffer destination = ByteBuffer.allocate(12);
+    destination.position(2);
+    destination.limit(10);
+
+    assertThat(stream.read(destination)).as("Should fill the destination").isEqualTo(8);
+    assertThat(destination.position()).as("Should advance the destination position").isEqualTo(10);
+    assertThat(destination.limit()).as("Should preserve the destination limit").isEqualTo(10);
+
+    destination.flip();
+    destination.position(2);
+    for (int i = 0; i < 8; i += 1) {
+      assertThat(destination.get()).as("Byte i should be i").isEqualTo((byte) i);
+    }
+
+    ByteBuffer full = ByteBuffer.allocate(0);
+    assertThat(stream.read(full)).as("Should read 0 bytes into a full destination").isEqualTo(0);
+
+    stream.skipFully(stream.available());
+    assertThat(stream.read(ByteBuffer.allocate(1))).as("Should return -1 at EOF").isEqualTo(-1);
+
+    checkOriginalData();
+  }
+
+  @Test
   @SuppressWarnings("LocalVariableName")
   public void testSlice() throws Exception {
     ByteBufferInputStream stream = newStream();


### PR DESCRIPTION
### What changes are included?

- Keep destination `ByteBuffer`s in write mode after `SingleBufferInputStream.read(ByteBuffer)`.
- Return `-1` at EOF while preserving `0` for destinations without remaining space.
- Add shared coverage that verifies the same behavior for single-buffer and multi-buffer streams.

### Why is this change necessary?

`ByteBufferInputStream.wrap` selects its implementation based on the number of source buffers. The single-buffer implementation flipped the destination after writing, while the multi-buffer implementation advanced its position normally. As a result, the destination state and EOF result depended on how the source was internally split.

### Testing

- `./gradlew :iceberg-core:test --tests org.apache.iceberg.io.TestSingleBufferInputStream --tests org.apache.iceberg.io.TestMultiBufferInputStream`
- `./gradlew :iceberg-core:spotlessCheck :iceberg-core:checkstyleMain :iceberg-core:checkstyleTest`

---
**AI Disclosure**
- Model: OpenAI language model
- Platform/Tool: OpenAI desktop app
- Human Oversight: fully reviewed
- Prompt Summary: Investigated inconsistent `ByteBufferInputStream` behavior, implemented a focused fix, and added regression coverage.
