### PR TITLE
fix: respect path boundary in compareToFileList location prefix matching (#16493)

### DIFF
--- a/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v3.5/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      // Ensure path boundary is respected: s3://bucket/table should not match
+      // s3://bucket/table-backup/... which is a sibling path, not a subdirectory
+      String locationPrefix =
+          location.endsWith("/") ? location : location + "/";
+      files =
+          files.filter(
+              files.col(FILE_PATH).startsWith(locationPrefix)
+                  .or(files.col(FILE_PATH).equalTo(location)));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v3.5/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1028,6 +1028,56 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testCompareToFileListDoesNotMatchSiblingPaths() throws IOException {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    // sibling paths that share the table location as a raw string prefix but are NOT
+    // subdirectories of the table location (e.g. table-backup/...). These must NOT be
+    // treated as in-scope orphan candidates.
+    String sibling1 = tableLocation + "-backup/data/sibling1.parquet";
+    String sibling2 = tableLocation + "_old/data/sibling2.parquet";
+    String insideLocation = tableLocation + "/data/inside.parquet";
+
+    List<FilePathLastModifiedRecord> mockFiles =
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord(sibling1, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(sibling2, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(insideLocation, new Timestamp(0L)));
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(mockFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .compareToFileList(compareToFileList)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(s -> {})
+            .execute();
+
+    // Only the file actually inside the table location should be considered in scope.
+    assertThat(result.orphanFileLocations())
+        .as("Only files inside the table location should be in scope")
+        .containsExactly(insideLocation);
+    assertThat(result.orphanFilesCount())
+        .as("Only 1 file inside the table location should be in scope")
+        .isEqualTo(1L);
+  }
+
+  @TestTemplate
   public void testRemoveOrphanFilesWithStatisticFiles() throws Exception {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      // Ensure path boundary is respected: s3://bucket/table should not match
+      // s3://bucket/table-backup/... which is a sibling path, not a subdirectory
+      String locationPrefix =
+          location.endsWith("/") ? location : location + "/";
+      files =
+          files.filter(
+              files.col(FILE_PATH).startsWith(locationPrefix)
+                  .or(files.col(FILE_PATH).equalTo(location)));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1028,6 +1028,56 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testCompareToFileListDoesNotMatchSiblingPaths() throws IOException {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    // sibling paths that share the table location as a raw string prefix but are NOT
+    // subdirectories of the table location (e.g. table-backup/...). These must NOT be
+    // treated as in-scope orphan candidates.
+    String sibling1 = tableLocation + "-backup/data/sibling1.parquet";
+    String sibling2 = tableLocation + "_old/data/sibling2.parquet";
+    String insideLocation = tableLocation + "/data/inside.parquet";
+
+    List<FilePathLastModifiedRecord> mockFiles =
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord(sibling1, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(sibling2, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(insideLocation, new Timestamp(0L)));
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(mockFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .compareToFileList(compareToFileList)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(s -> {})
+            .execute();
+
+    // Only the file actually inside the table location should be considered in scope.
+    assertThat(result.orphanFileLocations())
+        .as("Only files inside the table location should be in scope")
+        .containsExactly(insideLocation);
+    assertThat(result.orphanFilesCount())
+        .as("Only 1 file inside the table location should be in scope")
+        .isEqualTo(1L);
+  }
+
+  @TestTemplate
   public void testRemoveOrphanFilesWithStatisticFiles() throws Exception {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/DeleteOrphanFilesSparkAction.java
@@ -225,7 +225,14 @@ public class DeleteOrphanFilesSparkAction extends BaseSparkAction<DeleteOrphanFi
   private Dataset<String> filteredCompareToFileList() {
     Dataset<Row> files = compareToFileList;
     if (location != null) {
-      files = files.filter(files.col(FILE_PATH).startsWith(location));
+      // Ensure path boundary is respected: s3://bucket/table should not match
+      // s3://bucket/table-backup/... which is a sibling path, not a subdirectory
+      String locationPrefix =
+          location.endsWith("/") ? location : location + "/";
+      files =
+          files.filter(
+              files.col(FILE_PATH).startsWith(locationPrefix)
+                  .or(files.col(FILE_PATH).equalTo(location)));
     }
     return files
         .filter(files.col(LAST_MODIFIED).lt(new Timestamp(olderThanTimestamp)))

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRemoveOrphanFilesAction.java
@@ -1029,6 +1029,56 @@ public abstract class TestRemoveOrphanFilesAction extends TestBase {
   }
 
   @TestTemplate
+  public void testCompareToFileListDoesNotMatchSiblingPaths() throws IOException {
+    assumeThat(usePrefixListing)
+        .as("Should not test both prefix listing and Hadoop file listing (redundant)")
+        .isEqualTo(false);
+    Table table = TABLES.create(SCHEMA, PartitionSpec.unpartitioned(), properties, tableLocation);
+
+    List<ThreeColumnRecord> records =
+        Lists.newArrayList(new ThreeColumnRecord(1, "AAAAAAAAAA", "AAAA"));
+
+    Dataset<Row> df = spark.createDataFrame(records, ThreeColumnRecord.class).coalesce(1);
+
+    df.select("c1", "c2", "c3").write().format("iceberg").mode("append").save(tableLocation);
+
+    // sibling paths that share the table location as a raw string prefix but are NOT
+    // subdirectories of the table location (e.g. table-backup/...). These must NOT be
+    // treated as in-scope orphan candidates.
+    String sibling1 = tableLocation + "-backup/data/sibling1.parquet";
+    String sibling2 = tableLocation + "_old/data/sibling2.parquet";
+    String insideLocation = tableLocation + "/data/inside.parquet";
+
+    List<FilePathLastModifiedRecord> mockFiles =
+        Lists.newArrayList(
+            new FilePathLastModifiedRecord(sibling1, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(sibling2, new Timestamp(0L)),
+            new FilePathLastModifiedRecord(insideLocation, new Timestamp(0L)));
+
+    Dataset<Row> compareToFileList =
+        spark
+            .createDataFrame(mockFiles, FilePathLastModifiedRecord.class)
+            .withColumnRenamed("filePath", "file_path")
+            .withColumnRenamed("lastModified", "last_modified");
+
+    DeleteOrphanFiles.Result result =
+        SparkActions.get()
+            .deleteOrphanFiles(table)
+            .compareToFileList(compareToFileList)
+            .olderThan(System.currentTimeMillis())
+            .deleteWith(s -> {})
+            .execute();
+
+    // Only the file actually inside the table location should be considered in scope.
+    assertThat(result.orphanFileLocations())
+        .as("Only files inside the table location should be in scope")
+        .containsExactly(insideLocation);
+    assertThat(result.orphanFilesCount())
+        .as("Only 1 file inside the table location should be in scope")
+        .isEqualTo(1L);
+  }
+
+  @TestTemplate
   public void testRemoveOrphanFilesWithStatisticFiles() throws Exception {
     assumeThat(usePrefixListing)
         .as("Should not test both prefix listing and Hadoop file listing (redundant)")


### PR DESCRIPTION
Fixes #16493

## Why

When using `compareToFileList(Dataset)`, the `file_list_view` is filtered by `startsWith(tableLocation)`. This raw string prefix match incorrectly includes sibling paths that share a prefix with the table location. For example, a table at `s3://bucket/table` would also match `s3://bucket/table-backup/data/file.parquet` or `s3://bucket/table_old/data/file.parquet`, treating files outside the intended directory as in-scope orphan candidates.

## Summary

Normalize the location to ensure it ends with a path separator (`/`) before using `startsWith`, and also accept an exact match for the location itself. This ensures that only files actually under the table directory (or equal to the location) are treated as in-scope.

## How to Test

New test `testCompareToFileListDoesNotMatchSiblingPaths` verifies that:
- Files under `tableLocation + "-backup/"` (sibling prefix) are NOT in scope
- Files under `tableLocation + "_old/"` (sibling prefix) are NOT in scope
- Files under `tableLocation + "/data/"` are correctly in scope

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Documentation

## Checklist

- [x] Changes are tested
- [x] Changes follow the project's code style