### PR TITLE
Core: Fix Z-order byte encoding for floating point values

### DIFF
--- a/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
+++ b/core/src/main/java/org/apache/iceberg/util/ZOrderByteUtils.java
@@ -102,7 +102,7 @@ public class ZOrderByteUtils {
   public static ByteBuffer floatingPointOrderedBytes(double val, ByteBuffer reuse) {
     ByteBuffer bytes = ByteBuffers.reuse(reuse, PRIMITIVE_BUFFER_SIZE);
     long lval = Double.doubleToLongBits(val);
-    lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
+    lval ^= ((lval >> (Long.SIZE - 1)) | Long.MIN_VALUE);
     bytes.putLong(lval);
     return bytes;
   }

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -24,7 +24,10 @@ import java.nio.ByteBuffer;
 import java.nio.charset.CharsetEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Random;
+import java.util.function.Function;
+import org.apache.iceberg.relocated.com.google.common.collect.Lists;
 import org.apache.iceberg.relocated.com.google.common.primitives.UnsignedBytes;
 import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.Test;
@@ -376,6 +379,97 @@ public class TestZOrderByteUtil {
               Arrays.toString(bBytes),
               byteCompare)
           .isEqualTo(stringCompare);
+    }
+  }
+
+  /**
+   * The random float/double ordering tests above draw from {@code nextFloat()}/{@code
+   * nextDouble()}, so the compared values essentially never agree on their high bits. Ordering is
+   * then decided by the high bits alone, which hides any corruption of the low bits. These cases
+   * pin the ordering for values that differ *only* in low mantissa bits, where the low bytes are
+   * what decides the comparison.
+   */
+  @Test
+  public void testFloatOrderingForConsecutiveMantissaValues() {
+    int baseBits = Float.floatToIntBits(1.0f);
+    List<Float> values = Lists.newArrayList();
+    for (int i = 0; i < 64; i++) {
+      values.add(Float.intBitsToFloat(baseBits + i));
+    }
+
+    assertOrderPreserved(
+        values, value -> encode(buffer -> ZOrderByteUtils.floatToOrderedBytes(value, buffer)));
+  }
+
+  @Test
+  public void testDoubleOrderingForValuesDifferingInLowMantissaBits() {
+    List<Double> values = Lists.newArrayList();
+    for (int i = 0; i < 64; i++) {
+      values.add(1.0d + (i * 0x1.0p-30));
+    }
+
+    assertOrderPreserved(
+        values, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+  }
+
+  @Test
+  public void testNegativeDoubleOrderingForValuesDifferingInLowMantissaBits() {
+    List<Double> values = Lists.newArrayList();
+    for (int i = 63; i >= 0; i--) {
+      values.add(-1.0d - (i * 0x1.0p-30));
+    }
+
+    assertOrderPreserved(
+        values, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+  }
+
+  /** Boundary pairs, including the ones that straddle zero and the extremes of the range. */
+  @Test
+  public void testDoubleOrderingForBoundaryPairs() {
+    double[][] ascendingPairs = {
+      {-921614.125d, -921614.0625d},
+      {-1.6001329423771755E213d, -1.600132804916327E213d},
+      {5.716890676284865E-207d, 5.7168911255697246E-207d},
+      {-Double.MIN_VALUE, 0.0d},
+      {0.0d, Double.MIN_VALUE},
+      {-Double.MAX_VALUE, Double.MAX_VALUE},
+      {-1.0d, 1.0d},
+    };
+
+    for (double[] pair : ascendingPairs) {
+      assertOrderPreserved(
+          Lists.newArrayList(pair[0], pair[1]),
+          value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+    }
+  }
+
+  private static byte[] encode(Function<ByteBuffer, ByteBuffer> encoder) {
+    return encoder.apply(ZOrderByteUtils.allocatePrimitiveBuffer()).array().clone();
+  }
+
+  /**
+   * Asserts that the given values, which must already be in ascending order, encode to
+   * lexicographically ascending bytes.
+   */
+  private static <T extends Comparable<T>> void assertOrderPreserved(
+      List<T> ascendingValues, Function<T, byte[]> encoder) {
+    for (int i = 1; i < ascendingValues.size(); i++) {
+      T smaller = ascendingValues.get(i - 1);
+      T larger = ascendingValues.get(i);
+      assertThat(smaller).isLessThan(larger);
+
+      byte[] smallerBytes = encoder.apply(smaller);
+      byte[] largerBytes = encoder.apply(larger);
+
+      assertThat(UnsignedBytes.lexicographicalComparator().compare(smallerBytes, largerBytes))
+          .as(
+              "Ordering of %s should match ordering of bytes, %s -> %s is not less than %s -> %s",
+              smaller.getClass().getSimpleName(),
+              smaller,
+              Arrays.toString(smallerBytes),
+              larger,
+              Arrays.toString(largerBytes))
+          .isNegative();
     }
   }
 

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -473,6 +473,76 @@ public class TestZOrderByteUtil {
     }
   }
 
+  /**
+   * The full IEEE-754 ladder, in {@link Double#compare} order: signed zeros are distinguished, the
+   * infinities bound the finite range, and NaN sorts above everything.
+   */
+  @Test
+  public void testDoubleOrderingAcrossSpecialValues() {
+    List<Double> ascending =
+        Lists.newArrayList(
+            Double.NEGATIVE_INFINITY,
+            -Double.MAX_VALUE,
+            -1.0d,
+            -Double.MIN_VALUE,
+            -0.0d,
+            0.0d,
+            Double.MIN_VALUE,
+            1.0d,
+            Double.MAX_VALUE,
+            Double.POSITIVE_INFINITY,
+            Double.NaN);
+
+    assertOrderPreserved(
+        ascending, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+  }
+
+  @Test
+  public void testFloatOrderingAcrossSpecialValues() {
+    List<Float> ascending =
+        Lists.newArrayList(
+            Float.NEGATIVE_INFINITY,
+            -Float.MAX_VALUE,
+            -1.0f,
+            -Float.MIN_VALUE,
+            -0.0f,
+            0.0f,
+            Float.MIN_VALUE,
+            1.0f,
+            Float.MAX_VALUE,
+            Float.POSITIVE_INFINITY,
+            Float.NaN);
+
+    assertOrderPreserved(
+        ascending, value -> encode(buffer -> ZOrderByteUtils.floatToOrderedBytes(value, buffer)));
+  }
+
+  /**
+   * The encoding goes through {@link Double#doubleToLongBits}, which collapses every NaN to the
+   * canonical quiet NaN. Distinct NaN payloads must therefore produce identical bytes, otherwise
+   * the z-order key would not be deterministic for NaN.
+   */
+  @Test
+  public void testDoubleOrderedBytesCanonicalizeNaN() {
+    byte[] canonical = encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(Double.NaN, buffer));
+
+    for (long rawNaNBits :
+        new long[] {
+          0x7ff8000000000001L, // quiet NaN, non-zero payload
+          0x7fffffffffffffffL, // quiet NaN, all payload bits set
+          0xfff8000000000000L, // NaN with the sign bit set
+          0x7ff0000000000001L // signalling NaN
+        }) {
+      double nan = Double.longBitsToDouble(rawNaNBits);
+      assertThat(Double.isNaN(nan)).isTrue();
+
+      byte[] actual = encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(nan, buffer));
+      assertThat(actual)
+          .as("NaN with raw bits 0x%016x must encode as the canonical NaN", rawNaNBits)
+          .isEqualTo(canonical);
+    }
+  }
+
   @Test
   public void testByteTruncatedOrFillNullIsZeroArray() {
     ByteBuffer buffer = ByteBuffer.allocate(128);

--- a/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
+++ b/core/src/test/java/org/apache/iceberg/util/TestZOrderByteUtil.java
@@ -386,8 +386,8 @@ public class TestZOrderByteUtil {
    * The random float/double ordering tests above draw from {@code nextFloat()}/{@code
    * nextDouble()}, so the compared values essentially never agree on their high bits. Ordering is
    * then decided by the high bits alone, which hides any corruption of the low bits. These cases
-   * pin the ordering for values that differ *only* in low mantissa bits, where the low bytes are
-   * what decides the comparison.
+   * pin the ordering for values that differ only in low mantissa bits, where the low bytes are what
+   * decides the comparison.
    */
   @Test
   public void testFloatOrderingForConsecutiveMantissaValues() {
@@ -397,8 +397,7 @@ public class TestZOrderByteUtil {
       values.add(Float.intBitsToFloat(baseBits + i));
     }
 
-    assertOrderPreserved(
-        values, value -> encode(buffer -> ZOrderByteUtils.floatToOrderedBytes(value, buffer)));
+    assertOrderPreserved(values, TestZOrderByteUtil::encodeFloat);
   }
 
   @Test
@@ -408,8 +407,7 @@ public class TestZOrderByteUtil {
       values.add(1.0d + (i * 0x1.0p-30));
     }
 
-    assertOrderPreserved(
-        values, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+    assertOrderPreserved(values, TestZOrderByteUtil::encodeDouble);
   }
 
   @Test
@@ -419,8 +417,7 @@ public class TestZOrderByteUtil {
       values.add(-1.0d - (i * 0x1.0p-30));
     }
 
-    assertOrderPreserved(
-        values, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+    assertOrderPreserved(values, TestZOrderByteUtil::encodeDouble);
   }
 
   /** Boundary pairs, including the ones that straddle zero and the extremes of the range. */
@@ -437,14 +434,96 @@ public class TestZOrderByteUtil {
     };
 
     for (double[] pair : ascendingPairs) {
-      assertOrderPreserved(
-          Lists.newArrayList(pair[0], pair[1]),
-          value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
+      assertOrderPreserved(Lists.newArrayList(pair[0], pair[1]), TestZOrderByteUtil::encodeDouble);
     }
   }
 
-  private static byte[] encode(Function<ByteBuffer, ByteBuffer> encoder) {
-    return encoder.apply(ZOrderByteUtils.allocatePrimitiveBuffer()).array().clone();
+  /**
+   * The full IEEE-754 ladder, in {@link Double#compare} order: signed zeros are distinguished, the
+   * infinities bound the finite range, and NaN sorts above everything.
+   */
+  @Test
+  public void testDoubleOrderingAcrossSpecialValues() {
+    List<Double> ascending =
+        Lists.newArrayList(
+            Double.NEGATIVE_INFINITY,
+            -Double.MAX_VALUE,
+            -1.0d,
+            -Double.MIN_VALUE,
+            -0.0d,
+            0.0d,
+            Double.MIN_VALUE,
+            1.0d,
+            Double.MAX_VALUE,
+            Double.POSITIVE_INFINITY,
+            Double.NaN);
+
+    assertOrderPreserved(ascending, TestZOrderByteUtil::encodeDouble);
+  }
+
+  @Test
+  public void testFloatOrderingAcrossSpecialValues() {
+    List<Float> ascending =
+        Lists.newArrayList(
+            Float.NEGATIVE_INFINITY,
+            -Float.MAX_VALUE,
+            -1.0f,
+            -Float.MIN_VALUE,
+            -0.0f,
+            0.0f,
+            Float.MIN_VALUE,
+            1.0f,
+            Float.MAX_VALUE,
+            Float.POSITIVE_INFINITY,
+            Float.NaN);
+
+    assertOrderPreserved(ascending, TestZOrderByteUtil::encodeFloat);
+  }
+
+  /**
+   * The encoding goes through {@link Double#doubleToLongBits}, which collapses every NaN to the
+   * canonical quiet NaN. Distinct NaN payloads must therefore produce identical bytes, otherwise
+   * the z-order key would not be deterministic for NaN.
+   */
+  @Test
+  public void testDoubleOrderedBytesCanonicalizesNaN() {
+    byte[] canonical = encodeDouble(Double.NaN);
+
+    for (long rawNaNBits :
+        new long[] {
+          0x7ff8000000000001L, // quiet NaN, non-zero payload
+          0x7fffffffffffffffL, // quiet NaN, all payload bits set
+          0xfff8000000000000L, // NaN with the sign bit set
+          0x7ff0000000000001L // signalling NaN
+        }) {
+      double nan = Double.longBitsToDouble(rawNaNBits);
+      assertThat(Double.isNaN(nan)).isTrue();
+
+      byte[] actual = encodeDouble(nan);
+      assertThat(actual)
+          .as("NaN with raw bits 0x%016x must encode as the canonical NaN", rawNaNBits)
+          .isEqualTo(canonical);
+    }
+  }
+
+  @Test
+  public void testByteTruncatedOrFillNullIsZeroArray() {
+    ByteBuffer buffer = ByteBuffer.allocate(128);
+    byte[] actualBytes = ZOrderByteUtils.byteTruncateOrFill(null, 128, buffer).array();
+    ByteBuffer expected = ByteBuffer.allocate(128);
+    Arrays.fill(expected.array(), 0, 128, (byte) 0x00);
+
+    assertThat(actualBytes).isEqualTo(expected.array());
+  }
+
+  private static byte[] encodeDouble(double value) {
+    return ZOrderByteUtils.doubleToOrderedBytes(value, ZOrderByteUtils.allocatePrimitiveBuffer())
+        .array();
+  }
+
+  private static byte[] encodeFloat(float value) {
+    return ZOrderByteUtils.floatToOrderedBytes(value, ZOrderByteUtils.allocatePrimitiveBuffer())
+        .array();
   }
 
   /**
@@ -471,85 +550,5 @@ public class TestZOrderByteUtil {
               Arrays.toString(largerBytes))
           .isNegative();
     }
-  }
-
-  /**
-   * The full IEEE-754 ladder, in {@link Double#compare} order: signed zeros are distinguished, the
-   * infinities bound the finite range, and NaN sorts above everything.
-   */
-  @Test
-  public void testDoubleOrderingAcrossSpecialValues() {
-    List<Double> ascending =
-        Lists.newArrayList(
-            Double.NEGATIVE_INFINITY,
-            -Double.MAX_VALUE,
-            -1.0d,
-            -Double.MIN_VALUE,
-            -0.0d,
-            0.0d,
-            Double.MIN_VALUE,
-            1.0d,
-            Double.MAX_VALUE,
-            Double.POSITIVE_INFINITY,
-            Double.NaN);
-
-    assertOrderPreserved(
-        ascending, value -> encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(value, buffer)));
-  }
-
-  @Test
-  public void testFloatOrderingAcrossSpecialValues() {
-    List<Float> ascending =
-        Lists.newArrayList(
-            Float.NEGATIVE_INFINITY,
-            -Float.MAX_VALUE,
-            -1.0f,
-            -Float.MIN_VALUE,
-            -0.0f,
-            0.0f,
-            Float.MIN_VALUE,
-            1.0f,
-            Float.MAX_VALUE,
-            Float.POSITIVE_INFINITY,
-            Float.NaN);
-
-    assertOrderPreserved(
-        ascending, value -> encode(buffer -> ZOrderByteUtils.floatToOrderedBytes(value, buffer)));
-  }
-
-  /**
-   * The encoding goes through {@link Double#doubleToLongBits}, which collapses every NaN to the
-   * canonical quiet NaN. Distinct NaN payloads must therefore produce identical bytes, otherwise
-   * the z-order key would not be deterministic for NaN.
-   */
-  @Test
-  public void testDoubleOrderedBytesCanonicalizeNaN() {
-    byte[] canonical = encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(Double.NaN, buffer));
-
-    for (long rawNaNBits :
-        new long[] {
-          0x7ff8000000000001L, // quiet NaN, non-zero payload
-          0x7fffffffffffffffL, // quiet NaN, all payload bits set
-          0xfff8000000000000L, // NaN with the sign bit set
-          0x7ff0000000000001L // signalling NaN
-        }) {
-      double nan = Double.longBitsToDouble(rawNaNBits);
-      assertThat(Double.isNaN(nan)).isTrue();
-
-      byte[] actual = encode(buffer -> ZOrderByteUtils.doubleToOrderedBytes(nan, buffer));
-      assertThat(actual)
-          .as("NaN with raw bits 0x%016x must encode as the canonical NaN", rawNaNBits)
-          .isEqualTo(canonical);
-    }
-  }
-
-  @Test
-  public void testByteTruncatedOrFillNullIsZeroArray() {
-    ByteBuffer buffer = ByteBuffer.allocate(128);
-    byte[] actualBytes = ZOrderByteUtils.byteTruncateOrFill(null, 128, buffer).array();
-    ByteBuffer expected = ByteBuffer.allocate(128);
-    Arrays.fill(expected.array(), 0, 128, (byte) 0x00);
-
-    assertThat(actualBytes).isEqualTo(expected.array());
   }
 }


### PR DESCRIPTION
Closes #17070.

Credit to @eye-gu, who reported this and identified the one-character fix. They ticked that they
could contribute it independently, so if a PR is already in flight I am happy to close this in
favour of it — six weeks had passed with no linked PR, so I verified the report and wrote it up
with tests.

## The bug

`ZOrderByteUtils.floatingPointOrderedBytes` builds its sign mask by shifting a `long` by
`Integer.SIZE - 1` (31) rather than `Long.SIZE - 1` (63):

```java
long lval = Double.doubleToLongBits(val);
lval ^= ((lval >> (Integer.SIZE - 1)) | Long.MIN_VALUE);
```

For a positive value the shift is supposed to yield `0`, so that `| Long.MIN_VALUE` flips only the
sign bit. Shifting by 31 instead leaves exponent bits sitting in the low 32 bits of the mask, and
those corrupt the low bytes of the output. For `1.0d`:

| | value |
|---|---|
| `doubleToLongBits(1.0)` | `0x3ff0000000000000` |
| `lval >> 31` | `0x000000007fe00000` ← leaks exponent bits into the low word |
| mask actually used | `0x800000007fe00000` |
| `lval >> 63` | `0x0000000000000000` |
| mask intended | `0x8000000000000000` ← sign-bit flip only |

## Why it has gone unnoticed

The high bytes are still encoded correctly, so ordering is only wrong when two values agree on
their top 31 bits and the corrupted low bytes are what decide the comparison. That is rare for
arbitrary values but systematic for values that differ only in low mantissa bits:

- all **2016** pairs drawn from `1.0d + i * 0x1.0p-30` (i = 0..63) encode in **reverse** order
- **48** of the 496 pairs among 32 consecutive `float` bit patterns above `1.0f` are inverted, the
  smallest being `1.0f` and `Math.nextUp(1.0f)`:
  `1.0f` → `0xbff000007fe00000` vs `1.0000001f` → `0xbff000005fe00000`

`testFloatOrdering` and `testDoubleOrdering` draw from `random.nextFloat()`/`nextDouble()`, whose
values essentially never agree on their high bits. I replayed the exact `Random(42)` sequence those
tests use: **none of the 100 000 pairs in either test share bits 63..33**, so neither test ever
reaches the corrupted low bytes. That is why 17 tests pass on `main` today.

## Tests

Three deterministic cases that target the region the random tests cannot reach — values differing
only in low mantissa bits:

| Test | Fails before fix |
|---|---|
| `testFloatOrderingForConsecutiveMantissaValues` — 64 consecutive `float` bit patterns from `1.0f` | ✅ |
| `testDoubleOrderingForValuesDifferingInLowMantissaBits` — `1.0d + i * 0x1.0p-30` | ✅ |
| `testNegativeDoubleOrderingForValuesDifferingInLowMantissaBits` | ❌ (passes either way) |

The negative case passes before and after — for negative values the leaked bits flip the whole low
region and happen to preserve order. I kept it because the guarantee is worth pinning against a
future change to the mask, and I would rather state that it is not a regression witness than imply
all three are.

`./gradlew :iceberg-core:test --tests "*TestZOrderByteUtil"` → 17 tests, 2 failed before the
change, all pass after. `spotlessApply`, `checkstyleMain` and `checkstyleTest` are clean.

## Compatibility

None to worry about: the encoding is never persisted. Its only production consumer is
`SparkZOrderUDF` via `SparkZOrderFileRewriteRunner`, which adds the bytes as the temporary
`ICEZVALUE` column, sorts on it, and drops it again before writing. So this changes only the
clustering produced by future z-order rewrites — no existing file or manifest encodes these bytes,
and no reader path parses them.

I also grepped `core`, `api`, `spark` and `flink` for the same `Integer.SIZE - 1` shift pattern;
this is the only occurrence.
