### PR TITLE
API: Add Javadoc for the Metrics constructor parameters

### DIFF
--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -87,7 +87,7 @@ public class Metrics implements Serializable {
    * @param lowerBounds a map of field id to the lower bound of the column, or null if unknown
    * @param upperBounds a map of field id to the upper bound of the column, or null if unknown
    * @param originalTypes a map of field id to the original type of the lower/upper bound, or null
-   *  if unknown
+   *     if unknown
    */
   public Metrics(
       Long rowCount,

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -86,7 +86,8 @@ public class Metrics implements Serializable {
    * @param nanValueCounts a map of field id to the number of NaN values, or null if unknown
    * @param lowerBounds a map of field id to the lower bound of the column, or null if unknown
    * @param upperBounds a map of field id to the upper bound of the column, or null if unknown
-   * @param originalTypes a map of field id to the original type of the column, or null if unknown
+   * @param originalTypes a map of field id to the original type of the lower/upper bound, or null
+   *  if unknown
    */
   public Metrics(
       Long rowCount,

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -41,12 +41,28 @@ public class Metrics implements Serializable {
   // this is not serialized with all the other fields
   private Map<Integer, Type> originalTypes = null;
 
+  /** Creates an empty metrics instance with no statistics set. */
   public Metrics() {}
 
+  /**
+   * Creates a new metrics instance with only the row count set.
+   *
+   * @param rowCount the number of rows (records) in the file
+   */
   public Metrics(long rowCount) {
     this.rowCount = rowCount;
   }
 
+  /**
+   * Creates a new metrics instance.
+   *
+   * @param rowCount the number of rows (records) in the file, or null if unknown
+   * @param columnSizes a map of field id to the size in bytes of the column, or null if unknown
+   * @param valueCounts a map of field id to the number of all values (including nulls, NaN, and
+   *     repeated), or null if unknown
+   * @param nullValueCounts a map of field id to the number of null values, or null if unknown
+   * @param nanValueCounts a map of field id to the number of NaN values, or null if unknown
+   */
   public Metrics(
       Long rowCount,
       Map<Integer, Long> columnSizes,
@@ -56,6 +72,18 @@ public class Metrics implements Serializable {
     this(rowCount, columnSizes, valueCounts, nullValueCounts, nanValueCounts, null, null, null);
   }
 
+  /**
+   * Creates a new metrics instance.
+   *
+   * @param rowCount the number of rows (records) in the file, or null if unknown
+   * @param columnSizes a map of field id to the size in bytes of the column, or null if unknown
+   * @param valueCounts a map of field id to the number of all values (including nulls, NaN, and
+   *     repeated), or null if unknown
+   * @param nullValueCounts a map of field id to the number of null values, or null if unknown
+   * @param nanValueCounts a map of field id to the number of NaN values, or null if unknown
+   * @param lowerBounds a map of field id to the lower bound of the column, or null if unknown
+   * @param upperBounds a map of field id to the upper bound of the column, or null if unknown
+   */
   public Metrics(
       Long rowCount,
       Map<Integer, Long> columnSizes,

--- a/api/src/main/java/org/apache/iceberg/Metrics.java
+++ b/api/src/main/java/org/apache/iceberg/Metrics.java
@@ -75,6 +75,19 @@ public class Metrics implements Serializable {
         null);
   }
 
+  /**
+   * Creates a new metrics instance.
+   *
+   * @param rowCount the number of rows (records) in the file, or null if unknown
+   * @param columnSizes a map of field id to the size in bytes of the column, or null if unknown
+   * @param valueCounts a map of field id to the number of all values (including nulls, NaN, and
+   *     repeated), or null if unknown
+   * @param nullValueCounts a map of field id to the number of null values, or null if unknown
+   * @param nanValueCounts a map of field id to the number of NaN values, or null if unknown
+   * @param lowerBounds a map of field id to the lower bound of the column, or null if unknown
+   * @param upperBounds a map of field id to the upper bound of the column, or null if unknown
+   * @param originalTypes a map of field id to the original type of the column, or null if unknown
+   */
   public Metrics(
       Long rowCount,
       Map<Integer, Long> columnSizes,


### PR DESCRIPTION
The `Metrics` constructors have no Javadoc, so it isn't documented what each map holds or that they may be null. This documents the canonical constructor that the other three delegate to. Javadoc-only; no signature change.