### PR TITLE
OpenAPI: IRC spec changes for v4 (relax responses in place)

### DIFF
--- a/open-api/rest-catalog-open-api.py
+++ b/open-api/rest-catalog-open-api.py
@@ -330,7 +330,15 @@ class Summary(BaseModel):
     operation: Literal['append', 'replace', 'overwrite', 'delete']
 
 
-class Snapshot(BaseModel):
+class Snapshot1(BaseModel):
+    """
+    A snapshot of the table's contents at a point in time.
+
+
+    Format versions 1-3 use `manifest-list` and format version 4 uses `root-manifest`.
+
+    """
+
     snapshot_id: int = Field(..., alias='snapshot-id')
     parent_snapshot_id: int | None = Field(None, alias='parent-snapshot-id')
     sequence_number: int | None = Field(None, alias='sequence-number')
@@ -338,7 +346,12 @@ class Snapshot(BaseModel):
     manifest_list: str = Field(
         ...,
         alias='manifest-list',
-        description="Location of the snapshot's manifest list file",
+        description="Location of the snapshot's manifest list file. Used for format versions 1-3 and must be absent for format version 4, which uses `root-manifest` instead.",
+    )
+    root_manifest: str | None = Field(
+        None,
+        alias='root-manifest',
+        description="Location of the snapshot's root manifest. Required for format version 4 and must be absent for format versions 1-3.",
     )
     first_row_id: int | None = Field(
         None,
@@ -352,6 +365,50 @@ class Snapshot(BaseModel):
     )
     summary: Summary
     schema_id: int | None = Field(None, alias='schema-id')
+
+
+class Snapshot2(BaseModel):
+    """
+    A snapshot of the table's contents at a point in time.
+
+
+    Format versions 1-3 use `manifest-list` and format version 4 uses `root-manifest`.
+
+    """
+
+    snapshot_id: int = Field(..., alias='snapshot-id')
+    parent_snapshot_id: int | None = Field(None, alias='parent-snapshot-id')
+    sequence_number: int | None = Field(None, alias='sequence-number')
+    timestamp_ms: int = Field(..., alias='timestamp-ms')
+    manifest_list: str | None = Field(
+        None,
+        alias='manifest-list',
+        description="Location of the snapshot's manifest list file. Used for format versions 1-3 and must be absent for format version 4, which uses `root-manifest` instead.",
+    )
+    root_manifest: str = Field(
+        ...,
+        alias='root-manifest',
+        description="Location of the snapshot's root manifest. Required for format version 4 and must be absent for format versions 1-3.",
+    )
+    first_row_id: int | None = Field(
+        None,
+        alias='first-row-id',
+        description='The first _row_id assigned to the first row in the first data file in the first manifest',
+    )
+    added_rows: int | None = Field(
+        None,
+        alias='added-rows',
+        description='The upper bound of the number of rows with assigned row IDs',
+    )
+    summary: Summary
+    schema_id: int | None = Field(None, alias='schema-id')
+
+
+class Snapshot(RootModel[Snapshot1 | Snapshot2]):
+    root: Snapshot1 | Snapshot2 = Field(
+        ...,
+        description="A snapshot of the table's contents at a point in time.\n\n\nFormat versions 1-3 use `manifest-list` and format version 4 uses `root-manifest`.\n",
+    )
 
 
 class SnapshotReference(BaseModel):
@@ -1650,9 +1707,12 @@ class Apply(BaseModel):
 
 
 class TableMetadata(BaseModel):
-    format_version: int = Field(..., alias='format-version', ge=1, le=3)
+    format_version: int = Field(..., alias='format-version', ge=1, le=4)
     table_uuid: str = Field(..., alias='table-uuid')
-    location: str | None = None
+    location: str | None = Field(
+        None,
+        description="The table's base location. Required through format version 3, where it may be a path without a URI scheme; readers prepend a scheme for consistency with v4 absolute paths. Optional for format version 4, where the location may be managed externally and supplied by the catalog when the table is loaded, and where it must be an absolute path when present. See the `table-location` field of `LoadTableResult`.",
+    )
     last_updated_ms: int | None = Field(None, alias='last-updated-ms')
     next_row_id: int | None = Field(
         None,
@@ -1705,11 +1765,35 @@ class AddSchemaUpdate(BaseUpdate):
 
 class LoadTableResult(BaseModel):
     """
-    Result used when a table is successfully loaded.
+    Result used when a table is successfully loaded, for tables at any format version.
 
 
-    The table metadata JSON is returned in the `metadata` field. The corresponding file location of table metadata should be returned in the `metadata-location` field, unless the metadata is not yet committed. For example, a create transaction may return metadata that is staged but not committed.
-    Clients can check whether metadata has changed by comparing metadata locations after the table has been created.
+    The table metadata JSON is returned in the `metadata` field.
+    The location of the table metadata file is returned in the `metadata-location` field when the table has one, and the table's base location in the `table-location` field.
+
+
+    ## Metadata location
+
+
+    The `metadata-location` field is optional.
+    It is absent when the metadata is staged but not committed, as in a create transaction, and when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state and no metadata pointer need exist.
+
+
+    Clients must not require this field to be present, and must not use it to bypass the catalog for reads or commits.
+    To obtain a metadata location for a catalog-managed table, use the `unregisterTable` endpoint, which returns the table's last metadata location at the point the table leaves catalog control and further commits are rejected.
+
+
+    ## Table location
+
+
+    The `table-location` field carries the table's base location.
+    Format version 4 allows location fields in metadata to be relative, and such paths must be resolved against the table location.
+    Format version 4 also makes `metadata.location` optional, so a table may have metadata that contains relative paths and omits `location`.
+    Servers must populate `table-location` for any such table, because it cannot be read otherwise.
+
+
+    When both `metadata.location` and `table-location` are present, `table-location` takes precedence:
+    the catalog is authoritative for table state.
 
 
     The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
@@ -1756,7 +1840,12 @@ class LoadTableResult(BaseModel):
     metadata_location: str | None = Field(
         None,
         alias='metadata-location',
-        description='May be null if the table is staged as part of a transaction',
+        description='Location of the table metadata file. Absent when the metadata is staged but not committed, as in a create transaction, and when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state.',
+    )
+    table_location: str | None = Field(
+        None,
+        alias='table-location',
+        description="The table's base location, used to resolve relative paths in metadata. Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise. Takes precedence over `metadata.location`.",
     )
     metadata: TableMetadata
     config: dict[str, str] | None = None
@@ -1840,6 +1929,11 @@ class UnregisterTableResult(BaseModel):
         ...,
         alias='metadata-location',
         description='The last metadata location for the table at the time it was unregistered.',
+    )
+    table_location: str | None = Field(
+        None,
+        alias='table-location',
+        description="The table's base location, used to resolve relative paths in metadata. Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise. Takes precedence over `metadata.location`.",
     )
     metadata: TableMetadata
 
@@ -2026,7 +2120,24 @@ class FunctionStructField(BaseModel):
 
 
 class CommitTableResponse(BaseModel):
-    metadata_location: str = Field(..., alias='metadata-location')
+    """
+    Result used when a table is successfully updated, for tables at any format version.
+
+
+    The `table-location` field carries the table's base location, so that a client can resolve relative paths in the returned metadata.
+
+    """
+
+    metadata_location: str | None = Field(
+        None,
+        alias='metadata-location',
+        description='Location of the committed table metadata file. Absent when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state.',
+    )
+    table_location: str | None = Field(
+        None,
+        alias='table-location',
+        description="The table's base location, used to resolve relative paths in metadata. Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise. Takes precedence over `metadata.location`.",
+    )
     metadata: TableMetadata
 
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -2948,12 +2948,21 @@ components:
             type: string
 
     Snapshot:
+      description: |
+        A snapshot of the table's contents at a point in time.
+
+
+        Format versions 1-3 use `manifest-list` and format version 4 uses `root-manifest`.
       type: object
       required:
         - snapshot-id
         - timestamp-ms
-        - manifest-list
         - summary
+      oneOf:
+        - required:
+            - manifest-list
+        - required:
+            - root-manifest
       properties:
         snapshot-id:
           type: integer
@@ -2969,7 +2978,14 @@ components:
           format: int64
         manifest-list:
           type: string
-          description: Location of the snapshot's manifest list file
+          description:
+            Location of the snapshot's manifest list file.
+            Used for format versions 1-3 and must be absent for format version 4, which uses `root-manifest` instead.
+        root-manifest:
+          type: string
+          description:
+            Location of the snapshot's root manifest.
+            Required for format version 4 and must be absent for format versions 1-3.
         first-row-id:
           type: integer
           format: int64
@@ -3055,11 +3071,16 @@ components:
         format-version:
           type: integer
           minimum: 1
-          maximum: 3
+          maximum: 4
         table-uuid:
           type: string
         location:
           type: string
+          description:
+            The table's base location.
+            Required through format version 3, where it may be a path without a URI scheme; readers prepend a scheme for consistency with v4 absolute paths.
+            Optional for format version 4, where the location may be managed externally and supplied by the catalog when the table is loaded, and where it must be an absolute path when present.
+            See the `table-location` field of `LoadTableResult`.
         last-updated-ms:
           type: integer
           format: int64
@@ -3851,11 +3872,35 @@ components:
 
     LoadTableResult:
       description: |
-        Result used when a table is successfully loaded.
+        Result used when a table is successfully loaded, for tables at any format version.
 
 
-        The table metadata JSON is returned in the `metadata` field. The corresponding file location of table metadata should be returned in the `metadata-location` field, unless the metadata is not yet committed. For example, a create transaction may return metadata that is staged but not committed.
-        Clients can check whether metadata has changed by comparing metadata locations after the table has been created.
+        The table metadata JSON is returned in the `metadata` field.
+        The location of the table metadata file is returned in the `metadata-location` field when the table has one, and the table's base location in the `table-location` field.
+
+
+        ## Metadata location
+
+
+        The `metadata-location` field is optional.
+        It is absent when the metadata is staged but not committed, as in a create transaction, and when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state and no metadata pointer need exist.
+
+
+        Clients must not require this field to be present, and must not use it to bypass the catalog for reads or commits.
+        To obtain a metadata location for a catalog-managed table, use the `unregisterTable` endpoint, which returns the table's last metadata location at the point the table leaves catalog control and further commits are rejected.
+
+
+        ## Table location
+
+
+        The `table-location` field carries the table's base location.
+        Format version 4 allows location fields in metadata to be relative, and such paths must be resolved against the table location.
+        Format version 4 also makes `metadata.location` optional, so a table may have metadata that contains relative paths and omits `location`.
+        Servers must populate `table-location` for any such table, because it cannot be read otherwise.
+
+
+        When both `metadata.location` and `table-location` are present, `table-location` takes precedence:
+        the catalog is authoritative for table state.
 
 
         The `config` map returns table-specific configuration for the table's resources, including its HTTP client and FileIO. For example, config may contain a specific FileIO implementation class for the table depending on its underlying storage.
@@ -3896,15 +3941,21 @@ components:
          - `signer.uri` **DEPRECATED**.: the base URI to resolve `signer.endpoint` against. Only meaningful if `signer.endpoint` is a relative path. Defaults to the catalog's base URI if not set.
         If any of these properties is present, clients SHOULD use them to compute the actual remote signing endpoint URI to contact.
         If none of these properties is present, clients SHOULD contact the default remote signing endpoint using the catalog's base URI.
-
       type: object
       required:
         - metadata
       properties:
         metadata-location:
           type: string
-          description: May be null if the table is staged as part of a transaction
-          nullable: true
+          description:
+            Location of the table metadata file.
+            Absent when the metadata is staged but not committed, as in a create transaction, and when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state.
+        table-location:
+          type: string
+          description:
+            The table's base location, used to resolve relative paths in metadata.
+            Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise.
+            Takes precedence over `metadata.location`.
         metadata:
           $ref: '#/components/schemas/TableMetadata'
         config:
@@ -4163,6 +4214,12 @@ components:
           type: string
           description:
             The last metadata location for the table at the time it was unregistered.
+        table-location:
+          type: string
+          description:
+            The table's base location, used to resolve relative paths in metadata.
+            Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise.
+            Takes precedence over `metadata.location`.
         metadata:
           $ref: '#/components/schemas/TableMetadata'
 
@@ -4929,13 +4986,26 @@ components:
           nullable: true
 
     CommitTableResponse:
+      description: |
+        Result used when a table is successfully updated, for tables at any format version.
+
+
+        The `table-location` field carries the table's base location, so that a client can resolve relative paths in the returned metadata.
       type: object
       required:
-        - metadata-location
         - metadata
       properties:
         metadata-location:
           type: string
+          description:
+            Location of the committed table metadata file.
+            Absent when the table has no client-visible metadata location, as for a catalog-managed table where the catalog is the source of truth for table state.
+        table-location:
+          type: string
+          description:
+            The table's base location, used to resolve relative paths in metadata.
+            Must be an absolute path with a URI scheme when present, and must be present when the returned metadata contains relative paths and omits `location`, because the metadata cannot be resolved otherwise.
+            Takes precedence over `metadata.location`.
         metadata:
           $ref: '#/components/schemas/TableMetadata'
 

--- a/open-api/rest-catalog-open-api.yaml
+++ b/open-api/rest-catalog-open-api.yaml
@@ -1039,6 +1039,11 @@ paths:
         Load a table from the catalog.
 
 
+        This endpoint must not return a format version 4 table.
+        A server must not serve a format version 4 table through this endpoint, so that a client that does not support format version 4 is never handed a response it cannot read.
+        Format version 4 tables are loaded through the `/v2` endpoint instead.
+
+
         The response contains both configuration and table metadata. The configuration, if non-empty is used
         as additional configuration for the table that overrides catalog configuration. For example, this
         configuration may change the FileIO implementation to be used for the table.
@@ -1285,6 +1290,91 @@ paths:
         404:
           description:
             Not Found - NoSuchTableException, Table not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/IcebergErrorResponse'
+              examples:
+                TableToLoadDoesNotExist:
+                  $ref: '#/components/examples/NoSuchTableError'
+        419:
+          $ref: '#/components/responses/AuthenticationTimeoutResponse'
+        503:
+          $ref: '#/components/responses/ServiceUnavailableResponse'
+        5XX:
+          $ref: '#/components/responses/ServerErrorResponse'
+
+  /v2/{prefix}/namespaces/{namespace}/tables/{table}:
+    parameters:
+      - $ref: '#/components/parameters/prefix'
+      - $ref: '#/components/parameters/namespace'
+      - $ref: '#/components/parameters/table'
+
+    get:
+      tags:
+        - Catalog API
+      summary: Load a table from the catalog
+      operationId: loadTableV2
+      description:
+        Load a table from the catalog.
+
+
+        This endpoint returns the same response as the v1 `loadTable` endpoint and may return a table at any format version, including format version 4.
+        Clients that support format version 4 should load tables through this endpoint.
+
+
+        The response contains both configuration and table metadata. The configuration, if non-empty is used
+        as additional configuration for the table that overrides catalog configuration. For example, this
+        configuration may change the FileIO implementation to be used for the table.
+
+
+        The response also contains the table's full metadata, matching the table metadata JSON file.
+
+
+        The catalog configuration may contain credentials that should be used for subsequent requests for the
+        table. The configuration key "token" is used to pass an access token to be used as a bearer token
+        for table requests. Otherwise, a token may be passed using a RFC 8693 token type as a configuration
+        key. For example, "urn:ietf:params:oauth:token-type:jwt=<JWT-token>".
+      parameters:
+        - $ref: '#/components/parameters/data-access'
+        - name: If-None-Match
+          in: header
+          description:
+            An optional header that allows the server to return 304 (Not Modified) if the metadata
+            is current. The content is the value of the ETag received in a CreateTableResponse,
+            LoadTableResponse or CommitTableResponse.
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: snapshots
+          description:
+            The snapshots to return in the body of the metadata via the `snapshots` field. Setting
+            the value to `all` would return the full set of snapshots currently valid for the table.
+            Setting the value to `refs` would load all snapshots referenced by branches or tags.
+
+            Default if no param is provided is `all`.
+          required: false
+          schema:
+            type: string
+            enum: [ all, refs ]
+        - $ref: '#/components/parameters/referenced-by'
+      responses:
+        200:
+          $ref: '#/components/responses/LoadTableResponse'
+        304:
+          description:
+            Not Modified - Based on the content of the 'If-None-Match' header the table metadata has
+            not changed since.
+        400:
+          $ref: '#/components/responses/BadRequestErrorResponse'
+        401:
+          $ref: '#/components/responses/UnauthorizedResponse'
+        403:
+          $ref: '#/components/responses/ForbiddenResponse'
+        404:
+          description:
+            Not Found - NoSuchTableException, table to load does not exist
           content:
             application/json:
               schema:


### PR DESCRIPTION
Alternative to #17543.

Same goal — let the REST catalog carry table format version 4 — but this version relaxes the existing response schemas in place instead of introducing V2 schemas and `/v2` endpoints, and it does not bump the API version. Existing clients keep calling the same endpoints. A client that only understands format versions 1-3 reads the `format-version` in the returned metadata, sees 4, and stops, which the spec already requires.

Changes:
- `Snapshot`: add `root-manifest` and make `manifest-list` optional, with a `oneOf` requiring exactly one of the two. Format versions 1-3 use `manifest-list`; version 4 uses `root-manifest`.
- `TableMetadata`: raise the `format-version` maximum to 4 and make `location` optional.
- `LoadTableResult` / `UnregisterTableResult`: add `table-location` for resolving relative paths in v4 metadata.
- `CommitTableResponse`: add `table-location` and drop `metadata-location` from the required set (absent for catalog-managed tables).

This is a proposal to drive discussion; v4 is still in development.
