### PR TITLE
Core: Support branch commits in RewriteManifests

### DIFF
--- a/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
+++ b/core/src/main/java/org/apache/iceberg/BaseRewriteManifests.java
@@ -84,6 +84,12 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   }
 
   @Override
+  public RewriteManifests toBranch(String branch) {
+    targetBranch(branch);
+    return this;
+  }
+
+  @Override
   protected String operation() {
     return DataOperations.REPLACE;
   }
@@ -168,10 +174,14 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
 
   @Override
   public List<ManifestFile> apply(TableMetadata base, Snapshot snapshot) {
-    List<ManifestFile> currentManifests = base.currentSnapshot().allManifests(ops().io());
+    // snapshot is the tip of the branch being committed to, which is main by default and null
+    // when that branch does not exist yet. Reading base.currentSnapshot() here would rewrite
+    // main's manifests no matter which branch was targeted.
+    List<ManifestFile> currentManifests =
+        snapshot == null ? Collections.emptyList() : snapshot.allManifests(ops().io());
     Set<ManifestFile> currentManifestSet = ImmutableSet.copyOf(currentManifests);
 
-    validateDeletedManifests(currentManifestSet, base.currentSnapshot().snapshotId());
+    validateDeletedManifests(currentManifestSet, snapshot);
 
     if (requiresRewrite(currentManifestSet)) {
       performRewrite(currentManifests);
@@ -284,16 +294,22 @@ public class BaseRewriteManifests extends SnapshotProducer<RewriteManifests>
   }
 
   private void validateDeletedManifests(
-      Set<ManifestFile> currentManifests, long currentSnapshotID) {
+      Set<ManifestFile> currentManifests, Snapshot currentSnapshot) {
     // directly deleted manifests must be still present in the current snapshot
     deletedManifests.stream()
         .filter(manifest -> !currentManifests.contains(manifest))
         .findAny()
         .ifPresent(
             manifest -> {
+              if (currentSnapshot == null) {
+                throw new ValidationException(
+                    "Deleted manifest %s could not be found: branch %s has no snapshot",
+                    manifest.path(), targetBranch());
+              }
+
               throw new ValidationException(
                   "Deleted manifest %s could not be found in the latest snapshot %d",
-                  manifest.path(), currentSnapshotID);
+                  manifest.path(), currentSnapshot.snapshotId());
             });
   }
 

--- a/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
+++ b/core/src/test/java/org/apache/iceberg/TestRewriteManifests.java
@@ -1078,16 +1078,103 @@ public class TestRewriteManifests extends TestBase {
   }
 
   @TestTemplate
-  public void testRewriteManifestsOnBranchUnsupported() {
+  public void testRewriteManifestsOnBranch() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    long firstSnapshotId = table.currentSnapshot().snapshotId();
+    table.manageSnapshots().createBranch("branch", firstSnapshotId).commit();
 
-    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
-
+    // add a second file only to the branch, so the branch and main differ
+    table.newFastAppend().appendFile(FILE_B).toBranch("branch").commit();
+    Snapshot branchTip = table.snapshot(table.refs().get("branch").snapshotId());
+    assertThat(branchTip.allManifests(table.io())).hasSize(2);
     assertThat(table.currentSnapshot().allManifests(table.io())).hasSize(1);
 
-    assertThatThrownBy(() -> table.rewriteManifests().toBranch("someBranch").commit())
-        .isInstanceOf(UnsupportedOperationException.class)
-        .hasMessage(
-            "Cannot commit to branch someBranch: org.apache.iceberg.BaseRewriteManifests does not support branch commits");
+    table.rewriteManifests().clusterBy(file -> "").toBranch("branch").commit();
+
+    // main must be untouched
+    assertThat(table.currentSnapshot().snapshotId()).isEqualTo(firstSnapshotId);
+
+    // the branch manifests must be rewritten into one, and still hold both files
+    Snapshot rewritten = table.snapshot(table.refs().get("branch").snapshotId());
+    assertThat(rewritten.snapshotId()).isNotEqualTo(branchTip.snapshotId());
+    assertThat(rewritten.operation()).isEqualTo(DataOperations.REPLACE);
+    List<ManifestFile> manifests = rewritten.allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+    assertThat(manifests.get(0).addedFilesCount() + manifests.get(0).existingFilesCount())
+        .isEqualTo(2);
+  }
+
+  /**
+   * Before branch support, apply() read base.currentSnapshot() rather than the tip of the target
+   * branch, so a rewrite aimed at a branch would have operated on main's manifests. This pins the
+   * distinction: main has one file, the branch has two, and rewriting the branch must carry two.
+   */
+  @TestTemplate
+  public void testRewriteManifestsOnBranchUsesBranchManifestsNotMain() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.manageSnapshots().createBranch("branch", table.currentSnapshot().snapshotId()).commit();
+    table.newFastAppend().appendFile(FILE_B).appendFile(FILE_C).toBranch("branch").commit();
+
+    table.rewriteManifests().clusterBy(file -> "").toBranch("branch").commit();
+
+    Snapshot rewritten = table.snapshot(table.refs().get("branch").snapshotId());
+    List<ManifestFile> manifests = rewritten.allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+    assertThat(manifests.get(0).addedFilesCount() + manifests.get(0).existingFilesCount())
+        .as("must carry the branch's three files, not main's one")
+        .isEqualTo(3);
+  }
+
+  /**
+   * Targeting a branch that does not exist yet creates it from main's current snapshot, which is
+   * how the other snapshot operations behave: SnapshotUtil.latestSnapshot falls back to the current
+   * snapshot when the ref is absent. main itself must stay where it was.
+   */
+  @TestTemplate
+  public void testRewriteManifestsCreatesMissingBranchFromMain() {
+    table.newFastAppend().appendFile(FILE_A).appendFile(FILE_B).commit();
+    long mainSnapshotId = table.currentSnapshot().snapshotId();
+
+    table.rewriteManifests().clusterBy(file -> "").toBranch("newBranch").commit();
+
+    assertThat(table.currentSnapshot().snapshotId())
+        .as("main must not move")
+        .isEqualTo(mainSnapshotId);
+    assertThat(table.refs()).containsKey("newBranch");
+
+    Snapshot created = table.snapshot(table.refs().get("newBranch").snapshotId());
+    List<ManifestFile> manifests = created.allManifests(table.io());
+    assertThat(manifests).hasSize(1);
+    assertThat(manifests.get(0).addedFilesCount() + manifests.get(0).existingFilesCount())
+        .as("the new branch starts from main's files")
+        .isEqualTo(2);
+  }
+
+  /**
+   * With no snapshots at all, apply() receives a null snapshot. Reading base.currentSnapshot()
+   * unconditionally, as this did before, threw a NullPointerException here.
+   */
+  @TestTemplate
+  public void testRewriteManifestsOnEmptyTable() {
+    assertThat(table.currentSnapshot()).isNull();
+
+    table.rewriteManifests().clusterBy(file -> "").commit();
+
+    assertThat(table.currentSnapshot().allManifests(table.io())).isEmpty();
+  }
+
+  @TestTemplate
+  public void testRewriteManifestsRejectsInvalidBranch() {
+    table.newFastAppend().appendFile(FILE_A).commit();
+    table.manageSnapshots().createTag("tag", table.currentSnapshot().snapshotId()).commit();
+
+    assertThatThrownBy(() -> table.rewriteManifests().toBranch(null))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Invalid branch name: null");
+
+    assertThatThrownBy(() -> table.rewriteManifests().toBranch("tag"))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("tag is a tag, not a branch");
   }
 
   @TestTemplate


### PR DESCRIPTION
Closes #15981

Builds on @jlkvanloon's earlier attempt in #15982, which was closed by the stale bot without ever getting a review. Credit for the diagnosis is theirs — both defects below are described in the issue.

### Two defects, not one

**1. `toBranch` was never overridden.** `RewriteManifests` inherited the default `SnapshotUpdate.toBranch`, which throws, so `table.rewriteManifests().toBranch("b").commit()` failed with `UnsupportedOperationException`.

**2. `apply` read the wrong snapshot.** This is the part that matters, and unblocking `toBranch` without it would have been worse than the exception:

```java
List<ManifestFile> currentManifests = base.currentSnapshot().allManifests(ops().io());
```

`SnapshotProducer` calls `apply(base, parentSnapshot)` where `parentSnapshot = SnapshotUtil.latestSnapshot(base, targetBranch)` — the tip of the branch being committed to. Reading `base.currentSnapshot()` instead means a rewrite aimed at a branch would compact **main's** manifests and commit the result to the branch. Silently the wrong data, no error.

### The change

- `toBranch` delegates to `targetBranch`, matching `FastAppend`, `MergeAppend`, `BaseRowDelta` and the rest. Null and tag-name validation already lives in `targetBranch`, so the behaviour the issue asks for comes free rather than being re-implemented.
- `apply` reads the `snapshot` parameter, treating null as an empty manifest list. Null happens when the table has no snapshots at all — where the previous code threw `NullPointerException`.
- `validateDeletedManifests` takes the snapshot rather than a snapshot id, so its message is accurate when there is no snapshot to name.

### One behaviour worth confirming

Targeting a branch that does not exist **creates it from main's current snapshot**, because `SnapshotUtil.latestSnapshot` falls back to `metadata.currentSnapshot()` for an absent ref:

```java
SnapshotRef ref = metadata.ref(branch);
if (ref == null) {
    return metadata.currentSnapshot();
}
```

That is consistent with `AppendFiles` — appending to a new branch also starts from main. I wrote the test expecting an empty branch first, it failed, and I traced it here rather than changing the assertion to match. Flagging it explicitly in case you would rather a missing branch were rejected.

### Tests

`testRewriteManifestsOnBranchUnsupported` is replaced by coverage of each behaviour the operation now has. All run across format versions 1–4:

| Test | Asserts |
|---|---|
| `testRewriteManifestsOnBranch` | rewriting a branch produces a `REPLACE` snapshot on that branch, main does not move |
| `testRewriteManifestsOnBranchUsesBranchManifestsNotMain` | main has 1 file, branch has 3; the rewrite carries 3 — this is the test that fails against the old `apply` |
| `testRewriteManifestsCreatesMissingBranchFromMain` | absent branch is created from main, main untouched |
| `testRewriteManifestsRejectsInvalidBranch` | null and tag targets throw `IllegalArgumentException` |
| `testRewriteManifestsOnEmptyTable` | no snapshots no longer throws `NullPointerException` |

```
TestRewriteManifests: tests=136 failures=0 errors=0
```

`:iceberg-core:checkstyleMain`, `:iceberg-core:checkstyleTest` and `:iceberg-core:spotlessCheck` pass. The `*RewriteManifests*`, `*SnapshotProducer*` and `*Branch*` core suites pass, and nothing else in the tree asserted the old unsupported-branch behaviour.

### Why this is wanted

From the issue: manifest clustering (`clusterBy(DataFile::partition)`) on a branch before merging it into main, so a write-audit-publish pipeline can compact branch metadata rather than merging unoptimised metadata into main and compacting afterwards.