### PR TITLE
Core: Preserve delete file references for shared Puffin files

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/TableScanResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/TableScanResponseParser.java
@@ -34,6 +34,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.util.JsonUtil;
+import org.apache.iceberg.util.Pair;
 
 public class TableScanResponseParser {
 
@@ -41,6 +42,12 @@ public class TableScanResponseParser {
 
   static final String FILE_SCAN_TASKS = "file-scan-tasks";
   static final String DELETE_FILES = "delete-files";
+
+  private static Pair<String, Pair<Long, Long>> deleteFileKey(DeleteFile deleteFile) {
+    return Pair.of(
+        deleteFile.location().toString(),
+        Pair.of(deleteFile.contentOffset(), deleteFile.contentSizeInBytes()));
+  }
 
   public static List<DeleteFile> parseDeleteFiles(
       JsonNode node, Map<Integer, PartitionSpec> specsById) {
@@ -99,14 +106,14 @@ public class TableScanResponseParser {
       Map<Integer, PartitionSpec> specsById,
       JsonGenerator gen)
       throws IOException {
-    Map<String, Integer> deleteFilePathToIndex = Maps.newHashMap();
+    Map<Pair<String, Pair<Long, Long>>, Integer> deleteFileToIndex = Maps.newHashMap();
     if (deleteFiles != null && !deleteFiles.isEmpty()) {
       Preconditions.checkArgument(
           specsById != null, "Cannot serialize response without specs by ID defined");
       gen.writeArrayFieldStart(DELETE_FILES);
       for (int i = 0; i < deleteFiles.size(); i++) {
         DeleteFile deleteFile = deleteFiles.get(i);
-        deleteFilePathToIndex.put(deleteFile.location(), i);
+        deleteFileToIndex.put(deleteFileKey(deleteFile), i);
         ContentFileParser.toJson(deleteFiles.get(i), specsById.get(deleteFile.specId()), gen);
       }
 
@@ -119,7 +126,7 @@ public class TableScanResponseParser {
         Set<Integer> deleteFileReferences = Sets.newHashSet();
         if (deleteFiles != null) {
           for (DeleteFile taskDelete : fileScanTask.deletes()) {
-            deleteFileReferences.add(deleteFilePathToIndex.get(taskDelete.location()));
+            deleteFileReferences.add(deleteFileToIndex.get(deleteFileKey(taskDelete)));
           }
         }
 

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -33,6 +33,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SchemaParser;
@@ -270,6 +271,76 @@ public class TestPlanTableScanResponseParser {
             .build();
 
     assertThat(PlanTableScanResponseParser.toJson(copyResponse)).isEqualTo(expectedToJson);
+  }
+
+  @Test
+  void roundTripSerdeWithMultipleDVsInSamePuffinFile() {
+    DeleteFile firstDV =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/deletes.puffin")
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_A.location())
+            .withContentOffset(4)
+            .withContentSizeInBytes(20)
+            .build();
+    DeleteFile secondDV =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/deletes.puffin")
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=1")
+            .withRecordCount(1)
+            .withReferencedDataFile(FILE_B.location())
+            .withContentOffset(24)
+            .withContentSizeInBytes(30)
+            .build();
+    ResidualEvaluator residualEvaluator =
+        ResidualEvaluator.of(SPEC, Expressions.alwaysTrue(), true);
+    FileScanTask firstTask =
+        new BaseFileScanTask(
+            FILE_A,
+            new DeleteFile[] {firstDV},
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            residualEvaluator);
+    FileScanTask secondTask =
+        new BaseFileScanTask(
+            FILE_B,
+            new DeleteFile[] {secondDV},
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            residualEvaluator);
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withFileScanTasks(List.of(firstTask, secondTask))
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .build();
+
+    PlanTableScanResponse roundTripped =
+        PlanTableScanResponseParser.fromJson(
+            PlanTableScanResponseParser.toJson(response), PARTITION_SPECS_BY_ID, false);
+
+    assertThat(roundTripped.deleteFiles()).hasSize(2);
+    assertThat(roundTripped.fileScanTasks().get(0).deletes())
+        .singleElement()
+        .satisfies(
+            deleteFile -> {
+              assertThat(deleteFile.referencedDataFile()).isEqualTo(FILE_A.location());
+              assertThat(deleteFile.contentOffset()).isEqualTo(4L);
+              assertThat(deleteFile.contentSizeInBytes()).isEqualTo(20L);
+            });
+    assertThat(roundTripped.fileScanTasks().get(1).deletes())
+        .singleElement()
+        .satisfies(
+            deleteFile -> {
+              assertThat(deleteFile.referencedDataFile()).isEqualTo(FILE_B.location());
+              assertThat(deleteFile.contentOffset()).isEqualTo(24L);
+              assertThat(deleteFile.contentSizeInBytes()).isEqualTo(30L);
+            });
   }
 
   @Test


### PR DESCRIPTION
## Summary

- index delete files by location, content offset, and content size
- preserve references when multiple deletion vectors share a Puffin file
- add a round-trip regression test

## Testing

- `./gradlew :iceberg-core:test --tests org.apache.iceberg.rest.responses.TestPlanTableScanResponseParser --tests org.apache.iceberg.rest.responses.TestFetchScanTasksResponseParser --tests org.apache.iceberg.rest.responses.TestFetchPlanningResultResponseParser --no-daemon`
- `./gradlew spotlessCheck --no-daemon`

Fixes #17334
