### PR TITLE
Core: Remove deprecated REST namespace encoding helpers

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -565,6 +565,14 @@ acceptedBreaks:
     - code: "java.field.removed"
       old: "field org.apache.iceberg.PartitionStatsHandler.TOTAL_RECORD_COUNT"
       justification: "Removed deprecated functionality for partition stats"
+    - code: "java.field.removed"
+      old: "field org.apache.iceberg.rest.RESTUtil.NAMESPACE_JOINER"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
+    - code: "java.field.removed"
+      old: "field org.apache.iceberg.rest.RESTUtil.NAMESPACE_SPLITTER"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.PartitionStatsHandler.PARTITION_FIELD_ID"
       justification: "Removed deprecated functionality for partition stats"
@@ -577,6 +585,10 @@ acceptedBreaks:
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.TableProperties.MANIFEST_LISTS_ENABLED_DEFAULT"
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
+    - code: "java.field.removedWithConstant"
+      old: "field org.apache.iceberg.rest.RESTSessionCatalog.REST_PAGE_SIZE"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
     - code: "java.method.addedToInterface"
       new: "method boolean org.apache.iceberg.FieldStats<T>::hasNanValueCount()"
       justification: "These interfaces were package-private in 1.11.0 and could not\
@@ -629,6 +641,10 @@ acceptedBreaks:
       old: "method boolean org.apache.iceberg.util.TableScanUtil::hasEqDeletes(org.apache.iceberg.CombinedScanTask)"
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
+      old: "method java.lang.String org.apache.iceberg.rest.RESTUtil::encodeNamespace(org.apache.iceberg.catalog.Namespace)"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
+    - code: "java.method.removed"
       old: "method java.nio.ByteBuffer org.apache.iceberg.encryption.StandardEncryptionManager::unwrapKey(java.nio.ByteBuffer)"
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
@@ -662,6 +678,10 @@ acceptedBreaks:
       old: "method org.apache.iceberg.Schema org.apache.iceberg.PartitionStatsHandler::schema(org.apache.iceberg.types.Types.StructType,\
         \ int)"
       justification: "Removed deprecated functionality for partition stats"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.catalog.Namespace org.apache.iceberg.rest.RESTUtil::decodeNamespace(java.lang.String)"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.io.CloseableIterable<java.lang.String> org.apache.iceberg.ManifestFiles::readPaths(org.apache.iceberg.ManifestFile,\
         \ org.apache.iceberg.io.FileIO)"
@@ -729,6 +749,11 @@ acceptedBreaks:
         \ T extends org.apache.iceberg.ScanTask, G extends org.apache.iceberg.ScanTaskGroup<T\
         \ extends org.apache.iceberg.ScanTask>>"
       justification: "Removing deprecated API scheduled for removal in 1.12.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.rest.responses.LoadTableResponse org.apache.iceberg.rest.CatalogHandlers::loadTable(org.apache.iceberg.catalog.Catalog,\
+        \ org.apache.iceberg.catalog.TableIdentifier)"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
     - code: "java.method.removed"
       old: "method void org.apache.iceberg.data.avro.RawDecoder<D>::<init>(org.apache.iceberg.Schema,\
         \ java.util.function.Function<org.apache.avro.Schema, org.apache.avro.io.DatumReader<?>>,\

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -567,12 +567,10 @@ acceptedBreaks:
       justification: "Removed deprecated functionality for partition stats"
     - code: "java.field.removed"
       old: "field org.apache.iceberg.rest.RESTUtil.NAMESPACE_JOINER"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.field.removed"
       old: "field org.apache.iceberg.rest.RESTUtil.NAMESPACE_SPLITTER"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.PartitionStatsHandler.PARTITION_FIELD_ID"
       justification: "Removed deprecated functionality for partition stats"
@@ -587,8 +585,7 @@ acceptedBreaks:
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
     - code: "java.field.removedWithConstant"
       old: "field org.apache.iceberg.rest.RESTSessionCatalog.REST_PAGE_SIZE"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.method.addedToInterface"
       new: "method boolean org.apache.iceberg.FieldStats<T>::hasNanValueCount()"
       justification: "These interfaces were package-private in 1.11.0 and could not\
@@ -642,8 +639,7 @@ acceptedBreaks:
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
       old: "method java.lang.String org.apache.iceberg.rest.RESTUtil::encodeNamespace(org.apache.iceberg.catalog.Namespace)"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.method.removed"
       old: "method java.nio.ByteBuffer org.apache.iceberg.encryption.StandardEncryptionManager::unwrapKey(java.nio.ByteBuffer)"
       justification: "Removed deprecated API scheduled for removal in 1.12.0"
@@ -680,8 +676,7 @@ acceptedBreaks:
       justification: "Removed deprecated functionality for partition stats"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.catalog.Namespace org.apache.iceberg.rest.RESTUtil::decodeNamespace(java.lang.String)"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.method.removed"
       old: "method org.apache.iceberg.io.CloseableIterable<java.lang.String> org.apache.iceberg.ManifestFiles::readPaths(org.apache.iceberg.ManifestFile,\
         \ org.apache.iceberg.io.FileIO)"
@@ -752,8 +747,7 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method org.apache.iceberg.rest.responses.LoadTableResponse org.apache.iceberg.rest.CatalogHandlers::loadTable(org.apache.iceberg.catalog.Catalog,\
         \ org.apache.iceberg.catalog.TableIdentifier)"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     - code: "java.method.removed"
       old: "method void org.apache.iceberg.data.avro.RawDecoder<D>::<init>(org.apache.iceberg.Schema,\
         \ java.util.function.Function<org.apache.avro.Schema, org.apache.avro.io.DatumReader<?>>,\
@@ -769,8 +763,7 @@ acceptedBreaks:
       justification: "Removing deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
       old: "method void org.apache.iceberg.rest.ResourcePaths::<init>(java.lang.String)"
-      justification: "Removing deprecated REST namespace encoding API scheduled for\
-        \ removal in 1.12.0"
+      justification: "Removed deprecated functionality scheduled for removal in 1.12.0"
     org.apache.iceberg:iceberg-data:
     - code: "java.class.removed"
       old: "class org.apache.iceberg.data.BaseFileWriterFactory<T extends java.lang.Object>"

--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -767,6 +767,10 @@ acceptedBreaks:
     - code: "java.method.removed"
       old: "method void org.apache.iceberg.io.ContentCache::invalidateAll()"
       justification: "Removing deprecated API scheduled for removal in 1.12.0"
+    - code: "java.method.removed"
+      old: "method void org.apache.iceberg.rest.ResourcePaths::<init>(java.lang.String)"
+      justification: "Removing deprecated REST namespace encoding API scheduled for\
+        \ removal in 1.12.0"
     org.apache.iceberg:iceberg-data:
     - code: "java.class.removed"
       old: "class org.apache.iceberg.data.BaseFileWriterFactory<T extends java.lang.Object>"

--- a/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
+++ b/core/src/main/java/org/apache/iceberg/rest/CatalogHandlers.java
@@ -502,15 +502,6 @@ public class CatalogHandlers {
     }
   }
 
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0. Use {@link #loadTable(Catalog,
-   *     TableIdentifier, SnapshotMode)} instead.
-   */
-  @Deprecated
-  public static LoadTableResponse loadTable(Catalog catalog, TableIdentifier ident) {
-    return loadTable(catalog, ident, SnapshotMode.ALL);
-  }
-
   public static LoadTableResponse loadTable(
       Catalog catalog, TableIdentifier ident, SnapshotMode mode) {
     Table table = catalog.loadTable(ident);

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -119,12 +119,6 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
   private static final Logger LOG = LoggerFactory.getLogger(RESTSessionCatalog.class);
   private static final String DEFAULT_FILE_IO_IMPL = "org.apache.iceberg.io.ResolvingFileIO";
 
-  /**
-   * @deprecated will be removed in 1.12.0. Use {@link
-   *     org.apache.iceberg.rest.RESTCatalogProperties#PAGE_SIZE} instead.
-   */
-  @Deprecated public static final String REST_PAGE_SIZE = "rest-page-size";
-
   // these default endpoints must not be updated in order to maintain backwards compatibility with
   // legacy servers
   private static final Set<Endpoint> DEFAULT_ENDPOINTS =

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -40,20 +40,6 @@ public class RESTUtil {
   /** The namespace separator as url encoded UTF-8 character */
   static final String NAMESPACE_SEPARATOR_URLENCODED_UTF_8 = "%1F";
 
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     RESTUtil#namespaceToQueryParam(Namespace)}} instead.
-   */
-  @Deprecated
-  public static final Joiner NAMESPACE_JOINER = Joiner.on(NAMESPACE_SEPARATOR_AS_UNICODE);
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     RESTUtil#namespaceFromQueryParam(String)} instead.
-   */
-  @Deprecated
-  public static final Splitter NAMESPACE_SPLITTER = Splitter.on(NAMESPACE_SEPARATOR_AS_UNICODE);
-
   public static final String IDEMPOTENCY_KEY_HEADER = "Idempotency-Key";
 
   private RESTUtil() {}
@@ -171,9 +157,8 @@ public class RESTUtil {
 
   /**
    * This converts the given namespace to a string and separates each part in a multipart namespace
-   * using the unicode character '\u001f'. Note that this method is different from {@link
-   * RESTUtil#encodeNamespace(Namespace)}, which uses the UTF-8 escaped version of '\u001f', which
-   * is '0x1F'.
+   * using the unicode character '\u001f'. Note that this method uses the raw unicode separator,
+   * unlike the percent-encoded form used by the REST catalog path encoding.
    *
    * <p>{@link #namespaceFromQueryParam(String)} should be used to convert the namespace string back
    * to a {@link Namespace} instance.
@@ -188,8 +173,8 @@ public class RESTUtil {
 
   /**
    * This converts the given namespace to a string and separates each part in a multipart namespace
-   * using the provided unicode separator. Note that this method is different from {@link
-   * RESTUtil#encodeNamespace(Namespace)}, which uses a UTF-8 escaped separator.
+   * using the provided unicode separator. Note that this method uses the raw unicode separator,
+   * unlike the percent-encoded form used by the REST catalog path encoding.
    *
    * <p>{@link #namespaceFromQueryParam(String, String)} should be used to convert the namespace
    * string back to a {@link Namespace} instance.
@@ -259,24 +244,6 @@ public class RESTUtil {
    * <p>This function needs to be called when a namespace is used as a path variable (or query
    * parameter etc.), to format the namespace per the spec.
    *
-   * <p>{@link #decodeNamespace} should be used to parse the namespace from a URL parameter.
-   *
-   * @param ns namespace to encode
-   * @return UTF-8 encoded string representing the namespace, suitable for use as a URL parameter
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     RESTUtil#encodeNamespace(Namespace, String)} instead.
-   */
-  @Deprecated
-  public static String encodeNamespace(Namespace ns) {
-    return encodeNamespace(ns, NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
-  }
-
-  /**
-   * Returns a String representation of a namespace that is suitable for use in a URL / URI.
-   *
-   * <p>This function needs to be called when a namespace is used as a path variable (or query
-   * parameter etc.), to format the namespace per the spec.
-   *
    * <p>{@link RESTUtil#decodeNamespace(String, String)} should be used to parse the namespace from
    * a URL parameter.
    *
@@ -297,22 +264,6 @@ public class RESTUtil {
     }
 
     return Joiner.on(separator).join(encodedLevels);
-  }
-
-  /**
-   * Takes in a string representation of a namespace as used for a URL parameter and returns the
-   * corresponding namespace.
-   *
-   * <p>See also {@link #encodeNamespace} for generating correctly formatted URLs.
-   *
-   * @param encodedNs a namespace to decode
-   * @return a namespace
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     RESTUtil#decodeNamespace(String, String)} instead.
-   */
-  @Deprecated
-  public static Namespace decodeNamespace(String encodedNs) {
-    return decodeNamespace(encodedNs, NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
   }
 
   /**

--- a/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTUtil.java
@@ -157,8 +157,8 @@ public class RESTUtil {
 
   /**
    * This converts the given namespace to a string and separates each part in a multipart namespace
-   * using the unicode character '\u001f'. Note that this method uses the raw unicode separator,
-   * unlike the percent-encoded form used by the REST catalog path encoding.
+   * using the unicode character '\u001f'. Note that this method is different from {@link
+   * RESTUtil#encodeNamespace(Namespace, String)}, which URL-encodes each part of the namespace.
    *
    * <p>{@link #namespaceFromQueryParam(String)} should be used to convert the namespace string back
    * to a {@link Namespace} instance.
@@ -173,8 +173,7 @@ public class RESTUtil {
 
   /**
    * This converts the given namespace to a string and separates each part in a multipart namespace
-   * using the provided unicode separator. Note that this method uses the raw unicode separator,
-   * unlike the percent-encoded form used by the REST catalog path encoding.
+   * using the provided unicode separator.
    *
    * <p>{@link #namespaceFromQueryParam(String, String)} should be used to convert the namespace
    * string back to a {@link Namespace} instance.

--- a/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
+++ b/core/src/main/java/org/apache/iceberg/rest/ResourcePaths.java
@@ -73,15 +73,6 @@ public class ResourcePaths {
   private final String prefix;
   private final String namespaceSeparator;
 
-  /**
-   * @deprecated since 1.11.0, will be made private in 1.12.0; use {@link
-   *     ResourcePaths#forCatalogProperties(Map)} instead.
-   */
-  @Deprecated
-  public ResourcePaths(String prefix) {
-    this(prefix, RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
-  }
-
   private ResourcePaths(String prefix, String namespaceSeparator) {
     this.prefix = prefix;
     this.namespaceSeparator = namespaceSeparator;

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -118,7 +118,7 @@ public class TestRESTUtil {
     assertThat(namespaceAsUnicode).contains("\u001f");
 
     // newer server would try and decode the namespace with the separator it communicates to clients
-    String separator = RESTCatalogAdapter.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
+    String separator = "%2E";
     Namespace decodedNamespace = RESTUtil.decodeNamespace(encodedNamespace, separator);
     assertThat(decodedNamespace).isEqualTo(namespace);
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTUtil.java
@@ -108,8 +108,9 @@ public class TestRESTUtil {
   @Test
   public void encodeAsOldClientAndDecodeAsNewServer() {
     Namespace namespace = Namespace.of("first", "second", "third");
-    // old client would call encodeNamespace without specifying a separator
-    String encodedNamespace = RESTUtil.encodeNamespace(namespace);
+    // old client would call encodeNamespace with the legacy separator
+    String encodedNamespace =
+        RESTUtil.encodeNamespace(namespace, RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
     assertThat(encodedNamespace).contains(RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8);
 
     // old client would also call namespaceToQueryParam without specifying a separator
@@ -117,7 +118,7 @@ public class TestRESTUtil {
     assertThat(namespaceAsUnicode).contains("\u001f");
 
     // newer server would try and decode the namespace with the separator it communicates to clients
-    String separator = "%2E";
+    String separator = RESTCatalogAdapter.NAMESPACE_SEPARATOR_URLENCODED_UTF_8;
     Namespace decodedNamespace = RESTUtil.decodeNamespace(encodedNamespace, separator);
     assertThat(decodedNamespace).isEqualTo(namespace);
 
@@ -130,11 +131,13 @@ public class TestRESTUtil {
   @Test
   public void testNamespaceUrlEncodeDecodeDoesNotAllowNull() {
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RESTUtil.encodeNamespace(null))
+        .isThrownBy(
+            () -> RESTUtil.encodeNamespace(null, RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8))
         .withMessage("Invalid namespace: null");
 
     assertThatExceptionOfType(IllegalArgumentException.class)
-        .isThrownBy(() -> RESTUtil.decodeNamespace(null))
+        .isThrownBy(
+            () -> RESTUtil.decodeNamespace(null, RESTUtil.NAMESPACE_SEPARATOR_URLENCODED_UTF_8))
         .withMessage("Invalid namespace: null");
   }
 

--- a/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestResourcePaths.java
@@ -119,14 +119,15 @@ public class TestResourcePaths {
     // legacy separator is always used by default, so no need to configure it
     ResourcePaths pathsWithLegacySeparator = ResourcePaths.forCatalogProperties(ImmutableMap.of());
 
-    // Encode namespace using legacy separator. No need to provide the separator to encodeNamespace
-    String legacyEncodedNamespace = RESTUtil.encodeNamespace(namespace);
+    // Encode namespace using legacy separator.
+    String legacyEncodedNamespace = RESTUtil.encodeNamespace(namespace, legacySeparator);
     assertThat(pathsWithLegacySeparator.namespace(namespace))
         .contains(legacyEncodedNamespace)
         .contains(legacySeparator);
 
-    // Decode the namespace containing legacy separator without providing the separator
-    assertThat(RESTUtil.decodeNamespace(legacyEncodedNamespace)).isEqualTo(namespace);
+    // Decode the namespace containing legacy separator
+    assertThat(RESTUtil.decodeNamespace(legacyEncodedNamespace, legacySeparator))
+        .isEqualTo(namespace);
 
     // Decode the namespace containing legacy separator with providing the new separator
     assertThat(RESTUtil.decodeNamespace(legacyEncodedNamespace, newSeparator)).isEqualTo(namespace);


### PR DESCRIPTION
Removes REST API deprecated for removal in 1.12.0:

- RESTUtil.NAMESPACE_JOINER / NAMESPACE_SPLITTER, superseded by namespaceToQueryParam(Namespace) / namespaceFromQueryParam(String)
- RESTUtil.encodeNamespace(Namespace) / decodeNamespace(String), superseded by the two-arg overloads that take an explicit separator
- RESTSessionCatalog.REST_PAGE_SIZE, superseded by RESTCatalogProperties.PAGE_SIZE
- CatalogHandlers.loadTable(Catalog, TableIdentifier), superseded by the overload taking a SnapshotMode

Javadoc on namespaceToQueryParam and encodeNamespace no longer cross-links the removed single-arg encodeNamespace; the wording now describes the raw versus percent-encoded separator directly.


## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone