### PR TITLE
Core: Collapse redundant nested if statements

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -405,20 +405,16 @@ public class AllManifestsTable extends BaseMetadataTable {
 
       @Override
       public <T> Boolean in(BoundReference<T> ref, Set<T> literalSet) {
-        if (isSnapshotRef(ref)) {
-          if (!literalSet.contains(snapshotId)) {
-            return ROWS_CANNOT_MATCH;
-          }
+        if (isSnapshotRef(ref) && !literalSet.contains(snapshotId)) {
+          return ROWS_CANNOT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }
 
       @Override
       public <T> Boolean notIn(BoundReference<T> ref, Set<T> literalSet) {
-        if (isSnapshotRef(ref)) {
-          if (literalSet.contains(snapshotId)) {
-            return ROWS_CANNOT_MATCH;
-          }
+        if (isSnapshotRef(ref) && literalSet.contains(snapshotId)) {
+          return ROWS_CANNOT_MATCH;
         }
         return ROWS_MIGHT_MATCH;
       }

--- a/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ScanTaskIterable.java
@@ -185,10 +185,8 @@ class ScanTaskIterable implements CloseableIterable<FileScanTask> {
     private void offerInitialFileScanTasks() throws InterruptedException {
       while (!initialFileScanTasks.isEmpty() && !Thread.currentThread().isInterrupted()) {
         FileScanTask initialFileScanTask = initialFileScanTasks.poll();
-        if (initialFileScanTask != null) {
-          if (!offerWithTimeout(initialFileScanTask)) {
-            return;
-          }
+        if (initialFileScanTask != null && !offerWithTimeout(initialFileScanTask)) {
+          return;
         }
       }
     }

--- a/core/src/main/java/org/apache/iceberg/util/WapUtil.java
+++ b/core/src/main/java/org/apache/iceberg/util/WapUtil.java
@@ -50,10 +50,8 @@ public class WapUtil {
   public static String validateWapPublish(TableMetadata current, long wapSnapshotId) {
     Snapshot cherryPickSnapshot = current.snapshot(wapSnapshotId);
     String wapId = stagedWapId(cherryPickSnapshot);
-    if (wapId != null && !wapId.isEmpty()) {
-      if (WapUtil.isWapIdPublished(current, wapId)) {
-        throw new DuplicateWAPCommitException(wapId);
-      }
+    if (wapId != null && !wapId.isEmpty() && WapUtil.isWapIdPublished(current, wapId)) {
+      throw new DuplicateWAPCommitException(wapId);
     }
 
     return wapId;


### PR DESCRIPTION
Collapses nested `if` statements into a single condition (`if (A) { if (B) {...} }` -> `if (A && B) {...}`) in a few `core` classes, reducing nesting with no behavior change. In each case the outer `if` wrapped only the inner `if` (no `else`, nothing else in the block), and `&&` preserves the original short-circuit evaluation.