### PR TITLE
fix: Add VARIANT type support to Flink DynamicIcebergSink

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,18 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,18 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -181,6 +181,18 @@ public class CompareSchemasVisitor
     }
   }
 
+  @Override
+  public Result variant(Types.VariantType variant, Integer tableSchemaId) {
+    if (tableSchemaId == null) {
+      return Result.SCHEMA_UPDATE_NEEDED;
+    }
+    Type tableSchemaType = tableSchema.findField(tableSchemaId).type();
+    if (tableSchemaType.isVariantType()) {
+      return Result.SAME;
+    }
+    return Result.SCHEMA_UPDATE_NEEDED;
+  }
+
   /**
    * Whether {@link DataConverter} can convert input data of type {@code dataType} into the table's
    * {@code tableType}. Must stay in sync with the conversions {@link DataConverter#get} performs.

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/DataConverter.java
@@ -123,6 +123,8 @@ interface DataConverter {
         return new ArrayConverter((ArrayType) sourceType, (ArrayType) targetType);
       case MAP:
         return new MapConverter((MapType) sourceType, (MapType) targetType);
+      case VARIANT:
+        return object -> object;
       default:
         throw new UnsupportedOperationException("Not a supported type: " + targetType);
     }

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/EvolveSchemaVisitor.java
@@ -194,6 +194,11 @@ public class EvolveSchemaVisitor extends SchemaWithPartnerVisitor<Integer, Boole
     return partnerId == null;
   }
 
+  @Override
+  public Boolean variant(Types.VariantType variant, Integer partnerId) {
+    return partnerId == null;
+  }
+
   private Type findFieldType(int fieldId) {
     if (fieldId == -1) {
       return existingSchema.asStruct();


### PR DESCRIPTION
Flink: DynamicIcebergSink throws UnsupportedOperationException for VARIANT columns

## Problem
When using `DynamicIcebergSink` to write to an Iceberg table containing a VARIANT column, the following exception is thrown:

```
Caused by: java.lang.UnsupportedOperationException: Unsupported type: variant
  at org.apache.iceberg.schema.SchemaWithPartnerVisitor.variant(...)
  at org.apache.iceberg.flink.sink.dynamic.CompareSchemasVisitor.visit(...)
```

The root cause is that `CompareSchemasVisitor` and `EvolveSchemaVisitor` extend `SchemaWithPartnerVisitor` but do not override the `variant()` method, which by default throws `UnsupportedOperationException`.

## Changes
Applied the fix to all three Flink versions (v1.20, v2.0, v2.1):

1. **CompareSchemasVisitor.java** — Added `variant()` override that treats an existing VARIANT field as `Result.SAME`, and a missing field as `Result.SCHEMA_UPDATE_NEEDED`.

2. **EvolveSchemaVisitor.java** — Added `variant()` override that returns `false` (no evolution needed) when the VARIANT field already exists, and `true` (field is missing) when it doesn't.

3. **DataConverter.java** — Added `case VARIANT:` to the `get()` switch statement to handle VARIANT type identity conversion, preventing a secondary `UnsupportedOperationException` if `DATA_CONVERSION_NEEDED` is reached for a VARIANT field.

## Testing
- The fix follows the existing patterns for `primitive()` and other type handlers in the respective visitors.
- DataConverter's VARIANT case returns identity conversion (no transformation needed), consistent with how other pass-through types (BOOLEAN, INTEGER, VARCHAR, etc.) are handled.

Closes #17615