### PR TITLE
Flink: Remove unused logger in TestIcebergCommitter

### DIFF
--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -93,12 +93,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(ParameterizedTestExtension.class)
 class TestIcebergCommitter extends TestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(TestIcebergCommitter.class);
   public static final String OPERATOR_ID = "flink-sink";
   @TempDir File temporaryFolder;
 

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -93,12 +93,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(ParameterizedTestExtension.class)
 class TestIcebergCommitter extends TestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(TestIcebergCommitter.class);
   public static final String OPERATOR_ID = "flink-sink";
   @TempDir File temporaryFolder;
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/sink/TestIcebergCommitter.java
@@ -93,12 +93,9 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.io.TempDir;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @ExtendWith(ParameterizedTestExtension.class)
 class TestIcebergCommitter extends TestBase {
-  private static final Logger LOG = LoggerFactory.getLogger(TestIcebergCommitter.class);
   public static final String OPERATOR_ID = "flink-sink";
   @TempDir File temporaryFolder;
 


### PR DESCRIPTION
`TestIcebergCommitter` declares a `LOG` field that is never used, along with its two slf4j imports. This removes them from the Flink 1.20, 2.0 and 2.1 copies.
