### PR TITLE
Docs: Update Apache Fluss documentation link to correct path

### DIFF
--- a/site/mkdocs-dev.yml
+++ b/site/mkdocs-dev.yml
@@ -53,7 +53,7 @@ nav:
         - Apache Amoro: integrations/amoro.md
         - Apache Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
         - Apache Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
-        - Apache Fluss: https://fluss.apache.org/docs/next/streaming-lakehouse/integrate-data-lakes/iceberg/
+        - Apache Fluss: https://fluss.apache.org/docs/next/streaming-lakehouse/datalake-formats/iceberg/
         - BladePipe: https://www.bladepipe.com/docs/dataMigrationAndSync/datasource_func/Iceberg/props_for_iceberg_ds
         - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
         - Daft: integrations/daft.md

--- a/site/nav.yml
+++ b/site/nav.yml
@@ -69,7 +69,7 @@ nav:
         - Apache Amoro: integrations/amoro.md
         - Apache Doris: https://doris.apache.org/docs/dev/lakehouse/catalogs/iceberg-catalog
         - Apache Druid: https://druid.apache.org/docs/latest/development/extensions-contrib/iceberg/
-        - Apache Fluss: https://fluss.apache.org/docs/next/streaming-lakehouse/integrate-data-lakes/iceberg/
+        - Apache Fluss: https://fluss.apache.org/docs/next/streaming-lakehouse/datalake-formats/iceberg/
         - BladePipe: https://www.bladepipe.com/docs/dataMigrationAndSync/datasource_func/Iceberg/props_for_iceberg_ds
         - ClickHouse: https://clickhouse.com/docs/en/engines/table-engines/integrations/iceberg
         - Daft: integrations/daft.md


### PR DESCRIPTION
## Changes

Update the Apache Fluss integration link to its current location.

## Testing

- `cd site`
- `make serve`
- Verified that the updated URLs