### PR TITLE
Core: Restore the interrupt status in JdbcCatalog.execute

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -779,6 +779,7 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       sqlErrorHandler.accept(e);
       throw new UncheckedSQLException(e, "Failed to execute: %s", sql);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
       throw new UncheckedInterruptedException(e, "Interrupted in SQL command");
     }
   }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -39,6 +39,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
@@ -1292,5 +1297,52 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
     }
 
     return false;
+  }
+
+  @Test
+  public void testExecuteRestoresInterruptStatus() throws Exception {
+    try (JdbcCatalog interruptibleCatalog =
+        initCatalog(
+            "interrupt_jdbc_catalog", ImmutableMap.of(CatalogProperties.CLIENT_POOL_SIZE, "1"))) {
+      CountDownLatch connectionHeld = new CountDownLatch(1);
+      CountDownLatch releaseConnection = new CountDownLatch(1);
+      ExecutorService executor = Executors.newSingleThreadExecutor();
+      // Hold the only pooled connection, so that the next caller has to wait on the pool. That
+      // wait is where a thread that is already interrupted observes the interrupt.
+      Future<?> holder =
+          executor.submit(
+              () -> {
+                interruptibleCatalog
+                    .connectionPool()
+                    .run(
+                        conn -> {
+                          connectionHeld.countDown();
+                          try {
+                            releaseConnection.await();
+                          } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                          }
+                          return null;
+                        });
+                return null;
+              });
+
+      try {
+        assertThat(connectionHeld.await(30, TimeUnit.SECONDS)).isTrue();
+        Thread.currentThread().interrupt();
+        // purge = false keeps this on the execute() path. The default purge = true would first
+        // read table metadata through fetch(), which already restores the interrupt status.
+        assertThatThrownBy(
+                () -> interruptibleCatalog.dropTable(TableIdentifier.of("ns", "tbl"), false))
+            .isInstanceOf(UncheckedInterruptedException.class)
+            .hasMessage("Interrupted in SQL command");
+        assertThat(Thread.currentThread().isInterrupted()).isTrue();
+      } finally {
+        Thread.interrupted();
+        releaseConnection.countDown();
+        holder.get(30, TimeUnit.SECONDS);
+        executor.shutdownNow();
+      }
+    }
   }
 }


### PR DESCRIPTION
`JdbcCatalog` has four `InterruptedException` handlers. Three of them restore the interrupt status before rethrowing; `execute` does not.

| | restores |
| --- | --- |
| `initializeCatalogTables` (:227) | yes |
| `updateSchemaIfRequired` (:268) | yes |
| **`execute` (:781)** | **no** |
| `fetch` (:814) | yes |

`execute` backs every write path — `dropTable`, `renameTable`, `renameView`, `dropNamespace` and the namespace property insert/update/delete — so a task cancelled while waiting for a pooled connection ends up with a thread whose interrupt status has been cleared by `Object.wait`. Anything downstream that polls `Thread.interrupted()` to decide whether to stop, including the executors Spark and Flink use to cancel work, sees a thread that was never interrupted.

The fix is the same one line the other three handlers already have.

## Testing

`TestJdbcCatalog.testExecuteRestoresInterruptStatus` builds a catalog with `clients=1`, holds the single pooled connection from another thread through the existing `@VisibleForTesting connectionPool()` accessor, interrupts the test thread, and asserts that `dropTable` both throws `UncheckedInterruptedException` and leaves the interrupt status set. It fails on `main` with `Expecting value to be true but was false` and passes with this change. Two latches rather than sleeps, so there is no timing window.

One thing worth flagging for whoever reviews the test: it has to call `dropTable(ident, false)`. The single-argument `dropTable` defaults to `purge = true`, which reads table metadata through `fetch` first — and `fetch` already restores the status, so the assertion would pass even without the fix. The same trap applies to `dropNamespace` and the property setters.

- `:iceberg-core:test --tests "org.apache.iceberg.jdbc.*"` — passes
- `:iceberg-core:spotlessCheck` — passes
