### PR TITLE
Data, Spark: Support byte[] binary values in InternalRowConverter

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
@@ -251,9 +251,6 @@ class DataGenerators {
   }
 
   // Generator for reader default-value tests across primitive types.
-  // FIXED is excluded: Spark's InternalRowConverter expects a ByteBuffer but the generator produces
-  // byte[] (ClassCastException).
-  // TODO: include FIXED once Spark's converter handles it.
   static class PrimitiveDefaults implements DataGenerator {
     static final Schema READ_SCHEMA =
         new Schema(
@@ -302,7 +299,18 @@ class DataGenerators {
                 14,
                 "time_with_default",
                 Types.TimeType.get(),
-                Literal.of(DateTimeUtil.isoTimeToMicros("23:59:59.999999"))));
+                Literal.of(DateTimeUtil.isoTimeToMicros("23:59:59.999999"))),
+            optionalWithDefault(
+                15,
+                "fixed_with_default",
+                Types.FixedType.ofLength(16),
+                Literal.of(
+                        ByteBuffer.wrap(
+                            new byte[] {
+                              0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+                              0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f
+                            }))
+                    .to(Types.FixedType.ofLength(16))));
 
     static final Schema WRITE_SCHEMA = new Schema(required(1, "id", Types.LongType.get()));
 

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
@@ -27,13 +27,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
@@ -79,13 +79,7 @@ public class InternalRowConverter {
               : ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) value).atZone(ZoneId.of("UTC")));
       case STRING -> UTF8String.fromString((String) value);
       case UUID -> UTF8String.fromString(value.toString());
-      case FIXED, BINARY -> {
-        ByteBuffer buffer = (ByteBuffer) value;
-        yield Arrays.copyOfRange(
-            buffer.array(),
-            buffer.arrayOffset() + buffer.position(),
-            buffer.arrayOffset() + buffer.remaining());
-      }
+      case FIXED, BINARY -> toByteArray(value);
       case DECIMAL -> Decimal.apply((BigDecimal) value);
       case STRUCT -> convert((Types.StructType) type, (Record) value);
       case LIST ->
@@ -111,5 +105,16 @@ public class InternalRowConverter {
           throw new UnsupportedOperationException(
               "Unsupported type for conversion to InternalRow: " + type);
     };
+  }
+
+  private static byte[] toByteArray(Object value) {
+    if (value instanceof byte[] bytes) {
+      return bytes;
+    } else if (value instanceof ByteBuffer buffer) {
+      return ByteBuffers.toByteArray(buffer);
+    }
+
+    throw new UnsupportedOperationException(
+        "Unsupported binary value class: " + value.getClass().getName());
   }
 }

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
@@ -34,11 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 public class TestSparkFormatModel extends BaseFormatModelTests<InternalRow> {
 
   private static final Set<Type.TypeID> UNSUPPORTED_TYPE_IDS =
-      Set.of(
-          Type.TypeID.TIME,
-          Type.TypeID.TIMESTAMP_NANO,
-          // TODO: Remove once FIXED is working on TCK
-          Type.TypeID.FIXED);
+      Set.of(Type.TypeID.TIME, Type.TypeID.TIMESTAMP_NANO);
 
   @Override
   protected Collection<Type.TypeID> unsupportedTypeIds() {

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
@@ -27,13 +27,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
@@ -79,13 +79,7 @@ public class InternalRowConverter {
               : ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) value).atZone(ZoneId.of("UTC")));
       case STRING -> UTF8String.fromString((String) value);
       case UUID -> UTF8String.fromString(value.toString());
-      case FIXED, BINARY -> {
-        ByteBuffer buffer = (ByteBuffer) value;
-        yield Arrays.copyOfRange(
-            buffer.array(),
-            buffer.arrayOffset() + buffer.position(),
-            buffer.arrayOffset() + buffer.remaining());
-      }
+      case FIXED, BINARY -> toByteArray(value);
       case DECIMAL -> Decimal.apply((BigDecimal) value);
       case STRUCT -> convert((Types.StructType) type, (Record) value);
       case LIST ->
@@ -111,5 +105,16 @@ public class InternalRowConverter {
           throw new UnsupportedOperationException(
               "Unsupported type for conversion to InternalRow: " + type);
     };
+  }
+
+  private static byte[] toByteArray(Object value) {
+    if (value instanceof byte[] bytes) {
+      return bytes;
+    } else if (value instanceof ByteBuffer buffer) {
+      return ByteBuffers.toByteArray(buffer);
+    }
+
+    throw new UnsupportedOperationException(
+        "Unsupported binary value class: " + value.getClass().getName());
   }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
@@ -34,11 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 public class TestSparkFormatModel extends BaseFormatModelTests<InternalRow> {
 
   private static final Set<Type.TypeID> UNSUPPORTED_TYPE_IDS =
-      Set.of(
-          Type.TypeID.TIME,
-          Type.TypeID.TIMESTAMP_NANO,
-          // TODO: Remove once FIXED is working on TCK
-          Type.TypeID.FIXED);
+      Set.of(Type.TypeID.TIME, Type.TypeID.TIMESTAMP_NANO);
 
   @Override
   protected Collection<Type.TypeID> unsupportedTypeIds() {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java
@@ -27,13 +27,13 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.Record;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
+import org.apache.iceberg.util.ByteBuffers;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.catalyst.expressions.GenericInternalRow;
 import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
@@ -79,13 +79,7 @@ public class InternalRowConverter {
               : ChronoUnit.MICROS.between(EPOCH, ((LocalDateTime) value).atZone(ZoneId.of("UTC")));
       case STRING -> UTF8String.fromString((String) value);
       case UUID -> UTF8String.fromString(value.toString());
-      case FIXED, BINARY -> {
-        ByteBuffer buffer = (ByteBuffer) value;
-        yield Arrays.copyOfRange(
-            buffer.array(),
-            buffer.arrayOffset() + buffer.position(),
-            buffer.arrayOffset() + buffer.remaining());
-      }
+      case FIXED, BINARY -> toByteArray(value);
       case DECIMAL -> Decimal.apply((BigDecimal) value);
       case STRUCT -> convert((Types.StructType) type, (Record) value);
       case LIST ->
@@ -111,5 +105,16 @@ public class InternalRowConverter {
           throw new UnsupportedOperationException(
               "Unsupported type for conversion to InternalRow: " + type);
     };
+  }
+
+  private static byte[] toByteArray(Object value) {
+    if (value instanceof byte[] bytes) {
+      return bytes;
+    } else if (value instanceof ByteBuffer buffer) {
+      return ByteBuffers.toByteArray(buffer);
+    }
+
+    throw new UnsupportedOperationException(
+        "Unsupported binary value class: " + value.getClass().getName());
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java
@@ -34,11 +34,7 @@ import org.apache.spark.sql.catalyst.InternalRow;
 public class TestSparkFormatModel extends BaseFormatModelTests<InternalRow> {
 
   private static final Set<Type.TypeID> UNSUPPORTED_TYPE_IDS =
-      Set.of(
-          Type.TypeID.TIME,
-          Type.TypeID.TIMESTAMP_NANO,
-          // TODO: Remove once FIXED is working on TCK
-          Type.TypeID.FIXED);
+      Set.of(Type.TypeID.TIME, Type.TypeID.TIMESTAMP_NANO);
 
   @Override
   protected Collection<Type.TypeID> unsupportedTypeIds() {


### PR DESCRIPTION
[InternalRowConverter](https://github.com/apache/iceberg/blob/main/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java) cast both `FIXED` and `BINARY` to [ByteBuffer](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/InternalRowConverter.java#L83), but Iceberg's generic model represents fixed as `byte[]`, leading to `ClassCastException`. `FIXED` was [excluded](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/data/src/test/java/org/apache/iceberg/data/DataGenerators.java#L256) from the Spark TCK as a result.

1. `toByteArray` handles both, delegating to [ByteBuffers.toByteArray](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java#L29) for the buffer case.
2. Removes `FIXED` from [unsupportedTypeIds()](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkFormatModel.java#L44) in Spark `3.5`/`4.0`/`4.1`.
3. Adds `fixed_with_default` to [DataGenerators.PrimitiveDefaults](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/data/src/test/java/org/apache/iceberg/data/DataGenerators.java#L257), exercising both branches alongside [binary_with_default](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/data/src/test/java/org/apache/iceberg/data/DataGenerators.java#L291).

Refs: [GenericDataUtil.internalToGeneric](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/core/src/main/java/org/apache/iceberg/data/GenericDataUtil.java#L38), [RandomGenericData](https://github.com/apache/iceberg/blob/3c356c45ea00b6ac036684f8b7e24a326c2a55e8/data/src/test/java/org/apache/iceberg/data/RandomGenericData.java#L270).