### PR TITLE
fix: guard against null metadata in checkCurrentMetadataLocation

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
+++ b/core/src/main/java/org/apache/iceberg/BaseMetastoreTableOperations.java
@@ -333,6 +333,10 @@ public abstract class BaseMetastoreTableOperations extends BaseMetastoreOperatio
    */
   private boolean checkCurrentMetadataLocation(String newMetadataLocation) {
     TableMetadata metadata = refresh();
+    if (metadata == null) {
+      // the table does not exist in the catalog, so the commit could not have landed
+      return false;
+    }
     String currentMetadataFileLocation = metadata.metadataFileLocation();
     return currentMetadataFileLocation.equals(newMetadataLocation)
         || metadata.previousFiles().stream()


### PR DESCRIPTION
## Description

When `checkCommitStatus` is called during a CREATE TABLE operation (where `base == null`), `refresh()` returns `null` because the table does not yet exist in the metastore. The subsequent call to `metadata.metadataFileLocation()` throws a `NullPointerException`, which is swallowed by `.suppressFailureWhenFinished()`, resulting in a misleading `CommitStateUnknownException` that tells the user to perform unnecessary manual remediation.

### Fix

Add a null check after `refresh()`. If `refresh()` returns null, the table does not exist in the catalog, so the commit could not have landed — return `false` immediately.

### Root cause

`HiveTableOperations.doRefresh()` swallows `NoSuchObjectException` when `currentMetadataLocation()` is null (the CREATE TABLE case), leaving `currentMetadata == null` with `shouldRefresh = false`. The subsequent `refresh()` → `current()` call returns `null`, which `checkCurrentMetadataLocation` then dereferences.

### Testing

The existing test coverage for `checkCommitStatus` only covers the **update** path (table already exists). A CREATE TABLE failure path is not covered by `TestHiveCommits`. This fix adds a defensive null guard that is trivially correct — the only valid return value when the table metadata is null is `false` (commit did not land).

Closes #17462
