### PR TITLE
Core: Use TrackedFile constants for partition and content_stats fields

### DIFF
--- a/core/src/main/java/org/apache/iceberg/StatsUtil.java
+++ b/core/src/main/java/org/apache/iceberg/StatsUtil.java
@@ -129,7 +129,7 @@ class StatsUtil {
   }
 
   public static Types.NestedField contentStatsField(Types.StructType contentStats) {
-    return optional(146, "content_stats", contentStats);
+    return optional(TrackedFile.CONTENT_STATS_ID, TrackedFile.CONTENT_STATS_NAME, contentStats);
   }
 
   public static Types.StructType statsWriteSchema(Schema tableSchema, MetricsConfig metricsConfig) {

--- a/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
+++ b/core/src/main/java/org/apache/iceberg/TrackedFileStruct.java
@@ -85,7 +85,7 @@ class TrackedFileStruct extends SupportsIndexProjection implements TrackedFile, 
     super(BASE_TYPE, projection);
     // partition type may be null if the field was not projected, or unknown for unpartitioned
     // manifests
-    Type partType = projection.fieldType("partition");
+    Type partType = projection.fieldType(TrackedFile.PARTITION_NAME);
     if (partType != null && partType.isStructType()) {
       this.partitionData = new PartitionData(partType.asStructType());
     }


### PR DESCRIPTION
Replace the duplicated field ID and name literals with the constants that TrackedFile already declares, which both files use elsewhere.