### PR TITLE
Site: Improve table formatting on the spec page

### DIFF
--- a/site/docs/assets/stylesheets/extra.css
+++ b/site/docs/assets/stylesheets/extra.css
@@ -448,3 +448,11 @@ p {
 .footer-icons img {
   max-width: 100%;
 }
+
+.md-typeset table:not([class]) strong {
+  white-space: nowrap;
+}
+
+.md-main__inner.md-grid {
+  max-width: 72rem;
+}


### PR DESCRIPTION
## Changes
- Keep type names like decimal(P, S) on one line in tables (white-space: nowrap on strong cells)
- Widen the main content area from the Material default (61rem) to 72rem to claim the horizontal space and avoid horizontal scrolling.

## Testing
- Verified manually with `cd site && make serve-dev` - checked `/spec/#primitive-types` and the Appendix C schema JSON types table
- `git diff --check`

Fixes #17139