### PR TITLE
GCP: add pluggable GCS token credential provider

### DIFF
--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -72,6 +72,12 @@ public class GCPProperties implements Serializable {
    * implementation. When set, {@code PrefixedStorage} uses this provider to obtain {@link
    * com.google.auth.oauth2.GoogleCredentials} instead of reading a static {@link #GCS_OAUTH2_TOKEN}
    * property. The provider class must have a no-arg constructor.
+   *
+   * <p><b>Precedence:</b> This property is ignored if {@link #GCS_OAUTH2_TOKEN} or {@link
+   * #GCS_IMPERSONATE_SERVICE_ACCOUNT} is also set. The vended credential path sets both {@link
+   * #GCS_OAUTH2_TOKEN} (per-prefix token) and this provider (refresh source), so the token takes
+   * precedence. Impersonation similarly takes precedence to maintain deterministic credential
+   * selection.
    */
   public static final String GCS_TOKEN_CREDENTIAL_PROVIDER = "gcs.token-credential-provider";
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/GCPProperties.java
@@ -67,6 +67,22 @@ public class GCPProperties implements Serializable {
   public static final String GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED =
       "gcs.oauth2.refresh-credentials-enabled";
 
+  /**
+   * Class name of a custom {@link org.apache.iceberg.gcp.gcs.GcsTokenCredentialProvider}
+   * implementation. When set, {@code PrefixedStorage} uses this provider to obtain {@link
+   * com.google.auth.oauth2.GoogleCredentials} instead of reading a static {@link #GCS_OAUTH2_TOKEN}
+   * property. The provider class must have a no-arg constructor.
+   */
+  public static final String GCS_TOKEN_CREDENTIAL_PROVIDER = "gcs.token-credential-provider";
+
+  /**
+   * Property prefix for initializing a custom {@link
+   * org.apache.iceberg.gcp.gcs.GcsTokenCredentialProvider}. All properties under this prefix are
+   * extracted (without the prefix) and passed to {@link
+   * org.apache.iceberg.gcp.gcs.GcsTokenCredentialProvider#initialize(Map)}.
+   */
+  public static final String GCS_TOKEN_PROVIDER_PREFIX = "gcs.token-credential-provider.";
+
   /** Configure the batch size used when deleting multiple files from a given GCS bucket */
   public static final String GCS_DELETE_BATCH_SIZE = "gcs.delete.batch-size";
 
@@ -98,6 +114,7 @@ public class GCPProperties implements Serializable {
   private String gcsOauth2RefreshCredentialsEndpoint;
   private boolean gcsOauth2RefreshCredentialsEnabled;
   private boolean gcsAnalyticsCoreEnabled;
+  private String gcsTokenCredentialProvider;
 
   private String gcsImpersonateServiceAccount;
   private int gcsImpersonateLifetimeSeconds;
@@ -167,6 +184,8 @@ public class GCPProperties implements Serializable {
           new Date(Long.parseLong(properties.get(GCS_OAUTH2_TOKEN_EXPIRES_AT)));
     }
 
+    gcsTokenCredentialProvider = properties.get(GCS_TOKEN_CREDENTIAL_PROVIDER);
+
     gcsOauth2RefreshCredentialsEndpoint =
         RESTUtil.resolveEndpoint(
             properties.get(CatalogProperties.URI),
@@ -179,6 +198,11 @@ public class GCPProperties implements Serializable {
         "Invalid auth settings: must not configure %s and %s",
         GCS_NO_AUTH,
         GCS_OAUTH2_TOKEN);
+    Preconditions.checkState(
+        !(gcsTokenCredentialProvider != null && gcsNoAuth),
+        "Invalid auth settings: must not configure %s and %s",
+        GCS_NO_AUTH,
+        GCS_TOKEN_CREDENTIAL_PROVIDER);
 
     gcsDeleteBatchSize =
         PropertyUtil.propertyAsInt(
@@ -233,6 +257,10 @@ public class GCPProperties implements Serializable {
 
   public Optional<String> oauth2Token() {
     return Optional.ofNullable(gcsOAuth2Token);
+  }
+
+  public Optional<String> tokenCredentialProvider() {
+    return Optional.ofNullable(gcsTokenCredentialProvider);
   }
 
   public boolean noAuth() {

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProvider.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProvider.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.util.Map;
+
+public interface GcsTokenCredentialProvider {
+
+  GoogleCredentials credential();
+
+  /**
+   * Initialize GCS credential provider from provider properties.
+   *
+   * @param properties credential provider properties
+   */
+  void initialize(Map<String, String> properties);
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProvider.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProvider.java
@@ -23,6 +23,11 @@ import java.util.Map;
 
 public interface GcsTokenCredentialProvider {
 
+  /**
+   * Returns a GoogleCredentials instance for authenticating GCS requests.
+   *
+   * @return a GoogleCredentials instance, must not be null
+   */
   GoogleCredentials credential();
 
   /**

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProviders.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProviders.java
@@ -65,7 +65,8 @@ public class GcsTokenCredentialProviders {
     } catch (NoSuchMethodException e) {
       throw new IllegalArgumentException(
           String.format(
-              "Cannot initialize GcsTokenCredentialProvider, missing no-arg constructor: %s", impl),
+              "Cannot initialize GcsTokenCredentialProvider, cannot load class or missing no-arg constructor: %s",
+              impl),
           e);
     }
 

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProviders.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/GcsTokenCredentialProviders.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import org.apache.iceberg.common.DynConstructors;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.relocated.com.google.common.base.Strings;
+import org.apache.iceberg.util.PropertyUtil;
+
+public class GcsTokenCredentialProviders {
+
+  private static final DefaultGcsTokenCredentialProvider DEFAULT_PROVIDER =
+      new DefaultGcsTokenCredentialProvider();
+
+  private GcsTokenCredentialProviders() {}
+
+  public static GcsTokenCredentialProvider defaultFactory() {
+    return DEFAULT_PROVIDER;
+  }
+
+  public static GcsTokenCredentialProvider from(Map<String, String> properties) {
+    String providerImpl =
+        PropertyUtil.propertyAsString(
+            properties, GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER, null);
+    Map<String, String> credentialProviderProperties =
+        PropertyUtil.propertiesWithPrefix(properties, GCPProperties.GCS_TOKEN_PROVIDER_PREFIX);
+    return loadCredentialProvider(providerImpl, credentialProviderProperties);
+  }
+
+  private static GcsTokenCredentialProvider loadCredentialProvider(
+      String impl, Map<String, String> properties) {
+    if (Strings.isNullOrEmpty(impl)) {
+      GcsTokenCredentialProvider provider = defaultFactory();
+      provider.initialize(properties);
+      return provider;
+    }
+
+    DynConstructors.Ctor<GcsTokenCredentialProvider> ctor;
+    try {
+      ctor =
+          DynConstructors.builder(GcsTokenCredentialProvider.class)
+              .loader(GcsTokenCredentialProviders.class.getClassLoader())
+              .hiddenImpl(impl)
+              .buildChecked();
+    } catch (NoSuchMethodException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize GcsTokenCredentialProvider, missing no-arg constructor: %s", impl),
+          e);
+    }
+
+    GcsTokenCredentialProvider provider;
+    try {
+      provider = ctor.newInstance();
+    } catch (ClassCastException e) {
+      throw new IllegalArgumentException(
+          String.format(
+              "Cannot initialize GcsTokenCredentialProvider, %s does not implement GcsTokenCredentialProvider.",
+              impl),
+          e);
+    }
+
+    provider.initialize(properties);
+    return provider;
+  }
+
+  static class DefaultGcsTokenCredentialProvider implements GcsTokenCredentialProvider {
+
+    @Override
+    public GoogleCredentials credential() {
+      try {
+        return GoogleCredentials.getApplicationDefault();
+      } catch (IOException e) {
+        throw new UncheckedIOException("Failed to get application default GCS credentials", e);
+      }
+    }
+
+    @Override
+    public void initialize(Map<String, String> properties) {}
+  }
+}

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
@@ -36,8 +36,11 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.base.Strings;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.util.SerializableSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class PrefixedStorage implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(PrefixedStorage.class);
   private static final String GCS_FILE_IO_USER_AGENT = "gcsfileio/" + EnvironmentContext.get();
   private final String storagePrefix;
   private final GCPProperties gcpProperties;
@@ -157,11 +160,24 @@ class PrefixedStorage implements AutoCloseable {
       // Explicitly allow "no credentials" for testing purposes
       return NoCredentials.getInstance();
     } else if (properties.impersonateServiceAccount().isPresent()) {
+      if (gcpProperties.tokenCredentialProvider().isPresent()) {
+        LOG.warn(
+            "Both {} and {} are set; {} takes precedence and the provider is ignored",
+            GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT,
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT);
+      }
       return buildImpersonatedCredentials(properties);
     } else if (properties.tokenCredentialProvider().isPresent()) {
       // A custom provider yields a self-refreshing GoogleCredentials (e.g. built from a
       // caller-supplied source credential), addressing static-token expiry for non-vended setups.
-      return GcsTokenCredentialProviders.from(properties.properties()).credential();
+      GoogleCredentials credentials =
+          GcsTokenCredentialProviders.from(properties.properties()).credential();
+      Preconditions.checkState(
+          credentials != null,
+          "Provider %s returned null credentials",
+          gcpProperties.tokenCredentialProvider().get());
+      return credentials;
     } else {
       return null;
     }

--- a/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
+++ b/gcp/src/main/java/org/apache/iceberg/gcp/gcs/PrefixedStorage.java
@@ -158,6 +158,10 @@ class PrefixedStorage implements AutoCloseable {
       return NoCredentials.getInstance();
     } else if (properties.impersonateServiceAccount().isPresent()) {
       return buildImpersonatedCredentials(properties);
+    } else if (properties.tokenCredentialProvider().isPresent()) {
+      // A custom provider yields a self-refreshing GoogleCredentials (e.g. built from a
+      // caller-supplied source credential), addressing static-token expiry for non-vended setups.
+      return GcsTokenCredentialProviders.from(properties.properties()).credential();
     } else {
       return null;
     }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/TestGCPProperties.java
@@ -22,6 +22,7 @@ import static org.apache.iceberg.gcp.GCPProperties.GCS_NO_AUTH;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENABLED;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_REFRESH_CREDENTIALS_ENDPOINT;
 import static org.apache.iceberg.gcp.GCPProperties.GCS_OAUTH2_TOKEN;
+import static org.apache.iceberg.gcp.GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
@@ -48,6 +49,51 @@ public class TestGCPProperties {
     gcpProperties = new GCPProperties(ImmutableMap.of(GCS_NO_AUTH, "true"));
     assertThat(gcpProperties.noAuth()).isTrue();
     assertThat(gcpProperties.oauth2Token()).isNotPresent();
+  }
+
+  @Test
+  public void testTokenCredentialProviderWithNoAuth() {
+    assertThatIllegalStateException()
+        .isThrownBy(
+            () ->
+                new GCPProperties(
+                    ImmutableMap.of(
+                        GCS_TOKEN_CREDENTIAL_PROVIDER,
+                        "org.example.Provider",
+                        GCS_NO_AUTH,
+                        "true")))
+        .withMessage(
+            String.format(
+                "Invalid auth settings: must not configure %s and %s",
+                GCS_NO_AUTH, GCS_TOKEN_CREDENTIAL_PROVIDER));
+  }
+
+  @Test
+  public void testTokenCredentialProviderWithOAuth2Token() {
+    // Provider and oauth2 token may coexist (the vended case) - construction must not throw;
+    // PrefixedStorage resolves precedence.
+    GCPProperties gcpProperties =
+        new GCPProperties(
+            ImmutableMap.of(
+                GCS_TOKEN_CREDENTIAL_PROVIDER, "org.example.Provider", GCS_OAUTH2_TOKEN, "oauth"));
+    assertThat(gcpProperties.tokenCredentialProvider())
+        .isPresent()
+        .get()
+        .isEqualTo("org.example.Provider");
+    assertThat(gcpProperties.oauth2Token()).isPresent().get().isEqualTo("oauth");
+    assertThat(gcpProperties.noAuth()).isFalse();
+  }
+
+  @Test
+  public void testTokenCredentialProviderSet() {
+    GCPProperties gcpProperties =
+        new GCPProperties(ImmutableMap.of(GCS_TOKEN_CREDENTIAL_PROVIDER, "org.example.Provider"));
+    assertThat(gcpProperties.tokenCredentialProvider())
+        .isPresent()
+        .get()
+        .isEqualTo("org.example.Provider");
+    assertThat(gcpProperties.oauth2Token()).isNotPresent();
+    assertThat(gcpProperties.noAuth()).isFalse();
   }
 
   @Test

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsTokenCredentialProviders.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsTokenCredentialProviders.java
@@ -85,7 +85,7 @@ public class TestGcsTokenCredentialProviders {
     assertThatIllegalArgumentException()
         .isThrownBy(() -> GcsTokenCredentialProviders.from(properties))
         .withMessageContaining(
-            "Cannot initialize GcsTokenCredentialProvider, missing no-arg constructor");
+            "Cannot initialize GcsTokenCredentialProvider, cannot load class or missing no-arg constructor");
   }
 
   @Test

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsTokenCredentialProviders.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestGcsTokenCredentialProviders.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.gcp.gcs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import java.util.Map;
+import org.apache.iceberg.gcp.GCPProperties;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.junit.jupiter.api.Test;
+
+public class TestGcsTokenCredentialProviders {
+
+  @Test
+  public void useDefaultFactory() {
+    assertThat(GcsTokenCredentialProviders.defaultFactory())
+        .isNotNull()
+        .isInstanceOf(GcsTokenCredentialProviders.DefaultGcsTokenCredentialProvider.class);
+  }
+
+  @Test
+  public void emptyPropertiesWithNoProvider() {
+    assertThat(GcsTokenCredentialProviders.from(ImmutableMap.of()))
+        .isNotNull()
+        .isInstanceOf(GcsTokenCredentialProviders.DefaultGcsTokenCredentialProvider.class);
+  }
+
+  @Test
+  public void emptyCredentialProvider() {
+    Map<String, String> properties =
+        ImmutableMap.of(GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER, "");
+    assertThat(GcsTokenCredentialProviders.from(properties))
+        .isNotNull()
+        .isInstanceOf(GcsTokenCredentialProviders.DefaultGcsTokenCredentialProvider.class);
+  }
+
+  @Test
+  public void defaultProviderAsCredentialProvider() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            GcsTokenCredentialProviders.DefaultGcsTokenCredentialProvider.class.getName());
+    assertThat(GcsTokenCredentialProviders.from(properties))
+        .isNotNull()
+        .isInstanceOf(GcsTokenCredentialProviders.DefaultGcsTokenCredentialProvider.class);
+  }
+
+  @Test
+  public void customProviderAsCredentialProvider() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            DummyGcsTokenCredentialProvider.class.getName());
+    GcsTokenCredentialProvider provider = GcsTokenCredentialProviders.from(properties);
+
+    assertThat(provider).isNotNull().isInstanceOf(DummyGcsTokenCredentialProvider.class);
+    assertThat(provider.credential()).isNull();
+  }
+
+  @Test
+  public void nonExistentCredentialProvider() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            "org.apache.iceberg.gcp.gcs.NonExistentProvider");
+
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> GcsTokenCredentialProviders.from(properties))
+        .withMessageContaining(
+            "Cannot initialize GcsTokenCredentialProvider, missing no-arg constructor");
+  }
+
+  @Test
+  public void nonImplementingClassAsCredentialProvider() {
+    Map<String, String> properties =
+        ImmutableMap.of(GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER, "java.lang.String");
+    assertThatIllegalArgumentException()
+        .isThrownBy(() -> GcsTokenCredentialProviders.from(properties))
+        .withMessageContaining("java.lang.String does not implement GcsTokenCredentialProvider");
+  }
+
+  @Test
+  public void loadCredentialProviderWithProperties() {
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            DummyGcsTokenCredentialProvider.class.getName(),
+            GCPProperties.GCS_TOKEN_PROVIDER_PREFIX + "service-account-key",
+            "keyValue",
+            "custom.property",
+            "custom.value");
+
+    GcsTokenCredentialProvider provider = GcsTokenCredentialProviders.from(properties);
+    assertThat(provider).isInstanceOf(DummyGcsTokenCredentialProvider.class);
+    DummyGcsTokenCredentialProvider credentialProvider = (DummyGcsTokenCredentialProvider) provider;
+    assertThat(credentialProvider.properties())
+        .containsEntry("service-account-key", "keyValue")
+        .doesNotContainKey("custom.property")
+        .doesNotContainKey(GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER);
+  }
+
+  static class DummyGcsTokenCredentialProvider implements GcsTokenCredentialProvider {
+
+    private Map<String, String> properties;
+
+    @Override
+    public GoogleCredentials credential() {
+      return null;
+    }
+
+    @Override
+    public void initialize(Map<String, String> credentialProperties) {
+      this.properties = credentialProperties;
+    }
+
+    public Map<String, String> properties() {
+      return properties;
+    }
+  }
+}

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
@@ -25,6 +25,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsReadOptions;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -159,5 +160,57 @@ public class TestPrefixedStorage {
     assertThat(fileSystem).isNotNull();
     assertThat(fileSystem.getGcsClient()).isNotNull();
     assertThat(fileSystem.getFileSystemOptions()).isEqualTo(expectedOptions);
+  }
+
+  @Test
+  public void tokenCredentialProviderSet() {
+    // Verify that GCPProperties correctly parses gcs.token-credential-provider.
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    assertThat(storage.storagePrefix()).isEqualTo("gs://bucket");
+    assertThat(storage.gcpProperties().tokenCredentialProvider()).isPresent();
+  }
+
+  @Test
+  public void oauth2TokenTakesPrecedenceOverProvider() {
+    // Vended path: both token and provider are set. Token branch wins, provider ignored.
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_OAUTH2_TOKEN,
+            "token",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    assertThat(storage.storage()).isNotNull();
+    assertThat(storage.storage().getOptions().getCredentials())
+        .isInstanceOf(com.google.auth.oauth2.OAuth2Credentials.class);
+  }
+
+  @Test
+  public void impersonateTakesPrecedenceOverProvider() {
+    // Impersonation + provider: impersonation branch reached first (verified by exception).
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT,
+            "sa@project.iam.gserviceaccount.com",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    // Local placeholder throws to prevent production use; verifies impersonation branch executed.
+    assertThatThrownBy(storage::storage)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("Failed to create impersonated credentials for GCS");
   }
 }

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
@@ -26,6 +26,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsReadOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
+import java.io.UncheckedIOException;
 import java.util.Map;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -165,5 +166,57 @@ public class TestPrefixedStorage {
     assertThat(fileSystem).isNotNull();
     assertThat(fileSystem.getGcsClient()).isNotNull();
     assertThat(fileSystem.getFileSystemOptions()).isEqualTo(expectedOptions);
+  }
+
+  @Test
+  public void tokenCredentialProviderSet() {
+    // Verify that GCPProperties correctly parses gcs.token-credential-provider.
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    assertThat(storage.storagePrefix()).isEqualTo("gs://bucket");
+    assertThat(storage.gcpProperties().tokenCredentialProvider()).isPresent();
+  }
+
+  @Test
+  public void oauth2TokenTakesPrecedenceOverProvider() {
+    // Vended path: both token and provider are set. Token branch wins, provider ignored.
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_OAUTH2_TOKEN,
+            "token",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    assertThat(storage.storage()).isNotNull();
+    assertThat(storage.storage().getOptions().getCredentials())
+        .isInstanceOf(com.google.auth.oauth2.OAuth2Credentials.class);
+  }
+
+  @Test
+  public void impersonateTakesPrecedenceOverProvider() {
+    // Impersonation + provider: impersonation branch reached first (verified by exception).
+    Map<String, String> properties =
+        ImmutableMap.of(
+            GCPProperties.GCS_PROJECT_ID,
+            "myProject",
+            GCPProperties.GCS_IMPERSONATE_SERVICE_ACCOUNT,
+            "sa@project.iam.gserviceaccount.com",
+            GCPProperties.GCS_TOKEN_CREDENTIAL_PROVIDER,
+            TestGcsTokenCredentialProviders.DummyGcsTokenCredentialProvider.class.getName());
+    PrefixedStorage storage = new PrefixedStorage("gs://bucket", properties, null);
+
+    // Local placeholder throws to prevent production use; verifies impersonation branch executed.
+    assertThatThrownBy(storage::storage)
+        .isInstanceOf(UncheckedIOException.class)
+        .hasMessageContaining("Failed to create impersonated credentials for GCS");
   }
 }


### PR DESCRIPTION
## What

Adds a pluggable storage credential-provider SPI to the GCS FileIO in the `iceberg-gcp` module:

- `GcsTokenCredentialProvider` - interface returning a `com.google.auth.oauth2.GoogleCredentials`,
  with an `initialize(Map<String,String>)` hook for provider-specific config.
- `GcsTokenCredentialProviders` - factory that loads a custom implementation via `DynConstructors`
  from the new `gcs.token-credential-provider` property, with a `DefaultGcsTokenCredentialProvider`
  backed by Application Default Credentials.
- New `GCPProperties` constants (`gcs.token-credential-provider`,
  `gcs.token-credential-provider.` prefix), an accessor, and a precondition preventing it from being
  combined with `gcs.no-auth`.
- A new branch in `PrefixedStorage#credentials(...)` that uses the configured provider when present.
- Unit tests.

This is the GCS analogue of the existing Azure `AdlsTokenCredentialProvider` (#14136) and AWS's
`client.credentials-provider`.

## Why

The GCS FileIO today supports a static `gcs.oauth2.token`, `gcs.no-auth`, native impersonation, and
the vended refresh endpoint - but there is **no pluggable way to supply a caller-provided,
self-refreshing source credential** for non-vended setups. None of the existing paths covers this:

- `gcs.oauth2.token` is static - it never refreshes, so long-running jobs fail at token expiry.
- The vended refresh endpoint only refreshes REST-catalog-vended credentials, not a
  caller-supplied source.
- Native impersonation (`gcs.impersonate.service-account`) structurally starts from
  `GoogleCredentials.getApplicationDefault()` as its source credential - there is no property to
  inject an arbitrary caller-supplied source, so it does not cover the bring-your-own-credentials
  case.

This SPI lets integrators plug in a credential source that refreshes, without Iceberg taking on any
specific credential implementation. The default remains Application Default Credentials.

## Compatibility

- Purely additive. Default behaviour is unchanged: with no `gcs.token-credential-provider` set,
  credential resolution is identical to today (oauth2Token / no-auth / impersonation / ADC).
- No changes outside `iceberg-gcp`.

## Scope: this is storage-plane auth

GCP has two independent auth planes, and this PR touches only the first:

- **Storage plane** - how `GCSFileIO` / `PrefixedStorage` authenticate to GCS to read/write data
  files. This is where the new `gcs.token-credential-provider` SPI lives (properties are `gcs.*`).
- **Catalog plane** - how a REST catalog session authenticates, handled by `GoogleAuthManager`
  (properties are `gcp.auth.*`). This PR does **not** change it.

## Testing

- `TestGcsTokenCredentialProviders` - default factory, empty/blank provider, custom provider,
  missing no-arg ctor, non-implementing class, prefixed-property extraction.
- `TestGCPProperties` - provider property is read; mutual-exclusion with `gcs.no-auth` is enforced;
  provider + `gcs.oauth2.token` is allowed.
- `./gradlew :iceberg-gcp:spotlessCheck :iceberg-gcp:test` passes locally.