### PR TITLE
Parquet: Guard ordered predicates on variant/nested types in metrics row group filter

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -1260,6 +1260,62 @@ public class TestMetricsRowGroupFilter {
   }
 
   @TestTemplate
+  public void testVariantFieldLt() throws IOException {
+    assumeThat(format).isEqualTo(FileFormat.PARQUET);
+
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(lessThan("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant lt filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldLtEq() throws IOException {
+    assumeThat(format).isEqualTo(FileFormat.PARQUET);
+
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(lessThanOrEqual("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant ltEq filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldGt() throws IOException {
+    assumeThat(format).isEqualTo(FileFormat.PARQUET);
+
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(greaterThan("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant gt filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldGtEq() throws IOException {
+    assumeThat(format).isEqualTo(FileFormat.PARQUET);
+
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(greaterThanOrEqual("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant gtEq filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
   public void testUUID() {
     assumeThat(format).as("Only valid for Parquet").isEqualTo(FileFormat.PARQUET);
 

--- a/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
+++ b/data/src/test/java/org/apache/iceberg/data/TestMetricsRowGroupFilter.java
@@ -1260,6 +1260,54 @@ public class TestMetricsRowGroupFilter {
   }
 
   @TestTemplate
+  public void testVariantFieldLt() throws IOException {
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(lessThan("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant lt filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldLtEq() throws IOException {
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(lessThanOrEqual("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant ltEq filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldGt() throws IOException {
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(greaterThan("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant gt filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
+  public void testVariantFieldGtEq() throws IOException {
+    VariantMetadata md = Variants.metadata("k");
+    Variant v0 = createVariantWithKey(md, "v0");
+    List<GenericRecord> records = createVariantRecords(v0);
+
+    boolean shouldRead = shouldReadVariant(greaterThanOrEqual("variant_field", v0), records);
+    assertThat(shouldRead)
+        .as("Should read: variant gtEq filters must be evaluated post scan")
+        .isTrue();
+  }
+
+  @TestTemplate
   public void testUUID() {
     assumeThat(format).as("Only valid for Parquet").isEqualTo(FileFormat.PARQUET);
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -236,6 +236,12 @@ public class ParquetMetricsRowGroupFilter {
     public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      if (isNestedOrVariantType(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
         // the column is not present and is all nulls
@@ -265,6 +271,12 @@ public class ParquetMetricsRowGroupFilter {
     @Override
     public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
+
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      if (isNestedOrVariantType(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
@@ -296,6 +308,12 @@ public class ParquetMetricsRowGroupFilter {
     public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      if (isNestedOrVariantType(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
         // the column is not present and is all nulls
@@ -325,6 +343,12 @@ public class ParquetMetricsRowGroupFilter {
     @Override
     public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
+
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      if (isNestedOrVariantType(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetricsRowGroupFilter.java
@@ -237,6 +237,13 @@ public class ParquetMetricsRowGroupFilter {
     public <T> Boolean lt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      Type type = schema.findType(id);
+      if (type instanceof Type.NestedType || type.isVariantType()) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
         // the column is not present and is all nulls
@@ -266,6 +273,13 @@ public class ParquetMetricsRowGroupFilter {
     @Override
     public <T> Boolean ltEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
+
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      Type type = schema.findType(id);
+      if (type instanceof Type.NestedType || type.isVariantType()) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
@@ -297,6 +311,13 @@ public class ParquetMetricsRowGroupFilter {
     public <T> Boolean gt(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
 
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      Type type = schema.findType(id);
+      if (type instanceof Type.NestedType || type.isVariantType()) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {
         // the column is not present and is all nulls
@@ -326,6 +347,13 @@ public class ParquetMetricsRowGroupFilter {
     @Override
     public <T> Boolean gtEq(BoundReference<T> ref, Literal<T> lit) {
       int id = ref.fieldId();
+
+      // Leave all nested column type and variant type filters to be
+      // evaluated post scan.
+      Type type = schema.findType(id);
+      if (type instanceof Type.NestedType || type.isVariantType()) {
+        return ROWS_MIGHT_MATCH;
+      }
 
       Long valueCount = valueCounts.get(id);
       if (valueCount == null) {


### PR DESCRIPTION
`ParquetMetricsRowGroupFilter` already skips variant and nested types in `eq`, `in`, and `notNull`, leaving them to post-scan evaluation (#14081, #14279), since those columns have no primitive row-group stats keyed by field id. The ordered predicates `lt`, `ltEq`, `gt`, and `gtEq` were missed: a variant/nested reference falls through to `valueCount == null`, returns `ROWS_CANNOT_MATCH`, and the row group is skipped, dropping matching rows. This applies the same guard to the four ordered comparisons, following #14279.

Tested by `testVariantFieldLt/LtEq/Gt/GtEq`, which mirror the existing variant `eq`/`in` tests and fail without the change.