### PR TITLE
Docs: Add SeaweedFS to vendors and third-party catalogs nav

### DIFF
--- a/site/docs/vendors.md
+++ b/site/docs/vendors.md
@@ -177,6 +177,10 @@ Redpanda is both a cloud-native and self-hosted streaming platform whose [Iceber
 
 [Sail](https://github.com/lakehq/sail) is an open-source multimodal distributed compute framework, built in Rust, unifying batch, streaming, and AI workloads. For seamless adoption, Sail offers a drop-in replacement for the Spark SQL and DataFrame APIs in both single-host and distributed settings. Learn more about using Sail with Iceberg in the [Sail Iceberg guide](https://docs.lakesail.com/sail/latest/guide/sources/iceberg).
 
+### [SeaweedFS](https://seaweedfs.com/)
+
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) is an open-source distributed object store with an S3-compatible gateway. Its S3 Table Buckets provide both halves of an Iceberg deployment in a single service: an embedded Iceberg REST catalog serves table metadata, and the table bucket stores table data as Parquet files, with server-side compaction and snapshot expiration. Engines such as Spark, Trino, ClickHouse, DuckDB, Apache Doris, RisingWave, Dremio, and PyIceberg connect through the standard Iceberg REST catalog and S3 APIs.
+
 ### [SingleStore](https://singlestore.com/)
 
 SingleStore is a high‑performance, scalable, distributed SQL platform that makes real‑time analytics and transactional processing available at scale. Its native Apache Iceberg integration removes costly ETL steps and powers intelligent, millisecond‑response applications.

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -61,6 +61,7 @@ nav:
         - DataHub: https://docs.datahub.com/docs/iceberg-catalog
         - Google BigLake metastore: https://cloud.google.com/bigquery/docs/blms-manage-resources
         - Lakekeeper: https://github.com/lakekeeper/lakekeeper
+        - SeaweedFS: https://github.com/seaweedfs/seaweedfs
       - Integrations:
         - Amazon Athena: https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html
         - Amazon Data Firehose: https://docs.aws.amazon.com/firehose/latest/dev/apache-iceberg-destination.html


### PR DESCRIPTION
Adds SeaweedFS to the vendors page and the Third-party Catalogs list in the site navigation.

SeaweedFS S3 Table Buckets embed an Iceberg REST catalog in the SeaweedFS S3 gateway: the catalog serves table metadata and the table bucket stores table data as Parquet files, from a single service. The integration is exercised by per-engine CI suites in the SeaweedFS repository (Spark, Trino, ClickHouse, DuckDB-facing PyIceberg, Doris, RisingWave, Dremio): https://github.com/seaweedfs/seaweedfs/tree/master/test/s3tables