### PR TITLE
Kafka Connect: Remove deprecated TableReference and IcebergWriterResult members

### DIFF
--- a/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
+++ b/kafka-connect/kafka-connect-events/src/main/java/org/apache/iceberg/connect/events/TableReference.java
@@ -58,16 +58,6 @@ public class TableReference implements IndexedRecord {
           NestedField.optional(TABLE_UUID, "table_uuid", UUIDType.get()));
   private static final Schema AVRO_SCHEMA = AvroUtil.convert(ICEBERG_SCHEMA, TableReference.class);
 
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link TableReference#of(String,
-   *     TableIdentifier, UUID)}
-   */
-  @Deprecated
-  public static TableReference of(String catalog, TableIdentifier tableIdentifier) {
-    return new TableReference(
-        catalog, Arrays.asList(tableIdentifier.namespace().levels()), tableIdentifier.name(), null);
-  }
-
   public static TableReference of(String catalog, TableIdentifier tableIdentifier, UUID tableUuid) {
     return new TableReference(
         catalog,
@@ -79,21 +69,6 @@ public class TableReference implements IndexedRecord {
   // Used by Avro reflection to instantiate this class when reading events
   public TableReference(Schema avroSchema) {
     this.avroSchema = avroSchema;
-  }
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link TableReference#of(String,
-   *     TableIdentifier, UUID)}.
-   */
-  @Deprecated
-  public TableReference(String catalog, List<String> namespace, String name) {
-    Preconditions.checkNotNull(catalog, "Catalog cannot be null");
-    Preconditions.checkNotNull(namespace, "Namespace cannot be null");
-    Preconditions.checkNotNull(name, "Name cannot be null");
-    this.catalog = catalog;
-    this.namespace = namespace;
-    this.name = name;
-    this.avroSchema = AVRO_SCHEMA;
   }
 
   private TableReference(String catalog, List<String> namespace, String name, UUID uuid) {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterResult.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/IcebergWriterResult.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.connect.data;
 import java.util.List;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.DeleteFile;
-import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.types.Types.StructType;
 
@@ -43,33 +42,8 @@ public class IcebergWriterResult {
     this.partitionStruct = partitionStruct;
   }
 
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     IcebergWriterResult#IcebergWriterResult(TableReference, List, List, StructType)} instead
-   */
-  @Deprecated
-  public IcebergWriterResult(
-      TableIdentifier tableIdentifier,
-      List<DataFile> dataFiles,
-      List<DeleteFile> deleteFiles,
-      StructType partitionStruct) {
-    this.tableReference = TableReference.of("unknown", tableIdentifier);
-    this.dataFiles = dataFiles;
-    this.deleteFiles = deleteFiles;
-    this.partitionStruct = partitionStruct;
-  }
-
   public TableReference tableReference() {
     return tableReference;
-  }
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@code tableReference().identifier()}
-   *     instead
-   */
-  @Deprecated
-  public TableIdentifier tableIdentifier() {
-    return tableReference.identifier();
   }
 
   public List<DataFile> dataFiles() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestWorker.java
@@ -37,6 +37,7 @@ import org.apache.iceberg.connect.events.DataWritten;
 import org.apache.iceberg.connect.events.Event;
 import org.apache.iceberg.connect.events.PayloadType;
 import org.apache.iceberg.connect.events.StartCommit;
+import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
@@ -67,7 +68,7 @@ public class TestWorker extends ChannelTestBase {
 
       IcebergWriterResult writeResult =
           new IcebergWriterResult(
-              TableIdentifier.parse(TABLE_NAME),
+              TableReference.of("unknown", TableIdentifier.parse(TABLE_NAME), null),
               ImmutableList.of(EventTestUtil.createDataFile()),
               ImmutableList.of(),
               StructType.of());

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
@@ -39,6 +39,7 @@ import org.apache.iceberg.catalog.Namespace;
 import org.apache.iceberg.catalog.TableIdentifier;
 import org.apache.iceberg.connect.IcebergSinkConfig;
 import org.apache.iceberg.connect.TableSinkConfig;
+import org.apache.iceberg.connect.events.TableReference;
 import org.apache.iceberg.inmemory.InMemoryCatalog;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
@@ -164,7 +165,7 @@ public class TestSinkWriter {
 
     IcebergWriterResult writeResult =
         new IcebergWriterResult(
-            TableIdentifier.parse(TABLE_NAME),
+            TableReference.of("unknown", TableIdentifier.parse(TABLE_NAME), null),
             ImmutableList.of(mock(DataFile.class)),
             ImmutableList.of(),
             Types.StructType.of());
@@ -281,7 +282,7 @@ public class TestSinkWriter {
       Map<String, Object> value, IcebergSinkConfig config) {
     IcebergWriterResult writeResult =
         new IcebergWriterResult(
-            TableIdentifier.parse(TABLE_NAME),
+            TableReference.of("unknown", TableIdentifier.parse(TABLE_NAME), null),
             ImmutableList.of(mock(DataFile.class)),
             ImmutableList.of(),
             Types.StructType.of());


### PR DESCRIPTION
Remove deprecated method from #14979 for 1.12.0:
- TableReference.of(String, TableIdentifier) and the TableReference(String, List<String>, String) constructor
- IcebergWriterResult(TableIdentifier, List, List, StructType) and IcebergWriterResult.tableIdentifier()

Callers now construct a TableReference with an explicit table UUID; the two tests pass null to preserve their previous behavior.

## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone

