### PR TITLE
API: Add tests for BinaryUtil

### DIFF
--- a/api/src/test/java/org/apache/iceberg/util/TestBinaryUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestBinaryUtil.java
@@ -22,6 +22,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.nio.ByteBuffer;
+import org.apache.iceberg.expressions.Literal;
 import org.junit.jupiter.api.Test;
 
 class TestBinaryUtil {
@@ -76,6 +77,46 @@ class TestBinaryUtil {
   void truncateBinaryMaxReturnsNullWhenAllBytesOverflow() {
     // 0xFF bytes overflow when incremented, so no greater bound of this length exists
     ByteBuffer input = ByteBuffer.wrap(new byte[] {(byte) 0xFF, (byte) 0xFF, 1});
+    assertThat(BinaryUtil.truncateBinaryMax(input, 2)).isNull();
+  }
+
+  @Test
+  void truncateBinaryMinByteBuffer() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5});
+    // shorter than the input: the lower bound is the truncated prefix
+    assertThat(BinaryUtil.truncateBinaryMin(input, 3))
+        .isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    // a length covering the whole input returns the same buffer
+    assertThat(BinaryUtil.truncateBinaryMin(input, 5)).isSameAs(input);
+  }
+
+  @Test
+  void truncateBinaryMinLiteralReturnsSameLiteralWhenNotLonger() {
+    Literal<ByteBuffer> input = Literal.of(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+    // the Literal overload returns the input unchanged when the length covers the value
+    assertThat(BinaryUtil.truncateBinaryMin(input, 3)).isSameAs(input);
+    assertThat(BinaryUtil.truncateBinaryMin(input, 5)).isSameAs(input);
+  }
+
+  @Test
+  void truncateBinaryMinLiteralTruncatesWhenLonger() {
+    Literal<ByteBuffer> input = Literal.of(ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5}));
+    assertThat(BinaryUtil.truncateBinaryMin(input, 3).value())
+        .isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  void truncateBinaryMaxLiteralIncrementsLastByte() {
+    Literal<ByteBuffer> input = Literal.of(ByteBuffer.wrap(new byte[] {1, 2, 3, 4}));
+    assertThat(BinaryUtil.truncateBinaryMax(input, 2).value())
+        .isEqualTo(ByteBuffer.wrap(new byte[] {1, 3}));
+  }
+
+  @Test
+  void truncateBinaryMaxLiteralReturnsNullWhenAllBytesOverflow() {
+    // when the ByteBuffer overload returns null, the Literal overload propagates null
+    Literal<ByteBuffer> input =
+        Literal.of(ByteBuffer.wrap(new byte[] {(byte) 0xFF, (byte) 0xFF, 1}));
     assertThat(BinaryUtil.truncateBinaryMax(input, 2)).isNull();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/util/TestBinaryUtil.java
+++ b/api/src/test/java/org/apache/iceberg/util/TestBinaryUtil.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.nio.ByteBuffer;
+import org.junit.jupiter.api.Test;
+
+class TestBinaryUtil {
+
+  @Test
+  void truncateBinaryToShorterLength() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5});
+    ByteBuffer truncated = BinaryUtil.truncateBinary(input, 3);
+    assertThat(truncated).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2, 3}));
+  }
+
+  @Test
+  void truncateBinaryReturnsInputWhenLengthIsLarger() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3});
+    // when the requested length covers the whole input, the same buffer is returned
+    assertThat(BinaryUtil.truncateBinary(input, 5)).isSameAs(input);
+    assertThat(BinaryUtil.truncateBinary(input, 3)).isSameAs(input);
+  }
+
+  @Test
+  void truncateBinaryToZeroLength() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3});
+    assertThat(BinaryUtil.truncateBinary(input, 0).remaining()).isEqualTo(0);
+  }
+
+  @Test
+  void truncateBinaryRejectsNegativeLength() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3});
+    assertThatThrownBy(() -> BinaryUtil.truncateBinary(input, -1))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("Truncate length should be non-negative");
+  }
+
+  @Test
+  void truncateBinaryUnsafeSharesBackingData() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3, 4, 5});
+    ByteBuffer truncated = BinaryUtil.truncateBinaryUnsafe(input, 2);
+    assertThat(truncated).isEqualTo(ByteBuffer.wrap(new byte[] {1, 2}));
+    // the input buffer position and limit are not modified
+    assertThat(input.position()).isEqualTo(0);
+    assertThat(input.remaining()).isEqualTo(5);
+  }
+
+  @Test
+  void truncateBinaryMaxIncrementsLastByte() {
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {1, 2, 3, 4});
+    ByteBuffer max = BinaryUtil.truncateBinaryMax(input, 2);
+    assertThat(max).isEqualTo(ByteBuffer.wrap(new byte[] {1, 3}));
+  }
+
+  @Test
+  void truncateBinaryMaxReturnsNullWhenAllBytesOverflow() {
+    // 0xFF bytes overflow when incremented, so no greater bound of this length exists
+    ByteBuffer input = ByteBuffer.wrap(new byte[] {(byte) 0xFF, (byte) 0xFF, 1});
+    assertThat(BinaryUtil.truncateBinaryMax(input, 2)).isNull();
+  }
+}


### PR DESCRIPTION
Adds a unit test class for `BinaryUtil`, covering its public truncation helpers:
- `truncateBinary` - truncation to a shorter length, the fast path that returns the input buffer unchanged when the requested length already covers it, zero-length truncation, and the non-negative-length precondition.
- `truncateBinaryUnsafe` - the shared-backing-data view, and that the input buffer's position and limit are left unmodified.
- `truncateBinaryMin` - the `ByteBuffer` overload, and the `Literal` overload including its distinct branch that returns the input `Literal` unchanged when the length already covers the value.
- `truncateBinaryMax` - the `ByteBuffer` overload (incrementing the last byte to form the upper bound, and returning `null` when every byte overflows, all `0xFF`), and the `Literal` overload including its propagation of that `null` result.

Test-only; no production code changes.