### PR TITLE
API: Fix strict evaluation when null or NaN counts are unknown

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import java.util.Comparator;
 import java.util.Set;
 import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
 
@@ -40,19 +41,11 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
   /** Return true if null count is known and equal to value count, false otherwise. */
   protected abstract boolean containsNullsOnly(int id);
 
-  /**
-   * Return true if null counts are unavailable or if the null count is non-zero, false otherwise.
-   */
-  protected abstract boolean canContainNulls(int id);
-
   /** Return true if NaN count is non-zero or is unknown, false if NaN count is 0. */
   protected abstract boolean mayContainNaN(int id);
 
   /** Return true if NaN count is known and equal to value count, false otherwise. */
   protected abstract boolean containsNaNsOnly(int id);
-
-  /** Return true if the NaN count is known and non-zero, false otherwise. */
-  protected abstract boolean canContainNaNs(int id);
 
   /** Return the lower bound if it is known, or null otherwise. */
   protected abstract <T> T lowerBound(BoundReference<T> ref);
@@ -159,7 +152,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -184,7 +177,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -209,7 +202,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -235,7 +228,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -261,7 +254,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -325,7 +318,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -389,7 +382,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id)) {
+    if (canContainNulls(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -457,6 +450,27 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
     return ROWS_MIGHT_NOT_MATCH;
   }
 
+  /**
+   * Returns true if the field is optional and its null count is non-zero or unknown.
+   *
+   * <p>A null value does not match a comparison predicate, so all rows can only match when the
+   * field has no nulls.
+   */
+  private boolean canContainNulls(BoundReference<?> ref) {
+    return ref.producesNull() && mayContainNull(ref.fieldId());
+  }
+
+  /**
+   * Returns true if the field is a floating point type and its NaN count is non-zero or unknown.
+   *
+   * <p>A NaN value does not match a comparison predicate, so all rows can only match when the field
+   * has no NaNs. NaN counts are tracked only for floating point fields, so the type is checked to
+   * avoid assuming that other fields may contain NaN values.
+   */
+  private boolean canContainNaNs(BoundReference<?> ref) {
+    return isFloatingPoint(ref.type()) && mayContainNaN(ref.fieldId());
+  }
+
   /** Returns true if the field is not a top-level field of the schema. */
   private boolean isNestedColumn(int id) {
     return struct.field(id) == null;
@@ -473,5 +487,9 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
     }
 
     return false;
+  }
+
+  private static boolean isFloatingPoint(Type type) {
+    return Type.TypeID.FLOAT == type.typeId() || Type.TypeID.DOUBLE == type.typeId();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -108,11 +108,6 @@ public class StrictMetricsEvaluator {
     }
 
     @Override
-    protected boolean canContainNulls(int id) {
-      return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) > 0);
-    }
-
-    @Override
     protected boolean mayContainNaN(int id) {
       return nanCounts == null || !nanCounts.containsKey(id) || nanCounts.get(id) != 0;
     }
@@ -123,11 +118,6 @@ public class StrictMetricsEvaluator {
           && nanCounts.containsKey(id)
           && valueCounts != null
           && nanCounts.get(id).equals(valueCounts.get(id));
-    }
-
-    @Override
-    protected boolean canContainNaNs(int id) {
-      return nanCounts != null && nanCounts.containsKey(id) && nanCounts.get(id) > 0;
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
@@ -345,7 +345,9 @@ public class TestMetricsEvaluatorsNaNHandling {
           .isFalse();
 
       shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 1D)).eval(FILE);
-      assertThat(shouldRead).as("Should match: 1 is smaller than lower bound").isTrue();
+      assertThat(shouldRead)
+          .as("Should not match: NaN count is unknown so a NaN may not match")
+          .isFalse();
 
       shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 10D)).eval(FILE);
       assertThat(shouldRead).as("Should not match: 10 is larger than lower bound").isFalse();

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -208,6 +208,69 @@ public class TestStrictMetricsEvaluator {
           // upper bounds
           ImmutableMap.of(3, toByteBuffer(StringType.get(), "dC")));
 
+  // Int columns with bounds, but without any null value counts
+  private static final DataFile MISSING_NULL_COUNTS_FILE =
+      new TestDataFile(
+          "missing_null_counts.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(1, 50L, 2, 50L),
+          // null value counts
+          null,
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MIN_VALUE)),
+          // upper bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
+
+  // Int columns with bounds, where null value counts are tracked only for another column
+  private static final DataFile PARTIAL_NULL_COUNTS_FILE =
+      new TestDataFile(
+          "partial_null_counts.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(1, 50L, 2, 50L),
+          // null value counts
+          ImmutableMap.of(3, 0L),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MIN_VALUE)),
+          // upper bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
+
+  // Float columns without nulls, where NaN counts are tracked only for column 10 (no_nans)
+  private static final DataFile FLOAT_FILE =
+      new TestDataFile(
+          "float_file.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(10, 50L, 14, 50L),
+          // null value counts
+          ImmutableMap.of(10, 0L, 14, 0L),
+          // nan value counts
+          ImmutableMap.of(10, 0L),
+          // lower bounds
+          ImmutableMap.of(
+              10, toByteBuffer(Types.FloatType.get(), 1.0F),
+              14, toByteBuffer(Types.DoubleType.get(), 1.0D)),
+          // upper bounds
+          ImmutableMap.of(
+              10, toByteBuffer(Types.FloatType.get(), 5.0F),
+              14, toByteBuffer(Types.DoubleType.get(), 5.0D)));
+
   @Test
   public void testAllNulls() {
     boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
@@ -920,5 +983,48 @@ public class TestStrictMetricsEvaluator {
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, startsWith("struct.nested_string_col", "a")).eval(FILE);
     assertThat(shouldRead).as("Should not match: nested column is not supported").isFalse();
+  }
+
+  @Test
+  void missingNullCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
+            .eval(MISSING_NULL_COUNTS_FILE);
+    assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
+            .eval(MISSING_NULL_COUNTS_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: optional column may contain nulls without a null count")
+        .isFalse();
+  }
+
+  @Test
+  void partialNullCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
+            .eval(PARTIAL_NULL_COUNTS_FILE);
+    assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
+            .eval(PARTIAL_NULL_COUNTS_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: optional column may contain nulls without a null count")
+        .isFalse();
+  }
+
+  @Test
+  void missingNaNCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nans", 10.0F)).eval(FLOAT_FILE);
+    assertThat(shouldRead).as("Should match: float column has no nulls and no NaNs").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nan_stats", 10.0D)).eval(FLOAT_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: float column may contain NaNs without a NaN count")
+        .isFalse();
   }
 }


### PR DESCRIPTION
This applies on top of https://github.com/apache/iceberg/pull/17511

The strict evaluator assumed that a field has no nulls when a null count
is missing for the field, and that a field has no NaNs when a NaN count is
unavailable. Both assumptions allow reporting that all rows in a file match
a comparison predicate when they may not, because neither null nor NaN
matches a comparison predicate.

Treat unknown counts as possible nulls and NaNs instead. Optionality is used
to determine whether a field can contain nulls, and NaNs are only considered
for floating point fields, where NaN counts are tracked.