### PR TITLE
Kafka Connect: Support timestamp_ns in RecordConverter

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -68,6 +68,7 @@ import org.apache.iceberg.types.Types.ListType;
 import org.apache.iceberg.types.Types.MapType;
 import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StructType;
+import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.util.ByteBuffers;
 import org.apache.iceberg.util.DateTimeUtil;
@@ -161,6 +162,8 @@ class RecordConverter {
         return convertTimeValue(value);
       case TIMESTAMP:
         return convertTimestampValue(value, (TimestampType) type);
+      case TIMESTAMP_NANO:
+        return convertTimestampNanoValue(value, (TimestampNanoType) type);
       case VARIANT:
         return convertVariantValue(value);
     }
@@ -569,6 +572,24 @@ class RecordConverter {
   }
 
   protected Temporal convertTimestampValue(Object value, TimestampType type) {
+    if (type.shouldAdjustToUTC()) {
+      return convertOffsetDateTime(value);
+    }
+    return convertLocalDateTime(value);
+  }
+
+  /**
+   * Converts a value for a {@code timestamp_ns} column.
+   *
+   * <p>The Java representations are the same as for {@code timestamp} ({@link OffsetDateTime} and
+   * {@link LocalDateTime}), so the same converters are reused. Those types carry nanoseconds, and
+   * the ISO parser accepts them, so nanosecond precision survives for string and temporal inputs.
+   *
+   * <p>A numeric input is interpreted as milliseconds, consistent with {@code timestamp} in the
+   * same switch and with the Kafka Connect {@code Timestamp} logical type, which is
+   * millisecond-based and cannot express finer precision.
+   */
+  protected Temporal convertTimestampNanoValue(Object value, TimestampNanoType type) {
     if (type.shouldAdjustToUTC()) {
       return convertOffsetDateTime(value);
     }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -73,6 +73,7 @@ import org.apache.iceberg.types.Types.NestedField;
 import org.apache.iceberg.types.Types.StringType;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.types.Types.TimeType;
+import org.apache.iceberg.types.Types.TimestampNanoType;
 import org.apache.iceberg.types.Types.TimestampType;
 import org.apache.iceberg.types.Types.UUIDType;
 import org.apache.iceberg.types.Types.VariantType;
@@ -1805,5 +1806,67 @@ public class TestRecordConverter {
     GenericRecord rec = (GenericRecord) record;
     assertThat(rec.getField("ii")).isEqualTo(11);
     assertRecordValues((GenericRecord) rec.getField("st"));
+  }
+
+  /**
+   * timestamp_ns exists to carry nanoseconds, so the precision has to survive the conversion. A
+   * string and an OffsetDateTime both carry nanos, and reusing the timestamp converters preserves
+   * them.
+   */
+  @Test
+  public void testTimestampNanoConversionKeepsNanosecondPrecision() {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    OffsetDateTime expected = OffsetDateTime.parse("2023-05-18T07:14:21.123456789Z");
+
+    ImmutableList.of("2023-05-18T07:14:21.123456789Z", expected)
+        .forEach(
+            input -> {
+              Temporal val =
+                  converter.convertTimestampNanoValue(input, TimestampNanoType.withZone());
+              assertThat(val).isEqualTo(expected);
+              assertThat(((OffsetDateTime) val).getNano()).isEqualTo(123456789);
+            });
+  }
+
+  @Test
+  public void testTimestampNanoConversionWithoutZone() {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    LocalDateTime expected = LocalDateTime.parse("2023-05-18T07:14:21.123456789");
+
+    Temporal val =
+        converter.convertTimestampNanoValue(
+            "2023-05-18T07:14:21.123456789", TimestampNanoType.withoutZone());
+
+    assertThat(val).isEqualTo(expected);
+    assertThat(((LocalDateTime) val).getNano()).isEqualTo(123456789);
+  }
+
+  /**
+   * A numeric is milliseconds, matching the timestamp case in the same switch and the Kafka Connect
+   * Timestamp logical type. Pinned deliberately: reading it as nanoseconds instead would silently
+   * shift every such value by six orders of magnitude.
+   */
+  @Test
+  public void testTimestampNanoConversionTreatsNumberAsMillis() {
+    Table table = mock(Table.class);
+    when(table.schema()).thenReturn(SIMPLE_SCHEMA);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    long millis = OffsetDateTime.parse("2023-05-18T07:14:21Z").toInstant().toEpochMilli();
+
+    Temporal nanoVal = converter.convertTimestampNanoValue(millis, TimestampNanoType.withZone());
+    Temporal microVal = converter.convertTimestampValue(millis, TimestampType.withZone());
+
+    assertThat(nanoVal).isEqualTo(OffsetDateTime.parse("2023-05-18T07:14:21Z"));
+    assertThat(nanoVal).as("must agree with the timestamp path").isEqualTo(microVal);
   }
 }


### PR DESCRIPTION
Part of #15443.

### The gap

`RecordConverter` has no `case TIMESTAMP_NANO`, so writing to a table with a `timestamp_ns` column through the Kafka Connect sink fails outright, while Spark handles the same column:

```
UnsupportedOperationException: Unsupported type: timestamp_ns
```

The generic object model already supports the type, so the sink was the only thing missing:

```java
// GenericDataUtil.java:54
case TIMESTAMP_NANO:
  if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
    return DateTimeUtil.timestamptzFromNanos((Long) value);
  } else {
    return DateTimeUtil.timestampFromNanos((Long) value);
  }
```

### The change

The Java representations for `timestamp_ns` are the same as for `timestamp` — `OffsetDateTime` and `LocalDateTime` — so `convertTimestampNanoValue` mirrors `convertTimestampValue` and reuses the existing converters. Both types carry nanoseconds and the ISO parser accepts them, so precision survives for string and temporal inputs without any new parsing code.

### The one decision worth reviewing

**A numeric input stays milliseconds.** `convertOffsetDateTime` / `convertLocalDateTime` do `millis * 1000`, which is the Kafka Connect `Timestamp` logical type convention, and it is what `case TIMESTAMP` already does in the same switch.

I chose consistency over matching the column's unit, for two reasons: Connect's `Timestamp` is millisecond-based and cannot express finer precision anyway, and having two adjacent cases in one switch disagree about what a bare number means seemed worse than the theoretical loss. Nanosecond data realistically arrives as an ISO string or a temporal, both of which keep full precision here.

It is pinned by a test rather than left implicit, because reading a number as nanoseconds instead would shift every such value by six orders of magnitude **without failing**:

```java
Temporal nanoVal = converter.convertTimestampNanoValue(millis, TimestampNanoType.withZone());
Temporal microVal = converter.convertTimestampValue(millis, TimestampType.withZone());
assertThat(nanoVal).as("must agree with the timestamp path").isEqualTo(microVal);
```

If you would rather a numeric were interpreted as nanoseconds for this type, it is a small change and I am happy to make it — I would just want it to be a deliberate choice rather than mine.

### Tests

Three added, `TestRecordConverter` at 62 tests, 0 failures:

- nanosecond precision preserved from an ISO string and from an `OffsetDateTime` (`.getNano() == 123456789`)
- the same for `withoutZone()` / `LocalDateTime`
- a numeric agrees with the `timestamp` path, pinning the millisecond decision

`spotlessCheck`, `checkstyleMain` and `checkstyleTest` pass on the module.

### Deliberately not included

#15443 also mentions geometry, geography and unknown. I left those out:

- **geometry / geography** have no value representation in the generic object model — nothing in `GenericDataUtil` or `GenericRecord`, and `BaseParquetWriter` dispatches on Parquet primitives rather than Iceberg type ids. Supporting them here would mean inventing a Connect-to-WKB convention with no precedent in the generic path.
- **unknown** is documented in the spec as *"Must be optional with `null` defaults; not stored in data files"* (spec.md:267), so the current exception may well be correct. Whether the sink should write null instead is a behaviour decision I did not want to make unilaterally.

Variant, the original subject of #15443, is already supported on `main` — that issue predates it.