### PR TITLE
Core: Simplify list handling in manifest read and write paths

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -47,7 +47,6 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.math.IntMath;
-import org.apache.iceberg.util.Pair;
 import org.apache.iceberg.util.PropertyUtil;
 import org.apache.iceberg.util.Tasks;
 import org.slf4j.Logger;
@@ -631,24 +630,13 @@ public class ManifestFiles {
       Function<List<F>, List<ManifestFile>> writeFunc) {
     List<List<F>> groups = divide(files, parallelism);
 
-    // Pair each group with its index so results can be reassembled in input order.
-    List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayListWithCapacity(groups.size());
-    for (int i = 0; i < groups.size(); i++) {
-      groupsWithIndex.add(Pair.of(i, groups.get(i)));
-    }
-
     AtomicReferenceArray<List<ManifestFile>> results = new AtomicReferenceArray<>(groups.size());
 
-    Tasks.foreach(groupsWithIndex)
+    Tasks.range(groups.size())
         .stopOnFailure()
         .throwFailureWhenFinished()
         .executeWith(writePool)
-        .run(
-            indexedGroup -> {
-              int index = indexedGroup.first();
-              List<F> group = indexedGroup.second();
-              results.set(index, writeFunc.apply(group));
-            });
+        .run(index -> results.set(index, writeFunc.apply(groups.get(index))));
 
     ImmutableList.Builder<ManifestFile> builder = ImmutableList.builder();
     for (int i = 0; i < results.length(); i++) {

--- a/core/src/main/java/org/apache/iceberg/ManifestFiles.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFiles.java
@@ -632,7 +632,7 @@ public class ManifestFiles {
     List<List<F>> groups = divide(files, parallelism);
 
     // Pair each group with its index so results can be reassembled in input order.
-    List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayList();
+    List<Pair<Integer, List<F>>> groupsWithIndex = Lists.newArrayListWithCapacity(groups.size());
     for (int i = 0; i < groups.size(); i++) {
       groupsWithIndex.add(Pair.of(i, groups.get(i)));
     }

--- a/core/src/main/java/org/apache/iceberg/ManifestsTable.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestsTable.java
@@ -120,7 +120,7 @@ public class ManifestsTable extends BaseMetadataTable {
       return null;
     }
 
-    List<StaticDataTask.Row> rows = Lists.newArrayList();
+    List<StaticDataTask.Row> rows = Lists.newArrayListWithCapacity(summaries.size());
 
     for (int i = 0; i < summaries.size(); i += 1) {
       ManifestFile.PartitionFieldSummary summary = summaries.get(i);


### PR DESCRIPTION
Two small, behavior-preserving cleanups to how manifest code builds result lists:

- **`ManifestsTable#partitionSummariesToRows`** — the `rows` list is filled with exactly one row per entry in `summaries`, a size known up front, so it is allocated with `Lists.newArrayListWithCapacity(summaries.size())` instead of the default-capacity `newArrayList()`, avoiding intermediate resizes.

- **`ManifestFiles#writeParallel`** — replaced the intermediate `List<Pair<Integer, List<F>>>` (built only to carry each group's index) with `Tasks.range(groups.size())` indexing directly into `groups`. This drops the list, its build loop, one `Pair` allocation per group, the now-unused `Pair` import, and the comment that existed only to explain the pairing, and it makes the input-order guarantee visible in the `run` body. It also brings the method in line with the `Tasks.range(n)` idiom used by every other parallel fan-out in the codebase (`ManifestMergeManager`, `ManifestFilterManager`, `SnapshotProducer`, `DVUtil`, and the Spark/Flink planners); `writeParallel` was the sole outlier, having diverged when it was extracted from `SnapshotProducer` in #16730. The `AtomicReferenceArray` results assembly is unchanged.

The `ManifestsTable` pre-size is intentionally limited to this one spot rather than a codebase-wide sweep of every under-sized list, to keep the change small and easy to review.