### PR TITLE
Spark 4.1: Add per-task scanDuration metric

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -77,6 +77,10 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private final Iterator<TaskT> tasks;
   private final DeleteCounter counter;
   private final boolean cacheDeleteFilesOnExecutors;
+  // Wall time this task spent inside next(), i.e. opening files and pulling rows/batches from
+  // them. Nanoseconds, since a single split can be read in well under a millisecond. Timed per
+  // next() call rather than per row: a nanoTime pair per row costs more than the read it measures.
+  private long scanDurationNanos = 0L;
 
   private Map<String, InputFile> lazyInputFiles;
   private CloseableIterator<T> currentIterator;
@@ -132,7 +136,13 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
     return counter;
   }
 
+  /** Wall time spent reading in this task, in nanoseconds. */
+  protected long scanDurationNanos() {
+    return scanDurationNanos;
+  }
+
   public boolean next() throws IOException {
+    long start = System.nanoTime();
     try {
       while (true) {
         if (currentIterator.hasNext()) {
@@ -156,6 +166,8 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
         LOG.error("Error reading file(s): {}", filePaths, e);
       }
       throw e;
+    } finally {
+      this.scanDurationNanos += System.nanoTime() - start;
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BaseReader.java
@@ -77,9 +77,7 @@ abstract class BaseReader<T, TaskT extends ScanTask> implements Closeable {
   private final Iterator<TaskT> tasks;
   private final DeleteCounter counter;
   private final boolean cacheDeleteFilesOnExecutors;
-  // Wall time this task spent inside next(), i.e. opening files and pulling rows/batches from
-  // them. Nanoseconds, since a single split can be read in well under a millisecond. Timed per
-  // next() call rather than per row: a nanoTime pair per row costs more than the read it measures.
+  // nanos, not millis: a single split can be read in well under a millisecond
   private long scanDurationNanos = 0L;
 
   private Map<String, InputFile> lazyInputFiles;

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/BatchDataReader.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.spark.OrcBatchReadConf;
 import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.source.metrics.TaskNumDeletes;
 import org.apache.iceberg.spark.source.metrics.TaskNumSplits;
+import org.apache.iceberg.spark.source.metrics.TaskScanDuration;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
 import org.apache.spark.sql.connector.read.PartitionReader;
@@ -88,7 +89,9 @@ class BatchDataReader extends BaseBatchReader<FileScanTask>
   @Override
   public CustomTaskMetric[] currentMetricsValues() {
     return new CustomTaskMetric[] {
-      new TaskNumSplits(numSplits), new TaskNumDeletes(counter().get())
+      new TaskNumSplits(numSplits),
+      new TaskNumDeletes(counter().get()),
+      new TaskScanDuration(scanDurationNanos())
     };
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/RowDataReader.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.spark.source.metrics.TaskNumDeletes;
 import org.apache.iceberg.spark.source.metrics.TaskNumSplits;
+import org.apache.iceberg.spark.source.metrics.TaskScanDuration;
 import org.apache.spark.rdd.InputFileBlockHolder;
 import org.apache.spark.sql.catalyst.InternalRow;
 import org.apache.spark.sql.connector.metric.CustomTaskMetric;
@@ -72,7 +73,9 @@ class RowDataReader extends BaseRowReader<FileScanTask> implements PartitionRead
   @Override
   public CustomTaskMetric[] currentMetricsValues() {
     return new CustomTaskMetric[] {
-      new TaskNumSplits(numSplits), new TaskNumDeletes(counter().get())
+      new TaskNumSplits(numSplits),
+      new TaskNumDeletes(counter().get()),
+      new TaskScanDuration(scanDurationNanos())
     };
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScan.java
@@ -49,6 +49,7 @@ import org.apache.iceberg.spark.source.metrics.NumSplits;
 import org.apache.iceberg.spark.source.metrics.PositionalDeleteFiles;
 import org.apache.iceberg.spark.source.metrics.ResultDataFiles;
 import org.apache.iceberg.spark.source.metrics.ResultDeleteFiles;
+import org.apache.iceberg.spark.source.metrics.ScanDuration;
 import org.apache.iceberg.spark.source.metrics.ScannedDataManifests;
 import org.apache.iceberg.spark.source.metrics.ScannedDeleteManifests;
 import org.apache.iceberg.spark.source.metrics.SkippedDataFiles;
@@ -340,6 +341,7 @@ abstract class SparkScan implements Scan, SupportsReportStatistics {
 
       // common
       new TotalPlanningDuration(),
+      new ScanDuration(),
 
       // data manifests
       new TotalDataManifests(),

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.spark.sql.connector.metric.CustomSumMetric;
+
+public class ScanDuration extends CustomSumMetric {
+
+  public static final String NAME = "scanDuration";
+
+  @Override
+  public String name() {
+    return NAME;
+  }
+
+  @Override
+  public String description() {
+    return "total scan duration";
+  }
+
+  @Override
+  public String aggregateTaskMetrics(long[] taskMetrics) {
+    long totalNanos = 0L;
+    for (long taskMetric : taskMetrics) {
+      totalNanos += taskMetric;
+    }
+
+    // Values are nanoseconds, which are unreadable raw on the UI. Scale to the largest unit that
+    // keeps the number meaningful, matching how Spark renders its own duration metrics.
+    if (totalNanos < TimeUnit.MICROSECONDS.toNanos(1)) {
+      return totalNanos + " ns";
+    } else if (totalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMicros(totalNanos) + " us";
+    } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
+    } else {
+      return String.format("%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+    }
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
@@ -42,8 +42,7 @@ public class ScanDuration extends CustomSumMetric {
       totalNanos += taskMetric;
     }
 
-    // Values are nanoseconds, which are unreadable raw on the UI. Scale to the largest unit that
-    // keeps the number meaningful, matching how Spark renders its own duration metrics.
+    // raw nanos are unreadable on the UI, scale to the largest meaningful unit
     if (totalNanos < TimeUnit.MICROSECONDS.toNanos(1)) {
       return totalNanos + " ns";
     } else if (totalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.source.metrics;
 
+import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import org.apache.spark.sql.connector.metric.CustomSumMetric;
 
@@ -50,7 +51,8 @@ public class ScanDuration extends CustomSumMetric {
     } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
       return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
     } else {
-      return String.format("%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+      return String.format(
+          Locale.ROOT, "%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/ScanDuration.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.source.metrics;
 
+import java.util.Arrays;
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;
 import org.apache.spark.sql.connector.metric.CustomSumMetric;
@@ -38,21 +39,40 @@ public class ScanDuration extends CustomSumMetric {
 
   @Override
   public String aggregateTaskMetrics(long[] taskMetrics) {
+    if (taskMetrics.length == 0) {
+      return format(0L);
+    }
+
     long totalNanos = 0L;
     for (long taskMetric : taskMetrics) {
       totalNanos += taskMetric;
     }
 
+    // sort a copy: Spark reuses the array it hands us
+    long[] sorted = Arrays.copyOf(taskMetrics, taskMetrics.length);
+    Arrays.sort(sorted);
+
+    // mirrors MetricUtils.stringValue for Spark's own timing metrics, so a straggler task is
+    // visible instead of being hidden by the total
+    return String.format(
+        Locale.ROOT,
+        "total (min, med, max)\n%s (%s, %s, %s)",
+        format(totalNanos),
+        format(sorted[0]),
+        format(sorted[sorted.length / 2]),
+        format(sorted[sorted.length - 1]));
+  }
+
+  private String format(long nanos) {
     // raw nanos are unreadable on the UI, scale to the largest meaningful unit
-    if (totalNanos < TimeUnit.MICROSECONDS.toNanos(1)) {
-      return totalNanos + " ns";
-    } else if (totalNanos < TimeUnit.MILLISECONDS.toNanos(1)) {
-      return TimeUnit.NANOSECONDS.toMicros(totalNanos) + " us";
-    } else if (totalNanos < TimeUnit.SECONDS.toNanos(1)) {
-      return TimeUnit.NANOSECONDS.toMillis(totalNanos) + " ms";
+    if (nanos < TimeUnit.MICROSECONDS.toNanos(1)) {
+      return nanos + " ns";
+    } else if (nanos < TimeUnit.MILLISECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMicros(nanos) + " us";
+    } else if (nanos < TimeUnit.SECONDS.toNanos(1)) {
+      return TimeUnit.NANOSECONDS.toMillis(nanos) + " ms";
     } else {
-      return String.format(
-          Locale.ROOT, "%.1f s", totalNanos / (double) TimeUnit.SECONDS.toNanos(1));
+      return String.format(Locale.ROOT, "%.1f s", nanos / (double) TimeUnit.SECONDS.toNanos(1));
     }
   }
 }

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskScanDuration.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/metrics/TaskScanDuration.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import org.apache.spark.sql.connector.metric.CustomTaskMetric;
+
+public class TaskScanDuration implements CustomTaskMetric {
+
+  private final long value;
+
+  public TaskScanDuration(long value) {
+    this.value = value;
+  }
+
+  @Override
+  public String name() {
+    return ScanDuration.NAME;
+  }
+
+  @Override
+  public long value() {
+    return value;
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.iceberg.spark.source;
 
+import static org.apache.iceberg.spark.source.SparkSQLExecutionHelper.lastExecutedMetricValue;
 import static org.assertj.core.api.Assertions.assertThat;
 import static scala.collection.JavaConverters.seqAsJavaListConverter;
 
@@ -26,6 +27,7 @@ import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
 import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
+import org.apache.iceberg.spark.source.metrics.ScanDuration;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.catalyst.analysis.NoSuchTableException;
@@ -199,6 +201,30 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap)
         .hasEntrySatisfying(
             "skippedDeleteFiles", sqlMetric -> assertThat(sqlMetric.value()).isEqualTo(0));
+  }
+
+  @TestTemplate
+  public void testScanDurationAggregatedAcrossTasks() throws NoSuchTableException {
+    sql("CREATE TABLE %s (id BIGINT) USING iceberg", tableName);
+
+    spark.range(10000).coalesce(1).writeTo(tableName).append();
+    spark.range(10001, 20000).coalesce(1).writeTo(tableName).append();
+
+    Dataset<Row> df = spark.sql(String.format("SELECT * FROM %s", tableName));
+    assertThat(df.collectAsList()).hasSize(19999);
+
+    List<SparkPlan> sparkPlans =
+        seqAsJavaListConverter(df.queryExecution().executedPlan().collectLeaves()).asJava();
+    Map<String, SQLMetric> metricsMap =
+        JavaConverters.mapAsJavaMapConverter(sparkPlans.get(0).metrics()).asJava();
+
+    // the driver-side accumulator sums TaskScanDuration across all tasks of the scan
+    long aggregatedNanos = metricsMap.get("scanDuration").value();
+    assertThat(aggregatedNanos).isGreaterThan(0);
+
+    // the value the UI renders, read back from the SQL status store
+    assertThat(lastExecutedMetricValue(spark, new ScanDuration().description()))
+        .containsPattern("\\d+(\\.\\d+)? (ns|us|ms|s)");
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -24,6 +24,7 @@ import static scala.collection.JavaConverters.seqAsJavaListConverter;
 import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.ParameterizedTestExtension;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.spark.TestBaseWithCatalog;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Row;
@@ -198,6 +199,30 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap)
         .hasEntrySatisfying(
             "skippedDeleteFiles", sqlMetric -> assertThat(sqlMetric.value()).isEqualTo(0));
+  }
+
+  @TestTemplate
+  public void testScanDurationForNonVectorizedRead() throws NoSuchTableException {
+    // the other tests read through BatchDataReader, disable vectorization to cover RowDataReader
+    sql(
+        "CREATE TABLE %s (id BIGINT) USING iceberg TBLPROPERTIES ('%s'='false')",
+        tableName, TableProperties.PARQUET_VECTORIZATION_ENABLED);
+
+    spark.range(10000).coalesce(1).writeTo(tableName).append();
+
+    Dataset<Row> df = spark.sql(String.format("SELECT * FROM %s", tableName));
+    df.collect();
+
+    List<SparkPlan> sparkPlans =
+        seqAsJavaListConverter(df.queryExecution().executedPlan().collectLeaves()).asJava();
+    // sanity check that this really exercised the row-based path
+    assertThat(sparkPlans.get(0).supportsColumnar()).isFalse();
+
+    Map<String, SQLMetric> metricsMap =
+        JavaConverters.mapAsJavaMapConverter(sparkPlans.get(0).metrics()).asJava();
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            "scanDuration", sqlMetric -> assertThat(sqlMetric.value()).isGreaterThan(0));
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -63,6 +63,9 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap)
         .hasEntrySatisfying(
             "totalPlanningDuration", sqlMetric -> assertThat(sqlMetric.value()).isNotEqualTo(0));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            "scanDuration", sqlMetric -> assertThat(sqlMetric.value()).isGreaterThan(0));
 
     // data manifests
     assertThat(metricsMap)
@@ -139,6 +142,9 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap)
         .hasEntrySatisfying(
             "totalPlanningDuration", sqlMetric -> assertThat(sqlMetric.value()).isNotEqualTo(0));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            "scanDuration", sqlMetric -> assertThat(sqlMetric.value()).isGreaterThan(0));
 
     // data manifests
     assertThat(metricsMap)
@@ -222,6 +228,9 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
     assertThat(metricsMap)
         .hasEntrySatisfying(
             "totalPlanningDuration", sqlMetric -> assertThat(sqlMetric.value()).isNotEqualTo(0));
+    assertThat(metricsMap)
+        .hasEntrySatisfying(
+            "scanDuration", sqlMetric -> assertThat(sqlMetric.value()).isGreaterThan(0));
 
     // data manifests
     assertThat(metricsMap)

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestSparkReadMetrics.java
@@ -224,7 +224,12 @@ public class TestSparkReadMetrics extends TestBaseWithCatalog {
 
     // the value the UI renders, read back from the SQL status store
     assertThat(lastExecutedMetricValue(spark, new ScanDuration().description()))
-        .containsPattern("\\d+(\\.\\d+)? (ns|us|ms|s)");
+        .containsPattern(
+            "total \\(min, med, max\\)\\R"
+                + "\\d+(\\.\\d+)? (ns|us|ms|s) "
+                + "\\(\\d+(\\.\\d+)? (ns|us|ms|s), "
+                + "\\d+(\\.\\d+)? (ns|us|ms|s), "
+                + "\\d+(\\.\\d+)? (ns|us|ms|s)\\)");
   }
 
   @TestTemplate

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source.metrics;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+public class TestScanDuration {
+
+  @Test
+  public void testAggregateTaskMetrics() {
+    ScanDuration metric = new ScanDuration();
+
+    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
+    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L})).isEqualTo("700 ns");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L})).isEqualTo("4 us");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L})).isEqualTo("1 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500_000_000L, 1_000_000_000L}))
+        .isEqualTo("2.5 s");
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
@@ -29,12 +29,35 @@ public class TestScanDuration {
   public void testAggregateTaskMetrics() {
     ScanDuration metric = new ScanDuration();
 
-    assertThat(metric.aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
-    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L})).isEqualTo("700 ns");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L})).isEqualTo("4 us");
-    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L})).isEqualTo("1 ms");
+    assertThat(metric.aggregateTaskMetrics(new long[] {300L, 400L}))
+        .isEqualTo("total (min, med, max)\n700 ns (300 ns, 400 ns, 400 ns)");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_500L, 2_500L}))
+        .isEqualTo("total (min, med, max)\n4 us (1 us, 2 us, 2 us)");
+    assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L}))
+        .isEqualTo("total (min, med, max)\n1 ms (500 us, 1 ms, 1 ms)");
     assertThat(metric.aggregateTaskMetrics(new long[] {1_500_000_000L, 1_000_000_000L}))
-        .isEqualTo("2.5 s");
+        .isEqualTo("total (min, med, max)\n2.5 s (1.0 s, 1.5 s, 1.5 s)");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsWithNoTasks() {
+    assertThat(new ScanDuration().aggregateTaskMetrics(new long[] {})).isEqualTo("0 ns");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsSurfacesStragglers() {
+    // the total alone would hide that one task took the bulk of the time
+    assertThat(
+            new ScanDuration()
+                .aggregateTaskMetrics(new long[] {1_000_000L, 1_000_000L, 8_000_000L}))
+        .isEqualTo("total (min, med, max)\n10 ms (1 ms, 1 ms, 8 ms)");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsDoesNotMutateInput() {
+    long[] taskMetrics = new long[] {3_000_000L, 1_000_000L, 2_000_000L};
+    new ScanDuration().aggregateTaskMetrics(taskMetrics);
+    assertThat(taskMetrics).containsExactly(3_000_000L, 1_000_000L, 2_000_000L);
   }
 
   @Test
@@ -44,7 +67,7 @@ public class TestScanDuration {
       // a comma-decimal locale would render "2,5 s" without an explicit Locale.ROOT
       Locale.setDefault(Locale.GERMANY);
       assertThat(new ScanDuration().aggregateTaskMetrics(new long[] {2_500_000_000L}))
-          .isEqualTo("2.5 s");
+          .isEqualTo("total (min, med, max)\n2.5 s (2.5 s, 2.5 s, 2.5 s)");
     } finally {
       Locale.setDefault(previous);
     }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/metrics/TestScanDuration.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.spark.source.metrics;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Locale;
 import org.junit.jupiter.api.Test;
 
 public class TestScanDuration {
@@ -34,5 +35,18 @@ public class TestScanDuration {
     assertThat(metric.aggregateTaskMetrics(new long[] {1_000_000L, 500_000L})).isEqualTo("1 ms");
     assertThat(metric.aggregateTaskMetrics(new long[] {1_500_000_000L, 1_000_000_000L}))
         .isEqualTo("2.5 s");
+  }
+
+  @Test
+  public void testAggregateTaskMetricsIsLocaleIndependent() {
+    Locale previous = Locale.getDefault();
+    try {
+      // a comma-decimal locale would render "2,5 s" without an explicit Locale.ROOT
+      Locale.setDefault(Locale.GERMANY);
+      assertThat(new ScanDuration().aggregateTaskMetrics(new long[] {2_500_000_000L}))
+          .isEqualTo("2.5 s");
+    } finally {
+      Locale.setDefault(previous);
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Closes #17563.
- Iceberg's only read timer is `totalPlanningDuration`, which covers driver-side planning. There is no metric for time spent actually reading, so scan throughput can't be derived from Iceberg metrics alone.

## Changes

- Add `scanDuration`: wall time a task spends in `BaseReader.next()`, covering split open and iteration. Accumulated in a `finally`, so a task that throws still reports what it read.
- `TaskScanDuration` from `BatchDataReader` and `RowDataReader`, aggregated by `ScanDuration`, mirroring the `TotalPlanningDuration` pair.
- Nanoseconds rather than the millis used by `totalPlanningDuration`, since a split can be read in well under a millisecond.
- Aggregate renders as `total (min, med, max)`, matching `MetricUtils.stringValue`, so a straggler task stays visible.

## Testing done

- `TestSparkReadMetrics` (5): V1 and V2 tables, delete path, multi-task aggregation, and the non-vectorized `RowDataReader` path.
- `TestScanDuration` (5): rendering, empty and straggler cases, input not mutated, locale independence.
- 0 failures. `spotlessCheck` and `checkstyle` pass.

## Notes

- Scoped to `spark/v4.1`. Happy to backport to 4.0 and 3.5 in a follow-up.
