### PR TITLE
API: Avoid intermediate collections in IN predicate metrics evaluation

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/InclusiveEvalVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/InclusiveEvalVisitor.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.expressions;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.iceberg.transforms.Transform;
 import org.apache.iceberg.types.Comparators;
 import org.apache.iceberg.util.NaNUtil;
@@ -316,31 +315,18 @@ abstract class InclusiveEvalVisitor extends ExpressionVisitors.BoundVisitor<Bool
     }
 
     Comparator<T> comparator = ((BoundTerm<T>) term).comparator();
-
-    literals =
-        literals.stream()
-            .filter(v -> comparator.compare(lower, v) <= 0)
-            .collect(Collectors.toList());
-    // if all values are less than lower bound, rows cannot match
-    if (literals.isEmpty()) {
-      return ROWS_CANNOT_MATCH;
-    }
-
     T upper = evalUpperBound(term);
-    if (null == upper) {
-      return ROWS_MIGHT_MATCH;
+
+    // rows might match if any literal falls within [lower, upper]; a null upper means no upper
+    // bound
+    for (T literal : literals) {
+      if (comparator.compare(lower, literal) <= 0
+          && (null == upper || comparator.compare(upper, literal) >= 0)) {
+        return ROWS_MIGHT_MATCH;
+      }
     }
 
-    literals =
-        literals.stream()
-            .filter(v -> comparator.compare(upper, v) >= 0)
-            .collect(Collectors.toList());
-    // if remaining values are greater than upper bound, rows cannot match
-    if (literals.isEmpty()) {
-      return ROWS_CANNOT_MATCH;
-    }
-
-    return ROWS_MIGHT_MATCH;
+    return ROWS_CANNOT_MATCH;
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ManifestEvaluator.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.apache.iceberg.Accessors;
 import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.ManifestFile.PartitionFieldSummary;
@@ -296,25 +295,17 @@ public class ManifestEvaluator {
       }
 
       T lower = Conversions.fromByteBuffer(ref.type(), fieldStats.lowerBound());
-      literals =
-          literals.stream()
-              .filter(v -> ref.comparator().compare(lower, v) <= 0)
-              .collect(Collectors.toList());
-      if (literals.isEmpty()) { // if all values are less than lower bound, rows cannot match.
-        return ROWS_CANNOT_MATCH;
-      }
-
       T upper = Conversions.fromByteBuffer(ref.type(), fieldStats.upperBound());
-      literals =
-          literals.stream()
-              .filter(v -> ref.comparator().compare(upper, v) >= 0)
-              .collect(Collectors.toList());
-      if (literals
-          .isEmpty()) { // if all remaining values are greater than upper bound, rows cannot match.
-        return ROWS_CANNOT_MATCH;
+
+      // rows might match if any literal falls within the manifest's [lower, upper] bounds
+      for (T literal : literals) {
+        if (ref.comparator().compare(lower, literal) <= 0
+            && ref.comparator().compare(upper, literal) >= 0) {
+          return ROWS_MIGHT_MATCH;
+        }
       }
 
-      return ROWS_MIGHT_MATCH;
+      return ROWS_CANNOT_MATCH;
     }
 
     @Override


### PR DESCRIPTION
Evaluating an IN predicate against a file's column bounds ran the candidate literals through two chained stream().filter().collect() pipelines, allocating two Stream objects, two capturing lambdas, and an intermediate list per evaluation. Replace them with a single pass that short-circuits on the first literal within the file's bounds.

There is no behavior change and existing tests cover the change. 