### PR TITLE
Parquet, Spark, Flink: partial and multi column variant tests

### DIFF
--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantShreddingType.java
@@ -876,22 +876,101 @@ class TestFlinkVariantShreddingType extends CatalogTestBase {
     sql("DROP TEMPORARY VIEW IF EXISTS tmp_source");
   }
 
+  @TestTemplate
+  public void testReadMultipleShreddedVariantColumns() throws IOException {
+    String multiTable = "multi_shredded_variant";
+    sql(
+        """
+            CREATE TABLE %s (
+              id int NOT NULL,
+              v1 variant NOT NULL,
+              v2 variant NOT NULL
+            ) WITH (
+              'write.format.default'='%s',
+              'format-version'='3',
+              'shred-variants'='true',
+              'variant-inference-buffer-size'='10'
+            )
+            """,
+        multiTable, FileFormat.PARQUET.name());
+
+    sql(
+        """
+            INSERT INTO %s VALUES
+              (1, parse_json('{"name": "Alice", "age": 30}'), parse_json('{"city": "Seattle", "zip": 98101}')),
+              (2, parse_json('{"name": "Bob", "age": 25}'), parse_json('{"city": "Portland", "zip": 97201}'))
+            """,
+        multiTable);
+
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, multiTable));
+    assertShredded(table, "v1", "v2");
+
+    List<Row> rows =
+        sql(
+            """
+                SELECT id,
+                       json_value(v1, '$.name'),
+                       json_value(v1, '$.age' RETURNING int),
+                       json_value(v2, '$.city'),
+                       json_value(v2, '$.zip' RETURNING int)
+                FROM %s
+                ORDER BY id
+                """,
+            multiTable);
+    assertThat(rows).hasSize(2);
+    assertThat(rows.get(0).getField(1)).isEqualTo("Alice");
+    assertThat(rows.get(0).getField(2)).isEqualTo(30);
+    assertThat(rows.get(0).getField(3)).isEqualTo("Seattle");
+    assertThat(rows.get(0).getField(4)).isEqualTo(98101);
+    assertThat(rows.get(1).getField(1)).isEqualTo("Bob");
+    assertThat(rows.get(1).getField(2)).isEqualTo(25);
+    assertThat(rows.get(1).getField(3)).isEqualTo("Portland");
+    assertThat(rows.get(1).getField(4)).isEqualTo(97201);
+
+    sql("DROP TABLE %s", multiTable);
+  }
+
   private void verifyParquetSchema(Table table, MessageType expectedSchema) throws IOException {
-    table.refresh();
-    try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
-      assertThat(tasks).isNotEmpty();
+    assertThat(dataFileSchemas(table).get(0)).isEqualTo(expectedSchema);
+  }
 
-      FileScanTask task = tasks.iterator().next();
-      String path = task.file().location();
-
-      HadoopInputFile inputFile =
-          HadoopInputFile.fromPath(new org.apache.hadoop.fs.Path(path), new Configuration());
-
-      try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
-        MessageType actualSchema = reader.getFileMetaData().getSchema();
-        assertThat(actualSchema).isEqualTo(expectedSchema);
+  private void assertShredded(Table table, String... columns) throws IOException {
+    for (MessageType schema : dataFileSchemas(table)) {
+      for (String column : columns) {
+        assertThat(containsTypedValue(schema.getType(column)))
+            .as("Expected column %s to be shredded with a typed_value subtree", column)
+            .isTrue();
       }
     }
+  }
+
+  private List<MessageType> dataFileSchemas(Table table) throws IOException {
+    table.refresh();
+    List<MessageType> schemas = Lists.newArrayList();
+    try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
+      assertThat(tasks).isNotEmpty();
+      for (FileScanTask task : tasks) {
+        HadoopInputFile inputFile =
+            HadoopInputFile.fromPath(
+                new org.apache.hadoop.fs.Path(task.file().location()), new Configuration());
+        try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
+          schemas.add(reader.getFileMetaData().getSchema());
+        }
+      }
+    }
+    return schemas;
+  }
+
+  private static boolean containsTypedValue(Type type) {
+    if (type.isPrimitive()) {
+      return false;
+    }
+    for (Type child : type.asGroupType().getFields()) {
+      if (child.getName().equals("typed_value") || containsTypedValue(child)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static MessageType parquetSchema(Type variantTypes) {

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantType.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/TestFlinkVariantType.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.flink;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
@@ -104,25 +105,64 @@ class TestFlinkVariantType extends CatalogTestBase {
         .appendToTable(builder.build());
     icebergTable.refresh();
 
-    List<GenericRowData> genericRowData = Lists.newArrayList();
-    try (CloseableIterable<CombinedScanTask> combinedScanTasks =
-        icebergTable.newScan().planTasks()) {
-      for (CombinedScanTask combinedScanTask : combinedScanTasks) {
-        try (DataIterator<RowData> dataIterator =
-            ReaderUtil.createDataIterator(
-                combinedScanTask, icebergTable.schema(), icebergTable.schema())) {
-          while (dataIterator.hasNext()) {
-            GenericRowData rowData = (GenericRowData) dataIterator.next();
-            genericRowData.add(rowData);
-          }
-        }
-      }
-    }
+    List<GenericRowData> genericRowData = readRowData(icebergTable);
 
     assertThat(genericRowData).hasSize(1);
     assertThat(genericRowData.get(0).getField(1)).isInstanceOf(BinaryVariant.class);
     BinaryVariant binaryVariant = (BinaryVariant) genericRowData.get(0).getField(1);
     assertThat(binaryVariant.getField("name").getString()).isEqualTo("John Doe");
     assertThat(binaryVariant.getField("age").getByte()).isEqualTo((byte) 30);
+  }
+
+  @TestTemplate
+  public void testReadMultipleVariantColumns() throws Exception {
+    String multiTable = "multi_variant_table";
+    sql(
+        "CREATE TABLE %s (id int, v1 variant, v2 variant) "
+            + "with ('write.format.default'='%s','format-version'='3')",
+        multiTable, FileFormat.PARQUET.name());
+    Table table = validationCatalog.loadTable(TableIdentifier.of(icebergNamespace, multiTable));
+
+    VariantMetadata metadata = Variants.metadata("name", "city");
+    ShreddedObject value1 = Variants.object(metadata);
+    value1.put("name", Variants.of("Alice"));
+    ShreddedObject value2 = Variants.object(metadata);
+    value2.put("city", Variants.of("Seattle"));
+
+    new GenericAppenderHelper(table, FileFormat.PARQUET, warehouseDir)
+        .appendToTable(
+            ImmutableList.of(
+                GenericRecord.create(table.schema())
+                    .copy(
+                        "id", 1,
+                        "v1", Variant.of(metadata, value1),
+                        "v2", Variant.of(metadata, value2))));
+    table.refresh();
+
+    List<GenericRowData> rows = readRowData(table);
+    assertThat(rows).hasSize(1);
+    assertThat(rows.get(0).getField(1)).isInstanceOf(BinaryVariant.class);
+    assertThat(rows.get(0).getField(2)).isInstanceOf(BinaryVariant.class);
+    assertThat(((BinaryVariant) rows.get(0).getField(1)).getField("name").getString())
+        .isEqualTo("Alice");
+    assertThat(((BinaryVariant) rows.get(0).getField(2)).getField("city").getString())
+        .isEqualTo("Seattle");
+
+    sql("DROP TABLE %s", multiTable);
+  }
+
+  private List<GenericRowData> readRowData(Table table) throws IOException {
+    List<GenericRowData> rows = Lists.newArrayList();
+    try (CloseableIterable<CombinedScanTask> tasks = table.newScan().planTasks()) {
+      for (CombinedScanTask task : tasks) {
+        try (DataIterator<RowData> iter =
+            ReaderUtil.createDataIterator(task, table.schema(), table.schema())) {
+          while (iter.hasNext()) {
+            rows.add((GenericRowData) iter.next());
+          }
+        }
+      }
+    }
+    return rows;
   }
 }

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestVariantWriters.java
@@ -53,6 +53,7 @@ import org.apache.iceberg.variants.Variants;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.Type;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.FieldSource;
@@ -64,6 +65,15 @@ public class TestVariantWriters {
           Types.NestedField.required(2, "var", Types.VariantType.get()));
 
   private static final GenericRecord RECORD = GenericRecord.create(SCHEMA);
+
+  private static final Schema SCHEMA_TWO_VARIANTS =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.IntegerType.get()),
+          Types.NestedField.required(2, "var1", Types.VariantType.get()),
+          Types.NestedField.required(3, "var2", Types.VariantType.get()));
+
+  private static final GenericRecord RECORD_TWO_VARIANTS =
+      GenericRecord.create(SCHEMA_TWO_VARIANTS);
 
   private static final ByteBuffer TEST_METADATA_BUFFER =
       VariantTestUtil.createMetadata(ImmutableList.of("a", "b", "c", "d", "e"), true);
@@ -261,6 +271,98 @@ public class TestVariantWriters {
     }
   }
 
+  @Test
+  public void testPartialShreddingWithShreddedObject() throws IOException {
+    VariantMetadata metadata = Variants.metadata("id", "name", "city");
+
+    List<Record> records = Lists.newArrayList();
+    for (int i = 0; i < 3; i++) {
+      ShreddedObject obj = Variants.object(metadata);
+      obj.put("id", Variants.of(1000L + i));
+      obj.put("name", Variants.of("user_" + i));
+      obj.put("city", Variants.of("city_" + i));
+
+      Variant variant = Variant.of(metadata, obj);
+      Record record = RECORD.copy("id", i, "var", variant);
+      records.add(record);
+    }
+
+    VariantShreddingFunction partialShredding = (id, name) -> shredOnly("id");
+
+    List<Record> actual = writeAndRead(SCHEMA, partialShredding, records, "var");
+
+    assertThat(actual).hasSameSizeAs(records);
+    for (int i = 0; i < records.size(); i++) {
+      Record expected = records.get(i);
+      Record read = actual.get(i);
+
+      InternalTestHelpers.assertEquals(SCHEMA.asStruct(), expected, read);
+
+      Variant readVariant = (Variant) read.getField("var");
+      VariantObject readObj = readVariant.value().asObject();
+      assertThat(readObj.numFields()).isEqualTo(3);
+      assertThat(readObj.get("id").asPrimitive().get()).isEqualTo(1000L + i);
+      assertThat(readObj.get("name").asPrimitive().get()).isEqualTo("user_" + i);
+      assertThat(readObj.get("city").asPrimitive().get()).isEqualTo("city_" + i);
+    }
+  }
+
+  @Test
+  public void testPartialShreddingMultipleColumns() throws IOException {
+    VariantMetadata metadata1 = Variants.metadata("id", "name", "city");
+    VariantMetadata metadata2 = Variants.metadata("key", "val", "extra");
+
+    List<Record> records = Lists.newArrayList();
+    for (int i = 0; i < 3; i++) {
+      ShreddedObject object1 = Variants.object(metadata1);
+      object1.put("id", Variants.of(1000L + i));
+      object1.put("name", Variants.of("user_" + i));
+      object1.put("city", Variants.of("city_" + i));
+
+      ShreddedObject object2 = Variants.object(metadata2);
+      object2.put("key", Variants.of(2000L + i));
+      object2.put("val", Variants.of("val_" + i));
+      object2.put("extra", Variants.of("extra_" + i));
+
+      records.add(
+          RECORD_TWO_VARIANTS.copy(
+              "id", i,
+              "var1", Variant.of(metadata1, object1),
+              "var2", Variant.of(metadata2, object2)));
+    }
+
+    VariantShreddingFunction partialShredding =
+        (id, name) -> {
+          if (name.equals("var1")) {
+            return shredOnly("id");
+          } else if (name.equals("var2")) {
+            return shredOnly("key");
+          }
+          return null;
+        };
+
+    List<Record> actual =
+        writeAndRead(SCHEMA_TWO_VARIANTS, partialShredding, records, "var1", "var2");
+
+    assertThat(actual).hasSameSizeAs(records);
+    for (int i = 0; i < records.size(); i++) {
+      InternalTestHelpers.assertEquals(
+          SCHEMA_TWO_VARIANTS.asStruct(), records.get(i), actual.get(i));
+
+      VariantObject readObject1 = ((Variant) actual.get(i).getField("var1")).value().asObject();
+      assertThat(readObject1.numFields()).isEqualTo(3);
+      assertThat(readObject1.get("id").asPrimitive().get()).isEqualTo(1000L + i);
+      assertThat(readObject1.get("name").asPrimitive().get()).isEqualTo("user_" + i);
+      assertThat(readObject1.get("city").asPrimitive().get()).isEqualTo("city_" + i);
+
+      VariantObject readObject2 = ((Variant) actual.get(i).getField("var2")).value().asObject();
+      assertThat(readObject2.numFields()).isEqualTo(3);
+      assertThat(readObject2.get("key").asPrimitive().get()).isEqualTo(2000L + i);
+      assertThat(readObject2.get("val").asPrimitive().get()).isEqualTo("val_" + i);
+      assertThat(readObject2.get("extra").asPrimitive().get()).isEqualTo("extra_" + i);
+    }
+  }
+
   private static Record writeAndRead(VariantShreddingFunction shreddingFunc, Record record)
       throws IOException {
     return Iterables.getOnlyElement(writeAndRead(shreddingFunc, List.of(record)));
@@ -268,35 +370,58 @@ public class TestVariantWriters {
 
   private static List<Record> writeAndRead(
       VariantShreddingFunction shreddingFunc, List<Record> records) throws IOException {
+    return writeAndRead(SCHEMA, shreddingFunc, records);
+  }
+
+  private static List<Record> writeAndRead(
+      Schema schema, VariantShreddingFunction shreddingFunc, List<Record> records)
+      throws IOException {
+    return writeAndRead(schema, shreddingFunc, records, new String[0]);
+  }
+
+  private static List<Record> writeAndRead(
+      Schema schema,
+      VariantShreddingFunction shreddingFunc,
+      List<Record> records,
+      String... shreddedColumns)
+      throws IOException {
     OutputFile outputFile = new InMemoryOutputFile();
 
     try (FileAppender<Record> writer =
         Parquet.write(outputFile)
-            .schema(SCHEMA)
+            .schema(schema)
             .variantShreddingFunc(shreddingFunc)
-            .createWriterFunc(fileSchema -> InternalWriter.create(SCHEMA.asStruct(), fileSchema))
+            .createWriterFunc(fileSchema -> InternalWriter.create(schema.asStruct(), fileSchema))
             .build()) {
       for (Record record : records) {
         writer.add(record);
       }
     }
 
+    List<String> expectedShredded = ImmutableList.copyOf(shreddedColumns);
     try (ParquetFileReader reader =
         ParquetFileReader.open(ParquetIO.file(outputFile.toInputFile()))) {
-      MessageType schema = reader.getFileMetaData().getSchema();
-      for (Types.NestedField column : SCHEMA.columns()) {
+      MessageType parquetSchema = reader.getFileMetaData().getSchema();
+      for (Types.NestedField column : schema.columns()) {
         if (column.type() == Types.VariantType.get()) {
-          int fieldIndex = schema.getFieldIndex(column.name());
-          assertThat(schema.getFields().get(fieldIndex).getLogicalTypeAnnotation())
+          int fieldIndex = parquetSchema.getFieldIndex(column.name());
+          assertThat(parquetSchema.getFields().get(fieldIndex).getLogicalTypeAnnotation())
               .isEqualTo(LogicalTypeAnnotation.variantType(Variant.VARIANT_SPEC_VERSION));
+          if (expectedShredded.contains(column.name())) {
+            assertThat(containsTypedValue(parquetSchema.getType(column.name())))
+                .as(
+                    "Expected shredded variant column %s to have a typed_value subtree",
+                    column.name())
+                .isTrue();
+          }
         }
       }
     }
 
     try (CloseableIterable<Record> reader =
         Parquet.read(outputFile.toInputFile())
-            .project(SCHEMA)
-            .createReaderFunc(fileSchema -> InternalReader.create(SCHEMA, fileSchema))
+            .project(schema)
+            .createReaderFunc(fileSchema -> InternalReader.create(schema, fileSchema))
             .build()) {
       return Lists.newArrayList(reader);
     }
@@ -311,52 +436,21 @@ public class TestVariantWriters {
     return arr;
   }
 
-  @Test
-  public void testPartialShreddingWithShreddedObject() throws IOException {
-    // Test for issue #15086: partial shredding with ShreddedObject created using put()
-    // Create a ShreddedObject with multiple fields, then partially shred it
-    VariantMetadata metadata = Variants.metadata("id", "name", "city");
+  private static Type shredOnly(String field) {
+    ShreddedObject shredded = Variants.object(Variants.metadata(field));
+    shredded.put(field, Variants.of(0L));
+    return ParquetVariantUtil.toParquetSchema(shredded);
+  }
 
-    // Create objects using ShreddedObject.put() instead of serialized buffers
-    List<Record> records = Lists.newArrayList();
-    for (int i = 0; i < 3; i++) {
-      ShreddedObject obj = Variants.object(metadata);
-      obj.put("id", Variants.of(1000L + i));
-      obj.put("name", Variants.of("user_" + i));
-      obj.put("city", Variants.of("city_" + i));
-
-      Variant variant = Variant.of(metadata, obj);
-      Record record = RECORD.copy("id", i, "var", variant);
-      records.add(record);
+  private static boolean containsTypedValue(Type type) {
+    if (type.isPrimitive()) {
+      return false;
     }
-
-    // Shredding function that only shreds the "id" field
-    VariantShreddingFunction partialShredding =
-        (id, name) -> {
-          VariantMetadata shreddedMetadata = Variants.metadata("id");
-          ShreddedObject shreddedObject = Variants.object(shreddedMetadata);
-          shreddedObject.put("id", Variants.of(1234L));
-          return ParquetVariantUtil.toParquetSchema(shreddedObject);
-        };
-
-    // Write and read back
-    List<Record> actual = writeAndRead(partialShredding, records);
-
-    // Verify all records match
-    assertThat(actual).hasSameSizeAs(records);
-    for (int i = 0; i < records.size(); i++) {
-      Record expected = records.get(i);
-      Record read = actual.get(i);
-
-      InternalTestHelpers.assertEquals(SCHEMA.asStruct(), expected, read);
-
-      // Also verify the variant object has all fields intact
-      Variant readVariant = (Variant) read.getField("var");
-      VariantObject readObj = readVariant.value().asObject();
-      assertThat(readObj.numFields()).isEqualTo(3);
-      assertThat(readObj.get("id").asPrimitive().get()).isEqualTo(1000L + i);
-      assertThat(readObj.get("name").asPrimitive().get()).isEqualTo("user_" + i);
-      assertThat(readObj.get("city").asPrimitive().get()).isEqualTo("city_" + i);
+    for (Type child : type.asGroupType().getFields()) {
+      if (child.getName().equals("typed_value") || containsTypedValue(child)) {
+        return true;
+      }
     }
+    return false;
   }
 }

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
@@ -51,6 +52,7 @@ import org.apache.spark.unsafe.types.VariantVal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -106,10 +108,8 @@ public class TestSparkVariantRead extends TestBase {
     Object v1row2 = directRows.get(1).get(1);
     assertThat(v1row1).isInstanceOf(VariantVal.class);
     assertThat(v1row2).isInstanceOf(VariantVal.class);
-    VariantVal r1 = (VariantVal) v1row1;
-    VariantVal r2 = (VariantVal) v1row2;
-    Variant vv1 = new Variant(r1.getValue(), r1.getMetadata());
-    Variant vv2 = new Variant(r2.getValue(), r2.getMetadata());
+    Variant vv1 = asVariant(directRows.get(0), 1);
+    Variant vv2 = asVariant(directRows.get(1), 1);
 
     // row 1 has {"a":1}
     Variant fieldA = vv1.getFieldByKey("a");
@@ -225,10 +225,7 @@ public class TestSparkVariantRead extends TestBase {
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).getLong(0)).isEqualTo(2L);
 
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("b").getLong()).isEqualTo(2L);
 
     sql("DROP TABLE IF EXISTS %s", deleteTable);
@@ -256,13 +253,13 @@ public class TestSparkVariantRead extends TestBase {
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
     Object sv1 = rows.get(0).get(1);
     assertThat(sv1).isInstanceOf(VariantVal.class);
-    Variant sv1Var = new Variant(((VariantVal) sv1).getValue(), ((VariantVal) sv1).getMetadata());
+    Variant sv1Var = asVariant(rows.get(0), 1);
     assertThat(sv1Var.getFieldByKey("a").getLong()).isEqualTo(1L);
 
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
     Object sv2 = rows.get(1).get(1);
     assertThat(sv2).isInstanceOf(VariantVal.class);
-    Variant sv2Var = new Variant(((VariantVal) sv2).getValue(), ((VariantVal) sv2).getMetadata());
+    Variant sv2Var = asVariant(rows.get(1), 1);
     assertThat(sv2Var.getFieldByKey("b").getLong()).isEqualTo(2L);
 
     sql("DROP TABLE IF EXISTS %s", structTable);
@@ -291,25 +288,13 @@ public class TestSparkVariantRead extends TestBase {
         spark.table(arrayTable).selectExpr("id", "arr[0] as e0", "arr[1] as e1").orderBy("id");
     java.util.List<Row> rows = df.collectAsList();
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant e0r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
-    Variant e1r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(2)).getValue(),
-            ((VariantVal) rows.get(0).get(2)).getMetadata());
+    Variant e0r1 = asVariant(rows.get(0), 1);
+    Variant e1r1 = asVariant(rows.get(0), 2);
     assertThat(e0r1.getFieldByKey("a").getLong()).isEqualTo(1L);
     assertThat(e1r1.getFieldByKey("x").getLong()).isEqualTo(10L);
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant e0r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
-    Variant e1r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(2)).getValue(),
-            ((VariantVal) rows.get(1).get(2)).getMetadata());
+    Variant e0r2 = asVariant(rows.get(1), 1);
+    Variant e1r2 = asVariant(rows.get(1), 2);
     assertThat(e0r2.getFieldByKey("b").getLong()).isEqualTo(2L);
     assertThat(e1r2.getFieldByKey("y").getLong()).isEqualTo(20L);
 
@@ -346,25 +331,13 @@ public class TestSparkVariantRead extends TestBase {
             .orderBy("id");
     java.util.List<Row> rows = df.collectAsList();
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant k1r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
-    Variant k2r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(2)).getValue(),
-            ((VariantVal) rows.get(0).get(2)).getMetadata());
+    Variant k1r1 = asVariant(rows.get(0), 1);
+    Variant k2r1 = asVariant(rows.get(0), 2);
     assertThat(k1r1.getFieldByKey("a").getLong()).isEqualTo(1L);
     assertThat(k2r1.getFieldByKey("x").getLong()).isEqualTo(10L);
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant k1r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
-    Variant k2r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(2)).getValue(),
-            ((VariantVal) rows.get(1).get(2)).getMetadata());
+    Variant k1r2 = asVariant(rows.get(1), 1);
+    Variant k2r2 = asVariant(rows.get(1), 2);
     assertThat(k1r2.getFieldByKey("b").getLong()).isEqualTo(2L);
     assertThat(k2r2.getFieldByKey("y").getLong()).isEqualTo(20L);
 
@@ -400,18 +373,12 @@ public class TestSparkVariantRead extends TestBase {
 
     assertThat(rows).hasSize(2);
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).describedAs("v1.name").isEqualTo("alice");
     assertThat(v1.getFieldByKey("age").getLong()).describedAs("v1.age").isEqualTo(31L);
 
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).describedAs("v2.name").isEqualTo("bob");
     assertThat(v2.getFieldByKey("age").getLong()).describedAs("v2.age").isEqualTo(25L);
 
@@ -429,16 +396,11 @@ public class TestSparkVariantRead extends TestBase {
             + "TBLPROPERTIES ('format-version'='3', 'write.parquet.shred-variants'='true')",
         toggleTable);
 
-    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
-    try {
-      sql(
-          "INSERT INTO %s VALUES "
-              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
-              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
-          toggleTable);
-    } finally {
-      spark.conf().unset("spark.sql.iceberg.shred-variants");
-    }
+    insertShredded(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+        toggleTable);
 
     Table table = Spark3Util.loadIcebergTable(spark, toggleTable);
     assertHasTypedValueSubtree(table);
@@ -448,16 +410,10 @@ public class TestSparkVariantRead extends TestBase {
 
     List<Row> rows = spark.table(toggleTable).select("id", "v").orderBy("id").collectAsList();
     assertThat(rows).hasSize(2);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
     assertThat(v1.getFieldByKey("age").getLong()).isEqualTo(30L);
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
     assertThat(v2.getFieldByKey("age").getLong()).isEqualTo(25L);
 
@@ -478,16 +434,11 @@ public class TestSparkVariantRead extends TestBase {
             + "'write.metadata.metrics.default'='%s')",
         noStatsTable, metricsMode);
 
-    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
-    try {
-      sql(
-          "INSERT INTO %s VALUES "
-              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
-              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
-          noStatsTable);
-    } finally {
-      spark.conf().unset("spark.sql.iceberg.shred-variants");
-    }
+    insertShredded(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+        noStatsTable);
 
     Table table = Spark3Util.loadIcebergTable(spark, noStatsTable);
     assertHasTypedValueSubtree(table);
@@ -495,18 +446,82 @@ public class TestSparkVariantRead extends TestBase {
 
     List<Row> rows = spark.table(noStatsTable).select("id", "v").orderBy("id").collectAsList();
     assertThat(rows).hasSize(2);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
 
     sql("DROP TABLE IF EXISTS %s", noStatsTable);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testMultipleUnshreddedVariantColumns(boolean vectorized)
+      throws IOException, NoSuchTableException, ParseException {
+    assertMultipleVariantColumns(false, vectorized);
+  }
+
+  @Test
+  public void testMultipleShreddedVariantColumns()
+      throws IOException, NoSuchTableException, ParseException {
+    assertMultipleVariantColumns(true, true);
+  }
+
+  private void assertMultipleVariantColumns(boolean shredded, boolean vectorized)
+      throws IOException, NoSuchTableException, ParseException {
+    String multiTable = CATALOG + ".default.var_multi";
+    sql("DROP TABLE IF EXISTS %s", multiTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v1 VARIANT, v2 VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.parquet.shred-variants'='%s')",
+        multiTable, Boolean.toString(shredded));
+
+    String insert =
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}'), "
+            + "parse_json('{\"city\":\"nyc\",\"zip\":10001}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'), "
+            + "parse_json('{\"city\":\"la\",\"zip\":90001}'))";
+    if (shredded) {
+      insertShredded(insert, multiTable);
+      assertHasTypedValueSubtree(Spark3Util.loadIcebergTable(spark, multiTable), "v1", "v2");
+    } else {
+      sql(insert, multiTable);
+    }
+    setVectorization(multiTable, vectorized);
+
+    List<Row> rows = spark.table(multiTable).select("id", "v1", "v2").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+
+    Variant v1r1 = asVariant(rows.get(0), 1);
+    Variant v2r1 = asVariant(rows.get(0), 2);
+    assertThat(v1r1.getFieldByKey("name").getString()).isEqualTo("alice");
+    assertThat(v1r1.getFieldByKey("age").getLong()).isEqualTo(30L);
+    assertThat(v2r1.getFieldByKey("city").getString()).isEqualTo("nyc");
+    assertThat(v2r1.getFieldByKey("zip").getLong()).isEqualTo(10001L);
+
+    Variant v1r2 = asVariant(rows.get(1), 1);
+    Variant v2r2 = asVariant(rows.get(1), 2);
+    assertThat(v1r2.getFieldByKey("name").getString()).isEqualTo("bob");
+    assertThat(v1r2.getFieldByKey("age").getLong()).isEqualTo(25L);
+    assertThat(v2r2.getFieldByKey("city").getString()).isEqualTo("la");
+    assertThat(v2r2.getFieldByKey("zip").getLong()).isEqualTo(90001L);
+
+    sql("DROP TABLE IF EXISTS %s", multiTable);
+  }
+
+  private void insertShredded(String insertSql, Object... args) {
+    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
+    try {
+      sql(insertSql, args);
+    } finally {
+      spark.conf().unset("spark.sql.iceberg.shred-variants");
+    }
+  }
+
+  private static Variant asVariant(Row row, int col) {
+    VariantVal val = (VariantVal) row.get(col);
+    return new Variant(val.getValue(), val.getMetadata());
   }
 
   private void setVectorization(boolean on) {
@@ -522,15 +537,36 @@ public class TestSparkVariantRead extends TestBase {
   }
 
   private static void assertHasTypedValueSubtree(Table table) throws IOException {
+    forEachDataFileSchema(
+        table,
+        schema ->
+            assertThat(containsTypedValue(schema))
+                .as("Expected variant column to be shredded with a typed_value subtree")
+                .isTrue());
+  }
+
+  private static void assertHasTypedValueSubtree(Table table, String... columns)
+      throws IOException {
+    forEachDataFileSchema(
+        table,
+        schema -> {
+          for (String column : columns) {
+            assertThat(containsTypedValue(schema.getType(column)))
+                .as("Expected column %s to be shredded with a typed_value subtree", column)
+                .isTrue();
+          }
+        });
+  }
+
+  private static void forEachDataFileSchema(
+      Table table, Consumer<org.apache.parquet.schema.MessageType> schemaCheck) throws IOException {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       assertThat(tasks).isNotEmpty();
       for (FileScanTask task : tasks) {
         HadoopInputFile inputFile =
             HadoopInputFile.fromPath(new Path(task.file().location()), new Configuration());
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
-          assertThat(containsTypedValue(reader.getFileMetaData().getSchema()))
-              .as("Expected variant column to be shredded with a typed_value subtree")
-              .isTrue();
+          schemaCheck.accept(reader.getFileMetaData().getSchema());
         }
       }
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
@@ -23,6 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.iceberg.DataFile;
@@ -51,6 +52,7 @@ import org.apache.spark.unsafe.types.VariantVal;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
@@ -106,10 +108,8 @@ public class TestSparkVariantRead extends TestBase {
     Object v1row2 = directRows.get(1).get(1);
     assertThat(v1row1).isInstanceOf(VariantVal.class);
     assertThat(v1row2).isInstanceOf(VariantVal.class);
-    VariantVal r1 = (VariantVal) v1row1;
-    VariantVal r2 = (VariantVal) v1row2;
-    Variant vv1 = new Variant(r1.getValue(), r1.getMetadata());
-    Variant vv2 = new Variant(r2.getValue(), r2.getMetadata());
+    Variant vv1 = asVariant(directRows.get(0), 1);
+    Variant vv2 = asVariant(directRows.get(1), 1);
 
     // row 1 has {"a":1}
     Variant fieldA = vv1.getFieldByKey("a");
@@ -225,10 +225,7 @@ public class TestSparkVariantRead extends TestBase {
     assertThat(rows).hasSize(1);
     assertThat(rows.get(0).getLong(0)).isEqualTo(2L);
 
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("b").getLong()).isEqualTo(2L);
 
     sql("DROP TABLE IF EXISTS %s", deleteTable);
@@ -256,13 +253,13 @@ public class TestSparkVariantRead extends TestBase {
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
     Object sv1 = rows.get(0).get(1);
     assertThat(sv1).isInstanceOf(VariantVal.class);
-    Variant sv1Var = new Variant(((VariantVal) sv1).getValue(), ((VariantVal) sv1).getMetadata());
+    Variant sv1Var = asVariant(rows.get(0), 1);
     assertThat(sv1Var.getFieldByKey("a").getLong()).isEqualTo(1L);
 
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
     Object sv2 = rows.get(1).get(1);
     assertThat(sv2).isInstanceOf(VariantVal.class);
-    Variant sv2Var = new Variant(((VariantVal) sv2).getValue(), ((VariantVal) sv2).getMetadata());
+    Variant sv2Var = asVariant(rows.get(1), 1);
     assertThat(sv2Var.getFieldByKey("b").getLong()).isEqualTo(2L);
 
     sql("DROP TABLE IF EXISTS %s", structTable);
@@ -291,25 +288,13 @@ public class TestSparkVariantRead extends TestBase {
         spark.table(arrayTable).selectExpr("id", "arr[0] as e0", "arr[1] as e1").orderBy("id");
     java.util.List<Row> rows = df.collectAsList();
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant e0r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
-    Variant e1r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(2)).getValue(),
-            ((VariantVal) rows.get(0).get(2)).getMetadata());
+    Variant e0r1 = asVariant(rows.get(0), 1);
+    Variant e1r1 = asVariant(rows.get(0), 2);
     assertThat(e0r1.getFieldByKey("a").getLong()).isEqualTo(1L);
     assertThat(e1r1.getFieldByKey("x").getLong()).isEqualTo(10L);
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant e0r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
-    Variant e1r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(2)).getValue(),
-            ((VariantVal) rows.get(1).get(2)).getMetadata());
+    Variant e0r2 = asVariant(rows.get(1), 1);
+    Variant e1r2 = asVariant(rows.get(1), 2);
     assertThat(e0r2.getFieldByKey("b").getLong()).isEqualTo(2L);
     assertThat(e1r2.getFieldByKey("y").getLong()).isEqualTo(20L);
 
@@ -346,25 +331,13 @@ public class TestSparkVariantRead extends TestBase {
             .orderBy("id");
     java.util.List<Row> rows = df.collectAsList();
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant k1r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
-    Variant k2r1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(2)).getValue(),
-            ((VariantVal) rows.get(0).get(2)).getMetadata());
+    Variant k1r1 = asVariant(rows.get(0), 1);
+    Variant k2r1 = asVariant(rows.get(0), 2);
     assertThat(k1r1.getFieldByKey("a").getLong()).isEqualTo(1L);
     assertThat(k2r1.getFieldByKey("x").getLong()).isEqualTo(10L);
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant k1r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
-    Variant k2r2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(2)).getValue(),
-            ((VariantVal) rows.get(1).get(2)).getMetadata());
+    Variant k1r2 = asVariant(rows.get(1), 1);
+    Variant k2r2 = asVariant(rows.get(1), 2);
     assertThat(k1r2.getFieldByKey("b").getLong()).isEqualTo(2L);
     assertThat(k2r2.getFieldByKey("y").getLong()).isEqualTo(20L);
 
@@ -400,18 +373,12 @@ public class TestSparkVariantRead extends TestBase {
 
     assertThat(rows).hasSize(2);
     assertThat(rows.get(0).getLong(0)).isEqualTo(1L);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).describedAs("v1.name").isEqualTo("alice");
     assertThat(v1.getFieldByKey("age").getLong()).describedAs("v1.age").isEqualTo(31L);
 
     assertThat(rows.get(1).getLong(0)).isEqualTo(2L);
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).describedAs("v2.name").isEqualTo("bob");
     assertThat(v2.getFieldByKey("age").getLong()).describedAs("v2.age").isEqualTo(25L);
 
@@ -429,16 +396,11 @@ public class TestSparkVariantRead extends TestBase {
             + "TBLPROPERTIES ('format-version'='3', 'write.parquet.shred-variants'='true')",
         toggleTable);
 
-    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
-    try {
-      sql(
-          "INSERT INTO %s VALUES "
-              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
-              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
-          toggleTable);
-    } finally {
-      spark.conf().unset("spark.sql.iceberg.shred-variants");
-    }
+    insertShredded(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+        toggleTable);
 
     Table table = Spark3Util.loadIcebergTable(spark, toggleTable);
     assertHasTypedValueSubtree(table);
@@ -448,16 +410,10 @@ public class TestSparkVariantRead extends TestBase {
 
     List<Row> rows = spark.table(toggleTable).select("id", "v").orderBy("id").collectAsList();
     assertThat(rows).hasSize(2);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
     assertThat(v1.getFieldByKey("age").getLong()).isEqualTo(30L);
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
     assertThat(v2.getFieldByKey("age").getLong()).isEqualTo(25L);
 
@@ -478,16 +434,11 @@ public class TestSparkVariantRead extends TestBase {
             + "'write.metadata.metrics.default'='%s')",
         noStatsTable, metricsMode);
 
-    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
-    try {
-      sql(
-          "INSERT INTO %s VALUES "
-              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
-              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
-          noStatsTable);
-    } finally {
-      spark.conf().unset("spark.sql.iceberg.shred-variants");
-    }
+    insertShredded(
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+        noStatsTable);
 
     Table table = Spark3Util.loadIcebergTable(spark, noStatsTable);
     assertHasTypedValueSubtree(table);
@@ -495,18 +446,82 @@ public class TestSparkVariantRead extends TestBase {
 
     List<Row> rows = spark.table(noStatsTable).select("id", "v").orderBy("id").collectAsList();
     assertThat(rows).hasSize(2);
-    Variant v1 =
-        new Variant(
-            ((VariantVal) rows.get(0).get(1)).getValue(),
-            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    Variant v1 = asVariant(rows.get(0), 1);
     assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
-    Variant v2 =
-        new Variant(
-            ((VariantVal) rows.get(1).get(1)).getValue(),
-            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    Variant v2 = asVariant(rows.get(1), 1);
     assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
 
     sql("DROP TABLE IF EXISTS %s", noStatsTable);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testMultipleUnshreddedVariantColumns(boolean vectorized)
+      throws IOException, NoSuchTableException, ParseException {
+    assertMultipleVariantColumns(false, vectorized);
+  }
+
+  @Test
+  public void testMultipleShreddedVariantColumns()
+      throws IOException, NoSuchTableException, ParseException {
+    assertMultipleVariantColumns(true, true);
+  }
+
+  private void assertMultipleVariantColumns(boolean shredded, boolean vectorized)
+      throws IOException, NoSuchTableException, ParseException {
+    String multiTable = CATALOG + ".default.var_multi";
+    sql("DROP TABLE IF EXISTS %s", multiTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v1 VARIANT, v2 VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.parquet.shred-variants'='%s')",
+        multiTable, Boolean.toString(shredded));
+
+    String insert =
+        "INSERT INTO %s VALUES "
+            + "(1, parse_json('{\"name\":\"alice\",\"age\":30}'), "
+            + "parse_json('{\"city\":\"nyc\",\"zip\":10001}')), "
+            + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'), "
+            + "parse_json('{\"city\":\"la\",\"zip\":90001}'))";
+    if (shredded) {
+      insertShredded(insert, multiTable);
+      assertHasTypedValueSubtree(Spark3Util.loadIcebergTable(spark, multiTable), "v1", "v2");
+    } else {
+      sql(insert, multiTable);
+    }
+    setVectorization(multiTable, vectorized);
+
+    List<Row> rows = spark.table(multiTable).select("id", "v1", "v2").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+
+    Variant v1r1 = asVariant(rows.get(0), 1);
+    Variant v2r1 = asVariant(rows.get(0), 2);
+    assertThat(v1r1.getFieldByKey("name").getString()).isEqualTo("alice");
+    assertThat(v1r1.getFieldByKey("age").getLong()).isEqualTo(30L);
+    assertThat(v2r1.getFieldByKey("city").getString()).isEqualTo("nyc");
+    assertThat(v2r1.getFieldByKey("zip").getLong()).isEqualTo(10001L);
+
+    Variant v1r2 = asVariant(rows.get(1), 1);
+    Variant v2r2 = asVariant(rows.get(1), 2);
+    assertThat(v1r2.getFieldByKey("name").getString()).isEqualTo("bob");
+    assertThat(v1r2.getFieldByKey("age").getLong()).isEqualTo(25L);
+    assertThat(v2r2.getFieldByKey("city").getString()).isEqualTo("la");
+    assertThat(v2r2.getFieldByKey("zip").getLong()).isEqualTo(90001L);
+
+    sql("DROP TABLE IF EXISTS %s", multiTable);
+  }
+
+  private void insertShredded(String insertSql, Object... args) {
+    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
+    try {
+      sql(insertSql, args);
+    } finally {
+      spark.conf().unset("spark.sql.iceberg.shred-variants");
+    }
+  }
+
+  private static Variant asVariant(Row row, int col) {
+    VariantVal val = (VariantVal) row.get(col);
+    return new Variant(val.getValue(), val.getMetadata());
   }
 
   private void setVectorization(boolean on) {
@@ -522,15 +537,36 @@ public class TestSparkVariantRead extends TestBase {
   }
 
   private static void assertHasTypedValueSubtree(Table table) throws IOException {
+    forEachDataFileSchema(
+        table,
+        schema ->
+            assertThat(containsTypedValue(schema))
+                .as("Expected variant column to be shredded with a typed_value subtree")
+                .isTrue());
+  }
+
+  private static void assertHasTypedValueSubtree(Table table, String... columns)
+      throws IOException {
+    forEachDataFileSchema(
+        table,
+        schema -> {
+          for (String column : columns) {
+            assertThat(containsTypedValue(schema.getType(column)))
+                .as("Expected column %s to be shredded with a typed_value subtree", column)
+                .isTrue();
+          }
+        });
+  }
+
+  private static void forEachDataFileSchema(
+      Table table, Consumer<org.apache.parquet.schema.MessageType> schemaCheck) throws IOException {
     try (CloseableIterable<FileScanTask> tasks = table.newScan().planFiles()) {
       assertThat(tasks).isNotEmpty();
       for (FileScanTask task : tasks) {
         HadoopInputFile inputFile =
             HadoopInputFile.fromPath(new Path(task.file().location()), new Configuration());
         try (ParquetFileReader reader = ParquetFileReader.open(inputFile)) {
-          assertThat(containsTypedValue(reader.getFileMetaData().getSchema()))
-              .as("Expected variant column to be shredded with a typed_value subtree")
-              .isTrue();
+          schemaCheck.accept(reader.getFileMetaData().getSchema());
         }
       }
     }


### PR DESCRIPTION
## Rationale
- Partial shredding: [#15086](https://github.com/apache/iceberg/issues/15086) raised a concern with partially shredding a `ShreddedObject` (some fields shredded, the rest left in `value`). It wasn't a bug, but the path was untested.
- Multiple variant columns: reading more than one variant column per table wasn't sufficiently covered.

## Changes (tests only)
- Parquet (`TestVariantWriters`): partial shredding of one and of two variant columns
- Spark 4.0 / 4.1 (`TestSparkVariantRead`): multiple variant columns, shredded and unshredded, across the row and vectorized readers.
- Flink (`TestFlinkVariantType`, `TestFlinkVariantShreddingType`): multiple variant columns, shredded and unshredded.
- The rest is cleanup to use some of the helpers and common artifacts.