### PR TITLE
Core: Don't override equals() and hashCode() in V4 DeletionVector

### DIFF
--- a/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
+++ b/core/src/main/java/org/apache/iceberg/DeletionVectorStruct.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg;
 
 import java.io.Serializable;
-import java.util.Objects;
 import org.apache.iceberg.avro.SupportsIndexProjection;
 import org.apache.iceberg.relocated.com.google.common.base.MoreObjects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -127,26 +126,6 @@ class DeletionVectorStruct extends SupportsIndexProjection implements DeletionVe
 
   static Builder builder() {
     return new Builder();
-  }
-
-  @Override
-  public boolean equals(Object other) {
-    if (this == other) {
-      return true;
-    } else if (!(other instanceof DeletionVectorStruct)) {
-      return false;
-    }
-
-    DeletionVectorStruct that = (DeletionVectorStruct) other;
-    return Objects.equals(location, that.location)
-        && offset == that.offset
-        && sizeInBytes == that.sizeInBytes
-        && cardinality == that.cardinality;
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hash(location, offset, sizeInBytes, cardinality);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeletionVectorStruct.java
@@ -164,64 +164,6 @@ class TestDeletionVectorStruct {
   }
 
   @Test
-  void dvEquality() {
-    DeletionVectorStruct dv =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv.puffin")
-            .offset(256L)
-            .sizeInBytes(128L)
-            .cardinality(42L)
-            .build();
-
-    DeletionVectorStruct sameDv =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv.puffin")
-            .offset(256L)
-            .sizeInBytes(128L)
-            .cardinality(42L)
-            .build();
-
-    DeletionVectorStruct dvWithDifferentLocation =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv2.puffin")
-            .offset(256L)
-            .sizeInBytes(128L)
-            .cardinality(42L)
-            .build();
-
-    DeletionVectorStruct dvWithDifferentOffset =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv.puffin")
-            .offset(1L)
-            .sizeInBytes(128L)
-            .cardinality(42L)
-            .build();
-
-    DeletionVectorStruct dvWithDifferentSize =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv.puffin")
-            .offset(256L)
-            .sizeInBytes(8L)
-            .cardinality(42L)
-            .build();
-
-    DeletionVectorStruct dvWithDifferentCardinality =
-        DeletionVectorStruct.builder()
-            .location("s3://bucket/data/dv.puffin")
-            .offset(256L)
-            .sizeInBytes(128L)
-            .cardinality(2L)
-            .build();
-
-    assertThat(dv).isEqualTo(dv);
-    assertThat(dv).isEqualTo(sameDv);
-    assertThat(dv).isNotEqualTo(dvWithDifferentLocation);
-    assertThat(dv).isNotEqualTo(dvWithDifferentOffset);
-    assertThat(dv).isNotEqualTo(dvWithDifferentSize);
-    assertThat(dv).isNotEqualTo(dvWithDifferentCardinality);
-  }
-
-  @Test
   void builderRejectsInvalidValuesAtSetter() {
     assertThatThrownBy(() -> DeletionVectorStruct.builder().location(null))
         .isInstanceOf(IllegalArgumentException.class)


### PR DESCRIPTION
The convention for V4 metadata structs like `DeletionVectorStruct` is that we don't override `equals()` and `hashCode` only if it's inevitable. See [this comment](https://github.com/apache/iceberg/pull/16769#discussion_r3463448205) on a previous PR. These overrides were meant to be removed/not added in that PR, however, somehow went under the radar and made it in.
This PR removes unintentionally adding the overrides.