### PR TITLE
Core, REST: Fix garbled non-ASCII comments in REST request bodies

### DIFF
--- a/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
+++ b/core/src/main/java/org/apache/iceberg/rest/HTTPClient.java
@@ -313,7 +313,7 @@ public class HTTPClient extends BaseHTTPClient {
 
     String encodedBody = req.encodedBody();
     if (encodedBody != null) {
-      request.setEntity(new StringEntity(encodedBody));
+      request.setEntity(new StringEntity(encodedBody, StandardCharsets.UTF_8));
     }
 
     HttpContext context = HttpClientContext.create();

--- a/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestHTTPClient.java
@@ -56,13 +56,19 @@ import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.iceberg.IcebergBuild;
+import org.apache.iceberg.MetadataUpdate;
+import org.apache.iceberg.Schema;
 import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Sets;
 import org.apache.iceberg.rest.auth.AuthSession;
 import org.apache.iceberg.rest.auth.TLSConfigurer;
+import org.apache.iceberg.rest.requests.CreateTableRequest;
+import org.apache.iceberg.rest.requests.UpdateTableRequest;
 import org.apache.iceberg.rest.responses.ErrorResponse;
 import org.apache.iceberg.rest.responses.ErrorResponseParser;
+import org.apache.iceberg.types.Types;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -132,6 +138,81 @@ public class TestHTTPClient {
   @Test
   public void testPostSuccess() throws Exception {
     testHttpMethodOnSuccess(HttpMethod.POST);
+  }
+
+  @Test
+  public void testPostUnicodeBody() throws Exception {
+    String unicodeComment = "这是一个中文表注释";
+    assertUnicodeBodyRoundTrip("post_unicode", new Item(0L, unicodeComment), unicodeComment);
+  }
+
+  @Test
+  public void testPostCreateTableUnicodeColumnComment() throws Exception {
+    // Positive verification + negative reproduction: a non-ASCII column comment (doc) in the
+    // schema of a create-table request must be encoded as UTF-8.
+    String columnComment = "这是一个中文字段注释";
+    Schema schema =
+        new Schema(Types.NestedField.required(1, "id", Types.IntegerType.get(), columnComment));
+    CreateTableRequest body =
+        CreateTableRequest.builder().withName("table").withSchema(schema).build();
+    assertUnicodeBodyRoundTrip("post_create_table_unicode", body, columnComment);
+  }
+
+  @Test
+  public void testPostUpdateTableUnicodeColumnComment() throws Exception {
+    // Positive verification + negative reproduction: a non-ASCII column comment (doc) added via
+    // an add-column metadata update must be encoded as UTF-8.
+    String columnComment = "这是一个中文新增字段注释";
+    Schema newSchema =
+        new Schema(
+            Types.NestedField.required(1, "id", Types.IntegerType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get(), columnComment));
+    UpdateTableRequest body =
+        UpdateTableRequest.create(
+            TableIdentifier.of("ns", "table"),
+            ImmutableList.of(),
+            ImmutableList.of(new MetadataUpdate.AddSchema(newSchema)));
+    assertUnicodeBodyRoundTrip("post_update_table_unicode", body, columnComment);
+  }
+
+  private void assertUnicodeBodyRoundTrip(String path, RESTRequest body, String expectedUnicode)
+      throws JsonProcessingException {
+    String expectedJson = MAPPER.writeValueAsString(body);
+
+    HttpRequest mockRequest =
+        request("/" + path)
+            .withMethod(HttpMethod.POST.name().toUpperCase(Locale.ROOT))
+            .withHeader("Authorization", "Bearer " + BEARER_AUTH_TOKEN)
+            .withHeader(HTTPClient.CLIENT_VERSION_HEADER, icebergBuildFullVersion)
+            .withHeader(HTTPClient.CLIENT_GIT_COMMIT_SHORT_HEADER, icebergBuildGitCommitShort)
+            .withHeader(USER_AGENT, TEST_USER_AGENT)
+            .withBody(expectedJson);
+
+    Item expectedResponse = new Item(0L, expectedUnicode);
+    HttpResponse mockResponse =
+        response().withStatusCode(200).withBody(MAPPER.writeValueAsString(expectedResponse));
+    mockServer.when(mockRequest, Times.exactly(1)).respond(mockResponse);
+
+    ErrorHandler onError = mock(ErrorHandler.class);
+
+    Item response =
+        restClient.post(
+            path,
+            body,
+            Item.class,
+            ImmutableMap.of("Authorization", "Bearer " + BEARER_AUTH_TOKEN),
+            onError);
+
+    // Positive verification: the non-ASCII comment survives the round trip unchanged.
+    assertThat(response).isEqualTo(expectedResponse);
+
+    // Negative reproduction: the body actually received by the server must contain the correct
+    // UTF-8 encoded text rather than garbled characters.
+    HttpRequest[] recordedRequests =
+        mockServer.retrieveRecordedRequests(
+            request("/" + path).withMethod(HttpMethod.POST.name().toUpperCase(Locale.ROOT)));
+    assertThat(recordedRequests).hasSize(1);
+    assertThat(recordedRequests[0].getBodyAsString()).contains(expectedUnicode);
   }
 
   @Test

--- a/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/KafkaConnectUtils.java
+++ b/kafka-connect/kafka-connect-runtime/src/integration/java/org/apache/iceberg/connect/KafkaConnectUtils.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.connect;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -72,7 +73,7 @@ public class KafkaConnectUtils {
                   Locale.ROOT, "http://localhost:%d/connectors", TestContext.CONNECT_PORT));
       String body = TestContext.MAPPER.writeValueAsString(config);
       request.setHeader("Content-Type", "application/json");
-      request.setEntity(new StringEntity(body));
+      request.setEntity(new StringEntity(body, StandardCharsets.UTF_8));
       HTTP.execute(request, response -> null);
     } catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
## Problem
When creating a table or adding a column through the REST catalog, non-ASCII characters in comments (e.g. table comment property or column doc) are garbled on the server side.
## Root Cause
In HTTPClient#execute, the serialized request body is attached using the default StringEntity(String) constructor:
```java

request.setEntity(new StringEntity(encodedBody));

```
Apache HttpClient 5's StringEntity(String) defaults to text/plain; charset=ISO-8859-1. Although the body was correctly serialized to a UTF-8 String by Jackson, the entity encodes those bytes using ISO-8859-1. Non-ASCII characters cannot be represented in ISO-8859-1 and are irreversibly replaced with ?, so the server decodes garbled comments.
## Fix
Explicitly specify UTF-8 when constructing the entity:
```java

request.setEntity(new StringEntity(encodedBody, StandardCharsets.UTF_8));

```
This applies to both JSON bodies (create table, update table, etc.) and form-encoded bodies. The Content-Type header is unaffected because it is already set explicitly in buildRequest.

## Tests
Added TestHTTPClient#testPostUnicodeBody and related cases in TestHTTPClient, covering:
* testPostUnicodeBody – generic round-trip guard
* testPostCreateTableUnicodeColumnComment – non-ASCII column comment (doc) in a CreateTableRequest
* testPostUpdateTableUnicodeColumnComment – non-ASCII column comment added via an add-column MetadataUpdate