### PR TITLE
[1.11.x] Core, Spark: Do not rewrite delete files excluded from the copy plan

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -454,7 +454,9 @@ public class RewriteTablePathUtil {
       case POSITION_DELETES:
         DeleteFile posDeleteFile = newPositionDeleteEntry(file, spec, sourcePrefix, targetPrefix);
         appendEntryWithFile(entry, writer, posDeleteFile);
-        // keep the following entries in metadata but exclude them from copyPlan
+        // keep the following entries in metadata but exclude them from the copy plan
+        // and from physical rewriting, as their files may no longer exist on storage
+        // after expire_snapshots:
         // 1) deleted position delete files
         // 2) entries not changed by snapshotIds
         if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
@@ -464,8 +466,8 @@ public class RewriteTablePathUtil {
                   Pair.of(
                       stagingPath(file.location(), sourcePrefix, stagingLocation),
                       posDeleteFile.location()));
+          result.toRewrite().add(file.copy());
         }
-        result.toRewrite().add(file.copy());
         return result;
       case EQUALITY_DELETES:
         DeleteFile eqDeleteFile = newEqualityDeleteEntry(file, spec, sourcePrefix, targetPrefix);

--- a/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.4/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -764,6 +764,143 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  void rewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table tableWithPosDeletes =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletes"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(tableWithPosDeletes)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+
+    // the output file argument is ignored for format version >= 3: the deletion vector is
+    // written as a Puffin file into the table's data location
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                tableWithPosDeletes,
+                tableWithPosDeletes
+                    .io()
+                    .newOutputFile(tableWithPosDeletes.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    tableWithPosDeletes.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // compaction drops the position delete file, leaving a DELETED entry in the delete manifest
+    actions().rewriteDataFiles(tableWithPosDeletes).execute();
+    tableWithPosDeletes.refresh();
+
+    // expiring the older snapshots physically removes the dropped position delete file, while the
+    // DELETED entry referencing it survives in the current snapshot's delete manifest
+    actions()
+        .expireSnapshots(tableWithPosDeletes)
+        .expireOlderThan(tableWithPosDeletes.currentSnapshot().timestampMillis())
+        .execute();
+    tableWithPosDeletes.refresh();
+    assertThat(tableWithPosDeletes.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // a full rewrite must not attempt to physically rewrite an entry it does not copy
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(tableWithPosDeletes)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(tableWithPosDeletes.location(), targetTableLocation())
+            .execute();
+
+    assertThat(result.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(result);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(tableWithPosDeletes.location()).collectAsList());
+  }
+
+  @TestTemplate
+  void incrementalRewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table sourceTable =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletesIncremental"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(sourceTable)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable,
+                sourceTable.io().newOutputFile(sourceTable.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // replicate the table, including the live position delete file
+    RewriteTablePath.Result initialResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .execute();
+    assertThat(initialResult.rewrittenDeleteFilePathsCount()).isEqualTo(1);
+    copyTableFiles(initialResult);
+    String startVersion = fileName(currentMetadata(sourceTable).metadataFileLocation());
+
+    // on the source: compaction drops the position delete file, then expiry removes it from
+    // storage, while the DELETED entry survives in the current snapshot's delete manifest
+    actions().rewriteDataFiles(sourceTable).execute();
+    sourceTable.refresh();
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis())
+        .execute();
+    sourceTable.refresh();
+    assertThat(sourceTable.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // an incremental rewrite spanning the expiry must not attempt to physically rewrite the
+    // dropped position delete file
+    RewriteTablePath.Result incrementalResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .startVersion(startVersion)
+            .execute();
+    assertThat(incrementalResult.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(incrementalResult);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(sourceTable.location()).collectAsList());
+  }
+
+  @TestTemplate
   public void testExpireSnapshotBeforeRewrite() throws Exception {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -764,6 +764,143 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  void rewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table tableWithPosDeletes =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletes"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(tableWithPosDeletes)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+
+    // the output file argument is ignored for format version >= 3: the deletion vector is
+    // written as a Puffin file into the table's data location
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                tableWithPosDeletes,
+                tableWithPosDeletes
+                    .io()
+                    .newOutputFile(tableWithPosDeletes.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    tableWithPosDeletes.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // compaction drops the position delete file, leaving a DELETED entry in the delete manifest
+    actions().rewriteDataFiles(tableWithPosDeletes).execute();
+    tableWithPosDeletes.refresh();
+
+    // expiring the older snapshots physically removes the dropped position delete file, while the
+    // DELETED entry referencing it survives in the current snapshot's delete manifest
+    actions()
+        .expireSnapshots(tableWithPosDeletes)
+        .expireOlderThan(tableWithPosDeletes.currentSnapshot().timestampMillis())
+        .execute();
+    tableWithPosDeletes.refresh();
+    assertThat(tableWithPosDeletes.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // a full rewrite must not attempt to physically rewrite an entry it does not copy
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(tableWithPosDeletes)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(tableWithPosDeletes.location(), targetTableLocation())
+            .execute();
+
+    assertThat(result.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(result);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(tableWithPosDeletes.location()).collectAsList());
+  }
+
+  @TestTemplate
+  void incrementalRewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table sourceTable =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletesIncremental"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(sourceTable)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable,
+                sourceTable.io().newOutputFile(sourceTable.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // replicate the table, including the live position delete file
+    RewriteTablePath.Result initialResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .execute();
+    assertThat(initialResult.rewrittenDeleteFilePathsCount()).isEqualTo(1);
+    copyTableFiles(initialResult);
+    String startVersion = fileName(currentMetadata(sourceTable).metadataFileLocation());
+
+    // on the source: compaction drops the position delete file, then expiry removes it from
+    // storage, while the DELETED entry survives in the current snapshot's delete manifest
+    actions().rewriteDataFiles(sourceTable).execute();
+    sourceTable.refresh();
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis())
+        .execute();
+    sourceTable.refresh();
+    assertThat(sourceTable.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // an incremental rewrite spanning the expiry must not attempt to physically rewrite the
+    // dropped position delete file
+    RewriteTablePath.Result incrementalResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .startVersion(startVersion)
+            .execute();
+    assertThat(incrementalResult.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(incrementalResult);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(sourceTable.location()).collectAsList());
+  }
+
+  @TestTemplate
   public void testExpireSnapshotBeforeRewrite() throws Exception {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -764,6 +764,143 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  void rewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table tableWithPosDeletes =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletes"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(tableWithPosDeletes)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+
+    // the output file argument is ignored for format version >= 3: the deletion vector is
+    // written as a Puffin file into the table's data location
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                tableWithPosDeletes,
+                tableWithPosDeletes
+                    .io()
+                    .newOutputFile(tableWithPosDeletes.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    tableWithPosDeletes.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // compaction drops the position delete file, leaving a DELETED entry in the delete manifest
+    actions().rewriteDataFiles(tableWithPosDeletes).execute();
+    tableWithPosDeletes.refresh();
+
+    // expiring the older snapshots physically removes the dropped position delete file, while the
+    // DELETED entry referencing it survives in the current snapshot's delete manifest
+    actions()
+        .expireSnapshots(tableWithPosDeletes)
+        .expireOlderThan(tableWithPosDeletes.currentSnapshot().timestampMillis())
+        .execute();
+    tableWithPosDeletes.refresh();
+    assertThat(tableWithPosDeletes.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // a full rewrite must not attempt to physically rewrite an entry it does not copy
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(tableWithPosDeletes)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(tableWithPosDeletes.location(), targetTableLocation())
+            .execute();
+
+    assertThat(result.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(result);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(tableWithPosDeletes.location()).collectAsList());
+  }
+
+  @TestTemplate
+  void incrementalRewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table sourceTable =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletesIncremental"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(sourceTable)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable,
+                sourceTable.io().newOutputFile(sourceTable.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // replicate the table, including the live position delete file
+    RewriteTablePath.Result initialResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .execute();
+    assertThat(initialResult.rewrittenDeleteFilePathsCount()).isEqualTo(1);
+    copyTableFiles(initialResult);
+    String startVersion = fileName(currentMetadata(sourceTable).metadataFileLocation());
+
+    // on the source: compaction drops the position delete file, then expiry removes it from
+    // storage, while the DELETED entry survives in the current snapshot's delete manifest
+    actions().rewriteDataFiles(sourceTable).execute();
+    sourceTable.refresh();
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis())
+        .execute();
+    sourceTable.refresh();
+    assertThat(sourceTable.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // an incremental rewrite spanning the expiry must not attempt to physically rewrite the
+    // dropped position delete file
+    RewriteTablePath.Result incrementalResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .startVersion(startVersion)
+            .execute();
+    assertThat(incrementalResult.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(incrementalResult);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(sourceTable.location()).collectAsList());
+  }
+
+  @TestTemplate
   public void testExpireSnapshotBeforeRewrite() throws Exception {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -764,6 +764,143 @@ public class TestRewriteTablePathsAction extends TestBase {
   }
 
   @TestTemplate
+  void rewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table tableWithPosDeletes =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletes"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(tableWithPosDeletes)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+
+    // the output file argument is ignored for format version >= 3: the deletion vector is
+    // written as a Puffin file into the table's data location
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                tableWithPosDeletes,
+                tableWithPosDeletes
+                    .io()
+                    .newOutputFile(tableWithPosDeletes.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    tableWithPosDeletes.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // compaction drops the position delete file, leaving a DELETED entry in the delete manifest
+    actions().rewriteDataFiles(tableWithPosDeletes).execute();
+    tableWithPosDeletes.refresh();
+
+    // expiring the older snapshots physically removes the dropped position delete file, while the
+    // DELETED entry referencing it survives in the current snapshot's delete manifest
+    actions()
+        .expireSnapshots(tableWithPosDeletes)
+        .expireOlderThan(tableWithPosDeletes.currentSnapshot().timestampMillis())
+        .execute();
+    tableWithPosDeletes.refresh();
+    assertThat(tableWithPosDeletes.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // a full rewrite must not attempt to physically rewrite an entry it does not copy
+    RewriteTablePath.Result result =
+        actions()
+            .rewriteTablePath(tableWithPosDeletes)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(tableWithPosDeletes.location(), targetTableLocation())
+            .execute();
+
+    assertThat(result.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(result);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(tableWithPosDeletes.location()).collectAsList());
+  }
+
+  @TestTemplate
+  void incrementalRewriteAfterExpiringDeletedPositionDeleteFile() throws Exception {
+    assumeThat(formatVersion)
+        .as("Compaction only removes the delete file from storage once it is a deletion vector")
+        .isGreaterThanOrEqualTo(3);
+    Table sourceTable =
+        createTableWithSnapshots(
+            tableDir.toFile().toURI().toString().concat("expiredPosDeletesIncremental"), 2);
+
+    List<Pair<CharSequence, Long>> deletes =
+        Lists.newArrayList(
+            Pair.of(
+                SnapshotChanges.builderFor(sourceTable)
+                    .build()
+                    .addedDataFiles()
+                    .iterator()
+                    .next()
+                    .location(),
+                0L));
+    DeleteFile positionDeletes =
+        FileHelpers.writeDeleteFile(
+                sourceTable,
+                sourceTable.io().newOutputFile(sourceTable.location() + "/data/deletes.puffin"),
+                deletes,
+                formatVersion)
+            .first();
+    sourceTable.newRowDelta().addDeletes(positionDeletes).commit();
+
+    // replicate the table, including the live position delete file
+    RewriteTablePath.Result initialResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .execute();
+    assertThat(initialResult.rewrittenDeleteFilePathsCount()).isEqualTo(1);
+    copyTableFiles(initialResult);
+    String startVersion = fileName(currentMetadata(sourceTable).metadataFileLocation());
+
+    // on the source: compaction drops the position delete file, then expiry removes it from
+    // storage, while the DELETED entry survives in the current snapshot's delete manifest
+    actions().rewriteDataFiles(sourceTable).execute();
+    sourceTable.refresh();
+    actions()
+        .expireSnapshots(sourceTable)
+        .expireOlderThan(sourceTable.currentSnapshot().timestampMillis())
+        .execute();
+    sourceTable.refresh();
+    assertThat(sourceTable.io().newInputFile(positionDeletes.location()).exists())
+        .as("Expired position delete file should have been removed from storage")
+        .isFalse();
+
+    // an incremental rewrite spanning the expiry must not attempt to physically rewrite the
+    // dropped position delete file
+    RewriteTablePath.Result incrementalResult =
+        actions()
+            .rewriteTablePath(sourceTable)
+            .stagingLocation(stagingLocation())
+            .rewriteLocationPrefix(sourceTable.location(), targetTableLocation())
+            .startVersion(startVersion)
+            .execute();
+    assertThat(incrementalResult.rewrittenDeleteFilePathsCount())
+        .as("The expired DELETED entry must not be queued for physical rewriting")
+        .isEqualTo(0);
+
+    copyTableFiles(incrementalResult);
+    assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
+        .containsExactlyInAnyOrderElementsOf(
+            spark.read().format("iceberg").load(sourceTable.location()).collectAsList());
+  }
+
+  @TestTemplate
   public void testExpireSnapshotBeforeRewrite() throws Exception {
     // expire one snapshot
     actions().expireSnapshots(table).expireSnapshotId(table.currentSnapshot().parentId()).execute();


### PR DESCRIPTION
Closes #17498.

This targets `1.11.x` only. `main` is not affected: there, `positionDeletesToRewrite()` collects the files to rewrite from live manifest entries, so the bug does not exist and there is no corresponding `main` PR to backport from.

## Problem

`RewriteTablePathUtil.writeDeleteFileEntry` applies a filter when building the copy plan: only entries that are live and added within the requested delta are copied. Entries that are `DELETED` (history markers) or outside the delta are still written into the rewritten manifest, but excluded from the copy plan.

The physical-rewrite set did not apply the same filter — every position delete entry was queued unconditionally:

```java
if (entry.isLive() && snapshotIds.contains(entry.snapshotId())) {
  result.copyPlan().add(...);
}
result.toRewrite().add(file.copy());   // unconditional
```

Position delete files must be physically rewritten because they embed absolute data file paths, so `RewriteTablePathSparkAction` opens every file in `toRewrite`. When the entry is a `DELETED` marker whose underlying file was already removed by `expire_snapshots`, the open fails and the whole procedure aborts with `NotFoundException` / `NoSuchKey` — even though that file was never going to be copied.

Because the `DELETED` entry is baked into the current snapshot's delete manifest, the failure is not transient: every subsequent `rewrite_table_path` run fails the same way, breaking both full rewrites of such a table and incremental rewrites whose delta spans the expiry.

## Fix

Align the physical-rewrite set with the copy plan: an entry that is not copied is kept in the rewritten manifest exactly as the source has it, and is no longer opened. This makes the position-delete branch consistent with the data-file and equality-delete branches, which already behave this way.

This is safe because `DELETED` entries are never opened by readers (they exist only so the manifest history stays consistent), and out-of-delta `EXISTING` entries point at files the target already has from a previous incremental run. A live, still-needed delete file cannot be skipped as a result of expiry, since `expire_snapshots` never deletes a file that remains reachable from a retained snapshot.

Side effect worth noting: `rewrittenDeleteFilePathsCount` in the action result now only counts files that are actually copied. It previously also counted dead entries and entries outside the delta, which were staged and then discarded.

## Tests

Two regression tests, added to all Spark versions (3.4, 3.5, 4.0, 4.1), which share the fixed core code path but run their CI independently:

- `rewriteAfterExpiringDeletedPositionDeleteFile` — a deletion vector is dropped by compaction, leaving a `DELETED` entry in the current snapshot's delete manifest, and `expire_snapshots` then removes the file from storage. A full rewrite must not attempt to physically rewrite that entry. Without the fix this fails with `NotFoundException` from `PuffinReader`.
- `incrementalRewriteAfterExpiringDeletedPositionDeleteFile` — covers the second failure mode: an incremental rewrite whose `start..end` delta spans compaction and expiry of a position delete file must keep the surviving entry out of the physical-rewrite set.

Both assert `rewrittenDeleteFilePathsCount()` and compare target rows against source rows. They are limited to format version 3 and later: in v2, compaction does not remove the position delete file from storage, so the scenario does not arise.
