### PR TITLE
Parquet: POC page-level pruning using Parquet Page Index

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/Parquet.java
@@ -1289,6 +1289,7 @@ public class Parquet {
     private ReaderFunction readerFunction = null;
     private boolean filterRecords = true;
     private boolean caseSensitive = true;
+    private boolean pageIndexFilteringEnabledForPoc = false;
     private boolean callInit = false;
     private boolean reuseContainers = false;
     private int maxRecordsPerBatch = 10000;
@@ -1353,6 +1354,11 @@ public class Parquet {
 
     private ReadBuilder(InputFile file) {
       this.file = file;
+    }
+
+    ReadBuilder enablePageIndexFilteringForPoc() {
+      this.pageIndexFilteringEnabledForPoc = true;
+      return this;
     }
 
     /**
@@ -1585,6 +1591,9 @@ public class Parquet {
                 ? messageType -> batchedReaderFuncWithSchema.apply(schema, messageType)
                 : batchedReaderFunc;
         if (batchedFunc != null) {
+          Preconditions.checkArgument(
+              !pageIndexFilteringEnabledForPoc,
+              "POC page-index filtering only supports the row-based Parquet reader");
           return new VectorizedParquetReader<>(
               file,
               schema,
@@ -1604,7 +1613,15 @@ public class Parquet {
                   .apply();
 
           return new org.apache.iceberg.parquet.ParquetReader<>(
-              file, schema, options, readBuilder, mapping, filter, reuseContainers, caseSensitive);
+              file,
+              schema,
+              options,
+              readBuilder,
+              mapping,
+              filter,
+              reuseContainers,
+              caseSensitive,
+              pageIndexFilteringEnabledForPoc);
         }
       }
 

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetReader.java
@@ -46,6 +46,7 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
   private final boolean reuseContainers;
   private final boolean caseSensitive;
   private final NameMapping nameMapping;
+  private final boolean pageIndexFilteringEnabled;
 
   public ParquetReader(
       InputFile input,
@@ -56,15 +57,38 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
       Expression filter,
       boolean reuseContainers,
       boolean caseSensitive) {
+    this(
+        input,
+        expectedSchema,
+        options,
+        readerFunc,
+        nameMapping,
+        filter,
+        reuseContainers,
+        caseSensitive,
+        false);
+  }
+
+  ParquetReader(
+      InputFile input,
+      Schema expectedSchema,
+      ParquetReadOptions options,
+      Function<MessageType, ParquetValueReader<?>> readerFunc,
+      NameMapping nameMapping,
+      Expression filter,
+      boolean reuseContainers,
+      boolean caseSensitive,
+      boolean pageIndexFilteringEnabled) {
+
     this.input = input;
     this.expectedSchema = expectedSchema;
     this.options = options;
     this.readerFunc = readerFunc;
-    // replace alwaysTrue with null to avoid extra work evaluating a trivial filter
     this.filter = filter == Expressions.alwaysTrue() ? null : filter;
     this.reuseContainers = reuseContainers;
     this.caseSensitive = caseSensitive;
     this.nameMapping = nameMapping;
+    this.pageIndexFilteringEnabled = pageIndexFilteringEnabled;
   }
 
   private ReadConf<T> conf = null;
@@ -82,7 +106,8 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
               nameMapping,
               reuseContainers,
               caseSensitive,
-              null);
+              null,
+              pageIndexFilteringEnabled);
       this.conf = readConf.copy();
       return readConf;
     }
@@ -104,11 +129,15 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
     private final ParquetValueReader<T> model;
     private final long totalValues;
     private final boolean reuseContainers;
+    private final boolean pageIndexFilteringEnabled;
 
     private int nextRowGroup = 0;
     private long nextRowGroupStart = 0;
     private long valuesRead = 0;
     private T last = null;
+
+    private long currentGroupRemaining = 0L;
+    private boolean finished = false;
 
     FileIterator(ReadConf<T> conf) {
       this.reader = conf.reader();
@@ -116,16 +145,76 @@ public class ParquetReader<T> extends CloseableGroup implements CloseableIterabl
       this.model = conf.model();
       this.totalValues = conf.totalValues();
       this.reuseContainers = conf.reuseContainers();
+      this.pageIndexFilteringEnabled = conf.pageIndexFilteringEnabled();
     }
 
     @Override
     public boolean hasNext() {
-      return valuesRead < totalValues;
+      if (!pageIndexFilteringEnabled) {
+        return valuesRead < totalValues;
+      }
+      if (currentGroupRemaining > 0) {
+        return true;
+      }
+      if (finished) {
+        return false;
+      }
+      return advanceFiltered();
+    }
+
+    private boolean advanceFiltered() {
+      while (nextRowGroup < shouldSkip.length) {
+        int rowGroupIndex = nextRowGroup;
+        nextRowGroup += 1;
+
+        if (shouldSkip[rowGroupIndex]) {
+          continue;
+        }
+
+        PageReadStore pages;
+
+        try {
+          pages = reader.readFilteredRowGroup(rowGroupIndex);
+        } catch (IOException e) {
+          throw new RuntimeIOException(e);
+        }
+
+        // Page Index may eliminate every page in this row group.
+        if (pages == null || pages.getRowCount() == 0L) {
+          continue;
+        }
+
+        currentGroupRemaining = pages.getRowCount();
+
+        model.setPageSource(pages);
+
+        return true;
+      }
+
+      finished = true;
+      return false;
     }
 
     @Override
     public T next() {
       try {
+        if (pageIndexFilteringEnabled) {
+          if (!hasNext()) {
+            throw new java.util.NoSuchElementException();
+          }
+
+          if (reuseContainers) {
+            this.last = model.read(last);
+          } else {
+            this.last = model.read(null);
+          }
+
+          currentGroupRemaining -= 1L;
+          valuesRead += 1L;
+
+          return last;
+        }
+
         if (valuesRead >= nextRowGroupStart) {
           advance();
         }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetValueReaders.java
@@ -32,6 +32,7 @@ import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.PrimitiveIterator;
 import java.util.UUID;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.StructLike;
@@ -355,9 +356,30 @@ public class ParquetValueReaders {
   private static class PositionReader implements ParquetValueReader<Long> {
     private long rowOffset = -1;
     private long rowGroupStart;
+    private PrimitiveIterator.OfLong rowIndexes = null;
 
     @Override
     public Long read(Long reuse) {
+      if (rowIndexes != null) {
+        Preconditions.checkState(
+            rowIndexes.hasNext(), "No row index available for the next record");
+        /*
+         * PageReadStore.getRowIndexes() returns row-group-relative
+         * indexes for filtered reads.
+         *
+         * Convert them to the physical file position:
+         *
+         *   file position =
+         *       row-group start + relative row index
+         */
+        return rowGroupStart + rowIndexes.nextLong();
+      }
+
+      /*
+       * Normal unfiltered row-group read.
+       *
+       * Preserve the existing sequential behavior.
+       */
       rowOffset = rowOffset + 1;
       return rowGroupStart + rowOffset;
     }
@@ -381,6 +403,7 @@ public class ParquetValueReaders {
                   () ->
                       new IllegalArgumentException(
                           "PageReadStore does not contain row index offset"));
+      this.rowIndexes = pageStore.getRowIndexes().orElse(null);
       this.rowOffset = -1;
     }
   }

--- a/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ReadConf.java
@@ -32,6 +32,7 @@ import org.apache.iceberg.mapping.NameMapping;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.filter2.compat.FilterCompat;
 import org.apache.parquet.hadoop.ParquetFileReader;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
 import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
@@ -55,9 +56,35 @@ class ReadConf<T> {
   private final long totalValues;
   private final boolean reuseContainers;
   private final Integer batchSize;
+  private final boolean pageIndexFilteringEnabled;
 
   // List of column chunk metadata for each row group
   private final List<Map<ColumnPath, ColumnChunkMetaData>> columnChunkMetaDataForRowGroups;
+
+  ReadConf(
+      InputFile file,
+      ParquetReadOptions options,
+      Schema expectedSchema,
+      Expression filter,
+      Function<MessageType, ParquetValueReader<?>> readerFunc,
+      Function<MessageType, VectorizedReader<?>> batchedReaderFunc,
+      NameMapping nameMapping,
+      boolean reuseContainers,
+      boolean caseSensitive,
+      Integer bSize) {
+    this(
+        file,
+        options,
+        expectedSchema,
+        filter,
+        readerFunc,
+        batchedReaderFunc,
+        nameMapping,
+        reuseContainers,
+        caseSensitive,
+        bSize,
+        false);
+  }
 
   @SuppressWarnings("unchecked")
   ReadConf(
@@ -70,11 +97,25 @@ class ReadConf<T> {
       NameMapping nameMapping,
       boolean reuseContainers,
       boolean caseSensitive,
-      Integer bSize) {
+      Integer bSize,
+      boolean pageIndexFilteringEnabled) {
+
     this.file = file;
-    this.options = options;
-    this.reader = newReader(file, options);
-    MessageType fileSchema = reader.getFileMetaData().getSchema();
+    this.pageIndexFilteringEnabled = pageIndexFilteringEnabled;
+
+    /*
+     * POC:
+     *
+     * We need the physical Parquet schema before converting the Iceberg
+     * expression to a Parquet predicate because ParquetFilters resolves
+     * predicate columns through Schema.idToAlias(fieldId).
+     *
+     * Open once to discover the file schema. When page-index filtering is
+     * enabled, the reader is reopened below with the final filter options.
+     */
+    ParquetFileReader initialReader = newReader(file, options);
+
+    MessageType fileSchema = initialReader.getFileMetaData().getSchema();
 
     MessageType typeWithIds;
     if (ParquetSchemaUtil.hasIds(fileSchema)) {
@@ -88,6 +129,62 @@ class ReadConf<T> {
       this.projection = ParquetSchemaUtil.pruneColumnsFallback(fileSchema, expectedSchema);
     }
 
+    ParquetReadOptions effectiveOptions = options;
+    if (pageIndexFilteringEnabled && filter != null) {
+      /*
+       * Convert the physical Parquet schema to an Iceberg Schema containing
+       * aliases such as:
+       *
+       *   field ID 1 -> "id"
+       *
+       * ParquetFilters requires these aliases to construct Parquet column
+       * predicates.
+       */
+      Schema parquetFileSchema = ParquetSchemaUtil.convert(typeWithIds);
+
+      /*
+       * Bind the Iceberg expression against the logical expected schema,
+       * while using the physical aliases discovered from this Parquet file.
+       *
+       * For example:
+       *
+       *   logical field:
+       *     field ID 1 -> customer_id
+       *
+       *   physical Parquet path:
+       *     field ID 1 -> id
+       */
+      Schema filterSchema = new Schema(expectedSchema.columns(), parquetFileSchema.getAliases());
+
+      FilterCompat.Filter parquetFilter =
+          ParquetFilters.convert(filterSchema, filter, caseSensitive);
+
+      effectiveOptions =
+          ParquetReadOptions.builder(options.getConfiguration())
+              .copy(options)
+              /*
+               * Iceberg continues to own row-group pruning.
+               * parquet-java is used only for page-index pruning in this POC.
+               */
+              .useStatsFilter(false)
+              .useDictionaryFilter(false)
+              .useBloomFilter(false)
+              .useRecordFilter(false)
+              .useColumnIndexFilter(true)
+              .withRecordFilter(parquetFilter)
+              .build();
+      closeReader(initialReader, file);
+      this.reader = newReader(file, effectiveOptions);
+    } else {
+      /*
+       * No page-index POC filtering: reuse the reader that was already opened.
+       */
+      this.reader = initialReader;
+    }
+    this.options = effectiveOptions;
+    /*
+     * From this point onward, use the final reader.
+     */
     this.rowGroups = reader.getRowGroups();
     this.shouldSkip = new boolean[rowGroups.size()];
 
@@ -144,6 +241,7 @@ class ReadConf<T> {
     this.batchSize = toCopy.batchSize;
     this.vectorizedModel = toCopy.vectorizedModel;
     this.columnChunkMetaDataForRowGroups = toCopy.columnChunkMetaDataForRowGroups;
+    this.pageIndexFilteringEnabled = toCopy.pageIndexFilteringEnabled;
   }
 
   ParquetFileReader reader() {
@@ -185,6 +283,10 @@ class ReadConf<T> {
     return columnChunkMetaDataForRowGroups;
   }
 
+  boolean pageIndexFilteringEnabled() {
+    return pageIndexFilteringEnabled;
+  }
+
   ReadConf<T> copy() {
     return new ReadConf<>(this);
   }
@@ -194,6 +296,14 @@ class ReadConf<T> {
       return ParquetFileReader.open(ParquetIO.file(file), options);
     } catch (IOException e) {
       throw new RuntimeIOException(e, "Failed to open Parquet file: %s", file.location());
+    }
+  }
+
+  private static void closeReader(ParquetFileReader reader, InputFile file) {
+    try {
+      reader.close();
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close Parquet file: %s", file.location());
     }
   }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetPageIndexPruningBenchmarkPoc.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetPageIndexPruningBenchmarkPoc.java
@@ -1,0 +1,497 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnPath;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestParquetPageIndexPruningBenchmarkPoc {
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestParquetPageIndexPruningBenchmarkPoc.class);
+
+  private static final int BENCHMARK_RECORD_COUNT = 500_000;
+
+  private static final int BENCHMARK_PAGE_ROW_LIMIT = 1_000;
+
+  private static final int BENCHMARK_PAYLOAD_BYTES = 256;
+
+  /*
+   * This is intentionally not a formal JMH benchmark.
+   *
+   * Warmups reduce JVM/JIT noise and the median helps reduce the impact
+   * of occasional scheduling, GC, and filesystem-cache outliers.
+   */
+  private static final int WARMUP_RUNS = 2;
+  private static final int MEASUREMENT_RUNS = 5;
+
+  private static final long FILTER_START = 250_000L;
+  private static final long FILTER_END = 250_100L;
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.optional(2, "group_id", Types.IntegerType.get()),
+          Types.NestedField.optional(3, "payload", Types.StringType.get()));
+
+  /*
+   * Model the Spark-like path for:
+   *
+   *   SELECT payload
+   *   FROM table
+   *   WHERE id >= 250000 AND id < 250100
+   *
+   * The filter column is retained in the physical read schema because
+   * page pruning does not perform final row-level predicate evaluation.
+   */
+  private static final Schema BENCHMARK_READ_SCHEMA =
+      new Schema(SCHEMA.findField("id"), SCHEMA.findField("payload"));
+
+  @TempDir private File tempDir;
+
+  /**
+   * Counts the number of bytes successfully read from all streams opened through this InputFile.
+   *
+   * <p>This intentionally counts the extra footer/schema read caused by the current Page Index
+   * POC's double-open behavior.
+   */
+  private static class CountingInputFile implements InputFile {
+    private final InputFile delegate;
+    private final AtomicLong bytesRead = new AtomicLong();
+
+    private CountingInputFile(InputFile delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public long getLength() {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new CountingSeekableInputStream(delegate.newStream(), bytesRead);
+    }
+
+    @Override
+    public String location() {
+      return delegate.location();
+    }
+
+    @Override
+    public boolean exists() {
+      return delegate.exists();
+    }
+
+    private long bytesRead() {
+      return bytesRead.get();
+    }
+  }
+
+  /** Counts bytes actually consumed from the underlying seekable stream. */
+  private static class CountingSeekableInputStream extends SeekableInputStream {
+    private final SeekableInputStream delegate;
+    private final AtomicLong bytesRead;
+
+    private CountingSeekableInputStream(SeekableInputStream delegate, AtomicLong bytesRead) {
+      this.delegate = delegate;
+      this.bytesRead = bytesRead;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return delegate.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      delegate.seek(newPos);
+    }
+
+    @Override
+    public int read() throws IOException {
+      int value = delegate.read();
+      if (value >= 0) {
+        bytesRead.incrementAndGet();
+      }
+      return value;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      int read = delegate.read(buffer, offset, length);
+      if (read > 0) {
+        bytesRead.addAndGet(read);
+      }
+      return read;
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+
+  /** Result from one measured reader execution. */
+  private static class BenchmarkResult {
+
+    private final String scenario;
+    private final boolean pageIndexEnabled;
+    private final long fileSizeBytes;
+    private final long candidateRows;
+    private final long bytesRead;
+    private final long elapsedNanos;
+
+    private BenchmarkResult(
+        String scenario,
+        boolean pageIndexEnabled,
+        long fileSizeBytes,
+        long candidateRows,
+        long bytesRead,
+        long elapsedNanos) {
+      this.scenario = scenario;
+      this.pageIndexEnabled = pageIndexEnabled;
+      this.fileSizeBytes = fileSizeBytes;
+      this.candidateRows = candidateRows;
+      this.bytesRead = bytesRead;
+      this.elapsedNanos = elapsedNanos;
+    }
+
+    private double elapsedMillis() {
+      return elapsedNanos / 1_000_000.0;
+    }
+
+    private double bytesReadMiB() {
+      return bytesRead / (1024.0 * 1024.0);
+    }
+
+    private double fileSizeMiB() {
+      return fileSizeBytes / (1024.0 * 1024.0);
+    }
+  }
+
+  /**
+   * Writes one of the benchmark input layouts.
+   *
+   * <p>The three benchmark scenarios are:
+   *
+   * <ul>
+   *   <li>sorted + ColumnIndex
+   *   <li>random + ColumnIndex
+   *   <li>sorted + no ColumnIndex
+   * </ul>
+   */
+  private void writeBenchmarkFile(File parquetFile, boolean randomOrder, boolean columnIndexEnabled)
+      throws IOException {
+    OutputFile outputFile = Files.localOutput(parquetFile);
+    long[] ids = new long[BENCHMARK_RECORD_COUNT];
+    for (int i = 0; i < ids.length; i += 1) {
+      ids[i] = i;
+    }
+
+    if (randomOrder) {
+      Random random = new Random(34L);
+      for (int i = ids.length - 1; i > 0; i -= 1) {
+        int swapIndex = random.nextInt(i + 1);
+        long temp = ids[i];
+        ids[i] = ids[swapIndex];
+        ids[swapIndex] = temp;
+      }
+    }
+
+    String payloadPrefix = "x".repeat(BENCHMARK_PAYLOAD_BYTES);
+
+    try (FileAppender<Record> appender =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(512 * 1024 * 1024))
+            .set(TableProperties.PARQUET_PAGE_SIZE_BYTES, Integer.toString(1024 * 1024))
+            .set(TableProperties.PARQUET_PAGE_ROW_LIMIT, Integer.toString(BENCHMARK_PAGE_ROW_LIMIT))
+            .set(TableProperties.PARQUET_COMPRESSION, "uncompressed")
+            .set(
+                TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "id",
+                Boolean.toString(columnIndexEnabled))
+            .withDictionaryEncoding("id", false)
+            .build()) {
+
+      for (int physicalPosition = 0; physicalPosition < ids.length; physicalPosition += 1) {
+        long id = ids[physicalPosition];
+        GenericRecord record = GenericRecord.create(SCHEMA);
+        record.setField("id", id);
+        record.setField("group_id", (int) (id / 10_000L));
+        record.setField("payload", payloadPrefix + "-" + id);
+        appender.add(record);
+      }
+    }
+  }
+
+  /** Validates assumptions about the generated benchmark file before using it for measurements. */
+  private void validateBenchmarkFile(File parquetFile, boolean expectColumnIndex)
+      throws IOException {
+    InputFile inputFile = Files.localInput(parquetFile);
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(inputFile), ParquetReadOptions.builder().build())) {
+      assertThat(reader.getRowGroups()).as("Benchmark must use exactly one row group").hasSize(1);
+      BlockMetaData rowGroup = reader.getRowGroups().get(0);
+      assertThat(rowGroup.getRowCount())
+          .as("Benchmark row count")
+          .isEqualTo(BENCHMARK_RECORD_COUNT);
+      ColumnChunkMetaData idColumnChunk =
+          rowGroup.getColumns().stream()
+              .filter(column -> column.getPath().equals(ColumnPath.get("id")))
+              .findFirst()
+              .orElseThrow(
+                  () -> new IllegalStateException("Could not find column chunk metadata for id"));
+      Object columnIndex = reader.readColumnIndex(idColumnChunk);
+      if (expectColumnIndex) {
+        assertThat(columnIndex)
+            .as("Expected id ColumnIndex in %s", parquetFile.getName())
+            .isNotNull();
+      } else {
+        assertThat(columnIndex)
+            .as("Expected no id ColumnIndex in %s", parquetFile.getName())
+            .isNull();
+      }
+
+      LOG.info(
+          "BENCHMARK_FILE file={}, fileSizeMiB={}, " + "rowGroups={}, rows={}, hasIdColumnIndex={}",
+          parquetFile.getName(),
+          parquetFile.length() / (1024.0 * 1024.0),
+          reader.getRowGroups().size(),
+          rowGroup.getRowCount(),
+          columnIndex != null);
+    }
+  }
+
+  private static Expression benchmarkFilter() {
+    return Expressions.and(
+        Expressions.greaterThanOrEqual("id", FILTER_START), Expressions.lessThan("id", FILTER_END));
+  }
+
+  /**
+   * Runs one complete Iceberg custom-row-reader scan.
+   *
+   * <p>candidateRows means rows returned by the Parquet reader after page-level pruning. It does
+   * not mean rows satisfying the final record-level predicate.
+   */
+  private BenchmarkResult runBenchmarkOnce(
+      String scenario, File parquetFile, boolean pageIndexEnabled) throws IOException {
+    CountingInputFile countingInputFile = new CountingInputFile(Files.localInput(parquetFile));
+    Expression filter = benchmarkFilter();
+    long candidateRows = 0L;
+    long startNanos = System.nanoTime();
+
+    if (pageIndexEnabled) {
+      try (CloseableIterable<Record> rows =
+          Parquet.read(countingInputFile)
+              .project(BENCHMARK_READ_SCHEMA)
+              .filter(filter)
+              .createReaderFunc(GenericParquetReaders::buildReader)
+              .enablePageIndexFilteringForPoc()
+              .build()) {
+        for (Record ignored : rows) {
+          candidateRows += 1L;
+        }
+      }
+    } else {
+      try (CloseableIterable<Record> rows =
+          Parquet.read(countingInputFile)
+              .project(BENCHMARK_READ_SCHEMA)
+              .filter(filter)
+              .createReaderFunc(GenericParquetReaders::buildReader)
+              .build()) {
+        for (Record ignored : rows) {
+          candidateRows += 1L;
+        }
+      }
+    }
+
+    long elapsedNanos = System.nanoTime() - startNanos;
+
+    return new BenchmarkResult(
+        scenario,
+        pageIndexEnabled,
+        parquetFile.length(),
+        candidateRows,
+        countingInputFile.bytesRead(),
+        elapsedNanos);
+  }
+
+  /** Performs warmups and returns the measured run with the median elapsed time. */
+  private BenchmarkResult runMedianBenchmark(
+      String scenario, File parquetFile, boolean pageIndexEnabled) throws IOException {
+    for (int i = 0; i < WARMUP_RUNS; i += 1) {
+      runBenchmarkOnce(scenario, parquetFile, pageIndexEnabled);
+    }
+    List<BenchmarkResult> measurements = Lists.newArrayList();
+    for (int i = 0; i < MEASUREMENT_RUNS; i += 1) {
+      measurements.add(runBenchmarkOnce(scenario, parquetFile, pageIndexEnabled));
+    }
+    measurements.sort(Comparator.comparingLong(result -> result.elapsedNanos));
+    return measurements.get(measurements.size() / 2);
+  }
+
+  private static double reductionPercent(long baseline, long optimized) {
+    if (baseline == 0L) {
+      return 0.0;
+    }
+    return 100.0 * (baseline - optimized) / baseline;
+  }
+
+  private static void logComparison(BenchmarkResult off, BenchmarkResult on) {
+    assertThat(off.scenario).isEqualTo(on.scenario);
+    assertThat(off.pageIndexEnabled).isFalse();
+    assertThat(on.pageIndexEnabled).isTrue();
+
+    double candidateReduction = reductionPercent(off.candidateRows, on.candidateRows);
+    double byteReduction = reductionPercent(off.bytesRead, on.bytesRead);
+    double timeReduction = reductionPercent(off.elapsedNanos, on.elapsedNanos);
+
+    LOG.info(
+        "BENCHMARK_RESULT scenario={}, pageIndex=OFF, "
+            + "fileSizeMiB={}, candidateRows={}, "
+            + "bytesRead={}, bytesReadMiB={}, medianMs={}",
+        off.scenario,
+        off.fileSizeMiB(),
+        off.candidateRows,
+        off.bytesRead,
+        off.bytesReadMiB(),
+        off.elapsedMillis());
+
+    LOG.info(
+        "BENCHMARK_RESULT scenario={}, pageIndex=ON, "
+            + "fileSizeMiB={}, candidateRows={}, "
+            + "bytesRead={}, bytesReadMiB={}, medianMs={}",
+        on.scenario,
+        on.fileSizeMiB(),
+        on.candidateRows,
+        on.bytesRead,
+        on.bytesReadMiB(),
+        on.elapsedMillis());
+
+    LOG.info(
+        "BENCHMARK_COMPARISON scenario={}, "
+            + "candidateReductionPct={}, "
+            + "byteReductionPct={}, "
+            + "timeReductionPct={}",
+        on.scenario,
+        candidateReduction,
+        byteReduction,
+        timeReduction);
+  }
+
+  /**
+   * Best-case-ish workload for Page Index pruning.
+   *
+   * <p>The file is physically sorted by id, so page-level min/max ranges should be tight and the
+   * narrow predicate should select only a small number of pages.
+   */
+  @Test
+  public void benchmarkSortedData() throws IOException {
+    File parquetFile = new File(tempDir, "benchmark-sorted-index.parquet");
+    writeBenchmarkFile(parquetFile, false, true);
+    validateBenchmarkFile(parquetFile, true);
+    BenchmarkResult off = runMedianBenchmark("sorted", parquetFile, false);
+    BenchmarkResult on = runMedianBenchmark("sorted", parquetFile, true);
+
+    assertThat(off.candidateRows).isEqualTo(BENCHMARK_RECORD_COUNT);
+
+    assertThat(on.candidateRows)
+        .isGreaterThanOrEqualTo(FILTER_END - FILTER_START)
+        .isLessThan(off.candidateRows);
+    /*
+     * This is the key I/O assertion for the initial POC.
+     */
+    assertThat(on.bytesRead)
+        .as("Page Index should reduce physical reads for sorted data")
+        .isLessThan(off.bytesRead);
+    logComparison(off, on);
+  }
+
+  /**
+   * Negative/control workload.
+   *
+   * <p>The same ids are randomly distributed across pages. Page-level min/max ranges will generally
+   * be broad, so the ColumnIndex should have much less pruning power.
+   */
+  @Test
+  public void benchmarkRandomData() throws IOException {
+    File parquetFile = new File(tempDir, "benchmark-random-index.parquet");
+    writeBenchmarkFile(parquetFile, true, true);
+    validateBenchmarkFile(parquetFile, true);
+    BenchmarkResult off = runMedianBenchmark("random", parquetFile, false);
+    BenchmarkResult on = runMedianBenchmark("random", parquetFile, true);
+    assertThat(off.candidateRows).isEqualTo(BENCHMARK_RECORD_COUNT);
+
+    assertThat(on.candidateRows)
+        .isGreaterThanOrEqualTo(FILTER_END - FILTER_START)
+        .isLessThanOrEqualTo(BENCHMARK_RECORD_COUNT);
+
+    logComparison(off, on);
+  }
+
+  /**
+   * Compatibility/control workload for files that do not contain a usable ColumnIndex for the
+   * predicate column.
+   */
+  @Test
+  public void benchmarkFileWithoutColumnIndex() throws IOException {
+    File parquetFile = new File(tempDir, "benchmark-sorted-no-index.parquet");
+    writeBenchmarkFile(parquetFile, false, false);
+
+    validateBenchmarkFile(parquetFile, false);
+    BenchmarkResult off = runMedianBenchmark("sorted-no-index", parquetFile, false);
+    BenchmarkResult on = runMedianBenchmark("sorted-no-index", parquetFile, true);
+    assertThat(off.candidateRows).isEqualTo(BENCHMARK_RECORD_COUNT);
+    assertThat(on.candidateRows).isEqualTo(BENCHMARK_RECORD_COUNT);
+    logComparison(off, on);
+  }
+}

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetPageIndexPruningPoc.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestParquetPageIndexPruningPoc.java
@@ -1,0 +1,1075 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.parquet;
+
+import static org.apache.parquet.filter2.predicate.FilterApi.and;
+import static org.apache.parquet.filter2.predicate.FilterApi.gtEq;
+import static org.apache.parquet.filter2.predicate.FilterApi.longColumn;
+import static org.apache.parquet.filter2.predicate.FilterApi.lt;
+import static org.apache.parquet.filter2.predicate.FilterApi.or;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.PrimitiveIterator;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.TableProperties;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.data.parquet.GenericParquetReaders;
+import org.apache.iceberg.data.parquet.GenericParquetWriter;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.FileAppender;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.OutputFile;
+import org.apache.iceberg.io.SeekableInputStream;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
+import org.apache.iceberg.types.TypeUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.parquet.ParquetReadOptions;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.filter2.compat.FilterCompat;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetFileReader;
+import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.hadoop.metadata.ColumnChunkMetaData;
+import org.apache.parquet.internal.column.columnindex.ColumnIndex;
+import org.apache.parquet.internal.column.columnindex.OffsetIndex;
+import org.apache.parquet.schema.MessageType;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestParquetPageIndexPruningPoc {
+  private static final Logger LOG = LoggerFactory.getLogger(TestParquetPageIndexPruningPoc.class);
+  private static final int RECORD_COUNT = 100_000;
+
+  private static final Schema SCHEMA =
+      new Schema(
+          Types.NestedField.required(1, "id", Types.LongType.get()),
+          Types.NestedField.required(2, "group_id", Types.IntegerType.get()),
+          Types.NestedField.optional(3, "payload", Types.StringType.get()));
+
+  private static final Schema PAYLOAD_ONLY_SCHEMA = new Schema(SCHEMA.findField("payload"));
+
+  private static final Schema FILTER_AND_PAYLOAD_SCHEMA =
+      new Schema(SCHEMA.findField("id"), SCHEMA.findField("payload"));
+
+  private static final Schema SCHEMA_WITH_POS =
+      TypeUtil.join(SCHEMA, new Schema(MetadataColumns.ROW_POSITION));
+
+  private static final Schema SCHEMA_WITH_POS_AND_ROW_ID =
+      TypeUtil.join(SCHEMA, new Schema(MetadataColumns.ROW_POSITION, MetadataColumns.ROW_ID));
+
+  private static final long BASE_ROW_ID = 1_000_000L;
+
+  @TempDir private File tempDir;
+
+  @Test
+  public void testParquetJavaCanPrunePages() throws IOException {
+    File parquetFile = new File(tempDir, "page-index.parquet");
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    FilterPredicate predicate = and(gtEq(longColumn("id"), 50_000L), lt(longColumn("id"), 50_100L));
+
+    FilterCompat.Filter filter = FilterCompat.get(predicate);
+
+    // Disable other pruning mechanisms so this POC isolates ColumnIndex pruning.
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(filter)
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+
+      assertThat(reader.getRowGroups()).hasSize(1);
+
+      BlockMetaData rowGroup = reader.getRowGroups().get(0);
+      assertThat(rowGroup.getRowCount()).isEqualTo(RECORD_COUNT);
+
+      ColumnChunkMetaData idColumn =
+          rowGroup.getColumns().stream()
+              .filter(column -> column.getPath().toDotString().equals("id"))
+              .findFirst()
+              .orElseThrow(() -> new IllegalStateException("Cannot find id column"));
+
+      ColumnIndex columnIndex = reader.readColumnIndex(idColumn);
+      OffsetIndex offsetIndex = reader.readOffsetIndex(idColumn);
+
+      assertThat(columnIndex).isNotNull();
+      assertThat(offsetIndex).isNotNull();
+      assertThat(offsetIndex.getPageCount()).isGreaterThan(1);
+
+      long filteredRecordCount = reader.getFilteredRecordCount();
+
+      assertThat(filteredRecordCount).isGreaterThanOrEqualTo(100L).isLessThan(RECORD_COUNT);
+
+      PageReadStore pages = reader.readFilteredRowGroup(0);
+
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(filteredRecordCount);
+
+      PrimitiveIterator.OfLong rowIndexes =
+          pages
+              .getRowIndexes()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Filtered PageReadStore did not expose row indexes"));
+
+      long count = 0L;
+      long firstRowIndex = -1L;
+      long lastRowIndex = -1L;
+
+      while (rowIndexes.hasNext()) {
+        long rowIndex = rowIndexes.nextLong();
+
+        if (count == 0L) {
+          firstRowIndex = rowIndex;
+        }
+
+        lastRowIndex = rowIndex;
+        count += 1L;
+      }
+
+      assertThat(count).isEqualTo(filteredRecordCount);
+
+      // Page pruning is conservative. It may include extra rows from candidate pages,
+      // but it must cover every exact match in [50_000, 50_100).
+      assertThat(firstRowIndex).isLessThanOrEqualTo(50_000L);
+      assertThat(lastRowIndex).isGreaterThanOrEqualTo(50_099L);
+
+      LOG.info(
+          "rowGroups={}, pages={}, fullRows={}, candidateRows={}, "
+              + "firstRowIndex={}, lastRowIndex={}\n",
+          reader.getRowGroups().size(),
+          offsetIndex.getPageCount(),
+          RECORD_COUNT,
+          filteredRecordCount,
+          firstRowIndex,
+          lastRowIndex);
+    }
+  }
+
+  @Test
+  public void testParquetJavaCanEliminateAllPages() throws IOException {
+    File parquetFile = new File(tempDir, "page-index-no-match.parquet");
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    // The row-group range is [0, 100000), so this predicate cannot match any page.
+    FilterPredicate predicate =
+        and(gtEq(longColumn("id"), 200_000L), lt(longColumn("id"), 200_100L));
+
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(FilterCompat.get(predicate))
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+
+      assertThat(reader.getFilteredRecordCount()).isZero();
+      assertThat(reader.readFilteredRowGroup(0)).isNull();
+    }
+  }
+
+  @Test
+  public void testPageIndexWithFilterColumnInRequestedSchema() throws IOException {
+
+    File parquetFile = new File(tempDir, "page-index-filter-in-projection.parquet");
+
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    FilterPredicate predicate = and(gtEq(longColumn("id"), 50_000L), lt(longColumn("id"), 50_100L));
+
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(FilterCompat.get(predicate))
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+
+      MessageType fileSchema = reader.getFileMetaData().getSchema();
+
+      MessageType requestedSchema =
+          ParquetSchemaUtil.pruneColumns(fileSchema, FILTER_AND_PAYLOAD_SCHEMA);
+
+      assertThat(requestedSchema.getColumns())
+          .extracting(column -> column.getPath()[0])
+          .containsExactlyInAnyOrder("id", "payload");
+
+      reader.setRequestedSchema(requestedSchema);
+
+      long candidateRows = reader.getFilteredRecordCount();
+
+      assertThat(candidateRows).isGreaterThanOrEqualTo(100L).isLessThan(RECORD_COUNT);
+
+      PageReadStore pages = reader.readFilteredRowGroup(0);
+
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(candidateRows);
+
+      LOG.info(
+          "Spark-like path: requestedColumns={}, candidateRows={}",
+          requestedSchema.getColumns(),
+          candidateRows);
+    }
+  }
+
+  @Test
+  public void testFilterOutsideProjectionRequiresPlanningFirst() throws IOException {
+
+    File parquetFile = new File(tempDir, "page-index-filter-outside-projection.parquet");
+
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    FilterPredicate predicate = and(gtEq(longColumn("id"), 50_000L), lt(longColumn("id"), 50_100L));
+
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(FilterCompat.get(predicate))
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+
+      MessageType fileSchema = reader.getFileMetaData().getSchema();
+
+      MessageType payloadOnlySchema =
+          ParquetSchemaUtil.pruneColumns(fileSchema, PAYLOAD_ONLY_SCHEMA);
+
+      /*
+       * Plan and cache RowRanges while the filter column "id"
+       * is still available in the reader's internal path set.
+       */
+      long candidateRows = reader.getFilteredRecordCount();
+
+      assertThat(candidateRows).isGreaterThanOrEqualTo(100L).isLessThan(RECORD_COUNT);
+
+      /*
+       * Narrow the columns that will actually be loaded only after
+       * the page-index RowRanges have been planned.
+       */
+      reader.setRequestedSchema(payloadOnlySchema);
+
+      PageReadStore pages = reader.readFilteredRowGroup(0);
+
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(candidateRows);
+
+      assertThat(
+              pages.getPageReader(payloadOnlySchema.getColumnDescription(new String[] {"payload"})))
+          .isNotNull();
+
+      LOG.info(
+          "Filter outside projection works only when RowRanges "
+              + "are planned before projection: candidateRows={}",
+          candidateRows);
+    }
+  }
+
+  @Test
+  public void testPageIndexProducesDisjointRowRanges() throws IOException {
+
+    File parquetFile = new File(tempDir, "page-index-disjoint-ranges.parquet");
+
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    FilterPredicate firstRange =
+        and(gtEq(longColumn("id"), 10_000L), lt(longColumn("id"), 10_100L));
+
+    FilterPredicate secondRange =
+        and(gtEq(longColumn("id"), 50_000L), lt(longColumn("id"), 50_100L));
+
+    FilterPredicate predicate = or(firstRange, secondRange);
+
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(FilterCompat.get(predicate))
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+
+      long candidateRows = reader.getFilteredRecordCount();
+      LOG.info("candidateRows={}", candidateRows);
+
+      assertThat(candidateRows).isGreaterThanOrEqualTo(200L).isLessThan(RECORD_COUNT);
+
+      PageReadStore pages = reader.readFilteredRowGroup(0);
+
+      assertThat(pages).isNotNull();
+      assertThat(pages.getRowCount()).isEqualTo(candidateRows);
+
+      PrimitiveIterator.OfLong rowIndexes =
+          pages
+              .getRowIndexes()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Filtered PageReadStore did not expose row indexes"));
+
+      long count = 0L;
+      long firstRowIndex = -1L;
+      long lastRowIndex = -1L;
+
+      long previousRowIndex = -1L;
+      long firstGapStart = -1L;
+      long firstGapEnd = -1L;
+      boolean sawGap = false;
+
+      while (rowIndexes.hasNext()) {
+        long rowIndex = rowIndexes.nextLong();
+
+        if (count == 0L) {
+          firstRowIndex = rowIndex;
+        }
+
+        if (rowIndex == 10999) {
+          LOG.info("Saw rowIndex=999, which is a known gap in the filter predicate");
+        }
+
+        if (previousRowIndex >= 0L && rowIndex > previousRowIndex + 1L) {
+
+          if (!sawGap) {
+            firstGapStart = previousRowIndex + 1L;
+            firstGapEnd = rowIndex - 1L;
+          }
+
+          sawGap = true;
+        }
+
+        previousRowIndex = rowIndex;
+        lastRowIndex = rowIndex;
+        count += 1L;
+      }
+
+      assertThat(count).isEqualTo(candidateRows);
+      assertThat(sawGap).isTrue();
+
+      assertThat(firstRowIndex).isLessThanOrEqualTo(10_000L);
+      assertThat(lastRowIndex).isGreaterThanOrEqualTo(50_099L);
+
+      assertThat(firstGapStart).isPositive();
+      assertThat(firstGapEnd).isGreaterThan(firstGapStart);
+
+      LOG.info(
+          "candidateRows={}, firstRowIndex={}, lastRowIndex={}, " + "firstGap=[{},{}]",
+          candidateRows,
+          firstRowIndex,
+          lastRowIndex,
+          firstGapStart,
+          firstGapEnd);
+    }
+  }
+
+  @Test
+  public void testRowIndexCoordinateSystemAcrossRowGroups() throws IOException {
+    File parquetFile = new File(tempDir, "page-index-multiple-row-groups.parquet");
+    writeMultiRowGroupFile(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+    long secondRowGroupStart;
+    long secondRowGroupCount;
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(inputFile), ParquetReadOptions.builder().build())) {
+      assertThat(reader.getRowGroups().size())
+          .as("The test file must contain multiple row groups")
+          .isGreaterThan(1);
+      BlockMetaData firstRowGroup = reader.getRowGroups().get(0);
+      BlockMetaData secondRowGroup = reader.getRowGroups().get(1);
+      secondRowGroupStart = firstRowGroup.getRowCount();
+      secondRowGroupCount = secondRowGroup.getRowCount();
+      assertThat(secondRowGroupStart)
+          .as("The second row group must start after file row 0")
+          .isPositive();
+      assertThat(secondRowGroupCount)
+          .as("The second row group must be large enough for a selective range")
+          .isGreaterThan(200L);
+      LOG.info(
+          "rowGroupCount={}, firstRowGroupRows={}, "
+              + "secondRowGroupStart={}, secondRowGroupRows={}",
+          reader.getRowGroups().size(),
+          firstRowGroup.getRowCount(),
+          secondRowGroupStart,
+          secondRowGroupCount);
+    }
+
+    long targetStart = secondRowGroupStart + Math.min(1_000L, secondRowGroupCount / 2L);
+    long targetEnd = Math.min(targetStart + 100L, secondRowGroupStart + secondRowGroupCount);
+    FilterPredicate predicate =
+        and(gtEq(longColumn("id"), targetStart), lt(longColumn("id"), targetEnd));
+    ParquetReadOptions options =
+        ParquetReadOptions.builder()
+            .useStatsFilter(false)
+            .useDictionaryFilter(false)
+            .useBloomFilter(false)
+            .useRecordFilter(false)
+            .useColumnIndexFilter(true)
+            .withRecordFilter(FilterCompat.get(predicate))
+            .build();
+
+    try (ParquetFileReader reader = ParquetFileReader.open(ParquetIO.file(inputFile), options)) {
+      PageReadStore pages = reader.readFilteredRowGroup(1);
+      assertThat(pages).as("The target range must produce a filtered PageReadStore").isNotNull();
+      assertThat(pages.getRowCount())
+          .as("Page pruning is conservative but must reduce the row group")
+          .isGreaterThanOrEqualTo(targetEnd - targetStart)
+          .isLessThan(secondRowGroupCount);
+      long rowIndexOffset =
+          pages
+              .getRowIndexOffset()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Filtered PageReadStore did not expose a row-index offset"));
+      /*
+       * parquet-java 1.17.1 returns row-group-relative indexes from
+       * getRowIndexes(), while getRowIndexOffset() identifies the row group's
+       * file-level starting position.
+       */
+      assertThat(rowIndexOffset)
+          .as("Row-index offset must equal the second row group's file position")
+          .isEqualTo(secondRowGroupStart);
+      PrimitiveIterator.OfLong rowIndexes =
+          pages
+              .getRowIndexes()
+              .orElseThrow(
+                  () ->
+                      new IllegalStateException(
+                          "Filtered PageReadStore did not expose row indexes"));
+
+      long candidateRowCount = 0L;
+      long firstRelativeRowIndex = -1L;
+      long lastRelativeRowIndex = -1L;
+      while (rowIndexes.hasNext()) {
+        long relativeRowIndex = rowIndexes.nextLong();
+        if (candidateRowCount == 0L) {
+          firstRelativeRowIndex = relativeRowIndex;
+        }
+        lastRelativeRowIndex = relativeRowIndex;
+        candidateRowCount += 1L;
+      }
+      assertThat(candidateRowCount)
+          .as("The row-index iterator must cover every candidate row")
+          .isEqualTo(pages.getRowCount());
+      assertThat(firstRelativeRowIndex).isNotNegative();
+      assertThat(lastRelativeRowIndex)
+          .isGreaterThanOrEqualTo(firstRelativeRowIndex)
+          .isLessThan(secondRowGroupCount);
+      long relativeTargetStart = targetStart - secondRowGroupStart;
+      long relativeTargetEnd = targetEnd - secondRowGroupStart;
+      /*
+       * The returned row indexes are relative to the second row group.
+       * The candidate page may begin before and end after the exact predicate
+       * range, but it must cover the complete range.
+       */
+      assertThat(firstRelativeRowIndex)
+          .as("The first candidate row must begin at or before the target")
+          .isLessThanOrEqualTo(relativeTargetStart);
+      assertThat(lastRelativeRowIndex)
+          .as("The last candidate row must end at or after the target")
+          .isGreaterThanOrEqualTo(relativeTargetEnd - 1L);
+
+      long firstAbsoluteRowIndex = rowIndexOffset + firstRelativeRowIndex;
+      long lastAbsoluteRowIndex = rowIndexOffset + lastRelativeRowIndex;
+      assertThat(firstAbsoluteRowIndex)
+          .as("The absolute candidate range must begin at or before the target")
+          .isLessThanOrEqualTo(targetStart);
+      assertThat(lastAbsoluteRowIndex)
+          .as("The absolute candidate range must end at or after the target")
+          .isGreaterThanOrEqualTo(targetEnd - 1L);
+      assertThat(firstAbsoluteRowIndex)
+          .as("Candidate positions must belong to the second row group")
+          .isGreaterThanOrEqualTo(secondRowGroupStart);
+      assertThat(lastAbsoluteRowIndex)
+          .as("Candidate positions must not exceed the second row group")
+          .isLessThan(secondRowGroupStart + secondRowGroupCount);
+      LOG.info(
+          "secondRowGroupStart={}, rowIndexOffset={}, "
+              + "target=[{},{}), candidateRows={}, "
+              + "relativeRowIndexes=[{},{}], absoluteRowIndexes=[{},{}]",
+          secondRowGroupStart,
+          rowIndexOffset,
+          targetStart,
+          targetEnd,
+          candidateRowCount,
+          firstRelativeRowIndex,
+          lastRelativeRowIndex,
+          firstAbsoluteRowIndex,
+          lastAbsoluteRowIndex);
+    }
+  }
+
+  @Test
+  public void testIcebergRowReaderUsesPageIndex() throws IOException {
+    File parquetFile = new File(tempDir, "iceberg-page-index-reader.parquet");
+
+    writeSortedFile(parquetFile);
+
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    Expression filter =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", 50_000L), Expressions.lessThan("id", 50_100L));
+
+    long baselineCount = 0L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA)
+            .filter(filter)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .build()) {
+
+      for (Record ignored : rows) {
+        baselineCount += 1L;
+      }
+    }
+
+    assertThat(baselineCount).isEqualTo(RECORD_COUNT);
+
+    long candidateCount = 0L;
+    long minId = Long.MAX_VALUE;
+    long maxId = Long.MIN_VALUE;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA)
+            .filter(filter)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .enablePageIndexFilteringForPoc()
+            .build()) {
+
+      for (Record row : rows) {
+        long id = (Long) row.getField("id");
+
+        candidateCount += 1L;
+        minId = Math.min(minId, id);
+        maxId = Math.max(maxId, id);
+      }
+    }
+
+    assertThat(candidateCount).isGreaterThanOrEqualTo(100L).isLessThan(RECORD_COUNT);
+
+    assertThat(minId).isLessThanOrEqualTo(50_000L);
+    assertThat(maxId).isGreaterThanOrEqualTo(50_099L);
+
+    LOG.info(
+        "Iceberg reader POC: baselineRows={}, "
+            + "pageIndexCandidateRows={}, candidateIdRange=[{},{}]",
+        baselineCount,
+        candidateCount,
+        minId,
+        maxId);
+  }
+
+  @Test
+  public void testIcebergReaderPreservesPositionsForDisjointPageRanges() throws IOException {
+    File parquetFile = new File(tempDir, "page-index-position-disjoint.parquet");
+    writeSortedFile(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    Expression firstRange =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", 10_000L), Expressions.lessThan("id", 10_100L));
+    Expression secondRange =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", 50_000L), Expressions.lessThan("id", 50_100L));
+    Expression filter = Expressions.or(firstRange, secondRange);
+
+    long candidateCount = 0L;
+    long previousPosition = -1L;
+    boolean sawGap = false;
+
+    boolean sawFirstTarget = false;
+    boolean sawSecondTarget = false;
+
+    long firstPosition = -1L;
+    long lastPosition = -1L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA_WITH_POS)
+            .filter(filter)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .enablePageIndexFilteringForPoc()
+            .build()) {
+
+      for (Record row : rows) {
+        long id = (Long) row.getField("id");
+        long position = (Long) row.getField(MetadataColumns.ROW_POSITION.name());
+
+        /*
+         * writeSortedFile writes:
+         *
+         *   id == physical file row position
+         *
+         * so this is a very strong correctness assertion.
+         */
+        assertThat(position).as("Physical position for id=%s", id).isEqualTo(id);
+
+        if (candidateCount == 0L) {
+          firstPosition = position;
+        }
+
+        if (previousPosition >= 0L && position > previousPosition + 1L) {
+          sawGap = true;
+        }
+
+        if (id == 10_000L) {
+          sawFirstTarget = true;
+        }
+
+        if (id == 50_000L) {
+          sawSecondTarget = true;
+        }
+
+        previousPosition = position;
+        lastPosition = position;
+        candidateCount += 1L;
+      }
+    }
+
+    assertThat(candidateCount).isGreaterThanOrEqualTo(200L).isLessThan(RECORD_COUNT);
+
+    assertThat(sawGap)
+        .as("Page-index positions must preserve gaps between selected ranges")
+        .isTrue();
+
+    assertThat(sawFirstTarget).isTrue();
+    assertThat(sawSecondTarget).isTrue();
+
+    LOG.info(
+        "_pos POC: candidateRows={}, " + "firstPosition={}, lastPosition={}, sawGap={}",
+        candidateCount,
+        firstPosition,
+        lastPosition,
+        sawGap);
+  }
+
+  @Test
+  public void testFallbackRowIdUsesPhysicalPositionWithPageIndex() throws IOException {
+    File parquetFile = new File(tempDir, "page-index-fallback-row-id.parquet");
+    writeSortedFile(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    Expression firstRange =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", 10_000L), Expressions.lessThan("id", 10_100L));
+    Expression secondRange =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", 50_000L), Expressions.lessThan("id", 50_100L));
+    Expression filter = Expressions.or(firstRange, secondRange);
+
+    Map<Integer, Object> constants = ImmutableMap.of(MetadataColumns.ROW_ID.fieldId(), BASE_ROW_ID);
+
+    long candidateCount = 0L;
+    boolean sawGap = false;
+    long previousPosition = -1L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA_WITH_POS_AND_ROW_ID)
+            .filter(filter)
+            .createReaderFunc(
+                (expectedSchema, fileSchema) ->
+                    GenericParquetReaders.buildReader(expectedSchema, fileSchema, constants))
+            .enablePageIndexFilteringForPoc()
+            .build()) {
+
+      for (Record row : rows) {
+        long id = (Long) row.getField("id");
+        long position = (Long) row.getField(MetadataColumns.ROW_POSITION.name());
+        long rowId = (Long) row.getField(MetadataColumns.ROW_ID.name());
+
+        assertThat(position).as("_pos for id=%s", id).isEqualTo(id);
+        assertThat(rowId)
+            .as("Fallback _row_id for physical position %s", position)
+            .isEqualTo(BASE_ROW_ID + position);
+
+        if (previousPosition >= 0L && position > previousPosition + 1L) {
+          sawGap = true;
+        }
+
+        previousPosition = position;
+        candidateCount += 1L;
+      }
+    }
+
+    assertThat(candidateCount).isGreaterThanOrEqualTo(200L).isLessThan(RECORD_COUNT);
+    assertThat(sawGap).isTrue();
+
+    LOG.info(
+        "Fallback _row_id POC: candidateRows={}, " + "baseRowId={}, sawGap={}",
+        candidateCount,
+        BASE_ROW_ID,
+        sawGap);
+  }
+
+  @Test
+  public void testPhysicalPositionsAcrossFilteredRowGroups() throws IOException {
+    File parquetFile = new File(tempDir, "page-index-position-multiple-row-groups.parquet");
+    writeMultiRowGroupFile(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    long secondRowGroupStart;
+    long secondRowGroupCount;
+
+    try (ParquetFileReader reader =
+        ParquetFileReader.open(ParquetIO.file(inputFile), ParquetReadOptions.builder().build())) {
+
+      assertThat(reader.getRowGroups().size()).isGreaterThan(1);
+      secondRowGroupStart = reader.getRowGroups().get(0).getRowCount();
+      secondRowGroupCount = reader.getRowGroups().get(1).getRowCount();
+    }
+
+    long targetStart = secondRowGroupStart + Math.min(1_000L, secondRowGroupCount / 2L);
+    long targetEnd = Math.min(targetStart + 100L, secondRowGroupStart + secondRowGroupCount);
+
+    Expression filter =
+        Expressions.and(
+            Expressions.greaterThanOrEqual("id", targetStart),
+            Expressions.lessThan("id", targetEnd));
+
+    long candidateCount = 0L;
+    boolean sawTargetStart = false;
+    boolean sawTargetEnd = false;
+
+    long firstPosition = -1L;
+    long lastPosition = -1L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA_WITH_POS)
+            .filter(filter)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .enablePageIndexFilteringForPoc()
+            .build()) {
+
+      for (Record row : rows) {
+        long id = (Long) row.getField("id");
+        long position = (Long) row.getField(MetadataColumns.ROW_POSITION.name());
+
+        /*
+         * id is the physical file position in this test file.
+         */
+        assertThat(position).isEqualTo(id);
+        assertThat(position).isGreaterThanOrEqualTo(secondRowGroupStart);
+        assertThat(position).isLessThan(secondRowGroupStart + secondRowGroupCount);
+
+        if (candidateCount == 0L) {
+          firstPosition = position;
+        }
+
+        lastPosition = position;
+
+        if (position == targetStart) {
+          sawTargetStart = true;
+        }
+
+        if (position == targetEnd - 1L) {
+          sawTargetEnd = true;
+        }
+
+        candidateCount += 1L;
+      }
+    }
+
+    assertThat(candidateCount)
+        .isGreaterThanOrEqualTo(targetEnd - targetStart)
+        .isLessThan(secondRowGroupCount);
+
+    assertThat(sawTargetStart).isTrue();
+    assertThat(sawTargetEnd).isTrue();
+
+    LOG.info(
+        "Multiple row groups: secondRowGroupStart={}, "
+            + "target=[{},{}), candidateRows={}, "
+            + "physicalPositions=[{},{}]",
+        secondRowGroupStart,
+        targetStart,
+        targetEnd,
+        candidateCount,
+        firstPosition,
+        lastPosition);
+  }
+
+  @Test
+  public void testIcebergReaderHandlesZeroCandidateRowGroup() throws IOException {
+
+    File parquetFile = new File(tempDir, "page-index-zero-candidate.parquet");
+    writeFileWithPageGap(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+    Expression filter = Expressions.equal("id", 1_500L);
+
+    long candidateCount = 0L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA)
+            .filter(filter)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .enablePageIndexFilteringForPoc()
+            .build()) {
+
+      for (Record ignored : rows) {
+        candidateCount += 1L;
+      }
+    }
+
+    assertThat(candidateCount).isZero();
+
+    LOG.info("Zero-candidate row group handled correctly: candidateRows={}", candidateCount);
+  }
+
+  @Test
+  public void testPositionReaderStillWorksWithoutPageIndex() throws IOException {
+    File parquetFile = new File(tempDir, "position-without-page-index.parquet");
+    writeSortedFile(parquetFile);
+    InputFile inputFile = Files.localInput(parquetFile);
+
+    long count = 0L;
+
+    try (CloseableIterable<Record> rows =
+        Parquet.read(inputFile)
+            .project(SCHEMA_WITH_POS)
+            .createReaderFunc(GenericParquetReaders::buildReader)
+            .build()) {
+
+      for (Record row : rows) {
+        long id = (Long) row.getField("id");
+        long position = (Long) row.getField(MetadataColumns.ROW_POSITION.name());
+        assertThat(position).isEqualTo(id);
+        count += 1L;
+      }
+    }
+
+    assertThat(count).isEqualTo(RECORD_COUNT);
+  }
+
+  private static void writeSortedFile(File parquetFile) throws IOException {
+    OutputFile outputFile = Files.localOutput(parquetFile);
+
+    try (FileAppender<Record> appender =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(256 * 1024 * 1024))
+            .set(TableProperties.PARQUET_PAGE_SIZE_BYTES, Integer.toString(64 * 1024))
+            .set(TableProperties.PARQUET_PAGE_ROW_LIMIT, "1000")
+            .set(TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "id", "true")
+            .build()) {
+
+      for (long id = 0L; id < RECORD_COUNT; id += 1L) {
+        GenericRecord record = GenericRecord.create(SCHEMA);
+        record.setField("id", id);
+        record.setField("group_id", (int) (id / 10_000L));
+        record.setField("payload", "payload-" + id);
+
+        appender.add(record);
+      }
+    }
+  }
+
+  private static void writeMultiRowGroupFile(File parquetFile) throws IOException {
+    OutputFile outputFile = Files.localOutput(parquetFile);
+
+    try (FileAppender<Record> appender =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(512 * 1024))
+            .set(TableProperties.PARQUET_PAGE_SIZE_BYTES, Integer.toString(32 * 1024))
+            .set(TableProperties.PARQUET_PAGE_ROW_LIMIT, "500")
+            .set(TableProperties.PARQUET_COMPRESSION, "uncompressed")
+            .set(TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "id", "true")
+            .withDictionaryEncoding("id", false)
+            .build()) {
+
+      String payload = "x".repeat(256);
+
+      for (long id = 0L; id < RECORD_COUNT; id += 1L) {
+        GenericRecord record = GenericRecord.create(SCHEMA);
+        record.setField("id", id);
+        record.setField("group_id", (int) (id / 10_000L));
+        record.setField("payload", payload + id);
+
+        appender.add(record);
+      }
+    }
+  }
+
+  private static void writeFileWithPageGap(File parquetFile) throws IOException {
+
+    OutputFile outputFile = Files.localOutput(parquetFile);
+
+    try (FileAppender<Record> appender =
+        Parquet.write(outputFile)
+            .schema(SCHEMA)
+            .createWriterFunc(GenericParquetWriter::create)
+            .set(TableProperties.PARQUET_PAGE_ROW_LIMIT, "1000")
+            .set(TableProperties.PARQUET_PAGE_SIZE_BYTES, Integer.toString(1024 * 1024))
+            .set(TableProperties.PARQUET_ROW_GROUP_SIZE_BYTES, Integer.toString(128 * 1024 * 1024))
+            .set(TableProperties.PARQUET_COLUMN_STATS_ENABLED_PREFIX + "id", "true")
+            .withDictionaryEncoding("id", false)
+            .build()) {
+
+      for (long id = 0L; id < 1_000L; id += 1L) {
+        GenericRecord record = GenericRecord.create(SCHEMA);
+
+        record.setField("id", id);
+        record.setField("group_id", 0);
+        record.setField("payload", "low-" + id);
+
+        appender.add(record);
+      }
+
+      for (long id = 2_000L; id < 3_000L; id += 1L) {
+        GenericRecord record = GenericRecord.create(SCHEMA);
+
+        record.setField("id", id);
+        record.setField("group_id", 1);
+        record.setField("payload", "high-" + id);
+
+        appender.add(record);
+      }
+    }
+  }
+
+  private static class CountingInputFile implements InputFile {
+    private final InputFile delegate;
+    private final AtomicLong bytesRead = new AtomicLong();
+
+    private CountingInputFile(InputFile delegate) {
+      this.delegate = delegate;
+    }
+
+    @Override
+    public long getLength() {
+      return delegate.getLength();
+    }
+
+    @Override
+    public SeekableInputStream newStream() {
+      return new CountingSeekableInputStream(delegate.newStream(), bytesRead);
+    }
+
+    @Override
+    public String location() {
+      return delegate.location();
+    }
+
+    @Override
+    public boolean exists() {
+      return delegate.exists();
+    }
+
+    long bytesRead() {
+      return bytesRead.get();
+    }
+
+    void reset() {
+      bytesRead.set(0L);
+    }
+  }
+
+  private static class CountingSeekableInputStream extends SeekableInputStream {
+
+    private final SeekableInputStream delegate;
+    private final AtomicLong bytesRead;
+
+    private CountingSeekableInputStream(SeekableInputStream delegate, AtomicLong bytesRead) {
+      this.delegate = delegate;
+      this.bytesRead = bytesRead;
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      return delegate.getPos();
+    }
+
+    @Override
+    public void seek(long newPos) throws IOException {
+      delegate.seek(newPos);
+    }
+
+    @Override
+    public int read() throws IOException {
+      int value = delegate.read();
+      if (value >= 0) {
+        bytesRead.incrementAndGet();
+      }
+      return value;
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      int read = delegate.read(buffer, offset, length);
+      if (read > 0) {
+        bytesRead.addAndGet(read);
+      }
+      return read;
+    }
+
+    @Override
+    public void close() throws IOException {
+      delegate.close();
+    }
+  }
+}


### PR DESCRIPTION
## Context

Related to #17596.

This is a draft POC that about Parquet page-level pruning in Iceberg's custom row-based Parquet reader.

The purpose of this PR is to validate behaviors against the current Iceberg reader and parquet-java APIs before proposing a production-ready implementation.

This PR is not intended to merge in its current form.

## What this POC does

The POC:

- enables parquet-java ColumnIndex filtering;
- propagates filtered `PageReadStore` row indexes into Iceberg's position reader;
- preserves physical `_pos` for non-contiguous page selections;
- preserves fallback `_row_id` semantics derived from `_pos`.

The Page Index is used only for conservative I/O pruning. It does not perform final record-level filtering, and existing residual evaluation is still required.

## Tests

The included tests verify:

- disjoint candidate ranges;
- `_pos` correctness;
- multiple row groups;
- fallback `_row_id`;
- zero-candidate row groups;
- unchanged sequential `_pos` behavior without Page Index filtering.

## Initial measurements

A local POC microbenchmark used:

```text
500,000 rows
1 row group
~1,000 rows/page
uncompressed
projection: id, payload
predicate: id >= 250000 AND id < 250100
```

Results:

| Dataset | Page Index | Candidate Rows | Bytes Read | Median Time |
| --- | ---: | ---: | ---: | ---: |
| Sorted | OFF | 500,000 | 131.054 MiB | 67.79 ms |
| Sorted | ON | 1,000 | 0.288 MiB | 8.16 ms |
| Random | OFF | 500,000 | 131.054 MiB | 66.56 ms |
| Random | ON | 500,000 | 131.079 MiB | 69.72 ms |
| Sorted / no index | OFF | 500,000 | 131.054 MiB | 66.02 ms |
| Sorted / no index | ON | 500,000 | 131.070 MiB | 69.15 ms |

I would prefer to agree on the reader architecture and correctness constraints first. Then I can proceed to the next step of the work.