### PR TITLE
Core: Fix FixedByteBufferWriter to use writeFixed() for Avro fixed[N] fields

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/Avro.java
+++ b/core/src/main/java/org/apache/iceberg/avro/Avro.java
@@ -199,6 +199,7 @@ public class Avro {
         writerFunc = GenericAvroWriter::new;
       }
 
+      meta(AvroFileMetadataAware.FIXED_ENCODING_META_KEY, AvroFileMetadataAware.FIXED_ENCODING_V2);
       // add the Iceberg schema to keyValueMetadata
       meta("iceberg.schema", SchemaParser.toJson(schema));
 

--- a/core/src/main/java/org/apache/iceberg/avro/AvroFileMetadataAware.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroFileMetadataAware.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import java.util.Map;
+
+/**
+ * Interface for {@link org.apache.avro.io.DatumReader} implementations that need access to Avro
+ * file header metadata before reading records. {@link AvroIterable} calls {@link
+ * #setFileMetadata(Map)} after opening the file, allowing readers to adjust their behavior based on
+ * per-file encoding metadata.
+ */
+interface AvroFileMetadataAware {
+  /** Avro file metadata key that records the fixed-field encoding used when writing. */
+  String FIXED_ENCODING_META_KEY = "iceberg.avro.fixed-encoding";
+
+  /** Legacy encoding: fixed fields written with {@code encoder.writeBytes()} (length-prefixed). */
+  String FIXED_ENCODING_V1 = "v1";
+
+  /** Correct encoding: fixed fields written with {@code encoder.writeFixed()} (exact N bytes). */
+  String FIXED_ENCODING_V2 = "v2";
+
+  void setFileMetadata(Map<String, String> metadata);
+}

--- a/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
+++ b/core/src/main/java/org/apache/iceberg/avro/AvroIterable.java
@@ -77,6 +77,10 @@ public class AvroIterable<D> extends CloseableGroup implements CloseableIterable
   public CloseableIterator<D> iterator() {
     FileReader<D> fileReader = initMetadata(newFileReader());
 
+    if (reader instanceof AvroFileMetadataAware) {
+      ((AvroFileMetadataAware) reader).setFileMetadata(metadata);
+    }
+
     if (start != null) {
       if (reader instanceof SupportsRowPosition) {
         ((SupportsRowPosition) reader)

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -42,7 +42,8 @@ import org.apache.iceberg.util.Pair;
  *
  * @param <T> Java type returned by the reader
  */
-public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, SupportsCustomTypes {
+public class InternalReader<T>
+    implements DatumReader<T>, SupportsRowPosition, SupportsCustomTypes, AvroFileMetadataAware {
   private static final int ROOT_ID = -1;
 
   private final Types.StructType expectedType;
@@ -50,6 +51,7 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
   private final Map<Integer, Object> idToConstant = ImmutableMap.of();
   private Schema fileSchema = null;
   private ValueReader<T> reader = null;
+  private boolean useNewFixedEncoding = false;
 
   public static <D> InternalReader<D> create(org.apache.iceberg.Schema schema) {
     return new InternalReader<>(schema);
@@ -74,6 +76,18 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
   public void setSchema(Schema schema) {
     this.fileSchema = schema;
     initReader();
+  }
+
+  @Override
+  public void setFileMetadata(Map<String, String> metadata) {
+    this.useNewFixedEncoding =
+        AvroFileMetadataAware.FIXED_ENCODING_V2.equals(
+            metadata.getOrDefault(
+                AvroFileMetadataAware.FIXED_ENCODING_META_KEY,
+                AvroFileMetadataAware.FIXED_ENCODING_V1));
+    if (fileSchema != null) {
+      initReader();
+    }
   }
 
   @Override
@@ -222,7 +236,9 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
         case STRING:
           return ValueReaders.strings();
         case FIXED:
-          return ValueReaders.fixedBuffers(primitive.getFixedSize());
+          return useNewFixedEncoding
+              ? ValueReaders.fixedBuffers(primitive.getFixedSize())
+              : ValueReaders.byteBuffers();
         case BYTES:
           return ValueReaders.byteBuffers();
         case ENUM:

--- a/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/InternalReader.java
@@ -222,6 +222,7 @@ public class InternalReader<T> implements DatumReader<T>, SupportsRowPosition, S
         case STRING:
           return ValueReaders.strings();
         case FIXED:
+          return ValueReaders.fixedBuffers(primitive.getFixedSize());
         case BYTES:
           return ValueReaders.byteBuffers();
         case ENUM:

--- a/core/src/main/java/org/apache/iceberg/avro/NameMappingDatumReader.java
+++ b/core/src/main/java/org/apache/iceberg/avro/NameMappingDatumReader.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.avro;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.avro.Schema;
 import org.apache.avro.io.DatumReader;
@@ -31,7 +32,8 @@ import org.apache.iceberg.mapping.NameMapping;
  *
  * @param <D> Java class of datums produced by this reader
  */
-public class NameMappingDatumReader<D> implements DatumReader<D>, SupportsRowPosition {
+public class NameMappingDatumReader<D>
+    implements DatumReader<D>, SupportsRowPosition, AvroFileMetadataAware {
   private final NameMapping nameMapping;
   private final DatumReader<D> wrapped;
 
@@ -61,6 +63,13 @@ public class NameMappingDatumReader<D> implements DatumReader<D>, SupportsRowPos
   public void setRowPositionSupplier(Supplier<Long> posSupplier) {
     if (wrapped instanceof SupportsRowPosition) {
       ((SupportsRowPosition) wrapped).setRowPositionSupplier(posSupplier);
+    }
+  }
+
+  @Override
+  public void setFileMetadata(Map<String, String> fileMetadata) {
+    if (wrapped instanceof AvroFileMetadataAware) {
+      ((AvroFileMetadataAware) wrapped).setFileMetadata(fileMetadata);
     }
   }
 }

--- a/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueReaders.java
@@ -128,6 +128,10 @@ public class ValueReaders {
     return ByteBufferReader.INSTANCE;
   }
 
+  public static ValueReader<ByteBuffer> fixedBuffers(int length) {
+    return new FixedByteBufferReader(length);
+  }
+
   public static ValueReader<BigDecimal> decimal(ValueReader<byte[]> unscaledReader, int scale) {
     return new DecimalReader(unscaledReader, scale);
   }
@@ -703,6 +707,26 @@ public class ValueReaders {
     @Override
     public void skip(Decoder decoder) throws IOException {
       decoder.skipBytes();
+    }
+  }
+
+  private static class FixedByteBufferReader implements ValueReader<ByteBuffer> {
+    private final int length;
+
+    private FixedByteBufferReader(int length) {
+      this.length = length;
+    }
+
+    @Override
+    public ByteBuffer read(Decoder decoder, Object reuse) throws IOException {
+      byte[] bytes = new byte[length];
+      decoder.readFixed(bytes, 0, length);
+      return ByteBuffer.wrap(bytes);
+    }
+
+    @Override
+    public void skip(Decoder decoder) throws IOException {
+      decoder.skipFixed(length);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -360,7 +360,9 @@ public class ValueWriters {
           "Cannot write byte buffer of length %s as fixed[%s]",
           bytes.remaining(),
           length);
-      encoder.writeBytes(bytes);
+      byte[] arr = new byte[length];
+      bytes.duplicate().get(arr);
+      encoder.writeFixed(arr);
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
@@ -1,0 +1,156 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.avro;
+
+import static org.apache.iceberg.types.Types.NestedField.optional;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.EncoderFactory;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.ManifestFile;
+import org.apache.iceberg.ManifestFiles;
+import org.apache.iceberg.ManifestReader;
+import org.apache.iceberg.ManifestWriter;
+import org.apache.iceberg.PartitionSpec;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+public class TestFixedByteBufferWriter {
+
+  @TempDir java.nio.file.Path temp;
+
+  /**
+   * Regression test for FIXED(N) Avro encoding. FixedByteBufferWriter must call
+   * encoder.writeFixed() (exact N bytes) not encoder.writeBytes() (zigzag length prefix + data).
+   * With writeBytes(), the length prefix spills into the next field in the record and corrupts it.
+   */
+  @Test
+  public void testFixedWriterProducesExactBytes() throws IOException {
+    byte[] input = new byte[] {(byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
+    ByteBuffer value = ByteBuffer.wrap(input);
+
+    ValueWriter<ByteBuffer> writer = ValueWriters.fixedBuffers(3);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+    writer.write(value, encoder);
+    encoder.flush();
+
+    byte[] written = out.toByteArray();
+
+    // writeFixed emits exactly 3 bytes: AB CD EF
+    // writeBytes would emit 4 bytes: 06 AB CD EF  (zigzag(3)=0x06 prefix + data)
+    assertThat(written).hasSize(3);
+    assertThat(written).isEqualTo(input);
+  }
+
+  /**
+   * Regression test for manifest round-trip with a FIXED(N) identity-partition column. Verifies
+   * that record_count and partition value survive a write/read cycle without corruption. Before the
+   * fix, record_count read back as -568 instead of 4 because the zigzag length prefix written by
+   * writeBytes() spilled into the record_count varint.
+   */
+  @Test
+  public void testManifestRoundTripWithFixedPartition() throws IOException {
+    Schema schema =
+        new Schema(
+            optional(1, "val1", Types.IntegerType.get()),
+            optional(2, "val8", Types.FixedType.ofLength(3)));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("val8").build();
+
+    byte[] partitionBytes = new byte[] {(byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
+
+    DataFile dataFile =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(1024)
+            .withPartition(partitionData(spec, partitionBytes))
+            .withRecordCount(4)
+            .build();
+
+    OutputFile outputFile = Files.localOutput(temp.resolve("manifest.avro").toFile());
+    ManifestWriter<DataFile> writer = ManifestFiles.write(2, spec, outputFile, 1L);
+    try {
+      writer.add(dataFile);
+    } finally {
+      writer.close();
+    }
+
+    ManifestFile manifest = writer.toManifestFile();
+    FileIO fileIO =
+        new FileIO() {
+          @Override
+          public InputFile newInputFile(String path) {
+            return Files.localInput(path);
+          }
+
+          @Override
+          public OutputFile newOutputFile(String path) {
+            return Files.localOutput(path);
+          }
+
+          @Override
+          public void deleteFile(String path) {}
+        };
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, fileIO)) {
+      List<DataFile> files = Lists.newArrayList((CloseableIterable<DataFile>) reader);
+      assertThat(files).hasSize(1);
+
+      DataFile read = Iterables.getOnlyElement(files);
+
+      assertThat(read.recordCount())
+          .as("record_count must not be corrupted by a stray length-prefix byte")
+          .isEqualTo(4L);
+
+      ByteBuffer readPartition = (ByteBuffer) read.partition().get(0, ByteBuffer.class);
+      byte[] readBytes = new byte[readPartition.remaining()];
+      readPartition.duplicate().get(readBytes);
+      assertThat(readBytes)
+          .as("FIXED(3) partition value must survive the manifest round-trip unchanged")
+          .isEqualTo(partitionBytes);
+    }
+  }
+
+  private static org.apache.iceberg.StructLike partitionData(
+      PartitionSpec spec, byte[] fixedBytes) {
+    org.apache.iceberg.PartitionData data =
+        new org.apache.iceberg.PartitionData(spec.partitionType());
+    data.set(0, ByteBuffer.wrap(fixedBytes));
+    return data;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
@@ -22,10 +22,21 @@ import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
+import java.util.Map;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;
@@ -42,6 +53,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -142,6 +154,139 @@ public class TestFixedByteBufferWriter {
           .as("FIXED(3) partition value must survive the manifest round-trip unchanged")
           .isEqualTo(partitionBytes);
     }
+  }
+
+  /**
+   * End-to-end regression test for the backward-compat read path. Simulates a manifest written by a
+   * pre-fix writer: FIXED fields encoded with {@code writeBytes()} (length-prefixed) and no {@code
+   * iceberg.avro.fixed-encoding} header. The reader must detect the absent header, select {@link
+   * ValueReaders#byteBuffers()}, and decode the data without corruption.
+   */
+  @Test
+  public void testLegacyManifestRoundTrip() throws IOException {
+    Schema schema =
+        new Schema(
+            optional(1, "val1", Types.IntegerType.get()),
+            optional(2, "val8", Types.FixedType.ofLength(3)));
+
+    PartitionSpec spec = PartitionSpec.builderFor(schema).identity("val8").build();
+
+    byte[] partitionBytes = new byte[] {(byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
+
+    DataFile dataFile =
+        DataFiles.builder(spec)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(1024)
+            .withPartition(partitionData(spec, partitionBytes))
+            .withRecordCount(4)
+            .build();
+
+    // Write a normal v2 manifest to get the Avro schema, metadata, and encoded records.
+    File manifestFile = temp.resolve("manifest.avro").toFile();
+    ManifestWriter<DataFile> v2Writer =
+        ManifestFiles.write(2, spec, Files.localOutput(manifestFile), 1L);
+    try {
+      v2Writer.add(dataFile);
+    } finally {
+      v2Writer.close();
+    }
+    ManifestFile manifest = v2Writer.toManifestFile();
+
+    // Read the v2 manifest as generic Avro records, collecting schema and non-encoding metadata.
+    org.apache.avro.Schema avroSchema;
+    Map<String, byte[]> metaToCopy = Maps.newHashMap();
+    List<GenericRecord> rows = Lists.newArrayList();
+    try (DataFileReader<GenericRecord> dfr =
+        new DataFileReader<>(manifestFile, new GenericDatumReader<>())) {
+      avroSchema = dfr.getSchema();
+      for (String key : dfr.getMetaKeys()) {
+        // Skip Avro-reserved keys (written automatically by DataFileWriter) and the encoding
+        // stamp so the rewritten file looks like a pre-fix legacy manifest.
+        if (!key.startsWith("avro.")
+            && !AvroFileMetadataAware.FIXED_ENCODING_META_KEY.equals(key)) {
+          metaToCopy.put(key, dfr.getMeta(key));
+        }
+      }
+      while (dfr.hasNext()) {
+        rows.add(dfr.next());
+      }
+    }
+
+    // Overwrite the manifest with legacy encoding: writeBytes() for all FIXED fields, no stamp.
+    GenericDatumWriter<GenericRecord> legacyDatumWriter =
+        new GenericDatumWriter<GenericRecord>(avroSchema) {
+          @Override
+          protected void writeFixed(org.apache.avro.Schema schema, Object datum, Encoder out)
+              throws IOException {
+            out.writeBytes(ByteBuffer.wrap(((GenericData.Fixed) datum).bytes()));
+          }
+        };
+    try (DataFileWriter<GenericRecord> dfw = new DataFileWriter<>(legacyDatumWriter)) {
+      metaToCopy.forEach(dfw::setMeta);
+      dfw.create(avroSchema, manifestFile);
+      for (GenericRecord row : rows) {
+        dfw.append(row);
+      }
+    }
+
+    // Read back through ManifestFiles — exercises the full InternalReader dispatch path.
+    // The absent header causes InternalReader to use byteBuffers() instead of fixedBuffers().
+    FileIO fileIO =
+        new FileIO() {
+          @Override
+          public InputFile newInputFile(String path) {
+            return Files.localInput(path);
+          }
+
+          @Override
+          public OutputFile newOutputFile(String path) {
+            return Files.localOutput(path);
+          }
+
+          @Override
+          public void deleteFile(String path) {}
+        };
+
+    try (ManifestReader<DataFile> reader = ManifestFiles.read(manifest, fileIO)) {
+      List<DataFile> files = Lists.newArrayList((CloseableIterable<DataFile>) reader);
+      assertThat(files).hasSize(1);
+
+      DataFile read = Iterables.getOnlyElement(files);
+
+      assertThat(read.recordCount())
+          .as("record_count must not be corrupted when reading a legacy manifest")
+          .isEqualTo(4L);
+
+      ByteBuffer readPartition = (ByteBuffer) read.partition().get(0, ByteBuffer.class);
+      byte[] readBytes = new byte[readPartition.remaining()];
+      readPartition.duplicate().get(readBytes);
+      assertThat(readBytes)
+          .as("FIXED(3) partition value must be read correctly from a legacy manifest")
+          .isEqualTo(partitionBytes);
+    }
+  }
+
+  /**
+   * Verifies that the legacy reader ({@code ValueReaders.byteBuffers()}) correctly decodes bytes
+   * that were written with {@code encoder.writeBytes()} — the old buggy encoding used by pre-fix
+   * writers. The new reader uses {@link AvroFileMetadataAware} to detect old files (no {@code
+   * iceberg.avro.fixed-encoding} header) and falls back to this path automatically.
+   */
+  @Test
+  public void testLegacyReaderDecodesOldEncoding() throws IOException {
+    byte[] input = new byte[] {(byte) 0xAB, (byte) 0xCD, (byte) 0xEF};
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    BinaryEncoder encoder = EncoderFactory.get().binaryEncoder(out, null);
+    encoder.writeBytes(ByteBuffer.wrap(input));
+    encoder.flush();
+
+    BinaryDecoder decoder = DecoderFactory.get().binaryDecoder(out.toByteArray(), null);
+    ByteBuffer result = ValueReaders.byteBuffers().read(decoder, null);
+
+    byte[] readBytes = new byte[result.remaining()];
+    result.duplicate().get(readBytes);
+    assertThat(readBytes).isEqualTo(input);
   }
 
   private static org.apache.iceberg.StructLike partitionData(

--- a/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
+++ b/core/src/test/java/org/apache/iceberg/avro/TestFixedByteBufferWriter.java
@@ -26,8 +26,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.avro.io.BinaryEncoder;
-import org.apache.avro.io.DatumReader;
-import org.apache.avro.io.DecoderFactory;
 import org.apache.avro.io.EncoderFactory;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DataFiles;


### PR DESCRIPTION
## Problem

`FixedByteBufferWriter.write()` was calling `encoder.writeBytes()`, which prepends a zigzag-encoded length prefix before the payload. For Avro `fixed[N]` fields this is wrong — the reader expects exactly N bytes with no prefix. The stray length byte spills into the next field in the record and corrupts it.

For example, writing a `FIXED(3)` partition value `[AB CD EF]` produced `[06 AB CD EF]` on disk (where `06` is `zigzag(3)`). The reader then consumed `[06 AB CD]` as the partition value, and the leftover `[EF]` corrupted the subsequent `record_count` field, decoding it as `-568` instead of the actual row count.

## Fix

### Write path

`FixedByteBufferWriter.write()` now calls `encoder.writeFixed()` (exact N bytes, no prefix), matching the existing `FixedWriter` for `byte[]`.

### Read path — backward compatibility

Existing manifests on disk were written with the buggy `writeBytes()` encoding and cannot be re-written. To remain readable, the reader selects the correct decoder based on a per-file stamp in the Avro file header:

- **New writer** (`Avro.build()`) unconditionally writes `iceberg.avro.fixed-encoding = v2` into every file's Avro metadata header.
- **`AvroFileMetadataAware`** — new package-private interface. `AvroIterable.iterator()` calls `setFileMetadata(Map)` on any `DatumReader` that implements it after opening the file, bridging the timing gap between reader construction and file open.
- **`NameMappingDatumReader`** — now implements `AvroFileMetadataAware` and delegates to the wrapped reader.
- **`InternalReader`** — implements `AvroFileMetadataAware`. In `setFileMetadata()`, it checks for the `v2` stamp: present → `ValueReaders.fixedBuffers(n)` (new `readFixed` path); absent → `ValueReaders.byteBuffers()` (legacy `readBytes` path). The reader tree is rebuilt only when the encoding changes.

Mixed tables (some manifests old, some new) are handled automatically because the encoding is detected per file.

## Tests

`TestFixedByteBufferWriter` adds four regression tests:

- **`testFixedWriterProducesExactBytes`** — directly verifies the encoder emits exactly N bytes with no length prefix.
- **`testManifestRoundTripWithFixedPartition`** — writes and reads back a manifest with a `FIXED(3)` identity-partition column via the new encoding; asserts both the partition value and `record_count` survive uncorrupted.
- **`testLegacyManifestRoundTrip`** — simulates a pre-fix manifest (re-encodes a manifest with `writeBytes()` for fixed fields and strips the header stamp), then reads it back through `ManifestFiles.read()`. Covers the full backward-compat dispatch: absent stamp → `byteBuffers()`.
- **`testLegacyReaderDecodesOldEncoding`** — unit test for `ValueReaders.byteBuffers()` decoding a `writeBytes()`-encoded byte sequence.