### PR TITLE
kafka connect: coordinator only commits offsets when greater than existing offsets

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -154,14 +154,14 @@ abstract class Channel {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
     controlTopicOffsets.forEach(
         (partition, offsetToCommit) -> {
-          TopicPartition tp = new TopicPartition(controlTopic, partition);
-          Long lastCommittedOffset = committedOffsets.get(tp.partition());
+          Long lastCommittedOffset = committedOffsets.get(partition);
           if (lastCommittedOffset == null || offsetToCommit > lastCommittedOffset) {
+            TopicPartition tp = new TopicPartition(controlTopic, partition);
             offsetsToCommit.put(tp, new OffsetAndMetadata(offsetToCommit));
           }
         });
     if (!offsetsToCommit.isEmpty()) {
-      LOG.info("Coordinator committing offsets: {}", offsetsToCommit);
+      LOG.debug("Committing consumer offsets: {}", offsetsToCommit);
       consumer.commitSync(offsetsToCommit);
       offsetsToCommit.forEach(
           (topicPartition, metadata) ->

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.connect.channel;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -53,6 +52,7 @@ abstract class Channel {
   private final SinkTaskContext context;
   private final Admin admin;
   private final Map<Integer, Long> controlTopicOffsets = Maps.newHashMap();
+  private final Map<Integer, Long> committedOffsets = Maps.newHashMap();
   private final String producerId;
 
   Channel(
@@ -143,31 +143,34 @@ abstract class Channel {
     return controlTopicOffsets;
   }
 
+  /**
+   * Commit consumer offsets. Only commits offsets if it has not committed offsets before or the
+   * value is greater than the cached offset.
+   *
+   * <p>Note: there is a risk that two parallel coordinators may overwrite each other's offsets, to
+   * be fixed in a follow-up PR.
+   */
   protected void commitConsumerOffsets() {
-    Set<TopicPartition> partitions =
-        controlTopicOffsets().keySet().stream()
-            .map(k -> new TopicPartition(controlTopic, k))
-            .collect(Collectors.toSet());
-    Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(partitions);
-
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
-    controlTopicOffsets()
-        .forEach(
-            (partition, offsetToCommit) -> {
-              TopicPartition tp = new TopicPartition(controlTopic, partition);
-              OffsetAndMetadata lastCommitted = committed.get(tp);
-              if (lastCommitted == null || offsetToCommit > lastCommitted.offset()) {
-                offsetsToCommit.put(tp, new OffsetAndMetadata(offsetToCommit));
-              }
-            });
+    controlTopicOffsets.forEach(
+        (partition, offsetToCommit) -> {
+          TopicPartition tp = new TopicPartition(controlTopic, partition);
+          Long lastCommittedOffset = committedOffsets.get(tp.partition());
+          if (lastCommittedOffset == null || offsetToCommit > lastCommittedOffset) {
+            offsetsToCommit.put(tp, new OffsetAndMetadata(offsetToCommit));
+          }
+        });
     if (!offsetsToCommit.isEmpty()) {
       LOG.info("Coordinator committing offsets: {}", offsetsToCommit);
       consumer.commitSync(offsetsToCommit);
+      offsetsToCommit.forEach(
+          (topicPartition, metadata) ->
+              committedOffsets.put(topicPartition.partition(), metadata.offset()));
     } else {
-      LOG.info(
-          "Skipping consumer offset commit; local offsets {} are not ahead of committed offsets {}",
-          controlTopicOffsets(),
-          committed);
+      LOG.debug(
+          "Skipping consumer offset commit; local offsets {} are less than or equal to committed offsets {}",
+          controlTopicOffsets,
+          committedOffsets);
     }
   }
 

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.connect.channel;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.iceberg.connect.IcebergSinkConfig;
@@ -143,12 +144,31 @@ abstract class Channel {
   }
 
   protected void commitConsumerOffsets() {
+    Set<TopicPartition> partitions =
+        controlTopicOffsets().keySet().stream()
+            .map(k -> new TopicPartition(controlTopic, k))
+            .collect(Collectors.toSet());
+    Map<TopicPartition, OffsetAndMetadata> committed = consumer.committed(partitions);
+
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
     controlTopicOffsets()
         .forEach(
-            (k, v) ->
-                offsetsToCommit.put(new TopicPartition(controlTopic, k), new OffsetAndMetadata(v)));
-    consumer.commitSync(offsetsToCommit);
+            (partition, offsetToCommit) -> {
+              TopicPartition tp = new TopicPartition(controlTopic, partition);
+              OffsetAndMetadata lastCommitted = committed.get(tp);
+              if (lastCommitted == null || offsetToCommit > lastCommitted.offset()) {
+                offsetsToCommit.put(tp, new OffsetAndMetadata(offsetToCommit));
+              }
+            });
+    if (!offsetsToCommit.isEmpty()) {
+      LOG.info("Coordinator committing offsets: {}", offsetsToCommit);
+      consumer.commitSync(offsetsToCommit);
+    } else {
+      LOG.info(
+          "Skipping consumer offset commit; local offsets {} are not ahead of committed offsets {}",
+          controlTopicOffsets(),
+          committed);
+    }
   }
 
   void start() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/Channel.java
@@ -147,30 +147,37 @@ abstract class Channel {
    * Commit consumer offsets. Only commits offsets if it has not committed offsets before or the
    * value is greater than the cached offset.
    *
-   * <p>Note: there is a risk that two parallel coordinators may overwrite each other's offsets, to
-   * be fixed in a follow-up PR.
+   * <p>Note: there is a risk that two parallel coordinators may overwrite each other's offsets.
    */
   protected void commitConsumerOffsets() {
     Map<TopicPartition, OffsetAndMetadata> offsetsToCommit = Maps.newHashMap();
-    controlTopicOffsets.forEach(
-        (partition, offsetToCommit) -> {
-          Long lastCommittedOffset = committedOffsets.get(partition);
-          if (lastCommittedOffset == null || offsetToCommit > lastCommittedOffset) {
-            TopicPartition tp = new TopicPartition(controlTopic, partition);
-            offsetsToCommit.put(tp, new OffsetAndMetadata(offsetToCommit));
-          }
-        });
+    Map<Integer, Long> skippedOffsets = Maps.newHashMap();
+    controlTopicOffsets()
+        .forEach(
+            (partition, offsetToCommit) -> {
+              Long lastCommittedOffset = committedOffsets.get(partition);
+              if (lastCommittedOffset == null || offsetToCommit > lastCommittedOffset) {
+                TopicPartition topicPartition = new TopicPartition(controlTopic, partition);
+                offsetsToCommit.put(topicPartition, new OffsetAndMetadata(offsetToCommit));
+              } else {
+                skippedOffsets.put(partition, offsetToCommit);
+              }
+            });
+
+    if (!skippedOffsets.isEmpty()) {
+      LOG.debug(
+          "Skipping consumer offset commit for partitions with non-increasing offsets; "
+              + "local offsets {} are less than or equal to committed offsets {}",
+          skippedOffsets,
+          committedOffsets);
+    }
+
     if (!offsetsToCommit.isEmpty()) {
       LOG.debug("Committing consumer offsets: {}", offsetsToCommit);
       consumer.commitSync(offsetsToCommit);
       offsetsToCommit.forEach(
           (topicPartition, metadata) ->
               committedOffsets.put(topicPartition.partition(), metadata.offset()));
-    } else {
-      LOG.debug(
-          "Skipping consumer offset commit; local offsets {} are less than or equal to committed offsets {}",
-          controlTopicOffsets,
-          committedOffsets);
     }
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -378,8 +378,42 @@ public class TestCoordinator extends ChannelTestBase {
 
     assertThat(committed)
         .as(
-            "commitConsumerOffsets should not rewind offsets when consumer group was updated by another coordinator")
+            "commitConsumerOffsets should not commit offsets when offset has not changed relative to local cache")
         .isEqualTo(nextWatermark);
+  }
+
+  @Test
+  public void testCommitConsumerRewindsOffsetsWhenAnotherCoordinatorAdvancesOffsets() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+    long healthyWatermark = 100L;
+    coordinator.controlTopicOffsets().put(0, healthyWatermark);
+    coordinator.commitConsumerOffsets();
+
+    long nextWatermark = healthyWatermark + 5;
+    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(nextWatermark)));
+
+    long rewindWatermark = healthyWatermark + 3;
+    coordinator.controlTopicOffsets().put(0, rewindWatermark);
+    coordinator.commitConsumerOffsets();
+
+    OffsetAndMetadata committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
+
+    assertThat(committed)
+        .as(
+            "Expected Limitation: commitConsumerOffsets will rewind offsets if local offset advances and another coordinator committed a higher offset")
+        .isEqualTo(rewindWatermark);
   }
 
   @Test
@@ -471,16 +505,14 @@ public class TestCoordinator extends ChannelTestBase {
     Map<TopicPartition, OffsetAndMetadata> committedOffsetAndMetadata =
         consumer.committed(ImmutableSet.of(ctl0, ctl1));
 
-    long committed0 =
-        committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.get(ctl0).offset();
-    long committed1 =
-        committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.get(ctl1).offset();
+    OffsetAndMetadata committed0 = committedOffsetAndMetadata.get(ctl0);
+    OffsetAndMetadata committed1 = committedOffsetAndMetadata.get(ctl1);
 
-    assertThat(committed0)
+    assertThat(committed0 == null ? 0L : committed0.offset())
         .as("commitConsumerOffsets should advance the consumer group offsets")
         .isEqualTo(watermarkToCommit);
 
-    assertThat(committed1)
+    assertThat(committed1 == null ? 0L : committed1.offset())
         .as("commitConsumerOffsets should not rewind consumer group offsets")
         .isEqualTo(healthWatermark1);
   }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -402,6 +402,14 @@ public class TestCoordinator extends ChannelTestBase {
     long nextWatermark = healthyWatermark + 5;
     consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(nextWatermark)));
 
+    OffsetAndMetadata anotherCommittedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long anotherCommitted =
+        anotherCommittedOffsetAndMetadata == null ? 0L : anotherCommittedOffsetAndMetadata.offset();
+    assertThat(anotherCommitted)
+        .as("Precondition: another coordinator advanced the shared offset")
+        .isEqualTo(nextWatermark);
+
     long rewindWatermark = healthyWatermark + 3;
     coordinator.controlTopicOffsets().put(0, rewindWatermark);
     coordinator.commitConsumerOffsets();
@@ -413,7 +421,8 @@ public class TestCoordinator extends ChannelTestBase {
     assertThat(committed)
         .as(
             "Expected Limitation: commitConsumerOffsets will rewind offsets if local offset advances and another coordinator committed a higher offset")
-        .isEqualTo(rewindWatermark);
+        .isEqualTo(rewindWatermark)
+        .isLessThan(nextWatermark);
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.util.Set;
+import java.util.Map;
 import java.util.UUID;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -55,6 +55,7 @@ import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -320,7 +321,7 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   @Test
-  public void commitConsumerOffsetsShouldNotCommitLowerOffset() {
+  public void testCommitConsumerOffsetsDoesNotRewind() {
     when(config.commitIntervalMs()).thenReturn(0);
     when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
 
@@ -333,19 +334,155 @@ public class TestCoordinator extends ChannelTestBase {
     TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
 
     long healthyWatermark = 100L;
-    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(healthyWatermark)));
+    coordinator.controlTopicOffsets().put(0, healthyWatermark);
+    coordinator.commitConsumerOffsets();
 
     coordinator.controlTopicOffsets().put(0, 5L);
     coordinator.commitConsumerOffsets();
 
-    long committed =
-        consumer.committed(Set.of(ctl)).get(ctl) == null
-            ? 0L
-            : consumer.committed(Set.of(ctl)).get(ctl).offset();
+    OffsetAndMetadata committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
 
     assertThat(committed)
         .as("commitConsumerOffsets should not rewind the shared -coord consumer group offsets")
-        .isGreaterThanOrEqualTo(healthyWatermark);
+        .isEqualTo(healthyWatermark);
+  }
+
+  @Test
+  public void testCommitConsumerDuplicateDoesNotCommit() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+    long healthyWatermark = 100L;
+    coordinator.controlTopicOffsets().put(0, healthyWatermark);
+    coordinator.commitConsumerOffsets();
+
+    long nextWatermark = healthyWatermark + 5;
+    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(nextWatermark)));
+
+    coordinator.controlTopicOffsets().put(0, 100L);
+    coordinator.commitConsumerOffsets();
+
+    OffsetAndMetadata committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
+
+    assertThat(committed)
+        .as(
+            "commitConsumerOffsets should not rewind offsets when consumer group was updated by another coordinator")
+        .isEqualTo(nextWatermark);
+  }
+
+  @Test
+  public void testCommitNewConsumerAdvances() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    long newWatermark = 5L;
+
+    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
+    coordinator.controlTopicOffsets().put(0, newWatermark);
+
+    coordinator.commitConsumerOffsets();
+
+    OffsetAndMetadata committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
+
+    assertThat(committed)
+        .as("commitConsumerOffsets should advance offsets on its first commit")
+        .isEqualTo(newWatermark);
+  }
+
+  @Test
+  public void testCommitConsumerAdvances() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    long healthyWatermark = 100L;
+    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+    coordinator.controlTopicOffsets().put(0, healthyWatermark);
+    coordinator.commitConsumerOffsets();
+
+    long watermarkToCommit = 105L;
+    coordinator.controlTopicOffsets().put(0, watermarkToCommit);
+    coordinator.commitConsumerOffsets();
+
+    OffsetAndMetadata committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
+    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
+
+    assertThat(committed)
+        .as("commitConsumerOffsets should advance offsets when its value is greater")
+        .isEqualTo(watermarkToCommit);
+  }
+
+  @Test
+  public void testCommitConsumerMixedPartitionsRewindOrAdvance() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    long healthyWatermark0 = 100L;
+    long healthWatermark1 = 200L;
+    TopicPartition ctl0 = new TopicPartition(CTL_TOPIC_NAME, 0);
+    TopicPartition ctl1 = new TopicPartition(CTL_TOPIC_NAME, 1);
+
+    consumer.rebalance(ImmutableList.of(ctl0, ctl1));
+    consumer.updateBeginningOffsets(ImmutableMap.of(ctl0, 0L, ctl1, 0L));
+
+    coordinator.controlTopicOffsets().put(0, healthyWatermark0);
+    coordinator.controlTopicOffsets().put(1, healthWatermark1);
+    coordinator.commitConsumerOffsets();
+
+    long watermarkToCommit = 105L;
+    long watermarkToSkip = 195L;
+    coordinator.controlTopicOffsets().put(0, watermarkToCommit);
+    coordinator.controlTopicOffsets().put(1, watermarkToSkip);
+    coordinator.commitConsumerOffsets();
+
+    Map<TopicPartition, OffsetAndMetadata> committedOffsetAndMetadata =
+        consumer.committed(ImmutableSet.of(ctl0, ctl1));
+
+    long committed0 =
+        committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.get(ctl0).offset();
+    long committed1 =
+        committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.get(ctl1).offset();
+
+    assertThat(committed0)
+        .as("commitConsumerOffsets should advance the consumer group offsets")
+        .isEqualTo(watermarkToCommit);
+
+    assertThat(committed1)
+        .as("commitConsumerOffsets should not rewind consumer group offsets")
+        .isEqualTo(healthWatermark1);
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.when;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.iceberg.AppendFiles;
 import org.apache.iceberg.DataFile;
@@ -53,9 +54,11 @@ import org.apache.iceberg.connect.events.TopicPartitionOffset;
 import org.apache.iceberg.exceptions.CommitFailedException;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkTaskContext;
 import org.junit.jupiter.api.Test;
@@ -314,6 +317,35 @@ public class TestCoordinator extends ChannelTestBase {
     consumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, nextOffset++, "key", bytes));
 
     coordinator.process();
+  }
+
+  @Test
+  public void commitConsumerOffsetsShouldNotCommitLowerOffset() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+
+    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+    long healthyWatermark = 100L;
+    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(healthyWatermark)));
+
+    coordinator.controlTopicOffsets().put(0, 5L);
+    coordinator.commitConsumerOffsets();
+
+    long committed =
+        consumer.committed(Set.of(ctl)).get(ctl) == null
+            ? 0L
+            : consumer.committed(Set.of(ctl)).get(ctl).offset();
+
+    assertThat(committed)
+        .as("commitConsumerOffsets should not rewind the shared -coord consumer group offsets")
+        .isGreaterThanOrEqualTo(healthyWatermark);
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCoordinator.java
@@ -322,14 +322,7 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitConsumerOffsetsDoesNotRewind() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator();
 
     TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
 
@@ -351,14 +344,7 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitConsumerDuplicateDoesNotCommit() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator();
 
     TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
 
@@ -383,58 +369,8 @@ public class TestCoordinator extends ChannelTestBase {
   }
 
   @Test
-  public void testCommitConsumerRewindsOffsetsWhenAnotherCoordinatorAdvancesOffsets() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
-
-    TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
-
-    long healthyWatermark = 100L;
-    coordinator.controlTopicOffsets().put(0, healthyWatermark);
-    coordinator.commitConsumerOffsets();
-
-    long nextWatermark = healthyWatermark + 5;
-    consumer.commitSync(ImmutableMap.of(ctl, new OffsetAndMetadata(nextWatermark)));
-
-    OffsetAndMetadata anotherCommittedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long anotherCommitted =
-        anotherCommittedOffsetAndMetadata == null ? 0L : anotherCommittedOffsetAndMetadata.offset();
-    assertThat(anotherCommitted)
-        .as("Precondition: another coordinator advanced the shared offset")
-        .isEqualTo(nextWatermark);
-
-    long rewindWatermark = healthyWatermark + 3;
-    coordinator.controlTopicOffsets().put(0, rewindWatermark);
-    coordinator.commitConsumerOffsets();
-
-    OffsetAndMetadata committedOffsetAndMetadata =
-        consumer.committed(ImmutableSet.of(ctl)).get(ctl);
-    long committed = committedOffsetAndMetadata == null ? 0L : committedOffsetAndMetadata.offset();
-
-    assertThat(committed)
-        .as(
-            "Expected Limitation: commitConsumerOffsets will rewind offsets if local offset advances and another coordinator committed a higher offset")
-        .isEqualTo(rewindWatermark)
-        .isLessThan(nextWatermark);
-  }
-
-  @Test
   public void testCommitNewConsumerAdvances() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator();
 
     long newWatermark = 5L;
 
@@ -454,14 +390,7 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitConsumerAdvances() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator();
 
     long healthyWatermark = 100L;
     TopicPartition ctl = new TopicPartition(CTL_TOPIC_NAME, 0);
@@ -484,14 +413,7 @@ public class TestCoordinator extends ChannelTestBase {
 
   @Test
   public void testCommitConsumerMixedPartitionsRewindOrAdvance() {
-    when(config.commitIntervalMs()).thenReturn(0);
-    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
-
-    SinkTaskContext context = mock(SinkTaskContext.class);
-    Coordinator coordinator =
-        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
-    coordinator.start();
-    initConsumer();
+    Coordinator coordinator = startCoordinator();
 
     long healthyWatermark0 = 100L;
     long healthWatermark1 = 200L;
@@ -524,6 +446,18 @@ public class TestCoordinator extends ChannelTestBase {
     assertThat(committed1 == null ? 0L : committed1.offset())
         .as("commitConsumerOffsets should not rewind consumer group offsets")
         .isEqualTo(healthWatermark1);
+  }
+
+  private Coordinator startCoordinator() {
+    when(config.commitIntervalMs()).thenReturn(0);
+    when(config.commitTimeoutMs()).thenReturn(Integer.MAX_VALUE);
+
+    SinkTaskContext context = mock(SinkTaskContext.class);
+    Coordinator coordinator =
+        new Coordinator(catalog, config, ImmutableList.of(), clientFactory, context);
+    coordinator.start();
+    initConsumer();
+    return coordinator;
   }
 
   private void assertCommitTable(int idx, UUID commitId, OffsetDateTime ts) {


### PR DESCRIPTION
Fixes https://github.com/apache/iceberg/issues/17551

More context in that ticket on the exact sequence of events.

Overall, it's possible multiple coordinators exist, and one may commit old/stale offsets still in memory, which may be out of retention, and this sequence will cause data loss.

We do a check before writing the offset.

Note: it is possible that a race condition exists (eg coordinator A reads offset n, coordinator B reads offset n & commits offset n+2, and then coordinator A commits offset n+1). However, the committed offset still never drops below n, so the worst case is reprocessing a few records (ie duplicates), not data loss.

Also add some logging that makes these scenarios much more clear (eg when a stale coordinator may exist, what the coordinators offsets are that they are committing). 