### PR TITLE
API, Spark: Add direct UUID string-to-ByteBuffer conversion

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/UUIDUtil.java
+++ b/api/src/main/java/org/apache/iceberg/util/UUIDUtil.java
@@ -82,6 +82,89 @@ public class UUIDUtil {
     return buffer;
   }
 
+  /** Length of a UUID in its canonical 8-4-4-4-12 textual form. */
+  private static final int UUID_TEXT_LENGTH = 36;
+
+  private static final int[] DASH_POSITIONS = {8, 13, 18, 23};
+
+  /**
+   * Writes the UUID given in canonical textual form as 16 big-endian bytes.
+   *
+   * <p>The text is read directly from ASCII bytes, so this avoids the {@code String} allocation and
+   * UTF-8 decode, and the {@link UUID#fromString} parse and {@code UUID} allocation, that a caller
+   * holding raw bytes would otherwise pay per value. The result is identical to {@code
+   * convertToByteBuffer(UUID.fromString(new String(uuidText, StandardCharsets.UTF_8)), reuse)} for
+   * every canonical UUID.
+   *
+   * <p>Only the canonical form is accepted: 32 hexadecimal digits in 8-4-4-4-12 groups separated by
+   * {@code '-'}. Digits may be upper or lower case. Unlike {@link UUID#fromString}, shortened
+   * groups are rejected rather than zero-extended.
+   *
+   * @param uuidText ASCII bytes of a canonical UUID
+   * @param offset start of the UUID text within {@code uuidText}
+   * @param length length of the UUID text, which must be 36
+   * @param reuse buffer to write into, or null to allocate one
+   * @return a buffer of 16 bytes positioned at 0
+   */
+  public static ByteBuffer convertToByteBuffer(
+      byte[] uuidText, int offset, int length, ByteBuffer reuse) {
+    Preconditions.checkArgument(uuidText != null, "Invalid UUID text: null");
+    Preconditions.checkArgument(
+        length == UUID_TEXT_LENGTH, "Invalid UUID text: expected 36 characters, got %s", length);
+    Preconditions.checkArgument(
+        offset >= 0 && offset + length <= uuidText.length,
+        "UUID text out of bounds, offset=%s, length=%s, array length=%s",
+        offset,
+        length,
+        uuidText.length);
+    for (int dash : DASH_POSITIONS) {
+      Preconditions.checkArgument(
+          uuidText[offset + dash] == '-', "Invalid UUID text: expected '-' at position %s", dash);
+    }
+
+    // 8-4-4 before the third dash forms the most significant bits, 4-12 after it the least
+    long mostSigBits = readHex(uuidText, offset, 8);
+    mostSigBits = (mostSigBits << 16) | readHex(uuidText, offset + 9, 4);
+    mostSigBits = (mostSigBits << 16) | readHex(uuidText, offset + 14, 4);
+
+    long leastSigBits = readHex(uuidText, offset + 19, 4);
+    leastSigBits = (leastSigBits << 48) | readHex(uuidText, offset + 24, 12);
+
+    ByteBuffer buffer = reuse != null ? reuse : ByteBuffer.allocate(16);
+    buffer.order(ByteOrder.BIG_ENDIAN);
+    buffer.putLong(0, mostSigBits);
+    buffer.putLong(8, leastSigBits);
+    return buffer;
+  }
+
+  /** See {@link #convertToByteBuffer(byte[], int, int, ByteBuffer)}. */
+  public static ByteBuffer convertToByteBuffer(byte[] uuidText, ByteBuffer reuse) {
+    Preconditions.checkArgument(uuidText != null, "Invalid UUID text: null");
+    return convertToByteBuffer(uuidText, 0, uuidText.length, reuse);
+  }
+
+  /** Reads {@code count} hexadecimal digits as an unsigned value. */
+  private static long readHex(byte[] text, int offset, int count) {
+    long value = 0;
+    for (int i = 0; i < count; i += 1) {
+      value = (value << 4) | hexDigit(text[offset + i]);
+    }
+    return value;
+  }
+
+  private static int hexDigit(byte character) {
+    if (character >= '0' && character <= '9') {
+      return character - '0';
+    } else if (character >= 'a' && character <= 'f') {
+      return character - 'a' + 10;
+    } else if (character >= 'A' && character <= 'F') {
+      return character - 'A' + 10;
+    }
+
+    throw new IllegalArgumentException(
+        String.format("Invalid UUID text: '%s' is not a hexadecimal digit", (char) character));
+  }
+
   /**
    * Generate a RFC 9562 UUIDv7.
    *

--- a/api/src/test/java/org/apache/iceberg/util/TestUUIDUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestUUIDUtil.java
@@ -19,9 +19,14 @@
 package org.apache.iceberg.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestUUIDUtil {
 
@@ -30,5 +35,98 @@ public class TestUUIDUtil {
     UUID uuid = UUIDUtil.generateUuidV7();
     assertThat(uuid.version()).isEqualTo(7);
     assertThat(uuid.variant()).isEqualTo(2);
+  }
+
+  /**
+   * The direct path must agree with UUID.fromString for every UUID, since it replaces it on the
+   * Spark write path and the bytes end up in data files.
+   */
+  @Test
+  public void directConversionMatchesUuidFromString() {
+    for (int i = 0; i < 1000; i += 1) {
+      UUID expected = UUID.randomUUID();
+      assertThat(bytesOf(expected.toString()))
+          .as("round trip of %s", expected)
+          .isEqualTo(UUIDUtil.convert(UUIDUtil.convertToByteBuffer(expected).array()))
+          .isEqualTo(expected);
+    }
+  }
+
+  @Test
+  public void directConversionHandlesBoundaryValues() {
+    // all-zero, all-one, and a value whose most significant bit is set in both longs
+    for (String text :
+        new String[] {
+          "00000000-0000-0000-0000-000000000000",
+          "ffffffff-ffff-ffff-ffff-ffffffffffff",
+          "80000000-0000-0000-8000-000000000000",
+          "7fffffff-ffff-ffff-7fff-ffffffffffff"
+        }) {
+      assertThat(bytesOf(text)).as("boundary value %s", text).isEqualTo(UUID.fromString(text));
+    }
+  }
+
+  @Test
+  public void directConversionIsCaseInsensitive() {
+    String lower = "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11";
+    assertThat(bytesOf(lower.toUpperCase(java.util.Locale.ROOT))).isEqualTo(UUID.fromString(lower));
+  }
+
+  @Test
+  public void directConversionReusesTheGivenBuffer() {
+    ByteBuffer reuse = ByteBuffer.allocate(16);
+    UUID uuid = UUID.randomUUID();
+    ByteBuffer result =
+        UUIDUtil.convertToByteBuffer(uuid.toString().getBytes(StandardCharsets.UTF_8), reuse);
+
+    assertThat(result).isSameAs(reuse);
+    assertThat(UUIDUtil.convert(result.duplicate())).isEqualTo(uuid);
+  }
+
+  @Test
+  public void directConversionReadsAtAnOffset() {
+    UUID uuid = UUID.randomUUID();
+    byte[] padded = ("xx" + uuid + "yy").getBytes(StandardCharsets.UTF_8);
+    ByteBuffer result = UUIDUtil.convertToByteBuffer(padded, 2, 36, null);
+
+    assertThat(UUIDUtil.convert(result.duplicate())).isEqualTo(uuid);
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "", // empty
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a1", // one character short
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a111", // one character long
+        "a0eebc999c0b4ef8bb6d6bb9bd380a11", // no dashes
+        "a0eebc99+9c0b-4ef8-bb6d-6bb9bd380a11", // wrong separator
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a1g", // non hexadecimal digit
+        "a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a1 " // trailing space
+      })
+  public void directConversionRejectsNonCanonicalText(String text) {
+    byte[] bytes = text.getBytes(StandardCharsets.UTF_8);
+    assertThatThrownBy(() -> UUIDUtil.convertToByteBuffer(bytes, null))
+        .as("must reject %s", text)
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("Invalid UUID text");
+  }
+
+  /**
+   * UUID.fromString zero-extends short groups, so "1-2-3-4-5" parses there. The direct path is
+   * deliberately stricter, because a value that reaches a data file should be canonical.
+   */
+  @Test
+  public void directConversionIsStricterThanUuidFromString() {
+    assertThat(UUID.fromString("1-2-3-4-5")).isNotNull();
+    assertThatThrownBy(
+            () -> UUIDUtil.convertToByteBuffer("1-2-3-4-5".getBytes(StandardCharsets.UTF_8), null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("expected 36 characters");
+  }
+
+  private static UUID bytesOf(String uuidText) {
+    ByteBuffer buffer =
+        UUIDUtil.convertToByteBuffer(uuidText.getBytes(StandardCharsets.UTF_8), null);
+    return UUIDUtil.convert(buffer.duplicate());
   }
 }

--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
-import java.util.UUID;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.ValueWriter;
@@ -101,10 +100,10 @@ public class SparkValueWriters {
     @Override
     @SuppressWarnings("ByteBufferBackingArray")
     public void write(UTF8String s, Encoder encoder) throws IOException {
-      // TODO: direct conversion from string to byte buffer
-      UUID uuid = UUID.fromString(s.toString());
+      // read the UTF-8 bytes directly, avoiding the String allocation and UTF-8 decode of
+      // toString(), and the regex parse and object allocation of UUID.fromString()
       // calling array() is safe because the buffer is always allocated by the thread-local
-      encoder.writeFixed(UUIDUtil.convertToByteBuffer(uuid, BUFFER.get()).array());
+      encoder.writeFixed(UUIDUtil.convertToByteBuffer(s.getBytes(), BUFFER.get()).array());
     }
   }
 

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
-import java.util.UUID;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.ValueWriter;
@@ -107,10 +106,10 @@ public class SparkValueWriters {
     @Override
     @SuppressWarnings("ByteBufferBackingArray")
     public void write(UTF8String s, Encoder encoder) throws IOException {
-      // TODO: direct conversion from string to byte buffer
-      UUID uuid = UUID.fromString(s.toString());
+      // read the UTF-8 bytes directly, avoiding the String allocation and UTF-8 decode of
+      // toString(), and the regex parse and object allocation of UUID.fromString()
       // calling array() is safe because the buffer is always allocated by the thread-local
-      encoder.writeFixed(UUIDUtil.convertToByteBuffer(uuid, BUFFER.get()).array());
+      encoder.writeFixed(UUIDUtil.convertToByteBuffer(s.getBytes(), BUFFER.get()).array());
     }
   }
 

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/SparkValueWriters.java
@@ -23,7 +23,6 @@ import java.lang.reflect.Array;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
-import java.util.UUID;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.util.Utf8;
 import org.apache.iceberg.avro.ValueWriter;
@@ -107,10 +106,10 @@ public class SparkValueWriters {
     @Override
     @SuppressWarnings("ByteBufferBackingArray")
     public void write(UTF8String s, Encoder encoder) throws IOException {
-      // TODO: direct conversion from string to byte buffer
-      UUID uuid = UUID.fromString(s.toString());
+      // read the UTF-8 bytes directly, avoiding the String allocation and UTF-8 decode of
+      // toString(), and the regex parse and object allocation of UUID.fromString()
       // calling array() is safe because the buffer is always allocated by the thread-local
-      encoder.writeFixed(UUIDUtil.convertToByteBuffer(uuid, BUFFER.get()).array());
+      encoder.writeFixed(UUIDUtil.convertToByteBuffer(s.getBytes(), BUFFER.get()).array());
     }
   }
 


### PR DESCRIPTION
Closes #16003

### What

`SparkValueWriters.UUIDWriter` carried a TODO for exactly this:

```java
// TODO: direct conversion from string to byte buffer
UUID uuid = UUID.fromString(s.toString());
encoder.writeFixed(UUIDUtil.convertToByteBuffer(uuid, BUFFER.get()).array());
```

Two intermediate objects per row, on a write path: `s.toString()` allocates a `String` and decodes UTF-8, then `UUID.fromString` parses it with a regex, splits and `Long.parseLong` to build a `UUID` that is immediately destructured back into two longs for the buffer.

This adds `UUIDUtil.convertToByteBuffer(byte[] uuidText, int offset, int length, ByteBuffer reuse)`, which reads the canonical text straight from its ASCII bytes into the caller's buffer, plus a two-argument overload. The Spark writer now calls it with `s.getBytes()`. No `String`, no `UUID`, and the thread-local buffer is still reused.

### One deliberate behaviour difference

The new path is **stricter** than `UUID.fromString`, which zero-extends short groups — `UUID.fromString("1-2-3-4-5")` parses successfully today. Only the canonical 8-4-4-4-12 form is accepted, upper or lower case.

I chose strict because these bytes land in a data file, so accepting a non-canonical string would persist a value the writer never really validated. It is a narrowing, though, so if you would rather preserve the lenient behaviour exactly I am happy to change it — there is a test pinning the current choice either way.

### Tests

`TestUUIDUtil`, 14 tests, all passing:

- agreement with `UUID.fromString` over **1000 random UUIDs** — this is the property that matters, since the method replaces it on the write path
- the all-zero, all-ones and sign-bit boundaries (`80000000-...`, `7fffffff-...`), where a sloppy shift or a sign-extension bug would show up
- case insensitivity, buffer reuse returning the same instance, and reading at an offset
- seven non-canonical inputs rejected (too short, too long, no dashes, wrong separator, non-hex digit, trailing space, empty) rather than silently producing different bytes
- an explicit test documenting that `"1-2-3-4-5"` parses via `UUID.fromString` and is rejected here

```
TestUUIDUtil: tests=14 failures=0 errors=0
```

`:iceberg-api:checkstyleMain`, `:iceberg-api:checkstyleTest`, `:iceberg-api:spotlessCheck`, `:iceberg-spark:iceberg-spark-4.1_2.13:checkstyleMain` and `spotlessCheck` all pass, as do the Spark 4.1 Avro write tests.

### Spark versions

Applied to v3.5, v4.0 and v4.1, matching #17482. Only one Spark version configures in a local Gradle build at a time, so I verified the gates against 4.1; the change is byte-identical in all three.

### Not included

No JMH benchmark. The allocation reduction is structural — two objects and a regex parse removed per value — so I did not want to attach a synthetic number to it without a harness you would trust. Happy to add one if you would like the figure.