### PR TITLE
Parquet: Make createStructReader with fieldId abstract

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -630,6 +630,18 @@ acceptedBreaks:
       old: "class org.apache.iceberg.data.GenericAppenderFactory"
       justification: "Removing deprecated GenericAppenderFactory and BaseFileWriterFactory\
         \ scheduled for removal in 1.12.0"
+    org.apache.iceberg:iceberg-parquet:
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.parquet.ParquetValueReader<T> org.apache.iceberg.data.parquet.BaseParquetReaders<T>::createStructReader(java.util.List<org.apache.iceberg.parquet.ParquetValueReader<?>>,\
+        \ org.apache.iceberg.types.Types.StructType) @ org.apache.iceberg.data.parquet.GenericParquetReaders"
+      justification: "Removing deprecated createStructReader overload scheduled for\
+        \ removal in 1.12.0"
+    - code: "java.method.removed"
+      old: "method org.apache.iceberg.parquet.ParquetValueReader<T> org.apache.iceberg.data.parquet.BaseParquetReaders<T>::createStructReader(java.util.List<org.apache.iceberg.parquet.ParquetValueReader<?>>,\
+        \ org.apache.iceberg.types.Types.StructType) @ org.apache.iceberg.data.parquet.InternalReader<T\
+        \ extends org.apache.iceberg.StructLike>"
+      justification: "Removing deprecated createStructReader overload scheduled for\
+        \ removal in 1.12.0"
   "1.2.0":
     org.apache.iceberg:iceberg-api:
     - code: "java.field.constantValueChanged"

--- a/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
+++ b/parquet/src/main/java/org/apache/iceberg/data/parquet/BaseParquetReaders.java
@@ -78,26 +78,8 @@ abstract class BaseParquetReaders<T> {
     }
   }
 
-  /**
-   * @deprecated will be removed in 1.12.0. Subclasses should override {@link
-   *     #createStructReader(List, Types.StructType, Integer)} instead
-   */
-  @Deprecated
-  protected ParquetValueReader<T> createStructReader(
-      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType) {
-    throw new UnsupportedOperationException(
-        "Deprecated method is not used in this implementation, only createStructReader(list, Types.Struct, Integer) should be used");
-  }
-
-  /**
-   * This method can be overridden to provide a custom implementation which also uses the fieldId of
-   * the Schema when creating the struct reader
-   */
-  protected ParquetValueReader<T> createStructReader(
-      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType, Integer fieldId) {
-    // Fallback to the signature without fieldId if not overridden
-    return createStructReader(fieldReaders, structType);
-  }
+  protected abstract ParquetValueReader<T> createStructReader(
+      List<ParquetValueReader<?>> fieldReaders, Types.StructType structType, Integer fieldId);
 
   protected abstract ParquetValueReader<?> fixedReader(ColumnDescriptor desc);
 


### PR DESCRIPTION
createStructReader(List, StructType) was deprecated for removal in 1.12.0 in favor of createStructReader(List, StructType, Integer). The 2-arg form threw UnsupportedOperationException and the 3-arg form defaulted to delegating to it, so neither was usable without an override.

Remove the 2-arg method and make the 3-arg form abstract. Both subclasses (GenericParquetReaders, InternalReader) already override it, and BaseParquetReaders is package-private so no other subclass can exist.

## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone