### PR TITLE
Docs: Add Fivetran to Integrations list

### DIFF
--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -126,7 +126,7 @@ Firebolt is also available as [Firebolt Core](https://docs.firebolt.io/firebolt-
 Learn more about querying Iceberg with Firebolt [here](https://www.firebolt.io/blog/querying-apache-iceberg-with-sub-second-performance).
 
 ### [Fivetran](https://www.fivetran.com)
-[Fivetran](https://www.fivetran.com), the global leader in data movement, is trusted by Enterprises to centralize data from SaaS applications and databases into cloud destinations, including [Managed Data Lakes](https://fivetran.com/docs/destinations/managed-data-lake-service). Fivetran Managed Data Lakes provides a fully managed Iceberg Data Lake for users. Users can connect any of the 700+ connections that Fivetran supports and write them directly into a Storage Location of their choice. Fivetran Managed Data Lake Service handles the ingestion and maintenance of their Iceberg tables and hosts a Iceberg Rest Complaint catalog endpoint for downstream consumption.
+[Fivetran](https://www.fivetran.com), the global leader in data movement, is trusted by Enterprises to centralize data from SaaS applications and databases into cloud destinations, including [Managed Data Lakes](https://fivetran.com/docs/managed-data-lake-service). Fivetran Managed Data Lakes provides a fully managed Iceberg Data Lake for users. Users can connect any of the 700+ connections that Fivetran supports and write them directly into a Storage Location of their choice. Fivetran Managed Data Lake Service handles the ingestion and maintenance of their Iceberg tables and hosts a Iceberg Rest Complaint catalog endpoint for downstream consumption.
 
 ### [Google Cloud](https://cloud.google.com)
 Google Cloud offers first class support for Apache Iceberg through BigLake to

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -78,6 +78,7 @@ nav:
         - DuckDB: https://duckdb.org/docs/preview/core_extensions/iceberg/overview
         - Estuary: https://docs.estuary.dev/reference/Connectors/materialization-connectors/apache-iceberg/
         - Firebolt: https://docs.firebolt.io/reference-sql/functions-reference/table-valued/read_iceberg
+        - Fivetran: https://fivetran.com/docs/managed-data-lake-service
         - Google BigQuery: https://cloud.google.com/bigquery/docs/iceberg-tables
         - Impala: https://impala.apache.org/docs/build/html/topics/impala_iceberg.html
         - Memiiso Debezium: https://memiiso.github.io/debezium-server-iceberg/


### PR DESCRIPTION
## Summary
- Add Fivetran to the Integrations nav list (`site/nav.yml`), linking to the [Managed Data Lake Service docs](https://fivetran.com/docs/managed-data-lake-service). Fivetran is already listed on the Vendors page, and other data movement tools (BladePipe, Estuary, OLake) already appear in Integrations.
- Fix a stale link in the existing Fivetran blurb on the Vendors page (`site/docs/vendors.md`), which pointed to `/docs/destinations/managed-data-lake-service` — the correct, current URL is `/docs/managed-data-lake-service`.

## Test plan
- [x] Verified new/updated URLs resolve correctly (not redirects/404s)
- [x] Confirmed placement is alphabetically ordered within the Integrations list