### PR TITLE
Docs: Document missing read table properties in configuration

### DIFF
--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -32,10 +32,13 @@ Iceberg tables support table properties to configure table behavior, like the de
 | read.split.metadata-target-size   | 33554432 (32 MB)   | Target size when combining metadata input splits       |
 | read.split.planning-lookback      | 10                 | Number of bins to consider when combining input splits |
 | read.split.open-file-cost         | 4194304 (4 MB)     | The estimated cost to open a file, used as a minimum weight when combining splits. |
+| read.split.adaptive-size.enabled  | true               | Controls whether the split size is adjusted adaptively to the scan size and available parallelism when no explicit split size is set |
 | read.parquet.vectorization.enabled| true               | Controls whether Parquet vectorized reads are used     |
 | read.parquet.vectorization.batch-size| 5000            | The batch size for parquet vectorized reads            |
 | read.orc.vectorization.enabled    | false              | Controls whether orc vectorized reads are used         |
 | read.orc.vectorization.batch-size | 5000               | The batch size for orc vectorized reads                |
+| read.data-planning-mode           | auto               | Mode used to plan data manifests: auto, local, or distributed |
+| read.delete-planning-mode         | auto               | Mode used to plan delete manifests: auto, local, or distributed |
 
 ### Write properties
 


### PR DESCRIPTION
Three read table properties are defined in `TableProperties` and honored at scan planning time, but are missing from the configuration reference:

| Property | Default | Source |
| --- | --- | --- |
| `read.split.adaptive-size.enabled` | `true` | `ADAPTIVE_SPLIT_SIZE_ENABLED_DEFAULT` |
| `read.data-planning-mode` | `auto` | `PLANNING_MODE_DEFAULT` |
| `read.delete-planning-mode` | `auto` | `PLANNING_MODE_DEFAULT` |

The accepted planning modes (`auto`, `local`, `distributed`) come from the `PlanningMode` enum. Docs-only.
