### PR TITLE
fix: support java.util.Date in RecordConverter.convertLong

### DIFF
--- a/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
+++ b/kafka-connect/kafka-connect/src/main/java/org/apache/iceberg/connect/data/RecordConverter.java
@@ -434,6 +434,8 @@ class RecordConverter {
       return ((Number) value).longValue();
     } else if (value instanceof String) {
       return Long.parseLong((String) value);
+    } else if (value instanceof Date) {
+      return ((Date) value).getTime();
     }
     throw new IllegalArgumentException("Cannot convert to long: " + value.getClass().getName());
   }


### PR DESCRIPTION
Fixes #15344

### Problem
When using Confluent Avro converter, timestamp-millis fields are deserialized as `java.util.Date` objects. `RecordConverter.convertLong()` only handles `Number` and `String`, causing `IllegalArgumentException: Cannot convert to long: java.util.Date`.

### Fix
Add `Date` handling to `convertLong()` via `Date.getTime()` to extract epoch millis, matching the existing pattern used by `convertDateValue`, `convertTimeValue`, `convertOffsetDateTime`, and `convertLocalDateTime` which all handle `Date`.

### Testing
- [x] Existing test suite passes locally
- [x] New Date values are properly converted to long epoch millis