### PR TITLE
fix: discard changes when suppressing historical snapshots in CatalogHandlers

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -528,6 +528,7 @@ public class CatalogHandlers {
               TableMetadata.buildFrom(loadedMetadata)
                   .withMetadataLocation(loadedMetadata.metadataFileLocation())
                   .suppressHistoricalSnapshots()
+                  .discardChanges()
                   .build();
           break;
         default:


### PR DESCRIPTION
## Description

When `snapshot-loading-mode=refs`, `CatalogHandlers.loadTable` fails with `IllegalArgumentException: Cannot set metadata location with changes to table metadata: 1 changes` for tables that have statistics files attached to historical (unreferenced) snapshots.

## Root Cause

`suppressHistoricalSnapshots()` removes statistics from suppressed snapshots via `removeStatistics()` / `removePartitionStatistics()`, which record `MetadataUpdate.RemoveStatistics` / `RemovePartitionStatistics` changes. `build()` then rejects the combination of pending changes and a set metadata location.

## Fix

Added `.discardChanges()` after `.suppressHistoricalSnapshots()` in the builder chain, matching the client-side wrapper in `RESTSessionCatalog.loadTable` which already does this.

Closes #17538