### PR TITLE
Spark 4.1: Fix row lineage in vectorized ORC reads

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/LastUpdatedSeqColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/LastUpdatedSeqColumnVector.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class LastUpdatedSeqColumnVector extends ColumnVector {
+
+  private final long fileLastUpdated;
+  private final ColumnVector storedSeqs;
+
+  LastUpdatedSeqColumnVector(long fileLastUpdated, ColumnVector storedSeqs) {
+    super(SparkSchemaUtil.convert(Types.LongType.get()));
+    this.fileLastUpdated = fileLastUpdated;
+    this.storedSeqs = storedSeqs;
+  }
+
+  @Override
+  public long getLong(int rowId) {
+    if (storedSeqs != null && !storedSeqs.isNullAt(rowId)) {
+      return storedSeqs.getLong(rowId);
+    }
+
+    return fileLastUpdated;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public boolean hasNull() {
+    return false;
+  }
+
+  @Override
+  public int numNulls() {
+    return 0;
+  }
+
+  @Override
+  public boolean isNullAt(int rowId) {
+    return false;
+  }
+
+  @Override
+  public boolean getBoolean(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte getByte(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarArray getArray(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarMap getMap(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Decimal getDecimal(int rowId, int precision, int scale) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] getBinary(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnVector getChild(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/RowIdColumnVector.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/RowIdColumnVector.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.data.vectorized;
+
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.types.Decimal;
+import org.apache.spark.sql.vectorized.ColumnVector;
+import org.apache.spark.sql.vectorized.ColumnarArray;
+import org.apache.spark.sql.vectorized.ColumnarMap;
+import org.apache.spark.unsafe.types.UTF8String;
+
+public class RowIdColumnVector extends ColumnVector {
+
+  private final long firstRowId;
+  private final long batchOffsetInFile;
+  private final ColumnVector storedIds;
+
+  RowIdColumnVector(long firstRowId, long batchOffsetInFile, ColumnVector storedIds) {
+    super(SparkSchemaUtil.convert(Types.LongType.get()));
+    this.firstRowId = firstRowId;
+    this.batchOffsetInFile = batchOffsetInFile;
+    this.storedIds = storedIds;
+  }
+
+  @Override
+  public long getLong(int rowId) {
+    if (storedIds != null && !storedIds.isNullAt(rowId)) {
+      return storedIds.getLong(rowId);
+    }
+
+    return firstRowId + batchOffsetInFile + rowId;
+  }
+
+  @Override
+  public void close() {}
+
+  @Override
+  public boolean hasNull() {
+    return false;
+  }
+
+  @Override
+  public int numNulls() {
+    return 0;
+  }
+
+  @Override
+  public boolean isNullAt(int rowId) {
+    return false;
+  }
+
+  @Override
+  public boolean getBoolean(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte getByte(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public short getShort(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int getInt(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float getFloat(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double getDouble(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarArray getArray(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnarMap getMap(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Decimal getDecimal(int rowId, int precision, int scale) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public UTF8String getUTF8String(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[] getBinary(int rowId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public ColumnVector getChild(int ordinal) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java
@@ -23,11 +23,14 @@ import java.util.Map;
 import java.util.stream.IntStream;
 import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.Schema;
+import org.apache.iceberg.orc.ORCSchemaUtil;
 import org.apache.iceberg.orc.OrcBatchReader;
 import org.apache.iceberg.orc.OrcSchemaWithTypeVisitor;
 import org.apache.iceberg.orc.OrcValueReader;
 import org.apache.iceberg.orc.OrcValueReaders;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.relocated.com.google.common.collect.Maps;
 import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.data.SparkOrcValueReaders;
 import org.apache.iceberg.types.Type;
@@ -104,7 +107,7 @@ public class VectorizedSparkOrcReaders {
         TypeDescription record,
         List<String> names,
         List<Converter> fields) {
-      return new StructConverter(iStruct, fields, idToConstant);
+      return new StructConverter(iStruct, record, fields, idToConstant);
     }
 
     @Override
@@ -432,16 +435,85 @@ public class VectorizedSparkOrcReaders {
 
   private static class StructConverter implements Converter {
     private final Types.StructType structType;
+    private final Map<Integer, Integer> fieldIdToOrcIndex;
     private final List<Converter> fieldConverters;
     private final Map<Integer, ?> idToConstant;
 
     private StructConverter(
         Types.StructType structType,
+        TypeDescription orcType,
         List<Converter> fieldConverters,
         Map<Integer, ?> idToConstant) {
       this.structType = structType;
+      this.fieldIdToOrcIndex = buildFieldIdToOrcIndex(orcType);
       this.fieldConverters = fieldConverters;
       this.idToConstant = idToConstant;
+
+      Preconditions.checkState(
+          fieldConverters.size() <= orcType.getChildren().size(),
+          "Invalid ORC schema: %s converters for %s columns",
+          fieldConverters.size(),
+          orcType.getChildren().size());
+    }
+
+    private ColumnVector storedVector(
+        Types.NestedField field,
+        StructColumnVector structVector,
+        int batchSize,
+        long batchOffsetInFile,
+        boolean isSelectedInUse,
+        int[] selected) {
+      Integer orcIndex = fieldIdToOrcIndex.get(field.fieldId());
+      if (orcIndex == null) {
+        return null;
+      }
+
+      return fieldConverters
+          .get(orcIndex)
+          .convert(
+              structVector.fields[orcIndex],
+              batchSize,
+              batchOffsetInFile,
+              isSelectedInUse,
+              selected);
+    }
+
+    private ColumnVector rowIdVector(
+        Types.NestedField field,
+        StructColumnVector structVector,
+        int batchSize,
+        long batchOffsetInFile,
+        boolean isSelectedInUse,
+        int[] selected) {
+      Long firstRowId = (Long) idToConstant.get(field.fieldId());
+      if (firstRowId == null) {
+        return new ConstantColumnVector(field.type(), batchSize, null);
+      }
+
+      return new RowIdColumnVector(
+          firstRowId,
+          batchOffsetInFile,
+          storedVector(
+              field, structVector, batchSize, batchOffsetInFile, isSelectedInUse, selected));
+    }
+
+    private ColumnVector lastUpdatedSeqVector(
+        Types.NestedField field,
+        StructColumnVector structVector,
+        int batchSize,
+        long batchOffsetInFile,
+        boolean isSelectedInUse,
+        int[] selected) {
+      Long fileLastUpdated = (Long) idToConstant.get(field.fieldId());
+      Long firstRowId = (Long) idToConstant.get(MetadataColumns.ROW_ID.fieldId());
+      if (fileLastUpdated == null || firstRowId == null) {
+        return new ConstantColumnVector(field.type(), batchSize, null);
+      }
+
+      return new LastUpdatedSeqColumnVector(
+          fileLastUpdated,
+          storedVector(
+              field, structVector, batchSize, batchOffsetInFile, isSelectedInUse, selected));
     }
 
     @Override
@@ -456,7 +528,15 @@ public class VectorizedSparkOrcReaders {
       List<ColumnVector> fieldVectors = Lists.newArrayListWithExpectedSize(fields.size());
       for (int pos = 0, vectorIndex = 0; pos < fields.size(); pos += 1) {
         Types.NestedField field = fields.get(pos);
-        if (idToConstant.containsKey(field.fieldId())) {
+        if (field.equals(MetadataColumns.ROW_ID)) {
+          fieldVectors.add(
+              rowIdVector(
+                  field, structVector, batchSize, batchOffsetInFile, isSelectedInUse, selected));
+        } else if (field.equals(MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER)) {
+          fieldVectors.add(
+              lastUpdatedSeqVector(
+                  field, structVector, batchSize, batchOffsetInFile, isSelectedInUse, selected));
+        } else if (idToConstant.containsKey(field.fieldId())) {
           fieldVectors.add(
               new ConstantColumnVector(field.type(), batchSize, idToConstant.get(field.fieldId())));
         } else if (field.equals(MetadataColumns.ROW_POSITION)) {
@@ -487,6 +567,16 @@ public class VectorizedSparkOrcReaders {
           return fieldVectors.get(ordinal);
         }
       };
+    }
+
+    private static Map<Integer, Integer> buildFieldIdToOrcIndex(TypeDescription orcType) {
+      List<TypeDescription> children = orcType.getChildren();
+      Map<Integer, Integer> mapping = Maps.newHashMap();
+      for (int i = 0; i < children.size(); i++) {
+        mapping.put(ORCSchemaUtil.fieldId(children.get(i)), i);
+      }
+
+      return mapping;
     }
   }
 }

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestVectorizedOrcDataReader.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/data/TestVectorizedOrcDataReader.java
@@ -26,7 +26,9 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import org.apache.iceberg.Files;
+import org.apache.iceberg.MetadataColumns;
 import org.apache.iceberg.PartitionSpec;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.data.GenericRecord;
@@ -115,6 +117,12 @@ public class TestVectorizedOrcDataReader {
     assertThat(rowCount).isEqualTo(5);
   }
 
+  private void assertRow(InternalRow row, long expectedId, long expectedRowId, long expectedSeq) {
+    assertThat(row.getLong(0)).isEqualTo(expectedId);
+    assertThat(row.getLong(1)).isEqualTo(expectedRowId);
+    assertThat(row.getLong(2)).isEqualTo(expectedSeq);
+  }
+
   @Test
   public void testReader() throws IOException {
     try (CloseableIterable<ColumnarBatch> reader =
@@ -161,6 +169,68 @@ public class TestVectorizedOrcDataReader {
       assertThat(row.getLong(0)).isEqualTo(3L);
       assertThat(row.getString(1)).isEqualTo("c");
       assertThat(row.getArray(3).toIntArray()).isEqualTo(new int[] {3, 4, 5});
+      assertThat(rows).isExhausted();
+    }
+  }
+
+  @Test
+  public void testRowLineage() throws IOException {
+    Schema dataSchema = new Schema(Types.NestedField.required(1, "id", Types.LongType.get()));
+    Schema writeSchema = MetadataColumns.schemaWithRowLineage(dataSchema);
+
+    GenericRecord record = GenericRecord.create(writeSchema);
+    ImmutableList.Builder<Record> builder = ImmutableList.builder();
+    for (int i = 0; i < 4; i++) {
+      builder.add(
+          i % 2 == 0
+              ? record.copy(
+                  ImmutableMap.of(
+                      "id",
+                      (long) i,
+                      MetadataColumns.ROW_ID.name(),
+                      555L + i,
+                      MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.name(),
+                      7L))
+              : record.copy(ImmutableMap.of("id", (long) i)));
+    }
+
+    OutputFile lineageFile =
+        Files.localOutput(File.createTempFile("lineage", ".orc", temp.toFile()));
+    try (DataWriter<Record> dataWriter =
+        ORC.writeData(lineageFile)
+            .schema(writeSchema)
+            .createWriterFunc(GenericOrcWriter::buildWriter)
+            .overwrite()
+            .withSpec(PartitionSpec.unpartitioned())
+            .build()) {
+      for (Record rec : builder.build()) {
+        dataWriter.write(rec);
+      }
+    }
+
+    Schema projection =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            MetadataColumns.ROW_ID,
+            MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER);
+    Map<Integer, ?> idToConstant =
+        ImmutableMap.of(
+            MetadataColumns.ROW_ID.fieldId(), 100L,
+            MetadataColumns.LAST_UPDATED_SEQUENCE_NUMBER.fieldId(), 5L);
+
+    try (CloseableIterable<ColumnarBatch> reader =
+        ORC.read(lineageFile.toInputFile())
+            .project(projection)
+            .createBatchedReaderFunc(
+                readOrcSchema ->
+                    VectorizedSparkOrcReaders.buildReader(projection, readOrcSchema, idToConstant))
+            .build()) {
+      Iterator<InternalRow> rows = batchesToRows(reader.iterator());
+
+      assertRow(rows.next(), 0L, 555L, 7L);
+      assertRow(rows.next(), 1L, 101L, 5L);
+      assertRow(rows.next(), 2L, 557L, 7L);
+      assertRow(rows.next(), 3L, 103L, 5L);
       assertThat(rows).isExhausted();
     }
   }


### PR DESCRIPTION
[VectorizedSparkOrcReaders.StructConverter](https://github.com/apache/iceberg/blob/f610fab08773733dda8e4919d715ae25986cfb51/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java#L433) checked `idToConstant` before any metadata column, so `_row_id` matched the generic constant branch and every row received `first_row_id`. Stored per-row values were ignored and the position offset was never applied. `_last_updated_sequence_number` had the same problem.

`_row_id` for a file with `first_row_id = 100`. Rows 0 and 2 store explicit values (555, 557), rows 1 and 3 store null and should inherit `100 + position`.

| row | expected | before |
|-----|----------|--------|
| 0   | 555      | 100    |
| 1   | 101      | 100    |
| 2   | 557      | 100    |
| 3   | 103      | 100    |

The fix mirrors what the row-based reader already does in [OrcValueReaders](https://github.com/apache/iceberg/blob/main/orc/src/main/java/org/apache/iceberg/orc/OrcValueReaders.java): check the metadata columns first, and fall back to `first_row_id + position` only when the file has no stored value. Adds `RowIdColumnVector` and `LastUpdatedSeqColumnVector` for that, and passes the ORC schema into [StructConverter](https://github.com/apache/iceberg/blob/35889387c8c6ff0a3f57d17a304709dc1b7d9340/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/data/vectorized/VectorizedSparkOrcReaders.java#L433) so the stored columns can be found by field id.

Row based ORC got lineage support in #15776 and #16534, but the vectorized reader was not added.

Found while adding vectorized coverage to the format model TCK (#17610).