### PR TITLE
Core: Add max-file-group-input-files to valid rewrite options

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
@@ -149,7 +149,8 @@ public abstract class SizeBasedFileRewritePlanner<
         MAX_FILE_SIZE_BYTES,
         MIN_INPUT_FILES,
         REWRITE_ALL,
-        MAX_FILE_GROUP_SIZE_BYTES);
+        MAX_FILE_GROUP_SIZE_BYTES,
+        MAX_FILE_GROUP_INPUT_FILES);
   }
 
   @Override

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewriteFilePlanner.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewriteFilePlanner.java
@@ -176,6 +176,41 @@ class TestBinPackRewriteFilePlanner {
   }
 
   @Test
+  void testMaxFileGroupInputFiles() {
+    addFiles();
+    // First, establish baseline without the constraint
+    BinPackRewriteFilePlanner baselinePlanner = new BinPackRewriteFilePlanner(table);
+    baselinePlanner.init(REWRITE_ALL);
+    FileRewritePlan<FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup> baselinePlan =
+        baselinePlanner.plan();
+    int baselineGroupCount = baselinePlan.totalGroupCount();
+    int baselineGroupsInPartition0 = baselinePlan.groupsInPartition(FILE_1.partition());
+
+    // Now test with max-file-group-input-files set to 2, which limits each group to 2 files
+    // Partition 0 has 3 files (FILE_1, FILE_2, FILE_3), so it should be split into 2 groups
+    // Partition 1 has 2 files (FILE_4, FILE_5), so it should be 1 group
+    // Partition 2 has 1 file (FILE_6), so it should be 1 group
+    BinPackRewriteFilePlanner constrainedPlanner = new BinPackRewriteFilePlanner(table);
+    constrainedPlanner.init(
+        ImmutableMap.of(
+            BinPackRewriteFilePlanner.REWRITE_ALL,
+            "true",
+            BinPackRewriteFilePlanner.MAX_FILE_GROUP_INPUT_FILES,
+            "2"));
+
+    FileRewritePlan<FileGroupInfo, FileScanTask, DataFile, RewriteFileGroup> constrainedPlan =
+        constrainedPlanner.plan();
+
+    // Verify the constraint is honored: should have MORE groups when input files are limited
+    assertThat(constrainedPlan.totalGroupCount()).isGreaterThan(baselineGroupCount).isEqualTo(4);
+    assertThat(constrainedPlan.groupsInPartition(FILE_1.partition()))
+        .isGreaterThan(baselineGroupsInPartition0)
+        .isEqualTo(2);
+    assertThat(constrainedPlan.groupsInPartition(FILE_4.partition())).isEqualTo(1);
+    assertThat(constrainedPlan.groupsInPartition(FILE_6.partition())).isEqualTo(1);
+  }
+
+  @Test
   void testFilter() {
     addFiles();
     BinPackRewriteFilePlanner planner =
@@ -289,6 +324,7 @@ class TestBinPackRewriteFilePlanner {
                 BinPackRewriteFilePlanner.MIN_INPUT_FILES,
                 BinPackRewriteFilePlanner.REWRITE_ALL,
                 BinPackRewriteFilePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                BinPackRewriteFilePlanner.MAX_FILE_GROUP_INPUT_FILES,
                 BinPackRewriteFilePlanner.DELETE_FILE_THRESHOLD,
                 BinPackRewriteFilePlanner.DELETE_RATIO_THRESHOLD,
                 RewriteDataFiles.REWRITE_JOB_ORDER,

--- a/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewritePositionDeletePlanner.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestBinPackRewritePositionDeletePlanner.java
@@ -239,6 +239,7 @@ class TestBinPackRewritePositionDeletePlanner {
                 BinPackRewritePositionDeletePlanner.MIN_INPUT_FILES,
                 BinPackRewritePositionDeletePlanner.REWRITE_ALL,
                 BinPackRewritePositionDeletePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                BinPackRewritePositionDeletePlanner.MAX_FILE_GROUP_INPUT_FILES,
                 RewriteDataFiles.REWRITE_JOB_ORDER));
   }
 

--- a/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedFileRewritePlanner.java
+++ b/core/src/test/java/org/apache/iceberg/actions/TestSizeBasedFileRewritePlanner.java
@@ -103,7 +103,8 @@ class TestSizeBasedFileRewritePlanner {
                 BinPackRewriteFilePlanner.MAX_FILE_SIZE_BYTES,
                 BinPackRewriteFilePlanner.MIN_INPUT_FILES,
                 BinPackRewriteFilePlanner.REWRITE_ALL,
-                BinPackRewriteFilePlanner.MAX_FILE_GROUP_SIZE_BYTES));
+                BinPackRewriteFilePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                BinPackRewriteFilePlanner.MAX_FILE_GROUP_INPUT_FILES));
   }
 
   @Test

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
@@ -72,6 +72,7 @@ public class TestSparkShufflingDataRewritePlanner extends TestBase {
                 SparkShufflingDataRewritePlanner.MIN_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.REWRITE_ALL,
                 SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.DELETE_FILE_THRESHOLD,
                 SparkShufflingDataRewritePlanner.DELETE_RATIO_THRESHOLD,
                 RewriteDataFiles.REWRITE_JOB_ORDER,

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
@@ -72,6 +72,7 @@ public class TestSparkShufflingDataRewritePlanner extends TestBase {
                 SparkShufflingDataRewritePlanner.MIN_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.REWRITE_ALL,
                 SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.DELETE_FILE_THRESHOLD,
                 SparkShufflingDataRewritePlanner.DELETE_RATIO_THRESHOLD,
                 RewriteDataFiles.REWRITE_JOB_ORDER,

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteDataFilesAction.java
@@ -1487,6 +1487,26 @@ public class TestRewriteDataFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testMaxFileGroupInputFilesOption() {
+    Table table = createTable(4);
+    shouldHaveFiles(table, 4);
+
+    List<Object[]> originalData = currentData();
+    long dataSizeBefore = testDataSize(table);
+
+    RewriteDataFiles.Result result =
+        basicRewrite(table)
+            .option(SizeBasedFileRewritePlanner.MAX_FILE_GROUP_INPUT_FILES, "2")
+            .execute();
+
+    assertThat(result.rewriteResults()).as("Action should rewrite file groups").isNotEmpty();
+    assertThat(result.rewrittenBytesCount()).isEqualTo(dataSizeBefore);
+
+    table.refresh();
+    assertEquals("Rows must match", originalData, currentData());
+  }
+
+  @TestTemplate
   public void testSortMultipleGroups() {
     Table table = createTable(20);
     shouldHaveFiles(table, 20);

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestSparkShufflingDataRewritePlanner.java
@@ -72,6 +72,7 @@ public class TestSparkShufflingDataRewritePlanner extends TestBase {
                 SparkShufflingDataRewritePlanner.MIN_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.REWRITE_ALL,
                 SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_SIZE_BYTES,
+                SparkShufflingDataRewritePlanner.MAX_FILE_GROUP_INPUT_FILES,
                 SparkShufflingDataRewritePlanner.DELETE_FILE_THRESHOLD,
                 SparkShufflingDataRewritePlanner.DELETE_RATIO_THRESHOLD,
                 RewriteDataFiles.REWRITE_JOB_ORDER,


### PR DESCRIPTION
`max-file-group-input-files` is read and validated by `SizeBasedFileRewritePlanner` but is missing from `validOptions()`, so `rewrite_data_files` rejects it with `Cannot use options [max-file-group-input-files]`. Flink exposes it via `RewriteDataFiles.maxFileGroupInputFiles()` where it works, so the option is only broken from Spark. It was added in #14837 and `validOptions()` was not updated then.

Added a rewrite test that sets the option, which fails without this change, and a planner test that it caps input files per group.
