### PR TITLE
fix: re-add consumer group STABLE check in hasLeaderPartition

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/channel/CommitterImpl.java
@@ -29,6 +29,7 @@ import org.apache.iceberg.relocated.com.google.common.annotations.VisibleForTest
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTaskContext;
@@ -81,10 +82,12 @@ public class CommitterImpl implements Committer {
       groupDesc = KafkaUtils.consumerGroupDescription(config.connectGroupId(), admin);
     }
 
-    Collection<MemberDescription> members = groupDesc.members();
-    if (containsFirstPartition(members, currentAssignedPartitions)) {
-      membersWhenWorkerIsCoordinator = members;
-      return true;
+    if (groupDesc.state() == ConsumerGroupState.STABLE) {
+      Collection<MemberDescription> members = groupDesc.members();
+      if (containsFirstPartition(members, currentAssignedPartitions)) {
+        membersWhenWorkerIsCoordinator = members;
+        return true;
+      }
     }
 
     return false;

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/channel/TestCommitterImpl.java
@@ -39,6 +39,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.ConsumerGroupDescription;
 import org.apache.kafka.clients.admin.MemberAssignment;
 import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.common.ConsumerGroupState;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Test;
 import org.mockito.MockedStatic;
@@ -113,10 +114,58 @@ public class TestCommitterImpl {
           .when(() -> KafkaUtils.consumerGroupDescription(any(), any()))
           .thenReturn(consumerGroupDescription);
 
+      when(consumerGroupDescription.state()).thenReturn(ConsumerGroupState.STABLE);
       when(consumerGroupDescription.members()).thenReturn(members);
 
       assertThat(committer.hasLeaderPartition(leaderAssignments)).isTrue();
       assertThat(committer.hasLeaderPartition(nonLeaderAssignments)).isFalse();
+    }
+  }
+
+  @Test
+  public void testHasLeaderPartitionNotStable() throws NoSuchFieldException, IllegalAccessException {
+    MemberAssignment assignment1 =
+        new MemberAssignment(
+            ImmutableSet.of(new TopicPartition("topic1", 0), new TopicPartition("topic2", 1)));
+    MemberDescription member1 =
+        new MemberDescription(null, Optional.empty(), null, null, assignment1);
+
+    MemberAssignment assignment2 =
+        new MemberAssignment(
+            ImmutableSet.of(new TopicPartition("topic2", 0), new TopicPartition("topic1", 1)));
+    MemberDescription member2 =
+        new MemberDescription(null, Optional.empty(), null, null, assignment2);
+
+    List<MemberDescription> members = ImmutableList.of(member1, member2);
+
+    List<TopicPartition> leaderAssignments =
+        ImmutableList.of(new TopicPartition("topic2", 1), new TopicPartition("topic1", 0));
+
+    CommitterImpl committer = new CommitterImpl();
+    Field configField = CommitterImpl.class.getDeclaredField("config");
+    Field clientFactoryField = CommitterImpl.class.getDeclaredField("clientFactory");
+    configField.setAccessible(true);
+    clientFactoryField.setAccessible(true);
+
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.connectGroupId()).thenReturn("test-group");
+    configField.set(committer, config);
+
+    KafkaClientFactory clientFactory = mock(KafkaClientFactory.class);
+    Admin admin = mock(Admin.class);
+    when(clientFactory.createAdmin()).thenReturn(admin);
+    clientFactoryField.set(committer, clientFactory);
+
+    try (MockedStatic<KafkaUtils> mockKafkaUtils = mockStatic(KafkaUtils.class)) {
+      ConsumerGroupDescription consumerGroupDescription = mock(ConsumerGroupDescription.class);
+      mockKafkaUtils
+          .when(() -> KafkaUtils.consumerGroupDescription(any(), any()))
+          .thenReturn(consumerGroupDescription);
+
+      when(consumerGroupDescription.state()).thenReturn(ConsumerGroupState.REBALANCING);
+      when(consumerGroupDescription.members()).thenReturn(members);
+
+      assertThat(committer.hasLeaderPartition(leaderAssignments)).isFalse();
     }
   }
 


### PR DESCRIPTION
## Fix

Re-add the `ConsumerGroupState.STABLE` check in `hasLeaderPartition()` that was removed in PR #14395.

### Root cause

PR #14395 ("Don't check that consumer group is stable for coordinator leader election") removed the `groupDesc.state() == ConsumerGroupState.STABLE` guard from `hasLeaderPartition()`. Without this check, the coordinator can start firing commits before the `cg-control` consumer group has stabilized. When the data topic goes idle after initial consumption, the main consumer's `poll()` blocks for `max.poll.interval.ms` (default 60s), during which the `cg-control` consumer cannot heartbeat, causing its session timeout (45s) to expire and the group to never reach STABLE.

### Fix

Restore the STABLE state check: only consider this worker the leader when the consumer group is in the `STABLE` state, ensuring the `cg-control` consumer has joined before the coordinator starts commit cycles.

### Changes

1. **CommitterImpl.java**: Added `import org.apache.kafka.common.ConsumerGroupState` and re-added `if (groupDesc.state() == ConsumerGroupState.STABLE)` guard
2. **TestCommitterImpl.java**: Added `ConsumerGroupState.STABLE` mock to `testHasLeaderPartition`, added `testHasLeaderPartitionNotStable` test for the non-STABLE case

Fixes #17193