### PR TITLE
Azure: Return fully-qualified URIs from ADLSFileIO.listPrefix

### DIFF
--- a/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
+++ b/azure/src/integration/java/org/apache/iceberg/azure/adlsv2/TestADLSFileIO.java
@@ -169,7 +169,8 @@ public class TestADLSFileIO extends AzuriteTestBase {
 
     // assert that only files were returned and not directories
     FileInfo fileInfo = result.next();
-    assertThat(fileInfo.location()).isEqualTo("dir/file");
+    assertThat(fileInfo.location())
+        .isEqualTo("abfs://container@account.dfs.core.windows.net/dir/file");
     assertThat(fileInfo.size()).isEqualTo(123L);
     assertThat(fileInfo.createdAtMillis()).isEqualTo(now.toInstant().toEpochMilli());
 

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSFileIO.java
@@ -227,7 +227,7 @@ public class ADLSFileIO implements DelegateFileIO {
             .map(
                 pathItem ->
                     new FileInfo(
-                        pathItem.getName(),
+                        fullyQualifiedLocation(location, pathItem.getName()),
                         pathItem.getContentLength(),
                         pathItem.getCreationTime().toInstant().toEpochMilli()))
             .iterator();
@@ -265,5 +265,14 @@ public class ADLSFileIO implements DelegateFileIO {
     }
 
     DelegateFileIO.super.close();
+  }
+
+  private static String fullyQualifiedLocation(ADLSLocation location, String path) {
+    return location
+        .container()
+        .map(
+            container ->
+                String.format("%s://%s@%s/%s", location.scheme(), container, location.host(), path))
+        .orElseGet(() -> String.format("%s://%s/%s", location.scheme(), location.host(), path));
   }
 }

--- a/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
+++ b/azure/src/main/java/org/apache/iceberg/azure/adlsv2/ADLSLocation.java
@@ -46,6 +46,7 @@ import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 class ADLSLocation {
   private static final Pattern URI_PATTERN = Pattern.compile("^(abfss?|wasbs?)://([^/?#]+)(.*)?$");
 
+  private final String scheme;
   private final String storageAccount;
   private final String container;
   private final String path;
@@ -63,6 +64,7 @@ class ADLSLocation {
 
     ValidationException.check(matcher.matches(), "Invalid ADLS URI: %s", location);
 
+    this.scheme = matcher.group(1);
     String authority = matcher.group(2);
     String[] parts = authority.split("@", -1);
     if (parts.length > 1) {
@@ -77,6 +79,11 @@ class ADLSLocation {
 
     String uriPath = matcher.group(3);
     this.path = uriPath == null ? "" : uriPath.startsWith("/") ? uriPath.substring(1) : uriPath;
+  }
+
+  /** Returns URI scheme (abfs, abfss, wasb, or wasbs). */
+  public String scheme() {
+    return scheme;
   }
 
   /** Returns Azure storage account. */

--- a/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSLocation.java
+++ b/azure/src/test/java/org/apache/iceberg/azure/adlsv2/TestADLSLocation.java
@@ -34,6 +34,7 @@ public class TestADLSLocation {
     String p1 = scheme + "://container@account.dfs.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
+    assertThat(location.scheme()).isEqualTo(scheme);
     assertThat(location.storageAccount()).isEqualTo("account");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");
@@ -45,6 +46,7 @@ public class TestADLSLocation {
     String p1 = scheme + "://container@account.blob.core.windows.net/path/to/file";
     ADLSLocation location = new ADLSLocation(p1);
 
+    assertThat(location.scheme()).isEqualTo(scheme);
     assertThat(location.storageAccount()).isEqualTo("account");
     assertThat(location.container().get()).isEqualTo("container");
     assertThat(location.path()).isEqualTo("path/to/file");


### PR DESCRIPTION
`SupportsPrefixOperations.listPrefix` is a generic API whose callers feed each `FileInfo.location()` straight back into a `FileIO` (or use it to compare against Iceberg metadata locations). The two other cloud implementations honour this contract by returning fully-qualified URIs:
* `S3FileIO.listPrefix` → `s3://bucket/key`
* `GCSFileIO.listPrefix` → `gs://bucket/blob`

`ADLSFileIO.listPrefix`, however, was returning the raw `PathItem.getName()` from the Azure SDK, which is only the container-relative path (e.g. dir/file). That means the location it emits:
* cannot be re-parsed by `ADLSLocation` (its regex requires an abfs[s]/wasb[s] scheme, so anything passed back through `newInputFile`/`deleteFile` throws a `ValidationException`),
* is not round-trippable through `deletePrefix` the way S3/GCS are,
* silently misbehaves in generic prefix walkers like `FileSystemWalker.listDirRecursivelyWithFileIO` and downstream actions like `DeleteOrphanFilesSparkAction` / `RemoveOrphanFilesProcedure`, which rely on `FileInfo.location()` being a usable location string.

### What changed
  
* `ADLSLocation` now captures and exposes the URI scheme (abfs, abfss, wasb, wasbs) so it can be reconstituted on the way out.
* `ADLSFileIO.listPrefix` reconstructs a fully-qualified URI (`<scheme>://<container>@<host>/<path>`, or `<scheme>://<host>/<path>` when no container is present) from the input prefix's scheme/host/container and the `PathItem` name, bringing it in line with `S3FileIO` and `GCSFileIO`.
* Tests updated to assert the fully-qualified form and to cover `ADLSLocation#scheme()`.

### Compatibility

This is a behaviour change for any caller that was relying on the previous container-relative return value. Given the existing behaviour was inconsistent with the interface contract and with every other `DelegateFileIO` implementation - and would break in-tree callers such as orphan-file cleanup on ADLS - this is a bug fix rather than a semantic break.