### PR TITLE
fix: guard against Parquet getNumNulls returning -1 for missing null count

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetMetrics.java
@@ -315,7 +315,7 @@ class ParquetMetrics {
           return null;
         }
 
-        nullCount += stats.getNumNulls();
+        nullCount += Math.max(stats.getNumNulls(), 0);
         valueCount += column.getValueCount();
       }
 
@@ -344,7 +344,7 @@ class ParquetMetrics {
           return null;
         }
 
-        nullCount += stats.getNumNulls();
+        nullCount += Math.max(stats.getNumNulls(), 0);
         valueCount += column.getValueCount();
 
         if (stats.hasNonNullValue()) {
@@ -579,7 +579,7 @@ class ParquetMetrics {
           }
 
           valueCount += column.getValueCount();
-          nullCount += hasOnlyNullVariants ? column.getValueCount() : stats.getNumNulls();
+          nullCount += hasOnlyNullVariants ? column.getValueCount() : Math.max(stats.getNumNulls(), 0);
         }
 
         return new ParquetVariantUtil.VariantMetrics(valueCount, nullCount);
@@ -607,7 +607,7 @@ class ParquetMetrics {
             return null;
           }
 
-          nullCount += stats.getNumNulls();
+          nullCount += Math.max(stats.getNumNulls(), 0);
           valueCount += column.getValueCount();
 
           if (stats.hasNonNullValue()) {


### PR DESCRIPTION
Fixes #17558

Parquet's Statistics#getNumNulls returns -1 when null_count is missing from the column chunk statistics. The current code unconditionally adds -1 to the accumulated null count, which produces incorrect results when multiple row groups are merged across a column chunk.

For example, with row group 0 having 1 null and row group 1 missing null_count (returning -1), the total becomes 0 instead of at least 1. A query engine relying on null count could skip the file entirely when evaluating predicates like WHERE c IS NULL, causing wrong results.

This fix wraps all getNumNulls() calls with Math.max(..., 0) to safely handle the missing null_count case across all four code paths: counts(), bounds(), and the two variant metric methods.