### PR TITLE
Spark: Remove deprecated and unused methods in SparkRead/WriteConf and SparkSchemaUtil

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -197,25 +197,6 @@ public class SparkSchemaUtil {
    *
    * @param baseSchema a Schema on which conversion is based
    * @param sparkType a Spark StructType
-   * @return the equivalent Schema
-   * @throws IllegalArgumentException if the type cannot be converted or there are missing ids
-   * @deprecated since 1.11.0, will be removed in 1.12.0
-   */
-  @Deprecated
-  public static Schema convertWithFreshIds(Schema baseSchema, StructType sparkType) {
-    return convertWithFreshIds(baseSchema, sparkType, true);
-  }
-
-  /**
-   * Convert a Spark {@link StructType struct} to a {@link Schema} based on the given schema.
-   *
-   * <p>This conversion will assign new ids for fields that are not found in the base schema.
-   *
-   * <p>Data types, field order, and nullability will match the spark type. This conversion may
-   * return a schema that is not compatible with base schema.
-   *
-   * @param baseSchema a Schema on which conversion is based
-   * @param sparkType a Spark StructType
    * @param caseSensitive when false, case of field names in schema is ignored
    * @return the equivalent Schema
    * @throws IllegalArgumentException if the type cannot be converted or there are missing ids
@@ -246,32 +227,6 @@ public class SparkSchemaUtil {
   public static Schema prune(Schema schema, StructType requestedType) {
     return new Schema(
         TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, ImmutableSet.of()))
-            .asNestedType()
-            .asStructType()
-            .fields());
-  }
-
-  /**
-   * Prune columns from a {@link Schema} using a {@link StructType Spark type} projection.
-   *
-   * <p>This requires that the Spark type is a projection of the Schema. Nullability and types must
-   * match.
-   *
-   * <p>The filters list of {@link Expression} is used to ensure that columns referenced by filters
-   * are projected.
-   *
-   * @param schema a Schema
-   * @param requestedType a projection of the Spark representation of the Schema
-   * @param filters a list of filters
-   * @return a Schema corresponding to the Spark projection
-   * @throws IllegalArgumentException if the Spark type does not match the Schema
-   * @deprecated since 1.11.0, will be removed in 1.12.0
-   */
-  @Deprecated
-  public static Schema prune(Schema schema, StructType requestedType, List<Expression> filters) {
-    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), filters, true);
-    return new Schema(
-        TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
             .asNestedType()
             .asStructType()
             .fields());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkReadConf.java
@@ -64,16 +64,6 @@ public class SparkReadConf {
   }
 
   public SparkReadConf(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
-    this(spark, table, null, options);
-  }
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0. Use {@link #SparkReadConf(SparkSession,
-   *     Table, CaseInsensitiveStringMap)} instead.
-   */
-  @Deprecated
-  public SparkReadConf(
-      SparkSession spark, Table table, String branch, CaseInsensitiveStringMap options) {
     this.spark = spark;
     this.table = table;
     this.confParser = new SparkConfParser(spark, table, options);

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkSchemaUtil.java
@@ -198,25 +198,6 @@ public class SparkSchemaUtil {
    *
    * @param baseSchema a Schema on which conversion is based
    * @param sparkType a Spark StructType
-   * @return the equivalent Schema
-   * @throws IllegalArgumentException if the type cannot be converted or there are missing ids
-   * @deprecated since 1.11.0, will be removed in 1.12.0
-   */
-  @Deprecated
-  public static Schema convertWithFreshIds(Schema baseSchema, StructType sparkType) {
-    return convertWithFreshIds(baseSchema, sparkType, true);
-  }
-
-  /**
-   * Convert a Spark {@link StructType struct} to a {@link Schema} based on the given schema.
-   *
-   * <p>This conversion will assign new ids for fields that are not found in the base schema.
-   *
-   * <p>Data types, field order, and nullability will match the spark type. This conversion may
-   * return a schema that is not compatible with base schema.
-   *
-   * @param baseSchema a Schema on which conversion is based
-   * @param sparkType a Spark StructType
    * @param caseSensitive when false, case of field names in schema is ignored
    * @return the equivalent Schema
    * @throws IllegalArgumentException if the type cannot be converted or there are missing ids
@@ -247,32 +228,6 @@ public class SparkSchemaUtil {
   public static Schema prune(Schema schema, StructType requestedType) {
     return new Schema(
         TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, ImmutableSet.of()))
-            .asNestedType()
-            .asStructType()
-            .fields());
-  }
-
-  /**
-   * Prune columns from a {@link Schema} using a {@link StructType Spark type} projection.
-   *
-   * <p>This requires that the Spark type is a projection of the Schema. Nullability and types must
-   * match.
-   *
-   * <p>The filters list of {@link Expression} is used to ensure that columns referenced by filters
-   * are projected.
-   *
-   * @param schema a Schema
-   * @param requestedType a projection of the Spark representation of the Schema
-   * @param filters a list of filters
-   * @return a Schema corresponding to the Spark projection
-   * @throws IllegalArgumentException if the Spark type does not match the Schema
-   * @deprecated since 1.11.0, will be removed in 1.12.0
-   */
-  @Deprecated
-  public static Schema prune(Schema schema, StructType requestedType, List<Expression> filters) {
-    Set<Integer> filterRefs = Binder.boundReferences(schema.asStruct(), filters, true);
-    return new Schema(
-        TypeUtil.visit(schema, new PruneColumnsWithoutReordering(requestedType, filterRefs))
             .asNestedType()
             .asStructType()
             .fields());

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/SparkWriteConf.java
@@ -94,20 +94,10 @@ public class SparkWriteConf {
   private final SparkConfParser confParser;
 
   public SparkWriteConf(SparkSession spark, Table table) {
-    this(spark, table, null, CaseInsensitiveStringMap.empty());
+    this(spark, table, CaseInsensitiveStringMap.empty());
   }
 
   public SparkWriteConf(SparkSession spark, Table table, CaseInsensitiveStringMap options) {
-    this(spark, table, null, options);
-  }
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0. Use {@link #SparkWriteConf(SparkSession,
-   *     Table, CaseInsensitiveStringMap)} instead.
-   */
-  @Deprecated
-  public SparkWriteConf(
-      SparkSession spark, Table table, String branch, CaseInsensitiveStringMap options) {
     this.spark = spark;
     this.table = table;
     this.sessionConf = spark.conf();


### PR DESCRIPTION
Deprecated method in SparkTableUtil will follow up together with position-delete follow up

Note, https://github.com/apache/iceberg/pull/14308 only include the deprecation for latest spark 4.1 and it was later copied over to spark 4.0. Spark 3.5 was excluded as it was not marked as deprecated in iceberg 1.11 release and we anticipate that being removed given upcoming spark 4.2 integration

## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone