### PR TITLE
Parquet: Preserve non-contiguous row positions in vectorized reads

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/VectorizedArrowReader.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.arrow.vectorized;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.PrimitiveIterator;
 import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.vector.BigIntVector;
@@ -675,6 +676,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         ArrowSchemaUtil.convert(MetadataColumns.ROW_POSITION);
     private final boolean setArrowValidityVector;
     private long rowStart;
+    private PrimitiveIterator.OfLong rowIndexes;
     private int batchSize;
     private NullabilityHolder nulls;
 
@@ -694,8 +696,17 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
       }
 
       ArrowBuf dataBuffer = vec.getDataBuffer();
-      for (int i = 0; i < numValsToRead; i += 1) {
-        dataBuffer.setLong((long) i * Long.BYTES, rowStart + i);
+
+      if (rowIndexes != null) {
+        for (int i = 0; i < numValsToRead; i += 1) {
+          dataBuffer.setLong((long) i * Long.BYTES, rowStart + rowIndexes.nextLong());
+        }
+      } else {
+        for (int i = 0; i < numValsToRead; i += 1) {
+          dataBuffer.setLong((long) i * Long.BYTES, rowStart + i);
+        }
+
+        rowStart += numValsToRead;
       }
 
       if (setArrowValidityVector) {
@@ -705,7 +716,6 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
         }
       }
 
-      rowStart += numValsToRead;
       vec.setValueCount(numValsToRead);
 
       return new VectorHolder.PositionVectorHolder(vec, MetadataColumns.ROW_POSITION, nulls);
@@ -728,6 +738,7 @@ public class VectorizedArrowReader implements VectorizedReader<VectorHolder> {
                   () ->
                       new IllegalArgumentException(
                           "PageReadStore does not contain row index offset"));
+      this.rowIndexes = source.getRowIndexes().orElse(null);
     }
 
     @Override

--- a/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedArrowReader.java
+++ b/arrow/src/test/java/org/apache/iceberg/arrow/vectorized/TestVectorizedArrowReader.java
@@ -20,8 +20,16 @@ package org.apache.iceberg.arrow.vectorized;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.PrimitiveIterator;
+import org.apache.arrow.memory.ArrowBuf;
 import org.apache.arrow.vector.BigIntVector;
 import org.apache.iceberg.arrow.ArrowAllocation;
+import org.apache.parquet.column.ColumnDescriptor;
+import org.apache.parquet.column.page.PageReadStore;
+import org.apache.parquet.column.page.PageReader;
 import org.junit.jupiter.api.Test;
 
 class TestVectorizedArrowReader {
@@ -219,5 +227,85 @@ class TestVectorizedArrowReader {
     reader.close();
 
     assertThat(ArrowAllocation.rootAllocator().getAllocatedMemory()).isEqualTo(allocatedBefore);
+  }
+
+  @Test
+  void positionReaderWithSequentialRowsAcrossBatches() {
+    VectorizedArrowReader reader = VectorizedArrowReader.positions();
+    reader.setBatchSize(2);
+    reader.setRowGroupInfo(pageReadStore(1_000L, 4L), Collections.emptyMap());
+
+    assertPositions(reader.read(null, 2), 1_000L, 1_001L);
+    assertPositions(reader.read(null, 2), 1_002L, 1_003L);
+  }
+
+  @Test
+  public void positionReaderWithRowIndexesAcrossBatches() {
+    VectorizedArrowReader reader = VectorizedArrowReader.positions();
+    reader.setBatchSize(2);
+    reader.setRowGroupInfo(pageReadStore(1_000L, 10L, 11L, 100L, 101L), Collections.emptyMap());
+
+    assertPositions(reader.read(null, 2), 1_010L, 1_011L);
+    assertPositions(reader.read(null, 2), 1_100L, 1_101L);
+  }
+
+  @Test
+  public void positionReaderResetsForNewPageStore() {
+    VectorizedArrowReader reader = VectorizedArrowReader.positions();
+    reader.setBatchSize(2);
+
+    reader.setRowGroupInfo(pageReadStore(100L, 10L, 20L), Collections.emptyMap());
+    assertPositions(reader.read(null, 2), 110L, 120L);
+
+    reader.setRowGroupInfo(pageReadStore(1_000L, 2L), Collections.emptyMap());
+    assertPositions(reader.read(null, 2), 1_000L, 1_001L);
+  }
+
+  private static void assertPositions(VectorHolder holder, long... expectedPositions) {
+    try (BigIntVector vector = (BigIntVector) holder.vector()) {
+      assertThat(vector.getValueCount()).isEqualTo(expectedPositions.length);
+      ArrowBuf dataBuffer = vector.getDataBuffer();
+      for (int i = 0; i < expectedPositions.length; i += 1) {
+        assertThat(dataBuffer.getLong((long) i * Long.BYTES))
+            .as("Position at index %s", i)
+            .isEqualTo(expectedPositions[i]);
+      }
+    }
+  }
+
+  private static PageReadStore pageReadStore(long rowIndexOffset, long rowCount) {
+    return new TestPageReadStore(rowCount, rowIndexOffset, null);
+  }
+
+  private static PageReadStore pageReadStore(long rowIndexOffset, long... rowIndexes) {
+    return new TestPageReadStore(rowIndexes.length, rowIndexOffset, rowIndexes);
+  }
+
+  private record TestPageReadStore(long rowCount, long rowIndexOffset, long[] rowIndexes)
+      implements PageReadStore {
+
+    @Override
+    public PageReader getPageReader(ColumnDescriptor descriptor) {
+      throw new UnsupportedOperationException("Page readers are not used by position reader tests");
+    }
+
+    @Override
+    public long getRowCount() {
+      return rowCount;
+    }
+
+    @Override
+    public Optional<Long> getRowIndexOffset() {
+      return Optional.of(rowIndexOffset);
+    }
+
+    @Override
+    public Optional<PrimitiveIterator.OfLong> getRowIndexes() {
+      if (rowIndexes == null) {
+        return Optional.empty();
+      }
+
+      return Optional.of(Arrays.stream(rowIndexes).iterator());
+    }
   }
 }


### PR DESCRIPTION
## Summary

This is the first part of #17596.

Update the vectorized Parquet position reader to use row indexes exposed by `PageReadStore` when available, preserving physical row positions across non-contiguous reads and batch boundaries.

The existing sequential behavior remains unchanged when row indexes are not available.

This also benefits vectorized fallback row ID generation, which reuses the position reader.

Related PR: 
Related POC: #17597