### PR TITLE
Build: Bump com.google.cloud.gcs.analytics:gcs-analytics-core from 1.4.0 to 1.5.0

### DIFF
--- a/gcp-bundle/runtime-deps.txt
+++ b/gcp-bundle/runtime-deps.txt
@@ -31,9 +31,9 @@ com.google.apis:google-api-services-storage:v1-rev20260524-2.0
 com.google.auth:google-auth-library-credentials:1.50
 com.google.auth:google-auth-library-oauth2-http:1.50
 com.google.auto.value:auto-value-annotations:1.11
-com.google.cloud.gcs.analytics:client:1.4
-com.google.cloud.gcs.analytics:common:1.4
-com.google.cloud.gcs.analytics:gcs-analytics-core:1.4
+com.google.cloud.gcs.analytics:client:1.5
+com.google.cloud.gcs.analytics:common:1.5
+com.google.cloud.gcs.analytics:gcs-analytics-core:1.5
 com.google.cloud.opentelemetry:detector-resources-support:0.36
 com.google.cloud.opentelemetry:exporter-metrics:0.36
 com.google.cloud.opentelemetry:shared-resourcemapping:0.36

--- a/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
+++ b/gcp/src/test/java/org/apache/iceberg/gcp/gcs/TestPrefixedStorage.java
@@ -25,6 +25,7 @@ import com.google.cloud.gcs.analyticscore.client.GcsClientOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystem;
 import com.google.cloud.gcs.analyticscore.client.GcsFileSystemOptions;
 import com.google.cloud.gcs.analyticscore.client.GcsReadOptions;
+import com.google.cloud.gcs.analyticscore.client.GcsWriteOptions;
 import java.util.Map;
 import org.apache.iceberg.EnvironmentContext;
 import org.apache.iceberg.gcp.GCPProperties;
@@ -150,6 +151,11 @@ public class TestPrefixedStorage {
                             .setChunkSize(1024)
                             .setDecryptionKey("decryptionKey")
                             .setUserProjectId("userProject")
+                            .build())
+                    .setGcsWriteOptions(
+                        GcsWriteOptions.builder()
+                            .setEncryptionKey("encryptionKey")
+                            .setUserProject("userProject")
                             .build())
                     .build())
             .build();

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ flink120 = { strictly = "1.20.1"}
 flink20 = { strictly = "2.0.0"}
 flink21 = { strictly = "2.1.0"}
 google-libraries-bom = "26.86.0"
-gcs-analytics-core = "1.4.0"
+gcs-analytics-core = "1.5.0"
 guava = "33.6.0-jre"
 hadoop3 = "3.4.3"
 httpcomponents-httpclient5 = "5.6.3"


### PR DESCRIPTION
- Closes #17676