### PR TITLE
Docs: Align Spark docs with current engine

### DIFF
--- a/docs/docs/spark-configuration.md
+++ b/docs/docs/spark-configuration.md
@@ -58,7 +58,7 @@ A catalog is created and named by adding a property `spark.sql.catalog.(catalog-
 
 Iceberg supplies two implementations:
 
-* `org.apache.iceberg.spark.SparkCatalog` supports a Hive Metastore or a Hadoop warehouse as a catalog
+* `org.apache.iceberg.spark.SparkCatalog` supports Hive, Hadoop, REST, Glue, JDBC, and Nessie catalogs
 * `org.apache.iceberg.spark.SparkSessionCatalog` adds support for Iceberg tables to Spark's built-in catalog, and delegates to the built-in catalog for non-Iceberg tables
 
 Both catalogs are configured using properties nested under the catalog name. Common configuration properties for Hive and Hadoop are:

--- a/site/docs/contribute.md
+++ b/site/docs/contribute.md
@@ -111,7 +111,7 @@ Iceberg is built using Gradle with Java 17 or 21.
 * To invoke a build and run tests: `./gradlew build`
 * To skip tests: `./gradlew build -x test -x integrationTest`
 * To fix code style: `./gradlew spotlessApply`
-* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0 -DflinkVersions=1.20,2.0,2.1`
+* To build particular Spark/Flink Versions: `./gradlew build -DsparkVersions=3.5,4.0,4.1 -DflinkVersions=1.20,2.0,2.1`
 
 Iceberg table support is organized in library modules:
 
@@ -299,9 +299,9 @@ public interface ManageSnapshots extends PendingUpdate<Snapshot> {
 Java code adheres to the [Google style](https://google.github.io/styleguide/javaguide.html), which will be verified via `./gradlew spotlessCheck` during builds.
 In order to automatically fix Java code style issues, please use `./gradlew spotlessApply`.
 
-**NOTE**: The **google-java-format** plugin will always use the latest version of the **google-java-format**. However, `spotless` itself is configured to use **google-java-format** 1.7
-since that version is compatible with JDK 8. When formatting the code in the IDE, there is a slight chance that it will produce slightly different results. In such a case please run `./gradlew spotlessApply`
-as CI will check the style against **google-java-format** 1.7.
+**NOTE**: The **google-java-format** plugin will always use the latest version of the **google-java-format**. However, `spotless` itself is configured to use **google-java-format** 1.22.0
+to produce consistent results on JDK 17 and 21. When formatting the code in the IDE, there is a slight chance that it will produce slightly different results. In such a case please run `./gradlew spotlessApply`
+as CI will check the style against **google-java-format** 1.22.0.
 
 ### Copyright
 


### PR DESCRIPTION
contribute.md still listed Spark 3.5/4.0 and google-java-format 1.7 for JDK 8. Gradle defaults include Spark 4.1, and spotless uses google-java-format 1.22.0. The SparkCatalog blurb now matches the type table (REST/Glue/JDBC/Nessie).

Flink docs are in #17695. The contribute.md Gradle example keeps Flink 2.1 from that merge and adds Spark 4.1.

## How to test

* `gradle.properties`: `knownSparkVersions=3.5,4.0,4.1` and `knownFlinkVersions=1.20,2.0,2.1`
* `baseline.gradle`: `googleJavaFormat("1.22.0")`
* `make build` in `site/` (exit 0; Documentation built in 90.67 seconds)
* `make lint` in `site/` (exit 0)

---
**AI Disclosure**
- Model: Cursor Grok 4.6
- Platform/Tool: Cursor
- Human Oversight: fully reviewed
- Prompt Summary: Rebase onto main. Keep Spark 4.1 and google-java-format 1.22.0. Keep Flink 2.1 from #17695.
