### PR TITLE
Flink: Reuse the catalog in the dynamic sink serializer cache

### DIFF
--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
@@ -50,10 +50,10 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 class TableSerializerCache implements Serializable {
 
   private final CatalogLoader catalogLoader;
+  private final int maximumSize;
 
   // Intentionally not closed; the catalog is reused for the serializer's lifetime.
   private transient Catalog catalog;
-  private final int maximumSize;
   private transient Map<String, SerializerInfo> serializers;
 
   TableSerializerCache(CatalogLoader catalogLoader, int maximumSize) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
@@ -51,8 +51,7 @@ class TableSerializerCache implements Serializable {
 
   private final CatalogLoader catalogLoader;
 
-  // Loaded once and reused for all lookups; not closed here, cleanup is deferred to the
-  // planned TaskManager-level catalog cache. Transient: loaded on first use per instance.
+  // Intentionally not closed; the catalog is reused for the serializer's lifetime.
   private transient Catalog catalog;
   private final int maximumSize;
   private transient Map<String, SerializerInfo> serializers;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
@@ -30,10 +29,10 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
+import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.slf4j.Logger;
@@ -127,21 +126,17 @@ class TableSerializerCache implements Serializable {
     }
 
     private void update() {
-      // The serializer has no teardown hook, so the freshly loaded catalog is closed here, after
-      // reading the table metadata, to avoid leaking one per cache miss.
-      Catalog catalog = catalogLoader.loadCatalog();
-      try {
-        Table table = catalog.loadTable(TableIdentifier.parse(tableName));
+      // The serializer has no teardown hook, so a catalog cannot be held for reuse; load and
+      // close one per cache miss.
+      try (TableLoader tableLoader =
+          TableLoader.fromCatalog(catalogLoader, TableIdentifier.parse(tableName))) {
+        tableLoader.open();
+        Table table = tableLoader.loadTable();
         schemas = table.schemas();
         specs = table.specs();
-      } finally {
-        if (catalog instanceof Closeable) {
-          try {
-            ((Closeable) catalog).close();
-          } catch (IOException e) {
-            LOG.warn("Failed to close catalog {}", catalog.name(), e);
-          }
-        }
+      } catch (IOException e) {
+        // only close() throws IOException here; a failed close should not fail the lookup
+        LOG.warn("Failed to close catalog for table {}", tableName, e);
       }
     }
   }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
-import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -29,14 +28,12 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
-import org.apache.iceberg.flink.TableLoader;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A Cache which holds Flink's {@link RowDataSerializer} for a given table name and schema. This
@@ -52,9 +49,11 @@ import org.slf4j.LoggerFactory;
 @Internal
 class TableSerializerCache implements Serializable {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TableSerializerCache.class);
-
   private final CatalogLoader catalogLoader;
+
+  // Loaded once and reused for all lookups; not closed here, cleanup is deferred to the
+  // planned TaskManager-level catalog cache. Transient: loaded on first use per instance.
+  private transient Catalog catalog;
   private final int maximumSize;
   private transient Map<String, SerializerInfo> serializers;
 
@@ -126,18 +125,13 @@ class TableSerializerCache implements Serializable {
     }
 
     private void update() {
-      // The serializer has no teardown hook, so a catalog cannot be held for reuse; load and
-      // close one per cache miss.
-      try (TableLoader tableLoader =
-          TableLoader.fromCatalog(catalogLoader, TableIdentifier.parse(tableName))) {
-        tableLoader.open();
-        Table table = tableLoader.loadTable();
-        schemas = table.schemas();
-        specs = table.specs();
-      } catch (IOException e) {
-        // only close() throws IOException here; a failed close should not fail the lookup
-        LOG.warn("Failed to close catalog for table {}", tableName, e);
+      if (catalog == null) {
+        catalog = catalogLoader.loadCatalog();
       }
+
+      Table table = catalog.loadTable(TableIdentifier.parse(tableName));
+      schemas = table.schemas();
+      specs = table.specs();
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/TableSerializerCache.java
@@ -18,6 +18,8 @@
  */
 package org.apache.iceberg.flink.sink.dynamic;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -28,11 +30,14 @@ import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.FlinkSchemaUtil;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A Cache which holds Flink's {@link RowDataSerializer} for a given table name and schema. This
@@ -47,6 +52,8 @@ import org.apache.iceberg.relocated.com.google.common.collect.Maps;
  */
 @Internal
 class TableSerializerCache implements Serializable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableSerializerCache.class);
 
   private final CatalogLoader catalogLoader;
   private final int maximumSize;
@@ -120,9 +127,22 @@ class TableSerializerCache implements Serializable {
     }
 
     private void update() {
-      Table table = catalogLoader.loadCatalog().loadTable(TableIdentifier.parse(tableName));
-      schemas = table.schemas();
-      specs = table.specs();
+      // The serializer has no teardown hook, so the freshly loaded catalog is closed here, after
+      // reading the table metadata, to avoid leaking one per cache miss.
+      Catalog catalog = catalogLoader.loadCatalog();
+      try {
+        Table table = catalog.loadTable(TableIdentifier.parse(tableName));
+        schemas = table.schemas();
+        specs = table.specs();
+      } finally {
+        if (catalog instanceof Closeable) {
+          try {
+            ((Closeable) catalog).close();
+          } catch (IOException e) {
+            LOG.warn("Failed to close catalog {}", catalog.name(), e);
+          }
+        }
+      }
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -25,8 +25,9 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.types.Types.StringType;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.Closeable;
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 import java.util.function.Supplier;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
@@ -38,7 +39,6 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
-import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -128,45 +128,81 @@ class TestTableSerializerCache {
 
   @Test
   void testClosesCatalogAfterSchemaLookup() {
-    CloseCountingInMemoryCatalog catalog = new CloseCountingInMemoryCatalog();
-    catalog.initialize("tracking", Map.of());
-    catalog.createNamespace(Namespace.of("db"));
-    Table table = catalog.createTable(TableIdentifier.of("db", "table"), schema1);
-    cache = new TableSerializerCache(new SingleCatalogLoader(catalog), 10);
+    Table table =
+        CATALOG_EXTENSION
+            .catalogLoader()
+            .loadCatalog()
+            .createTable(TableIdentifier.of("table"), schema1);
+
+    CloseCountingCatalogLoader catalogLoader =
+        new CloseCountingCatalogLoader(CATALOG_EXTENSION.catalogLoader());
+    cache = new TableSerializerCache(catalogLoader, 10);
 
     // schema/spec ids are unknown, so this misses the cache and loads a catalog to resolve them
     cache.serializerWithSchemaAndSpec(
-        "db.table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
+        "table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
 
-    assertThat(catalog.closeCount).isEqualTo(1);
+    assertThat(catalogLoader.closeCount()).isEqualTo(1);
   }
 
-  private static class CloseCountingInMemoryCatalog extends InMemoryCatalog {
+  private static class CloseCountingCatalogLoader implements CatalogLoader {
+    private final CatalogLoader delegate;
     private int closeCount = 0;
 
-    @Override
-    public void close() throws IOException {
-      super.close();
-      closeCount += 1;
+    private CloseCountingCatalogLoader(CatalogLoader delegate) {
+      this.delegate = delegate;
     }
-  }
 
-  private static class SingleCatalogLoader implements CatalogLoader {
-    private final Catalog catalog;
-
-    private SingleCatalogLoader(Catalog catalog) {
-      this.catalog = catalog;
+    private int closeCount() {
+      return closeCount;
     }
 
     @Override
     public Catalog loadCatalog() {
-      return catalog;
+      return new CloseCountingCatalog(delegate.loadCatalog());
     }
 
     @Override
     @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
     public CatalogLoader clone() {
       return this;
+    }
+
+    private class CloseCountingCatalog implements Catalog, Closeable {
+      private final Catalog delegate;
+
+      private CloseCountingCatalog(Catalog delegate) {
+        this.delegate = delegate;
+      }
+
+      @Override
+      public List<TableIdentifier> listTables(Namespace namespace) {
+        return delegate.listTables(namespace);
+      }
+
+      @Override
+      public boolean dropTable(TableIdentifier identifier, boolean purge) {
+        return delegate.dropTable(identifier, purge);
+      }
+
+      @Override
+      public void renameTable(TableIdentifier from, TableIdentifier to) {
+        delegate.renameTable(from, to);
+      }
+
+      @Override
+      public Table loadTable(TableIdentifier identifier) {
+        return delegate.loadTable(identifier);
+      }
+
+      @Override
+      public void close() throws IOException {
+        if (delegate instanceof Closeable) {
+          ((Closeable) delegate).close();
+        }
+
+        closeCount += 1;
+      }
     }
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -24,13 +24,9 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.types.Types.StringType;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.withSettings;
 
-import java.io.Closeable;
+import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
@@ -38,9 +34,11 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
+import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -129,23 +127,46 @@ class TestTableSerializerCache {
   }
 
   @Test
-  void testClosesCatalogAfterSchemaLookup() throws Exception {
-    Table table =
-        CATALOG_EXTENSION
-            .catalogLoader()
-            .loadCatalog()
-            .createTable(TableIdentifier.of("table"), schema1);
-
-    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(Closeable.class));
-    when(catalog.loadTable(any(TableIdentifier.class))).thenReturn(table);
-    CatalogLoader catalogLoader = mock(CatalogLoader.class);
-    when(catalogLoader.loadCatalog()).thenReturn(catalog);
-    cache = new TableSerializerCache(catalogLoader, 10);
+  void testClosesCatalogAfterSchemaLookup() {
+    CloseCountingInMemoryCatalog catalog = new CloseCountingInMemoryCatalog();
+    catalog.initialize("tracking", Map.of());
+    catalog.createNamespace(Namespace.of("db"));
+    Table table = catalog.createTable(TableIdentifier.of("db", "table"), schema1);
+    cache = new TableSerializerCache(new SingleCatalogLoader(catalog), 10);
 
     // schema/spec ids are unknown, so this misses the cache and loads a catalog to resolve them
     cache.serializerWithSchemaAndSpec(
-        "table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
+        "db.table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
 
-    verify((Closeable) catalog).close();
+    assertThat(catalog.closeCount).isEqualTo(1);
+  }
+
+  private static class CloseCountingInMemoryCatalog extends InMemoryCatalog {
+    private int closeCount = 0;
+
+    @Override
+    public void close() throws IOException {
+      super.close();
+      closeCount += 1;
+    }
+  }
+
+  private static class SingleCatalogLoader implements CatalogLoader {
+    private final Catalog catalog;
+
+    private SingleCatalogLoader(Catalog catalog) {
+      this.catalog = catalog;
+    }
+
+    @Override
+    public Catalog loadCatalog() {
+      return catalog;
+    }
+
+    @Override
+    @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
+    public CatalogLoader clone() {
+      return this;
+    }
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -128,11 +128,7 @@ class TestTableSerializerCache {
 
   @Test
   void testClosesCatalogAfterSchemaLookup() {
-    Table table =
-        CATALOG_EXTENSION
-            .catalogLoader()
-            .loadCatalog()
-            .createTable(TableIdentifier.of("table"), schema1);
+    Table table = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), schema1);
 
     CloseCountingCatalogLoader catalogLoader =
         new CloseCountingCatalogLoader(CATALOG_EXTENSION.catalogLoader());

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -25,9 +25,6 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.types.Types.StringType;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.List;
 import java.util.function.Supplier;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
@@ -35,7 +32,6 @@ import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
-import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.flink.CatalogLoader;
 import org.apache.iceberg.flink.HadoopCatalogExtension;
@@ -127,78 +123,45 @@ class TestTableSerializerCache {
   }
 
   @Test
-  void testClosesCatalogAfterSchemaLookup() {
+  void testReusesCatalogAcrossLookups() {
     Table table = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table"), schema1);
+    Table table2 = CATALOG_EXTENSION.catalog().createTable(TableIdentifier.of("table2"), schema2);
 
-    CloseCountingCatalogLoader catalogLoader =
-        new CloseCountingCatalogLoader(CATALOG_EXTENSION.catalogLoader());
+    LoadCountingCatalogLoader catalogLoader =
+        new LoadCountingCatalogLoader(CATALOG_EXTENSION.catalogLoader());
     cache = new TableSerializerCache(catalogLoader, 10);
 
-    // schema/spec ids are unknown, so this misses the cache and loads a catalog to resolve them
+    // schema/spec ids are unknown, so both lookups miss the cache and need the catalog
     cache.serializerWithSchemaAndSpec(
         "table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
+    cache.serializerWithSchemaAndSpec(
+        "table2", table2.schema().schemaId(), PartitionSpec.unpartitioned().specId());
 
-    assertThat(catalogLoader.closeCount()).isEqualTo(1);
+    assertThat(catalogLoader.loadCount()).isEqualTo(1);
   }
 
-  private static class CloseCountingCatalogLoader implements CatalogLoader {
+  private static class LoadCountingCatalogLoader implements CatalogLoader {
     private final CatalogLoader delegate;
-    private int closeCount = 0;
+    private int loadCount = 0;
 
-    private CloseCountingCatalogLoader(CatalogLoader delegate) {
+    private LoadCountingCatalogLoader(CatalogLoader delegate) {
       this.delegate = delegate;
     }
 
-    private int closeCount() {
-      return closeCount;
+    private int loadCount() {
+      return loadCount;
     }
 
     @Override
     public Catalog loadCatalog() {
-      return new CloseCountingCatalog(delegate.loadCatalog());
+      loadCount += 1;
+      return delegate.loadCatalog();
     }
 
     @Override
     @SuppressWarnings({"checkstyle:NoClone", "checkstyle:SuperClone"})
     public CatalogLoader clone() {
       return this;
-    }
-
-    private class CloseCountingCatalog implements Catalog, Closeable {
-      private final Catalog delegate;
-
-      private CloseCountingCatalog(Catalog delegate) {
-        this.delegate = delegate;
-      }
-
-      @Override
-      public List<TableIdentifier> listTables(Namespace namespace) {
-        return delegate.listTables(namespace);
-      }
-
-      @Override
-      public boolean dropTable(TableIdentifier identifier, boolean purge) {
-        return delegate.dropTable(identifier, purge);
-      }
-
-      @Override
-      public void renameTable(TableIdentifier from, TableIdentifier to) {
-        delegate.renameTable(from, to);
-      }
-
-      @Override
-      public Table loadTable(TableIdentifier identifier) {
-        return delegate.loadTable(identifier);
-      }
-
-      @Override
-      public void close() throws IOException {
-        if (delegate instanceof Closeable) {
-          ((Closeable) delegate).close();
-        }
-
-        closeCount += 1;
-      }
     }
   }
 }

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/dynamic/TestTableSerializerCache.java
@@ -24,7 +24,13 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.apache.iceberg.types.Types.StringType;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.withSettings;
 
+import java.io.Closeable;
 import java.util.function.Supplier;
 import org.apache.flink.api.java.tuple.Tuple3;
 import org.apache.flink.table.runtime.typeutils.RowDataSerializer;
@@ -120,5 +126,26 @@ class TestTableSerializerCache {
   void testCacheSize() {
     cache = new TableSerializerCache(CATALOG_EXTENSION.catalogLoader(), 1000);
     assertThat(cache.maximumSize()).isEqualTo(1000);
+  }
+
+  @Test
+  void testClosesCatalogAfterSchemaLookup() throws Exception {
+    Table table =
+        CATALOG_EXTENSION
+            .catalogLoader()
+            .loadCatalog()
+            .createTable(TableIdentifier.of("table"), schema1);
+
+    Catalog catalog = mock(Catalog.class, withSettings().extraInterfaces(Closeable.class));
+    when(catalog.loadTable(any(TableIdentifier.class))).thenReturn(table);
+    CatalogLoader catalogLoader = mock(CatalogLoader.class);
+    when(catalogLoader.loadCatalog()).thenReturn(catalog);
+    cache = new TableSerializerCache(catalogLoader, 10);
+
+    // schema/spec ids are unknown, so this misses the cache and loads a catalog to resolve them
+    cache.serializerWithSchemaAndSpec(
+        "table", table.schema().schemaId(), PartitionSpec.unpartitioned().specId());
+
+    verify((Closeable) catalog).close();
   }
 }


### PR DESCRIPTION
 The dynamic sink's `TableSerializerCache` loads a catalog with `CatalogLoader.loadCatalog()` on every cache miss (an unknown schema or spec id, or an LRU eviction) but never closes it. Each call builds a fresh catalog whose resources, such as a REST HTTP client and thread pool or a Hive metastore client pool, are released only on close, so a long-running job that keeps missing the cache leaks connections and threads.

  The cache lives inside a Flink `TypeSerializer` that has no teardown hook, so closing a held catalog at this layer is not possible. Instead, the cache now loads a single catalog per serializer instance and reuses it for all lookups. This fixes the leak and also avoids the per-lookup catalog creation cost for jobs writing to many tables.

 The test verifies the catalog is loaded exactly once across lookups.