### PR TITLE
fix: apply schema-force-optional recursively in schema evolution path [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -253,7 +253,8 @@ class RecordConverter {
                     hasSchemaUpdates = true;
                   }
                   // make optional if needed and schema evolution is on
-                  if (tableField.isRequired() && recordField.schema().isOptional()) {
+                  if (tableField.isRequired()
+                      && (config.schemaForceOptional() || recordField.schema().isOptional())) {
                     String fieldName = tableSchema.findColumnName(tableField.fieldId());
                     schemaUpdateConsumer.makeOptional(fieldName);
                     hasSchemaUpdates = true;
@@ -315,7 +316,8 @@ class RecordConverter {
                 String fieldName = tableSchema.findColumnName(nestedField.fieldId());
                 schemaUpdateConsumer.updateType(fieldName, evolveDataType);
               }
-              if (nestedField.isRequired() && field.schema().isOptional()) {
+              if (nestedField.isRequired()
+                  && (config.schemaForceOptional() || field.schema().isOptional())) {
                 String fieldName = tableSchema.findColumnName(nestedField.fieldId());
                 schemaUpdateConsumer.makeOptional(fieldName);
               }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSchemaUtils.java
@@ -272,6 +272,37 @@ public class TestSchemaUtils {
     assertThat(structType.asStructType().field("i").isOptional()).isEqualTo(forceOptional);
   }
 
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testToIcebergTypeNestedStruct(boolean forceOptional) {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.schemaForceOptional()).thenReturn(forceOptional);
+
+    // nested struct: outer struct has a field "inner" which is itself a struct with two fields
+    org.apache.kafka.connect.data.Schema innerSchema =
+        SchemaBuilder.struct()
+            .field("a", Schema.INT32_SCHEMA)
+            .field("b", Schema.STRING_SCHEMA)
+            .build();
+    org.apache.kafka.connect.data.Schema outerSchema =
+        SchemaBuilder.struct().field("inner", innerSchema).build();
+
+    Type type = SchemaUtils.toIcebergType(outerSchema, config);
+    assertThat(type).isInstanceOf(StructType.class);
+    StructType outerStruct = type.asStructType();
+
+    NestedField innerField = outerStruct.field("inner");
+    assertThat(innerField).isNotNull();
+    assertThat(innerField.isOptional()).isEqualTo(forceOptional);
+    assertThat(innerField.type()).isInstanceOf(StructType.class);
+
+    StructType innerStruct = (StructType) innerField.type();
+    assertThat(innerStruct.field("a").isOptional()).isEqualTo(forceOptional);
+    assertThat(innerStruct.field("a").type()).isInstanceOf(IntegerType.class);
+    assertThat(innerStruct.field("b").isOptional()).isEqualTo(forceOptional);
+    assertThat(innerStruct.field("b").type()).isInstanceOf(StringType.class);
+  }
+
   @Test
   public void testInferIcebergType() {
     IcebergSinkConfig config = mock(IcebergSinkConfig.class);


### PR DESCRIPTION
## Description

When `iceberg.tables.schema-force-optional=true` is set and schema evolution is enabled, the `RecordConverter` only makes a table field optional when the incoming Connect record field's schema is already optional. It does not check `config.schemaForceOptional()`, so required nested struct fields in the Connect schema remain required in the Iceberg table.

This is a gap in the schema evolution path: `toIcebergType` already applies `schemaForceOptional` recursively for initial schema creation (auto-create), but the `makeOptional` logic in `RecordConverter` does not consult the flag.

### Changes

1. **RecordConverter.java** — `convertToStruct(Struct)`: Changed the `makeOptional` condition from `tableField.isRequired() && recordField.schema().isOptional()` to `tableField.isRequired() && (config.schemaForceOptional() || recordField.schema().isOptional())`.

2. **RecordConverter.java** — `evolveSchemaFromConnectSchema`: Same change for the nested-field case.

3. **TestSchemaUtils.java** — Added `testToIcebergTypeNestedStruct` parameterized test that verifies `toIcebergType` recursively applies `schemaForceOptional` to nested struct fields at every level.

### Impact

- `schemaForceOptional=true` now ensures that required fields in the Connect schema are marked optional in the Iceberg schema during evolution, matching the behavior already present in the auto-create path.
- Fixes the scenario where a CDC pipeline's `_cdc.key` struct (from DebeziumTransform) keeps required nested fields, causing writer failures when the source PK changes and old key fields disappear from incoming records.

Closes #17555
