### PR TITLE
Core: Keep NETFLIX_UNSAFE_PARQUET_ID_FALLBACK_ENABLED until 2.0 release

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -91,7 +91,7 @@ public class SystemConfigs {
           true,
           s -> {
             LOG.warn(
-                "Fallback ID assignment in Parquet is UNSAFE and will be removed in 1.12.0. Use name mapping instead.");
+                "Fallback ID assignment in Parquet is UNSAFE and will be removed in 2.0.0. Use name mapping instead.");
             return Boolean.parseBoolean(s);
           });
 

--- a/core/src/main/java/org/apache/iceberg/SystemConfigs.java
+++ b/core/src/main/java/org/apache/iceberg/SystemConfigs.java
@@ -81,7 +81,7 @@ public class SystemConfigs {
           Integer::parseUnsignedInt);
 
   /**
-   * @deprecated will be removed in 1.12.0; use name mapping instead
+   * @deprecated will be removed in 2.0.0; use name mapping instead
    */
   @Deprecated
   public static final ConfigEntry<Boolean> NETFLIX_UNSAFE_PARQUET_ID_FALLBACK_ENABLED =


### PR DESCRIPTION
partially revert the deprecation cycle change of NETFLIX_UNSAFE_PARQUET_ID_FALLBACK_ENABLED  in 831b4ea108b9def6ae92258a7382aab096d87ed2. The reason is this introduce a significant behavior change where parquet id is no longer position based and require explicit name mapping. 

This can impact any imported parquet files which is not written by iceberg, particular in addFiles procedure and migrated hive tables.

The effort required to remove this deprecated field can be found in https://github.com/dramaticlly/iceberg/pull/12/changes. I don't think it worth the significant effort before 2.0