### PR TITLE
fix: clear inherited credential on token-exchange derived sessions

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
+++ b/core/src/main/java/org/apache/iceberg/rest/auth/OAuth2Util.java
@@ -734,7 +734,18 @@ public class OAuth2Util {
               parent.scope(),
               parent.oauth2ServerUri(),
               parent.optionalOAuthParams());
-      return fromTokenResponse(client, executor, response, startTimeMillis, parent);
+      AuthSession session = fromTokenResponse(client, executor, response, startTimeMillis, parent);
+      // A session created by token exchange should be refreshed via token exchange,
+      // not by falling back to the parent's client credential. Clear the inherited
+      // credential and enable exchange on the child session so that refresh always
+      // uses the token exchange flow, independent of the catalog-level exchangeEnabled flag.
+      session.config =
+          AuthConfig.builder()
+              .from(session.config)
+              .credential(null)
+              .exchangeEnabled(true)
+              .build();
+      return session;
     }
   }
 }


### PR DESCRIPTION
Fixes #17600

## Problem

When `token-exchange-enabled` is set to `false`, a session created by token exchange (`AuthSession.fromTokenExchange`) inherits the parent catalog config — including `credential` and `exchangeEnabled=false`. On refresh, `OAuth2Util.refreshToken` checks `exchangeEnabled`, finds it `false`, and falls back to the `client_credentials` flow using the inherited credential. The refreshed token now identifies the catalog client rather than the exchanged subject, silently changing the session identity.

## Root cause

`AuthSession.fromTokenExchange` calls `fromTokenResponse`, which copies the parent config via `AuthConfig.builder().from(parent.config())`. This propagates both `credential` and `exchangeEnabled=false` to the child session. The `exchangeEnabled` flag was intended by #13809 to control how credential-derived sessions refresh, but applying it to token-exchange-derived sessions changes which principal the session represents.

## Fix

After building the session from `fromTokenResponse`, clear the inherited `credential` and set `exchangeEnabled=true` on the child session. This ensures that:
- The child session always refreshes via token exchange (using the current token), not via client credentials
- The `exchangeEnabled` flag only affects catalog-level credential-derived sessions as intended
- The session identity is preserved across token refreshes