### PR TITLE
Core: Fix JdbcCatalog metadata lookups matching unrelated tables

### DIFF
--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcCatalog.java
@@ -168,15 +168,17 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
     connections.run(
         conn -> {
           DatabaseMetaData dbMeta = conn.getMetaData();
+          String catalog = JdbcUtil.metadataCatalog(conn);
+          String escape = dbMeta.getSearchStringEscape();
 
           // check the existence of a table name
           Predicate<String> tableTest =
               name -> {
                 try (ResultSet result =
                     dbMeta.getTables(
-                        null /* catalog name */,
+                        catalog,
                         null /* schemaPattern */,
-                        name /* tableNamePattern */,
+                        JdbcUtil.escapeMetadataPattern(name, escape) /* tableNamePattern */,
                         null /* types */)) {
                   return result.next();
                 } catch (SQLException e) {
@@ -235,9 +237,13 @@ public class JdbcCatalog extends BaseMetastoreViewCatalog
       connections.run(
           conn -> {
             DatabaseMetaData dbMeta = conn.getMetaData();
+            String escape = dbMeta.getSearchStringEscape();
             try (ResultSet typeColumn =
                 dbMeta.getColumns(
-                    null, null, JdbcUtil.CATALOG_TABLE_VIEW_NAME, JdbcUtil.RECORD_TYPE)) {
+                    JdbcUtil.metadataCatalog(conn),
+                    null,
+                    JdbcUtil.escapeMetadataPattern(JdbcUtil.CATALOG_TABLE_VIEW_NAME, escape),
+                    JdbcUtil.escapeMetadataPattern(JdbcUtil.RECORD_TYPE, escape))) {
               if (typeColumn.next()) {
                 LOG.debug("{} already supports views", JdbcUtil.CATALOG_TABLE_VIEW_NAME);
                 schemaVersion = JdbcUtil.SchemaVersion.V1;

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -22,6 +22,7 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Collections;
 import java.util.Map;
@@ -540,18 +541,15 @@ final class JdbcUtil {
    * null to leave them unrestricted.
    *
    * <p>A null catalog does not restrict a lookup to the database the connection points at, so
-   * catalog tables in an unrelated database can be mistaken for this catalog's own. An empty
-   * catalog name is not used because it selects only objects that belong to no catalog.
+   * catalog tables in an unrelated database can be mistaken for this catalog's own.
    *
    * @param conn a connection to resolve the catalog of
    */
-  static String metadataCatalog(Connection conn) {
+  static String metadataCatalog(Connection conn) throws SQLException {
     try {
-      String catalog = conn.getCatalog();
-      return catalog == null || catalog.isEmpty() ? null : catalog;
-    } catch (SQLException e) {
-      // databases without catalog support may fail instead of reporting no catalog
-      LOG.debug("Cannot determine the connection catalog, searching all catalogs", e);
+      return conn.getCatalog();
+    } catch (SQLFeatureNotSupportedException e) {
+      LOG.debug("Driver does not support catalogs, searching all catalogs", e);
       return null;
     }
   }

--- a/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
+++ b/core/src/main/java/org/apache/iceberg/jdbc/JdbcUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.jdbc;
 
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -35,8 +36,12 @@ import org.apache.iceberg.relocated.com.google.common.base.Splitter;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.util.PropertyUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 final class JdbcUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcUtil.class);
+
   // property to control strict-mode (aka check if namespace exists when creating a table)
   static final String STRICT_MODE_PROPERTY = JdbcCatalog.PROPERTY_PREFIX + "strict-mode";
   // property to control if view support is added to the existing database
@@ -528,6 +533,58 @@ final class JdbcUtil {
     return ex instanceof SQLIntegrityConstraintViolationException
         || POSTGRES_UNIQUE_VIOLATION_SQLSTATE.equals(ex.getSQLState())
         || (ex.getMessage() != null && ex.getMessage().contains("constraint failed"));
+  }
+
+  /**
+   * Returns the catalog that {@link java.sql.DatabaseMetaData} lookups should be restricted to, or
+   * null to leave them unrestricted.
+   *
+   * <p>A null catalog does not restrict a lookup to the database the connection points at, so
+   * catalog tables in an unrelated database can be mistaken for this catalog's own. An empty
+   * catalog name is not used because it selects only objects that belong to no catalog.
+   *
+   * @param conn a connection to resolve the catalog of
+   */
+  static String metadataCatalog(Connection conn) {
+    try {
+      String catalog = conn.getCatalog();
+      return catalog == null || catalog.isEmpty() ? null : catalog;
+    } catch (SQLException e) {
+      // databases without catalog support may fail instead of reporting no catalog
+      LOG.debug("Cannot determine the connection catalog, searching all catalogs", e);
+      return null;
+    }
+  }
+
+  /**
+   * Escapes a literal name so that it matches only itself when used as a {@link
+   * java.sql.DatabaseMetaData} pattern.
+   *
+   * <p>Pattern arguments treat {@code _} and {@code %} as wildcards, so an unescaped name such as
+   * {@code iceberg_tables} also matches unrelated names like {@code iceberg1tables}. The name is
+   * returned unchanged when the driver reports no escape string, because escaping is not supported
+   * in that case.
+   *
+   * @param name a literal table or column name
+   * @param escape the driver's escape string, from {@link
+   *     java.sql.DatabaseMetaData#getSearchStringEscape()}
+   */
+  static String escapeMetadataPattern(String name, String escape) {
+    if (escape == null || escape.isEmpty()) {
+      return name;
+    }
+
+    StringBuilder escaped = new StringBuilder(name.length());
+    for (int i = 0; i < name.length(); i += 1) {
+      char current = name.charAt(i);
+      if (current == '_' || current == '%' || escape.indexOf(current) >= 0) {
+        escaped.append(escape);
+      }
+
+      escaped.append(current);
+    }
+
+    return escaped.toString();
   }
 
   private static int update(

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcCatalog.java
@@ -32,6 +32,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLNonTransientConnectionException;
@@ -305,6 +306,68 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
             () -> jdbcCatalog.buildView(TableIdentifier.of("namespace1", "view")).create())
         .isInstanceOf(UnsupportedOperationException.class)
         .hasMessage(JdbcCatalog.VIEW_WARNING_LOG_MESSAGE);
+  }
+
+  @Test
+  void catalogTablesAreCreatedWhenAnotherTableMatchesTheirNamePattern() throws Exception {
+    // as this test uses different connections, we can't use memory database (as it's per
+    // connection), but a file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergSimilarTable", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    // the underscore in iceberg_tables is a wildcard when used as a JDBC metadata pattern, so
+    // this unrelated table is reported as the catalog table unless the pattern is escaped
+    executeUpdate(jdbcUrl, "CREATE TABLE iceberg1tables (col VARCHAR(255))");
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+
+    try (JdbcCatalog jdbcCatalog = new JdbcCatalog()) {
+      jdbcCatalog.setConf(conf);
+      jdbcCatalog.initialize("similar_table_catalog", properties);
+
+      assertThat(catalogTablesExist(jdbcUrl)).isTrue();
+
+      TableIdentifier tableIdent = TableIdentifier.of(Namespace.of("ns1"), "tbl");
+      jdbcCatalog.buildTable(tableIdent, SCHEMA).create();
+      assertThat(jdbcCatalog.loadTable(tableIdent).schema().asStruct())
+          .isEqualTo(SCHEMA.asStruct());
+    }
+  }
+
+  @Test
+  void schemaVersionIgnoresColumnsOfTablesMatchingTheCatalogTableNamePattern() throws Exception {
+    // as this test uses different connections, we can't use memory database (as it's per
+    // connection), but a file database instead
+    java.nio.file.Path dbFile = Files.createTempFile("icebergSimilarColumn", "db");
+    String jdbcUrl = "jdbc:sqlite:" + dbFile.toAbsolutePath();
+
+    // create the catalog tables up front so that only schema version detection is exercised
+    executeUpdate(jdbcUrl, JdbcUtil.V0_CREATE_CATALOG_SQL);
+    executeUpdate(jdbcUrl, JdbcUtil.CREATE_NAMESPACE_PROPERTIES_TABLE_SQL);
+    // this table and its column match iceberg_tables and iceberg_type through the underscore
+    // wildcard, so an unescaped lookup reports view support that the catalog table lacks
+    executeUpdate(jdbcUrl, "CREATE TABLE iceberg1tables (iceberg1type VARCHAR(5))");
+
+    Map<String, String> properties = Maps.newHashMap();
+    properties.put(CatalogProperties.WAREHOUSE_LOCATION, this.tableDir.toAbsolutePath().toString());
+    properties.put(CatalogProperties.URI, jdbcUrl);
+
+    try (JdbcCatalog jdbcCatalog = new JdbcCatalog()) {
+      jdbcCatalog.setConf(conf);
+      jdbcCatalog.initialize("similar_column_catalog", properties);
+
+      // committing as V1 would write iceberg_type, which this V0 catalog table does not have
+      TableIdentifier tableIdent = TableIdentifier.of(Namespace.of("ns1"), "tbl");
+      jdbcCatalog.buildTable(tableIdent, SCHEMA).create();
+      assertThat(jdbcCatalog.loadTable(tableIdent).schema().asStruct())
+          .isEqualTo(SCHEMA.asStruct());
+
+      assertThatThrownBy(() -> jdbcCatalog.listViews(Namespace.of("ns1")))
+          .isInstanceOf(UnsupportedOperationException.class)
+          .hasMessage(JdbcCatalog.VIEW_WARNING_LOG_MESSAGE);
+    }
   }
 
   @Test
@@ -1259,6 +1322,16 @@ public class TestJdbcCatalog extends CatalogTests<JdbcCatalog> {
                   + table2MetadataLocation
                   + "',null)")
           .execute();
+    }
+  }
+
+  private void executeUpdate(String jdbcUrl, String sql) throws SQLException {
+    SQLiteDataSource dataSource = new SQLiteDataSource();
+    dataSource.setUrl(jdbcUrl);
+
+    try (Connection connection = dataSource.getConnection();
+        PreparedStatement statement = connection.prepareStatement(sql)) {
+      statement.executeUpdate();
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -21,9 +21,11 @@ package org.apache.iceberg.jdbc;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
+import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
 import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.Map;
 import java.util.Properties;
@@ -31,6 +33,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.sqlite.SQLiteDataSource;
 
 public class TestJdbcUtil {
@@ -172,5 +175,55 @@ public class TestJdbcUtil {
   public void emptyNamespaceInIdentifier() {
     assertThat(JdbcUtil.stringToTableIdentifier("", "tblName"))
         .isEqualTo(TableIdentifier.of(Namespace.empty(), "tblName"));
+  }
+
+  @Test
+  void metadataCatalogUsesConnectionCatalog() throws SQLException {
+    Connection conn = Mockito.mock(Connection.class);
+    Mockito.when(conn.getCatalog()).thenReturn("iceberg_db");
+
+    assertThat(JdbcUtil.metadataCatalog(conn)).isEqualTo("iceberg_db");
+  }
+
+  @Test
+  void metadataCatalogIsUnrestrictedWhenCatalogIsAbsent() throws SQLException {
+    Connection conn = Mockito.mock(Connection.class);
+
+    Mockito.when(conn.getCatalog()).thenReturn(null);
+    assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
+
+    Mockito.when(conn.getCatalog()).thenReturn("");
+    assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
+  }
+
+  @Test
+  void metadataCatalogIsUnrestrictedWhenCatalogLookupFails() throws SQLException {
+    Connection conn = Mockito.mock(Connection.class);
+    Mockito.when(conn.getCatalog()).thenThrow(new SQLFeatureNotSupportedException("no catalogs"));
+
+    assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
+  }
+
+  @Test
+  void escapeMetadataPatternEscapesWildcards() {
+    assertThat(JdbcUtil.escapeMetadataPattern(JdbcUtil.CATALOG_TABLE_VIEW_NAME, "\\"))
+        .isEqualTo("iceberg\\_tables");
+    assertThat(JdbcUtil.escapeMetadataPattern(JdbcUtil.RECORD_TYPE, "\\"))
+        .isEqualTo("iceberg\\_type");
+    assertThat(JdbcUtil.escapeMetadataPattern("tbl%name", "\\")).isEqualTo("tbl\\%name");
+    assertThat(JdbcUtil.escapeMetadataPattern("tbl\\name", "\\")).isEqualTo("tbl\\\\name");
+  }
+
+  @Test
+  void escapeMetadataPatternKeepsNamesWithoutWildcards() {
+    assertThat(JdbcUtil.escapeMetadataPattern("tables", "\\")).isEqualTo("tables");
+  }
+
+  @Test
+  void escapeMetadataPatternWithoutDriverSupport() {
+    assertThat(JdbcUtil.escapeMetadataPattern(JdbcUtil.CATALOG_TABLE_VIEW_NAME, null))
+        .isEqualTo(JdbcUtil.CATALOG_TABLE_VIEW_NAME);
+    assertThat(JdbcUtil.escapeMetadataPattern(JdbcUtil.CATALOG_TABLE_VIEW_NAME, ""))
+        .isEqualTo(JdbcUtil.CATALOG_TABLE_VIEW_NAME);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
+++ b/core/src/test/java/org/apache/iceberg/jdbc/TestJdbcUtil.java
@@ -19,6 +19,7 @@
 package org.apache.iceberg.jdbc;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.file.Files;
 import java.sql.Connection;
@@ -186,22 +187,29 @@ public class TestJdbcUtil {
   }
 
   @Test
-  void metadataCatalogIsUnrestrictedWhenCatalogIsAbsent() throws SQLException {
+  void metadataCatalogIsUnrestrictedWhenConnectionHasNoCatalog() throws SQLException {
     Connection conn = Mockito.mock(Connection.class);
-
     Mockito.when(conn.getCatalog()).thenReturn(null);
-    assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
 
-    Mockito.when(conn.getCatalog()).thenReturn("");
     assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
   }
 
   @Test
-  void metadataCatalogIsUnrestrictedWhenCatalogLookupFails() throws SQLException {
+  void metadataCatalogIsUnrestrictedWhenCatalogsAreNotSupported() throws SQLException {
     Connection conn = Mockito.mock(Connection.class);
     Mockito.when(conn.getCatalog()).thenThrow(new SQLFeatureNotSupportedException("no catalogs"));
 
     assertThat(JdbcUtil.metadataCatalog(conn)).isNull();
+  }
+
+  @Test
+  void metadataCatalogPropagatesConnectionFailures() throws SQLException {
+    Connection conn = Mockito.mock(Connection.class);
+    Mockito.when(conn.getCatalog()).thenThrow(new SQLException("connection failed"));
+
+    assertThatThrownBy(() -> JdbcUtil.metadataCatalog(conn))
+        .isInstanceOf(SQLException.class)
+        .hasMessage("connection failed");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fixes #17300

`JdbcCatalog` calls `DatabaseMetaData.getTables()` and `DatabaseMetaData.getColumns()` with a `null` catalog and with raw table and column names as the pattern arguments. Two things go wrong there.

A `null` catalog does not limit the lookup to the database the connection actually points at. MySQL Connector/J flipped the default of `nullCatalogMeansCurrent` to `false` in 8.0, so a null catalog now searches every database the user can see.

The pattern arguments also treat `_` and `%` as wildcards, so `iceberg_tables` matches unrelated names like `iceberg1tables`.

Together that means `updateSchemaIfRequired()` can find an `iceberg_type` column that does not exist in the current database, decide the schema is V1, and then fail every later query with `Unknown column 'iceberg_type' in 'field list'`. It also quietly overrides an explicit `jdbc.schema-version=V0`, since that property is only read when the column lookup comes back empty.

While digging into this I hit a worse variant in `atomicCreateTable()`. If an unrelated table matches the pattern, the catalog tables are never created because they look like they already exist, and initialization then fails with `no such table: iceberg_tables`.

## Fix

Scope both lookups to the connection's catalog, and escape the names before using them as patterns.

`JdbcUtil.metadataCatalog(Connection)` works out which catalog to restrict the lookup to. An empty catalog name becomes `null`, because `""` only selects objects that belong to no catalog at all. Some drivers throw instead of reporting that they have no catalog support, so that case falls back to the current unrestricted behavior rather than breaking initialization.

`JdbcUtil.escapeMetadataPattern(String, String)` escapes `_`, `%`, and the escape character itself. It takes the escape string from `DatabaseMetaData.getSearchStringEscape()` instead of hardcoding a backslash, and returns the name untouched when the driver reports no escape string.

Passing `conn.getCatalog()` here is what Oracle suggests as the workaround for this same driver behavior in [MySQL Bug #95717](https://bugs.mysql.com/bug.php?id=95717).

Databases without catalogs are not affected. SQLite and Derby report no catalog, and Derby reports no escape string, so both helpers hand back exactly what the code passes today.

## Tests

`TestJdbcCatalog.catalogTablesAreCreatedWhenAnotherTableMatchesTheirNamePattern` covers the initialization failure.

`TestJdbcCatalog.schemaVersionIgnoresColumnsOfTablesMatchingTheCatalogTableNamePattern` covers the false V1 detection. Without the fix it fails with `no such column: iceberg_type`, which is how SQLite words the error from the issue.

`TestJdbcUtil` covers `escapeMetadataPattern` plus all four `metadataCatalog` outcomes, including a driver that throws.

One gap worth calling out: the catalog scoping cannot be tested end to end against SQLite or Derby, since neither reports a catalog, so it is covered by unit tests on the helper instead. Happy to add a MySQL or PostgreSQL test if you would prefer one here.