### PR TITLE
REST: Quote ETag headers in REST catalog adapter

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/ETagProvider.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ETagProvider.java
@@ -45,6 +45,10 @@ class ETagProvider {
       stringToHash = COMMA.join(metadataLocation, PARAMS_JOINER.join(orderedParams));
     }
 
-    return MURMUR3.hashString(stringToHash, StandardCharsets.UTF_8).toString();
+    return quote(MURMUR3.hashString(stringToHash, StandardCharsets.UTF_8).toString());
+  }
+
+  private static String quote(String string) {
+    return String.format("\"%s\"", string);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/TestBaseWithRESTServer.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestBaseWithRESTServer.java
@@ -62,15 +62,6 @@ public abstract class TestBaseWithRESTServer {
 
   @TempDir private Path temp;
 
-  /**
-   * GZIP responses interfere with freshness-aware loading tests that assert on {@code ETag} and
-   * conditional requests. Subclasses may disable HTTP compression while keeping the default for
-   * other REST catalog tests.
-   */
-  protected boolean useHttpCompression() {
-    return true;
-  }
-
   @BeforeEach
   public void before() throws Exception {
     File warehouse = temp.toFile();
@@ -85,11 +76,9 @@ public abstract class TestBaseWithRESTServer {
         new ServletContextHandler(ServletContextHandler.NO_SESSIONS);
     servletContext.addServlet(
         new ServletHolder(new RESTCatalogServlet(adapterForRESTServer)), "/*");
-    if (useHttpCompression()) {
-      CompressionHandler compressionHandler = new CompressionHandler();
-      compressionHandler.putCompression(new GzipCompression());
-      servletContext.insertHandler(compressionHandler);
-    }
+    CompressionHandler compressionHandler = new CompressionHandler();
+    compressionHandler.putCompression(new GzipCompression());
+    servletContext.insertHandler(compressionHandler);
 
     this.httpServer = new Server(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0));
     httpServer.setHandler(servletContext);

--- a/core/src/test/java/org/apache/iceberg/rest/TestETagProvider.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestETagProvider.java
@@ -44,20 +44,21 @@ public class TestETagProvider {
 
   @Test
   public void testETagContent() {
-    assertThat("90b8ad4e")
+    assertThat("\"90b8ad4e\"")
         .isEqualTo(
             ETagProvider.of(METADATA_LOCATION, Map.of("param1", "value1", "param2", "value2")));
 
-    assertThat("cb787e6a")
+    assertThat("\"cb787e6a\"")
         .isEqualTo(
             ETagProvider.of(
                 METADATA_LOCATION, Map.of("param1", "other_value1", "param2", "other_value2")));
 
-    assertThat("55faa5d9").isEqualTo(ETagProvider.of("/short/path", null));
+    assertThat("\"55faa5d9\"").isEqualTo(ETagProvider.of("/short/path", null));
 
-    assertThat("55faa5d9").isEqualTo(ETagProvider.of("/short/path", Map.of()));
+    assertThat("\"55faa5d9\"").isEqualTo(ETagProvider.of("/short/path", Map.of()));
 
-    assertThat("8adf3766").isEqualTo(ETagProvider.of("/short/path", Map.of("param", "some_value")));
+    assertThat("\"8adf3766\"")
+        .isEqualTo(ETagProvider.of("/short/path", Map.of("param", "some_value")));
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestFreshnessAwareLoading.java
@@ -67,11 +67,6 @@ import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
 public class TestFreshnessAwareLoading extends TestBaseWithRESTServer {
-  @Override
-  protected boolean useHttpCompression() {
-    return false;
-  }
-
   private static final ResourcePaths RESOURCE_PATHS =
       ResourcePaths.forCatalogProperties(
           ImmutableMap.of(


### PR DESCRIPTION
HTTP entity tags are defined as quoted opaque tags by RFC 9110 §8.8.3: https://www.rfc-editor.org/rfc/rfc9110.html#section-8.8.3

The reference REST catalog adapter was returning raw hash values as ETags. This breaks components that rely on valid entity-tag syntax, such as Jetty's `CompressionHandler`, which adds and strips compression suffixes like `--gzip` for compressed responses.
