### PR TITLE
Kafka Connect: Start the worker for idle tasks so commits complete on time

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -188,10 +188,14 @@ public class CommitterImpl implements Committer {
 
   @Override
   public void save(Collection<SinkRecord> sinkRecords) {
-    if (sinkRecords != null && !sinkRecords.isEmpty()) {
+    if (ownsPartitions()) {
       startWorker();
-      worker.save(sinkRecords);
+
+      if (sinkRecords != null && !sinkRecords.isEmpty()) {
+        worker.save(sinkRecords);
+      }
     }
+
     processControlEvents();
   }
 
@@ -203,6 +207,10 @@ public class CommitterImpl implements Committer {
     if (worker != null) {
       worker.process();
     }
+  }
+
+  private boolean ownsPartitions() {
+    return isInitialized.get() && !context.assignment().isEmpty();
   }
 
   private void startWorker() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImplWorkerLifecycle.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImplWorkerLifecycle.java
@@ -1,0 +1,233 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.connect.channel;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.iceberg.connect.events.AvroUtil;
+import org.apache.iceberg.connect.events.DataComplete;
+import org.apache.iceberg.connect.events.Event;
+import org.apache.iceberg.connect.events.PayloadType;
+import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TopicPartitionOffset;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.MemberAssignment;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.MockConsumer;
+import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.producer.MockProducer;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.connect.sink.SinkTaskContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+
+/**
+ * The worker is not only the writer for the records handed to a task: it also answers the
+ * coordinator's commit requests for every partition the task is assigned, reporting a null offset
+ * for the partitions that received no records. A task therefore needs a worker for as long as it
+ * holds an assignment, whether or not records are flowing.
+ *
+ * <p>These tests cover a task that holds an assignment but receives no records, both from the start
+ * and after a rebalance has stopped its worker.
+ */
+@SuppressWarnings("deprecation")
+class TestCommitterImplWorkerLifecycle extends ChannelTestBase {
+
+  private static final TopicPartition LEADER_PARTITION = new TopicPartition(SRC_TOPIC_NAME, 0);
+  private static final TopicPartition TP_1 = new TopicPartition(SRC_TOPIC_NAME, 1);
+  private static final TopicPartition TP_2 = new TopicPartition(SRC_TOPIC_NAME, 2);
+  private static final TopicPartition CTL_PARTITION = new TopicPartition(CTL_TOPIC_NAME, 0);
+
+  private final AtomicReference<Set<TopicPartition>> assigned = new AtomicReference<>();
+  private SinkTaskContext context;
+  private MockedStatic<KafkaUtils> mockKafkaUtils;
+  private MockProducer<String, byte[]> ctlProducer;
+  private MockConsumer<String, byte[]> ctlConsumer;
+
+  @BeforeEach
+  void stubFrameworkAndClients() {
+    assigned.set(ImmutableSet.of(TP_1, TP_2));
+    context = mock(SinkTaskContext.class);
+    when(context.assignment()).thenAnswer(invocation -> assigned.get());
+
+    // KafkaUtils talks to a real broker and to the framework's own consumer; only the group
+    // lookup needs an answer here, the rest becomes a no-op
+    mockKafkaUtils = mockStatic(KafkaUtils.class);
+    ConsumerGroupDescription groupDesc = mock(ConsumerGroupDescription.class);
+    when(groupDesc.members())
+        .thenReturn(
+            ImmutableList.of(
+                member(ImmutableSet.of(LEADER_PARTITION)), member(ImmutableSet.of(TP_1, TP_2))));
+    mockKafkaUtils
+        .when(() -> KafkaUtils.consumerGroupDescription(any(), any()))
+        .thenReturn(groupDesc);
+
+    when(clientFactory.createProducer(any())).thenAnswer(invocation -> installProducer());
+    when(clientFactory.createConsumer(any())).thenAnswer(invocation -> installConsumer());
+  }
+
+  @AfterEach
+  void releaseStaticMock() {
+    mockKafkaUtils.close();
+  }
+
+  @Test
+  void idleTaskAnswersCommitRequestForAllAssignedPartitions() throws Exception {
+    CommitterImpl committer = openedCommitter();
+
+    // the empty put() the framework issues on every poll iteration is all this task ever gets
+    committer.save(ImmutableList.of());
+    assertThat(worker(committer)).isNotNull();
+
+    UUID commitId = requestCommit();
+    committer.save(ImmutableList.of());
+
+    assertNullOffsetsReported(commitId, TP_1.partition(), TP_2.partition());
+  }
+
+  @Test
+  void idleTaskAnswersCommitRequestAfterRebalance() throws Exception {
+    CommitterImpl committer = openedCommitter();
+    committer.save(ImmutableList.of());
+    Worker workerBeforeRebalance = worker(committer);
+    assertThat(workerBeforeRebalance).isNotNull();
+
+    // A cooperative rebalance revokes partition 1 only, which stops the worker. The framework does
+    // not call open() afterwards, since no partitions were added, so put() is the next callback
+    // this task sees even though it still owns partition 2.
+    committer.close(ImmutableList.of(TP_1));
+    assigned.set(ImmutableSet.of(TP_2));
+    assertThat(worker(committer)).isNull();
+
+    committer.save(ImmutableList.of());
+    assertThat(worker(committer)).isNotNull().isNotSameAs(workerBeforeRebalance);
+
+    UUID commitId = requestCommit();
+    committer.save(ImmutableList.of());
+
+    assertNullOffsetsReported(commitId, TP_2.partition());
+  }
+
+  @Test
+  void fullyRevokedTaskDoesNotRestartWorker() throws Exception {
+    CommitterImpl committer = openedCommitter();
+    committer.save(ImmutableList.of());
+    assertThat(worker(committer)).isNotNull();
+
+    committer.close(ImmutableList.of(TP_1, TP_2));
+    assigned.set(ImmutableSet.of());
+
+    committer.save(ImmutableList.of());
+    assertThat(worker(committer)).isNull();
+  }
+
+  /** Publishes a commit request on the control topic the newest worker is subscribed to. */
+  private UUID requestCommit() {
+    // assign after the worker has subscribed, since subscribe() resets the assignment
+    ctlConsumer.rebalance(ImmutableList.of(CTL_PARTITION));
+    ctlConsumer.updateBeginningOffsets(ImmutableMap.of(CTL_PARTITION, 0L));
+
+    UUID commitId = UUID.randomUUID();
+    byte[] bytes = AvroUtil.encode(new Event(config.connectGroupId(), new StartCommit(commitId)));
+    ctlConsumer.addRecord(new ConsumerRecord<>(CTL_TOPIC_NAME, 0, 0, "key", bytes));
+    return commitId;
+  }
+
+  /** Asserts the newest worker answered the request for exactly these partitions, with no data. */
+  private void assertNullOffsetsReported(UUID commitId, Integer... partitions) {
+    assertThat(ctlProducer.history()).hasSize(1);
+    Event event = AvroUtil.decode(ctlProducer.history().get(0).value());
+    assertThat(event.payload().type()).isEqualTo(PayloadType.DATA_COMPLETE);
+
+    DataComplete dataComplete = (DataComplete) event.payload();
+    assertThat(dataComplete.commitId()).isEqualTo(commitId);
+    assertThat(dataComplete.assignments())
+        .extracting(TopicPartitionOffset::partition)
+        .containsExactlyInAnyOrder(partitions);
+    assertThat(dataComplete.assignments())
+        .allSatisfy(assignment -> assertThat(assignment.offset()).isNull());
+  }
+
+  private MemberDescription member(Collection<TopicPartition> partitions) {
+    return new MemberDescription(
+        null, Optional.empty(), null, null, new MemberAssignment(ImmutableSet.copyOf(partitions)));
+  }
+
+  private MockProducer<String, byte[]> installProducer() {
+    ctlProducer = new MockProducer<>(false, new StringSerializer(), new ByteArraySerializer());
+    ctlProducer.initTransactions();
+    return ctlProducer;
+  }
+
+  private MockConsumer<String, byte[]> installConsumer() {
+    ctlConsumer = new MockConsumer<>(OffsetResetStrategy.EARLIEST);
+    return ctlConsumer;
+  }
+
+  /** A committer that has been handed its partitions, with the mock clients wired in. */
+  private CommitterImpl openedCommitter() throws Exception {
+    CommitterImpl committer = new CommitterImpl();
+    // bypass initialize() so the mock client factory is used instead of a real one
+    setField(committer, "catalog", catalog);
+    setField(committer, "config", config);
+    setField(committer, "context", context);
+    setField(committer, "clientFactory", clientFactory);
+    setField(committer, "taskId", "connector-0");
+    ((AtomicBoolean) field("isInitialized").get(committer)).set(true);
+
+    committer.open(catalog, config, context, ImmutableList.of(TP_1, TP_2));
+    // a coordinator would run on its own thread, where the static KafkaUtils mock does not apply,
+    // and would reach for a real broker rather than fail an assertion
+    assertThat(field("coordinatorThread").get(committer)).isNull();
+    return committer;
+  }
+
+  private Worker worker(CommitterImpl committer) throws Exception {
+    return (Worker) field("worker").get(committer);
+  }
+
+  private void setField(CommitterImpl committer, String name, Object value) throws Exception {
+    field(name).set(committer, value);
+  }
+
+  private Field field(String name) throws Exception {
+    Field field = CommitterImpl.class.getDeclaredField(name);
+    field.setAccessible(true);
+    return field;
+  }
+}


### PR DESCRIPTION
Closes #17811

## Problem

A sink task that holds partitions but receives no records never answers the
coordinator's commit requests. The coordinator waits for responses covering every
partition in the consumer group, so one such task stalls every commit round: the
round times out after `iceberg.control.commit.timeout-ms` and falls back to a
partial commit. Data still lands, but commit latency is pinned to the timeout
instead of completing as soon as the writers report, and partial commits never
set the `kafka.connect.valid-through-ts` snapshot property, so the watermark
stops advancing.

## Root cause

The worker is this task's side of the commit protocol. Besides writing records,
it reports every assigned partition on a commit request, filling in a null offset
for partitions that received no data. `Worker#receive` states the intent plainly:

```java
// include all assigned topic partitions even if no messages were read
// from a partition, as the coordinator will use that to determine
// when all data for a commit has been received
List<TopicPartitionOffset> assignments =
    context.assignment().stream()
        .map(
            tp -> {
              Offset offset = results.sourceOffsets().get(tp);
              if (offset == null) {
                offset = Offset.NULL_OFFSET;
              }
              ...
```

That code is correct. What was wrong is that nothing reached it: the worker's
lifetime was tied to records rather than to the assignment. `CommitterImpl#save`
created it only inside the branch guarded by
`sinkRecords != null && !sinkRecords.isEmpty()`, so an idle task never had a
worker for the block above to run in.

`close` stops the worker on every rebalance to discard uncommitted work, and a
cooperative rebalance that only revokes partitions is not followed by `open`, so
a task can keep partitions while its worker stays gone until the next record.

## Fix

Start the worker whenever the task holds an assignment:

```java
if (ownsPartitions()) {
  startWorker();

  if (sinkRecords != null && !sinkRecords.isEmpty()) {
    worker.save(sinkRecords);
  }
}

processControlEvents();
```

`ownsPartitions()` reads `SinkTaskContext#assignment`, so it follows the
framework's own view instead of tracking partitions separately. The
`isInitialized` check keeps a task that was never assigned any partitions -- and
therefore never saw `open` -- from dereferencing a context it does not have.

`save` is the only place this can be done: it is where `processControlEvents`
polls the control topic, so a worker started anywhere else would exist without
ever being driven.

## Testing

`TestCommitterImplWorkerLifecycle` adds three cases:

| Test | Covers |
| --- | --- |
| `idleTaskAnswersCommitRequestForAllAssignedPartitions` | a task that never receives a record still reports every assigned partition, with null offsets |
| `idleTaskAnswersCommitRequestAfterRebalance` | a cooperative rebalance that revokes one partition leaves the task able to answer for the rest, with a freshly created worker |
| `fullyRevokedTaskDoesNotRestartWorker` | a task that lost every partition does not get a worker back |

Verified by mutation: reverting `CommitterImpl`, making `Worker#process` a no-op,
removing `stopWorker` from `close`, or dropping the assignment check each turns
the suite red. The `isInitialized` check is pinned by the existing
`TestCommitterImpl` cases, which call `save` on a committer that never saw `open`.

Full module suite: 133 tests, 0 failures. `spotlessCheck` passes.

## Assumptions reviewers may want to check

The fix rests on two Kafka Connect behaviors that were confirmed by reading the
AK 4.3 source rather than by running a cluster:

- `WorkerSinkTask.HandleRebalance#onPartitionsAssigned` returns early on an empty
  collection, so a rebalance that only revokes partitions does not call `open`.
  This is why the worker has to be restarted from `save`.
- `WorkerSinkTask#deliverMessages` calls `put` unconditionally, so an idle task
  still receives an empty collection on every poll iteration. The `SinkTask`
  contract does not promise this.

The new tests mock the framework, so they pin `CommitterImpl`'s behavior under
those assumptions without verifying the assumptions themselves.

## Known limitation, unchanged by this PR

A worker subscribes to the control topic with a fresh group ID and
`auto.offset.reset=latest`, so a worker created after the coordinator has already
published a `StartCommit` misses that round. This patch narrows the window to
just after a rebalance rather than the whole idle period, but does not close it.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Investigate why idle Iceberg sink tasks stop answering commit
  requests after a rebalance, then fix the worker lifecycle so it follows the
  partition assignment rather than the arrival of records.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
