### PR TITLE
Core: Fix a typo in the comment

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableProperties.java
+++ b/core/src/main/java/org/apache/iceberg/TableProperties.java
@@ -289,7 +289,7 @@ public class TableProperties {
   public static final String OBJECT_STORE_ENABLED = "write.object-storage.enabled";
   public static final boolean OBJECT_STORE_ENABLED_DEFAULT = false;
 
-  // Excludes the partition values in the path when set to true and object store is enabled
+  // Includes the partition values in the path when set to true and object store is enabled
   public static final String WRITE_OBJECT_STORE_PARTITIONED_PATHS =
       "write.object-storage.partitioned-paths";
   public static final boolean WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT = true;


### PR DESCRIPTION
In [`ObjectStoreLocationProvider`](https://github.com/apache/iceberg/blob/apache-iceberg-1.11.0/core/src/main/java/org/apache/iceberg/LocationProviders.java), the property is used to include partition paths instead of excluding them.

```java
      this.includePartitionPaths =
          PropertyUtil.propertyAsBoolean(
              properties,
              TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS,
              TableProperties.WRITE_OBJECT_STORE_PARTITIONED_PATHS_DEFAULT);
```