### PR TITLE
Parquet: Fix notNaN for columns missing from files

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -175,12 +175,12 @@ public class ParquetDictionaryRowGroupFilter {
     public <T> Boolean notNaN(BoundReference<T> ref) {
       int id = ref.fieldId();
 
-      if (mayContainNulls.get(id)) {
+      Boolean hasNonDictPage = isFallback.get(id);
+      if (hasNonDictPage == null || hasNonDictPage) {
         return ROWS_MIGHT_MATCH;
       }
 
-      Boolean hasNonDictPage = isFallback.get(id);
-      if (hasNonDictPage == null || hasNonDictPage) {
+      if (mayContainNulls.get(id)) {
         return ROWS_MIGHT_MATCH;
       }
 

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -484,10 +484,15 @@ public class TestDictionaryRowGroupFilter {
   public void testColumnNotInFile() {
     Expression[] exprs =
         new Expression[] {
-          lessThan("not_in_file", 1.0f), lessThanOrEqual("not_in_file", 1.0f),
-          equal("not_in_file", 1.0f), greaterThan("not_in_file", 1.0f),
-          greaterThanOrEqual("not_in_file", 1.0f), notNull("not_in_file"),
-          isNull("not_in_file"), notEqual("not_in_file", 1.0f)
+          lessThan("not_in_file", 1.0f),
+          lessThanOrEqual("not_in_file", 1.0f),
+          equal("not_in_file", 1.0f),
+          greaterThan("not_in_file", 1.0f),
+          greaterThanOrEqual("not_in_file", 1.0f),
+          notNull("not_in_file"),
+          isNull("not_in_file"),
+          notEqual("not_in_file", 1.0f),
+          notNaN("not_in_file")
         };
 
     for (Expression expr : exprs) {


### PR DESCRIPTION
Fix #17632

Fix an NPE when a `notNaN` predicate references a column that has an initial default but is absent from an older Parquet file.

Treat missing null metadata conservatively and add regression coverage for columns absent from Parquet files.