### PR TITLE
Core: Reuse validated ViewOperations when loading views

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/view/BaseMetastoreViewCatalog.java
@@ -60,7 +60,7 @@ public abstract class BaseMetastoreViewCatalog extends BaseMetastoreCatalog impl
       if (ops.current() == null) {
         throw new NoSuchViewException("View does not exist: %s", identifier);
       } else {
-        return new BaseView(newViewOps(identifier), ViewUtil.fullViewName(name(), identifier));
+        return new BaseView(ops, ViewUtil.fullViewName(name(), identifier));
       }
     }
 

--- a/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
+++ b/core/src/test/java/org/apache/iceberg/view/ViewCatalogTests.java
@@ -23,9 +23,13 @@ import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 import java.nio.file.Path;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.Table;
@@ -202,6 +206,46 @@ public abstract class ViewCatalogTests<C extends ViewCatalog & SupportsNamespace
 
     assertThat(catalog().dropView(identifier)).isTrue();
     assertThat(catalog().viewExists(identifier)).as("View should not exist").isFalse();
+  }
+
+  @Test
+  public void loadViewReusesTheValidatedViewOperations() {
+    C catalog = catalog();
+    assumeThat(catalog)
+        .as("Only valid for BaseMetastoreViewCatalog implementations")
+        .isInstanceOf(BaseMetastoreViewCatalog.class);
+
+    TableIdentifier identifier = TableIdentifier.of("ns", "view");
+
+    if (requiresNamespaceCreate()) {
+      catalog.createNamespace(identifier.namespace());
+    }
+
+    catalog
+        .buildView(identifier)
+        .withSchema(SCHEMA)
+        .withDefaultNamespace(identifier.namespace())
+        .withQuery("spark", "select * from ns.tbl")
+        .create();
+
+    BaseMetastoreViewCatalog spyCatalog = spy((BaseMetastoreViewCatalog) catalog);
+    AtomicInteger newViewOpsCalls = new AtomicInteger(0);
+    AtomicReference<ViewOperations> validatedOps = new AtomicReference<>();
+    doAnswer(
+            invocation -> {
+              ViewOperations ops = (ViewOperations) invocation.callRealMethod();
+              validatedOps.set(ops);
+              newViewOpsCalls.incrementAndGet();
+              return ops;
+            })
+        .when(spyCatalog)
+        .newViewOps(identifier);
+
+    View view = spyCatalog.loadView(identifier);
+
+    assertThat(newViewOpsCalls.get()).as("newViewOps() call count").isEqualTo(1);
+    assertThat(((BaseView) view).operations()).isSameAs(validatedOps.get());
+    assertThat(catalog.dropView(identifier)).isTrue();
   }
 
   @Test


### PR DESCRIPTION
`loadView()` created a `ViewOperations` instance and called `ops.current()` to verify that the view exists. That refresh asks the catalog for the current metadata location and reads the metadata file, so a successful call means that ops has already loaded a readable view metadata snapshot.

The method then discarded that loaded ops and returned a `BaseView` backed by a second, freshly constructed `ViewOperations` instance. `BaseView` reads metadata lazily, so the caller's first access, such as `view.schema()`, triggered another refresh instead of using the metadata that `loadView()` had already loaded.

That second refresh is not just redundant. With Hive-backed `ViewOperations`, it re-queries HMS for the view's `metadata_location` and reads the referenced metadata JSON again. If a concurrent commit, drop, replace, cleanup, or storage visibility issue changes HMS or the files between the two reads, `loadView()` can succeed on one metadata version while the returned View immediately fails while reading another or no-longer-readable metadata location.

The race looks like this:

T1: `loadView` starts
T2: ops1 refreshes HMS -> metadata v1, reads v1 successfully
T3: `loadView` discards ops1 and returns BaseView with ops2
T4: concurrent commit/drop/replace/cleanup/storage visibility issue changes HMS or files
T5: caller asks `view.schema()`
T6: ops2 refreshes HMS again -> maybe metadata v2
T7: reading v2 fails

Reuse the validated `ViewOperations` instance so the returned View is backed by the same loaded metadata snapshot that passed the existence check. This also matches `BaseMetastoreCatalog#loadTable,` which returns a `BaseTable` using the `TableOperations` instance it already refreshed.

Adds shared `ViewCatalogTests` coverage asserting that `BaseMetastoreViewCatalog#loadView` constructs exactly one `ViewOperations` instance and returns a View backed by that same validated instance.