### PR TITLE
Core, Hive: Fix NPE in commit status check when a create commit fails

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -333,6 +333,13 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
    */
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     TableMetadata metadata = refresh();
+    if (metadata == null) {
+      // the table does not exist in the catalog. this happens when a create-table commit fails
+      // before the table is persisted, in which case the new metadata location cannot be the
+      // current one or part of the table's history
+      return false;
+    }
+
     String currentMetadataFileLocation = metadata.metadataFileLocation();
     return currentMetadataFileLocation.equals(newMetadataLocation)
         || metadata.previousFiles().stream()

--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -334,9 +334,7 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     TableMetadata metadata = refresh();
     if (metadata == null) {
-      // the table does not exist in the catalog. this happens when a create-table commit fails
-      // before the table is persisted, in which case the new metadata location cannot be the
-      // current one or part of the table's history
+      // Table creation may not have registered metadata yet.
       return false;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.apache.iceberg.BaseMetastoreOperations.CommitStatus;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+public class TestBaseMetastoreTableOperations {
+
+  private static final Schema SCHEMA =
+      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  private static final Map<String, String> FAST_STATUS_CHECKS =
+      ImmutableMap.of(
+          TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
+          TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
+          TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
+          TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100");
+
+  /**
+   * Mimics metastore-backed table operations for a table that was never persisted to the catalog,
+   * e.g. when a CREATE TABLE commit fails before the table is stored in the metastore. Like {@code
+   * HiveTableOperations#doRefresh()}, a missing table is not an error when no metadata location is
+   * known, and refreshing from a null metadata location leaves the current metadata null.
+   */
+  private static class NeverPersistedTableOperations extends BaseMetastoreTableOperations {
+
+    @Override
+    protected String tableName() {
+      return "db.never_persisted";
+    }
+
+    @Override
+    public FileIO io() {
+      return null;
+    }
+
+    @Override
+    protected void doRefresh() {
+      refreshFromMetadataLocation(null, 1);
+    }
+
+    private CommitStatus strictStatus(String newMetadataLocation, TableMetadata config) {
+      return checkCommitStatusStrict(newMetadataLocation, config);
+    }
+
+    private CommitStatus status(String newMetadataLocation, TableMetadata config) {
+      return checkCommitStatus(newMetadataLocation, config);
+    }
+  }
+
+  @Test
+  public void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
+    NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            "file:/tmp/db/never_persisted",
+            FAST_STATUS_CHECKS);
+
+    assertThat(
+            ops.strictStatus(
+                "file:/tmp/db/never_persisted/metadata/00000-uuid.metadata.json", metadata))
+        .isEqualTo(CommitStatus.FAILURE);
+  }
+
+  @Test
+  public void statusCheckIsUnknownWhenTableWasNeverPersisted() {
+    NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            "file:/tmp/db/never_persisted",
+            FAST_STATUS_CHECKS);
+
+    assertThat(
+            ops.status("file:/tmp/db/never_persisted/metadata/00000-uuid.metadata.json", metadata))
+        .isEqualTo(CommitStatus.UNKNOWN);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
@@ -43,12 +43,7 @@ class TestBaseMetastoreTableOperations {
               TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
               TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100"));
 
-  /**
-   * Mimics metastore-backed table operations for a table that was never persisted to the catalog,
-   * e.g. when a CREATE TABLE commit fails before the table is stored in the metastore. Like {@code
-   * HiveTableOperations#doRefresh()}, a missing table is not an error when no metadata location is
-   * known, and refreshing from a null metadata location leaves the current metadata null.
-   */
+  /** Table operations for a table that was never persisted, so refresh yields null metadata. */
   private static class NeverPersistedTableOperations extends BaseMetastoreTableOperations {
 
     @Override
@@ -65,27 +60,20 @@ class TestBaseMetastoreTableOperations {
     protected void doRefresh() {
       refreshFromMetadataLocation(null, 1);
     }
-
-    private CommitStatus strictStatus(String newMetadataLocation, TableMetadata config) {
-      return checkCommitStatusStrict(newMetadataLocation, config);
-    }
-
-    private CommitStatus status(String newMetadataLocation, TableMetadata config) {
-      return checkCommitStatus(newMetadataLocation, config);
-    }
   }
 
   @Test
   void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
 
-    assertThat(ops.strictStatus(METADATA_LOCATION, METADATA)).isEqualTo(CommitStatus.FAILURE);
+    assertThat(ops.checkCommitStatusStrict(METADATA_LOCATION, METADATA))
+        .isEqualTo(CommitStatus.FAILURE);
   }
 
   @Test
   void statusCheckIsUnknownWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
 
-    assertThat(ops.status(METADATA_LOCATION, METADATA)).isEqualTo(CommitStatus.UNKNOWN);
+    assertThat(ops.checkCommitStatus(METADATA_LOCATION, METADATA)).isEqualTo(CommitStatus.UNKNOWN);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
@@ -29,19 +29,20 @@ import org.junit.jupiter.api.Test;
 
 class TestBaseMetastoreTableOperations {
 
-  private static final Schema SCHEMA =
-      new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
-
   private static final String TABLE_LOCATION = "file:/tmp/db/never_persisted";
   private static final String METADATA_LOCATION =
       TABLE_LOCATION + "/metadata/00000-uuid.metadata.json";
 
-  private static final Map<String, String> FAST_STATUS_CHECKS =
-      ImmutableMap.of(
-          TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
-          TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
-          TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
-          TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100");
+  private static final TableMetadata METADATA =
+      TableMetadata.newTableMetadata(
+          new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get())),
+          PartitionSpec.unpartitioned(),
+          TABLE_LOCATION,
+          ImmutableMap.of(
+              TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
+              TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
+              TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
+              TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100"));
 
   /**
    * Mimics metastore-backed table operations for a table that was never persisted to the catalog,
@@ -78,31 +79,16 @@ class TestBaseMetastoreTableOperations {
   @Test
   void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
-    TableMetadata metadata =
-        TableMetadata.newTableMetadata(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            TABLE_LOCATION,
-            FAST_STATUS_CHECKS);
 
-    assertThat(
-            ops.strictStatus(
-                METADATA_LOCATION, metadata))
+    assertThat(ops.strictStatus(METADATA_LOCATION, METADATA))
         .isEqualTo(CommitStatus.FAILURE);
   }
 
   @Test
   void statusCheckIsUnknownWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
-    TableMetadata metadata =
-        TableMetadata.newTableMetadata(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            TABLE_LOCATION,
-            FAST_STATUS_CHECKS);
 
-    assertThat(
-            ops.status(METADATA_LOCATION, metadata))
+    assertThat(ops.status(METADATA_LOCATION, METADATA))
         .isEqualTo(CommitStatus.UNKNOWN);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
@@ -27,10 +27,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 
-public class TestBaseMetastoreTableOperations {
+class TestBaseMetastoreTableOperations {
 
   private static final Schema SCHEMA =
       new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get()));
+
+  private static final String TABLE_LOCATION = "file:/tmp/db/never_persisted";
+  private static final String METADATA_LOCATION =
+      TABLE_LOCATION + "/metadata/00000-uuid.metadata.json";
 
   private static final Map<String, String> FAST_STATUS_CHECKS =
       ImmutableMap.of(
@@ -72,33 +76,33 @@ public class TestBaseMetastoreTableOperations {
   }
 
   @Test
-  public void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
+  void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             SCHEMA,
             PartitionSpec.unpartitioned(),
-            "file:/tmp/db/never_persisted",
+            TABLE_LOCATION,
             FAST_STATUS_CHECKS);
 
     assertThat(
             ops.strictStatus(
-                "file:/tmp/db/never_persisted/metadata/00000-uuid.metadata.json", metadata))
+                METADATA_LOCATION, metadata))
         .isEqualTo(CommitStatus.FAILURE);
   }
 
   @Test
-  public void statusCheckIsUnknownWhenTableWasNeverPersisted() {
+  void statusCheckIsUnknownWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             SCHEMA,
             PartitionSpec.unpartitioned(),
-            "file:/tmp/db/never_persisted",
+            TABLE_LOCATION,
             FAST_STATUS_CHECKS);
 
     assertThat(
-            ops.status("file:/tmp/db/never_persisted/metadata/00000-uuid.metadata.json", metadata))
+            ops.status(METADATA_LOCATION, metadata))
         .isEqualTo(CommitStatus.UNKNOWN);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
+++ b/core/src/test/java/org/apache/iceberg/TestBaseMetastoreTableOperations.java
@@ -20,7 +20,6 @@ package org.apache.iceberg;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import java.util.Map;
 import org.apache.iceberg.BaseMetastoreOperations.CommitStatus;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -80,15 +79,13 @@ class TestBaseMetastoreTableOperations {
   void strictStatusCheckIsFailureWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
 
-    assertThat(ops.strictStatus(METADATA_LOCATION, METADATA))
-        .isEqualTo(CommitStatus.FAILURE);
+    assertThat(ops.strictStatus(METADATA_LOCATION, METADATA)).isEqualTo(CommitStatus.FAILURE);
   }
 
   @Test
   void statusCheckIsUnknownWhenTableWasNeverPersisted() {
     NeverPersistedTableOperations ops = new NeverPersistedTableOperations();
 
-    assertThat(ops.status(METADATA_LOCATION, METADATA))
-        .isEqualTo(CommitStatus.UNKNOWN);
+    assertThat(ops.status(METADATA_LOCATION, METADATA)).isEqualTo(CommitStatus.UNKNOWN);
   }
 }

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -276,6 +276,13 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
    */
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     ViewMetadata metadata = refresh();
+    if (metadata == null) {
+      // the view does not exist in the catalog. this happens when a create-view commit fails
+      // before the view is persisted, in which case the new metadata location cannot be the
+      // current one
+      return false;
+    }
+
     return newMetadataLocation.equals(metadata.metadataFileLocation());
   }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -277,9 +277,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     ViewMetadata metadata = refresh();
     if (metadata == null) {
-      // the view does not exist in the catalog. this happens when a create-view commit fails
-      // before the view is persisted, in which case the new metadata location cannot be the
-      // current one
+      // Table creation may not have registered metadata yet.
       return false;
     }
 

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -274,7 +274,8 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
    * @param newMetadataLocation newly written metadata location
    * @return true if the new metadata location is the current metadata location
    */
-  private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
+  @VisibleForTesting
+  boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     ViewMetadata metadata = refresh();
     if (metadata == null) {
       // Table creation may not have registered metadata yet.

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -274,8 +274,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
    * @param newMetadataLocation newly written metadata location
    * @return true if the new metadata location is the current metadata location
    */
-  @VisibleForTesting
-  boolean checkCurrentMetadataLocation(String newMetadataLocation) {
+  private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     ViewMetadata metadata = refresh();
     if (metadata == null) {
       // Table creation may not have registered metadata yet.

--- a/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
+++ b/hive-metastore/src/main/java/org/apache/iceberg/hive/HiveViewOperations.java
@@ -277,7 +277,7 @@ final class HiveViewOperations extends BaseViewOperations implements HiveOperati
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     ViewMetadata metadata = refresh();
     if (metadata == null) {
-      // Table creation may not have registered metadata yet.
+      // View creation may not have registered metadata yet.
       return false;
     }
 

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -32,11 +32,15 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.fs.Path;
+import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -596,6 +600,63 @@ public class TestHiveCommits extends HiveTableTestBase {
         .persistTable(any(), anyBoolean(), any());
   }
 
+  /**
+   * Pins the table-specific doRefresh wiring for a never-persisted table: a CREATE TABLE commit
+   * that fails with a non-specific exception must resolve the commit status cleanly instead of
+   * NPE-ing in checkCurrentMetadataLocation (#17462). refresh() yields null current metadata and
+   * the status check supplier resolves to false (a new metadata location cannot be current for a
+   * table that does not exist). The relaxed check then maps that to UNKNOWN.
+   */
+  @Test
+  public void testThriftExceptionUnknownStateOnCreateCommitWhenTableNeverPersisted()
+      throws TException, InterruptedException, IOException {
+    TableIdentifier createIdentifier = TableIdentifier.of(DB_NAME, "create_commit_failed_table");
+    HiveTableOperations ops = (HiveTableOperations) catalog.newTableOps(createIdentifier);
+    HiveTableOperations spyOps = spy(ops);
+
+    failCommitAndThrowException(spyOps);
+
+    Path createLocation = getTableLocationPath("create_commit_failed_table");
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            createLocation.toString(),
+            ImmutableMap.of(
+                TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
+                TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
+                TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
+                TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100"));
+
+    try {
+      assertThatThrownBy(() -> spyOps.commit(null, metadata))
+          .isInstanceOf(CommitStateUnknownException.class)
+          .hasMessageStartingWith("Datacenter on fire");
+
+      assertThat(catalog.tableExists(createIdentifier))
+          .as("The table should not have been created")
+          .isFalse();
+
+      // pins the table-specific doRefresh wiring: a missing table is not an error when no
+      // metadata location is known, so refreshing a never-persisted table must yield null metadata
+      assertThat(ops.refresh())
+          .as("Refreshing a never-persisted table should yield null metadata")
+          .isNull();
+
+      // and the commit status check supplier must resolve to false for the null metadata instead
+      // of throwing an NPE
+      assertThat(
+              checkCurrentMetadataLocation(
+                  ops, createLocation + "/metadata/00000-uuid.metadata.json"))
+          .as("A new metadata location cannot be current for a never-persisted table")
+          .isFalse();
+    } finally {
+      createLocation
+          .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())
+          .delete(createLocation, true);
+    }
+  }
+
   private void failCommitAndThrowException(HiveTableOperations spyOperations)
       throws TException, InterruptedException {
     doThrow(new TException("Datacenter on fire"))
@@ -606,6 +667,20 @@ public class TestHiveCommits extends HiveTableTestBase {
   private void breakFallbackCatalogCommitCheck(HiveTableOperations spyOperations) {
     when(spyOperations.refresh())
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
+  }
+
+  private static boolean checkCurrentMetadataLocation(
+      HiveTableOperations ops, String newMetadataLocation) {
+    try {
+      return (Boolean)
+          ReflectionSupport.invokeMethod(
+              BaseMetastoreTableOperations.class.getDeclaredMethod(
+                  "checkCurrentMetadataLocation", String.class),
+              ops,
+              newMetadataLocation);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private boolean metadataFileExists(TableMetadata metadata) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -603,9 +603,9 @@ public class TestHiveCommits extends HiveTableTestBase {
   /**
    * Pins the table-specific doRefresh wiring for a never-persisted table: a CREATE TABLE commit
    * that fails with a non-specific exception must resolve the commit status cleanly instead of
-   * NPE-ing in checkCurrentMetadataLocation (#17462). refresh() yields null current metadata and
-   * the status check supplier resolves to false (a new metadata location cannot be current for a
-   * table that does not exist). The relaxed check then maps that to UNKNOWN.
+   * NPE-ing in checkCurrentMetadataLocation (#17462). Pins the Hive-specific doRefresh wiring:
+   * refreshing a never-persisted table yields null metadata. The null-metadata handling itself is
+   * covered by TestBaseMetastoreTableOperations.
    */
   @Test
   public void testThriftExceptionUnknownStateOnCreateCommitWhenTableNeverPersisted()
@@ -642,14 +642,6 @@ public class TestHiveCommits extends HiveTableTestBase {
       assertThat(ops.refresh())
           .as("Refreshing a never-persisted table should yield null metadata")
           .isNull();
-
-      // and the commit status check supplier must resolve to false for the null metadata instead
-      // of throwing an NPE
-      assertThat(
-              checkCurrentMetadataLocation(
-                  ops, createLocation + "/metadata/00000-uuid.metadata.json"))
-          .as("A new metadata location cannot be current for a never-persisted table")
-          .isFalse();
     } finally {
       createLocation
           .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())
@@ -669,19 +661,6 @@ public class TestHiveCommits extends HiveTableTestBase {
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
   }
 
-  private static boolean checkCurrentMetadataLocation(
-      HiveTableOperations ops, String newMetadataLocation) {
-    try {
-      return (Boolean)
-          ReflectionSupport.invokeMethod(
-              BaseMetastoreTableOperations.class.getDeclaredMethod(
-                  "checkCurrentMetadataLocation", String.class),
-              ops,
-              newMetadataLocation);
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   private boolean metadataFileExists(TableMetadata metadata) {
     return new File(metadata.metadataFileLocation().replace("file:", "")).exists();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveCommits.java
@@ -32,15 +32,11 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
-import org.apache.hadoop.fs.Path;
-import org.apache.iceberg.BaseMetastoreTableOperations;
 import org.apache.iceberg.HasTableOperations;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.AlreadyExistsException;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -600,55 +596,6 @@ public class TestHiveCommits extends HiveTableTestBase {
         .persistTable(any(), anyBoolean(), any());
   }
 
-  /**
-   * Pins the table-specific doRefresh wiring for a never-persisted table: a CREATE TABLE commit
-   * that fails with a non-specific exception must resolve the commit status cleanly instead of
-   * NPE-ing in checkCurrentMetadataLocation (#17462). Pins the Hive-specific doRefresh wiring:
-   * refreshing a never-persisted table yields null metadata. The null-metadata handling itself is
-   * covered by TestBaseMetastoreTableOperations.
-   */
-  @Test
-  public void testThriftExceptionUnknownStateOnCreateCommitWhenTableNeverPersisted()
-      throws TException, InterruptedException, IOException {
-    TableIdentifier createIdentifier = TableIdentifier.of(DB_NAME, "create_commit_failed_table");
-    HiveTableOperations ops = (HiveTableOperations) catalog.newTableOps(createIdentifier);
-    HiveTableOperations spyOps = spy(ops);
-
-    failCommitAndThrowException(spyOps);
-
-    Path createLocation = getTableLocationPath("create_commit_failed_table");
-    TableMetadata metadata =
-        TableMetadata.newTableMetadata(
-            SCHEMA,
-            PartitionSpec.unpartitioned(),
-            createLocation.toString(),
-            ImmutableMap.of(
-                TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
-                TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
-                TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
-                TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100"));
-
-    try {
-      assertThatThrownBy(() -> spyOps.commit(null, metadata))
-          .isInstanceOf(CommitStateUnknownException.class)
-          .hasMessageStartingWith("Datacenter on fire");
-
-      assertThat(catalog.tableExists(createIdentifier))
-          .as("The table should not have been created")
-          .isFalse();
-
-      // pins the table-specific doRefresh wiring: a missing table is not an error when no
-      // metadata location is known, so refreshing a never-persisted table must yield null metadata
-      assertThat(ops.refresh())
-          .as("Refreshing a never-persisted table should yield null metadata")
-          .isNull();
-    } finally {
-      createLocation
-          .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())
-          .delete(createLocation, true);
-    }
-  }
-
   private void failCommitAndThrowException(HiveTableOperations spyOperations)
       throws TException, InterruptedException {
     doThrow(new TException("Datacenter on fire"))
@@ -660,7 +607,6 @@ public class TestHiveCommits extends HiveTableTestBase {
     when(spyOperations.refresh())
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
   }
-
 
   private boolean metadataFileExists(TableMetadata metadata) {
     return new File(metadata.metadataFileLocation().replace("file:", "")).exists();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.exceptions.CommitFailedException;
@@ -50,6 +51,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.view.BaseView;
 import org.apache.iceberg.view.ImmutableSQLViewRepresentation;
+import org.apache.iceberg.view.ImmutableViewVersion;
 import org.apache.iceberg.view.View;
 import org.apache.iceberg.view.ViewMetadata;
 import org.apache.thrift.TException;
@@ -214,6 +216,78 @@ public class TestHiveViewCommits {
             "New metadata files should still exist, new location not in history but"
                 + " the commit may still succeed")
         .isEqualTo(2);
+  }
+
+  /**
+   * Pretends we throw an unclear error while persisting a create-view commit, for a view that was
+   * never stored in the metastore. The commit status check must resolve cleanly instead of NPE-ing:
+   * the view-specific {@code doRefresh} treats a missing view as non-fatal when no metadata
+   * location is known and refreshes from a null location, so the status-check supplier observes
+   * null current metadata and resolves to false (a new metadata location cannot be current for a
+   * view that does not exist). The relaxed check then maps that to UNKNOWN.
+   */
+  @Test
+  public void testThriftExceptionUnknownStateOnCreateCommitWhenViewNeverPersisted()
+      throws TException, InterruptedException, IOException {
+    TableIdentifier createIdentifier = TableIdentifier.of(NS, "create_commit_failed_view");
+    HiveViewOperations ops = (HiveViewOperations) catalog.newViewOps(createIdentifier);
+    HiveViewOperations spyOps = spy(ops);
+
+    failCommitAndThrowException(spyOps);
+
+    Path createLocation = new Path(viewLocation.getParent(), "create_commit_failed_view");
+    ViewMetadata metadata =
+        ViewMetadata.builder()
+            .setLocation(createLocation.toString())
+            .setProperties(
+                ImmutableMap.of(
+                    TableProperties.COMMIT_NUM_STATUS_CHECKS, "1",
+                    TableProperties.COMMIT_STATUS_CHECKS_MIN_WAIT_MS, "1",
+                    TableProperties.COMMIT_STATUS_CHECKS_MAX_WAIT_MS, "10",
+                    TableProperties.COMMIT_STATUS_CHECKS_TOTAL_WAIT_MS, "100"))
+            .setCurrentVersion(
+                ImmutableViewVersion.builder()
+                    .versionId(1)
+                    .schemaId(SCHEMA.schemaId())
+                    .timestampMillis(System.currentTimeMillis())
+                    .defaultNamespace(NS)
+                    .putSummary("operation", "create")
+                    .addRepresentations(
+                        ImmutableSQLViewRepresentation.builder()
+                            .sql(VIEW_QUERY)
+                            .dialect("hive")
+                            .build())
+                    .build(),
+                SCHEMA)
+            .build();
+
+    try {
+      assertThatThrownBy(() -> spyOps.commit(null, metadata))
+          .isInstanceOf(CommitStateUnknownException.class)
+          .hasMessageStartingWith("Datacenter on fire");
+
+      assertThat(catalog.viewExists(createIdentifier))
+          .as("The view should not have been created")
+          .isFalse();
+
+      // pins the view-specific doRefresh wiring: a missing view is not an error when no metadata
+      // location is known, so refreshing a never-persisted view must yield null metadata
+      assertThat(ops.refresh())
+          .as("Refreshing a never-persisted view should yield null metadata")
+          .isNull();
+
+      // and the commit status check supplier must resolve to false for the null metadata instead
+      // of throwing an NPE
+      assertThat(
+              checkCurrentMetadataLocation(
+                  ops, createLocation + "/metadata/00000-uuid.metadata.json"))
+          .as("A new metadata location cannot be current for a never-persisted view")
+          .isFalse();
+    } finally {
+      createLocation
+          .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())
+          .delete(createLocation, true);
+    }
   }
 
   /** Pretends we throw an error while persisting that actually does commit serverside. */
@@ -592,6 +666,20 @@ public class TestHiveViewCommits {
   private void breakFallbackCatalogCommitCheck(HiveViewOperations spyOperations) {
     when(spyOperations.refresh())
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
+  }
+
+  private static boolean checkCurrentMetadataLocation(
+      HiveViewOperations ops, String newMetadataLocation) {
+    try {
+      return (Boolean)
+          ReflectionSupport.invokeMethod(
+              HiveViewOperations.class.getDeclaredMethod(
+                  "checkCurrentMetadataLocation", String.class),
+              ops,
+              newMetadataLocation);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   private boolean metadataFileExists(ViewMetadata metadata) {

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -279,8 +279,8 @@ public class TestHiveViewCommits {
       // and the commit status check supplier must resolve to false for the null metadata instead
       // of throwing an NPE
       assertThat(
-              checkCurrentMetadataLocation(
-                  ops, createLocation + "/metadata/00000-uuid.metadata.json"))
+              ops.checkCurrentMetadataLocation(
+                  createLocation + "/metadata/00000-uuid.metadata.json"))
           .as("A new metadata location cannot be current for a never-persisted view")
           .isFalse();
     } finally {
@@ -668,19 +668,6 @@ public class TestHiveViewCommits {
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
   }
 
-  private static boolean checkCurrentMetadataLocation(
-      HiveViewOperations ops, String newMetadataLocation) {
-    try {
-      return (Boolean)
-          ReflectionSupport.invokeMethod(
-              HiveViewOperations.class.getDeclaredMethod(
-                  "checkCurrentMetadataLocation", String.class),
-              ops,
-              newMetadataLocation);
-    } catch (NoSuchMethodException e) {
-      throw new RuntimeException(e);
-    }
-  }
 
   private boolean metadataFileExists(ViewMetadata metadata) {
     return new File(metadata.metadataFileLocation().replace("file:", "")).exists();

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -668,7 +668,6 @@ public class TestHiveViewCommits {
         .thenThrow(new RuntimeException("Still on fire")); // Failure on commit check
   }
 
-
   private boolean metadataFileExists(ViewMetadata metadata) {
     return new File(metadata.metadataFileLocation().replace("file:", "")).exists();
   }

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -220,17 +220,10 @@ public class TestHiveViewCommits {
         .isEqualTo(2);
   }
 
-  /**
-   * Pretends we throw an unclear error while persisting a create-view commit, for a view that was
-   * never stored in the metastore. The commit status check must resolve cleanly instead of NPE-ing:
-   * the view-specific {@code doRefresh} treats a missing view as non-fatal when no metadata
-   * location is known and refreshes from a null location, so the status-check supplier observes
-   * null current metadata and resolves to false (a new metadata location cannot be current for a
-   * view that does not exist). The relaxed check then maps that to UNKNOWN.
-   */
+  /** Pretends we throw an unclear error while persisting a create-view commit for a new view. */
   @Test
   public void testThriftExceptionUnknownStateOnCreateCommitWhenViewNeverPersisted()
-      throws TException, InterruptedException, IOException {
+      throws TException, InterruptedException {
     TableIdentifier createIdentifier = TableIdentifier.of(NS, "create_commit_failed_view");
     HiveViewOperations ops = (HiveViewOperations) catalog.newViewOps(createIdentifier);
     HiveViewOperations spyOps = spy(ops);
@@ -263,23 +256,17 @@ public class TestHiveViewCommits {
                 SCHEMA)
             .build();
 
-    try {
-      assertThatThrownBy(() -> spyOps.commit(null, metadata))
-          .isInstanceOf(CommitStateUnknownException.class)
-          .hasMessageStartingWith("Datacenter on fire");
+    assertThatThrownBy(() -> spyOps.commit(null, metadata))
+        .isInstanceOf(CommitStateUnknownException.class)
+        .hasMessageStartingWith("Datacenter on fire");
 
-      assertThat(catalog.viewExists(createIdentifier))
-          .as("The view should not have been created")
-          .isFalse();
+    assertThat(catalog.viewExists(createIdentifier))
+        .as("The view should not have been created")
+        .isFalse();
 
-      // the configured status check must run to completion: once from current(), once from
-      // inside checkCurrentMetadataLocation, which resolves the null metadata instead of throwing
-      verify(spyOps, times(2)).refresh();
-    } finally {
-      createLocation
-          .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())
-          .delete(createLocation, true);
-    }
+    // the configured status check must run to completion: once from current(), once from
+    // inside checkCurrentMetadataLocation, which resolves the null metadata instead of throwing
+    verify(spyOps, times(2)).refresh();
   }
 
   /** Pretends we throw an error while persisting that actually does commit serverside. */

--- a/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
+++ b/hive-metastore/src/test/java/org/apache/iceberg/hive/TestHiveViewCommits.java
@@ -28,6 +28,8 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
@@ -270,19 +272,9 @@ public class TestHiveViewCommits {
           .as("The view should not have been created")
           .isFalse();
 
-      // pins the view-specific doRefresh wiring: a missing view is not an error when no metadata
-      // location is known, so refreshing a never-persisted view must yield null metadata
-      assertThat(ops.refresh())
-          .as("Refreshing a never-persisted view should yield null metadata")
-          .isNull();
-
-      // and the commit status check supplier must resolve to false for the null metadata instead
-      // of throwing an NPE
-      assertThat(
-              ops.checkCurrentMetadataLocation(
-                  createLocation + "/metadata/00000-uuid.metadata.json"))
-          .as("A new metadata location cannot be current for a never-persisted view")
-          .isFalse();
+      // the configured status check must run to completion: once from current(), once from
+      // inside checkCurrentMetadataLocation, which resolves the null metadata instead of throwing
+      verify(spyOps, times(2)).refresh();
     } finally {
       createLocation
           .getFileSystem(HIVE_METASTORE_EXTENSION.hiveConf())


### PR DESCRIPTION
## Which issue does this PR close?

- Closes #17462

## What changes are included in this PR?

When a CREATE TABLE commit fails with a non-specific exception (e.g. a Thrift socket timeout from HMS), `HiveTableOperations#doCommit` calls `checkCommitStatus(...)` to determine whether the commit landed. For a table that was never persisted, `doRefresh()` swallows `NoSuchObjectException` (expected for creates) and refreshes from a `null` metadata location, leaving `current()` as `null`. `checkCurrentMetadataLocation` then dereferences the null metadata and throws an NPE on every status-check attempt. The NPEs are suppressed (`suppressFailureWhenFinished`), the status stays `UNKNOWN`, and the user gets a `CommitStateUnknownException` recommending manual intervention - even though the outcome was knowable.

This PR null-guards the commit status supplier in two places:

- `BaseMetastoreTableOperations#checkCurrentMetadataLocation`: if `refresh()` yields no metadata, the table does not exist in the catalog, so the new metadata location cannot be current or in history - return `false`.
- `HiveViewOperations#checkCurrentMetadataLocation`: same pattern and null-guard for the view counterpart.

With the guard in place:

- `checkCommitStatusStrict` now correctly resolves to `FAILURE` for failed create commits (previously: NPE -> suppressed -> `UNKNOWN`), so the concurrent-modification branch in `HiveTableOperations#doCommit` throws `CommitFailedException` instead of `CommitStateUnknownException`.
- The relaxed `checkCommitStatus` cleanly resolves the supplier to `false` and maps it to `UNKNOWN` per its documented semantics (#12637), with no NPE spam in the logs. Whether failed creates should hard-fail in the relaxed path as well is a semantics question intentionally left out of this PR (see the review discussion on #6499).

This revives the core part of #6499, which diagnosed and fixed the same problem in Dec 2022 but was closed by the stale bot without a decision. The code has since moved (the status check was refactored into `BaseMetastoreOperations` by #12637), so the guard now lives in `checkCurrentMetadataLocation`.

## Are these changes tested?

Yes - a new core unit test, `TestBaseMetastoreTableOperations`, with a minimal `BaseMetastoreTableOperations` subclass whose `doRefresh()` mimics `HiveTableOperations` for a never-persisted table (missing table is not an error when no metadata location is known -> refresh from `null` -> current metadata stays `null`):

- `strictStatusCheckIsFailureWhenTableWasNeverPersisted` - fails without the fix (the NPE is suppressed and the status stays `UNKNOWN`) and passes with it.
- `statusCheckIsUnknownWhenTableWasNeverPersisted` - pins the relaxed-check semantics for the same scenario.

Verified locally: the strict test fails on `main` without the fix and passes with it; `:iceberg-core:test` and `:iceberg-hive-metastore:test` both pass with the change.