### PR TITLE
Flink: Backport fix NPE in ExpireSnapshots config when retain-last is unset to 2.0 and 1.20

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import java.time.Duration;
-import java.util.Optional;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -109,16 +108,23 @@ public class ExpireSnapshots {
     }
 
     public Builder config(ExpireSnapshotsConfig expireSnapshotsConfig) {
-      return this.scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount())
-          .scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()))
-          .deleteBatchSize(expireSnapshotsConfig.deleteBatchSize())
-          .maxSnapshotAge(
-              Optional.ofNullable(expireSnapshotsConfig.maxSnapshotAgeSeconds())
-                  .map(Duration::ofSeconds)
-                  .orElse(null))
-          .retainLast(expireSnapshotsConfig.retainLast())
-          .cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata())
-          .planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+      scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount());
+      scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()));
+      deleteBatchSize(expireSnapshotsConfig.deleteBatchSize());
+      cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata());
+      planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+
+      Integer retainLast = expireSnapshotsConfig.retainLast();
+      if (retainLast != null) {
+        retainLast(retainLast);
+      }
+
+      Long maxSnapshotAgeSeconds = expireSnapshotsConfig.maxSnapshotAgeSeconds();
+      if (maxSnapshotAgeSeconds != null) {
+        maxSnapshotAge(Duration.ofSeconds(maxSnapshotAgeSeconds));
+      }
+
+      return this;
     }
 
     @Override

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.Map;
 import org.apache.flink.configuration.Configuration;
@@ -80,5 +81,13 @@ public class TestExpireSnapshotsConfig extends OperatorTestBase {
         .isEqualTo(ExpireSnapshotsConfig.DELETE_BATCH_SIZE_OPTION.defaultValue());
     assertThat(config.cleanExpiredMetadata()).isTrue();
     assertThat(config.planningWorkerPoolSize()).isEqualTo(ThreadPools.WORKER_THREAD_POOL_SIZE);
+  }
+
+  @Test
+  void configureBuilderWithoutRetainLast() {
+    ExpireSnapshotsConfig config =
+        new ExpireSnapshotsConfig(table, Maps.newHashMap(), new Configuration());
+
+    assertThatNoException().isThrownBy(() -> ExpireSnapshots.builder().config(config));
   }
 }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/ExpireSnapshots.java
@@ -19,7 +19,6 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import java.time.Duration;
-import java.util.Optional;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
@@ -109,16 +108,23 @@ public class ExpireSnapshots {
     }
 
     public Builder config(ExpireSnapshotsConfig expireSnapshotsConfig) {
-      return this.scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount())
-          .scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()))
-          .deleteBatchSize(expireSnapshotsConfig.deleteBatchSize())
-          .maxSnapshotAge(
-              Optional.ofNullable(expireSnapshotsConfig.maxSnapshotAgeSeconds())
-                  .map(Duration::ofSeconds)
-                  .orElse(null))
-          .retainLast(expireSnapshotsConfig.retainLast())
-          .cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata())
-          .planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+      scheduleOnCommitCount(expireSnapshotsConfig.scheduleOnCommitCount());
+      scheduleOnInterval(Duration.ofSeconds(expireSnapshotsConfig.scheduleOnIntervalSecond()));
+      deleteBatchSize(expireSnapshotsConfig.deleteBatchSize());
+      cleanExpiredMetadata(expireSnapshotsConfig.cleanExpiredMetadata());
+      planningWorkerPoolSize(expireSnapshotsConfig.planningWorkerPoolSize());
+
+      Integer retainLast = expireSnapshotsConfig.retainLast();
+      if (retainLast != null) {
+        retainLast(retainLast);
+      }
+
+      Long maxSnapshotAgeSeconds = expireSnapshotsConfig.maxSnapshotAgeSeconds();
+      if (maxSnapshotAgeSeconds != null) {
+        maxSnapshotAge(Duration.ofSeconds(maxSnapshotAgeSeconds));
+      }
+
+      return this;
     }
 
     @Override

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestExpireSnapshotsConfig.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.flink.maintenance.api;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
 import java.util.Map;
 import org.apache.flink.configuration.Configuration;
@@ -80,5 +81,13 @@ public class TestExpireSnapshotsConfig extends OperatorTestBase {
         .isEqualTo(ExpireSnapshotsConfig.DELETE_BATCH_SIZE_OPTION.defaultValue());
     assertThat(config.cleanExpiredMetadata()).isTrue();
     assertThat(config.planningWorkerPoolSize()).isEqualTo(ThreadPools.WORKER_THREAD_POOL_SIZE);
+  }
+
+  @Test
+  void configureBuilderWithoutRetainLast() {
+    ExpireSnapshotsConfig config =
+        new ExpireSnapshotsConfig(table, Maps.newHashMap(), new Configuration());
+
+    assertThatNoException().isThrownBy(() -> ExpireSnapshots.builder().config(config));
   }
 }


### PR DESCRIPTION
## Summary

- Backport of #17277 to the Flink 2.0 and 1.20 modules, requested by @pvary on that PR.
- `ExpireSnapshots.Builder.config()` passed `ExpireSnapshotsConfig.retainLast()` straight into `retainLast(int)`. That getter returns `null` when the `retain-last` option is unset, so unboxing it threw `NullPointerException` and `config()` was unusable for anyone who left the option out.
- `config()` now calls `retainLast()` and `maxSnapshotAge()` only when the config holds a value, keeping the builder defaults otherwise, and drops the then-unused `java.util.Optional` import.
- Same diff as d07a574742173bbc43ae2d84d4e7875c4245ebfd on 2.1; the surrounding code was identical, so it applied without adaptation. `ExpireSnapshots.java` and `TestExpireSnapshotsConfig.java` are now byte-identical across 1.20, 2.0 and 2.1.

## Testing done

- Backported `TestExpireSnapshotsConfig#configureBuilderWithoutRetainLast`, which asserts `ExpireSnapshots.builder().config(config)` does not throw for a config with no options set.
- `:iceberg-flink:iceberg-flink-1.20:test` and `:iceberg-flink:iceberg-flink-2.0:test` with `--tests "*TestExpireSnapshotsConfig*"` — 3 tests passed on each.
- Reverting the production change makes the new test fail with the NPE, so it covers the bug.
- `spotlessCheck` passes on both modules.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Backport the already-merged fix from #17277 (NPE in `ExpireSnapshots.Builder.config()` when `retain-last` is unset) and its test from the Flink 2.1 module to the Flink 2.0 and 1.20 modules in a single PR, then build and run the affected tests on both versions.


