### PR TITLE
fix: check mayContainNulls in ParquetDictionaryRowGroupFilter.notStartsWith

### DIFF
--- a/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
+++ b/parquet/src/main/java/org/apache/iceberg/parquet/ParquetDictionaryRowGroupFilter.java
@@ -398,6 +398,10 @@ public class ParquetDictionaryRowGroupFilter {
         return ROWS_MIGHT_MATCH;
       }
 
+      if (mayContainNulls.get(id)) {
+        return ROWS_MIGHT_MATCH;
+      }
+
       Set<T> dictionary = dict(id, lit.comparator());
       for (T item : dictionary) {
         if (!item.toString().startsWith(lit.value().toString())) {

--- a/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
+++ b/parquet/src/test/java/org/apache/iceberg/parquet/TestDictionaryRowGroupFilter.java
@@ -462,7 +462,7 @@ public class TestDictionaryRowGroupFilter {
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, notStartsWith("some_nulls", "some"))
             .shouldRead(parquetSchema, rowGroupMetadata, dictionaryStore);
-    assertThat(shouldRead).as("Should skip: no match in dictionary").isFalse();
+    assertThat(shouldRead).as("Should read: row group contains nulls matching notStartsWith").isTrue();
 
     shouldRead =
         new ParquetDictionaryRowGroupFilter(SCHEMA, notStartsWith("no_nulls", "xxx"))


### PR DESCRIPTION
Fixes #17655

## Problem

`ParquetDictionaryRowGroupFilter.notStartsWith` can skip row groups that contain null values, silently dropping rows from scan results.

The filter decides whether a row group can be skipped by inspecting only the column's dictionary. A Parquet dictionary contains non-null values only, so when every dictionary entry starts with the prefix the filter returns `ROWS_CANNOT_MATCH` — even when the column also contains nulls.

In Iceberg a null value matches `notStartsWith`: `Evaluator` implements it as `!startsWith(...)`, and `startsWith` evaluates to false for null. A row group holding nulls therefore does contain matching rows and must not be skipped.

## Fix

Add a `mayContainNulls` check to `notStartsWith`, consistent with how `notEq`, `notIn`, and `notNaN` already handle null-containing row groups.

## Changes

1. **`ParquetDictionaryRowGroupFilter.java`**: Added `if (mayContainNulls.get(id)) return ROWS_MIGHT_MATCH;` in `notStartsWith`, matching the pattern used by `notNaN`.
2. **`TestDictionaryRowGroupFilter.java`**: Updated the assertion for `notStartsWith("some_nulls", "some")` from `isFalse()` to `isTrue()` — this row group contains nulls, so it must be read.
