### PR TITLE
Parquet: Validate geospatial projection parameters

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/MessageTypeToType.java
@@ -149,6 +149,10 @@ class MessageTypeToType extends ParquetTypeVisitor<Type> {
 
   @Override
   public Type primitive(PrimitiveType primitive) {
+    return convertPrimitive(primitive);
+  }
+
+  static Type convertPrimitive(PrimitiveType primitive) {
     // first, use the logical type annotation, if present
     LogicalTypeAnnotation logicalType = primitive.getLogicalTypeAnnotation();
     if (logicalType != null) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -159,6 +159,12 @@ public class ParquetSchemaUtil {
     int ordinal = 1;
     for (Type type : fileSchema.getFields()) {
       if (selectedIds.contains(ordinal)) {
+        Types.NestedField expectedField = expectedSchema.findField(ordinal);
+        if (type.isPrimitive() && expectedField.type().isPrimitiveType()) {
+          PruneColumns.validatePrimitive(
+              expectedField.type().asPrimitiveType(), type.asPrimitiveType());
+        }
+
         builder.addField(type.withId(ordinal));
       }
       ordinal += 1;

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetSchemaUtil.java
@@ -160,10 +160,7 @@ public class ParquetSchemaUtil {
     for (Type type : fileSchema.getFields()) {
       if (selectedIds.contains(ordinal)) {
         Types.NestedField expectedField = expectedSchema.findField(ordinal);
-        if (type.isPrimitive() && expectedField.type().isPrimitiveType()) {
-          PruneColumns.validatePrimitive(
-              expectedField.type().asPrimitiveType(), type.asPrimitiveType());
-        }
+        PruneColumns.validateFallbackType(expectedField.type(), type, type.getName());
 
         builder.addField(type.withId(ordinal));
       }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -166,6 +166,12 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   @Override
   public Type primitive(
       org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+    validatePrimitive(expected, primitive);
+    return null;
+  }
+
+  static void validatePrimitive(
+      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
     if (expected != null && (expected.typeId() == GEOMETRY || expected.typeId() == GEOGRAPHY)) {
       Preconditions.checkArgument(
           TypeUtil.isPromotionAllowed(MessageTypeToType.convertPrimitive(primitive), expected),
@@ -173,8 +179,6 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
           primitive,
           expected);
     }
-
-    return null;
   }
 
   private Integer getId(Type type) {

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -18,12 +18,16 @@
  */
 package org.apache.iceberg.parquet;
 
+import static org.apache.iceberg.types.Type.TypeID.GEOGRAPHY;
+import static org.apache.iceberg.types.Type.TypeID.GEOMETRY;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
@@ -162,6 +166,14 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   @Override
   public Type primitive(
       org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+    if (expected != null && (expected.typeId() == GEOMETRY || expected.typeId() == GEOGRAPHY)) {
+      Preconditions.checkArgument(
+          TypeUtil.isPromotionAllowed(MessageTypeToType.convertPrimitive(primitive), expected),
+          "Cannot read Parquet type %s as Iceberg type %s",
+          primitive,
+          expected);
+    }
+
     return null;
   }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -18,15 +18,13 @@
  */
 package org.apache.iceberg.parquet;
 
-import static org.apache.iceberg.types.Type.TypeID.GEOGRAPHY;
-import static org.apache.iceberg.types.Type.TypeID.GEOMETRY;
-
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.apache.iceberg.relocated.com.google.common.base.Objects;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Type.TypeID;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
@@ -172,7 +170,8 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
 
   static void validatePrimitive(
       org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
-    if (expected != null && (expected.typeId() == GEOMETRY || expected.typeId() == GEOGRAPHY)) {
+    if (expected != null
+        && (expected.typeId() == TypeID.GEOMETRY || expected.typeId() == TypeID.GEOGRAPHY)) {
       Preconditions.checkArgument(
           TypeUtil.isPromotionAllowed(MessageTypeToType.convertPrimitive(primitive), expected),
           "Cannot read Parquet type %s as Iceberg type %s",

--- a/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/PruneColumns.java
@@ -164,19 +164,80 @@ class PruneColumns extends TypeWithSchemaVisitor<Type> {
   @Override
   public Type primitive(
       org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
-    validatePrimitive(expected, primitive);
+    validatePrimitive(expected, primitive, String.join(".", currentPath()));
     return null;
   }
 
   static void validatePrimitive(
-      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive) {
+      org.apache.iceberg.types.Type.PrimitiveType expected, PrimitiveType primitive, String path) {
     if (expected != null
         && (expected.typeId() == TypeID.GEOMETRY || expected.typeId() == TypeID.GEOGRAPHY)) {
       Preconditions.checkArgument(
           TypeUtil.isPromotionAllowed(MessageTypeToType.convertPrimitive(primitive), expected),
-          "Cannot read Parquet type %s as Iceberg type %s",
+          "Cannot read Parquet type %s as Iceberg type %s for field %s",
           primitive,
-          expected);
+          expected,
+          path);
+    }
+  }
+
+  static void validateFallbackType(org.apache.iceberg.types.Type expected, Type type, String path) {
+    if (expected == null) {
+      return;
+    }
+
+    if (expected.isPrimitiveType() || type.isPrimitive()) {
+      if (expected.isPrimitiveType() && type.isPrimitive()) {
+        validatePrimitive(expected.asPrimitiveType(), type.asPrimitiveType(), path);
+      }
+
+      return;
+    }
+
+    GroupType group = type.asGroupType();
+    if (expected.isStructType()) {
+      validateFallbackStruct(expected.asStructType(), group, path);
+    } else if (expected.isListType()) {
+      validateFallbackList(expected.asListType(), group, path);
+    } else if (expected.isMapType()) {
+      validateFallbackMap(expected.asMapType(), group, path);
+    }
+  }
+
+  private static void validateFallbackStruct(StructType expected, GroupType struct, String path) {
+    List<NestedField> expectedFields = expected.fields();
+    int fieldCount = Math.min(expectedFields.size(), struct.getFieldCount());
+    for (int i = 0; i < fieldCount; i += 1) {
+      Type field = struct.getType(i);
+      validateFallbackType(expectedFields.get(i).type(), field, path + "." + field.getName());
+    }
+  }
+
+  private static void validateFallbackList(ListType expected, GroupType list, String path) {
+    Type element = ParquetSchemaUtil.determineListElementType(list);
+    String elementPath = path;
+    if (!element.isRepetition(Type.Repetition.REPEATED)) {
+      elementPath += "." + list.getFieldName(0);
+    }
+
+    validateFallbackType(expected.elementType(), element, elementPath + "." + element.getName());
+  }
+
+  private static void validateFallbackMap(MapType expected, GroupType map, String path) {
+    GroupType repeated = map.getType(0).asGroupType();
+    String repeatedPath = path + "." + repeated.getName();
+    if (repeated.getFieldCount() == 2) {
+      Type key = repeated.getType(0);
+      Type value = repeated.getType(1);
+      validateFallbackType(expected.keyType(), key, repeatedPath + "." + key.getName());
+      validateFallbackType(expected.valueType(), value, repeatedPath + "." + value.getName());
+
+    } else if (repeated.getFieldCount() == 1) {
+      Type keyOrValue = repeated.getType(0);
+      org.apache.iceberg.types.Type expectedKeyOrValue =
+          keyOrValue.getName().equalsIgnoreCase("key") ? expected.keyType() : expected.valueType();
+      validateFallbackType(
+          expectedKeyOrValue, keyOrValue, repeatedPath + "." + keyOrValue.getName());
     }
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
@@ -411,6 +411,7 @@ public class TestPruneColumns {
     assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumns(fileSchema, projection))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("KARNEY")
         .hasMessageContaining("geography(OGC:CRS84, spherical)");
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
@@ -363,6 +363,22 @@ public class TestPruneColumns {
   }
 
   @Test
+  public void rejectsGeometryCrsMismatchWithoutIds() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+            .named("geom")
+            .named("table");
+    Schema projection = new Schema(NestedField.optional(1, "geom", GeometryType.crs84()));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumnsFallback(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("geometry(OGC:CRS84)");
+  }
+
+  @Test
   public void rejectsGeographyCrsMismatch() {
     MessageType fileSchema =
         Types.buildMessage()

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
@@ -19,10 +19,14 @@
 package org.apache.iceberg.parquet;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.EdgeAlgorithm;
 import org.apache.iceberg.types.Types.DoubleType;
+import org.apache.iceberg.types.Types.GeographyType;
+import org.apache.iceberg.types.Types.GeometryType;
 import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
@@ -31,6 +35,7 @@ import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.VariantType;
 import org.apache.iceberg.variants.Variant;
+import org.apache.parquet.column.schema.EdgeInterpolationAlgorithm;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 import org.apache.parquet.schema.MessageType;
 import org.apache.parquet.schema.PrimitiveType.PrimitiveTypeName;
@@ -303,6 +308,94 @@ public class TestPruneColumns {
 
     MessageType actual = ParquetSchemaUtil.pruneColumns(fileSchema, projection);
     assertThat(actual).as("Pruned schema should be matched").isEqualTo(expected);
+  }
+
+  @Test
+  public void acceptsMatchingGeospatialParameters() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType(null))
+            .id(1)
+            .named("geom_default")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+            .id(2)
+            .named("geom_projected")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geographyType(null, null))
+            .id(3)
+            .named("geog_default")
+            .optional(PrimitiveTypeName.BINARY)
+            .as(
+                LogicalTypeAnnotation.geographyType(
+                    "EPSG:4326", EdgeInterpolationAlgorithm.ANDOYER))
+            .id(4)
+            .named("geog_custom")
+            .named("table");
+
+    Schema projection =
+        new Schema(
+            NestedField.optional(1, "geom_default", GeometryType.crs84()),
+            NestedField.optional(2, "geom_projected", GeometryType.of("epsg:3857")),
+            NestedField.optional(3, "geog_default", GeographyType.crs84()),
+            NestedField.optional(
+                4, "geog_custom", GeographyType.of("epsg:4326", EdgeAlgorithm.ANDOYER)));
+
+    assertThat(ParquetSchemaUtil.pruneColumns(fileSchema, projection)).isEqualTo(fileSchema);
+  }
+
+  @Test
+  public void rejectsGeometryCrsMismatch() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+            .id(1)
+            .named("geom")
+            .named("table");
+    Schema projection = new Schema(NestedField.optional(1, "geom", GeometryType.crs84()));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumns(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("geometry(OGC:CRS84)");
+  }
+
+  @Test
+  public void rejectsGeographyCrsMismatch() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .optional(PrimitiveTypeName.BINARY)
+            .as(
+                LogicalTypeAnnotation.geographyType(
+                    "EPSG:4326", EdgeInterpolationAlgorithm.SPHERICAL))
+            .id(1)
+            .named("geog")
+            .named("table");
+    Schema projection = new Schema(NestedField.optional(1, "geog", GeographyType.crs84()));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumns(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("geography(OGC:CRS84, spherical)");
+  }
+
+  @Test
+  public void rejectsGeographyAlgorithmMismatch() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .optional(PrimitiveTypeName.BINARY)
+            .as(LogicalTypeAnnotation.geographyType("OGC:CRS84", EdgeInterpolationAlgorithm.KARNEY))
+            .id(1)
+            .named("geog")
+            .named("table");
+    Schema projection = new Schema(NestedField.optional(1, "geog", GeographyType.crs84()));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumns(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("geography(OGC:CRS84, spherical)");
   }
 
   private static Type buildVariantType(int id, String name) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestPruneColumns.java
@@ -359,6 +359,7 @@ public class TestPruneColumns {
     assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumns(fileSchema, projection))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("field geom")
         .hasMessageContaining("geometry(OGC:CRS84)");
   }
 
@@ -375,6 +376,88 @@ public class TestPruneColumns {
     assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumnsFallback(fileSchema, projection))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("field geom")
+        .hasMessageContaining("geometry(OGC:CRS84)");
+  }
+
+  @Test
+  public void rejectsNestedStructGeometryCrsMismatchWithoutIds() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .optional(PrimitiveTypeName.BINARY)
+                    .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+                    .named("geom")
+                    .named("location"))
+            .named("table");
+    Schema projection =
+        new Schema(
+            NestedField.optional(
+                1,
+                "location",
+                StructType.of(NestedField.optional(2, "geom", GeometryType.crs84()))));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumnsFallback(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("field location.geom")
+        .hasMessageContaining("geometry(OGC:CRS84)");
+  }
+
+  @Test
+  public void rejectsListElementGeometryCrsMismatchWithoutIds() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.buildGroup(Type.Repetition.REPEATED)
+                            .optional(PrimitiveTypeName.BINARY)
+                            .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+                            .named("element")
+                            .named("list"))
+                    .as(LogicalTypeAnnotation.listType())
+                    .named("locations"))
+            .named("table");
+    Schema projection =
+        new Schema(
+            NestedField.optional(1, "locations", ListType.ofOptional(2, GeometryType.crs84())));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumnsFallback(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("field locations.list.element")
+        .hasMessageContaining("geometry(OGC:CRS84)");
+  }
+
+  @Test
+  public void rejectsMapValueGeometryCrsMismatchWithoutIds() {
+    MessageType fileSchema =
+        Types.buildMessage()
+            .addField(
+                Types.buildGroup(Type.Repetition.OPTIONAL)
+                    .addField(
+                        Types.buildGroup(Type.Repetition.REPEATED)
+                            .required(PrimitiveTypeName.BINARY)
+                            .as(LogicalTypeAnnotation.stringType())
+                            .named("key")
+                            .optional(PrimitiveTypeName.BINARY)
+                            .as(LogicalTypeAnnotation.geometryType("EPSG:3857"))
+                            .named("value")
+                            .named("key_value"))
+                    .as(LogicalTypeAnnotation.mapType())
+                    .named("locations"))
+            .named("table");
+    Schema projection =
+        new Schema(
+            NestedField.optional(
+                1, "locations", MapType.ofOptional(2, 3, StringType.get(), GeometryType.crs84())));
+
+    assertThatThrownBy(() -> ParquetSchemaUtil.pruneColumnsFallback(fileSchema, projection))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Cannot read Parquet type")
+        .hasMessageContaining("field locations.key_value.value")
         .hasMessageContaining("geometry(OGC:CRS84)");
   }
 


### PR DESCRIPTION
## Summary

- validate Parquet geometry and geography logical-type parameters against the projected Iceberg type
- reuse the existing Parquet-to-Iceberg primitive conversion so omitted defaults and case-insensitive CRS matching remain consistent
- add focused coverage for matching parameters, geometry and geography CRS mismatches, and geography edge-algorithm mismatches

## Context

Parquet geospatial values carry their CRS and edge interpolation algorithm in the logical-type annotation rather than in the WKB payload. `PruneColumns` previously ignored these parameters, so a file could be interpreted using incompatible parameters from the projected Iceberg schema.

This is the Java-side counterpart discovered while reviewing [apache/iceberg-cpp#880](https://github.com/apache/iceberg-cpp/pull/880).

## Testing

- `./gradlew :iceberg-parquet:test --tests org.apache.iceberg.parquet.TestPruneColumns`
- `./gradlew :iceberg-parquet:spotlessJavaCheck`
- `git diff --check`

---

**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: User requested the fix; this draft is awaiting human review.
- Prompt Summary: Compare the Iceberg C++ geospatial reader behavior with Java, confirm whether Java has the same issue, and create a Java-side fix PR.
