### PR TITLE
Flink: Remove deprecated RewriteDataFiles.Builder.filter(Expression)

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -210,20 +210,6 @@ public class RewriteDataFiles {
     }
 
     /**
-     * A user provided filter for determining which files will be considered by the rewrite
-     * strategy.
-     *
-     * @param newFilter the filter expression to apply
-     * @return this for method chaining
-     * @deprecated will be removed in 1.12.0. Use {@link #filter(SerializableSupplier)} instead
-     */
-    @Deprecated
-    public Builder filter(Expression newFilter) {
-      this.filterSupplier = () -> newFilter;
-      return this;
-    }
-
-    /**
      * A user-provided supplier of a filter expression that determines which files are considered by
      * the rewrite strategy.
      *

--- a/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v1.20/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -546,7 +546,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
             .minFileSizeBytes(500_000L)
             .minInputFiles(2)
             // Only rewrite data files where id is 1 or 2 for testing rewrite
-            .filter(Expressions.in("id", 1, 2))
+            .filter(() -> Expressions.in("id", 1, 2))
             .partialProgressEnabled(true)
             .partialProgressMaxCommits(1)
             .maxRewriteBytes(100_000L)

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -210,20 +210,6 @@ public class RewriteDataFiles {
     }
 
     /**
-     * A user provided filter for determining which files will be considered by the rewrite
-     * strategy.
-     *
-     * @param newFilter the filter expression to apply
-     * @return this for method chaining
-     * @deprecated will be removed in 1.12.0. Use {@link #filter(SerializableSupplier)} instead
-     */
-    @Deprecated
-    public Builder filter(Expression newFilter) {
-      this.filterSupplier = () -> newFilter;
-      return this;
-    }
-
-    /**
      * A user-provided supplier of a filter expression that determines which files are considered by
      * the rewrite strategy.
      *

--- a/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.0/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -546,7 +546,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
             .minFileSizeBytes(500_000L)
             .minInputFiles(2)
             // Only rewrite data files where id is 1 or 2 for testing rewrite
-            .filter(Expressions.in("id", 1, 2))
+            .filter(() -> Expressions.in("id", 1, 2))
             .partialProgressEnabled(true)
             .partialProgressMaxCommits(1)
             .maxRewriteBytes(100_000L)

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/maintenance/api/RewriteDataFiles.java
@@ -210,20 +210,6 @@ public class RewriteDataFiles {
     }
 
     /**
-     * A user provided filter for determining which files will be considered by the rewrite
-     * strategy.
-     *
-     * @param newFilter the filter expression to apply
-     * @return this for method chaining
-     * @deprecated will be removed in 1.12.0. Use {@link #filter(SerializableSupplier)} instead
-     */
-    @Deprecated
-    public Builder filter(Expression newFilter) {
-      this.filterSupplier = () -> newFilter;
-      return this;
-    }
-
-    /**
      * A user-provided supplier of a filter expression that determines which files are considered by
      * the rewrite strategy.
      *

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/maintenance/api/TestRewriteDataFiles.java
@@ -546,7 +546,7 @@ class TestRewriteDataFiles extends MaintenanceTaskTestBase {
             .minFileSizeBytes(500_000L)
             .minInputFiles(2)
             // Only rewrite data files where id is 1 or 2 for testing rewrite
-            .filter(Expressions.in("id", 1, 2))
+            .filter(() -> Expressions.in("id", 1, 2))
             .partialProgressEnabled(true)
             .partialProgressMaxCommits(1)
             .maxRewriteBytes(100_000L)


### PR DESCRIPTION
Deprecated for removal in 1.12.0 in favor of
filter(SerializableSupplier<Expression>). Updated the one test caller in each version to pass a supplier.

Applies to Flink 1.20, 2.0 and 2.1.

## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone

FYI @Guosmilesmile if you want to check 