### PR TITLE
Flink: Backport RowDataWrapper per-row getter allocation fix to 2.0 and 1.20 (#16789)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -48,7 +48,14 @@ public class RowDataWrapper implements StructLike {
 
     for (int i = 0; i < size; i++) {
       types[i] = rowType.getTypeAt(i);
-      getters[i] = buildGetter(types[i], struct.fields().get(i).type());
+      PositionalGetter<?> getter = buildGetter(types[i], struct.fields().get(i).type());
+      if (getter == null) {
+        // Pre-build the Flink field getter once instead of recreating it on every access.
+        RowData.FieldGetter fieldGetter = FlinkRowData.createFieldGetter(types[i], i);
+        getter = (row, pos) -> fieldGetter.getFieldOrNull(row);
+      }
+
+      getters[i] = getter;
     }
   }
 
@@ -66,12 +73,9 @@ public class RowDataWrapper implements StructLike {
   public <T> T get(int pos, Class<T> javaClass) {
     if (rowData.isNullAt(pos)) {
       return null;
-    } else if (getters[pos] != null) {
-      return javaClass.cast(getters[pos].get(rowData, pos));
     }
 
-    Object value = FlinkRowData.createFieldGetter(types[pos], pos).getFieldOrNull(rowData);
-    return javaClass.cast(value);
+    return javaClass.cast(getters[pos].get(rowData, pos));
   }
 
   @Override

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/RowDataWrapper.java
@@ -48,7 +48,14 @@ public class RowDataWrapper implements StructLike {
 
     for (int i = 0; i < size; i++) {
       types[i] = rowType.getTypeAt(i);
-      getters[i] = buildGetter(types[i], struct.fields().get(i).type());
+      PositionalGetter<?> getter = buildGetter(types[i], struct.fields().get(i).type());
+      if (getter == null) {
+        // Pre-build the Flink field getter once instead of recreating it on every access.
+        RowData.FieldGetter fieldGetter = FlinkRowData.createFieldGetter(types[i], i);
+        getter = (row, pos) -> fieldGetter.getFieldOrNull(row);
+      }
+
+      getters[i] = getter;
     }
   }
 
@@ -66,12 +73,9 @@ public class RowDataWrapper implements StructLike {
   public <T> T get(int pos, Class<T> javaClass) {
     if (rowData.isNullAt(pos)) {
       return null;
-    } else if (getters[pos] != null) {
-      return javaClass.cast(getters[pos].get(rowData, pos));
     }
 
-    Object value = FlinkRowData.createFieldGetter(types[pos], pos).getFieldOrNull(rowData);
-    return javaClass.cast(value);
+    return javaClass.cast(getters[pos].get(rowData, pos));
   }
 
   @Override


### PR DESCRIPTION
Backport of #16789 to Flink 2.0 and 1.20. The `RowDataWrapper` files were identical across the three versions, so this is a direct copy of the merged change: the fallback field getter for the `default` case of `buildGetter` (`INT`, `BIGINT`, `BOOLEAN`, `FLOAT`, `DOUBLE`, `DATE`) is pre-built once in the constructor instead of being recreated on every `get`, which allocated two lambdas per field access on the partitioned-write, equality-delete and range-shuffle hot paths.

Existing `TestRowDataWrapper` coverage passes unchanged on both versions.

---
**AI Disclosure**
- Model: Claude Opus 5
- Platform/Tool: Claude Code
- Human Oversight: fully reviewed
- Prompt Summary: Backport the merged RowDataWrapper per-row field getter allocation fix from #16789 to the Flink 2.0 and 1.20 modules.
