### PR TITLE
fix: use writeFixed instead of writeBytes for FixedByteBufferWriter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -360,7 +360,9 @@ public class ValueWriters {
           "Cannot write byte buffer of length %s as fixed[%s]",
           bytes.remaining(),
           length);
-      encoder.writeBytes(bytes);
+      byte[] arr = new byte[bytes.remaining()];
+      bytes.duplicate().get(arr);
+      encoder.writeFixed(arr);
     }
   }
 


### PR DESCRIPTION
## Bug fix: `FixedByteBufferWriter` uses `writeBytes` instead of `writeFixed` for Avro `fixed[N]` fields

Fixes #17501

### Problem

`ValueWriters.FixedByteBufferWriter.write(ByteBuffer, Encoder)` calls `encoder.writeBytes(bytes)` instead of `encoder.writeFixed(bytes)`. For Avro `fixed[N]` fields this is wrong: `writeBytes` prepends a zigzag-encoded length prefix before the data, but the Avro reader consumes exactly N bytes for a `fixed` field and has no length prefix to skip. The stray prefix byte spills into the next field in the record.

### Fix

Convert the `ByteBuffer` to a `byte[]` and call `encoder.writeFixed(arr)` instead.

### Testing

Existing tests for `fixed[N]` fields with `ByteBuffer` values should now pass without corruption. The sibling class `FixedWriter` (which handles `byte[]`) already uses `writeFixed` correctly.