### PR TITLE
fix: apply S3 service configurations to async S3 client (#14575)

### DIFF
--- a/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/AwsClientFactories.java
@@ -138,6 +138,7 @@ public class AwsClientFactories {
           .applyMutation(
               b -> s3FileIOProperties.applyCredentialConfigurations(awsClientProperties, b))
           .applyMutation(s3FileIOProperties::applyEndpointConfigurations)
+          .applyMutation(s3FileIOProperties::applyServiceConfigurations)
           .build();
     }
 

--- a/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
+++ b/aws/src/main/java/org/apache/iceberg/aws/s3/S3FileIOProperties.java
@@ -1006,7 +1006,7 @@ public class S3FileIOProperties implements Serializable {
    *     S3Client.builder().applyMutation(s3FileIOProperties::applyS3ServiceConfigurations)
    * </pre>
    */
-  public <T extends S3ClientBuilder> void applyServiceConfigurations(T builder) {
+  public <T extends S3BaseClientBuilder> void applyServiceConfigurations(T builder) {
     builder
         .dualstackEnabled(isDualStackEnabled)
         .crossRegionAccessEnabled(isCrossRegionAccessEnabled)


### PR DESCRIPTION
## What this PR does

Fixes S3 service configurations (pathStyleAccess, dualStack, crossRegionAccess, useArnRegion, accelerateMode, chunkedEncoding) not being applied to the non-CRT async S3 client.

## Root cause

`DefaultAwsClientFactory.s3Async()` used `S3AsyncClient.builder()` but never called `applyServiceConfigurations` on it. The sync `s3()` method did apply these settings, but the async path was missing the call.

## Changes

1. **S3FileIOProperties.java**: Changed `applyServiceConfigurations` generic bound from `<T extends S3ClientBuilder>` to `<T extends S3BaseClientBuilder>` — `S3BaseClientBuilder` is the common base for both `S3ClientBuilder` (sync) and `S3AsyncClientBuilder` (async), and defines all the methods used (`dualstackEnabled`, `crossRegionAccessEnabled`, `serviceConfiguration`).

2. **AwsClientFactories.java**: Added `.applyMutation(s3FileIOProperties::applyServiceConfigurations)` to the non-CRT `S3AsyncClient.builder()` chain.

## Verification

- `applyServiceConfigurations` accepts `S3BaseClientBuilder` which both sync and async builders extend
- The existing sync `s3()` method continues to call `applyServiceConfigurations` unchanged
- The CRT async path (`S3CrtAsyncClientBuilder`) is unaffected — it uses a separate builder hierarchy

Closes #14575
