### PR TITLE
core,api: Make BaseSnapshot and Schema lazy fields thread-safe [fj4WqyCCw3C5ShR1RfB7MoBPTpkRrBFYP1uT35g3MvT]

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Schema.java
+++ b/api/src/main/java/org/apache/iceberg/Schema.java
@@ -74,13 +74,13 @@ public class Schema implements Serializable {
   private final int[] identifierFieldIds;
   private final int highestFieldId;
 
-  private transient BiMap<String, Integer> aliasToId = null;
-  private transient Map<Integer, NestedField> idToField = null;
-  private transient Map<String, Integer> nameToId = null;
-  private transient Map<String, Integer> lowerCaseNameToId = null;
-  private transient Map<Integer, Accessor<StructLike>> idToAccessor = null;
-  private transient Map<Integer, String> idToName = null;
-  private transient Set<Integer> identifierFieldIdSet = null;
+  private transient volatile BiMap<String, Integer> aliasToId = null;
+  private transient volatile Map<Integer, NestedField> idToField = null;
+  private transient volatile Map<String, Integer> nameToId = null;
+  private transient volatile Map<String, Integer> lowerCaseNameToId = null;
+  private transient volatile Map<Integer, Accessor<StructLike>> idToAccessor = null;
+  private transient volatile Map<Integer, String> idToName = null;
+  private transient volatile Set<Integer> identifierFieldIdSet = null;
   private final transient Map<Integer, Integer> idsToReassigned;
   private final transient Map<Integer, Integer> idsToOriginal;
 
@@ -214,42 +214,66 @@ public class Schema implements Serializable {
 
   private Map<Integer, NestedField> lazyIdToField() {
     if (idToField == null) {
-      this.idToField = TypeUtil.indexById(struct);
+      synchronized (this) {
+        if (idToField == null) {
+          this.idToField = TypeUtil.indexById(struct);
+        }
+      }
     }
     return idToField;
   }
 
   private Map<String, Integer> lazyNameToId() {
     if (nameToId == null) {
-      this.nameToId = ImmutableMap.copyOf(TypeUtil.indexByName(struct));
+      synchronized (this) {
+        if (nameToId == null) {
+          this.nameToId = ImmutableMap.copyOf(TypeUtil.indexByName(struct));
+        }
+      }
     }
     return nameToId;
   }
 
   private Map<Integer, String> lazyIdToName() {
     if (idToName == null) {
-      this.idToName = ImmutableMap.copyOf(TypeUtil.indexNameById(struct));
+      synchronized (this) {
+        if (idToName == null) {
+          this.idToName = ImmutableMap.copyOf(TypeUtil.indexNameById(struct));
+        }
+      }
     }
     return idToName;
   }
 
   private Map<String, Integer> lazyLowerCaseNameToId() {
     if (lowerCaseNameToId == null) {
-      this.lowerCaseNameToId = ImmutableMap.copyOf(TypeUtil.indexByLowerCaseName(struct));
+      synchronized (this) {
+        if (lowerCaseNameToId == null) {
+          this.lowerCaseNameToId = ImmutableMap.copyOf(TypeUtil.indexByLowerCaseName(struct));
+        }
+      }
     }
     return lowerCaseNameToId;
   }
 
   private Map<Integer, Accessor<StructLike>> lazyIdToAccessor() {
     if (idToAccessor == null) {
-      idToAccessor = Accessors.forSchema(this);
+      synchronized (this) {
+        if (idToAccessor == null) {
+          idToAccessor = Accessors.forSchema(this);
+        }
+      }
     }
     return idToAccessor;
   }
 
   private Set<Integer> lazyIdentifierFieldIdSet() {
     if (identifierFieldIdSet == null) {
-      identifierFieldIdSet = ImmutableSet.copyOf(Ints.asList(identifierFieldIds));
+      synchronized (this) {
+        if (identifierFieldIdSet == null) {
+          identifierFieldIdSet = ImmutableSet.copyOf(Ints.asList(identifierFieldIds));
+        }
+      }
     }
     return identifierFieldIdSet;
   }

--- a/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
+++ b/core/src/main/java/org/apache/iceberg/BaseSnapshot.java
@@ -48,13 +48,13 @@ class BaseSnapshot implements Snapshot {
   private final String keyId;
 
   // lazily initialized
-  private transient List<ManifestFile> allManifests = null;
-  private transient List<ManifestFile> dataManifests = null;
-  private transient List<ManifestFile> deleteManifests = null;
-  private transient List<DataFile> addedDataFiles = null;
-  private transient List<DataFile> removedDataFiles = null;
-  private transient List<DeleteFile> addedDeleteFiles = null;
-  private transient List<DeleteFile> removedDeleteFiles = null;
+  private transient volatile List<ManifestFile> allManifests = null;
+  private transient volatile List<ManifestFile> dataManifests = null;
+  private transient volatile List<ManifestFile> deleteManifests = null;
+  private transient volatile List<DataFile> addedDataFiles = null;
+  private transient volatile List<DataFile> removedDataFiles = null;
+  private transient volatile List<DeleteFile> addedDeleteFiles = null;
+  private transient volatile List<DeleteFile> removedDeleteFiles = null;
 
   BaseSnapshot(
       long sequenceNumber,
@@ -203,7 +203,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public List<ManifestFile> allManifests(FileIO fileIO) {
     if (allManifests == null) {
-      cacheManifests(fileIO);
+      synchronized (this) {
+        if (allManifests == null) {
+          cacheManifests(fileIO);
+        }
+      }
     }
     return allManifests;
   }
@@ -211,7 +215,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public List<ManifestFile> dataManifests(FileIO fileIO) {
     if (dataManifests == null) {
-      cacheManifests(fileIO);
+      synchronized (this) {
+        if (dataManifests == null) {
+          cacheManifests(fileIO);
+        }
+      }
     }
     return dataManifests;
   }
@@ -219,7 +227,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public List<ManifestFile> deleteManifests(FileIO fileIO) {
     if (deleteManifests == null) {
-      cacheManifests(fileIO);
+      synchronized (this) {
+        if (deleteManifests == null) {
+          cacheManifests(fileIO);
+        }
+      }
     }
     return deleteManifests;
   }
@@ -227,7 +239,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public List<DataFile> addedDataFiles(FileIO fileIO) {
     if (addedDataFiles == null) {
-      cacheDataFileChanges(fileIO);
+      synchronized (this) {
+        if (addedDataFiles == null) {
+          cacheDataFileChanges(fileIO);
+        }
+      }
     }
     return addedDataFiles;
   }
@@ -235,7 +251,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public List<DataFile> removedDataFiles(FileIO fileIO) {
     if (removedDataFiles == null) {
-      cacheDataFileChanges(fileIO);
+      synchronized (this) {
+        if (removedDataFiles == null) {
+          cacheDataFileChanges(fileIO);
+        }
+      }
     }
     return removedDataFiles;
   }
@@ -243,7 +263,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public Iterable<DeleteFile> addedDeleteFiles(FileIO fileIO) {
     if (addedDeleteFiles == null) {
-      cacheDeleteFileChanges(fileIO);
+      synchronized (this) {
+        if (addedDeleteFiles == null) {
+          cacheDeleteFileChanges(fileIO);
+        }
+      }
     }
     return addedDeleteFiles;
   }
@@ -251,7 +275,11 @@ class BaseSnapshot implements Snapshot {
   @Override
   public Iterable<DeleteFile> removedDeleteFiles(FileIO fileIO) {
     if (removedDeleteFiles == null) {
-      cacheDeleteFileChanges(fileIO);
+      synchronized (this) {
+        if (removedDeleteFiles == null) {
+          cacheDeleteFileChanges(fileIO);
+        }
+      }
     }
     return removedDeleteFiles;
   }


### PR DESCRIPTION
Fixes #17585

`RESTTableCache` caches `TableMetadata` and shares it across threads. `TableMetadata` lazily-initializes fields in `BaseSnapshot` and `Schema` without synchronization, while `PartitionSpec` correctly uses `synchronized` + `volatile` (double-checked locking).

This PR applies the same thread-safe lazy-initialization pattern:

- **BaseSnapshot**: mark 7 lazy fields `volatile` and guard `allManifests`/`dataManifests`/`deleteManifests`/`addedDataFiles`/`removedDataFiles`/`addedDeleteFiles`/`removedDeleteFiles` getters with double-checked locking (`synchronized (this)` + inner null check).
- **Schema**: mark 7 lazy fields `volatile` and guard the 6 `lazy*()` initializers (`lazyIdToField`, `lazyNameToId`, `lazyIdToName`, `lazyLowerCaseNameToId`, `lazyIdToAccessor`, `lazyIdentifierFieldIdSet`) with double-checked locking.

This eliminates the data race on lazily-initialized fields when `TableMetadata` is shared across threads (e.g. via `RESTSessionCatalog`'s `RESTTableCache`), matching the existing `PartitionSpec` pattern.