### PR TITLE
fix: ValueWriters.FixedByteBufferWriter should use writeFixed(), not writeBytes() [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
+++ b/core/src/main/java/org/apache/iceberg/avro/ValueWriters.java
@@ -360,7 +360,9 @@ public class ValueWriters {
           "Cannot write byte buffer of length %s as fixed[%s]",
           bytes.remaining(),
           length);
-      encoder.writeBytes(bytes);
+      byte[] arr = new byte[length];
+      bytes.duplicate().get(arr);
+      encoder.writeFixed(arr, 0, length);
     }
   }
 


### PR DESCRIPTION
## Description

For Avro `fixed[N]` fields, the encoder must write fixed-length data
without a length prefix. `writeBytes()` writes a length-prefixed bytes
value, which corrupts the Avro binary encoding for `fixed[N]` schema.

## Fix

Replace `encoder.writeBytes(bytes)` with the correct fixed-length write:

```java
byte[] arr = new byte[length];
bytes.duplicate().get(arr);
encoder.writeFixed(arr, 0, length);
```

## Testing

- The `Preconditions.checkArgument` validates `bytes.remaining() == length` before the write
- `duplicate()` creates a view so the original buffer's position is not modified
- All existing tests should pass (the fix only changes the Avro encoding method, not the data)

Fixes #17501
