### PR TITLE
AWS: Guard refreshCredentialsEndpoint against null in AwsClientProperties

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientProperties.java
@@ -213,8 +213,10 @@ public class AwsClientProperties implements Serializable {
   public AwsCredentialsProvider credentialsProvider(
       String accessKeyId, String secretAccessKey, String sessionToken) {
     if (!Strings.isNullOrEmpty(this.clientCredentialsProvider)) {
-      clientCredentialsProviderProperties.put(
-          VendedCredentialsProvider.URI, refreshCredentialsEndpoint);
+      if (!Strings.isNullOrEmpty(refreshCredentialsEndpoint)) {
+        clientCredentialsProviderProperties.put(
+            VendedCredentialsProvider.URI, refreshCredentialsEndpoint);
+      }
       return credentialsProvider(this.clientCredentialsProvider);
     }
 


### PR DESCRIPTION
Closes #17536

## Summary

In `AwsClientProperties.credentialsProvider()`, when `client.credentials-provider` is set, the code unconditionally puts `refreshCredentialsEndpoint` into `clientCredentialsProviderProperties` under `VendedCredentialsProvider.URI`. When `refreshCredentialsEndpoint` is `null` (i.e. neither `CatalogProperties.URI` nor `client.refresh-credentials-endpoint` is configured), this puts a `null` value into the map.

This null value propagates to custom `AwsCredentialsProvider` implementations that receive the properties map, causing a `NullPointerException` in `PropertyUtil.filterProperties` when the map is processed:

```
java.lang.NullPointerException
    at java.util.Objects.requireNonNull(Objects.java:233)
    at java.util.stream.Collectors.lambda$uniqKeysMapAccumulator$1(Collectors.java:180)
    ...
    at org.apache.iceberg.util.PropertyUtil.filterProperties(PropertyUtil.java:191)
    at org.apache.iceberg.aws.AwsClientProperties.<init>(AwsClientProperties.java:116)
```

## Fix

Guard the `put` with a null/empty check on `refreshCredentialsEndpoint`, matching the pattern already used in the `VendedCredentialsProvider` branch below it. This ensures a `null` value is never inserted into the properties map when the endpoint is not configured.

## Testing

No new tests added — this is a defensive null-safety fix. The existing `TestAwsClientProperties` suite covers the unaffected paths. Manually verified that the `refreshCredentialsEndpoint` is only put into the map when it is non-null/non-empty.