### PR TITLE
Build: Fix OpenAPI test fixtures runtime dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1077,6 +1077,12 @@ project(':iceberg-open-api') {
   apply plugin: 'java-test-fixtures'
   apply plugin: 'com.gradleup.shadow'
 
+  // There are no main sources, so drop the implicit test fixtures -> main component dependency that
+  // would otherwise put the disabled main JAR on consumers' classpaths
+  configurations.testFixturesApi.dependencies.removeIf {
+    it instanceof ProjectDependency && it.path == project.path
+  }
+
   build.dependsOn shadowJar
 
   dependencies {


### PR DESCRIPTION
## Summary

- remove the implicit dependency from the OpenAPI test fixtures to the OpenAPI main component
- retain the test fixtures' actual transitive runtime dependencies for all consumers
- prevent Spark JMH packaging from resolving the disabled normal `iceberg-open-api` JAR without consumer-specific workarounds

## Root cause

The Java test-fixtures plugin adds an implicit dependency from a project's test fixtures to its main component. `:iceberg-open-api` has no main sources and disables its normal `jar` task in favor of `shadowJar`, but its published test-fixtures runtime still depended on that disabled main component.

After PR #10837 made the Spark 4.1 OpenAPI test-fixtures dependency transitive, Spark's `jmhJar` task attempted to expand the nonexistent normal OpenAPI JAR:

```
Cannot expand ZIP .../iceberg-open-api-<version>.jar as it does not exist.
```

The fix removes the implicit self-dependency from `testFixturesApi`. Consumers continue to receive the real OpenAPI fixture runtime—including Jetty and SQLite—without resolving the disabled main artifact. This addresses the issue once in the OpenAPI producer rather than adding overrides to individual Spark versions.

This fixes the failure observed in https://github.com/apache/iceberg/actions/runs/30725020250/job/91434956426.

## Validation

- verified the Spark 4.1 test runtime dependency graph no longer contains the `iceberg-open-api` self-dependency
- exact failing clean, no-build-cache `:iceberg-spark:iceberg-spark-4.1_2.13:jmhJar` packaging task with the benchmark selector (`BUILD SUCCESSFUL` in 1m18s)
- `TestSparkMonthsFunction` and `TestRewriteTablePathsAction` (127 tests total)
- `./gradlew spotlessCheck`
- `git diff --check`

The benchmark itself was not executed; the reported failure occurred during `jmhJar` packaging before benchmark execution.

The final code change is limited to the OpenAPI project configuration in `build.gradle`.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: partially reviewed
- Prompt Summary: Diagnose the recurring JMH packaging failure, fix follow-up CI classpath issues, and apply the centralized OpenAPI test-fixtures solution requested in review.
