### PR TITLE
Core: Handle UnknownType in SingleValueParser

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SingleValueParser.java
+++ b/core/src/main/java/org/apache/iceberg/SingleValueParser.java
@@ -180,6 +180,10 @@ public class SingleValueParser {
         return mapFromJson(type, defaultValue);
       case STRUCT:
         return structFromJson(type, defaultValue);
+      case UNKNOWN:
+        Preconditions.checkArgument(
+            defaultValue.isTextual(), "Cannot parse default as a %s value: %s", type, defaultValue);
+        return defaultValue.textValue();
       default:
         throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));
     }
@@ -409,6 +413,9 @@ public class SingleValueParser {
           }
         }
         generator.writeEndObject();
+        break;
+      case UNKNOWN:
+        generator.writeString(String.valueOf(defaultValue));
         break;
       default:
         throw new UnsupportedOperationException(String.format("Type: %s is not supported", type));

--- a/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestContentFileParser.java
@@ -612,4 +612,58 @@ public class TestContentFileParser {
     assertThat(actual.equalityFieldIds()).isEqualTo(expected.equalityFieldIds());
     assertThat(actual.sortOrderId()).isEqualTo(expected.sortOrderId());
   }
+
+  @Test
+  void partitionSerializationWithDroppedSourceColumn() throws Exception {
+    // Reproduce the scenario from Issue #17324:
+    // A data file was written with a partition spec that includes column "c",
+    // but "c" has since been dropped from the table schema.
+    Schema fullSchema =
+        new Schema(
+            Types.NestedField.required(1, "a", Types.StringType.get()),
+            Types.NestedField.required(2, "b", Types.BooleanType.get()),
+            Types.NestedField.required(3, "c", Types.DateType.get()),
+            Types.NestedField.required(4, "d", Types.IntegerType.get()));
+
+    PartitionSpec originalSpec =
+        PartitionSpec.builderFor(fullSchema).identity("a").identity("c").build();
+
+    PartitionData partitionData = new PartitionData(originalSpec.partitionType());
+    partitionData.set(0, "test");
+    // DATE type is stored as days since epoch
+    partitionData.set(1, 4888);
+
+    DataFile dataFile =
+        DataFiles.builder(originalSpec)
+            .withPath("/path/to/data.parquet")
+            .withFileSizeInBytes(10)
+            .withRecordCount(1)
+            .withPartition(partitionData)
+            .build();
+
+    // Simulate schema evolution: column "c" is dropped
+    Schema evolvedSchema =
+        new Schema(
+            Types.NestedField.required(1, "a", Types.StringType.get()),
+            Types.NestedField.required(2, "b", Types.BooleanType.get()),
+            Types.NestedField.required(4, "d", Types.IntegerType.get()));
+
+    // Re-bind the spec to the evolved schema (as done for historical specs)
+    PartitionSpec evolvedSpec = originalSpec.toUnbound().bind(evolvedSchema, true);
+
+    // Serialization must produce valid JSON instead of throwing mid-stream
+    String json = ContentFileParser.toJson(dataFile, evolvedSpec);
+    assertThat(json).contains("\"partition\":");
+    // The dropped column value is serialized as its string representation
+    assertThat(json).contains("\"partition\":[\"test\",\"4888\"]");
+
+    // Verify round-trip deserialization
+    JsonNode jsonNode = JsonUtil.mapper().readTree(json);
+    ContentFile<?> parsed =
+        ContentFileParser.fromJson(jsonNode, Map.of(evolvedSpec.specId(), evolvedSpec));
+    assertThat(parsed).isInstanceOf(DataFile.class);
+    assertThat(parsed.partition().get(0, String.class)).isEqualTo("test");
+    // The dropped column value is preserved as a string
+    assertThat(parsed.partition().get(1, String.class)).isEqualTo("4888");
+  }
 }

--- a/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
+++ b/core/src/test/java/org/apache/iceberg/TestSingleValueParser.java
@@ -168,6 +168,27 @@ public class TestSingleValueParser {
         .hasMessageStartingWith("Cannot parse default as a timestamptz_ns value");
   }
 
+  @Test
+  void unknownTypeRoundTrip() throws IOException {
+    // When a partition spec references a dropped column, the type becomes UNKNOWN.
+    // Serialization should produce the value's string representation,
+    // and deserialization should parse it back as a string.
+    Type unknownType = Types.UnknownType.get();
+
+    // null values
+    jsonStringEquals("null", defaultValueParseAndUnParseRoundTrip(unknownType, "null"));
+
+    // integer value serialized as string (e.g., days since epoch for a dropped DATE column)
+    String intResult = SingleValueParser.toJson(unknownType, 4888);
+    jsonStringEquals("\"4888\"", intResult);
+    assertThat(SingleValueParser.fromJson(unknownType, intResult)).isEqualTo("4888");
+
+    // string value round-trips correctly
+    String strResult = SingleValueParser.toJson(unknownType, "hello");
+    jsonStringEquals("\"hello\"", strResult);
+    assertThat(SingleValueParser.fromJson(unknownType, strResult)).isEqualTo("hello");
+  }
+
   // serialize to json and deserialize back should return the same result
   private static String defaultValueParseAndUnParseRoundTrip(Type type, String defaultValue) {
     Object javaDefaultValue = SingleValueParser.fromJson(type, defaultValue);


### PR DESCRIPTION
Fixes #17324

### What changes were proposed in this pull request?

This PR adds support for `TypeID.UNKNOWN` in `SingleValueParser`, fixing an issue where the REST catalog's `/plan` endpoint can fail with a truncated `HTTP 200 OK` response.

### Why are the changes needed?

When a partition field references a column that is subsequently dropped from the table schema, `PartitionSpec.resultType()` falls back to `Types.UnknownType.get()`.

However, when `ContentFileParser` serializes the data file's partition values, `SingleValueParser.toJson()` does not handle `UNKNOWN` and throws an `UnsupportedOperationException`.

This can occur while the JSON response is being streamed, resulting in a partially written response when serialization fails.

### How was this patch tested?

* Added `TestSingleValueParser.unknownTypeRoundTrip` to verify that `UnknownType` correctly handles nulls, integer values serialized as strings, and string values.
* Added `TestContentFileParser.partitionSerializationWithDroppedSourceColumn` to reproduce the issue by simulating a dropped source column, re-binding the historical partition spec, and verifying that the partition data can be serialized and deserialized successfully.
* Verified locally with `./gradlew :iceberg-core:test`.
* Ran `./gradlew spotlessApply`.
