### PR TITLE
Core: Treat path prefixes as literals in RewriteTablePathUtil.replacePaths

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -107,7 +107,7 @@ public class RewriteTablePathUtil {
    */
   public static TableMetadata replacePaths(
       TableMetadata metadata, String sourcePrefix, String targetPrefix) {
-    String newLocation = metadata.location().replaceFirst(sourcePrefix, targetPrefix);
+    String newLocation = newPath(metadata.location(), sourcePrefix, targetPrefix);
     List<Snapshot> newSnapshots = updatePathInSnapshots(metadata, sourcePrefix, targetPrefix);
     List<TableMetadata.MetadataLogEntry> metadataLogEntries =
         updatePathInMetadataLogs(metadata, sourcePrefix, targetPrefix);

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -198,6 +198,47 @@ public class TestRewriteTablePathUtil extends TestBase {
   }
 
   @Test
+  public void testReplacePathsTreatsPrefixAsLiteral() {
+    // Prefixes are literal paths, not regular expressions. A prefix containing regex
+    // metacharacters must match only itself.
+    String sourcePrefix = "s3://bucket/warehouse.db/table";
+    String targetPrefix = "s3://bucket/restored.db/table";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), sourcePrefix, ImmutableMap.of());
+
+    TableMetadata replaced =
+        RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
+    assertThat(replaced.location()).isEqualTo(targetPrefix);
+
+    // The '.' in the source prefix must not match an arbitrary character, so a location that
+    // only matches when the prefix is read as a regex is rejected.
+    TableMetadata unrelated =
+        TableMetadata.newTableMetadata(
+            SCHEMA,
+            PartitionSpec.unpartitioned(),
+            "s3://bucket/warehouseXdb/table",
+            ImmutableMap.of());
+    assertThatThrownBy(
+            () -> RewriteTablePathUtil.replacePaths(unrelated, sourcePrefix, targetPrefix))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("does not start with");
+  }
+
+  @Test
+  public void testReplacePathsWithTrailingSeparatorInPrefix() {
+    // A source prefix with a trailing separator still matches the table location.
+    String location = "s3://bucket/warehouse/table";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), location, ImmutableMap.of());
+
+    TableMetadata replaced =
+        RewriteTablePathUtil.replacePaths(metadata, location + "/", "s3://bucket/restored/table");
+    assertThat(replaced.location()).isEqualTo("s3://bucket/restored/table");
+  }
+
+  @Test
   public void testNewPathTableRename() {
     // Rename /tableX to /table (target is substring of source name)
     assertThat(RewriteTablePathUtil.newPath("/tableX/data/file.parquet", "/tableX", "/table"))

--- a/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteTablePathUtil.java
@@ -199,30 +199,78 @@ public class TestRewriteTablePathUtil extends TestBase {
 
   @Test
   public void testReplacePathsTreatsPrefixAsLiteral() {
-    // Prefixes are literal paths, not regular expressions. A prefix containing regex
-    // metacharacters must match only itself.
+    // The '.' in the prefix is a literal character, not a regex wildcard; a location matching the
+    // prefix literally is rewritten to the target.
     String sourcePrefix = "s3://bucket/warehouse.db/table";
     String targetPrefix = "s3://bucket/restored.db/table";
     TableMetadata metadata =
         TableMetadata.newTableMetadata(
             SCHEMA, PartitionSpec.unpartitioned(), sourcePrefix, ImmutableMap.of());
 
-    TableMetadata replaced =
-        RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix);
-    assertThat(replaced.location()).isEqualTo(targetPrefix);
+    assertThat(RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix).location())
+        .isEqualTo(targetPrefix);
+  }
 
-    // The '.' in the source prefix must not match an arbitrary character, so a location that
-    // only matches when the prefix is read as a regex is rejected.
-    TableMetadata unrelated =
+  @Test
+  public void testReplacePathsRejectsRegexOnlyPrefixMatch() {
+    // Read as a regex, "warehouse.db" would match "warehouseXdb" ('.' matches 'X'). As a literal
+    // prefix it must not, so a location that only matches under regex semantics is rejected.
+    String sourcePrefix = "s3://bucket/warehouse.db/table";
+    String targetPrefix = "s3://bucket/restored.db/table";
+    TableMetadata metadata =
         TableMetadata.newTableMetadata(
             SCHEMA,
             PartitionSpec.unpartitioned(),
             "s3://bucket/warehouseXdb/table",
             ImmutableMap.of());
+
     assertThatThrownBy(
-            () -> RewriteTablePathUtil.replacePaths(unrelated, sourcePrefix, targetPrefix))
+            () -> RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("does not start with");
+  }
+
+  @Test
+  public void testReplacePathsTargetWithDollarSign() {
+    // '$1' in the target is a literal path segment, not a regex replacement group reference
+    // (which previously threw IndexOutOfBoundsException: No group 1).
+    String sourcePrefix = "s3://bucket/db/table";
+    String targetPrefix = "s3://bucket/cost$1/table";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), sourcePrefix, ImmutableMap.of());
+
+    assertThat(RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix).location())
+        .isEqualTo(targetPrefix);
+  }
+
+  @Test
+  public void testReplacePathsSourceWithUnbalancedBracket() {
+    // An unbalanced '[' in the prefix would be an invalid regex (PatternSyntaxException); as a
+    // literal it matches itself.
+    String sourcePrefix = "s3://bucket/db/table[0";
+    String targetPrefix = "s3://bucket/db/restored";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), sourcePrefix, ImmutableMap.of());
+
+    assertThat(RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix).location())
+        .isEqualTo(targetPrefix);
+  }
+
+  @Test
+  public void testReplacePathsSourceWithCharacterClass() {
+    // '[0]' is a valid regex character class matching '0', so as a regex it silently missed the
+    // real directory "table[0]" (while matching an unrelated "table0"); as a literal prefix it
+    // must match "table[0]".
+    String sourcePrefix = "s3://bucket/db/table[0]";
+    String targetPrefix = "s3://bucket/db/restored";
+    TableMetadata metadata =
+        TableMetadata.newTableMetadata(
+            SCHEMA, PartitionSpec.unpartitioned(), sourcePrefix, ImmutableMap.of());
+
+    assertThat(RewriteTablePathUtil.replacePaths(metadata, sourcePrefix, targetPrefix).location())
+        .isEqualTo(targetPrefix);
   }
 
   @Test


### PR DESCRIPTION
`RewriteTablePathUtil.replacePaths` rewrote the table location with
`String.replaceFirst(sourcePrefix, targetPrefix)`, which interprets the user-supplied
`sourcePrefix` as a **regular expression** and `targetPrefix` as a **replacement string**.
Both are file paths, so this misbehaves whenever a path contains regex metacharacters:

- `sourcePrefix = s3://bucket/warehouse.db/table` also matches
  `s3://bucket/warehouseXdb/table`, rewriting a location that is not under the prefix.
- A `sourcePrefix` with a trailing separator (e.g. `s3://bucket/warehouse/table/`) does not
  match at all, so the location is silently left pointing at the **source** while every
  other path is rewritten to the target.
- A `targetPrefix` containing `$` fails with `IndexOutOfBoundsException: No group 1`, and a
  path containing an unbalanced `[` fails with `PatternSyntaxException`.

Every other path rewrite in this class already goes through `newPath()` -> `relativize()`,
which compares prefixes literally (`startsWith` + `substring`), normalizes trailing
separators, and raises a clear `IllegalArgumentException` when a path is not under the
source prefix. In `RewriteTablePathSparkAction#rewriteVersionFile` the immediately
preceding `stagingPath(...)` call already applies that literal check, so this change makes
the location rewrite consistent with the validation already performed one line earlier.

Both prefixes are user-supplied through the public
`RewriteTablePath.rewriteLocationPrefix(sourcePrefix, targetPrefix)` API.

Tested with `TestRewriteTablePathUtil` (core) and `TestRewriteTablePathsAction` on Spark
3.5, 4.0 and 4.1.

Note: #14355 makes the same one-line change as a side effect of adding multiple
source/destination prefixes. This is the minimal standalone fix plus regression tests for
the metacharacter and trailing-separator cases, so it can land independently; whichever
merges first, the other should rebase cleanly on this method.