### PR TITLE
fix: handle empty struct in CompareSchemasVisitor.struct()

### DIFF
--- a/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v1.20/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -86,7 +86,7 @@ public class CompareSchemasVisitor
       return Result.SCHEMA_UPDATE_NEEDED;
     }
 
-    Result result = fields.stream().reduce(Result::merge).orElse(Result.SCHEMA_UPDATE_NEEDED);
+    Result result = fields.stream().reduce(Result::merge).orElse(Result.SAME);
 
     if (result == Result.SCHEMA_UPDATE_NEEDED) {
       return Result.SCHEMA_UPDATE_NEEDED;

--- a/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.0/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -86,7 +86,7 @@ public class CompareSchemasVisitor
       return Result.SCHEMA_UPDATE_NEEDED;
     }
 
-    Result result = fields.stream().reduce(Result::merge).orElse(Result.SCHEMA_UPDATE_NEEDED);
+    Result result = fields.stream().reduce(Result::merge).orElse(Result.SAME);
 
     if (result == Result.SCHEMA_UPDATE_NEEDED) {
       return Result.SCHEMA_UPDATE_NEEDED;

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/sink/dynamic/CompareSchemasVisitor.java
@@ -86,7 +86,7 @@ public class CompareSchemasVisitor
       return Result.SCHEMA_UPDATE_NEEDED;
     }
 
-    Result result = fields.stream().reduce(Result::merge).orElse(Result.SCHEMA_UPDATE_NEEDED);
+    Result result = fields.stream().reduce(Result::merge).orElse(Result.SAME);
 
     if (result == Result.SCHEMA_UPDATE_NEEDED) {
       return Result.SCHEMA_UPDATE_NEEDED;


### PR DESCRIPTION
Fixes #17650

## Problem

`CompareSchemasVisitor.struct()` computes its result as:

```java
Result result = fields.stream().reduce(Result::merge).orElse(Result.SCHEMA_UPDATE_NEEDED);
```

For a struct with zero fields, the `reduce` is empty, so `orElse(SCHEMA_UPDATE_NEEDED)` always fires. Consequently any schema containing an empty struct (e.g. derived from an Avro union whose branch is a zero-field marker record) can never compare `SAME` with any table schema — including a table created from that exact schema.

In the Dynamic Sink this is fatal: `TableUpdater.findOrCreateSchema` sees `SCHEMA_UPDATE_NEEDED`, applies `EvolveSchemaVisitor` (a no-op here), commits, re-compares — still `SCHEMA_UPDATE_NEEDED` — and `TableMetadataCache.schema()` caches and returns `NOT_FOUND`, whose `resolvedTableSchema()` is null.

## Fix

Change `orElse(Result.SCHEMA_UPDATE_NEEDED)` to `orElse(Result.SAME)` — when both structs have zero fields, they are semantically identical.

## Changes

- `flink/v1.20/flink/src/main/java/.../CompareSchemasVisitor.java`
- `flink/v2.0/flink/src/main/java/.../CompareSchemasVisitor.java`
- `flink/v2.1/flink/src/main/java/.../CompareSchemasVisitor.java`

All three versions had the same bug (identical content).
