### PR TITLE
Data, Spark 4.1: Add format model TCK coverage for vectorized reads

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/DataGenerator.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataGenerator.java
@@ -22,7 +22,7 @@ import java.util.List;
 import org.apache.iceberg.Schema;
 
 /** Interface for generating test data with different schema types. */
-interface DataGenerator {
+public interface DataGenerator {
 
   /** Returns the Iceberg schema for this test data. */
   Schema schema();

--- a/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
+++ b/data/src/test/java/org/apache/iceberg/data/DataGenerators.java
@@ -32,9 +32,9 @@ import org.apache.iceberg.util.DateTimeUtil;
  * Test data generators for different schema types. Add new generators to ALL array to include them
  * in format model tests.
  */
-class DataGenerators {
+public class DataGenerators {
 
-  static final DataGenerator[] ALL =
+  public static final DataGenerator[] ALL =
       new DataGenerator[] {
         new Primitives(),
         new UUID(),

--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -117,6 +117,11 @@ public abstract class ReadFormatModelTests<T> {
     return false;
   }
 
+  protected void assertRecordsEqual(Schema schema, List<Record> expected, List<T> actual) {
+    assertThat(actual).hasSize(expected.size());
+    assertEquals(schema, convertToEngineRecords(expected, schema), actual);
+  }
+
   @TempDir private File tableDir;
 
   /**
@@ -259,9 +264,8 @@ public abstract class ReadFormatModelTests<T> {
             .project(schema)
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(schema, genericRecords, readRecords);
     }
-
-    assertEquals(schema, convertToEngineRecords(genericRecords, schema), readRecords);
   }
 
   /** Write with Generic Record, read with engine type T */
@@ -301,9 +305,8 @@ public abstract class ReadFormatModelTests<T> {
             .project(schema)
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(schema, genericRecords, readRecords);
     }
-
-    assertEquals(schema, convertToEngineRecords(genericRecords, schema), readRecords);
   }
 
   /** Write position deletes, read with Generic Record */
@@ -362,8 +365,6 @@ public abstract class ReadFormatModelTests<T> {
     writeGenericRecords(fileFormat, fullSchema, genericRecords);
 
     List<Record> projectedGenericRecords = project(genericRecords, projectedSchema);
-    List<T> expectedEngineRecords =
-        convertToEngineRecords(projectedGenericRecords, projectedSchema);
 
     InputFile inputFile = encryptedFile.encryptingOutputFile().toInputFile();
     List<T> readRecords;
@@ -372,9 +373,8 @@ public abstract class ReadFormatModelTests<T> {
             .project(projectedSchema)
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(projectedSchema, projectedGenericRecords, readRecords);
     }
-
-    assertEquals(projectedSchema, expectedEngineRecords, readRecords);
   }
 
   @ParameterizedTest
@@ -488,6 +488,7 @@ public abstract class ReadFormatModelTests<T> {
   @FieldSource("FILE_FORMATS")
   void testReaderBuilderSplit(FileFormat fileFormat) throws IOException {
 
+    assumeFalse(supportsBatchReads(), "Batch reads return batches, not rows");
     assumeSupports(fileFormat, FEATURE_SPLIT);
 
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
@@ -543,7 +544,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testReaderBuilderReuseContainers(FileFormat fileFormat) throws IOException {
-
+    assumeFalse(supportsBatchReads(), "Batch reads reuse differently");
     assumeSupports(fileFormat, FEATURE_REUSE_CONTAINERS);
 
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
@@ -678,6 +679,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testNestedDefaultValue(FileFormat fileFormat) throws IOException {
+    assumeFalse(supportsBatchReads(), "Vectorized reads do not support nested types");
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 
     Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
@@ -744,6 +746,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testMapNestedDefaultValue(FileFormat fileFormat) throws IOException {
+    assumeFalse(supportsBatchReads(), "Vectorized reads do not support nested types");
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 
     Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
@@ -831,6 +834,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testListNestedDefaultValue(FileFormat fileFormat) throws IOException {
+    assumeFalse(supportsBatchReads(), "Vectorized reads do not support nested types");
     assumeSupports(fileFormat, FEATURE_READER_DEFAULT);
 
     Types.NestedField idField = Types.NestedField.required(1, "id", Types.LongType.get());
@@ -1343,7 +1347,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testReadMetadataColumnIsDeleted(FileFormat fileFormat) throws IOException {
-
+    assumeFalse(supportsBatchReads(), "DeletedColumnVector requires a delete filter");
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
     List<Record> genericRecords = dataGenerator.generateRecords();
@@ -1363,7 +1367,10 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testReadMetadataColumnRowLineage(FileFormat fileFormat) throws IOException {
-
+    // TODO: ORC's vectorized reader treats _row_id as a plain constant
+    // (VectorizedSparkOrcReaders.StructConverter) rather than applying row-lineage rules,
+    // unlike Arrow's RowIdVectorReader.
+    assumeFalse(supportsBatchReads(), "Row lineage is incorrect for vectorized ORC reads");
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema schema = dataGenerator.schema();
     List<Record> genericRecords = dataGenerator.generateRecords();
@@ -1396,7 +1403,10 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testReadMetadataColumnRowLineageExistingValues(FileFormat fileFormat) throws IOException {
-
+    // TODO: ORC's vectorized reader treats _row_id as a plain constant
+    // (VectorizedSparkOrcReaders.StructConverter) rather than applying row-lineage rules,
+    // unlike Arrow's RowIdVectorReader.
+    assumeFalse(supportsBatchReads(), "Row lineage is incorrect for vectorized ORC reads");
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema dataSchema = dataGenerator.schema();
 
@@ -1856,6 +1866,7 @@ public abstract class ReadFormatModelTests<T> {
   @ParameterizedTest
   @FieldSource("FILE_FORMATS")
   void testSchemaEvolutionEmptyProjection(FileFormat fileFormat) throws IOException {
+    assumeFalse(supportsBatchReads(), "Row count assertion does not apply to batches");
     DataGenerator dataGenerator = new DataGenerators.DefaultSchema();
     Schema writeSchema = dataGenerator.schema();
 
@@ -1899,9 +1910,8 @@ public abstract class ReadFormatModelTests<T> {
             .withNameMapping(nameMapping)
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(icebergSchema, genericRecords, readRecords);
     }
-
-    assertEquals(icebergSchema, convertToEngineRecords(genericRecords, icebergSchema), readRecords);
   }
 
   protected void readAndAssertGenericRecords(
@@ -1956,7 +1966,7 @@ public abstract class ReadFormatModelTests<T> {
     assumeThat(MISSING_FEATURES.getOrDefault(fileFormat, new String[] {})).doesNotContain(feature);
   }
 
-  private static boolean supportsGenerator(FileFormat fileFormat, DataGenerator generator) {
+  protected static boolean supportsGenerator(FileFormat fileFormat, DataGenerator generator) {
     boolean hasVariant =
         TypeUtil.find(generator.schema(), type -> type.typeId() == Type.TypeID.VARIANT) != null;
     return !hasVariant || supportsFeature(fileFormat, FEATURE_VARIANT);
@@ -2361,11 +2371,8 @@ public abstract class ReadFormatModelTests<T> {
 
     try (CloseableIterable<T> reader = readerBuilder.build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(projectionSchema, expectedRecords, readRecords);
     }
-
-    assertThat(readRecords).hasSize(expectedRecords.size());
-    assertEquals(
-        projectionSchema, convertToEngineRecords(expectedRecords, projectionSchema), readRecords);
   }
 
   private static Record copy(Record source, Schema sourceSchema, Schema targetSchema) {
@@ -2412,10 +2419,7 @@ public abstract class ReadFormatModelTests<T> {
             .project(readSchema)
             .build()) {
       readRecords = ImmutableList.copyOf(reader);
+      assertRecordsEqual(readSchema, expectedGenericRecords, readRecords);
     }
-
-    assertThat(readRecords).hasSize(expectedGenericRecords.size());
-    assertEquals(
-        readSchema, convertToEngineRecords(expectedGenericRecords, readSchema), readRecords);
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVectorizedFormatModel.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestSparkVectorizedFormatModel.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.data.DataGenerators;
+import org.apache.iceberg.data.ReadFormatModelTests;
+import org.apache.iceberg.data.Record;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.spark.SparkUtil;
+import org.apache.iceberg.types.Type;
+import org.apache.spark.sql.vectorized.ColumnarBatch;
+import org.junit.jupiter.params.provider.Arguments;
+
+class TestSparkVectorizedFormatModel extends ReadFormatModelTests<ColumnarBatch> {
+
+  private static final FileFormat[] FILE_FORMATS = {FileFormat.ORC, FileFormat.PARQUET};
+
+  private static final List<Arguments> FORMAT_AND_GENERATOR =
+      Arrays.stream(FILE_FORMATS)
+          .flatMap(
+              format ->
+                  Arrays.stream(DataGenerators.ALL)
+                      .filter(generator -> supportsGenerator(format, generator))
+                      .map(generator -> Arguments.of(format, generator)))
+          .toList();
+
+  private static final Set<Type.TypeID> UNSUPPORTED_TYPE_IDS =
+      Set.of(
+          Type.TypeID.TIME,
+          Type.TypeID.TIMESTAMP_NANO,
+          Type.TypeID.STRUCT,
+          Type.TypeID.LIST,
+          Type.TypeID.MAP,
+          Type.TypeID.UUID);
+
+  @Override
+  protected Collection<Type.TypeID> unsupportedTypeIds() {
+    return UNSUPPORTED_TYPE_IDS;
+  }
+
+  @Override
+  protected boolean supportsBatchReads() {
+    return true;
+  }
+
+  @Override
+  protected Object engineSchema(Schema schema) {
+    return SparkSchemaUtil.convert(schema);
+  }
+
+  @Override
+  protected Object convertConstantToEngine(Type type, Object value) {
+    return SparkUtil.internalToSpark(type, value);
+  }
+
+  @Override
+  protected Class<ColumnarBatch> engineType() {
+    return ColumnarBatch.class;
+  }
+
+  @Override
+  protected ColumnarBatch convertToEngine(Record record, Schema schema) {
+    throw new UnsupportedOperationException("Vectorized reads are read-only");
+  }
+
+  @Override
+  protected void assertEquals(
+      Schema schema, List<ColumnarBatch> expected, List<ColumnarBatch> actual) {
+    throw new UnsupportedOperationException("Use assertRecordsEqual for batch reads");
+  }
+
+  @Override
+  protected void assertRecordsEqual(
+      Schema schema, List<Record> expected, List<ColumnarBatch> actual) {
+    int rowId = 0;
+    for (ColumnarBatch batch : actual) {
+      for (int i = 0; i < batch.numRows(); i++) {
+        TestHelpers.assertEquals(
+            schema, InternalRowConverter.convert(schema, expected.get(rowId)), batch.getRow(i));
+        rowId++;
+      }
+    }
+
+    assertThat(rowId).isEqualTo(expected.size());
+  }
+}


### PR DESCRIPTION
Adds a TCK subclass for Spark's vectorized `ColumnarBatch` read path.

`TestSparkVectorizedFormatModel` extends `ReadFormatModelTests` and redefines `FILE_FORMATS` and `FORMAT_AND_GENERATOR` to skip Avro, which has no `ColumnarBatch` model registered. This required making `DataGenerator`, `DataGenerators` and `DataGenerators.ALL` public in the test package.

Two base class changes were needed:

- `assertRecordsEqual()` - read tests built expectations via `convertToEngineRecords`, which can't work for a batch type
- Read assertions moved inside try-with-resources, columnar batches don't survive the reader closing