### PR TITLE
Build: Remove unused Avro dependency from iceberg-orc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -895,9 +895,6 @@ project(':iceberg-orc') {
     api project(':iceberg-api')
     implementation project(':iceberg-common')
     implementation project(':iceberg-core')
-    implementation(libs.avro.avro) {
-      exclude group: 'org.tukaani' // xz compression is not supported
-    }
 
     implementation("${libs.orc.core.get().module}:${libs.versions.orc.get()}:nohive") {
       exclude group: 'org.apache.hadoop'


### PR DESCRIPTION
`iceberg-orc` declares a direct `implementation` dependency on Avro, but the module does not reference any Avro classes, there is no `org.apache.avro.*` or `org.apache.iceberg.avro.*` usage anywhere under `orc/src`. The palantir `checkUnusedDependencies` baseline also reports it as unused. Avro remains available transitively where needed: `iceberg-core` (which `iceberg-orc` depends on) declares Avro as an `api` dependency, so dropping this redundant direct declaration does not change any module's compile or runtime classpath. Build-only; no source changes. `iceberg-orc` compiles and its tests pass with the dependency removed.