### PR TITLE
CI: Run PR title check after pushes

### DIFF
--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -18,7 +18,7 @@ name: PR Title Check
 
 on:
   pull_request:
-    types: [opened, edited, reopened]
+    types: [opened, edited, reopened, synchronize]
 
 concurrency:
   group: pr-title-${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- run the PR title check for `synchronize` pull request events
- ensure the title validation result is attached to the current PR head commit after new commits are pushed

## Root cause

The workflow only handled `opened`, `edited`, and `reopened`. A title-check failure attached to an older head commit disappeared from the current check rollup after a subsequent push because `synchronize` events did not run the workflow.

## Validation

- `git diff --check`
- parsed `.github/workflows/pr-title-check.yml` with Ruby YAML

---
**AI Disclosure**
- Model: GPT-5.6
- Platform/Tool: Codex
- Human Oversight: reviewed
- Prompt Summary: Diagnose why PR #17422 did not show the PR title check on its latest commit and open a PR to fix the workflow trigger.
