### PR TITLE
Common: Fail fast when DynConstructors impl does not implement base class

### DIFF
--- a/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
+++ b/common/src/main/java/org/apache/iceberg/common/DynConstructors.java
@@ -157,6 +157,18 @@ public class DynConstructors {
         return this;
       }
 
+      // validate assignability if baseClass is set
+      if (baseClass != null && !baseClass.isAssignableFrom(targetClass)) {
+        problems.put(
+            methodName(targetClass, types),
+            new IllegalArgumentException(
+                "Implementation class "
+                    + targetClass.getName()
+                    + " does not implement "
+                    + baseClass.getName()));
+        return this;
+      }
+
       try {
         ctor = new Ctor<>(targetClass.getConstructor(types), targetClass);
       } catch (NoSuchMethodException e) {
@@ -189,6 +201,18 @@ public class DynConstructors {
         return this;
       }
 
+      // validate assignability if baseClass is set
+      if (baseClass != null && !baseClass.isAssignableFrom(targetClass)) {
+        problems.put(
+            methodName(targetClass, types),
+            new IllegalArgumentException(
+                "Implementation class "
+                    + targetClass.getName()
+                    + " does not implement "
+                    + baseClass.getName()));
+        return this;
+      }
+
       try {
         Constructor<T> hidden = targetClass.getDeclaredConstructor(types);
         AccessController.doPrivileged(new MakeAccessible(hidden));
@@ -208,6 +232,12 @@ public class DynConstructors {
       if (ctor != null) {
         return (Ctor<C>) ctor;
       }
+      // throw assignability errors with priority
+      for (Throwable problem : problems.values()) {
+        if (problem instanceof IllegalArgumentException) {
+          throw (IllegalArgumentException) problem;
+        }
+      }
       throw buildCheckedException(baseClass, problems);
     }
 
@@ -215,6 +245,12 @@ public class DynConstructors {
     public <C> Ctor<C> build() {
       if (ctor != null) {
         return (Ctor<C>) ctor;
+      }
+      // throw assignability errors with priority
+      for (Throwable problem : problems.values()) {
+        if (problem instanceof IllegalArgumentException) {
+          throw (IllegalArgumentException) problem;
+        }
       }
       throw buildRuntimeException(baseClass, problems);
     }

--- a/common/src/test/java/org/apache/iceberg/common/TestDynConstructors.java
+++ b/common/src/test/java/org/apache/iceberg/common/TestDynConstructors.java
@@ -42,29 +42,25 @@ public class TestDynConstructors {
 
   @Test
   public void testInterfaceWrongImplString() throws Exception {
-    DynConstructors.Ctor<MyInterface> ctor =
+    DynConstructors.Builder builder =
         DynConstructors.builder(MyInterface.class)
-            // TODO this should throw, since the MyUnrelatedClass does not implement MyInterface
-            .impl("org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass")
-            .buildChecked();
-    assertThatThrownBy(ctor::newInstance)
-        .isInstanceOf(ClassCastException.class)
-        .hasMessageStartingWith(
-            "class org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass cannot be cast to class org.apache.iceberg.common.TestDynConstructors$MyInterface");
+            .impl("org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass");
+    assertThatThrownBy(builder::buildChecked)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Implementation class org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass"
+                + " does not implement org.apache.iceberg.common.TestDynConstructors$MyInterface");
   }
 
   @Test
   public void testInterfaceWrongImplClass() throws Exception {
-    DynConstructors.Ctor<MyInterface> ctor =
-        DynConstructors.builder(MyInterface.class)
-            // TODO this should throw or not compile at all, since the MyUnrelatedClass does not
-            // implement MyInterface
-            .impl(MyUnrelatedClass.class)
-            .buildChecked();
-    assertThatThrownBy(ctor::newInstance)
-        .isInstanceOf(ClassCastException.class)
-        .hasMessageStartingWith(
-            "class org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass cannot be cast to class org.apache.iceberg.common.TestDynConstructors$MyInterface");
+    DynConstructors.Builder builder =
+        DynConstructors.builder(MyInterface.class).impl(MyUnrelatedClass.class);
+    assertThatThrownBy(builder::buildChecked)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining(
+            "Implementation class org.apache.iceberg.common.TestDynConstructors$MyUnrelatedClass"
+                + " does not implement org.apache.iceberg.common.TestDynConstructors$MyInterface");
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Validate DynConstructors implementation classes against the configured base class at build time
- Throw `IllegalArgumentException` with a clear message when an impl does not implement the base class
- Update `TestDynConstructors` to assert build-time failure instead of `ClassCastException` at instantiation

## Test plan
- [x] `./gradlew :iceberg-common:test --tests org.apache.iceberg.common.TestDynConstructors`

Closes #17506