### PR TITLE
Kafka Connect: Preserve explicit null values instead of replacing them with schema defaults

### DIFF
--- a/docs/docs/kafka-connect.md
+++ b/docs/docs/kafka-connect.md
@@ -71,6 +71,7 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 | iceberg.tables.evolve-schema-enabled       | Set to `true` to add any missing record fields to the table schema, default is `false`                           |
 | iceberg.tables.schema-force-optional       | Set to `true` to set columns as optional during table create and evolution, default is `false` to respect schema |
 | iceberg.tables.schema-case-insensitive     | Set to `true` to look up table columns by case-insensitive name, default is `false` for case-sensitive           |
+| iceberg.tables.replace-null-with-default   | Set to `false` to preserve explicit null values instead of replacing them with the record schema default value, default is `true` |
 | iceberg.tables.auto-create-props.*         | Properties set on new tables during auto-create                                                                  |
 | iceberg.tables.write-props.*               | Properties passed through to Iceberg writer initialization, these take precedence                                |
 | iceberg.table.<_table-name_\>.commit-branch | Table-specific branch for commits, use `iceberg.tables.default-commit-branch` if not specified                   |
@@ -93,6 +94,11 @@ for exactly-once semantics. This requires Kafka 2.5 or later.
 If `iceberg.tables.dynamic-enabled` is `false` (the default) then you must specify `iceberg.tables`. If
 `iceberg.tables.dynamic-enabled` is `true` then you must specify `iceberg.tables.route-field` which will
 contain the name of the table.
+
+When `iceberg.tables.replace-null-with-default` is set to `false`, a record whose route field is
+explicitly null is skipped, like any other record with a null route value. Note that the JSON
+converter applies its own `replace.null.with.default` setting during (de)serialization, so it must
+also be set to `false` wherever that converter is used.
 
 ### Kafka configuration
 

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/CopyValue.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/CopyValue.java
@@ -90,9 +90,10 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
     Struct updatedValue = new Struct(updatedSchema);
 
     for (Field field : value.schema().fields()) {
-      updatedValue.put(field.name(), value.get(field));
+      // getWithoutDefault so an explicit null is not replaced by the schema default value
+      updatedValue.put(field.name(), value.getWithoutDefault(field.name()));
     }
-    updatedValue.put(targetField, value.get(sourceField));
+    updatedValue.put(targetField, value.getWithoutDefault(sourceField));
 
     return newRecord(record, updatedSchema, updatedValue);
   }

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/DebeziumTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/DebeziumTransform.java
@@ -107,7 +107,8 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
     Struct newValue = new Struct(newValueSchema);
 
     for (Field field : payloadSchema.fields()) {
-      newValue.put(field.name(), payload.get(field));
+      // getWithoutDefault so an explicit null is not replaced by the schema default value
+      newValue.put(field.name(), payload.getWithoutDefault(field.name()));
     }
     newValue.put(CdcConstants.COL_CDC, cdcMetadata);
 

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
@@ -243,7 +243,8 @@ public class KafkaMetadataTransform implements Transformation<SinkRecord> {
     Schema newSchema = makeUpdatedSchema(record.valueSchema());
     Struct newValue = new Struct(newSchema);
     for (Field field : record.valueSchema().fields()) {
-      newValue.put(field.name(), value.get(field));
+      // getWithoutDefault so an explicit null is not replaced by the schema default value
+      newValue.put(field.name(), value.getWithoutDefault(field.name()));
     }
     recordAppender.addToStruct(record, newValue);
     return record.newRecord(

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestCopyValue.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestCopyValue.java
@@ -86,4 +86,31 @@ public class TestCopyValue {
       assertThat(newValue.get("data_copy")).isEqualTo("foobar");
     }
   }
+
+  @Test
+  public void testCopyValueWithSchemaPreservesNullOfFieldWithDefault() {
+    Map<String, String> props =
+        ImmutableMap.of(
+            "source.field", "data",
+            "target.field", "data_copy");
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("data", SchemaBuilder.string().optional().defaultValue("").build());
+
+    Struct value = new Struct(schema).put("id", 123L).put("data", null);
+
+    try (CopyValue<SinkRecord> smt = new CopyValue<>()) {
+      smt.configure(props);
+      SinkRecord record = new SinkRecord("topic", 0, null, null, schema, value, 0);
+      SinkRecord result = smt.apply(record);
+
+      Struct newValue = (Struct) result.value();
+
+      // the explicit null is preserved for both the copied and the target field
+      assertThat(newValue.getWithoutDefault("data")).isNull();
+      assertThat(newValue.getWithoutDefault("data_copy")).isNull();
+    }
+  }
 }

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestDebeziumTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestDebeziumTransform.java
@@ -41,6 +41,7 @@ public class TestDebeziumTransform {
           .field("account_id", Schema.INT64_SCHEMA)
           .field("balance", Decimal.schema(2))
           .field("last_updated", Schema.STRING_SCHEMA)
+          .field("memo", SchemaBuilder.string().optional().defaultValue("").build())
           .build();
 
   private static final Schema SOURCE_SCHEMA =
@@ -115,6 +116,24 @@ public class TestDebeziumTransform {
     }
   }
 
+  @Test
+  public void testDebeziumTransformPreservesNullOfFieldWithDefault() {
+    try (DebeziumTransform<SinkRecord> smt = new DebeziumTransform<>()) {
+      smt.configure(ImmutableMap.of("cdc.target.pattern", "{db}_x.{table}_x"));
+
+      Struct event = createDebeziumEventStruct("u");
+      Struct key = new Struct(KEY_SCHEMA).put("account_id", 1L);
+      SinkRecord record = new SinkRecord("topic", 0, KEY_SCHEMA, key, VALUE_SCHEMA, event, 0);
+
+      SinkRecord result = smt.apply(record);
+      Struct value = (Struct) result.value();
+
+      // the explicit null is preserved, and the schema still carries the default
+      assertThat(value.getWithoutDefault("memo")).isNull();
+      assertThat(value.get("memo")).isEqualTo("");
+    }
+  }
+
   private Map<String, Object> createDebeziumEventMap(String operation) {
     Map<String, Object> source =
         ImmutableMap.of(
@@ -144,7 +163,8 @@ public class TestDebeziumTransform {
         new Struct(ROW_SCHEMA)
             .put("account_id", 1L)
             .put("balance", BigDecimal.valueOf(100))
-            .put("last_updated", Instant.now().toString());
+            .put("last_updated", Instant.now().toString())
+            .put("memo", null);
 
     return new Struct(VALUE_SCHEMA)
         .put("op", operation)

--- a/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/test/java/org/apache/iceberg/connect/transforms/TestKafkaMetadataTransform.java
@@ -196,6 +196,37 @@ public class TestKafkaMetadataTransform {
   }
 
   @Test
+  @DisplayName("should preserve explicit nulls for struct fields with schema defaults")
+  public void testPreservesNullOfFieldWithDefault() {
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("id", Schema.STRING_SCHEMA)
+            .field("memo", SchemaBuilder.string().optional().defaultValue("").build())
+            .build();
+    Struct struct = new Struct(schema).put("id", "value").put("memo", null);
+    SinkRecord record =
+        new SinkRecord(
+            TOPIC,
+            PARTITION,
+            KEY_SCHEMA,
+            KEY_VALUE,
+            schema,
+            struct,
+            OFFSET,
+            TIMESTAMP,
+            TimestampType.CREATE_TIME);
+    try (KafkaMetadataTransform smt = new KafkaMetadataTransform()) {
+      smt.configure(ImmutableMap.of());
+      SinkRecord result = smt.apply(record);
+      Struct value = (Struct) result.value();
+
+      // the explicit null is preserved, and the schema still carries the default
+      assertThat(value.getWithoutDefault("memo")).isNull();
+      assertThat(value.get("memo")).isEqualTo("");
+    }
+  }
+
+  @Test
   @DisplayName("should append kafka metadata to maps")
   public void testAppendToMaps() {
     SinkRecord record =

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/IcebergSinkConfig.java
@@ -79,6 +79,8 @@ public class IcebergSinkConfig extends AbstractConfig {
       "iceberg.tables.schema-force-optional";
   private static final String TABLES_SCHEMA_CASE_INSENSITIVE_PROP =
       "iceberg.tables.schema-case-insensitive";
+  private static final String TABLES_REPLACE_NULL_WITH_DEFAULT_PROP =
+      "iceberg.tables.replace-null-with-default";
   private static final String CONTROL_TOPIC_PROP = "iceberg.control.topic";
   private static final String CONTROL_GROUP_ID_PREFIX_PROP = "iceberg.control.group-id-prefix";
   private static final String COMMIT_INTERVAL_MS_PROP = "iceberg.control.commit.interval-ms";
@@ -179,6 +181,12 @@ public class IcebergSinkConfig extends AbstractConfig {
         false,
         Importance.MEDIUM,
         "Set to true to add any missing record fields to the table schema, false otherwise");
+    configDef.define(
+        TABLES_REPLACE_NULL_WITH_DEFAULT_PROP,
+        ConfigDef.Type.BOOLEAN,
+        true,
+        Importance.MEDIUM,
+        "Set to false to preserve explicit null values instead of replacing them with the record schema default value, true otherwise");
     configDef.define(
         CATALOG_NAME_PROP,
         ConfigDef.Type.STRING,
@@ -461,6 +469,10 @@ public class IcebergSinkConfig extends AbstractConfig {
 
   public boolean schemaCaseInsensitive() {
     return getBoolean(TABLES_SCHEMA_CASE_INSENSITIVE_PROP);
+  }
+
+  public boolean replaceNullWithDefault() {
+    return getBoolean(TABLES_REPLACE_NULL_WITH_DEFAULT_PROP);
   }
 
   public JsonConverter jsonConverter() {

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -259,7 +259,7 @@ class RecordConverter {
                     hasSchemaUpdates = true;
                   }
                 }
-                Object recordFieldValue = struct.get(recordField);
+                Object recordFieldValue = fieldValue(struct, recordField);
                 if (recordFieldValue == null && schemaUpdateConsumer != null && !hasSchemaUpdates) {
                   evolveSchemaFromConnectSchema(
                       recordField.schema(),
@@ -360,6 +360,18 @@ class RecordConverter {
       org.apache.kafka.connect.data.Schema.Type recordSchemaType, Type tableType) {
     LOG.warn(
         "Record schema of type {} does not match table of type {}", recordSchemaType, tableType);
+  }
+
+  /**
+   * Reads a struct field value. {@link Struct#get(Field)} substitutes the schema default value when
+   * the stored value is null, which turns an explicit null into the default; whether that
+   * substitution happens is controlled by the {@code iceberg.tables.replace-null-with-default}
+   * setting.
+   */
+  private Object fieldValue(Struct struct, Field field) {
+    return config.replaceNullWithDefault()
+        ? struct.get(field)
+        : struct.getWithoutDefault(field.name());
   }
 
   private NestedField lookupStructField(String fieldName, StructType schema, int structFieldId) {
@@ -591,7 +603,7 @@ class RecordConverter {
    * null, scalar values, and empty maps, lists, or structs. Map keys must be strings; non-string
    * keys cause IllegalArgumentException.
    */
-  private static Set<String> collectFieldNames(Object value) {
+  private Set<String> collectFieldNames(Object value) {
     if (value == null) {
       return Collections.emptySet();
     }
@@ -628,7 +640,7 @@ class RecordConverter {
       fields.forEach(
           field -> {
             names.add(field.name());
-            names.addAll(collectFieldNames(struct.get(field)));
+            names.addAll(collectFieldNames(fieldValue(struct, field)));
           });
       return names;
     }
@@ -639,7 +651,7 @@ class RecordConverter {
    * Recursively converts a Java object to a VariantValue using the given shared metadata for all
    * nested maps. Handles primitives, List (array), and Map (object); map keys become field names.
    */
-  private static VariantValue objectToVariantValue(
+  private VariantValue objectToVariantValue(
       Object value, VariantMetadata metadata, org.apache.kafka.connect.data.Schema schema) {
     if (value == null) {
       return Variants.ofNull();
@@ -663,7 +675,9 @@ class RecordConverter {
     if (value instanceof Struct struct) {
       ShreddedObject object = Variants.object(metadata);
       for (Field field : struct.schema().fields()) {
-        object.put(field.name(), objectToVariantValue(struct.get(field), metadata, field.schema()));
+        object.put(
+            field.name(),
+            objectToVariantValue(fieldValue(struct, field), metadata, field.schema()));
       }
       return object;
     }
@@ -671,7 +685,7 @@ class RecordConverter {
   }
 
   /** Converts a Map to VariantValue; throw IllegalArgumentException if the key is not a string. */
-  private static VariantValue mapToVariantValue(
+  private VariantValue mapToVariantValue(
       Map<?, ?> map, VariantMetadata metadata, org.apache.kafka.connect.data.Schema schema) {
     ShreddedObject object = Variants.object(metadata);
     org.apache.kafka.connect.data.Schema mapValueSchema =

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordUtils.java
@@ -48,10 +48,11 @@ import org.apache.kafka.connect.data.Struct;
 class RecordUtils {
 
   @SuppressWarnings("unchecked")
-  static Object extractFromRecordValue(Object recordValue, String fieldName) {
+  static Object extractFromRecordValue(
+      Object recordValue, String fieldName, IcebergSinkConfig config) {
     List<String> fields = Splitter.on('.').splitToList(fieldName);
     if (recordValue instanceof Struct) {
-      return valueFromStruct((Struct) recordValue, fields);
+      return valueFromStruct((Struct) recordValue, fields, config.replaceNullWithDefault());
     } else if (recordValue instanceof Map) {
       return valueFromMap((Map<String, ?>) recordValue, fields);
     } else {
@@ -60,25 +61,28 @@ class RecordUtils {
     }
   }
 
-  private static Object valueFromStruct(Struct parent, List<String> fields) {
+  private static Object valueFromStruct(
+      Struct parent, List<String> fields, boolean replaceNullWithDefault) {
     Struct struct = parent;
     for (int idx = 0; idx < fields.size() - 1; idx++) {
-      Object value = fieldValueFromStruct(struct, fields.get(idx));
+      Object value = fieldValueFromStruct(struct, fields.get(idx), replaceNullWithDefault);
       if (value == null) {
         return null;
       }
       Preconditions.checkState(value instanceof Struct, "Expected a struct type");
       struct = (Struct) value;
     }
-    return fieldValueFromStruct(struct, fields.get(fields.size() - 1));
+    return fieldValueFromStruct(struct, fields.get(fields.size() - 1), replaceNullWithDefault);
   }
 
-  private static Object fieldValueFromStruct(Struct struct, String fieldName) {
+  private static Object fieldValueFromStruct(
+      Struct struct, String fieldName, boolean replaceNullWithDefault) {
     Field structField = struct.schema().field(fieldName);
     if (structField == null) {
       return null;
     }
-    return struct.get(structField);
+    // Struct.get() substitutes the schema default value when the stored value is null
+    return replaceNullWithDefault ? struct.get(structField) : struct.getWithoutDefault(fieldName);
   }
 
   @SuppressWarnings("unchecked")

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/SinkWriter.java
@@ -132,7 +132,7 @@ public class SinkWriter {
     if (recordValue == null) {
       return null;
     }
-    Object routeValue = RecordUtils.extractFromRecordValue(recordValue, routeField);
+    Object routeValue = RecordUtils.extractFromRecordValue(recordValue, routeField, config);
     return routeValue == null ? null : routeValue.toString();
   }
 

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/TestIcebergSinkConfig.java
@@ -57,6 +57,7 @@ public class TestIcebergSinkConfig {
             "iceberg.tables", "db.landing");
     IcebergSinkConfig config = new IcebergSinkConfig(props);
     assertThat(config.commitIntervalMs()).isEqualTo(300_000);
+    assertThat(config.replaceNullWithDefault()).isTrue();
   }
 
   @Test

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordConverter.java
@@ -220,6 +220,7 @@ public class TestRecordConverter {
   public void before() {
     this.config = mock(IcebergSinkConfig.class);
     when(config.jsonConverter()).thenReturn(JSON_CONVERTER);
+    when(config.replaceNullWithDefault()).thenReturn(true);
   }
 
   @Test
@@ -449,6 +450,31 @@ public class TestRecordConverter {
     } else {
       assertThat(record1.getField("ii")).isEqualTo(null);
       assertThat(record2.getField("ii")).isEqualTo(null);
+    }
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testReplaceNullWithDefault(boolean replaceNullWithDefault) {
+    Table table = mock(Table.class);
+    when(table.schema())
+        .thenReturn(new org.apache.iceberg.Schema(NestedField.optional(1, "s", StringType.get())));
+
+    when(config.replaceNullWithDefault()).thenReturn(replaceNullWithDefault);
+
+    RecordConverter converter = new RecordConverter(table, config);
+
+    Schema connectSchema =
+        SchemaBuilder.struct()
+            .field("s", SchemaBuilder.string().optional().defaultValue("").build())
+            .build();
+    Struct data = new Struct(connectSchema).put("s", null);
+    Record record = converter.convert(data);
+
+    if (replaceNullWithDefault) {
+      assertThat(record.getField("s")).isEqualTo("");
+    } else {
+      assertThat(record.getField("s")).isNull();
     }
   }
 
@@ -1754,6 +1780,29 @@ public class TestRecordConverter {
 
     assertThat(innerVal.asObject().get("d").type()).isEqualTo(PhysicalType.DATE);
     assertThat(innerVal.asObject().get("d").asPrimitive().get()).isEqualTo(20182);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {false, true})
+  public void testConvertVariantValueFromStructReplaceNullWithDefault(
+      boolean replaceNullWithDefault) {
+    when(config.replaceNullWithDefault()).thenReturn(replaceNullWithDefault);
+
+    Schema schema =
+        SchemaBuilder.struct()
+            .field("id", Schema.INT64_SCHEMA)
+            .field("memo", SchemaBuilder.string().optional().defaultValue("").build())
+            .build();
+    Struct struct = new Struct(schema).put("id", 100L).put("memo", null);
+
+    Variant variant = variantConverter().convertVariantValue(struct);
+
+    assertThat(variant.value().asObject().get("id").asPrimitive().get()).isEqualTo(100L);
+    if (replaceNullWithDefault) {
+      assertThat(variant.value().asObject().get("memo").asPrimitive().get()).isEqualTo("");
+    } else {
+      assertThat(variant.value().asObject().get("memo").type()).isEqualTo(PhysicalType.NULL);
+    }
   }
 
   public static Map<String, Object> createMapData() {

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestRecordUtils.java
@@ -20,6 +20,8 @@ package org.apache.iceberg.connect.data;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Map;
 import java.util.UUID;
@@ -30,15 +32,26 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestRecordUtils extends WriterTestBase {
+
+  private IcebergSinkConfig config;
+
+  @BeforeEach
+  public void initConfig() {
+    this.config = mock(IcebergSinkConfig.class);
+    when(config.replaceNullWithDefault()).thenReturn(true);
+  }
 
   @Test
   public void testExtractFromRecordValueStruct() {
     Schema valSchema = SchemaBuilder.struct().field("key", Schema.INT64_SCHEMA).build();
     Struct val = new Struct(valSchema).put("key", 123L);
-    Object result = RecordUtils.extractFromRecordValue(val, "key");
+    Object result = RecordUtils.extractFromRecordValue(val, "key", config);
     assertThat(result).isEqualTo(123L);
   }
 
@@ -52,7 +65,7 @@ public class TestRecordUtils extends WriterTestBase {
     Struct data = new Struct(dataSchema).put("id", id);
     Struct val = new Struct(valSchema).put("data", data);
 
-    Object result = RecordUtils.extractFromRecordValue(val, "data.id.key");
+    Object result = RecordUtils.extractFromRecordValue(val, "data.id.key", config);
     assertThat(result).isEqualTo(123L);
   }
 
@@ -61,17 +74,37 @@ public class TestRecordUtils extends WriterTestBase {
     Schema valSchema = SchemaBuilder.struct().field("key", Schema.INT64_SCHEMA).build();
     Struct val = new Struct(valSchema).put("key", 123L);
 
-    Object result = RecordUtils.extractFromRecordValue(val, "");
+    Object result = RecordUtils.extractFromRecordValue(val, "", config);
     assertThat(result).isNull();
 
-    result = RecordUtils.extractFromRecordValue(val, "xkey");
+    result = RecordUtils.extractFromRecordValue(val, "xkey", config);
     assertThat(result).isNull();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testExtractFromRecordValueStructReplaceNullWithDefault(
+      boolean replaceNullWithDefault) {
+    when(config.replaceNullWithDefault()).thenReturn(replaceNullWithDefault);
+
+    Schema valSchema =
+        SchemaBuilder.struct()
+            .field("key", SchemaBuilder.string().optional().defaultValue("default").build())
+            .build();
+    Struct val = new Struct(valSchema).put("key", null);
+
+    Object result = RecordUtils.extractFromRecordValue(val, "key", config);
+    if (replaceNullWithDefault) {
+      assertThat(result).isEqualTo("default");
+    } else {
+      assertThat(result).isNull();
+    }
   }
 
   @Test
   public void testExtractFromRecordValueMap() {
     Map<String, Object> val = ImmutableMap.of("key", 123L);
-    Object result = RecordUtils.extractFromRecordValue(val, "key");
+    Object result = RecordUtils.extractFromRecordValue(val, "key", config);
     assertThat(result).isEqualTo(123L);
   }
 
@@ -81,7 +114,7 @@ public class TestRecordUtils extends WriterTestBase {
     Map<String, Object> data = ImmutableMap.of("id", id);
     Map<String, Object> val = ImmutableMap.of("data", data);
 
-    Object result = RecordUtils.extractFromRecordValue(val, "data.id.key");
+    Object result = RecordUtils.extractFromRecordValue(val, "data.id.key", config);
     assertThat(result).isEqualTo(123L);
   }
 
@@ -89,10 +122,10 @@ public class TestRecordUtils extends WriterTestBase {
   public void testExtractFromRecordValueMapNull() {
     Map<String, Object> val = ImmutableMap.of("key", 123L);
 
-    Object result = RecordUtils.extractFromRecordValue(val, "");
+    Object result = RecordUtils.extractFromRecordValue(val, "", config);
     assertThat(result).isNull();
 
-    result = RecordUtils.extractFromRecordValue(val, "xkey");
+    result = RecordUtils.extractFromRecordValue(val, "xkey", config);
     assertThat(result).isNull();
   }
 
@@ -104,13 +137,13 @@ public class TestRecordUtils extends WriterTestBase {
             "topics", "source-topic",
             "iceberg.tables", "default.events",
             "iceberg.table.default.events.id-columns", "missing_col");
-    IcebergSinkConfig config = new IcebergSinkConfig(props);
+    IcebergSinkConfig sinkConfig = new IcebergSinkConfig(props);
     TableReference tableReference =
         TableReference.of(
             "test_catalog", TableIdentifier.of("default", "events"), UUID.randomUUID());
 
     // the per-table id-columns config is only found when looked up by the full table identifier
-    assertThatThrownBy(() -> RecordUtils.createTableWriter(table, tableReference, config))
+    assertThatThrownBy(() -> RecordUtils.createTableWriter(table, tableReference, sinkConfig))
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("ID column not found: missing_col");
   }

--- a/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
+++ b/kafka-connect/kafka-connect/src/test/java/org/apache/iceberg/connect/data/TestSinkWriter.java
@@ -46,10 +46,14 @@ import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.types.Types;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.record.TimestampType;
+import org.apache.kafka.connect.data.SchemaBuilder;
+import org.apache.kafka.connect.data.Struct;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 public class TestSinkWriter {
 
@@ -153,6 +157,51 @@ public class TestSinkWriter {
     assertThat(writerResults).hasSize(1);
     IcebergWriterResult writerResult = writerResults.get(0);
     assertThat(writerResult.tableReference().identifier()).isEqualTo(TABLE_IDENTIFIER);
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  public void testDynamicRouteReplaceNullWithDefault(boolean replaceNullWithDefault) {
+    IcebergSinkConfig config = mock(IcebergSinkConfig.class);
+    when(config.tables()).thenReturn(ImmutableList.of(TABLE_IDENTIFIER.toString()));
+    when(config.tableConfig(any())).thenReturn(mock(TableSinkConfig.class));
+    when(config.dynamicTablesEnabled()).thenReturn(true);
+    when(config.tablesRouteField()).thenReturn(ROUTE_FIELD);
+    when(config.replaceNullWithDefault()).thenReturn(replaceNullWithDefault);
+
+    org.apache.kafka.connect.data.Schema valueSchema =
+        SchemaBuilder.struct()
+            .field("id", org.apache.kafka.connect.data.Schema.OPTIONAL_INT64_SCHEMA)
+            .field(
+                ROUTE_FIELD,
+                SchemaBuilder.string().optional().defaultValue(TABLE_IDENTIFIER.toString()).build())
+            .build();
+    Struct value = new Struct(valueSchema).put("id", 123L).put(ROUTE_FIELD, null);
+
+    SinkWriter sinkWriter = new SinkWriter(catalog, config);
+    SinkRecord rec =
+        new SinkRecord(
+            "topic",
+            1,
+            null,
+            "key",
+            valueSchema,
+            value,
+            100L,
+            Instant.now().toEpochMilli(),
+            TimestampType.LOG_APPEND_TIME);
+    sinkWriter.save(ImmutableList.of(rec));
+    SinkWriterResult result = sinkWriter.completeWrite();
+
+    if (replaceNullWithDefault) {
+      // the schema default is used as the route value
+      assertThat(result.writerResults()).hasSize(1);
+      assertThat(result.writerResults().get(0).tableReference().identifier())
+          .isEqualTo(TABLE_IDENTIFIER);
+    } else {
+      // an explicitly-null route field is skipped like any other null route value
+      assertThat(result.writerResults()).isEmpty();
+    }
   }
 
   @Test


### PR DESCRIPTION
Closes #17652

### Problem

Kafka Connect's `Struct.get(Field)` returns the field's schema `defaultValue` when the stored value is null, without checking `isOptional()` ([KAFKA-8713](https://issues.apache.org/jira/browse/KAFKA-8713)). The sink and its bundled SMTs read field values with `get()`, so an explicit `NULL` in the source is silently written to the Iceberg table as the column default — no error or warning is raised.

The most common trigger is Debezium CDC, which propagates a column's DDL `DEFAULT` clause into the Connect schema's `defaultValue`: for any column that is **nullable with a non-NULL default** (e.g. MySQL `VARCHAR(255) NULL DEFAULT ''`), every explicitly NULL value is replaced:

```
source row: NULL  →  Kafka message: null (correct)  →  Iceberg table: '' (corrupted)
```

We hit this in production: for affected columns, 100% of NULLs had been written as the column default. No converter configuration can prevent it — even when the deserializing converter preserves the null, the Connect schema still carries the `defaultValue`, and the sink's own reads re-apply it on every `Struct.get()`.

The same bug class has been fixed across the ecosystem: Debezium uses `getWithoutDefault` unconditionally in its own SMTs ([`ExtractNewRecordState#L191-L193`](https://github.com/debezium/debezium/blob/v3.2.0.Final/debezium-core/src/main/java/io/debezium/transforms/ExtractNewRecordState.java#L191-L193)), Kafka core added a `replace.null.with.default` option to nine SMTs ([KIP-1040](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1040%3A+Improve+handling+of+nullable+values+in+InsertField%2C+ExtractField%2C+and+other+transformations)) and to `JsonConverter` ([KIP-581](https://cwiki.apache.org/confluence/display/KAFKA/KIP-581%3A+Value+of+optional+null+field+which+has+default+value)), and the JDBC sinks fixed it as well ([confluentinc/kafka-connect-jdbc#1433](https://github.com/confluentinc/kafka-connect-jdbc/pull/1433), [DBZ-7191](https://issues.redhat.com/browse/DBZ-7191)).

### Changes

A `Struct` preserves an explicit null only as long as nobody copies it with `get()`: the copied schema still carries the `defaultValue`, so the first `get()` in the chain irreversibly bakes the default into the stored value. The SMTs are therefore pure pass-throughs, and the single behavioral decision happens at the final read, controlled by one sink option:

- **Bundled SMTs** (`DebeziumTransform`, `KafkaMetadataTransform`, `CopyValue`): copy fields with `getWithoutDefault` so the stored null survives the copy, as Debezium's own SMTs do. This is not an observable behavior change on the default path: the output schema still carries the `defaultValue`, so any consumer reading with `get()` (including today's `RecordConverter`) receives exactly the same values as before. The new SMT tests assert both halves (the stored null and the retained schema default).
- **`IcebergSinkConfig`**: new option `iceberg.tables.replace-null-with-default`, default `true`, which preserves the current behavior. Set to `false` to keep explicit nulls.
- **`RecordConverter`**: struct field reads, including the variant conversion path, go through a shared helper gated by the option.
- **`RecordUtils` / `SinkWriter`**: route-field extraction is gated by the same option: with the option disabled, an explicitly null route field is skipped like any other null route value, keeping writes and routing consistent.
- **Docs**: config table row plus a note on the routing behavior and on the JSON converter's own `replace.null.with.default` setting.

### Design notes

- **Why unconditional SMT changes instead of per-SMT options (the [KIP-1040](https://cwiki.apache.org/confluence/display/KAFKA/KIP-1040%3A+Improve+handling+of+nullable+values+in+InsertField%2C+ExtractField%2C+and+other+transformations) pattern):** a single SMT in the chain left at `true` silently defeats the sink-level option, turning one bug into a configuration puzzle; and as noted above, the unconditional change is not observable to `get()` readers. Happy to switch to per-SMT options if that's preferred; the sink-level option composes with either choice.
- **Why the default is `true`:** purely for backward compatibility. Given that a null that reaches the sink is always an explicitly written null, there is also a case for defaulting to `false`; happy to go either way.

### Testing

Unit tests cover the transform, converter (struct and variant), routing, and config-default paths; each new behavior is parameterized over both option values. All `kafka-connect` module tests pass.

---

Generative AI (Claude) was used to help draft the changes and tests.
All changes were reviewed and verified by the author.
