### PR TITLE
API: Respect plaintext files in EncryptingFileIO bulkDecrypt

### DIFF
--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.util.List;
 import java.util.Map;
 import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.DataFile;
@@ -37,7 +38,7 @@ import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
-import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 
 public class EncryptingFileIO implements FileIO, Serializable {
   public static EncryptingFileIO combine(FileIO io, EncryptionManager em) {
@@ -68,11 +69,19 @@ public class EncryptingFileIO implements FileIO, Serializable {
   }
 
   public Map<String, InputFile> bulkDecrypt(Iterable<? extends ContentFile<?>> files) {
-    Iterable<InputFile> decrypted = em.decrypt(Iterables.transform(files, this::wrap));
-
     ImmutableMap.Builder<String, InputFile> builder = ImmutableMap.builder();
-    for (InputFile in : decrypted) {
-      builder.put(in.location(), in);
+
+    List<EncryptedInputFile> encryptedFiles = Lists.newArrayList();
+    for (ContentFile<?> file : files) {
+      if (file.keyMetadata() != null) {
+        encryptedFiles.add(wrap(file));
+      } else {
+        builder.put(file.location(), io.newInputFile(file.location(), file.fileSizeInBytes()));
+      }
+    }
+
+    for (InputFile file : em.decrypt(encryptedFiles)) {
+      builder.put(file.location(), file);
     }
 
     return builder.buildKeepingLast();

--- a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
+++ b/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java
@@ -80,8 +80,10 @@ public class EncryptingFileIO implements FileIO, Serializable {
       }
     }
 
-    for (InputFile file : em.decrypt(encryptedFiles)) {
-      builder.put(file.location(), file);
+    if (!encryptedFiles.isEmpty()) {
+      for (InputFile file : em.decrypt(encryptedFiles)) {
+        builder.put(file.location(), file);
+      }
     }
 
     return builder.buildKeepingLast();

--- a/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
+++ b/api/src/test/java/org/apache/iceberg/encryption/TestEncryptingFileIO.java
@@ -19,20 +19,26 @@
 package org.apache.iceberg.encryption;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.withSettings;
 
 import java.io.Closeable;
+import java.nio.ByteBuffer;
 import java.util.List;
 import java.util.Map;
+import org.apache.iceberg.ContentFile;
 import org.apache.iceberg.io.DelegateFileIO;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.io.FileInfo;
+import org.apache.iceberg.io.InputFile;
 import org.apache.iceberg.io.SupportsBulkOperations;
 import org.apache.iceberg.io.SupportsPrefixOperations;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 public class TestEncryptingFileIO {
 
@@ -152,6 +158,58 @@ public class TestEncryptingFileIO {
   }
 
   @Test
+  public void bulkDecryptRoutesFilesByKeyMetadata() {
+    EncryptionManager em = mock(EncryptionManager.class);
+    FileIO io = mock(FileIO.class);
+
+    ContentFile<?> plaintextFile = mockContentFile("s3://bucket/plaintext.parquet", 100L, null);
+    ContentFile<?> encryptedFile =
+        mockContentFile(
+            "s3://bucket/encrypted.parquet", 200L, ByteBuffer.wrap(new byte[] {1, 2, 3}));
+
+    InputFile plaintextInputFile = mockInputFile(io, plaintextFile);
+    InputFile encryptedRawInputFile = mockInputFile(io, encryptedFile);
+
+    InputFile decryptedInputFile = mock(InputFile.class);
+    when(decryptedInputFile.location()).thenReturn("s3://bucket/encrypted.parquet");
+    ArgumentCaptor<Iterable<EncryptedInputFile>> captor = ArgumentCaptor.forClass(Iterable.class);
+    when(em.decrypt(captor.capture())).thenReturn(List.of(decryptedInputFile));
+
+    Map<String, InputFile> result =
+        EncryptingFileIO.combine(io, em).bulkDecrypt(List.of(plaintextFile, encryptedFile));
+
+    assertThat(result)
+        .containsEntry("s3://bucket/plaintext.parquet", plaintextInputFile)
+        .containsEntry("s3://bucket/encrypted.parquet", decryptedInputFile)
+        .hasSize(2);
+
+    assertThat(captor.getValue())
+        .singleElement()
+        .satisfies(
+            encrypted -> {
+              assertThat(encrypted.encryptedInputFile()).isEqualTo(encryptedRawInputFile);
+              assertThat(encrypted.keyMetadata().buffer())
+                  .isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+            });
+  }
+
+  @Test
+  public void bulkDecryptSkipsEncryptionManagerWhenAllFilesArePlaintext() {
+    EncryptionManager em = mock(EncryptionManager.class);
+    FileIO io = mock(FileIO.class);
+
+    ContentFile<?> plaintextFile = mockContentFile("s3://bucket/plaintext.parquet", 100L, null);
+    InputFile plaintextInputFile = mockInputFile(io, plaintextFile);
+
+    Map<String, InputFile> result =
+        EncryptingFileIO.combine(io, em).bulkDecrypt(List.of(plaintextFile));
+
+    assertThat(result)
+        .containsExactly(Map.entry("s3://bucket/plaintext.parquet", plaintextInputFile));
+    verify(em, never()).decrypt(any(Iterable.class));
+  }
+
+  @Test
   public void properties() {
     EncryptionManager em = mock(EncryptionManager.class);
     FileIO io = mock(FileIO.class);
@@ -159,5 +217,20 @@ public class TestEncryptingFileIO {
 
     assertThat(EncryptingFileIO.combine(io, em).properties())
         .containsExactly(Map.entry("key", "value"));
+  }
+
+  private static ContentFile<?> mockContentFile(
+      String location, long size, ByteBuffer keyMetadata) {
+    ContentFile<?> file = mock(ContentFile.class);
+    when(file.location()).thenReturn(location);
+    when(file.fileSizeInBytes()).thenReturn(size);
+    when(file.keyMetadata()).thenReturn(keyMetadata);
+    return file;
+  }
+
+  private static InputFile mockInputFile(FileIO io, ContentFile<?> file) {
+    InputFile inputFile = mock(InputFile.class);
+    when(io.newInputFile(file.location(), file.fileSizeInBytes())).thenReturn(inputFile);
+    return inputFile;
   }
 }


### PR DESCRIPTION
`EncryptingFileIO` methods are currently written to handle the case where key metadata may be null, e.g. https://github.com/apache/iceberg/blob/60b42ec0550bcb31c1a05000f34b5ca24016221a/api/src/main/java/org/apache/iceberg/encryption/EncryptingFileIO.java#L101-L107

However, `bulkDecrypt` currently calls `wrap` on all `ContentFile`; for those without key metadata it'd create an `EncryptedInputFile` with `EncryptionKeyMetadata.empty()`. `StandardEncryptionManager#decrypt` is called which returns `StandardDecryptedInputFile`. Any attempt to parse the key metadata to `StandardKeyMetadata` will fail due to `Null key metadata buffer` (https://github.com/apache/iceberg/blob/60b42ec0550bcb31c1a05000f34b5ca24016221a/core/src/main/java/org/apache/iceberg/encryption/StandardKeyMetadata.java#L110-L112).

This change makes `bulkDecrypt` resilient to `ContentFile` where key metadata is null. This preserves the previous behaviour where `em.decrypt` is called in bulk fashion (passing a list of files), hence the accumulation of  `encryptedFiles` in the first pass through `files`.