### PR TITLE
Core: RewriteDataFiles add max file group count to valid options

### DIFF
--- a/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
+++ b/core/src/main/java/org/apache/iceberg/actions/SizeBasedFileRewritePlanner.java
@@ -149,7 +149,8 @@ public abstract class SizeBasedFileRewritePlanner<
         MAX_FILE_SIZE_BYTES,
         MIN_INPUT_FILES,
         REWRITE_ALL,
-        MAX_FILE_GROUP_SIZE_BYTES);
+        MAX_FILE_GROUP_SIZE_BYTES,
+        MAX_FILE_GROUP_INPUT_FILES);
   }
 
   @Override


### PR DESCRIPTION
New compaction option `max-file-group-input-files` was added in #14837 but didn't include it as a valid option. Adding it here so systems can rely on `validOptions()` to validate user configuration.