### PR TITLE
[1.11.x] Core, REST: Fix delete file references for DVs in the same Puffin file

### DIFF
--- a/api/src/main/java/org/apache/iceberg/util/DeleteFileSet.java
+++ b/api/src/main/java/org/apache/iceberg/util/DeleteFileSet.java
@@ -18,7 +18,6 @@
  */
 package org.apache.iceberg.util;
 
-import java.util.Objects;
 import org.apache.iceberg.DeleteFile;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
@@ -62,54 +61,5 @@ public class DeleteFileSet extends WrapperSet<DeleteFile> {
   @Override
   protected Class<DeleteFile> elementClass() {
     return DeleteFile.class;
-  }
-
-  private static class DeleteFileWrapper implements Wrapper<DeleteFile> {
-    private DeleteFile file;
-
-    private DeleteFileWrapper(DeleteFile file) {
-      this.file = file;
-    }
-
-    private static DeleteFileWrapper wrap(DeleteFile deleteFile) {
-      return new DeleteFileWrapper(deleteFile);
-    }
-
-    @Override
-    public DeleteFile get() {
-      return file;
-    }
-
-    @Override
-    public Wrapper<DeleteFile> set(DeleteFile deleteFile) {
-      this.file = deleteFile;
-      return this;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) {
-        return true;
-      }
-
-      if (!(o instanceof DeleteFileWrapper)) {
-        return false;
-      }
-
-      DeleteFileWrapper that = (DeleteFileWrapper) o;
-      return Objects.equals(file.location(), that.file.location())
-          && Objects.equals(file.contentOffset(), that.file.contentOffset())
-          && Objects.equals(file.contentSizeInBytes(), that.file.contentSizeInBytes());
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(file.location(), file.contentOffset(), file.contentSizeInBytes());
-    }
-
-    @Override
-    public String toString() {
-      return file.location();
-    }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/util/DeleteFileWrapper.java
+++ b/api/src/main/java/org/apache/iceberg/util/DeleteFileWrapper.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import java.util.Objects;
+import org.apache.iceberg.DeleteFile;
+
+/**
+ * Wrapper class to adapt DeleteFile for use in maps and sets.
+ *
+ * <p>Delete files are identified by location and content range rather than location alone, as a
+ * single Puffin file can hold multiple deletion vectors.
+ */
+public class DeleteFileWrapper implements WrapperSet.Wrapper<DeleteFile> {
+  public static DeleteFileWrapper wrap(DeleteFile deleteFile) {
+    return new DeleteFileWrapper(deleteFile);
+  }
+
+  private DeleteFile file;
+
+  private DeleteFileWrapper(DeleteFile file) {
+    this.file = file;
+  }
+
+  @Override
+  public DeleteFile get() {
+    return file;
+  }
+
+  @Override
+  public DeleteFileWrapper set(DeleteFile deleteFile) {
+    this.file = deleteFile;
+    return this;
+  }
+
+  @Override
+  public boolean equals(Object other) {
+    if (this == other) {
+      return true;
+    }
+
+    if (!(other instanceof DeleteFileWrapper)) {
+      return false;
+    }
+
+    DeleteFileWrapper that = (DeleteFileWrapper) other;
+    return Objects.equals(file.location(), that.file.location())
+        && Objects.equals(file.contentOffset(), that.file.contentOffset())
+        && Objects.equals(file.contentSizeInBytes(), that.file.contentSizeInBytes());
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(file.location(), file.contentOffset(), file.contentSizeInBytes());
+  }
+
+  @Override
+  public String toString() {
+    return file.location();
+  }
+}

--- a/core/src/main/java/org/apache/iceberg/rest/TableScanResponseParser.java
+++ b/core/src/main/java/org/apache/iceberg/rest/TableScanResponseParser.java
@@ -33,6 +33,7 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
+import org.apache.iceberg.util.DeleteFileWrapper;
 import org.apache.iceberg.util.JsonUtil;
 
 public class TableScanResponseParser {
@@ -99,15 +100,16 @@ public class TableScanResponseParser {
       Map<Integer, PartitionSpec> specsById,
       JsonGenerator gen)
       throws IOException {
-    Map<String, Integer> deleteFilePathToIndex = Maps.newHashMap();
+    // DeleteFileWrapper is required for uniqueness by location and content range
+    Map<DeleteFileWrapper, Integer> deleteFileToIndex = Maps.newHashMap();
     if (deleteFiles != null && !deleteFiles.isEmpty()) {
       Preconditions.checkArgument(
           specsById != null, "Cannot serialize response without specs by ID defined");
       gen.writeArrayFieldStart(DELETE_FILES);
       for (int i = 0; i < deleteFiles.size(); i++) {
         DeleteFile deleteFile = deleteFiles.get(i);
-        deleteFilePathToIndex.put(deleteFile.location(), i);
-        ContentFileParser.toJson(deleteFiles.get(i), specsById.get(deleteFile.specId()), gen);
+        deleteFileToIndex.put(DeleteFileWrapper.wrap(deleteFile), i);
+        ContentFileParser.toJson(deleteFile, specsById.get(deleteFile.specId()), gen);
       }
 
       gen.writeEndArray();
@@ -119,7 +121,12 @@ public class TableScanResponseParser {
         Set<Integer> deleteFileReferences = Sets.newHashSet();
         if (deleteFiles != null) {
           for (DeleteFile taskDelete : fileScanTask.deletes()) {
-            deleteFileReferences.add(deleteFilePathToIndex.get(taskDelete.location()));
+            Integer index = deleteFileToIndex.get(DeleteFileWrapper.wrap(taskDelete));
+            Preconditions.checkArgument(
+                index != null,
+                "Cannot serialize scan task with delete file missing from delete files: %s",
+                taskDelete.location());
+            deleteFileReferences.add(index);
           }
         }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestTableScanResponseParser.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.rest;
+
+import static org.apache.iceberg.TestBase.FILE_A;
+import static org.apache.iceberg.TestBase.FILE_A_DELETES;
+import static org.apache.iceberg.TestBase.FILE_B_DELETES;
+import static org.apache.iceberg.TestBase.PARTITION_SPECS_BY_ID;
+import static org.apache.iceberg.TestBase.SCHEMA;
+import static org.apache.iceberg.TestBase.SPEC;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.PartitionSpecParser;
+import org.apache.iceberg.SchemaParser;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.expressions.ResidualEvaluator;
+import org.apache.iceberg.util.JsonUtil;
+import org.junit.jupiter.api.Test;
+
+public class TestTableScanResponseParser {
+
+  @Test
+  public void cannotSerializeScanTaskWithDeleteFileMissingFromDeleteFiles() {
+    ResidualEvaluator residualEvaluator =
+        ResidualEvaluator.of(SPEC, Expressions.alwaysTrue(), true);
+    FileScanTask fileScanTask =
+        new BaseFileScanTask(
+            FILE_A,
+            new DeleteFile[] {FILE_A_DELETES},
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            residualEvaluator);
+
+    // The task references FILE_A_DELETES, but the delete files list only contains FILE_B_DELETES,
+    // so the referenced delete file cannot be resolved to an index.
+    assertThatThrownBy(
+            () ->
+                JsonUtil.generate(
+                    gen -> {
+                      gen.writeStartObject();
+                      TableScanResponseParser.serializeScanTasks(
+                          List.of(fileScanTask),
+                          List.of(FILE_B_DELETES),
+                          PARTITION_SPECS_BY_ID,
+                          gen);
+                      gen.writeEndObject();
+                    },
+                    false))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(
+            "Cannot serialize scan task with delete file missing from delete files: "
+                + FILE_A_DELETES.location());
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
+++ b/core/src/test/java/org/apache/iceberg/rest/responses/TestPlanTableScanResponseParser.java
@@ -32,7 +32,10 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.apache.iceberg.BaseFileScanTask;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
 import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileMetadata;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.PartitionSpecParser;
 import org.apache.iceberg.SchemaParser;
@@ -384,6 +387,94 @@ public class TestPlanTableScanResponseParser {
             + "}";
     String json = PlanTableScanResponseParser.toJson(response, true);
     assertThat(json).isEqualTo(expectedJson);
+  }
+
+  @Test
+  public void deleteFileReferencesDistinguishDVsInTheSamePuffinFile() {
+    DataFile dataFile1 =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-1.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    DataFile dataFile2 =
+        DataFiles.builder(SPEC)
+            .withPath("/path/to/data-2.parquet")
+            .withFileSizeInBytes(10)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .build();
+
+    // A single Puffin file holds a DV for each data file, distinguished only by content range
+    DeleteFile dv1 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/deletes.puffin")
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .withReferencedDataFile(dataFile1.location())
+            .withContentOffset(4)
+            .withContentSizeInBytes(40)
+            .build();
+
+    DeleteFile dv2 =
+        FileMetadata.deleteFileBuilder(SPEC)
+            .ofPositionDeletes()
+            .withPath("/path/to/deletes.puffin")
+            .withFileSizeInBytes(100)
+            .withPartitionPath("data_bucket=0")
+            .withRecordCount(1)
+            .withReferencedDataFile(dataFile2.location())
+            .withContentOffset(44)
+            .withContentSizeInBytes(30)
+            .build();
+
+    ResidualEvaluator residualEvaluator =
+        ResidualEvaluator.of(SPEC, Expressions.alwaysTrue(), true);
+    FileScanTask task1 =
+        new BaseFileScanTask(
+            dataFile1,
+            new DeleteFile[] {dv1},
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            residualEvaluator);
+    FileScanTask task2 =
+        new BaseFileScanTask(
+            dataFile2,
+            new DeleteFile[] {dv2},
+            SchemaParser.toJson(SCHEMA),
+            PartitionSpecParser.toJson(SPEC),
+            residualEvaluator);
+
+    PlanTableScanResponse response =
+        PlanTableScanResponse.builder()
+            .withPlanStatus(PlanStatus.COMPLETED)
+            .withFileScanTasks(List.of(task1, task2))
+            .withSpecsById(PARTITION_SPECS_BY_ID)
+            .build();
+
+    String json = PlanTableScanResponseParser.toJson(response);
+    PlanTableScanResponse fromResponse =
+        PlanTableScanResponseParser.fromJson(json, PARTITION_SPECS_BY_ID, false);
+
+    assertThat(fromResponse.deleteFiles()).hasSize(2);
+
+    List<FileScanTask> tasks = fromResponse.fileScanTasks();
+    assertThat(tasks).hasSize(2);
+
+    // each task must resolve back to the DV covering its own data file
+    for (FileScanTask task : tasks) {
+      assertThat(task.deletes()).hasSize(1);
+      DeleteFile taskDelete = task.deletes().get(0);
+      assertThat(taskDelete.referencedDataFile()).isEqualTo(task.file().location());
+
+      DeleteFile expected = task.file().location().equals(dataFile1.location()) ? dv1 : dv2;
+      assertThat(taskDelete.contentOffset()).isEqualTo(expected.contentOffset());
+      assertThat(taskDelete.contentSizeInBytes()).isEqualTo(expected.contentSizeInBytes());
+    }
   }
 
   @Test

--- a/core/src/test/java/org/apache/iceberg/util/TestDeleteFileWrapper.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestDeleteFileWrapper.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.apache.iceberg.TestBase.FILE_A_DELETES;
+import static org.apache.iceberg.TestBase.FILE_B_DELETES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.DeleteFile;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.FileMetadata;
+import org.apache.iceberg.PartitionSpec;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Testing {@link DeleteFileWrapper} is easier in iceberg-core since the delete file builders are
+ * located here
+ */
+public class TestDeleteFileWrapper {
+
+  // TestBase does not provide two deletion vectors at the same location which is required to
+  // exercise the content offset/size identity, so build them locally.
+  private static DeleteFile dv(String path, long contentOffset, long contentSizeInBytes) {
+    return FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+        .ofPositionDeletes()
+        .withPath(path)
+        .withFormat(FileFormat.PUFFIN)
+        .withFileSizeInBytes(100)
+        .withRecordCount(1)
+        .withReferencedDataFile("/path/to/data.parquet")
+        .withContentOffset(contentOffset)
+        .withContentSizeInBytes(contentSizeInBytes)
+        .build();
+  }
+
+  @Test
+  public void equalsWithSameLocationOffsetAndSize() {
+    // different DeleteFile instances with the same location but differing metadata
+    DeleteFile copy =
+        FileMetadata.deleteFileBuilder(PartitionSpec.unpartitioned())
+            .ofPositionDeletes()
+            .withPath(FILE_A_DELETES.location())
+            .withFileSizeInBytes(1234)
+            .withRecordCount(567)
+            .build();
+
+    DeleteFileWrapper one = DeleteFileWrapper.wrap(FILE_A_DELETES);
+    DeleteFileWrapper two = DeleteFileWrapper.wrap(copy);
+
+    assertThat(one).isEqualTo(two);
+    assertThat(one.hashCode()).isEqualTo(two.hashCode());
+  }
+
+  @Test
+  public void notEqualsWithDifferentLocation() {
+    assertThat(DeleteFileWrapper.wrap(FILE_A_DELETES))
+        .isNotEqualTo(DeleteFileWrapper.wrap(FILE_B_DELETES));
+  }
+
+  @Test
+  public void notEqualsWithSameLocationButDifferentContentOffset() {
+    // two deletion vectors held in the same Puffin file, differing only by content offset
+    DeleteFileWrapper first = DeleteFileWrapper.wrap(dv("/path/to/dv.puffin", 0, 10));
+    DeleteFileWrapper second = DeleteFileWrapper.wrap(dv("/path/to/dv.puffin", 10, 10));
+
+    assertThat(first).isNotEqualTo(second);
+    assertThat(first.hashCode()).isNotEqualTo(second.hashCode());
+  }
+
+  @Test
+  public void notEqualsWithSameLocationButDifferentContentSize() {
+    // two deletion vectors held in the same Puffin file, differing only by content size
+    DeleteFileWrapper first = DeleteFileWrapper.wrap(dv("/path/to/dv.puffin", 0, 10));
+    DeleteFileWrapper second = DeleteFileWrapper.wrap(dv("/path/to/dv.puffin", 0, 20));
+
+    assertThat(first).isNotEqualTo(second);
+    assertThat(first.hashCode()).isNotEqualTo(second.hashCode());
+  }
+
+  @Test
+  public void set() {
+    DeleteFileWrapper wrapper = DeleteFileWrapper.wrap(FILE_A_DELETES);
+    assertThat(wrapper.get()).isEqualTo(FILE_A_DELETES);
+    assertThat(wrapper).isEqualTo(DeleteFileWrapper.wrap(FILE_A_DELETES));
+
+    // set returns the same wrapper, allowing reuse for lookups
+    assertThat(wrapper.set(FILE_B_DELETES)).isSameAs(wrapper);
+    assertThat(wrapper.get()).isEqualTo(FILE_B_DELETES);
+    assertThat(wrapper).isEqualTo(DeleteFileWrapper.wrap(FILE_B_DELETES));
+    assertThat(wrapper.hashCode()).isEqualTo(DeleteFileWrapper.wrap(FILE_B_DELETES).hashCode());
+  }
+
+  @Test
+  public void toStringReturnsLocation() {
+    assertThat(DeleteFileWrapper.wrap(FILE_A_DELETES)).hasToString(FILE_A_DELETES.location());
+  }
+
+  @Test
+  public void notEqualsWithNonWrapper() {
+    assertThat(DeleteFileWrapper.wrap(FILE_A_DELETES)).isNotEqualTo(FILE_A_DELETES);
+  }
+
+  @Test
+  public void notEqualsWithNull() {
+    assertThat(DeleteFileWrapper.wrap(FILE_A_DELETES)).isNotNull();
+  }
+}


### PR DESCRIPTION
This PR aims to backport the following PR to branch 1.11
- https://github.com/apache/iceberg/pull/17497