### PR TITLE
Core: Add option to skip column stats in SnapshotChanges

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotChanges.java
@@ -45,6 +45,7 @@ public class SnapshotChanges {
   private final FileIO io;
   private final Map<Integer, PartitionSpec> specsById;
   private final ExecutorService executorService;
+  private final boolean columnStats;
 
   private List<DataFile> addedDataFiles = null;
   private List<DataFile> removedDataFiles = null;
@@ -55,7 +56,8 @@ public class SnapshotChanges {
       Snapshot snapshot,
       FileIO io,
       Map<Integer, PartitionSpec> specsById,
-      ExecutorService executorService) {
+      ExecutorService executorService,
+      boolean columnStats) {
     Preconditions.checkArgument(snapshot != null, "Snapshot cannot be null");
     Preconditions.checkArgument(io != null, "FileIO cannot be null");
     Preconditions.checkArgument(specsById != null, "Partition specs cannot be null");
@@ -63,6 +65,7 @@ public class SnapshotChanges {
     this.io = io;
     this.specsById = specsById;
     this.executorService = executorService;
+    this.columnStats = columnStats;
   }
 
   /**
@@ -155,10 +158,14 @@ public class SnapshotChanges {
     this.removedDataFiles = deletes.build();
   }
 
+  private List<String> manifestColumns(ManifestFile manifest) {
+    return columnStats ? ManifestReader.ALL_COLUMNS : BaseScan.scanColumns(manifest.content());
+  }
+
   private CloseableIterable<Pair<ManifestEntry.Status, DataFile>> readDataManifest(
       ManifestFile manifest) {
     CloseableIterable<ManifestEntry<DataFile>> entries =
-        ManifestFiles.read(manifest, io, specsById).entries();
+        ManifestFiles.read(manifest, io, specsById).select(manifestColumns(manifest)).entries();
 
     CloseableIterable<ManifestEntry<DataFile>> relevant =
         CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
@@ -167,7 +174,7 @@ public class SnapshotChanges {
         relevant,
         entry -> {
           if (entry.status() == ManifestEntry.Status.ADDED) {
-            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());
+            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy(columnStats));
           } else {
             return Pair.of(ManifestEntry.Status.DELETED, entry.file().copyWithoutStats());
           }
@@ -209,7 +216,9 @@ public class SnapshotChanges {
   private CloseableIterable<Pair<ManifestEntry.Status, DeleteFile>> readDeleteManifest(
       ManifestFile manifest) {
     CloseableIterable<ManifestEntry<DeleteFile>> entries =
-        ManifestFiles.readDeleteManifest(manifest, io, specsById).entries();
+        ManifestFiles.readDeleteManifest(manifest, io, specsById)
+            .select(manifestColumns(manifest))
+            .entries();
 
     CloseableIterable<ManifestEntry<DeleteFile>> relevant =
         CloseableIterable.filter(entries, e -> e.status() != ManifestEntry.Status.EXISTING);
@@ -218,7 +227,7 @@ public class SnapshotChanges {
         relevant,
         entry -> {
           if (entry.status() == ManifestEntry.Status.ADDED) {
-            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy());
+            return Pair.of(ManifestEntry.Status.ADDED, entry.file().copy(columnStats));
           } else {
             return Pair.of(ManifestEntry.Status.DELETED, entry.file().copyWithoutStats());
           }
@@ -230,6 +239,7 @@ public class SnapshotChanges {
     private final FileIO io;
     private final Map<Integer, PartitionSpec> specsById;
     private ExecutorService executorService = null;
+    private boolean columnStats = true;
 
     private Builder(Snapshot snapshot, FileIO io, Map<Integer, PartitionSpec> specsById) {
       this.snapshot = snapshot;
@@ -260,12 +270,23 @@ public class SnapshotChanges {
     }
 
     /**
+     * Configure whether to read column-level statistics for added files, defaults to true.
+     *
+     * @param include whether to read column-level statistics
+     * @return this builder for method chaining
+     */
+    public Builder includeColumnStats(boolean include) {
+      this.columnStats = include;
+      return this;
+    }
+
+    /**
      * Build the SnapshotChanges instance.
      *
      * @return a new SnapshotChanges instance
      */
     public SnapshotChanges build() {
-      return new SnapshotChanges(snapshot, io, specsById, executorService);
+      return new SnapshotChanges(snapshot, io, specsById, executorService, columnStats);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -22,6 +22,10 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.Map;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.Conversions;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +42,30 @@ public class TestSnapshotChanges {
 
   // Partition spec used to create tables
   protected static final PartitionSpec SPEC = PartitionSpec.builderFor(SCHEMA).build();
+
+  private static final Map<Integer, Long> COLUMN_SIZES = ImmutableMap.of(3, 20L);
+  private static final Map<Integer, Long> VALUE_COUNTS = ImmutableMap.of(3, 1L);
+  private static final Map<Integer, Long> NULL_VALUE_COUNTS = ImmutableMap.of(3, 0L);
+  private static final Map<Integer, ByteBuffer> LOWER_BOUNDS =
+      ImmutableMap.of(3, Conversions.toByteBuffer(Types.IntegerType.get(), 1));
+  private static final Map<Integer, ByteBuffer> UPPER_BOUNDS =
+      ImmutableMap.of(3, Conversions.toByteBuffer(Types.IntegerType.get(), 2));
+
+  private static final DataFile FILE_WITH_STATS =
+      DataFiles.builder(SPEC)
+          .withPath("/path/to/file-with-stats.parquet")
+          .withFileSizeInBytes(10)
+          .withRecordCount(1)
+          .withMetrics(
+              new Metrics(
+                  1L,
+                  COLUMN_SIZES,
+                  VALUE_COUNTS,
+                  NULL_VALUE_COUNTS,
+                  null,
+                  LOWER_BOUNDS,
+                  UPPER_BOUNDS))
+          .build();
 
   public TestTables.TestTable table = null;
 
@@ -145,5 +173,114 @@ public class TestSnapshotChanges {
 
     // Both calls should return the same reference (cached)
     assertThat(firstCallResult).isSameAs(secondCallResult);
+  }
+
+  @Test
+  public void testColumnStatsRetainedByDefault() {
+    table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
+
+    DataFile file =
+        SnapshotChanges.builderFor(table)
+            .snapshot(table.currentSnapshot())
+            .build()
+            .addedDataFiles()
+            .iterator()
+            .next();
+
+    assertThat(file.columnSizes()).isEqualTo(COLUMN_SIZES);
+    assertThat(file.valueCounts()).isEqualTo(VALUE_COUNTS);
+    assertThat(file.nullValueCounts()).isEqualTo(NULL_VALUE_COUNTS);
+    assertThat(file.lowerBounds()).isEqualTo(LOWER_BOUNDS);
+    assertThat(file.upperBounds()).isEqualTo(UPPER_BOUNDS);
+  }
+
+  @Test
+  public void testIncludeColumnStatsFalseDropsStats() {
+    table.newFastAppend().appendFile(FILE_WITH_STATS).commit();
+
+    DataFile file =
+        SnapshotChanges.builderFor(table)
+            .snapshot(table.currentSnapshot())
+            .includeColumnStats(false)
+            .build()
+            .addedDataFiles()
+            .iterator()
+            .next();
+
+    assertThat(file.columnSizes()).isNull();
+    assertThat(file.valueCounts()).isNull();
+    assertThat(file.nullValueCounts()).isNull();
+    assertThat(file.lowerBounds()).isNull();
+    assertThat(file.upperBounds()).isNull();
+
+    assertThat(file.location()).isEqualTo(FILE_WITH_STATS.location());
+    assertThat(file.fileSizeInBytes()).isEqualTo(10);
+    assertThat(file.recordCount()).isEqualTo(1);
+    assertThat(file.specId()).isEqualTo(table.spec().specId());
+  }
+
+  @Test
+  public void testIncludeColumnStatsFalseRetainsPartition() {
+    PartitionSpec spec = PartitionSpec.builderFor(SCHEMA).identity("data").build();
+    TestTables.TestTable partitioned =
+        TestTables.create(new File(tableDir, "partitioned"), "partitioned", SCHEMA, spec, 2);
+    partitioned
+        .newFastAppend()
+        .appendFile(
+            DataFiles.builder(spec)
+                .withPath("/path/to/partitioned.parquet")
+                .withFileSizeInBytes(10)
+                .withRecordCount(1)
+                .withPartitionPath("data=a")
+                .build())
+        .commit();
+
+    DataFile file =
+        SnapshotChanges.builderFor(partitioned)
+            .snapshot(partitioned.currentSnapshot())
+            .includeColumnStats(false)
+            .build()
+            .addedDataFiles()
+            .iterator()
+            .next();
+
+    assertThat(file.partition().get(0, String.class)).isEqualTo("a");
+  }
+
+  @Test
+  public void testIncludeColumnStatsFalseRetainsDeleteFileFields() {
+    DeleteFile positionDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/position-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    DeleteFile equalityDeletes =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofEqualityDeletes(3)
+            .withPath("/path/to/equality-deletes.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .build();
+
+    table.newRowDelta().addDeletes(positionDeletes).addDeletes(equalityDeletes).commit();
+
+    Iterable<DeleteFile> files =
+        SnapshotChanges.builderFor(table)
+            .snapshot(table.currentSnapshot())
+            .includeColumnStats(false)
+            .build()
+            .addedDeleteFiles();
+
+    // content is read from the manifest rather than inherited, so it must stay in the projection
+    assertThat(files)
+        .extracting(DeleteFile::content)
+        .containsExactlyInAnyOrder(FileContent.POSITION_DELETES, FileContent.EQUALITY_DELETES);
+    assertThat(files)
+        .filteredOn(file -> file.content() == FileContent.EQUALITY_DELETES)
+        .singleElement()
+        .satisfies(file -> assertThat(file.equalityFieldIds()).containsExactly(3));
   }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotChanges.java
@@ -46,6 +46,7 @@ public class TestSnapshotChanges {
   private static final Map<Integer, Long> COLUMN_SIZES = ImmutableMap.of(3, 20L);
   private static final Map<Integer, Long> VALUE_COUNTS = ImmutableMap.of(3, 1L);
   private static final Map<Integer, Long> NULL_VALUE_COUNTS = ImmutableMap.of(3, 0L);
+  private static final Map<Integer, Long> NAN_VALUE_COUNTS = ImmutableMap.of(3, 1L);
   private static final Map<Integer, ByteBuffer> LOWER_BOUNDS =
       ImmutableMap.of(3, Conversions.toByteBuffer(Types.IntegerType.get(), 1));
   private static final Map<Integer, ByteBuffer> UPPER_BOUNDS =
@@ -62,7 +63,7 @@ public class TestSnapshotChanges {
                   COLUMN_SIZES,
                   VALUE_COUNTS,
                   NULL_VALUE_COUNTS,
-                  null,
+                  NAN_VALUE_COUNTS,
                   LOWER_BOUNDS,
                   UPPER_BOUNDS))
           .build();
@@ -190,6 +191,7 @@ public class TestSnapshotChanges {
     assertThat(file.columnSizes()).isEqualTo(COLUMN_SIZES);
     assertThat(file.valueCounts()).isEqualTo(VALUE_COUNTS);
     assertThat(file.nullValueCounts()).isEqualTo(NULL_VALUE_COUNTS);
+    assertThat(file.nanValueCounts()).isEqualTo(NAN_VALUE_COUNTS);
     assertThat(file.lowerBounds()).isEqualTo(LOWER_BOUNDS);
     assertThat(file.upperBounds()).isEqualTo(UPPER_BOUNDS);
   }
@@ -210,10 +212,13 @@ public class TestSnapshotChanges {
     assertThat(file.columnSizes()).isNull();
     assertThat(file.valueCounts()).isNull();
     assertThat(file.nullValueCounts()).isNull();
+    assertThat(file.nanValueCounts()).isNull();
     assertThat(file.lowerBounds()).isNull();
     assertThat(file.upperBounds()).isNull();
 
     assertThat(file.location()).isEqualTo(FILE_WITH_STATS.location());
+    assertThat(file.format()).isEqualTo(FileFormat.PARQUET);
+    assertThat(file.content()).isEqualTo(FileContent.DATA);
     assertThat(file.fileSizeInBytes()).isEqualTo(10);
     assertThat(file.recordCount()).isEqualTo(1);
     assertThat(file.specId()).isEqualTo(table.spec().specId());


### PR DESCRIPTION
`SnapshotChanges` reads manifests with no projection and copies added files with
`entry.file().copy()`, so the per-column statistics maps (`column_sizes`, `value_counts`,
`null_value_counts`, `nan_value_counts`, `lower_bounds`, `upper_bounds`) are always decoded and
retained. Callers that only need file identity — path, size, partition, spec — pay for stats they
never read, which on wide tables dominates the retained heap of the cached file lists. The removed
path already uses `copyWithoutStats()`.

Adds `SnapshotChanges.Builder#includeColumnStats(boolean)`, defaulting to `true`. When `false`,
manifests are read with `BaseScan.scanColumns(manifest.content())` — the same curated projection
`PartitionsTable` and `PartitionStatsHandler` already use for direct manifest reads — and files are
copied without stats. Selecting by manifest content type keeps `content`, `referenced_data_file`,
`content_offset`, `content_size_in_bytes` and `equality_ids` on delete files; a single
caller-supplied column list would not be correct for both manifest types.

The default maps to `ManifestReader.ALL_COLUMNS`, which `Schema#select` short-circuits, so existing
callers are unaffected. The polarity is inverted relative to `Scan#includeColumnStats()`, which is
opt-in because scans default to dropping stats.

### Testing

Four tests in `TestSnapshotChanges` cover the default, the opt-out, partition values on a
partitioned table, and `content`/`equalityFieldIds` on delete files.