### PR TITLE
Core: Call close on iterables returned by ManifestReader.liveEntries() in ManifestFilterManager

### DIFF
--- a/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
+++ b/core/src/main/java/org/apache/iceberg/ManifestFilterManager.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.expressions.InclusiveMetricsEvaluator;
 import org.apache.iceberg.expressions.ManifestEvaluator;
 import org.apache.iceberg.expressions.ResidualEvaluator;
 import org.apache.iceberg.expressions.StrictMetricsEvaluator;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.relocated.com.google.common.base.Joiner;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
@@ -455,36 +456,40 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     boolean isDelete = reader.isDeleteManifestReader();
 
-    for (ManifestEntry<F> entry : reader.liveEntries()) {
-      F file = entry.file();
-      boolean markedForDelete =
-          deletePaths.contains(file.location())
-              || deleteFiles.contains(file)
-              || dropPartitions.contains(file.specId(), file.partition())
-              || (isDelete
-                  && entry.isLive()
-                  && entry.dataSequenceNumber() > 0
-                  && entry.dataSequenceNumber() < minSequenceNumber)
-              || (isDelete && isDanglingDV((DeleteFile) file));
+    try (CloseableIterable<ManifestEntry<F>> liveEntries = reader.liveEntries()) {
+      for (ManifestEntry<F> entry : liveEntries) {
+        F file = entry.file();
+        boolean markedForDelete =
+            deletePaths.contains(file.location())
+                || deleteFiles.contains(file)
+                || dropPartitions.contains(file.specId(), file.partition())
+                || (isDelete
+                    && entry.isLive()
+                    && entry.dataSequenceNumber() > 0
+                    && entry.dataSequenceNumber() < minSequenceNumber)
+                || (isDelete && isDanglingDV((DeleteFile) file));
 
-      if (markedForDelete || evaluator.rowsMightMatch(file)) {
-        boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
-        ValidationException.check(
-            allRowsMatch
-                || isDelete, // ignore delete files where some records may not match the expression
-            "Cannot delete file where some, but not all, rows match filter %s: %s",
-            this.deleteExpression,
-            file.location());
+        if (markedForDelete || evaluator.rowsMightMatch(file)) {
+          boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
+          ValidationException.check(
+              allRowsMatch || isDelete, // ignore delete files where some records may not match the
+              // expression
+              "Cannot delete file where some, but not all, rows match filter %s: %s",
+              this.deleteExpression,
+              file.location());
 
-        if (allRowsMatch) {
-          if (failAnyDelete) {
-            throw new DeleteException(reader.spec().partitionToPath(file.partition()));
+          if (allRowsMatch) {
+            if (failAnyDelete) {
+              throw new DeleteException(reader.spec().partitionToPath(file.partition()));
+            }
+
+            // as soon as a deleted file is detected, stop scanning
+            return true;
           }
-
-          // as soon as a deleted file is detected, stop scanning
-          return true;
         }
       }
+    } catch (IOException e) {
+      throw new RuntimeIOException(e, "Failed to close manifest entries: %s", manifest);
     }
 
     return false;
@@ -504,58 +509,58 @@ abstract class ManifestFilterManager<F extends ContentFile<F>> {
 
     try {
       ManifestWriter<F> writer = newManifestWriter(reader.spec());
-      try {
-        reader
-            .liveEntries()
-            .forEach(
-                entry -> {
-                  F file = entry.file();
-                  boolean isDanglingDV = isDelete && isDanglingDV((DeleteFile) file);
-                  boolean markedForDelete =
-                      isDanglingDV
-                          || deletePaths.contains(file.location())
-                          || deleteFiles.contains(file)
-                          || dropPartitions.contains(file.specId(), file.partition())
-                          || (isDelete
-                              && entry.isLive()
-                              && entry.dataSequenceNumber() > 0
-                              && entry.dataSequenceNumber() < minSequenceNumber);
-                  if (markedForDelete || evaluator.rowsMightMatch(file)) {
-                    boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
-                    ValidationException.check(
-                        allRowsMatch
-                            || isDelete, // ignore delete files where some records may not match
-                        // the expression
-                        "Cannot delete file where some, but not all, rows match filter %s: %s",
-                        this.deleteExpression,
+      try (CloseableIterable<ManifestEntry<F>> liveEntries = reader.liveEntries()) {
+        liveEntries.forEach(
+            entry -> {
+              F file = entry.file();
+              boolean isDanglingDV = isDelete && isDanglingDV((DeleteFile) file);
+              boolean markedForDelete =
+                  isDanglingDV
+                      || deletePaths.contains(file.location())
+                      || deleteFiles.contains(file)
+                      || dropPartitions.contains(file.specId(), file.partition())
+                      || (isDelete
+                          && entry.isLive()
+                          && entry.dataSequenceNumber() > 0
+                          && entry.dataSequenceNumber() < minSequenceNumber);
+              if (markedForDelete || evaluator.rowsMightMatch(file)) {
+                boolean allRowsMatch = markedForDelete || evaluator.rowsMustMatch(file);
+                ValidationException.check(
+                    allRowsMatch
+                        || isDelete, // ignore delete files where some records may not match
+                    // the expression
+                    "Cannot delete file where some, but not all, rows match filter %s: %s",
+                    this.deleteExpression,
+                    file.location());
+
+                if (allRowsMatch) {
+                  writer.delete(entry);
+                  F fileCopy = file.copyWithoutStats();
+                  // add the file here in case it was deleted using an expression. The
+                  // DeleteManifestFilterManager will then remove its matching DV
+                  deleteFiles.add(fileCopy);
+
+                  if (deletedFiles.contains(file)) {
+                    LOG.warn(
+                        "Deleting a duplicate path from manifest {}: {}",
+                        manifest.path(),
                         file.location());
-
-                    if (allRowsMatch) {
-                      writer.delete(entry);
-                      F fileCopy = file.copyWithoutStats();
-                      // add the file here in case it was deleted using an expression. The
-                      // DeleteManifestFilterManager will then remove its matching DV
-                      deleteFiles.add(fileCopy);
-
-                      if (deletedFiles.contains(file)) {
-                        LOG.warn(
-                            "Deleting a duplicate path from manifest {}: {}",
-                            manifest.path(),
-                            file.location());
-                        duplicateDeleteCount += 1;
-                      } else {
-                        // only add the file to deletes if it is a new delete
-                        // this keeps the snapshot summary accurate for non-duplicate data
-                        deletedFiles.add(fileCopy);
-                      }
-                    } else {
-                      writer.existing(entry);
-                    }
-
+                    duplicateDeleteCount += 1;
                   } else {
-                    writer.existing(entry);
+                    // only add the file to deletes if it is a new delete
+                    // this keeps the snapshot summary accurate for non-duplicate data
+                    deletedFiles.add(fileCopy);
                   }
-                });
+                } else {
+                  writer.existing(entry);
+                }
+
+              } else {
+                writer.existing(entry);
+              }
+            });
+      } catch (IOException e) {
+        throw new RuntimeIOException(e, "Failed to close manifest entries: %s", manifest);
       } finally {
         writer.close();
       }

--- a/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
+++ b/core/src/test/java/org/apache/iceberg/TestDeleteFiles.java
@@ -26,12 +26,16 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.iceberg.ManifestEntry.Status;
 import org.apache.iceberg.exceptions.ValidationException;
 import org.apache.iceberg.expressions.Expression;
 import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.FileIO;
+import org.apache.iceberg.io.InputFile;
+import org.apache.iceberg.io.SeekableInputStream;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableMap;
 import org.apache.iceberg.relocated.com.google.common.collect.Iterables;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -40,6 +44,7 @@ import org.apache.iceberg.util.StructLikeWrapper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
 
 @ExtendWith(ParameterizedTestExtension.class)
 public class TestDeleteFiles extends TestBase {
@@ -738,7 +743,53 @@ public class TestDeleteFiles extends TestBase {
         statuses(Status.DELETED, Status.DELETED));
   }
 
+  @TestTemplate
+  public void filterManifestsWithLimitedIOPool() {
+    AtomicInteger peakOpenStreams = new AtomicInteger(0);
+    TestTables.TestTableOperations ops =
+        new TestTables.TestTableOperations("limited-test", tableDir, trackingIO(peakOpenStreams));
+    Table testTable =
+        TestTables.create(
+            tableDir, "limited-test", SCHEMA, SPEC, SortOrder.unsorted(), formatVersion, ops);
+    commit(testTable, testTable.newFastAppend().appendFile(FILE_A), branch);
+    Snapshot deleteSnap = commit(testTable, testTable.newDelete().deleteFile(FILE_A), branch);
+    assertThat(deleteSnap.summary()).containsEntry(SnapshotSummary.DELETED_FILES_PROP, "1");
+    assertThat(peakOpenStreams.get()).isEqualTo(1);
+  }
+
   private static ByteBuffer longToBuffer(long value) {
     return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, value);
+  }
+
+  /** Returns a {@link FileIO} that records the peak number of concurrently open input streams. */
+  private static FileIO trackingIO(AtomicInteger peakOpenStreams) {
+    AtomicInteger openStreams = new AtomicInteger(0);
+    FileIO io = Mockito.spy(new TestTables.LocalFileIO());
+
+    Mockito.doAnswer(
+            newInputFile -> {
+              InputFile file = Mockito.spy((InputFile) newInputFile.callRealMethod());
+              Mockito.doAnswer(
+                      newStream -> {
+                        peakOpenStreams.accumulateAndGet(openStreams.incrementAndGet(), Math::max);
+                        SeekableInputStream stream =
+                            Mockito.spy((SeekableInputStream) newStream.callRealMethod());
+                        Mockito.doAnswer(
+                                close -> {
+                                  openStreams.decrementAndGet();
+                                  return close.callRealMethod();
+                                })
+                            .when(stream)
+                            .close();
+                        return stream;
+                      })
+                  .when(file)
+                  .newStream();
+              return file;
+            })
+        .when(io)
+        .newInputFile(Mockito.anyString());
+
+    return io;
   }
 }


### PR DESCRIPTION
Backport of #15713 to the 1.11.x branch.