### PR TITLE
Core, Spark: fix reported manifest length to be same as actual 

### DIFF
--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -394,17 +394,57 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix)
       throws IOException {
+    return rewriteDataManifestAndMeasureLength(
+            manifestFile, snapshotIds, outputFile, io, format, specsById, sourcePrefix, targetPrefix)
+        .first();
+  }
+
+  /**
+   * Rewrite a data manifest, replacing path references, and return the rewritten manifest's byte
+   * length.
+   *
+   * <p>The length is read from the closed manifest writer rather than via a separate {@code
+   * getLength()} call, avoiding an extra stat request per manifest against object storage. Callers
+   * record this length as the {@code manifest_length} of the rewritten manifest in the manifest
+   * list.
+   *
+   * @param manifestFile source manifest file to rewrite
+   * @param snapshotIds snapshot ids for filtering returned data manifest entries
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
+   *     manifest's byte length
+   */
+  public static Pair<RewriteResult<DataFile>, Long> rewriteDataManifestAndMeasureLength(
+      ManifestFile manifestFile,
+      Set<Long> snapshotIds,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix)
+      throws IOException {
     PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
-    try (ManifestWriter<DataFile> writer =
-            ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+    ManifestWriter<DataFile> writer =
+        ManifestFiles.write(format, spec, outputFile, manifestFile.snapshotId());
+    RewriteResult<DataFile> result;
+    try (writer;
         ManifestReader<DataFile> reader =
             ManifestFiles.read(manifestFile, io, specsById).select(Arrays.asList("*"))) {
-      return StreamSupport.stream(reader.entries().spliterator(), false)
-          .map(
-              entry ->
-                  writeDataFileEntry(entry, snapshotIds, spec, sourcePrefix, targetPrefix, writer))
-          .reduce(new RewriteResult<>(), RewriteResult::append);
+      result =
+          StreamSupport.stream(reader.entries().spliterator(), false)
+              .map(
+                  entry ->
+                      writeDataFileEntry(
+                          entry, snapshotIds, spec, sourcePrefix, targetPrefix, writer))
+              .reduce(new RewriteResult<>(), RewriteResult::append);
     }
+    return Pair.of(result, writer.length());
   }
 
   /**
@@ -484,26 +524,79 @@ public class RewriteTablePathUtil {
       String stagingLocation,
       Map<String, Long> rewrittenDeleteFileSizes)
       throws IOException {
+    return rewriteDeleteManifestAndMeasureLength(
+            manifestFile,
+            snapshotIds,
+            outputFile,
+            io,
+            format,
+            specsById,
+            sourcePrefix,
+            targetPrefix,
+            stagingLocation,
+            rewrittenDeleteFileSizes)
+        .first();
+  }
+
+  /**
+   * Rewrite a delete manifest, replacing path references, and return the rewritten manifest's byte
+   * length.
+   *
+   * <p>The length is read from the closed manifest writer rather than via a separate {@code
+   * getLength()} call, avoiding an extra stat request per manifest against object storage. Callers
+   * record this length as the {@code manifest_length} of the rewritten manifest in the manifest
+   * list.
+   *
+   * @param manifestFile source delete manifest to rewrite
+   * @param snapshotIds snapshot ids for filtering returned delete manifest entries
+   * @param outputFile output file to rewrite manifest file to
+   * @param io file io
+   * @param format format of the manifest file
+   * @param specsById map of partition specs by id
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @param stagingLocation staging location for rewritten position delete files
+   * @param rewrittenDeleteFileSizes map from source position delete file path to the actual size of
+   *     the rewritten file; entries absent from the map keep their original size
+   * @return the copy plan of content files in the rewritten manifest, paired with the rewritten
+   *     manifest's byte length
+   */
+  public static Pair<RewriteResult<DeleteFile>, Long> rewriteDeleteManifestAndMeasureLength(
+      ManifestFile manifestFile,
+      Set<Long> snapshotIds,
+      OutputFile outputFile,
+      FileIO io,
+      int format,
+      Map<Integer, PartitionSpec> specsById,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingLocation,
+      Map<String, Long> rewrittenDeleteFileSizes)
+      throws IOException {
     PartitionSpec spec = specsById.get(manifestFile.partitionSpecId());
-    try (ManifestWriter<DeleteFile> writer =
-            ManifestFiles.writeDeleteManifest(format, spec, outputFile, manifestFile.snapshotId());
+    ManifestWriter<DeleteFile> writer =
+        ManifestFiles.writeDeleteManifest(format, spec, outputFile, manifestFile.snapshotId());
+    RewriteResult<DeleteFile> result;
+    try (writer;
         ManifestReader<DeleteFile> reader =
             ManifestFiles.readDeleteManifest(manifestFile, io, specsById)
                 .select(Arrays.asList("*"))) {
-      return StreamSupport.stream(reader.entries().spliterator(), false)
-          .map(
-              entry ->
-                  writeDeleteFileEntry(
-                      entry,
-                      snapshotIds,
-                      spec,
-                      sourcePrefix,
-                      targetPrefix,
-                      stagingLocation,
-                      writer,
-                      rewrittenDeleteFileSizes))
-          .reduce(new RewriteResult<>(), RewriteResult::append);
+      result =
+          StreamSupport.stream(reader.entries().spliterator(), false)
+              .map(
+                  entry ->
+                      writeDeleteFileEntry(
+                          entry,
+                          snapshotIds,
+                          spec,
+                          sourcePrefix,
+                          targetPrefix,
+                          stagingLocation,
+                          writer,
+                          rewrittenDeleteFileSizes))
+              .reduce(new RewriteResult<>(), RewriteResult::append);
     }
+    return Pair.of(result, writer.length());
   }
 
   private static RewriteResult<DataFile> writeDataFileEntry(

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -261,6 +261,46 @@ public class RewriteTablePathUtil {
    * @param outputPath location to write the manifest list
    * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
    *     list
+   * @deprecated Use {@link #rewriteManifestList(Snapshot, FileIO, TableMetadata, Set, String,
+   *     String, String, String, Map)} instead
+   */
+  @Deprecated
+  public static RewriteResult<ManifestFile> rewriteManifestList(
+      Snapshot snapshot,
+      FileIO io,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      String sourcePrefix,
+      String targetPrefix,
+      String stagingDir,
+      String outputPath) {
+    return rewriteManifestList(
+        snapshot,
+        io,
+        tableMetadata,
+        manifestsToRewrite,
+        sourcePrefix,
+        targetPrefix,
+        stagingDir,
+        outputPath,
+        ImmutableMap.of());
+  }
+
+  /**
+   * Rewrite a manifest list representing a snapshot, replacing path references.
+   *
+   * @param snapshot snapshot represented by the manifest list
+   * @param io file io
+   * @param tableMetadata metadata of table
+   * @param manifestsToRewrite a list of manifest files to filter for rewrite
+   * @param sourcePrefix source prefix that will be replaced
+   * @param targetPrefix target prefix that will replace it
+   * @param stagingDir staging directory
+   * @param outputPath location to write the manifest list
+   * @param rewrittenManifestSizes map from source manifest path to actual byte size of the
+   *     rewritten staging file; used to record correct lengths in the manifest list
+   * @return a copy plan for manifest files whose metadata were contained in the rewritten manifest
+   *     list
    */
   public static RewriteResult<ManifestFile> rewriteManifestList(
       Snapshot snapshot,

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -342,7 +342,8 @@ public class RewriteTablePathUtil {
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
-        ((StructLike) newFile).set(1, rewrittenManifestSizes.getOrDefault(file.path(), file.length()));
+        ((StructLike) newFile)
+            .set(1, rewrittenManifestSizes.getOrDefault(file.path(), file.length()));
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -395,7 +395,14 @@ public class RewriteTablePathUtil {
       String targetPrefix)
       throws IOException {
     return rewriteDataManifestAndMeasureLength(
-            manifestFile, snapshotIds, outputFile, io, format, specsById, sourcePrefix, targetPrefix)
+            manifestFile,
+            snapshotIds,
+            outputFile,
+            io,
+            format,
+            specsById,
+            sourcePrefix,
+            targetPrefix)
         .first();
   }
 

--- a/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
+++ b/core/src/main/java/org/apache/iceberg/RewriteTablePathUtil.java
@@ -270,7 +270,8 @@ public class RewriteTablePathUtil {
       String sourcePrefix,
       String targetPrefix,
       String stagingDir,
-      String outputPath) {
+      String outputPath,
+      Map<String, Long> rewrittenManifestSizes) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
     OutputFile outputFile = io.newOutputFile(outputPath);
 
@@ -301,6 +302,7 @@ public class RewriteTablePathUtil {
       for (ManifestFile file : manifestFiles) {
         ManifestFile newFile = file.copy();
         ((StructLike) newFile).set(0, newPath(newFile.path(), sourcePrefix, targetPrefix));
+        ((StructLike) newFile).set(1, rewrittenManifestSizes.getOrDefault(file.path(), file.length()));
         writer.add(newFile);
 
         if (manifestsToRewrite.contains(file.path())) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/actions/RewriteTablePathSparkAction.java
@@ -302,21 +302,7 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
     Set<Snapshot> validSnapshots =
         Sets.difference(snapshotSet(endMetadata), snapshotSet(startMetadata));
 
-    // rebuild manifest-list files
-    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
-    Tasks.foreach(validSnapshots)
-        .noRetry()
-        .throwFailureWhenFinished()
-        .executeWith(executorService)
-        .run(
-            snapshot ->
-                manifestListResults.add(
-                    rewriteManifestList(snapshot, endMetadata, manifestsToRewrite)));
-
-    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
-    manifestListResults.forEach(rewriteManifestListResult::append);
-
-    Set<ManifestFile> manifestFiles = rewriteManifestListResult.toRewrite();
+    Set<ManifestFile> manifestFiles = collectManifestFiles(validSnapshots, manifestsToRewrite);
 
     // rebuild position delete files
     Set<ManifestFile> deleteManifests =
@@ -333,6 +319,23 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             endMetadata,
             manifestFiles,
             sparkContext().broadcast(rewrittenDeleteFileSizes));
+
+    Map<String, Long> rewrittenManifestSizes = collectRewrittenManifestSizes(manifestFiles);
+
+    // rebuild manifest-list files
+    Set<RewriteResult<ManifestFile>> manifestListResults = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                manifestListResults.add(
+                    rewriteManifestList(
+                        snapshot, endMetadata, manifestsToRewrite, rewrittenManifestSizes)));
+
+    RewriteResult<ManifestFile> rewriteManifestListResult = new RewriteResult<>();
+    manifestListResults.forEach(rewriteManifestListResult::append);
 
     ImmutableRewriteTablePath.Result.Builder builder =
         ImmutableRewriteTablePath.Result.builder()
@@ -499,7 +502,10 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
    *     well as for the manifest list itself
    */
   private RewriteResult<ManifestFile> rewriteManifestList(
-      Snapshot snapshot, TableMetadata tableMetadata, Set<String> manifestsToRewrite) {
+      Snapshot snapshot,
+      TableMetadata tableMetadata,
+      Set<String> manifestsToRewrite,
+      Map<String, Long> rewrittenManifestSizes) {
     RewriteResult<ManifestFile> result = new RewriteResult<>();
 
     String path = snapshot.manifestListLocation();
@@ -513,7 +519,8 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
             sourcePrefix,
             targetPrefix,
             stagingDir,
-            outputPath);
+            outputPath,
+            rewrittenManifestSizes);
 
     result.append(rewriteResult);
     // add the manifest list copy plan itself to the result
@@ -549,6 +556,30 @@ public class RewriteTablePathSparkAction extends BaseSparkAction<RewriteTablePat
               + "Please choose an earlier version without invalid snapshots.",
           e);
     }
+  }
+
+  private Set<ManifestFile> collectManifestFiles(
+      Set<Snapshot> validSnapshots, Set<String> manifestsToRewrite) {
+    Set<ManifestFile> result = Sets.newConcurrentHashSet();
+    Tasks.foreach(validSnapshots)
+        .noRetry()
+        .throwFailureWhenFinished()
+        .executeWith(executorService)
+        .run(
+            snapshot ->
+                snapshot.allManifests(table.io()).stream()
+                    .filter(mf -> manifestsToRewrite.contains(mf.path()))
+                    .forEach(result::add));
+    return result;
+  }
+
+  private Map<String, Long> collectRewrittenManifestSizes(Set<ManifestFile> manifestFiles) {
+    Map<String, Long> sizes = Maps.newHashMapWithExpectedSize(manifestFiles.size());
+    for (ManifestFile mf : manifestFiles) {
+      String stagingPath = RewriteTablePathUtil.stagingPath(mf.path(), sourcePrefix, stagingDir);
+      sizes.put(mf.path(), table.io().newInputFile(stagingPath).getLength());
+    }
+    return sizes;
   }
 
   public static class RewriteContentFileResult extends RewriteResult<ContentFile<?>> {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -223,6 +223,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation);
 
     // verify the data file path after the rebuild
     List<String> validDataFilesAfterRebuilt =
@@ -415,6 +416,8 @@ public class TestRewriteTablePathsAction extends TestBase {
     // copy the metadata files and data files
     copyTableFiles(result);
 
+    assertManifestLengthsMatchActual(targetTableLocation());
+
     // verify data rows
     Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation());
     assertThat(resultDF.as(Encoders.bean(ThreeColumnRecord.class)).collectAsList())
@@ -485,6 +488,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation());
 
     // Positional delete affects a single row, so only one row must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -523,6 +527,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation());
 
     // check copied position delete row - only v2 stores row data with position deletes
     // v3+ uses Deletion Vectors (DV) which only store position information
@@ -986,6 +991,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation());
 
     // Equality deletes affect three rows, so just two rows must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -1109,6 +1115,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation());
 
     // expect deleted data file is excluded from rewrite and copy
     List<String> copiedDataFiles =
@@ -1561,6 +1568,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     checkFileNum(3, 2, 2, 9, result);
     // one data and one metadata file
     copyTableFiles(result);
+    assertManifestLengthsMatchActual(targetTableLocation());
 
     // register table
     String metadataLocation = currentMetadata(sourceTable).metadataFileLocation();
@@ -1793,6 +1801,19 @@ public class TestRewriteTablePathsAction extends TestBase {
 
   protected String toAbsolute(Path relative) {
     return relative.toFile().toURI().toString();
+  }
+
+  private void assertManifestLengthsMatchActual(String tableLocation) {
+    Table targetTable = TABLES.load(tableLocation);
+    for (ManifestFile manifest : targetTable.currentSnapshot().allManifests(targetTable.io())) {
+      long recordedLength = manifest.length();
+      long actualLength = targetTable.io().newInputFile(manifest.path()).getLength();
+      assertThat(recordedLength)
+          .as(
+              "Manifest %s: length recorded in manifest list (%d) should match actual file size (%d)",
+              manifest.path(), recordedLength, actualLength)
+          .isEqualTo(actualLength);
+    }
   }
 
   private void copyTableFiles(RewriteTablePath.Result result) throws Exception {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -223,7 +223,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation);
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation));
 
     // verify the data file path after the rebuild
     List<String> validDataFilesAfterRebuilt =
@@ -416,7 +416,7 @@ public class TestRewriteTablePathsAction extends TestBase {
     // copy the metadata files and data files
     copyTableFiles(result);
 
-    assertManifestLengthsMatchActual(targetTableLocation());
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation()));
 
     // verify data rows
     Dataset<Row> resultDF = spark.read().format("iceberg").load(targetTableLocation());
@@ -488,7 +488,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation());
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation()));
 
     // Positional delete affects a single row, so only one row must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -527,7 +527,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation());
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation()));
 
     // check copied position delete row - only v2 stores row data with position deletes
     // v3+ uses Deletion Vectors (DV) which only store position information
@@ -991,7 +991,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation());
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation()));
 
     // Equality deletes affect three rows, so just two rows must remain
     assertThat(spark.read().format("iceberg").load(targetTableLocation()).collectAsList())
@@ -1115,7 +1115,7 @@ public class TestRewriteTablePathsAction extends TestBase {
 
     // copy the metadata files and data files
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation());
+    assertManifestLengthsMatchActual(TABLES.load(targetTableLocation()));
 
     // expect deleted data file is excluded from rewrite and copy
     List<String> copiedDataFiles =
@@ -1568,7 +1568,6 @@ public class TestRewriteTablePathsAction extends TestBase {
     checkFileNum(3, 2, 2, 9, result);
     // one data and one metadata file
     copyTableFiles(result);
-    assertManifestLengthsMatchActual(targetTableLocation());
 
     // register table
     String metadataLocation = currentMetadata(sourceTable).metadataFileLocation();
@@ -1576,6 +1575,8 @@ public class TestRewriteTablePathsAction extends TestBase {
     String targetTableName = String.format("copiedV%sTable", formatVersion);
     TableIdentifier tableIdentifier = TableIdentifier.of("default", targetTableName);
     catalog.registerTable(tableIdentifier, targetTableLocation() + "/metadata/" + versionFile);
+
+    assertManifestLengthsMatchActual(catalog.loadTable(tableIdentifier));
 
     List<Object[]> copiedData =
         rowsToJava(
@@ -1803,11 +1804,10 @@ public class TestRewriteTablePathsAction extends TestBase {
     return relative.toFile().toURI().toString();
   }
 
-  private void assertManifestLengthsMatchActual(String location) {
-    Table targetTable = TABLES.load(location);
-    for (ManifestFile manifest : targetTable.currentSnapshot().allManifests(targetTable.io())) {
+  private void assertManifestLengthsMatchActual(Table table) {
+    for (ManifestFile manifest : table.currentSnapshot().allManifests(table.io())) {
       long recordedLength = manifest.length();
-      long actualLength = targetTable.io().newInputFile(manifest.path()).getLength();
+      long actualLength = table.io().newInputFile(manifest.path()).getLength();
       assertThat(recordedLength)
           .as(
               "Manifest %s: length recorded in manifest list (%d) should match actual file size (%d)",

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/actions/TestRewriteTablePathsAction.java
@@ -1803,8 +1803,8 @@ public class TestRewriteTablePathsAction extends TestBase {
     return relative.toFile().toURI().toString();
   }
 
-  private void assertManifestLengthsMatchActual(String tableLocation) {
-    Table targetTable = TABLES.load(tableLocation);
+  private void assertManifestLengthsMatchActual(String location) {
+    Table targetTable = TABLES.load(location);
     for (ManifestFile manifest : targetTable.currentSnapshot().allManifests(targetTable.io())) {
       long recordedLength = manifest.length();
       long actualLength = targetTable.io().newInputFile(manifest.path()).getLength();


### PR DESCRIPTION
As of now tests (**TestRewriteTablePathsAction.java**) are not testing parquet manifest over non Hadoop where we have this silent bug.
As parquet depends on the reported file length we need to provide it correctly, rewriteTablePath updates the manifestlist before writing the manifestfile so it is not aware of manifest actual size and hence it just doesn't change it so stale size is kept from source.
[x] Fix the test to fail without any code changes 
[] Fix the code 