### PR TITLE
fix: use getWithoutDefault to avoid Connect schema default for null values

### DIFF
--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/CopyValue.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/CopyValue.java
@@ -73,7 +73,7 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
     Map<String, Object> value = Requirements.requireMap(record.value(), "copy value");
 
     Map<String, Object> updatedValue = Maps.newHashMap(value);
-    updatedValue.put(targetField, value.get(sourceField));
+    updatedValue.put(targetField, value.getWithoutDefault(sourceField));
 
     return newRecord(record, null, updatedValue);
   }
@@ -90,9 +90,9 @@ public class CopyValue<R extends ConnectRecord<R>> implements Transformation<R> 
     Struct updatedValue = new Struct(updatedSchema);
 
     for (Field field : value.schema().fields()) {
-      updatedValue.put(field.name(), value.get(field));
+      updatedValue.put(field.name(), value.getWithoutDefault(field.name()));
     }
-    updatedValue.put(targetField, value.get(sourceField));
+    updatedValue.put(targetField, value.getWithoutDefault(sourceField));
 
     return newRecord(record, updatedSchema, updatedValue);
   }

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/DebeziumTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/DebeziumTransform.java
@@ -107,7 +107,7 @@ public class DebeziumTransform<R extends ConnectRecord<R>> implements Transforma
     Struct newValue = new Struct(newValueSchema);
 
     for (Field field : payloadSchema.fields()) {
-      newValue.put(field.name(), payload.get(field));
+      newValue.put(field.name(), payload.getWithoutDefault(field.name()));
     }
     newValue.put(CdcConstants.COL_CDC, cdcMetadata);
 

--- a/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
+++ b/kafka-connect/kafka-connect-transforms/src/main/java/org/apache/iceberg/connect/transforms/KafkaMetadataTransform.java
@@ -243,7 +243,7 @@ public class KafkaMetadataTransform implements Transformation<SinkRecord> {
     Schema newSchema = makeUpdatedSchema(record.valueSchema());
     Struct newValue = new Struct(newSchema);
     for (Field field : record.valueSchema().fields()) {
-      newValue.put(field.name(), value.get(field));
+      newValue.put(field.name(), value.getWithoutDefault(field.name()));
     }
     recordAppender.addToStruct(record, newValue);
     return record.newRecord(

--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -259,7 +259,7 @@ class RecordConverter {
                     hasSchemaUpdates = true;
                   }
                 }
-                Object recordFieldValue = struct.get(recordField);
+                Object recordFieldValue = struct.getWithoutDefault(recordField.name());
                 if (recordFieldValue == null && schemaUpdateConsumer != null && !hasSchemaUpdates) {
                   evolveSchemaFromConnectSchema(
                       recordField.schema(),
@@ -628,7 +628,7 @@ class RecordConverter {
       fields.forEach(
           field -> {
             names.add(field.name());
-            names.addAll(collectFieldNames(struct.get(field)));
+            names.addAll(collectFieldNames(struct.getWithoutDefault(field.name())));
           });
       return names;
     }
@@ -663,7 +663,7 @@ class RecordConverter {
     if (value instanceof Struct struct) {
       ShreddedObject object = Variants.object(metadata);
       for (Field field : struct.schema().fields()) {
-        object.put(field.name(), objectToVariantValue(struct.get(field), metadata, field.schema()));
+        object.put(field.name(), objectToVariantValue(struct.getWithoutDefault(field.name()), metadata, field.schema()));
       }
       return object;
     }


### PR DESCRIPTION
Fixes #17652

## Problem

Kafka Connect's `Struct.get(Field)` returns the field's schema `defaultValue` when the stored value is `null`, without checking `isOptional()` (longstanding Connect behavior, see KAFKA-8713). The Iceberg sink and its bundled SMTs read field values with `get()` in several places, so an explicit `NULL` in the source ends up written to the Iceberg table as the column's default value.

The most common trigger is Debezium CDC: for any column that is nullable with a non-NULL default (e.g. MySQL `VARCHAR(255) NULL DEFAULT ''`), every explicitly NULL value is replaced with the default.

## Fix

Replace `Struct.get(Field)` with `Struct.getWithoutDefault(String)` at all affected call sites. `getWithoutDefault` returns the actual stored value without applying the schema default, so null values are preserved as null.

## Changes

- `DebeziumTransform.java` — copy loop in `applyWithSchema`
- `KafkaMetadataTransform.java` — copy loop in `applyWithSchema`
- `CopyValue.java` — copy loop and single-field copy in `applyWithSchema`
- `RecordConverter.java` — field reads in `structToIceberg`, `collectFieldNames`, and `structToVariant`
