### PR TITLE
Parquet: Fix per-column statistics disabling across multiple columns

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -365,7 +365,9 @@ public class Parquet {
                 }
                 boolean enabled = Boolean.parseBoolean(isEnabled);
                 withColumnStatsEnabled.accept(parquetColumnPath, enabled);
-                conf.set("parquet.column.statistics.enabled#" + parquetColumnPath, String.valueOf(enabled));
+                conf.set(
+                    "parquet.column.statistics.enabled#" + parquetColumnPath,
+                    String.valueOf(enabled));
               });
     }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -363,7 +363,9 @@ public class Parquet {
                   LOG.warn("Skipping column statistics config for missing field: {}", colPath);
                   return;
                 }
-                withColumnStatsEnabled.accept(parquetColumnPath, Boolean.valueOf(isEnabled));
+                boolean enabled = Boolean.parseBoolean(isEnabled);
+                withColumnStatsEnabled.accept(parquetColumnPath, enabled);
+                conf.set("parquet.column.statistics.enabled#" + parquetColumnPath, String.valueOf(enabled));
               });
     }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquet.java
@@ -289,6 +289,55 @@ public class TestParquet {
   }
 
   @Test
+  public void testMultipleColumnStatisticsDisabled() throws Exception {
+    Schema schema =
+        new Schema(
+            optional(1, "int_field", IntegerType.get()),
+            optional(2, "string_field", Types.StringType.get()),
+            optional(3, "long_field", Types.LongType.get()));
+
+    File file = createTempFile(temp);
+
+    List<GenericData.Record> records = Lists.newArrayListWithCapacity(5);
+    org.apache.avro.Schema avroSchema = AvroSchemaUtil.convert(schema.asStruct());
+    for (int i = 1; i <= 5; i++) {
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put("int_field", i);
+      record.put("string_field", "test");
+      record.put("long_field", (long) i);
+      records.add(record);
+    }
+
+    write(
+        file,
+        schema,
+        ImmutableMap.<String, String>builder()
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "int_field", "false")
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "string_field", "false")
+            .put(PARQUET_COLUMN_STATS_ENABLED_PREFIX + "long_field", "true")
+            .buildOrThrow(),
+        ParquetAvroWriter::buildWriter,
+        records.toArray(new GenericData.Record[] {}));
+
+    InputFile inputFile = Files.localInput(file);
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile))) {
+      for (BlockMetaData block : reader.getFooter().getBlocks()) {
+        for (ColumnChunkMetaData column : block.getColumns()) {
+          boolean emptyStats = column.getStatistics().isEmpty();
+          if (column.getPath().toDotString().equals("int_field")) {
+            assertThat(emptyStats).as("int_field has statistics disabled").isEqualTo(true);
+          } else if (column.getPath().toDotString().equals("string_field")) {
+            assertThat(emptyStats).as("string_field has statistics disabled").isEqualTo(true);
+          } else if (column.getPath().toDotString().equals("long_field")) {
+            assertThat(emptyStats).as("long_field has statistics enabled").isEqualTo(false);
+          }
+        }
+      }
+    }
+  }
+
+  @Test
   public void testGeospatialFooterMetricsSkipParquetBounds() throws IOException {
     Schema binarySchema = new Schema(optional(1, "geom", Types.BinaryType.get()));
     Schema geometrySchema = new Schema(optional(1, "geom", Types.GeometryType.crs84()));


### PR DESCRIPTION
Closes #15347.

`Parquet.setColumnStatsConfig` previously applied per-column statistics enablement via `withColumnStatsEnabled.accept(...)` on `ParquetProperties.Builder` / `ParquetWriter.Builder` but did not propagate `parquet.column.statistics.enabled#<column>` into the Hadoop `Configuration` instance (`conf`). 

When users configured multiple table properties to disable statistics across multiple columns (e.g., `write.parquet.stats-enabled.column.colA = false` and `write.parquet.stats-enabled.column.colB = false`), statistics were only disabled for the first column processed while subsequent columns continued to write statistics into the Parquet file header.

This change explicitly passes per-column statistics enablement settings into `conf` as well (`parquet.column.statistics.enabled#<parquetColumnPath>`), ensuring consistent behavior across all configured columns regardless of write path.

## Tests Added
- `testMultipleColumnStatisticsDisabled` in `TestParquet.java`: Validates that configuring `write.parquet.stats-enabled.column.<col> = false` across multiple columns disables statistics for all specified columns in the generated Parquet file.