### PR TITLE
Core: Preserve snapshot pruning when ignoring residuals in AllManifestsTable

### DIFF
--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -123,12 +123,14 @@ public class AllManifestsTable extends BaseMetadataTable {
       FileIO io = table().io();
       Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
       Schema dataTableSchema = table().schema();
-      Expression filter = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : filter();
+      Expression rowFilter = filter();
 
       SnapshotEvaluator snapshotEvaluator =
-          new SnapshotEvaluator(filter, MANIFEST_FILE_SCHEMA.asStruct(), isCaseSensitive());
+          new SnapshotEvaluator(rowFilter, MANIFEST_FILE_SCHEMA.asStruct(), isCaseSensitive());
       Iterable<Snapshot> filteredSnapshots =
           Iterables.filter(table().snapshots(), snapshotEvaluator::eval);
+
+      Expression residual = shouldIgnoreResiduals() ? Expressions.alwaysTrue() : rowFilter;
 
       return CloseableIterable.withNoopClose(
           Iterables.transform(
@@ -141,7 +143,7 @@ public class AllManifestsTable extends BaseMetadataTable {
                       schema(),
                       specs,
                       new BaseManifestListFile(snap.manifestListLocation(), snap.keyId()),
-                      filter,
+                      residual,
                       snap.snapshotId());
                 } else {
                   return StaticDataTask.of(

--- a/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
+++ b/core/src/test/java/org/apache/iceberg/TestMetadataTableScans.java
@@ -491,6 +491,25 @@ public class TestMetadataTableScans extends MetadataTableScanTestBase {
   }
 
   @TestTemplate
+  public void allManifestsTablePreservesSnapshotPruningWhenIgnoringResiduals() throws IOException {
+    // Snapshots 1,2,3,4
+    preparePartitionedTableData();
+
+    Table allManifestsTable = new AllManifestsTable(table);
+    TableScan scan =
+        allManifestsTable
+            .newScan()
+            .filter(Expressions.equal("reference_snapshot_id", 2L))
+            .ignoreResiduals();
+
+    assertThat(scannedPaths(scan))
+        .as("Snapshot pruning should be preserved when residuals are ignored")
+        .isEqualTo(expectedManifestListPaths(table.snapshots(), 2L));
+
+    validateTaskScanResiduals(scan, true);
+  }
+
+  @TestTemplate
   public void allManifestsTableNegatedPredicateOnNonSnapshotColumn() {
     // Snapshots 1,2,3,4
     preparePartitionedTableData();


### PR DESCRIPTION
## Description

Use the original row filter for snapshot pruning in AllManifestsTable when residuals are ignored.

`ignoreResiduals()` now only replaces the task residual with alwaysTrue, while safe snapshot pruning remains enabled.

## Testing

Added a test to verify that snapshot pruning is preserved and task residuals are ignored.