### PR TITLE
API, Core, Spark, Flink: add version-agnostic Snapshot.rootLocation()

### DIFF
--- a/api/src/main/java/org/apache/iceberg/FileWithKeyId.java
+++ b/api/src/main/java/org/apache/iceberg/FileWithKeyId.java
@@ -18,22 +18,15 @@
  */
 package org.apache.iceberg;
 
-import java.nio.ByteBuffer;
-import org.apache.iceberg.encryption.EncryptionManager;
-
 /**
- * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link FileWithKeyId} instead.
+ * A file that may be encrypted. If it is encrypted, its encrypted key metadata is tracked in the
+ * table metadata encryption keys and is referenced by a key ID.
  */
-@Deprecated
-public interface ManifestListFile extends FileWithKeyId {
-  /** The manifest list key metadata can be encrypted. Returns ID of encryption key */
-  String encryptionKeyID();
+public interface FileWithKeyId {
 
-  @Override
-  default String keyId() {
-    return encryptionKeyID();
-  }
+  /** Location of the file. */
+  String location();
 
-  /** Decrypt and return the manifest list key metadata */
-  ByteBuffer decryptKeyMetadata(EncryptionManager em);
+  /** Returns the encryption key ID for this file, or null if the file is not encrypted. */
+  String keyId();
 }

--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -29,10 +29,7 @@ import org.apache.iceberg.types.Types;
 public interface ManifestFile {
   int PARTITION_SUMMARIES_ELEMENT_ID = 508;
 
-  /**
-   * Sentinel returned by {@link Snapshot#formatVersion()} for snapshots that do not report a format
-   * version — e.g. v3-and-earlier snapshots whose top-level file is a manifest list.
-   */
+  /** Format version for pre-v4 manifest files. */
   int LEGACY_FORMAT_VERSION = 0;
 
   Types.NestedField PATH =

--- a/api/src/main/java/org/apache/iceberg/ManifestFile.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestFile.java
@@ -29,6 +29,12 @@ import org.apache.iceberg.types.Types;
 public interface ManifestFile {
   int PARTITION_SUMMARIES_ELEMENT_ID = 508;
 
+  /**
+   * Sentinel returned by {@link Snapshot#formatVersion()} for snapshots that do not report a format
+   * version — e.g. v3-and-earlier snapshots whose top-level file is a manifest list.
+   */
+  int LEGACY_FORMAT_VERSION = 0;
+
   Types.NestedField PATH =
       required(500, "manifest_path", Types.StringType.get(), "Location URI with FS scheme");
   Types.NestedField LENGTH =

--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -167,8 +167,31 @@ public interface Snapshot extends Serializable {
    * Return the location of this snapshot's manifest list, or null if it is not separate.
    *
    * @return the location of the manifest list for this Snapshot
+   * @deprecated since 1.13.0; use {@link #snapshotFileLocation()}, which returns the manifest list
+   *     for v3 and earlier and the root manifest for v4+.
    */
+  @Deprecated
   String manifestListLocation();
+
+  /**
+   * Returns the location of this snapshot's top-level file — a manifest list for v3 and earlier, or
+   * a root manifest for v4+.
+   *
+   * @return the location of the snapshot file for this Snapshot
+   */
+  default String snapshotFileLocation() {
+    return manifestListLocation();
+  }
+
+  /**
+   * Returns the format version this snapshot was written under, or {@link
+   * ManifestFile#LEGACY_FORMAT_VERSION} for snapshots that do not report one.
+   *
+   * @return the snapshot's format version
+   */
+  default int formatVersion() {
+    return ManifestFile.LEGACY_FORMAT_VERSION;
+  }
 
   /**
    * Return the id of the schema used when this snapshot was created, or null if this information is

--- a/api/src/main/java/org/apache/iceberg/Snapshot.java
+++ b/api/src/main/java/org/apache/iceberg/Snapshot.java
@@ -167,8 +167,31 @@ public interface Snapshot extends Serializable {
    * Return the location of this snapshot's manifest list, or null if it is not separate.
    *
    * @return the location of the manifest list for this Snapshot
+   * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link #rootLocation()}, which returns
+   *     the manifest list for v3 and earlier and the root manifest for v4+.
    */
+  @Deprecated
   String manifestListLocation();
+
+  /**
+   * Returns the location of this snapshot's root metadata file — a manifest list for v3 and
+   * earlier, or a root manifest for v4+.
+   *
+   * @return the location of the root file for this Snapshot
+   */
+  default String rootLocation() {
+    return manifestListLocation();
+  }
+
+  /**
+   * Returns the format version this snapshot was written under, or 0 if the snapshot does not
+   * report one.
+   *
+   * @return the snapshot's format version
+   */
+  default int formatVersion() {
+    return 0;
+  }
 
   /**
    * Return the id of the schema used when this snapshot was created, or null if this information is

--- a/api/src/main/java/org/apache/iceberg/SnapshotFile.java
+++ b/api/src/main/java/org/apache/iceberg/SnapshotFile.java
@@ -18,10 +18,22 @@
  */
 package org.apache.iceberg;
 
+import java.nio.ByteBuffer;
+import org.apache.iceberg.encryption.EncryptionManager;
+
 /**
- * A v3-and-earlier manifest list file.
- *
- * @deprecated since 1.13.0; prefer {@link SnapshotFile}, which also covers v4+ root manifests.
+ * The top-level file that a {@link Snapshot} points at. For v3 and earlier this is a manifest list
+ * (see {@link ManifestListFile}); for v4+ it is a root manifest carrying a mix of data-file entries
+ * and leaf-manifest entries.
  */
-@Deprecated
-public interface ManifestListFile extends SnapshotFile {}
+public interface SnapshotFile {
+
+  /** Location of the snapshot file. */
+  String location();
+
+  /** The snapshot file key metadata can be encrypted. Returns ID of encryption key. */
+  String encryptionKeyID();
+
+  /** Decrypt and return the snapshot file key metadata. */
+  ByteBuffer decryptKeyMetadata(EncryptionManager em);
+}

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestListFile;
+import org.apache.iceberg.SnapshotFile;
 import org.apache.iceberg.io.BulkDeletionFailureException;
 import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileIO;
@@ -120,13 +121,22 @@ public class EncryptingFileIO implements FileIO, Serializable {
   }
 
   @Override
-  public InputFile newInputFile(ManifestListFile manifestList) {
-    if (manifestList.encryptionKeyID() != null) {
-      ByteBuffer keyMetadata = manifestList.decryptKeyMetadata(em);
-      return newDecryptingInputFile(manifestList.location(), keyMetadata);
+  public InputFile newInputFile(SnapshotFile snapshotFile) {
+    if (snapshotFile.encryptionKeyID() != null) {
+      ByteBuffer keyMetadata = snapshotFile.decryptKeyMetadata(em);
+      return newDecryptingInputFile(snapshotFile.location(), keyMetadata);
     } else {
-      return newInputFile(manifestList.location());
+      return newInputFile(snapshotFile.location());
     }
+  }
+
+  /**
+   * @deprecated since 1.13.0; use {@link #newInputFile(SnapshotFile)}.
+   */
+  @Deprecated
+  @Override
+  public InputFile newInputFile(ManifestListFile manifestList) {
+    return newInputFile((SnapshotFile) manifestList);
   }
 
   public InputFile newDecryptingInputFile(String path, ByteBuffer buffer) {

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileWithKeyId;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestListFile;
 import org.apache.iceberg.io.BulkDeletionFailureException;
@@ -130,6 +131,11 @@ public class EncryptingFileIO implements FileIO, Serializable {
     }
   }
 
+  /**
+   * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link #newInputFile(FileWithKeyId)}
+   *     instead.
+   */
+  @Deprecated
   @Override
   public InputFile newInputFile(ManifestListFile manifestList) {
     if (manifestList.encryptionKeyID() != null) {
@@ -137,6 +143,16 @@ public class EncryptingFileIO implements FileIO, Serializable {
       return newDecryptingInputFile(manifestList.location(), keyMetadata);
     } else {
       return newInputFile(manifestList.location());
+    }
+  }
+
+  @Override
+  public InputFile newInputFile(FileWithKeyId file) {
+    if (file.keyId() != null) {
+      ByteBuffer keyMetadata = em.decryptKeyMetadata(file.keyId());
+      return newDecryptingInputFile(file.location(), keyMetadata);
+    } else {
+      return newInputFile(file.location());
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptionManager.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptionManager.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.encryption;
 
 import java.io.Serializable;
+import java.nio.ByteBuffer;
 import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -49,6 +50,17 @@ public interface EncryptionManager extends Serializable {
    */
   default Iterable<InputFile> decrypt(Iterable<EncryptedInputFile> encrypted) {
     return Iterables.transform(encrypted, this::decrypt);
+  }
+
+  /**
+   * Decrypt an encrypted key metadata referred by a key id.
+   *
+   * @param keyId the encryption key ID
+   * @return the decrypted key metadata buffer
+   */
+  default ByteBuffer decryptKeyMetadata(String keyId) {
+    throw new UnsupportedOperationException(
+        this.getClass().getName() + " does not support key metadata decryption");
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -25,6 +25,7 @@ import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestListFile;
+import org.apache.iceberg.SnapshotFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 
 /**
@@ -71,13 +72,21 @@ public interface FileIO extends Serializable, Closeable {
     return newInputFile(manifest.path(), manifest.length());
   }
 
-  default InputFile newInputFile(ManifestListFile manifestList) {
+  default InputFile newInputFile(SnapshotFile snapshotFile) {
     Preconditions.checkArgument(
-        manifestList.encryptionKeyID() == null,
-        "Cannot decrypt manifest list: %s (use EncryptingFileIO)",
-        manifestList.location());
+        snapshotFile.encryptionKeyID() == null,
+        "Cannot decrypt snapshot file: %s (use EncryptingFileIO)",
+        snapshotFile.location());
     // cannot pass length because it is not tracked outside of key metadata
-    return newInputFile(manifestList.location());
+    return newInputFile(snapshotFile.location());
+  }
+
+  /**
+   * @deprecated since 1.13.0; use {@link #newInputFile(SnapshotFile)}.
+   */
+  @Deprecated
+  default InputFile newInputFile(ManifestListFile manifestList) {
+    return newInputFile((SnapshotFile) manifestList);
   }
 
   /** Get a {@link OutputFile} instance to write bytes to the file at the given path. */

--- a/api/src/main/java/org/apache/iceberg/io/FileIO.java
+++ b/api/src/main/java/org/apache/iceberg/io/FileIO.java
@@ -23,6 +23,7 @@ import java.io.Serializable;
 import java.util.Map;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileWithKeyId;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestListFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
@@ -71,6 +72,11 @@ public interface FileIO extends Serializable, Closeable {
     return newInputFile(manifest.path(), manifest.length());
   }
 
+  /**
+   * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link #newInputFile(FileWithKeyId)}
+   *     instead.
+   */
+  @Deprecated
   default InputFile newInputFile(ManifestListFile manifestList) {
     Preconditions.checkArgument(
         manifestList.encryptionKeyID() == null,
@@ -78,6 +84,13 @@ public interface FileIO extends Serializable, Closeable {
         manifestList.location());
     // cannot pass length because it is not tracked outside of key metadata
     return newInputFile(manifestList.location());
+  }
+
+  default InputFile newInputFile(FileWithKeyId file) {
+    Preconditions.checkArgument(
+        file.keyId() == null, "Cannot decrypt file: %s (use EncryptingFileIO)", file.location());
+    // cannot pass length because it is not tracked outside of key metadata
+    return newInputFile(file.location());
   }
 
   /** Get a {@link OutputFile} instance to write bytes to the file at the given path. */

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -134,13 +134,13 @@ public class AllManifestsTable extends BaseMetadataTable {
           Iterables.transform(
               filteredSnapshots,
               snap -> {
-                if (snap.manifestListLocation() != null) {
+                if (snap.snapshotFileLocation() != null) {
                   return new ManifestListReadTask(
                       dataTableSchema,
                       io,
                       schema(),
                       specs,
-                      new BaseManifestListFile(snap.manifestListLocation(), snap.keyId()),
+                      new BaseManifestListFile(snap.snapshotFileLocation(), snap.keyId()),
                       filter,
                       snap.snapshotId());
                 } else {

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -165,7 +165,7 @@ public class AllManifestsTable extends BaseMetadataTable {
     private final FileIO io;
     private final Schema schema;
     private final Map<Integer, PartitionSpec> specs;
-    private final ManifestListFile manifestList;
+    private final FileWithKeyId manifestList;
     private final Expression residual;
     private final long referenceSnapshotId;
     private DataFile lazyDataFile = null;
@@ -175,7 +175,7 @@ public class AllManifestsTable extends BaseMetadataTable {
         FileIO io,
         Schema schema,
         Map<Integer, PartitionSpec> specs,
-        ManifestListFile manifestList,
+        FileWithKeyId manifestList,
         Expression residual,
         long referenceSnapshotId) {
       this.dataTableSchema = dataTableSchema;
@@ -276,7 +276,7 @@ public class AllManifestsTable extends BaseMetadataTable {
       return specs;
     }
 
-    ManifestListFile manifestList() {
+    FileWithKeyId manifestList() {
       return manifestList;
     }
 

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTable.java
@@ -136,13 +136,13 @@ public class AllManifestsTable extends BaseMetadataTable {
           Iterables.transform(
               filteredSnapshots,
               snap -> {
-                if (snap.manifestListLocation() != null) {
+                if (snap.rootLocation() != null) {
                   return new ManifestListReadTask(
                       dataTableSchema,
                       io,
                       schema(),
                       specs,
-                      new BaseManifestListFile(snap.manifestListLocation(), snap.keyId()),
+                      new BaseFileWithKeyId(snap.rootLocation(), snap.keyId()),
                       residual,
                       snap.snapshotId());
                 } else {

--- a/core/src/main/java/org/apache/iceberg/AllManifestsTableTaskParser.java
+++ b/core/src/main/java/org/apache/iceberg/AllManifestsTableTaskParser.java
@@ -65,8 +65,8 @@ class AllManifestsTableTaskParser {
     generator.writeEndArray();
 
     generator.writeStringField(MANIFEST_LIST_LOCATION, task.manifestList().location());
-    if (task.manifestList().encryptionKeyID() != null) {
-      generator.writeStringField(MANIFEST_LIST_KEY_ID, task.manifestList().encryptionKeyID());
+    if (task.manifestList().keyId() != null) {
+      generator.writeStringField(MANIFEST_LIST_KEY_ID, task.manifestList().keyId());
     }
 
     generator.writeFieldName(RESIDUAL);

--- a/core/src/main/java/org/apache/iceberg/BaseFileWithKeyId.java
+++ b/core/src/main/java/org/apache/iceberg/BaseFileWithKeyId.java
@@ -18,22 +18,24 @@
  */
 package org.apache.iceberg;
 
-import java.nio.ByteBuffer;
-import org.apache.iceberg.encryption.EncryptionManager;
+import java.io.Serializable;
 
-/**
- * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link FileWithKeyId} instead.
- */
-@Deprecated
-public interface ManifestListFile extends FileWithKeyId {
-  /** The manifest list key metadata can be encrypted. Returns ID of encryption key */
-  String encryptionKeyID();
+class BaseFileWithKeyId implements FileWithKeyId, Serializable {
+  private final String location;
+  private final String keyId;
 
-  @Override
-  default String keyId() {
-    return encryptionKeyID();
+  BaseFileWithKeyId(String location, String encryptionKeyID) {
+    this.location = location;
+    this.keyId = encryptionKeyID;
   }
 
-  /** Decrypt and return the manifest list key metadata */
-  ByteBuffer decryptKeyMetadata(EncryptionManager em);
+  @Override
+  public String location() {
+    return location;
+  }
+
+  @Override
+  public String keyId() {
+    return keyId;
+  }
 }

--- a/core/src/main/java/org/apache/iceberg/BaseManifestListFile.java
+++ b/core/src/main/java/org/apache/iceberg/BaseManifestListFile.java
@@ -18,28 +18,23 @@
  */
 package org.apache.iceberg;
 
-import java.io.Serializable;
 import java.nio.ByteBuffer;
 import org.apache.iceberg.encryption.EncryptionManager;
 import org.apache.iceberg.encryption.EncryptionUtil;
 
-class BaseManifestListFile implements ManifestListFile, Serializable {
-  private final String location;
-  private final String encryptionKeyID;
+/**
+ * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link BaseFileWithKeyId} instead.
+ */
+@Deprecated
+class BaseManifestListFile extends BaseFileWithKeyId implements ManifestListFile {
 
   BaseManifestListFile(String location, String encryptionKeyID) {
-    this.location = location;
-    this.encryptionKeyID = encryptionKeyID;
-  }
-
-  @Override
-  public String location() {
-    return location;
+    super(location, encryptionKeyID);
   }
 
   @Override
   public String encryptionKeyID() {
-    return encryptionKeyID;
+    return keyId();
   }
 
   @Override

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -38,7 +38,7 @@ class BaseSnapshot implements Snapshot {
   private final Long parentId;
   private final long sequenceNumber;
   private final long timestampMillis;
-  private final String manifestListLocation;
+  private final String snapshotFileLocation;
   private final String operation;
   private final Map<String, String> summary;
   private final Integer schemaId;
@@ -64,7 +64,7 @@ class BaseSnapshot implements Snapshot {
       String operation,
       Map<String, String> summary,
       Integer schemaId,
-      String manifestList,
+      String snapshotFileLocation,
       Long firstRowId,
       Long addedRows,
       String keyId) {
@@ -86,7 +86,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.schemaId = schemaId;
-    this.manifestListLocation = manifestList;
+    this.snapshotFileLocation = snapshotFileLocation;
     this.v1ManifestLocations = null;
     this.firstRowId = firstRowId;
     this.addedRows = firstRowId != null ? addedRows : null;
@@ -109,7 +109,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.schemaId = schemaId;
-    this.manifestListLocation = null;
+    this.snapshotFileLocation = null;
     this.v1ManifestLocations = v1ManifestLocations;
     this.firstRowId = null;
     this.addedRows = null;
@@ -185,7 +185,7 @@ class BaseSnapshot implements Snapshot {
       this.allManifests =
           ManifestLists.read(
               ManifestLists.newInputFile(
-                  fileIO, new BaseManifestListFile(manifestListLocation, keyId)));
+                  fileIO, new BaseManifestListFile(snapshotFileLocation, keyId)));
     }
 
     if (dataManifests == null || deleteManifests == null) {
@@ -257,8 +257,13 @@ class BaseSnapshot implements Snapshot {
   }
 
   @Override
+  public String snapshotFileLocation() {
+    return snapshotFileLocation;
+  }
+
+  @Override
   public String manifestListLocation() {
-    return manifestListLocation;
+    return snapshotFileLocation;
   }
 
   private void cacheDeleteFileChanges(FileIO fileIO) {
@@ -369,7 +374,7 @@ class BaseSnapshot implements Snapshot {
         .add("timestamp_ms", timestampMillis)
         .add("operation", operation)
         .add("summary", summary)
-        .add("manifest-list", manifestListLocation)
+        .add("snapshot-file", snapshotFileLocation)
         .add("schema-id", schemaId)
         .add("first-row-id", firstRowId)
         .add("added-rows", addedRows)

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -38,7 +38,7 @@ class BaseSnapshot implements Snapshot {
   private final Long parentId;
   private final long sequenceNumber;
   private final long timestampMillis;
-  private final String manifestListLocation;
+  private final String rootLocation;
   private final String operation;
   private final Map<String, String> summary;
   private final Integer schemaId;
@@ -64,7 +64,7 @@ class BaseSnapshot implements Snapshot {
       String operation,
       Map<String, String> summary,
       Integer schemaId,
-      String manifestList,
+      String rootLocation,
       Long firstRowId,
       Long addedRows,
       String keyId) {
@@ -86,7 +86,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.schemaId = schemaId;
-    this.manifestListLocation = manifestList;
+    this.rootLocation = rootLocation;
     this.v1ManifestLocations = null;
     this.firstRowId = firstRowId;
     this.addedRows = firstRowId != null ? addedRows : null;
@@ -109,7 +109,7 @@ class BaseSnapshot implements Snapshot {
     this.operation = operation;
     this.summary = summary;
     this.schemaId = schemaId;
-    this.manifestListLocation = null;
+    this.rootLocation = null;
     this.v1ManifestLocations = v1ManifestLocations;
     this.firstRowId = null;
     this.addedRows = null;
@@ -181,11 +181,10 @@ class BaseSnapshot implements Snapshot {
     }
 
     if (allManifests == null) {
-      // if manifests isn't set, then the snapshotFile is set and should be read to get the list
+      // if manifests isn't set, then the root location is set and should be read to get the list
       this.allManifests =
           ManifestLists.read(
-              ManifestLists.newInputFile(
-                  fileIO, new BaseManifestListFile(manifestListLocation, keyId)));
+              ManifestLists.newInputFile(fileIO, new BaseFileWithKeyId(rootLocation, keyId)));
     }
 
     if (dataManifests == null || deleteManifests == null) {
@@ -257,8 +256,13 @@ class BaseSnapshot implements Snapshot {
   }
 
   @Override
+  public String rootLocation() {
+    return rootLocation;
+  }
+
+  @Override
   public String manifestListLocation() {
-    return manifestListLocation;
+    return rootLocation;
   }
 
   private void cacheDeleteFileChanges(FileIO fileIO) {
@@ -369,7 +373,7 @@ class BaseSnapshot implements Snapshot {
         .add("timestamp_ms", timestampMillis)
         .add("operation", operation)
         .add("summary", summary)
-        .add("manifest-list", manifestListLocation)
+        .add("root-location", rootLocation)
         .add("schema-id", schemaId)
         .add("first-row-id", firstRowId)
         .add("added-rows", addedRows)

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -470,7 +470,7 @@ public class BaseTransaction implements Transaction {
     for (long snapshotId : snapshotIds) {
       Snapshot snap = ops.current().snapshot(snapshotId);
       if (snap != null) {
-        committedFiles.add(snap.manifestListLocation());
+        committedFiles.add(snap.snapshotFileLocation());
         snap.allManifests(ops.io()).forEach(manifest -> committedFiles.add(manifest.path()));
       } else {
         return null;

--- a/core/src/main/java/org/apache/iceberg/BaseTransaction.java
+++ b/core/src/main/java/org/apache/iceberg/BaseTransaction.java
@@ -458,7 +458,7 @@ public class BaseTransaction implements Transaction {
     Set<String> committedFiles = Sets.newHashSet();
 
     for (Snapshot snap : snapshots) {
-      committedFiles.add(snap.manifestListLocation());
+      committedFiles.add(snap.rootLocation());
       snap.allManifests(io).forEach(manifest -> committedFiles.add(manifest.path()));
     }
 

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -102,14 +102,14 @@ public class CatalogUtil {
     // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
     // as much of the delete work as possible and avoid orphaned data or manifest files.
 
-    Set<String> manifestListsToDelete = Sets.newHashSet();
+    Set<String> snapshotFilesToDelete = Sets.newHashSet();
     Set<ManifestFile> manifestsToDelete = Sets.newHashSet();
     for (Snapshot snapshot : metadata.snapshots()) {
       // add all manifests to the delete set because both data and delete files should be removed
       Iterables.addAll(manifestsToDelete, snapshot.allManifests(io));
-      // add the manifest list to the delete set, if present
-      if (snapshot.manifestListLocation() != null) {
-        manifestListsToDelete.add(snapshot.manifestListLocation());
+      // add the top-level snapshot file (manifest list for v3, root manifest for v4+) if present
+      if (snapshot.snapshotFileLocation() != null) {
+        snapshotFilesToDelete.add(snapshot.snapshotFileLocation());
       }
     }
 
@@ -131,7 +131,7 @@ public class CatalogUtil {
     }
 
     deleteFiles(io, Iterables.transform(manifestsToDelete, ManifestFile::path), "manifest");
-    deleteFiles(io, manifestListsToDelete, "manifest list");
+    deleteFiles(io, snapshotFilesToDelete, "snapshot file");
     deleteFiles(
         io,
         Iterables.transform(metadata.previousFiles(), TableMetadata.MetadataLogEntry::file),

--- a/core/src/main/java/org/apache/iceberg/CatalogUtil.java
+++ b/core/src/main/java/org/apache/iceberg/CatalogUtil.java
@@ -102,14 +102,14 @@ public class CatalogUtil {
     // Reads and deletes are done using Tasks.foreach(...).suppressFailureWhenFinished to complete
     // as much of the delete work as possible and avoid orphaned data or manifest files.
 
-    Set<String> manifestListsToDelete = Sets.newHashSet();
+    Set<String> snapshotFilesToDelete = Sets.newHashSet();
     Set<ManifestFile> manifestsToDelete = Sets.newHashSet();
     for (Snapshot snapshot : metadata.snapshots()) {
       // add all manifests to the delete set because both data and delete files should be removed
       Iterables.addAll(manifestsToDelete, snapshot.allManifests(io));
-      // add the manifest list to the delete set, if present
-      if (snapshot.manifestListLocation() != null) {
-        manifestListsToDelete.add(snapshot.manifestListLocation());
+      // add the top-level snapshot file (manifest list for v3, root manifest for v4+) if present
+      if (snapshot.rootLocation() != null) {
+        snapshotFilesToDelete.add(snapshot.rootLocation());
       }
     }
 
@@ -131,7 +131,7 @@ public class CatalogUtil {
     }
 
     deleteFiles(io, Iterables.transform(manifestsToDelete, ManifestFile::path), "manifest");
-    deleteFiles(io, manifestListsToDelete, "manifest list");
+    deleteFiles(io, snapshotFilesToDelete, "snapshot file");
     deleteFiles(
         io,
         Iterables.transform(metadata.previousFiles(), TableMetadata.MetadataLogEntry::file),

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -91,9 +91,9 @@ abstract class FileCleanupStrategy {
               ManifestFile.DELETED_FILES_COUNT.fieldId()));
 
   protected CloseableIterable<ManifestFile> readManifests(Snapshot snapshot) {
-    if (snapshot.manifestListLocation() != null) {
+    if (snapshot.snapshotFileLocation() != null) {
       return InternalData.read(
-              FileFormat.AVRO, fileIO.newInputFile(snapshot.manifestListLocation()))
+              FileFormat.AVRO, fileIO.newInputFile(snapshot.snapshotFileLocation()))
           .setRootType(GenericManifestFile.class)
           .project(MANIFEST_PROJECTION)
           .reuseContainers()

--- a/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
+++ b/core/src/main/java/org/apache/iceberg/FileCleanupStrategy.java
@@ -92,9 +92,8 @@ abstract class FileCleanupStrategy {
               ManifestFile.DELETED_FILES_COUNT.fieldId()));
 
   protected CloseableIterable<ManifestFile> readManifests(Snapshot snapshot) {
-    if (snapshot.manifestListLocation() != null) {
-      return InternalData.read(
-              FileFormat.AVRO, fileIO.newInputFile(snapshot.manifestListLocation()))
+    if (snapshot.rootLocation() != null) {
+      return InternalData.read(FileFormat.AVRO, fileIO.newInputFile(snapshot.rootLocation()))
           .setRootType(GenericManifestFile.class)
           .project(MANIFEST_PROJECTION)
           .reuseContainers()

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -124,7 +124,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                 LOG.warn(
                     "Failed on snapshot {} while reading manifest list: {}",
                     snapshot.snapshotId(),
-                    snapshot.manifestListLocation(),
+                    snapshot.snapshotFileLocation(),
                     exc))
         .run(
             snapshot -> {
@@ -155,12 +155,12 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
 
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.snapshotFileLocation());
               }
             });
 
     // find manifests to clean up that were only referenced by snapshots that have expired
-    Set<String> manifestListsToDelete = ConcurrentHashMap.newKeySet();
+    Set<String> snapshotFilesToDelete = ConcurrentHashMap.newKeySet();
     Set<String> manifestsToDelete = ConcurrentHashMap.newKeySet();
     Set<ManifestFile> manifestsToRevert = ConcurrentHashMap.newKeySet();
     Tasks.foreach(beforeExpiration.snapshots())
@@ -172,7 +172,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                 LOG.warn(
                     "Failed on snapshot {} while reading manifest list: {}",
                     snapshot.snapshotId(),
-                    snapshot.manifestListLocation(),
+                    snapshot.snapshotFileLocation(),
                     exc))
         .run(
             snapshot -> {
@@ -248,12 +248,12 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                   }
                 } catch (IOException e) {
                   throw new RuntimeIOException(
-                      e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                      e, "Failed to close manifest list: %s", snapshot.snapshotFileLocation());
                 }
 
                 // add the manifest list to the delete set, if present
-                if (snapshot.manifestListLocation() != null) {
-                  manifestListsToDelete.add(snapshot.manifestListLocation());
+                if (snapshot.snapshotFileLocation() != null) {
+                  snapshotFilesToDelete.add(snapshot.snapshotFileLocation());
                 }
               }
             });
@@ -268,8 +268,8 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
 
     LOG.debug("Deleting {} manifest files", manifestsToDelete.size());
     deleteFiles(manifestsToDelete, "manifest");
-    LOG.debug("Deleting {} manifest-list files", manifestListsToDelete.size());
-    deleteFiles(manifestListsToDelete, "manifest list");
+    LOG.debug("Deleting {} manifest-list files", snapshotFilesToDelete.size());
+    deleteFiles(snapshotFilesToDelete, "manifest list");
 
     if (hasAnyStatisticsFiles(beforeExpiration)) {
       Set<String> expiredStatisticsFilesLocations =

--- a/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/IncrementalFileCleanup.java
@@ -124,7 +124,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                 LOG.warn(
                     "Failed on snapshot {} while reading manifest list: {}",
                     snapshot.snapshotId(),
-                    snapshot.manifestListLocation(),
+                    snapshot.rootLocation(),
                     exc))
         .run(
             snapshot -> {
@@ -155,12 +155,12 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
 
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.rootLocation());
               }
             });
 
     // find manifests to clean up that were only referenced by snapshots that have expired
-    Set<String> manifestListsToDelete = ConcurrentHashMap.newKeySet();
+    Set<String> snapshotFilesToDelete = ConcurrentHashMap.newKeySet();
     Set<String> manifestsToDelete = ConcurrentHashMap.newKeySet();
     Set<ManifestFile> manifestsToRevert = ConcurrentHashMap.newKeySet();
     Tasks.foreach(beforeExpiration.snapshots())
@@ -172,7 +172,7 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                 LOG.warn(
                     "Failed on snapshot {} while reading manifest list: {}",
                     snapshot.snapshotId(),
-                    snapshot.manifestListLocation(),
+                    snapshot.rootLocation(),
                     exc))
         .run(
             snapshot -> {
@@ -248,12 +248,12 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
                   }
                 } catch (IOException e) {
                   throw new RuntimeIOException(
-                      e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                      e, "Failed to close manifest list: %s", snapshot.rootLocation());
                 }
 
                 // add the manifest list to the delete set, if present
-                if (snapshot.manifestListLocation() != null) {
-                  manifestListsToDelete.add(snapshot.manifestListLocation());
+                if (snapshot.rootLocation() != null) {
+                  snapshotFilesToDelete.add(snapshot.rootLocation());
                 }
               }
             });
@@ -268,8 +268,8 @@ class IncrementalFileCleanup extends FileCleanupStrategy {
 
     LOG.debug("Deleting {} manifest files", manifestsToDelete.size());
     deleteFiles(manifestsToDelete, "manifest");
-    LOG.debug("Deleting {} manifest-list files", manifestListsToDelete.size());
-    deleteFiles(manifestListsToDelete, "manifest list");
+    LOG.debug("Deleting {} manifest-list files", snapshotFilesToDelete.size());
+    deleteFiles(snapshotFilesToDelete, "manifest list");
 
     if (hasAnyStatisticsFiles(beforeExpiration)) {
       Set<String> expiredStatisticsFilesLocations =

--- a/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestListWriter.java
@@ -93,7 +93,7 @@ abstract class ManifestListWriter implements FileAppender<ManifestFile> {
     return null;
   }
 
-  public ManifestListFile toManifestListFile() {
+  public FileWithKeyId toManifestListFile() {
     if (manifestListKeyMetadata != null && manifestListKeyMetadata.encryptionKey() != null) {
       String manifestListKeyID =
           standardEncryptionManager.addManifestListKeyMetadata(

--- a/core/src/main/java/org/apache/iceberg/ManifestLists.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestLists.java
@@ -32,7 +32,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 class ManifestLists {
   private ManifestLists() {}
 
-  static InputFile newInputFile(FileIO io, ManifestListFile manifestList) {
+  static InputFile newInputFile(FileIO io, FileWithKeyId manifestList) {
     InputFile input = io.newInputFile(manifestList);
     if (ManifestFiles.cachingEnabled(io)) {
       return ManifestFiles.contentCache(io).tryCache(input);

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -77,7 +77,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
   protected DataTask task(TableScan scan) {
     FileIO io = table().io();
-    String location = scan.snapshot().manifestListLocation();
+    String location = scan.snapshot().snapshotFileLocation();
     Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
 
     return StaticDataTask.of(

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -77,7 +77,7 @@ public class ManifestsTable extends BaseMetadataTable {
 
   protected DataTask task(TableScan scan) {
     FileIO io = table().io();
-    String location = scan.snapshot().manifestListLocation();
+    String location = scan.snapshot().rootLocation();
     Map<Integer, PartitionSpec> specs = Maps.newHashMap(table().specs());
 
     return StaticDataTask.of(

--- a/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
@@ -59,7 +59,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
       return;
     }
 
-    Set<String> manifestListsToDelete = Sets.newHashSet();
+    Set<String> snapshotFilesToDelete = Sets.newHashSet();
 
     Set<Snapshot> snapshotsBeforeExpiration = Sets.newHashSet(beforeExpiration.snapshots());
     Set<Snapshot> snapshotsAfterExpiration = Sets.newHashSet(afterExpiration.snapshots());
@@ -67,8 +67,8 @@ class ReachableFileCleanup extends FileCleanupStrategy {
     for (Snapshot snapshot : snapshotsBeforeExpiration) {
       if (!snapshotsAfterExpiration.contains(snapshot)) {
         expiredSnapshots.add(snapshot);
-        if (snapshot.manifestListLocation() != null) {
-          manifestListsToDelete.add(snapshot.manifestListLocation());
+        if (snapshot.snapshotFileLocation() != null) {
+          snapshotFilesToDelete.add(snapshot.snapshotFileLocation());
         }
       }
     }
@@ -95,8 +95,8 @@ class ReachableFileCleanup extends FileCleanupStrategy {
       }
     }
 
-    LOG.debug("Deleting {} manifest-list files", manifestListsToDelete.size());
-    deleteFiles(manifestListsToDelete, "manifest list");
+    LOG.debug("Deleting {} manifest-list files", snapshotFilesToDelete.size());
+    deleteFiles(snapshotFilesToDelete, "manifest list");
 
     if (hasAnyStatisticsFiles(beforeExpiration)) {
       Set<String> expiredStatisticsFilesLocations =
@@ -134,7 +134,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
                 }
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.snapshotFileLocation());
               }
             });
 
@@ -160,7 +160,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
                 }
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.snapshotFileLocation());
               }
             });
 

--- a/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileCleanup.java
@@ -59,7 +59,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
       return;
     }
 
-    Set<String> manifestListsToDelete = Sets.newHashSet();
+    Set<String> snapshotFilesToDelete = Sets.newHashSet();
 
     Set<Snapshot> snapshotsBeforeExpiration = Sets.newHashSet(beforeExpiration.snapshots());
     Set<Snapshot> snapshotsAfterExpiration = Sets.newHashSet(afterExpiration.snapshots());
@@ -67,8 +67,8 @@ class ReachableFileCleanup extends FileCleanupStrategy {
     for (Snapshot snapshot : snapshotsBeforeExpiration) {
       if (!snapshotsAfterExpiration.contains(snapshot)) {
         expiredSnapshots.add(snapshot);
-        if (snapshot.manifestListLocation() != null) {
-          manifestListsToDelete.add(snapshot.manifestListLocation());
+        if (snapshot.rootLocation() != null) {
+          snapshotFilesToDelete.add(snapshot.rootLocation());
         }
       }
     }
@@ -95,8 +95,8 @@ class ReachableFileCleanup extends FileCleanupStrategy {
       }
     }
 
-    LOG.debug("Deleting {} manifest-list files", manifestListsToDelete.size());
-    deleteFiles(manifestListsToDelete, "manifest list");
+    LOG.debug("Deleting {} manifest-list files", snapshotFilesToDelete.size());
+    deleteFiles(snapshotFilesToDelete, "manifest list");
 
     if (hasAnyStatisticsFiles(beforeExpiration)) {
       Set<String> expiredStatisticsFilesLocations =
@@ -134,7 +134,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
                 }
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.rootLocation());
               }
             });
 
@@ -160,7 +160,7 @@ class ReachableFileCleanup extends FileCleanupStrategy {
                 }
               } catch (IOException e) {
                 throw new RuntimeIOException(
-                    e, "Failed to close manifest list: %s", snapshot.manifestListLocation());
+                    e, "Failed to close manifest list: %s", snapshot.rootLocation());
               }
             });
 

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -99,36 +99,56 @@ public class ReachableFileUtil {
   }
 
   /**
-   * Returns locations of manifest lists in a table.
-   *
-   * @param table table for which manifestList needs to be fetched
-   * @return the location of manifest lists
+   * @deprecated since 1.13.0; use {@link #snapshotFileLocations(Table)}. The method returns v4+
+   *     root manifest locations too, so the name no longer matches its behavior.
    */
+  @Deprecated
   public static List<String> manifestListLocations(Table table) {
-    return manifestListLocations(table, null);
+    return snapshotFileLocations(table, null);
   }
 
   /**
-   * Returns locations of manifest lists in a table.
-   *
-   * @param table table for which manifestList needs to be fetched
-   * @param snapshotIds ids of snapshots for which manifest lists will be returned
-   * @return the location of manifest lists
+   * @deprecated since 1.13.0; use {@link #snapshotFileLocations(Table, Set)}. The method returns
+   *     v4+ root manifest locations too, so the name no longer matches its behavior.
    */
+  @Deprecated
   public static List<String> manifestListLocations(Table table, Set<Long> snapshotIds) {
+    return snapshotFileLocations(table, snapshotIds);
+  }
+
+  /**
+   * Returns the snapshot-file location for every snapshot in the table — a manifest list for v3 and
+   * earlier, or a root manifest for v4+.
+   *
+   * @param table table whose snapshot-file locations should be fetched
+   * @return the snapshot-file location per snapshot
+   */
+  public static List<String> snapshotFileLocations(Table table) {
+    return snapshotFileLocations(table, null);
+  }
+
+  /**
+   * Returns the snapshot-file location for each snapshot filtered by id — a manifest list for v3
+   * and earlier, or a root manifest for v4+.
+   *
+   * @param table table whose snapshot-file locations should be fetched
+   * @param snapshotIds ids of snapshots to include, or null for every snapshot
+   * @return the snapshot-file location per matching snapshot
+   */
+  public static List<String> snapshotFileLocations(Table table, Set<Long> snapshotIds) {
     Iterable<Snapshot> snapshots = table.snapshots();
     if (snapshotIds != null) {
       snapshots = Iterables.filter(snapshots, s -> snapshotIds.contains(s.snapshotId()));
     }
 
-    List<String> manifestListLocations = Lists.newArrayList();
+    List<String> snapshotFileLocations = Lists.newArrayList();
     for (Snapshot snapshot : snapshots) {
-      String manifestListLocation = snapshot.manifestListLocation();
-      if (manifestListLocation != null) {
-        manifestListLocations.add(manifestListLocation);
+      String location = snapshot.snapshotFileLocation();
+      if (location != null) {
+        snapshotFileLocations.add(location);
       }
     }
-    return manifestListLocations;
+    return snapshotFileLocations;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
+++ b/core/src/main/java/org/apache/iceberg/ReachableFileUtil.java
@@ -99,36 +99,57 @@ public class ReachableFileUtil {
   }
 
   /**
-   * Returns locations of manifest lists in a table.
-   *
-   * @param table table for which manifestList needs to be fetched
-   * @return the location of manifest lists
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link #rootLocations(Table)}. The
+   *     method returns v4+ root manifest locations too, so the name no longer matches its behavior.
    */
+  @Deprecated
   public static List<String> manifestListLocations(Table table) {
-    return manifestListLocations(table, null);
+    return rootLocations(table, null);
   }
 
   /**
-   * Returns locations of manifest lists in a table.
-   *
-   * @param table table for which manifestList needs to be fetched
-   * @param snapshotIds ids of snapshots for which manifest lists will be returned
-   * @return the location of manifest lists
+   * @deprecated since 1.12.0, will be removed in 1.13.0; use {@link #rootLocations(Table, Set)}.
+   *     The method returns v4+ root manifest locations too, so the name no longer matches its
+   *     behavior.
    */
+  @Deprecated
   public static List<String> manifestListLocations(Table table, Set<Long> snapshotIds) {
+    return rootLocations(table, snapshotIds);
+  }
+
+  /**
+   * Returns the root location for every snapshot in the table — a manifest list for v3 and earlier,
+   * or a root manifest for v4+.
+   *
+   * @param table table whose root locations should be fetched
+   * @return the root location per snapshot
+   */
+  public static List<String> rootLocations(Table table) {
+    return rootLocations(table, null);
+  }
+
+  /**
+   * Returns the root location for each snapshot filtered by id — a manifest list for v3 and
+   * earlier, or a root manifest for v4+.
+   *
+   * @param table table whose root locations should be fetched
+   * @param snapshotIds ids of snapshots to include, or null for every snapshot
+   * @return the root location per matching snapshot
+   */
+  public static List<String> rootLocations(Table table, Set<Long> snapshotIds) {
     Iterable<Snapshot> snapshots = table.snapshots();
     if (snapshotIds != null) {
       snapshots = Iterables.filter(snapshots, s -> snapshotIds.contains(s.snapshotId()));
     }
 
-    List<String> manifestListLocations = Lists.newArrayList();
+    List<String> rootLocations = Lists.newArrayList();
     for (Snapshot snapshot : snapshots) {
-      String manifestListLocation = snapshot.manifestListLocation();
-      if (manifestListLocation != null) {
-        manifestListLocations.add(manifestListLocation);
+      String location = snapshot.rootLocation();
+      if (location != null) {
+        rootLocations.add(location);
       }
     }
-    return manifestListLocations;
+    return rootLocations;
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -229,7 +229,7 @@ public class RewriteTablePathUtil {
     List<Snapshot> newSnapshots = Lists.newArrayListWithCapacity(metadata.snapshots().size());
     for (Snapshot snapshot : metadata.snapshots()) {
       String newManifestListLocation =
-          newPath(snapshot.manifestListLocation(), sourcePrefix, targetPrefix);
+          newPath(snapshot.snapshotFileLocation(), sourcePrefix, targetPrefix);
       Snapshot newSnapshot =
           new BaseSnapshot(
               snapshot.sequenceNumber(),
@@ -313,12 +313,12 @@ public class RewriteTablePathUtil {
       return result;
     } catch (IOException e) {
       throw new UncheckedIOException(
-          "Failed to rewrite the manifest list file " + snapshot.manifestListLocation(), e);
+          "Failed to rewrite the manifest list file " + snapshot.snapshotFileLocation(), e);
     }
   }
 
   private static List<ManifestFile> manifestFilesInSnapshot(FileIO io, Snapshot snapshot) {
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.snapshotFileLocation();
     List<ManifestFile> manifestFiles = Lists.newArrayList();
     try {
       manifestFiles = ManifestLists.read(io.newInputFile(path));

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -242,8 +242,7 @@ public class RewriteTablePathUtil {
       TableMetadata metadata, String sourcePrefix, String targetPrefix) {
     List<Snapshot> newSnapshots = Lists.newArrayListWithCapacity(metadata.snapshots().size());
     for (Snapshot snapshot : metadata.snapshots()) {
-      String newManifestListLocation =
-          newPath(snapshot.manifestListLocation(), sourcePrefix, targetPrefix);
+      String newManifestListLocation = newPath(snapshot.rootLocation(), sourcePrefix, targetPrefix);
       Snapshot newSnapshot =
           new BaseSnapshot(
               snapshot.sequenceNumber(),
@@ -308,7 +307,7 @@ public class RewriteTablePathUtil {
           "{} of {} manifests in {} were not rewritten in this run and keep their source length",
           carriedOver,
           manifestFiles.size(),
-          snapshot.manifestListLocation());
+          snapshot.rootLocation());
     }
 
     EncryptionManager encryptionManager =
@@ -343,7 +342,7 @@ public class RewriteTablePathUtil {
       return result;
     } catch (IOException e) {
       throw new UncheckedIOException(
-          "Failed to rewrite the manifest list file " + snapshot.manifestListLocation(), e);
+          "Failed to rewrite the manifest list file " + snapshot.rootLocation(), e);
     }
   }
 
@@ -351,7 +350,7 @@ public class RewriteTablePathUtil {
     try {
       return snapshot.allManifests(io);
     } catch (RuntimeIOException e) {
-      LOG.warn("Failed to read manifest list {}", snapshot.manifestListLocation(), e);
+      LOG.warn("Failed to read manifest list {}", snapshot.rootLocation(), e);
       return ImmutableList.of();
     }
   }

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -82,10 +82,10 @@ public class SnapshotParser {
       generator.writeEndObject();
     }
 
-    String manifestList = snapshot.manifestListLocation();
-    if (manifestList != null) {
+    String snapshotFile = snapshot.snapshotFileLocation();
+    if (snapshotFile != null) {
       // write just the location. manifests should not be embedded in JSON along with a list
-      generator.writeStringField(MANIFEST_LIST, manifestList);
+      generator.writeStringField(MANIFEST_LIST, snapshotFile);
     } else {
       // embed the manifest list in the JSON, v1 only
       JsonUtil.writeStringArray(

--- a/core/src/main/java/org/apache/iceberg/SnapshotParser.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotParser.java
@@ -82,10 +82,10 @@ public class SnapshotParser {
       generator.writeEndObject();
     }
 
-    String manifestList = snapshot.manifestListLocation();
-    if (manifestList != null) {
+    String snapshotFile = snapshot.rootLocation();
+    if (snapshotFile != null) {
       // write just the location. manifests should not be embedded in JSON along with a list
-      generator.writeStringField(MANIFEST_LIST, manifestList);
+      generator.writeStringField(MANIFEST_LIST, snapshotFile);
     } else {
       // embed the manifest list in the JSON, v1 only
       JsonUtil.writeStringArray(

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -107,7 +107,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private final String commitUUID = UUID.randomUUID().toString();
   private final AtomicInteger manifestCount = new AtomicInteger(0);
   private final AtomicInteger attempt = new AtomicInteger(0);
-  private final List<String> manifestLists = Lists.newArrayList();
+  private final List<String> snapshotFiles = Lists.newArrayList();
   private final long targetManifestSizeBytes;
   private final FileFormat manifestFormat;
   private final Map<String, String> manifestWriterProps;
@@ -314,8 +314,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             base.nextRowId());
 
     try (writer) {
-      // keep track of the manifest lists created
-      manifestLists.add(manifestList.location());
+      // keep track of the snapshot files created
+      snapshotFiles.add(manifestList.location());
 
       ManifestFile[] manifestFiles = new ManifestFile[manifests.size()];
 
@@ -545,10 +545,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             cleanUncommitted(Sets.newHashSet(saved.allManifests(ops.io())));
           }
 
-          // also clean up unused manifest lists created by multiple attempts
-          for (String manifestList : manifestLists) {
-            if (!saved.manifestListLocation().equals(manifestList)) {
-              deleteFile(manifestList);
+          // also clean up unused snapshot files (manifest lists for v3, root manifests for v4)
+          // created by multiple attempts.
+          String committedLocation = saved.snapshotFileLocation();
+          for (String snapshotFile : snapshotFiles) {
+            if (!snapshotFile.equals(committedLocation)) {
+              deleteFile(snapshotFile);
             }
           }
         } else {
@@ -597,10 +599,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   protected void cleanAll() {
-    for (String manifestList : manifestLists) {
-      deleteFile(manifestList);
+    for (String snapshotFile : snapshotFiles) {
+      deleteFile(snapshotFile);
     }
-    manifestLists.clear();
+    snapshotFiles.clear();
     cleanUncommitted(EMPTY_SET);
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -364,7 +364,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
         manifestList.location(),
         nextRowId,
         assignedRows,
-        writer.toManifestListFile().encryptionKeyID());
+        writer.toManifestListFile().keyId());
   }
 
   private void runValidations(Snapshot parentSnapshot) {

--- a/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotProducer.java
@@ -106,7 +106,7 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   private final String commitUUID = UUID.randomUUID().toString();
   private final AtomicInteger manifestCount = new AtomicInteger(0);
   private final AtomicInteger attempt = new AtomicInteger(0);
-  private final List<String> manifestLists = Lists.newArrayList();
+  private final List<String> snapshotFiles = Lists.newArrayList();
   private final long targetManifestSizeBytes;
   private final FileFormat manifestFormat;
   private final Map<String, String> manifestWriterProps;
@@ -313,8 +313,8 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             base.nextRowId());
 
     try (writer) {
-      // keep track of the manifest lists created
-      manifestLists.add(manifestList.location());
+      // keep track of the snapshot files created
+      snapshotFiles.add(manifestList.location());
 
       ManifestFile[] manifestFiles = new ManifestFile[manifests.size()];
 
@@ -544,10 +544,12 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
             cleanUncommitted(Sets.newHashSet(saved.allManifests(ops.io())));
           }
 
-          // also clean up unused manifest lists created by multiple attempts
-          for (String manifestList : manifestLists) {
-            if (!saved.manifestListLocation().equals(manifestList)) {
-              deleteFile(manifestList);
+          // also clean up unused snapshot files (manifest lists for v3, root manifests for v4)
+          // created by multiple attempts.
+          String committedLocation = saved.rootLocation();
+          for (String snapshotFile : snapshotFiles) {
+            if (!snapshotFile.equals(committedLocation)) {
+              deleteFile(snapshotFile);
             }
           }
         } else {
@@ -596,10 +598,10 @@ abstract class SnapshotProducer<ThisT> implements SnapshotUpdate<ThisT> {
   }
 
   protected void cleanAll() {
-    for (String manifestList : manifestLists) {
-      deleteFile(manifestList);
+    for (String snapshotFile : snapshotFiles) {
+      deleteFile(snapshotFile);
     }
-    manifestLists.clear();
+    snapshotFiles.clear();
     cleanUncommitted(EMPTY_SET);
   }
 

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -37,7 +37,8 @@ public class SnapshotsTable extends BaseMetadataTable {
           Types.NestedField.optional(
               6,
               "summary",
-              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())));
+              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())),
+          Types.NestedField.optional(9, "snapshot_file", Types.StringType.get()));
 
   SnapshotsTable(Table table) {
     this(table, table.name() + ".snapshots");
@@ -94,13 +95,16 @@ public class SnapshotsTable extends BaseMetadataTable {
     }
   }
 
-  private static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+  static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+    boolean adaptive = snap.formatVersion() != ManifestFile.LEGACY_FORMAT_VERSION;
+    String location = snap.snapshotFileLocation();
     return StaticDataTask.Row.of(
         snap.timestampMillis() * 1000,
         snap.snapshotId(),
         snap.parentId(),
         snap.operation(),
-        snap.manifestListLocation(),
-        snap.summary());
+        adaptive ? null : location,
+        snap.summary(),
+        location);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotsTable.java
@@ -37,7 +37,8 @@ public class SnapshotsTable extends BaseMetadataTable {
           Types.NestedField.optional(
               6,
               "summary",
-              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())));
+              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())),
+          Types.NestedField.optional(9, "root_location", Types.StringType.get()));
 
   SnapshotsTable(Table table) {
     this(table, table.name() + ".snapshots");
@@ -94,13 +95,16 @@ public class SnapshotsTable extends BaseMetadataTable {
     }
   }
 
-  private static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+  static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+    boolean adaptive = snap.formatVersion() != TableMetadata.UNREPORTED_FORMAT_VERSION;
+    String location = snap.rootLocation();
     return StaticDataTask.Row.of(
         snap.timestampMillis() * 1000,
         snap.snapshotId(),
         snap.parentId(),
         snap.operation(),
-        snap.manifestListLocation(),
-        snap.summary());
+        adaptive ? null : location,
+        snap.summary(),
+        location);
   }
 }

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -56,6 +56,7 @@ public class TableMetadata implements Serializable {
   static final long INVALID_SEQUENCE_NUMBER = -1;
   static final int DEFAULT_TABLE_FORMAT_VERSION = 2;
   static final int SUPPORTED_TABLE_FORMAT_VERSION = 4;
+  static final int UNREPORTED_FORMAT_VERSION = 0;
   static final int MIN_FORMAT_VERSION_ROW_LINEAGE = 3;
   static final int MIN_FORMAT_VERSION_PARQUET_MANIFESTS = 4;
   static final int MIN_FORMAT_VERSION_OPTIONAL_LOCATION = 4;

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
 import org.apache.iceberg.ManifestListFile;
+import org.apache.iceberg.SnapshotFile;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynConstructors;
 import org.apache.iceberg.io.OutputFile;
@@ -135,24 +136,43 @@ public class EncryptionUtil {
   }
 
   /**
+   * Decrypt the key metadata for the top-level file that a snapshot points at (a v3 manifest list
+   * or a v4+ root manifest).
+   *
+   * @param snapshotFile a SnapshotFile
+   * @param em the table's EncryptionManager
+   * @return a decrypted key metadata buffer
+   */
+  public static ByteBuffer decryptSnapshotFileKeyMetadata(
+      SnapshotFile snapshotFile, EncryptionManager em) {
+    return decryptSnapshotFileKeyMetadata(snapshotFile.encryptionKeyID(), em);
+  }
+
+  /**
    * Decrypt the key metadata for a manifest list.
    *
    * @param manifestList a ManifestListFile
    * @param em the table's EncryptionManager
    * @return a decrypted key metadata buffer
+   * @deprecated since 1.13.0; use {@link #decryptSnapshotFileKeyMetadata(SnapshotFile,
+   *     EncryptionManager)}.
    */
+  @Deprecated
   public static ByteBuffer decryptManifestListKeyMetadata(
       ManifestListFile manifestList, EncryptionManager em) {
+    return decryptSnapshotFileKeyMetadata(manifestList.encryptionKeyID(), em);
+  }
+
+  private static ByteBuffer decryptSnapshotFileKeyMetadata(String keyId, EncryptionManager em) {
     Preconditions.checkState(
         em instanceof StandardEncryptionManager,
         "Snapshot key metadata encryption requires a StandardEncryptionManager");
     StandardEncryptionManager sem = (StandardEncryptionManager) em;
-    String manifestListKeyId = manifestList.encryptionKeyID();
     Map<String, EncryptedKey> encryptionKeys = sem.encryptionKeys();
-    EncryptedKey manifestListKey = encryptionKeys.get(manifestListKeyId);
-    ByteBuffer encryptedKeyMetadata = manifestListKey.encryptedKeyMetadata();
-    String keyEncryptionKeyID = manifestListKey.encryptedById();
-    ByteBuffer keyEncryptionKey = sem.encryptedByKey(manifestListKeyId);
+    EncryptedKey snapshotFileKey = encryptionKeys.get(keyId);
+    ByteBuffer encryptedKeyMetadata = snapshotFileKey.encryptedKeyMetadata();
+    String keyEncryptionKeyID = snapshotFileKey.encryptedById();
+    ByteBuffer keyEncryptionKey = sem.encryptedByKey(keyId);
     String keyEncryptionKeyTimestamp =
         encryptionKeys
             .get(keyEncryptionKeyID)

--- a/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/EncryptionUtil.java
@@ -25,6 +25,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.FileWithKeyId;
 import org.apache.iceberg.ManifestListFile;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.common.DynConstructors;
@@ -140,19 +141,36 @@ public class EncryptionUtil {
    * @param manifestList a ManifestListFile
    * @param em the table's EncryptionManager
    * @return a decrypted key metadata buffer
+   * @deprecated since 1.12.0. Will be removed in 2.0.0; use {@link
+   *     #decryptKeyMetadata(FileWithKeyId, EncryptionManager)} instead.
    */
+  @Deprecated
   public static ByteBuffer decryptManifestListKeyMetadata(
       ManifestListFile manifestList, EncryptionManager em) {
+    return decryptKeyMetadata(manifestList.encryptionKeyID(), em);
+  }
+
+  /**
+   * Decrypt the key metadata of an encryptable file.
+   *
+   * @param file a FileWithKeyId
+   * @param em the table's EncryptionManager
+   * @return a decrypted key metadata buffer
+   */
+  public static ByteBuffer decryptKeyMetadata(FileWithKeyId file, EncryptionManager em) {
+    return decryptKeyMetadata(file.keyId(), em);
+  }
+
+  static ByteBuffer decryptKeyMetadata(String encryptionKeyId, EncryptionManager em) {
     Preconditions.checkState(
         em instanceof StandardEncryptionManager,
         "Snapshot key metadata encryption requires a StandardEncryptionManager");
     StandardEncryptionManager sem = (StandardEncryptionManager) em;
-    String manifestListKeyId = manifestList.encryptionKeyID();
     Map<String, EncryptedKey> encryptionKeys = sem.encryptionKeys();
-    EncryptedKey manifestListKey = encryptionKeys.get(manifestListKeyId);
-    ByteBuffer encryptedKeyMetadata = manifestListKey.encryptedKeyMetadata();
-    String keyEncryptionKeyID = manifestListKey.encryptedById();
-    ByteBuffer keyEncryptionKey = sem.encryptedByKey(manifestListKeyId);
+    EncryptedKey encryptionKey = encryptionKeys.get(encryptionKeyId);
+    ByteBuffer encryptedKeyMetadata = encryptionKey.encryptedKeyMetadata();
+    String keyEncryptionKeyID = encryptionKey.encryptedById();
+    ByteBuffer keyEncryptionKey = sem.encryptedByKey(encryptionKeyId);
     String keyEncryptionKeyTimestamp =
         encryptionKeys
             .get(keyEncryptionKeyID)

--- a/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
+++ b/core/src/main/java/org/apache/iceberg/encryption/StandardEncryptionManager.java
@@ -106,6 +106,11 @@ public class StandardEncryptionManager implements EncryptionManager {
     return Iterables.transform(encrypted, this::decrypt);
   }
 
+  @Override
+  public ByteBuffer decryptKeyMetadata(String keyId) {
+    return EncryptionUtil.decryptKeyMetadata(keyId, this);
+  }
+
   private LoadingCache<String, ByteBuffer> unwrappedKeyCache() {
     if (this.unwrappedKeyCache == null) {
       this.unwrappedKeyCache =

--- a/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestAllManifestsTableTaskParser.java
@@ -148,8 +148,7 @@ public class TestAllManifestsTableTaskParser {
 
     assertThat(actual.specsById()).isEqualTo(expected.specsById());
     assertThat(actual.manifestList().location()).isEqualTo(expected.manifestList().location());
-    assertThat(actual.manifestList().encryptionKeyID())
-        .isEqualTo(expected.manifestList().encryptionKeyID());
+    assertThat(actual.manifestList().keyId()).isEqualTo(expected.manifestList().keyId());
     assertThat(actual.residual().toString()).isEqualTo(expected.residual().toString());
     assertThat(actual.referenceSnapshotId()).isEqualTo(expected.referenceSnapshotId());
   }

--- a/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
@@ -46,17 +46,21 @@ public class TestDataTaskParser {
           Types.NestedField.optional(
               6,
               "summary",
-              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())));
+              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())),
+          Types.NestedField.optional(9, "snapshot_file", Types.StringType.get()));
 
-  // copied from SnapshotsTable to avoid making it package public
+  // mirrors SnapshotsTable.snapshotToRow, which is package-private
   private static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+    boolean adaptive = snap.formatVersion() != ManifestFile.LEGACY_FORMAT_VERSION;
+    String location = snap.snapshotFileLocation();
     return StaticDataTask.Row.of(
         snap.timestampMillis() * 1000,
         snap.snapshotId(),
         snap.parentId(),
         snap.operation(),
-        snap.manifestListLocation(),
-        snap.summary());
+        adaptive ? null : location,
+        snap.summary(),
+        location);
   }
 
   @Test
@@ -134,7 +138,8 @@ public class TestDataTaskParser {
             + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
             + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
             + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-            + "\"value\":\"string\",\"value-required\":true}}]},"
+            + "\"value\":\"string\",\"value-required\":true}},"
+            + "{\"id\":9,\"name\":\"snapshot_file\",\"required\":false,\"type\":\"string\"}]},"
             + "\"projection\":{\"type\":\"struct\",\"schema-id\":0,"
             + "\"fields\":[{\"id\":1,\"name\":\"committed_at\",\"required\":true,\"type\":\"timestamptz\"},"
             + "{\"id\":2,\"name\":\"snapshot_id\",\"required\":true,\"type\":\"long\"},"
@@ -143,7 +148,8 @@ public class TestDataTaskParser {
             + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
             + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
             + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-            + "\"value\":\"string\",\"value-required\":true}}]},"
+            + "\"value\":\"string\",\"value-required\":true}},"
+            + "{\"id\":9,\"name\":\"snapshot_file\",\"required\":false,\"type\":\"string\"}]},"
             + "\"metadata-file\":{\"spec-id\":0,\"content\":\"data\","
             + "\"file-path\":\"/tmp/metadata2.json\","
             + "\"file-format\":\"metadata\",\"partition\":[],"
@@ -253,7 +259,8 @@ public class TestDataTaskParser {
         + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
         + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
         + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-        + "\"value\":\"string\",\"value-required\":true}}]},"
+        + "\"value\":\"string\",\"value-required\":true}},"
+        + "{\"id\":9,\"name\":\"snapshot_file\",\"required\":false,\"type\":\"string\"}]},"
         + "\"projection\":{\"type\":\"struct\",\"schema-id\":0,"
         + "\"fields\":[{\"id\":1,\"name\":\"committed_at\",\"required\":true,\"type\":\"timestamptz\"},"
         + "{\"id\":2,\"name\":\"snapshot_id\",\"required\":true,\"type\":\"long\"},"
@@ -262,7 +269,8 @@ public class TestDataTaskParser {
         + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
         + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
         + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-        + "\"value\":\"string\",\"value-required\":true}}]},"
+        + "\"value\":\"string\",\"value-required\":true}},"
+        + "{\"id\":9,\"name\":\"snapshot_file\",\"required\":false,\"type\":\"string\"}]},"
         + "\"metadata-file\":{\"spec-id\":0,\"content\":\"data\","
         + "\"file-path\":\"/tmp/metadata2.json\","
         + "\"file-format\":\"metadata\",\"partition\":[],"
@@ -272,13 +280,15 @@ public class TestDataTaskParser {
         + "\"6\":{\"keys\":[\"added-data-files\",\"added-records\",\"added-files-size\",\"changed-partition-count\","
         + "\"total-records\",\"total-files-size\",\"total-data-files\",\"total-delete-files\","
         + "\"total-position-deletes\",\"total-equality-deletes\"],"
-        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"1\",\"10\",\"1\",\"0\",\"0\",\"0\"]}},"
+        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"1\",\"10\",\"1\",\"0\",\"0\",\"0\"]},"
+        + "\"9\":\"file:/tmp/manifest1.avro\"},"
         + "{\"1\":\"2282-12-22T20:13:30+00:00\",\"2\":2,\"3\":1,\"4\":\"append\","
         + "\"5\":\"file:/tmp/manifest2.avro\","
         + "\"6\":{\"keys\":[\"added-data-files\",\"added-records\",\"added-files-size\",\"changed-partition-count\","
         + "\"total-records\",\"total-files-size\",\"total-data-files\",\"total-delete-files\","
         + "\"total-position-deletes\",\"total-equality-deletes\"],"
-        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"2\",\"20\",\"2\",\"0\",\"0\",\"0\"]}}]}";
+        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"2\",\"20\",\"2\",\"0\",\"0\",\"0\"]},"
+        + "\"9\":\"file:/tmp/manifest2.avro\"}]}";
   }
 
   private void assertDataTaskEquals(StaticDataTask expected, StaticDataTask actual) {

--- a/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestDataTaskParser.java
@@ -46,17 +46,21 @@ public class TestDataTaskParser {
           Types.NestedField.optional(
               6,
               "summary",
-              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())));
+              Types.MapType.ofRequired(7, 8, Types.StringType.get(), Types.StringType.get())),
+          Types.NestedField.optional(9, "root_location", Types.StringType.get()));
 
-  // copied from SnapshotsTable to avoid making it package public
+  // mirrors SnapshotsTable.snapshotToRow, which is package-private
   private static StaticDataTask.Row snapshotToRow(Snapshot snap) {
+    boolean adaptive = snap.formatVersion() != TableMetadata.UNREPORTED_FORMAT_VERSION;
+    String location = snap.rootLocation();
     return StaticDataTask.Row.of(
         snap.timestampMillis() * 1000,
         snap.snapshotId(),
         snap.parentId(),
         snap.operation(),
-        snap.manifestListLocation(),
-        snap.summary());
+        adaptive ? null : location,
+        snap.summary(),
+        location);
   }
 
   @Test
@@ -134,7 +138,8 @@ public class TestDataTaskParser {
             + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
             + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
             + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-            + "\"value\":\"string\",\"value-required\":true}}]},"
+            + "\"value\":\"string\",\"value-required\":true}},"
+            + "{\"id\":9,\"name\":\"root_location\",\"required\":false,\"type\":\"string\"}]},"
             + "\"projection\":{\"type\":\"struct\",\"schema-id\":0,"
             + "\"fields\":[{\"id\":1,\"name\":\"committed_at\",\"required\":true,\"type\":\"timestamptz\"},"
             + "{\"id\":2,\"name\":\"snapshot_id\",\"required\":true,\"type\":\"long\"},"
@@ -143,7 +148,8 @@ public class TestDataTaskParser {
             + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
             + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
             + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-            + "\"value\":\"string\",\"value-required\":true}}]},"
+            + "\"value\":\"string\",\"value-required\":true}},"
+            + "{\"id\":9,\"name\":\"root_location\",\"required\":false,\"type\":\"string\"}]},"
             + "\"metadata-file\":{\"spec-id\":0,\"content\":\"data\","
             + "\"file-path\":\"/tmp/metadata2.json\","
             + "\"file-format\":\"metadata\",\"partition\":[],"
@@ -253,7 +259,8 @@ public class TestDataTaskParser {
         + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
         + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
         + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-        + "\"value\":\"string\",\"value-required\":true}}]},"
+        + "\"value\":\"string\",\"value-required\":true}},"
+        + "{\"id\":9,\"name\":\"root_location\",\"required\":false,\"type\":\"string\"}]},"
         + "\"projection\":{\"type\":\"struct\",\"schema-id\":0,"
         + "\"fields\":[{\"id\":1,\"name\":\"committed_at\",\"required\":true,\"type\":\"timestamptz\"},"
         + "{\"id\":2,\"name\":\"snapshot_id\",\"required\":true,\"type\":\"long\"},"
@@ -262,7 +269,8 @@ public class TestDataTaskParser {
         + "{\"id\":5,\"name\":\"manifest_list\",\"required\":false,\"type\":\"string\"},"
         + "{\"id\":6,\"name\":\"summary\",\"required\":false,\"type\":{\"type\":\"map\","
         + "\"key-id\":7,\"key\":\"string\",\"value-id\":8,"
-        + "\"value\":\"string\",\"value-required\":true}}]},"
+        + "\"value\":\"string\",\"value-required\":true}},"
+        + "{\"id\":9,\"name\":\"root_location\",\"required\":false,\"type\":\"string\"}]},"
         + "\"metadata-file\":{\"spec-id\":0,\"content\":\"data\","
         + "\"file-path\":\"/tmp/metadata2.json\","
         + "\"file-format\":\"metadata\",\"partition\":[],"
@@ -272,13 +280,15 @@ public class TestDataTaskParser {
         + "\"6\":{\"keys\":[\"added-data-files\",\"added-records\",\"added-files-size\",\"changed-partition-count\","
         + "\"total-records\",\"total-files-size\",\"total-data-files\",\"total-delete-files\","
         + "\"total-position-deletes\",\"total-equality-deletes\"],"
-        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"1\",\"10\",\"1\",\"0\",\"0\",\"0\"]}},"
+        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"1\",\"10\",\"1\",\"0\",\"0\",\"0\"]},"
+        + "\"9\":\"file:/tmp/manifest1.avro\"},"
         + "{\"1\":\"2282-12-22T20:13:30+00:00\",\"2\":2,\"3\":1,\"4\":\"append\","
         + "\"5\":\"file:/tmp/manifest2.avro\","
         + "\"6\":{\"keys\":[\"added-data-files\",\"added-records\",\"added-files-size\",\"changed-partition-count\","
         + "\"total-records\",\"total-files-size\",\"total-data-files\",\"total-delete-files\","
         + "\"total-position-deletes\",\"total-equality-deletes\"],"
-        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"2\",\"20\",\"2\",\"0\",\"0\",\"0\"]}}]}";
+        + "\"values\":[\"1\",\"1\",\"10\",\"1\",\"2\",\"20\",\"2\",\"0\",\"0\",\"0\"]},"
+        + "\"9\":\"file:/tmp/manifest2.avro\"}]}";
   }
 
   private void assertDataTaskEquals(StaticDataTask expected, StaticDataTask actual) {

--- a/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
+++ b/core/src/test/java/org/apache/iceberg/TestManifestListEncryption.java
@@ -220,7 +220,7 @@ public class TestManifestListEncryption {
             SNAPSHOT_FIRST_ROW_ID);
     writer.add(TEST_MANIFEST);
     writer.close();
-    ManifestListFile manifestListFile = writer.toManifestListFile();
+    FileWithKeyId manifestListFile = writer.toManifestListFile();
 
     // First try to read without decryption
     assertThatThrownBy(() -> ManifestLists.read(outputFile.toInputFile()))

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotsTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotsTable.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+public class TestSnapshotsTable {
+
+  private static final String LOCATION = "file:/tmp/snap-1.avro";
+
+  @Test
+  public void legacySnapshotPopulatesManifestListAndSnapshotFile() {
+    Snapshot snap = stubSnapshot(ManifestFile.LEGACY_FORMAT_VERSION);
+    StaticDataTask.Row row = SnapshotsTable.snapshotToRow(snap);
+
+    assertThat(row.get(4, String.class))
+        .as("manifest_list should be populated for legacy snapshots")
+        .isEqualTo(LOCATION);
+    assertThat(row.get(6, String.class))
+        .as("snapshot_file should always be populated")
+        .isEqualTo(LOCATION);
+  }
+
+  @Test
+  public void adaptiveSnapshotNullsManifestListAndPopulatesSnapshotFile() {
+    Snapshot snap = stubSnapshot(4);
+    StaticDataTask.Row row = SnapshotsTable.snapshotToRow(snap);
+
+    assertThat(row.get(4, String.class))
+        .as("manifest_list should be null for adaptive snapshots")
+        .isNull();
+    assertThat(row.get(6, String.class))
+        .as("snapshot_file should be populated")
+        .isEqualTo(LOCATION);
+  }
+
+  private static Snapshot stubSnapshot(int formatVersion) {
+    Snapshot snap = mock(Snapshot.class);
+    when(snap.formatVersion()).thenReturn(formatVersion);
+    when(snap.snapshotFileLocation()).thenReturn(LOCATION);
+    when(snap.timestampMillis()).thenReturn(1L);
+    when(snap.snapshotId()).thenReturn(1L);
+    when(snap.parentId()).thenReturn(null);
+    when(snap.operation()).thenReturn("append");
+    when(snap.summary()).thenReturn(null);
+    return snap;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestSnapshotsTable.java
+++ b/core/src/test/java/org/apache/iceberg/TestSnapshotsTable.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+
+public class TestSnapshotsTable {
+
+  private static final String LOCATION = "file:/tmp/snap-1.avro";
+
+  @Test
+  public void legacySnapshotPopulatesManifestListAndRootLocation() {
+    Snapshot snap = stubSnapshot(TableMetadata.UNREPORTED_FORMAT_VERSION);
+    StaticDataTask.Row row = SnapshotsTable.snapshotToRow(snap);
+
+    assertThat(row.get(4, String.class))
+        .as("manifest_list should be populated for legacy snapshots")
+        .isEqualTo(LOCATION);
+    assertThat(row.get(6, String.class))
+        .as("root_location should always be populated")
+        .isEqualTo(LOCATION);
+  }
+
+  @Test
+  public void adaptiveSnapshotNullsManifestListAndPopulatesRootLocation() {
+    Snapshot snap = stubSnapshot(4);
+    StaticDataTask.Row row = SnapshotsTable.snapshotToRow(snap);
+
+    assertThat(row.get(4, String.class))
+        .as("manifest_list should be null for adaptive snapshots")
+        .isNull();
+    assertThat(row.get(6, String.class))
+        .as("root_location should be populated")
+        .isEqualTo(LOCATION);
+  }
+
+  private static Snapshot stubSnapshot(int formatVersion) {
+    Snapshot snap = mock(Snapshot.class);
+    when(snap.formatVersion()).thenReturn(formatVersion);
+    when(snap.rootLocation()).thenReturn(LOCATION);
+    when(snap.timestampMillis()).thenReturn(1L);
+    when(snap.snapshotId()).thenReturn(1L);
+    when(snap.parentId()).thenReturn(null);
+    when(snap.operation()).thenReturn("append");
+    when(snap.summary()).thenReturn(null);
+    return snap;
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
+++ b/core/src/test/java/org/apache/iceberg/hadoop/TestCatalogUtilDropTable.java
@@ -31,11 +31,11 @@ import java.util.stream.Collectors;
 import org.apache.iceberg.CatalogUtil;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileWithKeyId;
 import org.apache.iceberg.GenericBlobMetadata;
 import org.apache.iceberg.GenericStatisticsFile;
 import org.apache.iceberg.ImmutableGenericPartitionStatisticsFile;
 import org.apache.iceberg.ManifestFile;
-import org.apache.iceberg.ManifestListFile;
 import org.apache.iceberg.PartitionStatisticsFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.SnapshotChanges;
@@ -199,9 +199,8 @@ public class TestCatalogUtilDropTable extends HadoopTableTestBase {
         .thenAnswer(
             invocation ->
                 wrapped.newInputFile(invocation.getArgument(0), invocation.getArgument(1)));
-    Mockito.when(mockIO.newInputFile(Mockito.any(ManifestListFile.class)))
-        .thenAnswer(
-            invocation -> wrapped.newInputFile((ManifestListFile) invocation.getArgument(0)));
+    Mockito.when(mockIO.newInputFile(Mockito.any(FileWithKeyId.class)))
+        .thenAnswer(invocation -> wrapped.newInputFile((FileWithKeyId) invocation.getArgument(0)));
     Mockito.when(mockIO.newInputFile(Mockito.any(ManifestFile.class)))
         .thenAnswer(invocation -> wrapped.newInputFile((ManifestFile) invocation.getArgument(0)));
     Mockito.when(mockIO.newInputFile(Mockito.any(DataFile.class)))

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.snapshotFileLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.rootLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.snapshotFileLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.snapshotFileLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.rootLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.2/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.rootLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
+++ b/flink/v2.3/flink/src/main/java/org/apache/iceberg/flink/maintenance/operator/ListMetadataFiles.java
@@ -72,7 +72,7 @@ public class ListMetadataFiles extends ProcessFunction<Trigger, String> {
           .forEach(
               snapshot -> {
                 // Manifest lists
-                collector.collect(snapshot.manifestListLocation());
+                collector.collect(snapshot.rootLocation());
                 // Snapshot JSONs
                 ReachableFileUtil.metadataFileLocations(table, false).forEach(collector::collect);
                 // Statistics files

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -502,7 +502,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.snapshotFileLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -507,7 +507,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.rootLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -939,6 +939,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("snapshot_file", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -954,6 +955,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("snapshot_file", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -939,6 +939,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("root_location", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -954,6 +955,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("root_location", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -216,7 +216,7 @@ public class TestSelect extends CatalogTestBase {
   public void testMetadataTables() {
     assertEquals(
         "Snapshot metadata table",
-        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY)),
+        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY, ANY)),
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -502,7 +502,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.snapshotFileLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -507,7 +507,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.rootLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -939,6 +939,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("snapshot_file", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -954,6 +955,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("snapshot_file", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -939,6 +939,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("root_location", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -954,6 +955,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("root_location", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -219,7 +219,7 @@ public class TestSelect extends CatalogTestBase {
   public void testMetadataTables() {
     assertEquals(
         "Snapshot metadata table",
-        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY)),
+        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY, ANY)),
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -502,7 +502,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.snapshotFileLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -507,7 +507,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.rootLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -944,6 +944,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("snapshot_file", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -959,6 +960,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("snapshot_file", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -944,6 +944,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("root_location", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -959,6 +960,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("root_location", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -218,7 +218,7 @@ public class TestSelect extends CatalogTestBase {
   public void testMetadataTables() {
     assertEquals(
         "Snapshot metadata table",
-        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY)),
+        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY, ANY)),
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 

--- a/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.2/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -507,7 +507,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
       Snapshot snapshot, TableMetadata tableMetadata, Map<String, Long> rewrittenManifestLengths) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
-    String path = snapshot.manifestListLocation();
+    String path = snapshot.rootLocation();
     String outputPath = RewriteTablePathUtil.stagingPath(path, sourcePrefix, stagingDir);
     RewriteResult<ManifestFile> rewriteResult =
         RewriteTablePathUtil.rewriteManifestList(

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/source/TestIcebergSourceTablesBase.java
@@ -944,6 +944,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-data-files", "1",
                         "total-records", "1"))
+                .set("root_location", firstManifestList)
                 .build(),
             builder
                 .set("committed_at", secondSnapshotTimestamp * 1000)
@@ -959,6 +960,7 @@ public abstract class TestIcebergSourceTablesBase extends TestBase {
                         "changed-partition-count", "1",
                         "total-records", "0",
                         "total-data-files", "0"))
+                .set("root_location", secondManifestList)
                 .build());
 
     assertThat(actual).as("Snapshots table should have a row for each snapshot").hasSize(2);

--- a/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
+++ b/spark/v4.2/spark/src/test/java/org/apache/iceberg/spark/sql/TestSelect.java
@@ -218,7 +218,7 @@ public class TestSelect extends CatalogTestBase {
   public void testMetadataTables() {
     assertEquals(
         "Snapshot metadata table",
-        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY)),
+        ImmutableList.of(row(ANY, ANY, null, "append", ANY, ANY, ANY)),
         sql("SELECT * FROM %s.snapshots", tableName));
   }
 


### PR DESCRIPTION
Stacked on [#17545](https://github.com/apache/iceberg/pull/17545) (`FileWithKeyId`).

Add `Snapshot.rootLocation()` as the version-agnostic accessor for the file a snapshot points at, so later v4 work can address a root manifest through the same accessor that v3 uses for a manifest list. The default returns `manifestListLocation()`, which is now deprecated, and internal callers across core, Spark, and Flink are migrated to the new accessor. `ReachableFileUtil.manifestListLocations()` is likewise replaced by `rootLocations()`.

The file itself needs no new type: `FileWithKeyId` already carries the location and encryption key ID for files whose key metadata lives in `TableMetadata.encryptionKeys`, and a v4 root manifest is such a file.

Evolve the `SnapshotsTable` metadata schema to expose the location under a version-agnostic name: add an optional `snapshot_file` column (field ID 9) populated for every snapshot. Whether the row also populates `manifest_list` is dispatched per-snapshot via a new default `Snapshot#formatVersion()`. Core compares that against package-private `TableMetadata.UNREPORTED_FORMAT_VERSION` so v3-produced snapshots on a v3→v4 upgraded table keep reporting `manifest_list` correctly.

### Alternative considered: a separate `Snapshot#rootManifestLocation()`

A more literal encoding would keep `manifestListLocation()` for v3 and add a sibling `rootManifestLocation()` for v4+. That was rejected because every caller that just wants "where is this snapshot's top-level file" would have to branch on format version. `rootLocation()` collapses that decision into the interface — v3 snapshots return their manifest list, v4+ snapshots return their root manifest, and callers stop caring about the difference. The manifest list (v3) and the root manifest (v4+) play the same structural role: they are the one file the snapshot addresses directly, and everything else is reached transitively.

---
**AI Disclosure**
- Model: Cursor Grok 4.6
- Platform/Tool: Cursor
- Human Oversight: fully reviewed
- Prompt Summary: Rebase PR 17523 onto Gabor's FileWithKeyId PR 17545, drop the extra SnapshotFile type, rename snapshotFileLocation to rootLocation, and move the unreported format-version sentinel into core.