### PR TITLE
API, AWS, BigQuery, Core, Flink, Hive, Nessie, ORC, Parquet, Spark: Use Locale.ROOT instead of Locale.ENGLISH for case conversion

### DIFF
--- a/api/src/main/java/org/apache/iceberg/DistributionMode.java
+++ b/api/src/main/java/org/apache/iceberg/DistributionMode.java
@@ -54,7 +54,7 @@ public enum DistributionMode {
   public static DistributionMode fromName(String modeName) {
     Preconditions.checkArgument(null != modeName, "Invalid distribution mode: null");
     try {
-      return DistributionMode.valueOf(modeName.toUpperCase(Locale.ENGLISH));
+      return DistributionMode.valueOf(modeName.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(String.format("Invalid distribution mode: %s", modeName));
     }

--- a/api/src/main/java/org/apache/iceberg/FileFormat.java
+++ b/api/src/main/java/org/apache/iceberg/FileFormat.java
@@ -78,7 +78,7 @@ public enum FileFormat {
   public static FileFormat fromString(String fileFormat) {
     Preconditions.checkArgument(null != fileFormat, "Invalid file format: null");
     try {
-      return FileFormat.valueOf(fileFormat.toUpperCase(Locale.ENGLISH));
+      return FileFormat.valueOf(fileFormat.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(String.format("Invalid file format: %s", fileFormat), e);
     }

--- a/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
+++ b/api/src/main/java/org/apache/iceberg/RewriteJobOrder.java
@@ -59,7 +59,7 @@ public enum RewriteJobOrder {
     // Replace the hyphen in order name with underscore to map to the enum value. For example:
     // bytes-asc to BYTES_ASC
     try {
-      return RewriteJobOrder.valueOf(orderName.replaceFirst("-", "_").toUpperCase(Locale.ENGLISH));
+      return RewriteJobOrder.valueOf(orderName.replaceFirst("-", "_").toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid rewrite job order name: %s", orderName), e);

--- a/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotRefType.java
@@ -28,7 +28,7 @@ public enum SnapshotRefType {
   public static SnapshotRefType fromString(String snapshotRefType) {
     Preconditions.checkArgument(null != snapshotRefType, "Invalid snapshot ref type: null");
     try {
-      return SnapshotRefType.valueOf(snapshotRefType.toUpperCase(Locale.ENGLISH));
+      return SnapshotRefType.valueOf(snapshotRefType.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid snapshot ref type: %s", snapshotRefType), e);

--- a/api/src/main/java/org/apache/iceberg/SortDirection.java
+++ b/api/src/main/java/org/apache/iceberg/SortDirection.java
@@ -28,7 +28,7 @@ public enum SortDirection {
   public static SortDirection fromString(String directionAsString) {
     Preconditions.checkArgument(null != directionAsString, "Invalid sort direction: null");
     try {
-      return SortDirection.valueOf(directionAsString.toUpperCase(Locale.ENGLISH));
+      return SortDirection.valueOf(directionAsString.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid sort direction: %s", directionAsString), e);

--- a/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
+++ b/api/src/main/java/org/apache/iceberg/actions/DeleteOrphanFiles.java
@@ -163,7 +163,7 @@ public interface DeleteOrphanFiles extends Action<DeleteOrphanFiles, DeleteOrpha
     public static PrefixMismatchMode fromString(String modeAsString) {
       Preconditions.checkArgument(modeAsString != null, "Invalid mode: null");
       try {
-        return PrefixMismatchMode.valueOf(modeAsString.toUpperCase(Locale.ENGLISH));
+        return PrefixMismatchMode.valueOf(modeAsString.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(String.format("Invalid mode: %s", modeAsString), e);
       }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -53,7 +53,7 @@ public interface Expression extends Serializable {
     public static Operation fromString(String operationType) {
       Preconditions.checkArgument(null != operationType, "Invalid operation type: null");
       try {
-        return Expression.Operation.valueOf(operationType.toUpperCase(Locale.ENGLISH));
+        return Expression.Operation.valueOf(operationType.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(
             String.format("Invalid operation type: %s", operationType), e);

--- a/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
+++ b/api/src/main/java/org/apache/iceberg/metrics/MetricsContext.java
@@ -48,7 +48,7 @@ public interface MetricsContext extends Serializable {
     public static Unit fromDisplayName(String displayName) {
       Preconditions.checkArgument(null != displayName, "Invalid unit: null");
       try {
-        return Unit.valueOf(displayName.toUpperCase(Locale.ENGLISH));
+        return Unit.valueOf(displayName.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(String.format("Invalid unit: %s", displayName), e);
       }

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -83,7 +83,7 @@ public class Transforms {
       }
     }
 
-    String lowerTransform = transform.toLowerCase(Locale.ENGLISH);
+    String lowerTransform = transform.toLowerCase(Locale.ROOT);
     switch (lowerTransform) {
       case "identity":
         return Identity.get(type);

--- a/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
+++ b/api/src/main/java/org/apache/iceberg/types/CheckCompatibility.java
@@ -270,7 +270,7 @@ public class CheckCompatibility extends TypeUtil.CustomOrderSchemaVisitor<List<S
       return ImmutableList.of(
           String.format(
               ": %s cannot be read as a %s",
-              currentType.typeId().toString().toLowerCase(Locale.ENGLISH), readPrimitive));
+              currentType.typeId().toString().toLowerCase(Locale.ROOT), readPrimitive));
     }
 
     if (!TypeUtil.isPromotionAllowed(currentType.asPrimitiveType(), readPrimitive)) {

--- a/api/src/main/java/org/apache/iceberg/types/EdgeAlgorithm.java
+++ b/api/src/main/java/org/apache/iceberg/types/EdgeAlgorithm.java
@@ -47,7 +47,7 @@ public enum EdgeAlgorithm {
   public static EdgeAlgorithm fromName(String algorithmName) {
     Preconditions.checkNotNull(algorithmName, "Invalid edge interpolation algorithm: null");
     try {
-      return EdgeAlgorithm.valueOf(algorithmName.toUpperCase(Locale.ENGLISH));
+      return EdgeAlgorithm.valueOf(algorithmName.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid edge interpolation algorithm: %s", algorithmName), e);
@@ -56,6 +56,6 @@ public enum EdgeAlgorithm {
 
   @Override
   public String toString() {
-    return name().toLowerCase(Locale.ENGLISH);
+    return name().toLowerCase(Locale.ROOT);
   }
 }

--- a/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
+++ b/aws/src/integration/java/org/apache/iceberg/aws/glue/TestGlueCatalogTable.java
@@ -99,7 +99,7 @@ public class TestGlueCatalogTable extends GlueTestBase {
     assertThat(response.table().parameters())
         .containsEntry(
             BaseMetastoreTableOperations.TABLE_TYPE_PROP,
-            BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH))
+            BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT))
         .containsKey(BaseMetastoreTableOperations.METADATA_LOCATION_PROP);
     assertThat(response.table().storageDescriptor().columns()).hasSameSizeAs(schema.columns());
     assertThat(response.table().partitionKeys()).hasSameSizeAs(partitionSpec.fields());

--- a/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/dynamodb/DynamoDbTableOperations.java
@@ -180,7 +180,7 @@ class DynamoDbTableOperations extends BaseMetastoreTableOperations {
       GetItemResponse response, String newMetadataLocation) {
     Map<String, String> properties =
         response.hasItem() ? getProperties(response) : Maps.newHashMap();
-    properties.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+    properties.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT));
     properties.put(METADATA_LOCATION_PROP, newMetadataLocation);
     if (currentMetadataLocation() != null && !currentMetadataLocation().isEmpty()) {
       properties.put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/GlueTableOperations.java
@@ -291,7 +291,7 @@ class GlueTableOperations extends BaseMetastoreTableOperations {
   private Map<String, String> prepareProperties(Table glueTable, String newMetadataLocation) {
     Map<String, String> properties =
         glueTable != null ? Maps.newHashMap(glueTable.parameters()) : Maps.newHashMap();
-    properties.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH));
+    properties.put(TABLE_TYPE_PROP, ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT));
     properties.put(METADATA_LOCATION_PROP, newMetadataLocation);
     if (currentMetadataLocation() != null && !currentMetadataLocation().isEmpty()) {
       properties.put(PREVIOUS_METADATA_LOCATION_PROP, currentMetadataLocation());

--- a/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/glue/IcebergToGlueConverter.java
@@ -339,7 +339,7 @@ class IcebergToGlueConverter {
         return String.format(
             "map<%s,%s>", toTypeString(mapType.keyType()), toTypeString(mapType.valueType()));
       default:
-        return type.typeId().name().toLowerCase(Locale.ENGLISH);
+        return type.typeId().name().toLowerCase(Locale.ROOT);
     }
   }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3RequestUtil.java
@@ -102,7 +102,7 @@ public class S3RequestUtil {
       Function<String, S3Request.Builder> customKeySetter,
       Function<String, S3Request.Builder> customMd5Setter) {
 
-    switch (s3FileIOProperties.sseType().toLowerCase(Locale.ENGLISH)) {
+    switch (s3FileIOProperties.sseType().toLowerCase(Locale.ROOT)) {
       case S3FileIOProperties.SSE_TYPE_NONE:
         break;
 

--- a/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
+++ b/bigquery/src/main/java/org/apache/iceberg/gcp/bigquery/BigQueryMetastoreClientImpl.java
@@ -434,7 +434,7 @@ public final class BigQueryMetastoreClientImpl implements BigQueryMetastoreClien
 
       if (response.getStatusCode() == HttpStatusCodes.STATUS_CODE_NOT_FOUND) {
         String responseString = response.parseAsString();
-        if (responseString.toLowerCase(Locale.ENGLISH).contains("not found: connection")) {
+        if (responseString.toLowerCase(Locale.ROOT).contains("not found: connection")) {
           throw new BadRequestException("%s", responseString);
         }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -314,7 +314,7 @@ public class CatalogUtil {
     if (catalogImpl == null) {
       String catalogType =
           PropertyUtil.propertyAsString(options, ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-      switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+      switch (catalogType.toLowerCase(Locale.ROOT)) {
         case ICEBERG_CATALOG_TYPE_HIVE:
           catalogImpl = ICEBERG_CATALOG_HIVE;
           break;

--- a/core/src/main/java/org/apache/iceberg/ContentFileParser.java
+++ b/core/src/main/java/org/apache/iceberg/ContentFileParser.java
@@ -90,11 +90,10 @@ public class ContentFileParser {
     generator.writeNumberField(SPEC_ID, contentFile.specId());
     // Since 1.11, we serialize content as lowercase kebab-case values like "equality-deletes"
     generator.writeStringField(
-        CONTENT, contentFile.content().name().toLowerCase(Locale.ENGLISH).replace('_', '-'));
+        CONTENT, contentFile.content().name().toLowerCase(Locale.ROOT).replace('_', '-'));
     generator.writeStringField(FILE_PATH, contentFile.location());
     // Since 1.11, we serialize format as lower-case strings like "parquet"
-    generator.writeStringField(
-        FILE_FORMAT, contentFile.format().name().toLowerCase(Locale.ENGLISH));
+    generator.writeStringField(FILE_FORMAT, contentFile.format().name().toLowerCase(Locale.ROOT));
 
     if (contentFile.partition() != null) {
       generator.writeFieldName(PARTITION);

--- a/core/src/main/java/org/apache/iceberg/IsolationLevel.java
+++ b/core/src/main/java/org/apache/iceberg/IsolationLevel.java
@@ -43,7 +43,7 @@ public enum IsolationLevel {
   public static IsolationLevel fromName(String levelName) {
     Preconditions.checkArgument(levelName != null, "Invalid isolation level: null");
     try {
-      return IsolationLevel.valueOf(levelName.toUpperCase(Locale.ENGLISH));
+      return IsolationLevel.valueOf(levelName.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(
           String.format("Invalid isolation level: %s", levelName), e);

--- a/core/src/main/java/org/apache/iceberg/MetricsModes.java
+++ b/core/src/main/java/org/apache/iceberg/MetricsModes.java
@@ -45,7 +45,7 @@ public class MetricsModes {
       return Full.get();
     }
 
-    Matcher truncateMatcher = TRUNCATE.matcher(mode.toLowerCase(Locale.ENGLISH));
+    Matcher truncateMatcher = TRUNCATE.matcher(mode.toLowerCase(Locale.ROOT));
     if (truncateMatcher.matches()) {
       int length = Integer.parseInt(truncateMatcher.group(1));
       return Truncate.withLength(length);

--- a/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotRefParser.java
@@ -46,7 +46,7 @@ public class SnapshotRefParser {
   public static void toJson(SnapshotRef ref, JsonGenerator generator) throws IOException {
     generator.writeStartObject();
     generator.writeNumberField(SNAPSHOT_ID, ref.snapshotId());
-    generator.writeStringField(TYPE, ref.type().name().toLowerCase(Locale.ENGLISH));
+    generator.writeStringField(TYPE, ref.type().name().toLowerCase(Locale.ROOT));
     JsonUtil.writeIntegerFieldIf(
         ref.minSnapshotsToKeep() != null,
         MIN_SNAPSHOTS_TO_KEEP,

--- a/core/src/main/java/org/apache/iceberg/SortOrderParser.java
+++ b/core/src/main/java/org/apache/iceberg/SortOrderParser.java
@@ -56,7 +56,7 @@ public class SortOrderParser {
   }
 
   private static String toJson(SortDirection direction) {
-    return direction.toString().toLowerCase(Locale.ENGLISH);
+    return direction.toString().toLowerCase(Locale.ROOT);
   }
 
   private static String toJson(NullOrder nullOrder) {

--- a/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadataParser.java
@@ -60,7 +60,7 @@ public class TableMetadataParser {
     public static Codec fromName(String codecName) {
       Preconditions.checkArgument(codecName != null, "Codec name is null");
       try {
-        return Codec.valueOf(codecName.toUpperCase(Locale.ENGLISH));
+        return Codec.valueOf(codecName.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         throw new IllegalArgumentException(String.format("Invalid codec name: %s", codecName), e);
       }

--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -248,7 +248,7 @@ public class Avro {
       private static CodecFactory toCodec(String codecAsString, String compressionLevel) {
         CodecFactory codecFactory;
         try {
-          switch (Codec.valueOf(codecAsString.toUpperCase(Locale.ENGLISH))) {
+          switch (Codec.valueOf(codecAsString.toUpperCase(Locale.ROOT))) {
             case UNCOMPRESSED:
               codecFactory = CodecFactory.nullCodec();
               break;

--- a/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/ExpressionParser.java
@@ -230,7 +230,7 @@ public class ExpressionParser {
     }
 
     private String operationType(Expression.Operation op) {
-      return op.toString().replaceAll("_", "-").toLowerCase(Locale.ENGLISH);
+      return op.toString().replaceAll("_", "-").toLowerCase(Locale.ROOT);
     }
 
     private void term(Term term) throws IOException {

--- a/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
+++ b/core/src/main/java/org/apache/iceberg/metrics/TimerResultParser.java
@@ -52,7 +52,7 @@ class TimerResultParser {
 
     gen.writeStartObject();
     gen.writeNumberField(COUNT, timer.count());
-    gen.writeStringField(TIME_UNIT, timer.timeUnit().name().toLowerCase(Locale.ENGLISH));
+    gen.writeStringField(TIME_UNIT, timer.timeUnit().name().toLowerCase(Locale.ROOT));
     gen.writeNumberField(TOTAL_DURATION, fromDuration(timer.totalDuration(), timer.timeUnit()));
     gen.writeEndObject();
   }
@@ -112,7 +112,7 @@ class TimerResultParser {
 
   private static TimeUnit toTimeUnit(String timeUnit) {
     try {
-      return TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH));
+      return TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ROOT));
     } catch (IllegalArgumentException e) {
       throw new IllegalArgumentException(String.format("Invalid time unit: %s", timeUnit), e);
     }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequest.java
@@ -37,7 +37,7 @@ public interface ReportMetricsRequest extends RESTRequest {
     static ReportType fromString(String reportType) {
       Preconditions.checkArgument(null != reportType, "Invalid report type: null");
       try {
-        return ReportType.valueOf(reportType.toUpperCase(Locale.ENGLISH));
+        return ReportType.valueOf(reportType.toUpperCase(Locale.ROOT));
       } catch (IllegalArgumentException e) {
         return UNKNOWN;
       }

--- a/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequestParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/requests/ReportMetricsRequestParser.java
@@ -63,7 +63,7 @@ public class ReportMetricsRequestParser {
   }
 
   private static String fromReportType(ReportType reportType) {
-    return reportType.name().replaceAll("_", "-").toLowerCase(Locale.ENGLISH);
+    return reportType.name().replaceAll("_", "-").toLowerCase(Locale.ROOT);
   }
 
   private static ReportType toReportType(String type) {

--- a/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewRepresentationParser.java
@@ -33,7 +33,7 @@ class ViewRepresentationParser {
   static void toJson(ViewRepresentation representation, JsonGenerator generator)
       throws IOException {
     Preconditions.checkArgument(representation != null, "Invalid view representation: null");
-    switch (representation.type().toLowerCase(Locale.ENGLISH)) {
+    switch (representation.type().toLowerCase(Locale.ROOT)) {
       case ViewRepresentation.Type.SQL:
         SQLViewRepresentationParser.toJson((SQLViewRepresentation) representation, generator);
         break;
@@ -57,7 +57,7 @@ class ViewRepresentationParser {
     Preconditions.checkArgument(node != null, "Cannot parse view representation from null object");
     Preconditions.checkArgument(
         node.isObject(), "Cannot parse view representation from non-object: %s", node);
-    String type = JsonUtil.getString(TYPE, node).toLowerCase(Locale.ENGLISH);
+    String type = JsonUtil.getString(TYPE, node).toLowerCase(Locale.ROOT);
     switch (type) {
       case ViewRepresentation.Type.SQL:
         return SQLViewRepresentationParser.fromJson(node);

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -99,7 +99,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-    switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+    switch (catalogType.toLowerCase(Locale.ROOT)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
         // that case it will

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -99,7 +99,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-    switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+    switch (catalogType.toLowerCase(Locale.ROOT)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
         // that case it will

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/FlinkCatalogFactory.java
@@ -99,7 +99,7 @@ public class FlinkCatalogFactory implements CatalogFactory {
     }
 
     String catalogType = properties.getOrDefault(ICEBERG_CATALOG_TYPE, ICEBERG_CATALOG_TYPE_HIVE);
-    switch (catalogType.toLowerCase(Locale.ENGLISH)) {
+    switch (catalogType.toLowerCase(Locale.ROOT)) {
       case ICEBERG_CATALOG_TYPE_HIVE:
         // The values of properties 'uri', 'warehouse', 'hive-conf-dir' are allowed to be null, in
         // that case it will

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HMSTablePropertyHelper.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HMSTablePropertyHelper.java
@@ -105,7 +105,7 @@ public class HMSTablePropertyHelper {
         obsoleteProps,
         currentLocation,
         parameters,
-        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ENGLISH),
+        BaseMetastoreTableOperations.ICEBERG_TABLE_TYPE_VALUE.toUpperCase(Locale.ROOT),
         metadata.schema(),
         maxHiveTablePropertySize);
     setStorageHandler(parameters, hiveEngineEnabled);
@@ -151,7 +151,7 @@ public class HMSTablePropertyHelper {
         obsoleteProps,
         currentLocation,
         parameters,
-        HiveOperationsBase.ICEBERG_VIEW_TYPE_VALUE.toUpperCase(Locale.ENGLISH),
+        HiveOperationsBase.ICEBERG_VIEW_TYPE_VALUE.toUpperCase(Locale.ROOT),
         metadata.schema(),
         maxHiveTablePropertySize);
     tbl.setParameters(parameters);

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieCatalog.java
@@ -422,7 +422,7 @@ public class NessieCatalog extends BaseMetastoreViewCatalog
         fromReference.equalsIgnoreCase(toReference),
         "Cannot rename %s '%s' on reference '%s' to '%s' on reference '%s':"
             + " source and target references must be the same.",
-        NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH),
+        NessieUtil.contentTypeString(type).toLowerCase(Locale.ROOT),
         fromTableReference.getName(),
         fromReference,
         toTableReference.getName(),

--- a/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
+++ b/nessie/src/main/java/org/apache/iceberg/nessie/NessieIcebergClient.java
@@ -169,7 +169,7 @@ public class NessieIcebergClient implements AutoCloseable {
       throw new NoSuchNamespaceException(
           ex,
           "Unable to list %ss due to missing ref '%s'",
-          NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH),
+          NessieUtil.contentTypeString(type).toLowerCase(Locale.ROOT),
           getRef().getName());
     }
   }
@@ -466,7 +466,7 @@ public class NessieIcebergClient implements AutoCloseable {
     IcebergContent existingToContent = fetchContent(to);
     validateToContentForRename(from, to, existingToContent);
 
-    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH);
+    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ROOT);
     try {
       commitRetry(
           String.format("Iceberg rename %s from '%s' to '%s'", contentType, from, to),
@@ -566,7 +566,7 @@ public class NessieIcebergClient implements AutoCloseable {
               identifier, NessieUtil.contentTypeString(type)));
     }
 
-    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ENGLISH);
+    String contentType = NessieUtil.contentTypeString(type).toLowerCase(Locale.ROOT);
 
     if (purge) {
       LOG.info(

--- a/orc/src/main/java/org/apache/iceberg/orc/ORC.java
+++ b/orc/src/main/java/org/apache/iceberg/orc/ORC.java
@@ -376,7 +376,7 @@ public class ORC {
 
       private static CompressionKind toCompressionKind(String codecAsString) {
         try {
-          return CompressionKind.valueOf(codecAsString.toUpperCase(Locale.ENGLISH));
+          return CompressionKind.valueOf(codecAsString.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
         }
@@ -384,7 +384,7 @@ public class ORC {
 
       private static CompressionStrategy toCompressionStrategy(String strategyAsString) {
         try {
-          return CompressionStrategy.valueOf(strategyAsString.toUpperCase(Locale.ENGLISH));
+          return CompressionStrategy.valueOf(strategyAsString.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException(
               "Unsupported compression strategy: " + strategyAsString);

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -785,7 +785,7 @@ public class Parquet {
 
       private static CompressionCodecName toCodec(String codecAsString) {
         try {
-          return CompressionCodecName.valueOf(codecAsString.toUpperCase(Locale.ENGLISH));
+          return CompressionCodecName.valueOf(codecAsString.toUpperCase(Locale.ROOT));
         } catch (IllegalArgumentException e) {
           throw new IllegalArgumentException("Unsupported compression codec: " + codecAsString);
         }

--- a/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v3.5/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -120,13 +120,13 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       .flatMap(retention => Option(retention.maxSnapshotAge()))
       .map(retention =>
         TimeUnit
-          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retention.number().getText.toLong))
     val branchRetention =
       branchOptionsContext.flatMap(branchOptions => Option(branchOptions.refRetain()))
     val branchRefAgeMs = branchRetention.map(retain =>
       TimeUnit
-        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
         .toMillis(retain.number().getText.toLong))
     val create = createOrReplaceBranchClause.CREATE() != null
     val replace = ctx.createReplaceBranchClause().REPLACE() != null
@@ -160,7 +160,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       val tagRetain = tagOptionsContext.flatMap(tagOptions => Option(tagOptions.refRetain()))
       val tagRefAgeMs = tagRetain.map(retain =>
         TimeUnit
-          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retain.number().getText.toLong))
       val tagOptions = TagOptions(snapshotId, tagRefAgeMs)
 

--- a/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v3.5/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -89,7 +89,7 @@ public class TestTagDDL extends ExtensionsTestBase {
           .isEqualTo(firstSnapshotId);
       assertThat(ref.maxRefAgeMs().longValue())
           .as("The tag needs to have the correct max ref age.")
-          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH)).toMillis(maxRefAge));
+          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ROOT)).toMillis(maxRefAge));
     }
 
     String tagName = "t1";

--- a/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v4.0/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -107,13 +107,13 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       .flatMap(retention => Option(retention.maxSnapshotAge()))
       .map(retention =>
         TimeUnit
-          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retention.number().getText.toLong))
     val branchRetention =
       branchOptionsContext.flatMap(branchOptions => Option(branchOptions.refRetain()))
     val branchRefAgeMs = branchRetention.map(retain =>
       TimeUnit
-        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
         .toMillis(retain.number().getText.toLong))
     val create = createOrReplaceBranchClause.CREATE() != null
     val replace = ctx.createReplaceBranchClause().REPLACE() != null
@@ -147,7 +147,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       val tagRetain = tagOptionsContext.flatMap(tagOptions => Option(tagOptions.refRetain()))
       val tagRefAgeMs = tagRetain.map(retain =>
         TimeUnit
-          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retain.number().getText.toLong))
       val tagOptions = TagOptions(snapshotId, tagRefAgeMs)
 

--- a/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v4.0/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -89,7 +89,7 @@ public class TestTagDDL extends ExtensionsTestBase {
           .isEqualTo(firstSnapshotId);
       assertThat(ref.maxRefAgeMs().longValue())
           .as("The tag needs to have the correct max ref age.")
-          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH)).toMillis(maxRefAge));
+          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ROOT)).toMillis(maxRefAge));
     }
 
     String tagName = "t1";

--- a/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
+++ b/spark/v4.1/spark-extensions/src/main/scala/org/apache/spark/sql/catalyst/parser/extensions/IcebergSqlExtensionsAstBuilder.scala
@@ -107,13 +107,13 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       .flatMap(retention => Option(retention.maxSnapshotAge()))
       .map(retention =>
         TimeUnit
-          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retention.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retention.number().getText.toLong))
     val branchRetention =
       branchOptionsContext.flatMap(branchOptions => Option(branchOptions.refRetain()))
     val branchRefAgeMs = branchRetention.map(retain =>
       TimeUnit
-        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+        .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
         .toMillis(retain.number().getText.toLong))
     val create = createOrReplaceBranchClause.CREATE() != null
     val replace = ctx.createReplaceBranchClause().REPLACE() != null
@@ -147,7 +147,7 @@ class IcebergSqlExtensionsAstBuilder(delegate: ParserInterface)
       val tagRetain = tagOptionsContext.flatMap(tagOptions => Option(tagOptions.refRetain()))
       val tagRefAgeMs = tagRetain.map(retain =>
         TimeUnit
-          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ENGLISH))
+          .valueOf(retain.timeUnit().getText.toUpperCase(Locale.ROOT))
           .toMillis(retain.number().getText.toLong))
       val tagOptions = TagOptions(snapshotId, tagRefAgeMs)
 

--- a/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
+++ b/spark/v4.1/spark-extensions/src/test/java/org/apache/iceberg/spark/extensions/TestTagDDL.java
@@ -89,7 +89,7 @@ public class TestTagDDL extends ExtensionsTestBase {
           .isEqualTo(firstSnapshotId);
       assertThat(ref.maxRefAgeMs().longValue())
           .as("The tag needs to have the correct max ref age.")
-          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ENGLISH)).toMillis(maxRefAge));
+          .isEqualTo(TimeUnit.valueOf(timeUnit.toUpperCase(Locale.ROOT)).toMillis(maxRefAge));
     }
 
     String tagName = "t1";


### PR DESCRIPTION
This aligns the whole codebase on `Locale.ROOT` for locale-independent case conversion, which is the project convention (the checkstyle / Error Prone locale rules recommend `Locale.ROOT`, and the tree already used it in ~374 places versus a residual ~58 uses of `Locale.ENGLISH`).

This PR replaces every remaining `Locale.ENGLISH` with `Locale.ROOT` across all modules (API, AWS, BigQuery, Core,Flink, Hive, Nessie, ORC, Parquet, Spark).

Output is byte-identical: these call sites all pass an explicit locale to `toUpperCase` / `toLowerCase` over ASCII enum names and canonical tokens, and `Locale.ROOT` and `Locale.ENGLISH` produce the same result for ASCII, so there is no behavior change. The `SortOrderParser` change is kept as the first commit and the remaining occurrences are swept in a follow-up commit; one line in `ContentFileParser` is reflowed by spotless because `Locale.ROOT` is shorter.
