### PR TITLE
Core: Refresh exchanged sessions by token exchange

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -665,7 +665,14 @@ public class OAuth2Util {
               parent.scope(),
               parent.oauth2ServerUri(),
               parent.optionalOAuthParams());
-      return fromTokenResponse(client, executor, response, startTimeMillis, parent, credential);
+      return fromTokenResponse(
+          client,
+          executor,
+          response,
+          startTimeMillis,
+          parent,
+          credential,
+          parent.config().exchangeEnabled());
     }
 
     public static AuthSession fromTokenResponse(
@@ -675,7 +682,13 @@ public class OAuth2Util {
         long startTimeMillis,
         AuthSession parent) {
       return fromTokenResponse(
-          client, executor, response, startTimeMillis, parent, parent.credential());
+          client,
+          executor,
+          response,
+          startTimeMillis,
+          parent,
+          parent.credential(),
+          parent.config().exchangeEnabled());
     }
 
     private static AuthSession fromTokenResponse(
@@ -684,7 +697,8 @@ public class OAuth2Util {
         OAuthTokenResponse response,
         long startTimeMillis,
         AuthSession parent,
-        String credential) {
+        String credential,
+        boolean exchangeEnabled) {
       // issued_token_type is required in RFC 8693 but not in RFC 6749,
       // thus assume type is access_token for compatibility with RFC 6749.
       // See https://datatracker.ietf.org/doc/html/rfc6749#section-4.4.3
@@ -701,6 +715,7 @@ public class OAuth2Util {
                   .token(response.token())
                   .tokenType(issuedTokenType)
                   .credential(credential)
+                  .exchangeEnabled(exchangeEnabled)
                   .expiresAtMillis(OAuth2Util.expiresAtMillis(response.token()))
                   .build());
 
@@ -734,7 +749,10 @@ public class OAuth2Util {
               parent.scope(),
               parent.oauth2ServerUri(),
               parent.optionalOAuthParams());
-      return fromTokenResponse(client, executor, response, startTimeMillis, parent);
+      // Renew by exchange regardless of the parent's setting: the parent's credential identifies
+      // the parent, so refreshing with it would replace the exchanged identity.
+      return fromTokenResponse(
+          client, executor, response, startTimeMillis, parent, parent.credential(), true);
     }
   }
 }

--- a/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
+++ b/core/src/test/java/org/apache/iceberg/rest/auth/TestOAuth2Util.java
@@ -253,6 +253,53 @@ public class TestOAuth2Util {
     }
   }
 
+  @Test
+  void exchangedSessionRefreshesByExchangeWhenExchangeIsDisabled() throws IOException {
+    AuthConfig parentConfig =
+        AuthConfig.builder()
+            .token(tokenWithExp(7200))
+            .tokenType(OAuth2Properties.ACCESS_TOKEN_TYPE)
+            .credential("testClientId:testClientSecret")
+            .keepRefreshed(true)
+            .exchangeEnabled(false)
+            .oauth2ServerUri("/v1/token")
+            .build();
+
+    try (RESTClient client = Mockito.mock(RESTClient.class);
+        AuthSession parent = new AuthSession(Map.of(), parentConfig)) {
+      Mockito.when(client.postForm(any(), anyMap(), any(), anyMap(), any()))
+          .thenReturn(
+              childTokenResponse("exchanged_token", 3600),
+              childTokenResponse("refreshed_token", 3600));
+
+      try (AuthSession child =
+          AuthSession.fromTokenExchange(
+              client, null, "user_subject_token", OAuth2Properties.JWT_TOKEN_TYPE, parent)) {
+        child.refresh(client);
+
+        Mockito.verify(client)
+            .postForm(
+                any(),
+                argThat(
+                    formData ->
+                        "urn:ietf:params:oauth:grant-type:token-exchange"
+                                .equals(formData.get(GRANT_TYPE))
+                            && "exchanged_token".equals(formData.get("subject_token"))),
+                Mockito.eq(OAuthTokenResponse.class),
+                anyMap(),
+                any());
+        Mockito.verify(client, Mockito.never())
+            .postForm(
+                any(),
+                argThat(formData -> CLIENT_CREDENTIALS.equals(formData.get(GRANT_TYPE))),
+                Mockito.eq(OAuthTokenResponse.class),
+                anyMap(),
+                any());
+        assertThat(child.token()).isEqualTo("refreshed_token");
+      }
+    }
+  }
+
   private static AuthSession parentSession(long expSeconds) {
     String parentToken = tokenWithExp(expSeconds);
     AuthConfig parentConfig =


### PR DESCRIPTION
Fixes #17600.

A session created by exchanging a subject token is built through `fromTokenResponse`, which copies the parent configuration with `AuthConfig.builder().from(parent.config())`. That inherits both `credential` and `exchangeEnabled` from the catalog session.

`OAuth2Util.refreshToken` branches only on `exchangeEnabled`. So when `token-exchange-enabled` is `false`, an exchanged session refreshes itself with the parent's client credential and receives a token for the catalog client. The session keeps working, but it no longer represents the exchanged subject.

This pins `exchangeEnabled` to `true` for sessions built by `fromTokenExchange`, so how a session was obtained decides how it is renewed. #13809 added the flag to control how credential derived sessions refresh, and that behaviour is unchanged.

Two points worth calling out for review:

1. This makes `exchangeEnabled` on a child session record how the session was obtained, rather than only reflecting what was configured. An alternative is a separate field on `AuthConfig` for provenance, at the cost of a wider change. I went with the smaller one, happy to switch.

2. The pinned value propagates one level further, because `RESTSessionCatalog` passes the contextual session as the parent of table sessions and `fromAccessToken` also copies the parent config. A vended credential table session under an exchanged session therefore re-exchanges its own token instead of falling back to the client credential. That looks like the correct behaviour for the same reason, but it is a behaviour change beyond the contextual session itself.

Not addressed here: `fromAccessToken` inherits the parent credential in the same way, so the bearer token path carries a similar hazard. Left for a separate change to keep this one reviewable.

Testing: added `exchangedSessionRefreshesByExchangeWhenExchangeIsDisabled` to `TestOAuth2Util`. It fails without the production change. No existing test reaches this path, since the two tests in `TestRESTCatalog` that disable token exchange never create a session through `fromTokenExchange`.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: GitHub Copilot
- Human Oversight: fully reviewed
- Prompt Summary: Investigate why an exchanged REST catalog session loses its identity after refresh, confirm the behaviour on main, and produce a minimal fix with a regression test.
