### PR TITLE
INFRA: Use PR titles for squash commits

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -31,6 +31,7 @@ github:
   enabled_merge_buttons:
     merge: false
     squash: true
+    squash_commit_message: PR_TITLE_AND_COMMIT_DETAILS
     rebase: true
 
   pull_requests:


### PR DESCRIPTION
## Summary

Closes #17467

Configure squash merges to always use the pull request title while preserving the existing commit-message details in the squash commit body.

`PR_TITLE_AND_COMMIT_DETAILS` is the only ASF merge-button option that changes the squash commit title to `PR_TITLE` without changing the current body behavior:

## Why not other options?

https://github.com/apache/infrastructure-asfyaml#merge-buttons
```
    # default commit message when merging with a squash commit
    # can either be: DEFAULT | PR_TITLE | PR_TITLE_AND_COMMIT_DETAILS | PR_TITLE_AND_DESC
```

- `DEFAULT` retains `COMMIT_OR_PR_TITLE`, so a single-commit PR can still produce an unhelpful title such as "Initial commit".
- `PR_TITLE` always uses the PR title but makes the squash commit body blank.
- `PR_TITLE_AND_DESC` copies the entire PR description, which can add templates, checklists, mentions, embedded HTML, and bot-generated content to the Git history.
- `PR_TITLE_AND_COMMIT_DETAILS` maps to `PR_TITLE` plus `COMMIT_MESSAGES`, fixing the inconsistent title while preserving the current commit-body setting.

This matches the conclusion of the [dev mailing-list discussion](https://lists.apache.org/thread/29sl2x4mh1j99d74g230129qq3yqm2rm) and keeps the final merge message editable by the committer.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: i validated the changes 😄 