### PR TITLE
Core: Add strict content stats evaluator

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictEvalVisitor.java
@@ -21,6 +21,7 @@ package org.apache.iceberg.expressions;
 import java.util.Comparator;
 import java.util.Set;
 import org.apache.iceberg.types.Comparators;
+import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types.StructType;
 import org.apache.iceberg.util.NaNUtil;
 
@@ -40,19 +41,11 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
   /** Return true if null count is known and equal to value count, false otherwise. */
   protected abstract boolean containsNullsOnly(int id);
 
-  /**
-   * Return true if null counts are unavailable or if the null count is non-zero, false otherwise.
-   */
-  protected abstract boolean canContainNulls(int id);
-
   /** Return true if NaN count is non-zero or is unknown, false if NaN count is 0. */
   protected abstract boolean mayContainNaN(int id);
 
   /** Return true if NaN count is known and equal to value count, false otherwise. */
   protected abstract boolean containsNaNsOnly(int id);
-
-  /** Return true if the NaN count is known and non-zero, false otherwise. */
-  protected abstract boolean canContainNaNs(int id);
 
   /** Return the lower bound if it is known, or null otherwise. */
   protected abstract <T> T lowerBound(BoundReference<T> ref);
@@ -159,7 +152,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -184,7 +177,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -209,7 +202,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -235,7 +228,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -261,7 +254,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -325,7 +318,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id) || canContainNaNs(id)) {
+    if (canContainNulls(ref) || canContainNaNs(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -389,7 +382,7 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
       return ROWS_MIGHT_NOT_MATCH;
     }
 
-    if (canContainNulls(id)) {
+    if (canContainNulls(ref)) {
       return ROWS_MIGHT_NOT_MATCH;
     }
 
@@ -457,6 +450,27 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
     return ROWS_MIGHT_NOT_MATCH;
   }
 
+  /**
+   * Returns true if the field is optional and its null count is non-zero or unknown.
+   *
+   * <p>A null value does not match a comparison predicate, so all rows can only match when the
+   * field has no nulls.
+   */
+  private boolean canContainNulls(BoundReference<?> ref) {
+    return ref.producesNull() && mayContainNull(ref.fieldId());
+  }
+
+  /**
+   * Returns true if the field is a floating point type and its NaN count is non-zero or unknown.
+   *
+   * <p>A NaN value does not match a comparison predicate, so all rows can only match when the field
+   * has no NaNs. NaN counts are tracked only for floating point fields, so the type is checked to
+   * avoid assuming that other fields may contain NaN values.
+   */
+  private boolean canContainNaNs(BoundReference<?> ref) {
+    return isFloatingPoint(ref.type()) && mayContainNaN(ref.fieldId());
+  }
+
   /** Returns true if the field is not a top-level field of the schema. */
   private boolean isNestedColumn(int id) {
     return struct.field(id) == null;
@@ -473,5 +487,9 @@ abstract class StrictEvalVisitor extends ExpressionVisitors.BoundExpressionVisit
     }
 
     return false;
+  }
+
+  private static boolean isFloatingPoint(Type type) {
+    return Type.TypeID.FLOAT == type.typeId() || Type.TypeID.DOUBLE == type.typeId();
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/StrictMetricsEvaluator.java
@@ -108,11 +108,6 @@ public class StrictMetricsEvaluator {
     }
 
     @Override
-    protected boolean canContainNulls(int id) {
-      return nullCounts == null || (nullCounts.containsKey(id) && nullCounts.get(id) > 0);
-    }
-
-    @Override
     protected boolean mayContainNaN(int id) {
       return nanCounts == null || !nanCounts.containsKey(id) || nanCounts.get(id) != 0;
     }
@@ -123,11 +118,6 @@ public class StrictMetricsEvaluator {
           && nanCounts.containsKey(id)
           && valueCounts != null
           && nanCounts.get(id).equals(valueCounts.get(id));
-    }
-
-    @Override
-    protected boolean canContainNaNs(int id) {
-      return nanCounts != null && nanCounts.containsKey(id) && nanCounts.get(id) > 0;
     }
 
     @Override

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
@@ -345,7 +345,9 @@ public class TestMetricsEvaluatorsNaNHandling {
           .isFalse();
 
       shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 1D)).eval(FILE);
-      assertThat(shouldRead).as("Should match: 1 is smaller than lower bound").isTrue();
+      assertThat(shouldRead)
+          .as("Should not match: NaN count is unknown so a NaN may not match")
+          .isFalse();
 
       shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 10D)).eval(FILE);
       assertThat(shouldRead).as("Should not match: 10 is larger than lower bound").isFalse();

--- a/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestMetricsEvaluatorsNaNHandling.java
@@ -37,8 +37,8 @@ import org.junit.jupiter.api.Test;
 /**
  * This test class ensures that metrics evaluators could handle NaN as upper/lower bounds correctly.
  */
-public class TestMetricsEvaluatorsNaNHandling {
-  private static final Schema SCHEMA =
+public class TestMetricsEvaluatorsNaNHandling<F> {
+  protected static final Schema SCHEMA =
       new Schema(
           required(1, "all_nan", Types.DoubleType.get()),
           required(2, "max_nan", Types.DoubleType.get()),
@@ -89,6 +89,16 @@ public class TestMetricsEvaluatorsNaNHandling {
 
   private static final Set<BiFunction<String, Number, Expression>> GREATER_THAN_EXPRESSIONS =
       ImmutableSet.of(Expressions::greaterThan, Expressions::greaterThanOrEqual);
+
+  /** Returns whether all rows in the file match the expression. */
+  protected boolean allRowsMatch(Schema schema, Expression expr, F testFile) {
+    return new StrictMetricsEvaluator(schema, expr).eval((DataFile) testFile);
+  }
+
+  @SuppressWarnings("unchecked")
+  protected F file() {
+    return (F) FILE;
+  }
 
   @Test
   public void testInclusiveMetricsEvaluatorLessThanAndLessThanOrEqual() {
@@ -311,199 +321,133 @@ public class TestMetricsEvaluatorsNaNHandling {
   }
 
   @Test
-  public void testStrictMetricsEvaluatorLessThanAndLessThanOrEqual() {
+  public void testStrictEvaluatorLessThanAndLessThanOrEqual() {
     for (BiFunction<String, Number, Expression> func : LESS_THAN_EXPRESSIONS) {
-      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("all_nan", 1D)).eval(FILE);
-      assertThat(shouldRead)
-          .as("Should not match: all nan column doesn't contain number")
-          .isFalse();
+      boolean matches = allRowsMatch(SCHEMA, func.apply("all_nan", 1D), file());
+      assertThat(matches).as("Should not match: all nan column doesn't contain number").isFalse();
 
-      shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 10D)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: 10 is less than upper bound").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("max_nan", 10D), file());
+      assertThat(matches).as("Should not match: 10 is less than upper bound").isFalse();
 
-      shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("min_max_nan", 1F)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: no visibility").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("min_max_nan", 1F), file());
+      assertThat(matches).as("Should not match: no visibility").isFalse();
 
-      shouldRead =
-          new StrictMetricsEvaluator(SCHEMA, func.apply("all_nan_null_bounds", 1D)).eval(FILE);
-      assertThat(shouldRead)
-          .as("Should not match: all nan column doesn't contain number")
-          .isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("all_nan_null_bounds", 1D), file());
+      assertThat(matches).as("Should not match: all nan column doesn't contain number").isFalse();
 
-      shouldRead =
-          new StrictMetricsEvaluator(SCHEMA, func.apply("some_nan_correct_bounds", 30F)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: nan value exists").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("some_nan_correct_bounds", 30F), file());
+      assertThat(matches).as("Should not match: nan value exists").isFalse();
     }
   }
 
   @Test
-  public void testStrictMetricsEvaluatorGreaterThanAndGreaterThanOrEqual() {
+  public void testStrictEvaluatorGreaterThanAndGreaterThanOrEqual() {
     for (BiFunction<String, Number, Expression> func : GREATER_THAN_EXPRESSIONS) {
-      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("all_nan", 1D)).eval(FILE);
-      assertThat(shouldRead)
-          .as("Should not match: all nan column doesn't contain number")
-          .isFalse();
+      boolean matches = allRowsMatch(SCHEMA, func.apply("all_nan", 1D), file());
+      assertThat(matches).as("Should not match: all nan column doesn't contain number").isFalse();
 
-      shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 1D)).eval(FILE);
-      assertThat(shouldRead)
+      matches = allRowsMatch(SCHEMA, func.apply("max_nan", 1D), file());
+      assertThat(matches)
           .as("Should not match: NaN count is unknown so a NaN may not match")
           .isFalse();
 
-      shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("max_nan", 10D)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: 10 is larger than lower bound").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("max_nan", 10D), file());
+      assertThat(matches).as("Should not match: 10 is larger than lower bound").isFalse();
 
-      shouldRead = new StrictMetricsEvaluator(SCHEMA, func.apply("min_max_nan", 1F)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: no visibility").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("min_max_nan", 1F), file());
+      assertThat(matches).as("Should not match: no visibility").isFalse();
 
-      shouldRead =
-          new StrictMetricsEvaluator(SCHEMA, func.apply("all_nan_null_bounds", 1D)).eval(FILE);
-      assertThat(shouldRead)
-          .as("Should not match: all nan column doesn't contain number")
-          .isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("all_nan_null_bounds", 1D), file());
+      assertThat(matches).as("Should not match: all nan column doesn't contain number").isFalse();
 
-      shouldRead =
-          new StrictMetricsEvaluator(SCHEMA, func.apply("some_nan_correct_bounds", 30)).eval(FILE);
-      assertThat(shouldRead).as("Should not match: nan value exists").isFalse();
+      matches = allRowsMatch(SCHEMA, func.apply("some_nan_correct_bounds", 30), file());
+      assertThat(matches).as("Should not match: nan value exists").isFalse();
     }
   }
 
   @Test
-  public void testStrictMetricsEvaluatorNotEquals() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("all_nan", 1D)).eval(FILE);
-    assertThat(shouldRead).as("Should match: all nan column doesn't contain number").isTrue();
+  public void testStrictEvaluatorNotEquals() {
+    boolean matches = allRowsMatch(SCHEMA, Expressions.notEqual("all_nan", 1D), file());
+    assertThat(matches).as("Should match: all nan column doesn't contain number").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("max_nan", 1D)).eval(FILE);
-    assertThat(shouldRead).as("Should match: 1 is smaller than lower bound").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("max_nan", 1D), file());
+    assertThat(matches).as("Should match: 1 is smaller than lower bound").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("max_nan", 10D)).eval(FILE);
-    assertThat(shouldRead).as("Should not match: 10 is within bounds").isFalse();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("max_nan", 10D), file());
+    assertThat(matches).as("Should not match: 10 is within bounds").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("min_max_nan", 1F)).eval(FILE);
-    assertThat(shouldRead).as("Should not match: no visibility").isFalse();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("min_max_nan", 1F), file());
+    assertThat(matches).as("Should not match: no visibility").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("all_nan_null_bounds", 1D))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: all nan column doesn't contain number").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("all_nan_null_bounds", 1D), file());
+    assertThat(matches).as("Should match: all nan column doesn't contain number").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 1F))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: 1 is smaller than lower bound").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 1F), file());
+    assertThat(matches).as("Should match: 1 is smaller than lower bound").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 10F))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should not match: 10 is within bounds").isFalse();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 10F), file());
+    assertThat(matches).as("Should not match: 10 is within bounds").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 30))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: 30 is greater than upper bound").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notEqual("some_nan_correct_bounds", 30), file());
+    assertThat(matches).as("Should match: 30 is greater than upper bound").isTrue();
   }
 
   @Test
-  public void testStrictMetricsEvaluatorEquals() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.equal("all_nan", 1D)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("max_nan", 1D)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("max_nan", 10D)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("min_max_nan", 1F)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("all_nan_null_bounds", 1D))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("some_nan_correct_bounds", 1F))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("some_nan_correct_bounds", 10F))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("some_nan_correct_bounds", 30))
-                .eval(FILE);
-    assertThat(shouldRead).as("Should not match: bounds not equal to given value").isFalse();
+  public void testStrictEvaluatorEquals() {
+    boolean matches = allRowsMatch(SCHEMA, Expressions.equal("all_nan", 1D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.equal("max_nan", 1D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.equal("max_nan", 10D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.equal("min_max_nan", 1F), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.equal("all_nan_null_bounds", 1D), file());
+    matches =
+        matches | allRowsMatch(SCHEMA, Expressions.equal("some_nan_correct_bounds", 1F), file());
+    matches =
+        matches | allRowsMatch(SCHEMA, Expressions.equal("some_nan_correct_bounds", 10F), file());
+    matches =
+        matches | allRowsMatch(SCHEMA, Expressions.equal("some_nan_correct_bounds", 30), file());
+    assertThat(matches).as("Should not match: bounds not equal to given value").isFalse();
   }
 
   @Test
-  public void testStrictMetricsEvaluatorNotIn() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("all_nan", 1D, 10D, 30D)).eval(FILE);
-    assertThat(shouldRead).as("Should match: all nan column doesn't contain number").isTrue();
+  public void testStrictEvaluatorNotIn() {
+    boolean matches = allRowsMatch(SCHEMA, Expressions.notIn("all_nan", 1D, 10D, 30D), file());
+    assertThat(matches).as("Should match: all nan column doesn't contain number").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("max_nan", 1D, 10D, 30D)).eval(FILE);
-    assertThat(shouldRead).as("Should not match: 10 and 30 are greater than lower bound").isFalse();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("max_nan", 1D, 10D, 30D), file());
+    assertThat(matches).as("Should not match: 10 and 30 are greater than lower bound").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("max_nan", 1D)).eval(FILE);
-    assertThat(shouldRead).as("Should match: 1 is less than lower bound").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("max_nan", 1D), file());
+    assertThat(matches).as("Should match: 1 is less than lower bound").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("min_max_nan", 1F, 10F, 30F))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should not match: no visibility").isFalse();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("min_max_nan", 1F, 10F, 30F), file());
+    assertThat(matches).as("Should not match: no visibility").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("all_nan_null_bounds", 1D, 10D, 30D))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: all nan column doesn't contain number").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("all_nan_null_bounds", 1D, 10D, 30D), file());
+    assertThat(matches).as("Should match: all nan column doesn't contain number").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA, Expressions.notIn("some_nan_correct_bounds", 1F, 10F, 30F))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should not match: 10 within bounds").isFalse();
+    matches =
+        allRowsMatch(SCHEMA, Expressions.notIn("some_nan_correct_bounds", 1F, 10F, 30F), file());
+    assertThat(matches).as("Should not match: 10 within bounds").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("some_nan_correct_bounds", 1D))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: 1 not within bounds").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("some_nan_correct_bounds", 1D), file());
+    assertThat(matches).as("Should match: 1 not within bounds").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.notIn("some_nan_correct_bounds", 30D))
-            .eval(FILE);
-    assertThat(shouldRead).as("Should match: 30 not within bounds").isTrue();
+    matches = allRowsMatch(SCHEMA, Expressions.notIn("some_nan_correct_bounds", 30D), file());
+    assertThat(matches).as("Should match: 30 not within bounds").isTrue();
   }
 
   @Test
-  public void testStrictMetricsEvaluatorIn() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, Expressions.in("all_nan", 1D)).eval(FILE);
-    shouldRead =
-        shouldRead | new StrictMetricsEvaluator(SCHEMA, Expressions.in("max_nan", 1D)).eval(FILE);
-    shouldRead =
-        shouldRead | new StrictMetricsEvaluator(SCHEMA, Expressions.in("max_nan", 10D)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.in("min_max_nan", 1F)).eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.in("all_nan_null_bounds", 1D))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.in("some_nan_correct_bounds", 1F))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.in("some_nan_correct_bounds", 10F))
-                .eval(FILE);
-    shouldRead =
-        shouldRead
-            | new StrictMetricsEvaluator(SCHEMA, Expressions.equal("some_nan_correct_bounds", 30))
-                .eval(FILE);
-    assertThat(shouldRead).as("Should not match: bounds not equal to given value").isFalse();
+  public void testStrictEvaluatorIn() {
+    boolean matches = allRowsMatch(SCHEMA, Expressions.in("all_nan", 1D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.in("max_nan", 1D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.in("max_nan", 10D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.in("min_max_nan", 1F), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.in("all_nan_null_bounds", 1D), file());
+    matches = matches | allRowsMatch(SCHEMA, Expressions.in("some_nan_correct_bounds", 1F), file());
+    matches =
+        matches | allRowsMatch(SCHEMA, Expressions.in("some_nan_correct_bounds", 10F), file());
+    matches =
+        matches | allRowsMatch(SCHEMA, Expressions.equal("some_nan_correct_bounds", 30), file());
+    assertThat(matches).as("Should not match: bounds not equal to given value").isFalse();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -208,6 +208,69 @@ public class TestStrictMetricsEvaluator {
           // upper bounds
           ImmutableMap.of(3, toByteBuffer(StringType.get(), "dC")));
 
+  // Int columns with bounds, but without any null value counts
+  private static final DataFile MISSING_NULL_COUNTS_FILE =
+      new TestDataFile(
+          "missing_null_counts.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(1, 50L, 2, 50L),
+          // null value counts
+          null,
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MIN_VALUE)),
+          // upper bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
+
+  // Int columns with bounds, where null value counts are tracked only for another column
+  private static final DataFile PARTIAL_NULL_COUNTS_FILE =
+      new TestDataFile(
+          "partial_null_counts.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(1, 50L, 2, 50L),
+          // null value counts
+          ImmutableMap.of(3, 0L),
+          // nan value counts
+          null,
+          // lower bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MIN_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MIN_VALUE)),
+          // upper bounds
+          ImmutableMap.of(
+              1, toByteBuffer(IntegerType.get(), INT_MAX_VALUE),
+              2, toByteBuffer(IntegerType.get(), INT_MAX_VALUE)));
+
+  // Float columns without nulls, where NaN counts are tracked only for column 10 (no_nans)
+  private static final DataFile FLOAT_FILE =
+      new TestDataFile(
+          "float_file.avro",
+          Row.of(),
+          50,
+          // any value counts, including nulls
+          ImmutableMap.of(10, 50L, 14, 50L),
+          // null value counts
+          ImmutableMap.of(10, 0L, 14, 0L),
+          // nan value counts
+          ImmutableMap.of(10, 0L),
+          // lower bounds
+          ImmutableMap.of(
+              10, toByteBuffer(Types.FloatType.get(), 1.0F),
+              14, toByteBuffer(Types.DoubleType.get(), 1.0D)),
+          // upper bounds
+          ImmutableMap.of(
+              10, toByteBuffer(Types.FloatType.get(), 5.0F),
+              14, toByteBuffer(Types.DoubleType.get(), 5.0D)));
+
   @Test
   public void testAllNulls() {
     boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
@@ -920,5 +983,48 @@ public class TestStrictMetricsEvaluator {
     boolean shouldRead =
         new StrictMetricsEvaluator(SCHEMA, startsWith("struct.nested_string_col", "a")).eval(FILE);
     assertThat(shouldRead).as("Should not match: nested column is not supported").isFalse();
+  }
+
+  @Test
+  void missingNullCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
+            .eval(MISSING_NULL_COUNTS_FILE);
+    assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
+            .eval(MISSING_NULL_COUNTS_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: optional column may contain nulls without a null count")
+        .isFalse();
+  }
+
+  @Test
+  void partialNullCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
+            .eval(PARTIAL_NULL_COUNTS_FILE);
+    assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
+            .eval(PARTIAL_NULL_COUNTS_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: optional column may contain nulls without a null count")
+        .isFalse();
+  }
+
+  @Test
+  void missingNaNCounts() {
+    boolean shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nans", 10.0F)).eval(FLOAT_FILE);
+    assertThat(shouldRead).as("Should match: float column has no nulls and no NaNs").isTrue();
+
+    shouldRead =
+        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nan_stats", 10.0D)).eval(FLOAT_FILE);
+    assertThat(shouldRead)
+        .as("Should not match: float column may contain NaNs without a NaN count")
+        .isFalse();
   }
 }

--- a/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
+++ b/api/src/test/java/org/apache/iceberg/expressions/TestStrictMetricsEvaluator.java
@@ -52,8 +52,8 @@ import org.apache.iceberg.types.Types.IntegerType;
 import org.apache.iceberg.types.Types.StringType;
 import org.junit.jupiter.api.Test;
 
-public class TestStrictMetricsEvaluator {
-  private static final Schema SCHEMA =
+public class TestStrictMetricsEvaluator<F> {
+  protected static final Schema SCHEMA =
       new Schema(
           required(1, "id", IntegerType.get()),
           optional(2, "no_stats", IntegerType.get()),
@@ -77,8 +77,8 @@ public class TestStrictMetricsEvaluator {
                   Types.NestedField.optional(17, "nested_col_with_stats", Types.IntegerType.get()),
                   Types.NestedField.optional(18, "nested_string_col", Types.StringType.get()))));
 
-  private static final int INT_MIN_VALUE = 30;
-  private static final int INT_MAX_VALUE = 79;
+  protected static final int INT_MIN_VALUE = 30;
+  protected static final int INT_MAX_VALUE = 79;
 
   private static final DataFile FILE =
       new TestDataFile(
@@ -271,134 +271,182 @@ public class TestStrictMetricsEvaluator {
               10, toByteBuffer(Types.FloatType.get(), 5.0F),
               14, toByteBuffer(Types.DoubleType.get(), 5.0D)));
 
+  private static final DataFile MISSING_STATS = new TestDataFile("file.parquet", Row.of(), 50);
+
+  private static final DataFile EMPTY_FILE = new TestDataFile("file.parquet", Row.of(), 0);
+
+  protected boolean shouldRead(Schema schema, Expression expr, F testFile) {
+    return new StrictMetricsEvaluator(schema, expr).eval((DataFile) testFile);
+  }
+
+  protected F file() {
+    return asFile(FILE);
+  }
+
+  protected F file2() {
+    return asFile(FILE_2);
+  }
+
+  protected F file3() {
+    return asFile(FILE_3);
+  }
+
+  protected F stringFile() {
+    return asFile(STRING_FILE);
+  }
+
+  protected F stringFile2() {
+    return asFile(STRING_FILE_2);
+  }
+
+  protected F missingNullCountsFile() {
+    return asFile(MISSING_NULL_COUNTS_FILE);
+  }
+
+  protected F partialNullCountsFile() {
+    return asFile(PARTIAL_NULL_COUNTS_FILE);
+  }
+
+  protected F floatFile() {
+    return asFile(FLOAT_FILE);
+  }
+
+  protected F missingStats() {
+    return asFile(MISSING_STATS);
+  }
+
+  protected F emptyFile() {
+    return asFile(EMPTY_FILE);
+  }
+
+  @SuppressWarnings("unchecked")
+  private F asFile(DataFile dataFile) {
+    return (F) dataFile;
+  }
+
   @Test
   public void testAllNulls() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("all_nulls")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notNull("all_nulls"), file());
     assertThat(shouldRead).as("Should not match: no non-null value in all null column").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("some_nulls")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNull("some_nulls"), file());
     assertThat(shouldRead)
         .as("Should not match: column with some nulls contains a non-null value")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("no_nulls")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNull("no_nulls"), file());
     assertThat(shouldRead).as("Should match: non-null column contains no null values").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("all_nulls", "a")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("all_nulls", "a"), file());
     assertThat(shouldRead).as("Should match: notEqual on all nulls column").isTrue();
   }
 
   @Test
   public void testNoNulls() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("all_nulls")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, isNull("all_nulls"), file());
     assertThat(shouldRead).as("Should match: all values are null").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("some_nulls")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNull("some_nulls"), file());
     assertThat(shouldRead).as("Should not match: not all values are null").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("no_nulls")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNull("no_nulls"), file());
     assertThat(shouldRead).as("Should not match: no values are null").isFalse();
   }
 
   @Test
   public void testSomeNulls() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("some_nulls", "ggg")).eval(FILE_2);
+    boolean shouldRead = shouldRead(SCHEMA, lessThan("some_nulls", "ggg"), file2());
     assertThat(shouldRead).as("Should not match: lessThan on some nulls column").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("some_nulls", "eee")).eval(FILE_2);
+    shouldRead = shouldRead(SCHEMA, lessThanOrEqual("some_nulls", "eee"), file2());
     assertThat(shouldRead).as("Should not match: lessThanOrEqual on some nulls column").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("some_nulls", "aaa")).eval(FILE_2);
+    shouldRead = shouldRead(SCHEMA, greaterThan("some_nulls", "aaa"), file2());
     assertThat(shouldRead).as("Should not match: greaterThan on some nulls column").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("some_nulls", "bbb")).eval(FILE_2);
+    shouldRead = shouldRead(SCHEMA, greaterThanOrEqual("some_nulls", "bbb"), file2());
     assertThat(shouldRead)
         .as("Should not match: greaterThanOrEqual on some nulls column")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("some_nulls", "bbb")).eval(FILE_3);
+    shouldRead = shouldRead(SCHEMA, equal("some_nulls", "bbb"), file3());
     assertThat(shouldRead).as("Should not match: equal on some nulls column").isFalse();
   }
 
   @Test
   public void testIsNaN() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("all_nans")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, isNaN("all_nans"), file());
     assertThat(shouldRead).as("Should match: all values are nan").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("some_nans")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("some_nans"), file());
     assertThat(shouldRead)
         .as("Should not match: at least one non-nan value in some nan column")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("no_nans")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("no_nans"), file());
     assertThat(shouldRead)
         .as("Should not match: at least one non-nan value in no nan column")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("all_nulls_double")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("all_nulls_double"), file());
     assertThat(shouldRead)
         .as("Should not match: at least one non-nan value in all null column")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("no_nan_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("no_nan_stats"), file());
     assertThat(shouldRead).as("Should not match: cannot determine without nan stats").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("all_nans_v1_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("all_nans_v1_stats"), file());
     assertThat(shouldRead).as("Should not match: cannot determine without nan stats").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNaN("nan_and_null_only")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNaN("nan_and_null_only"), file());
     assertThat(shouldRead).as("Should not match: null values are not nan").isFalse();
   }
 
   @Test
   public void testNotNaN() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("all_nans")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notNaN("all_nans"), file());
     assertThat(shouldRead).as("Should not match: all values are nan").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("some_nans")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("some_nans"), file());
     assertThat(shouldRead)
         .as("Should not match: at least one nan value in some nan column")
         .isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("no_nans")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("no_nans"), file());
     assertThat(shouldRead).as("Should match: no value is nan").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("all_nulls_double")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("all_nulls_double"), file());
     assertThat(shouldRead).as("Should match: no nan value in all null column").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("no_nan_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("no_nan_stats"), file());
     assertThat(shouldRead).as("Should not match: cannot determine without nan stats").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("all_nans_v1_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("all_nans_v1_stats"), file());
     assertThat(shouldRead).as("Should not match: all values are nan").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notNaN("nan_and_null_only")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNaN("nan_and_null_only"), file());
     assertThat(shouldRead).as("Should not match: null values are not nan").isFalse();
   }
 
   @Test
   public void testRequiredColumn() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, notNull("required")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notNull("required"), file());
     assertThat(shouldRead).as("Should match: required columns are always non-null").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, isNull("required")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNull("required"), file());
     assertThat(shouldRead).as("Should not match: required columns never contain null").isFalse();
   }
 
   @Test
   public void testMissingColumn() {
-    assertThatThrownBy(() -> new StrictMetricsEvaluator(SCHEMA, lessThan("missing", 5)).eval(FILE))
+    assertThatThrownBy(() -> shouldRead(SCHEMA, lessThan("missing", 5), file()))
         .isInstanceOf(ValidationException.class)
         .hasMessageContaining("Cannot find field 'missing'");
   }
 
   @Test
   public void testMissingStats() {
-    DataFile missingStats = new TestDataFile("file.parquet", Row.of(), 50);
-
     Expression[] exprs =
         new Expression[] {
           lessThan("no_stats", 5),
@@ -414,7 +462,7 @@ public class TestStrictMetricsEvaluator {
         };
 
     for (Expression expr : exprs) {
-      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, expr).eval(missingStats);
+      boolean shouldRead = shouldRead(SCHEMA, expr, missingStats());
       assertThat(shouldRead)
           .as("Should never match when stats are missing for expr: " + expr)
           .isFalse();
@@ -423,8 +471,6 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   public void testZeroRecordFile() {
-    DataFile empty = new TestDataFile("file.parquet", Row.of(), 0);
-
     Expression[] exprs =
         new Expression[] {
           lessThan("id", 5),
@@ -440,7 +486,7 @@ public class TestStrictMetricsEvaluator {
         };
 
     for (Expression expr : exprs) {
-      boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, expr).eval(empty);
+      boolean shouldRead = shouldRead(SCHEMA, expr, emptyFile());
       assertThat(shouldRead).as("Should always match 0-record file: " + expr).isTrue();
     }
   }
@@ -448,12 +494,10 @@ public class TestStrictMetricsEvaluator {
   @Test
   public void testNot() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, not(lessThan("id", INT_MIN_VALUE - 25))).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, not(lessThan("id", INT_MIN_VALUE - 25)), file());
     assertThat(shouldRead).as("Should not match: not(false)").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, not(greaterThan("id", INT_MIN_VALUE - 25))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(greaterThan("id", INT_MIN_VALUE - 25)), file());
     assertThat(shouldRead).as("Should match: not(true)").isFalse();
   }
 
@@ -461,28 +505,24 @@ public class TestStrictMetricsEvaluator {
   public void testAnd() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
     boolean shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                and(greaterThan("id", INT_MIN_VALUE - 25), lessThanOrEqual("id", INT_MIN_VALUE)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            and(greaterThan("id", INT_MIN_VALUE - 25), lessThanOrEqual("id", INT_MIN_VALUE)),
+            file());
     assertThat(shouldRead).as("Should not match: range may not overlap data").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                and(
-                    lessThan("id", INT_MIN_VALUE - 25),
-                    greaterThanOrEqual("id", INT_MIN_VALUE - 30)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            and(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MIN_VALUE - 30)),
+            file());
     assertThat(shouldRead).as("Should not match: range does not overlap data").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                and(
-                    lessThan("id", INT_MAX_VALUE + 6),
-                    greaterThanOrEqual("id", INT_MIN_VALUE - 30)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            and(lessThan("id", INT_MAX_VALUE + 6), greaterThanOrEqual("id", INT_MIN_VALUE - 30)),
+            file());
     assertThat(shouldRead).as("Should match: range includes all data").isTrue();
   }
 
@@ -490,365 +530,309 @@ public class TestStrictMetricsEvaluator {
   public void testOr() {
     // this test case must use a real predicate, not alwaysTrue(), or binding will simplify it out
     boolean shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                or(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MAX_VALUE + 1)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            or(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MAX_VALUE + 1)),
+            file());
     assertThat(shouldRead).as("Should not match: no matching values").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                or(
-                    lessThan("id", INT_MIN_VALUE - 25),
-                    greaterThanOrEqual("id", INT_MAX_VALUE - 19)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            or(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MAX_VALUE - 19)),
+            file());
     assertThat(shouldRead).as("Should not match: some values do not match").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA,
-                or(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MIN_VALUE)))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA,
+            or(lessThan("id", INT_MIN_VALUE - 25), greaterThanOrEqual("id", INT_MIN_VALUE)),
+            file());
     assertThat(shouldRead).as("Should match: all values match >= 30").isTrue();
   }
 
   @Test
   public void testIntegerLt() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MIN_VALUE)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, lessThan("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: always false").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MIN_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThan("id", INT_MIN_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: 32 and greater not in range").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should not match: 79 not in range").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should match: all values in range").isTrue();
   }
 
   @Test
   public void testIntegerLtEq() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", INT_MIN_VALUE - 1)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, lessThanOrEqual("id", INT_MIN_VALUE - 1), file());
     assertThat(shouldRead).as("Should not match: always false").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThanOrEqual("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: 31 and greater not in range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", INT_MAX_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThanOrEqual("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should match: all values in range").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThanOrEqual("id", INT_MAX_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, lessThanOrEqual("id", INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should match: all values in range").isTrue();
   }
 
   @Test
   public void testIntegerGt() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThan("id", INT_MAX_VALUE)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, greaterThan("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should not match: always false").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThan("id", INT_MAX_VALUE - 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThan("id", INT_MAX_VALUE - 1), file());
     assertThat(shouldRead).as("Should not match: 77 and less not in range").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, greaterThan("id", INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThan("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: 30 not in range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThan("id", INT_MIN_VALUE - 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThan("id", INT_MIN_VALUE - 1), file());
     assertThat(shouldRead).as("Should match: all values in range").isTrue();
   }
 
   @Test
   public void testIntegerGtEq() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", INT_MAX_VALUE + 1)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, greaterThanOrEqual("id", INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: no values in range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", INT_MAX_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThanOrEqual("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should not match: 78 and lower are not in range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", INT_MIN_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThanOrEqual("id", INT_MIN_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: 30 not in range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, greaterThanOrEqual("id", INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, greaterThanOrEqual("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should match: all values in range").isTrue();
   }
 
   @Test
   public void testIntegerEq() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, equal("id", INT_MIN_VALUE - 25)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, equal("id", INT_MIN_VALUE - 25), file());
     assertThat(shouldRead).as("Should not match: all values != 5").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, equal("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: some values != 30").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", INT_MAX_VALUE - 4)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, equal("id", INT_MAX_VALUE - 4), file());
     assertThat(shouldRead).as("Should not match: some values != 75").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", INT_MAX_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, equal("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should not match: some values != 79").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, equal("id", INT_MAX_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, equal("id", INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: some values != 80").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, equal("always_5", INT_MIN_VALUE - 25)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, equal("always_5", INT_MIN_VALUE - 25), file());
     assertThat(shouldRead).as("Should match: all values == 5").isTrue();
   }
 
   @Test
   public void testIntegerNotEq() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MIN_VALUE - 25)).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MIN_VALUE - 25), file());
     assertThat(shouldRead).as("Should match: no values == 5").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MIN_VALUE - 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MIN_VALUE - 1), file());
     assertThat(shouldRead).as("Should match: no values == 39").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: some value may be == 30").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MAX_VALUE - 4)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MAX_VALUE - 4), file());
     assertThat(shouldRead).as("Should not match: some value may be == 75").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MAX_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("Should not match: some value may be == 79").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MAX_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should match: no values == 80").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notEqual("id", INT_MAX_VALUE + 6)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notEqual("id", INT_MAX_VALUE + 6), file());
     assertThat(shouldRead).as("Should read: no values == 85").isTrue();
   }
 
   @Test
   public void testIntegerNotEqRewritten() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MIN_VALUE - 25))).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MIN_VALUE - 25)), file());
     assertThat(shouldRead).as("Should match: no values == 5").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MIN_VALUE - 1))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MIN_VALUE - 1)), file());
     assertThat(shouldRead).as("Should match: no values == 39").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MIN_VALUE))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MIN_VALUE)), file());
     assertThat(shouldRead).as("Should not match: some value may be == 30").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MAX_VALUE - 4))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MAX_VALUE - 4)), file());
     assertThat(shouldRead).as("Should not match: some value may be == 75").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MAX_VALUE))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MAX_VALUE)), file());
     assertThat(shouldRead).as("Should not match: some value may be == 79").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MAX_VALUE + 1))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MAX_VALUE + 1)), file());
     assertThat(shouldRead).as("Should match: no values == 80").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, not(equal("id", INT_MAX_VALUE + 6))).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, not(equal("id", INT_MAX_VALUE + 6)), file());
     assertThat(shouldRead).as("Should read: no values == 85").isTrue();
   }
 
   @Test
   public void testIntegerIn() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, in("id", INT_MIN_VALUE - 25, INT_MIN_VALUE - 24))
-            .eval(FILE);
+        shouldRead(SCHEMA, in("id", INT_MIN_VALUE - 25, INT_MIN_VALUE - 24), file());
     assertThat(shouldRead).as("Should not match: all values != 5 and != 6").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, in("id", INT_MIN_VALUE - 1, INT_MIN_VALUE)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("id", INT_MIN_VALUE - 1, INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: some values != 30 and != 31").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, in("id", INT_MAX_VALUE - 4, INT_MAX_VALUE - 3))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("id", INT_MAX_VALUE - 4, INT_MAX_VALUE - 3), file());
     assertThat(shouldRead).as("Should not match: some values != 75 and != 76").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, in("id", INT_MAX_VALUE, INT_MAX_VALUE + 1)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("id", INT_MAX_VALUE, INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: some values != 78 and != 79").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, in("id", INT_MAX_VALUE + 1, INT_MAX_VALUE + 2))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("id", INT_MAX_VALUE + 1, INT_MAX_VALUE + 2), file());
     assertThat(shouldRead).as("Should not match: some values != 80 and != 81)").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, in("always_5", 5, 6)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("always_5", 5, 6), file());
     assertThat(shouldRead).as("Should match: all values == 5").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, in("all_nulls", "abc", "def")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("all_nulls", "abc", "def"), file());
     assertThat(shouldRead).as("Should not match: in on all nulls column").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, in("some_nulls", "abc", "def")).eval(FILE_3);
+    shouldRead = shouldRead(SCHEMA, in("some_nulls", "abc", "def"), file3());
     assertThat(shouldRead).as("Should not match: in on some nulls column").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, in("no_nulls", "abc", "def")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, in("no_nulls", "abc", "def"), file());
     assertThat(shouldRead).as("Should not match: no_nulls field does not have bounds").isFalse();
   }
 
   @Test
   public void testIntegerNotIn() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MIN_VALUE - 25, INT_MIN_VALUE - 24))
-            .eval(FILE);
+        shouldRead(SCHEMA, notIn("id", INT_MIN_VALUE - 25, INT_MIN_VALUE - 24), file());
     assertThat(shouldRead).as("Should match: all values !=5 and !=6").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MIN_VALUE - 1, INT_MIN_VALUE))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("id", INT_MIN_VALUE - 1, INT_MIN_VALUE), file());
     assertThat(shouldRead).as("Should not match: some values may be == 30").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MAX_VALUE - 4, INT_MAX_VALUE - 3))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("id", INT_MAX_VALUE - 4, INT_MAX_VALUE - 3), file());
     assertThat(shouldRead).as("Should not match: some value may be == 75 or == 76").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MAX_VALUE, INT_MAX_VALUE + 1))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("id", INT_MAX_VALUE, INT_MAX_VALUE + 1), file());
     assertThat(shouldRead).as("Should not match: some value may be == 79").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notIn("id", INT_MAX_VALUE + 1, INT_MAX_VALUE + 2))
-            .eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("id", INT_MAX_VALUE + 1, INT_MAX_VALUE + 2), file());
     assertThat(shouldRead).as("Should match: no values == 80 or == 81").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("always_5", 5, 6)).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("always_5", 5, 6), file());
     assertThat(shouldRead).as("Should not match: all values == 5").isFalse();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("all_nulls", "abc", "def")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("all_nulls", "abc", "def"), file());
     assertThat(shouldRead).as("Should match: notIn on all nulls column").isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("some_nulls", "abc", "def")).eval(FILE_3);
+    shouldRead = shouldRead(SCHEMA, notIn("some_nulls", "abc", "def"), file3());
     assertThat(shouldRead)
         .as("Should match: notIn on some nulls column, 'bbb' > 'abc' and 'bbb' < 'def'")
         .isTrue();
 
-    shouldRead = new StrictMetricsEvaluator(SCHEMA, notIn("no_nulls", "abc", "def")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notIn("no_nulls", "abc", "def"), file());
     assertThat(shouldRead).as("Should not match: no_nulls field does not have bounds").isFalse();
   }
 
   @Test
   public void testEvaluateOnNestedColumnWithoutStats() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA, greaterThanOrEqual("struct.nested_col_no_stats", INT_MIN_VALUE))
-            .eval(FILE);
+        shouldRead(SCHEMA, greaterThanOrEqual("struct.nested_col_no_stats", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("greaterThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA, lessThanOrEqual("struct.nested_col_no_stats", INT_MAX_VALUE))
-            .eval(FILE);
+        shouldRead(SCHEMA, lessThanOrEqual("struct.nested_col_no_stats", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("lessThanOrEqual nested column should not match").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_no_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNull("struct.nested_col_no_stats"), file());
     assertThat(shouldRead).as("isNull nested column should not match").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_no_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNull("struct.nested_col_no_stats"), file());
     assertThat(shouldRead).as("notNull nested column should not match").isFalse();
   }
 
   @Test
   public void testEvaluateOnNestedColumnWithStats() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA, greaterThanOrEqual("struct.nested_col_with_stats", INT_MIN_VALUE))
-            .eval(FILE);
+        shouldRead(
+            SCHEMA, greaterThanOrEqual("struct.nested_col_with_stats", INT_MIN_VALUE), file());
     assertThat(shouldRead).as("greaterThanOrEqual nested column should not match").isFalse();
 
     shouldRead =
-        new StrictMetricsEvaluator(
-                SCHEMA, lessThanOrEqual("struct.nested_col_with_stats", INT_MAX_VALUE))
-            .eval(FILE);
+        shouldRead(SCHEMA, lessThanOrEqual("struct.nested_col_with_stats", INT_MAX_VALUE), file());
     assertThat(shouldRead).as("lessThanOrEqual nested column should not match").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, isNull("struct.nested_col_with_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, isNull("struct.nested_col_with_stats"), file());
     assertThat(shouldRead).as("isNull nested column should not match").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notNull("struct.nested_col_with_stats")).eval(FILE);
+    shouldRead = shouldRead(SCHEMA, notNull("struct.nested_col_with_stats"), file());
     assertThat(shouldRead).as("notNull nested column should not match").isFalse();
   }
 
   @Test
   public void testNotStartsWithAllNulls() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("all_nulls", "a")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("all_nulls", "a"), file());
     assertThat(shouldRead).as("Should match: all null values satisfy notStartsWith").isTrue();
   }
 
   @Test
   public void testNotStartsWithBoundsAbovePrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "aaa")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "aaa"), stringFile());
     assertThat(shouldRead).as("Should match: all values are above the prefix range").isTrue();
   }
 
   @Test
   public void testNotStartsWithBoundsBelowPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "zzz")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "zzz"), stringFile());
     assertThat(shouldRead).as("Should match: all values are below the prefix range").isTrue();
   }
 
   @Test
   public void testNotStartsWithBoundsOverlapPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "ab")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "ab"), stringFile());
     assertThat(shouldRead).as("Should not match: bounds overlap the prefix range").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abc")).eval(STRING_FILE);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("required", "abc"), stringFile());
     assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
   }
 
   @Test
   public void testNotStartsWithWiderRange() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "e")).eval(STRING_FILE_2);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "e"), stringFile2());
     assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(STRING_FILE_2);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("required", "a"), stringFile2());
     assertThat(shouldRead).as("Should not match: lower bound starts with the prefix").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "c")).eval(STRING_FILE_2);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("required", "c"), stringFile2());
     assertThat(shouldRead).as("Should not match: prefix is within the bounds range").isFalse();
   }
 
   @Test
   public void testNotStartsWithNoStats() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "a")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "a"), file());
     assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
   }
 
   @Test
   void testStartsWithBothBoundsMatchPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "ab")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "ab"), stringFile());
     assertThat(shouldRead).as("Should match: both bounds start with the prefix").isTrue();
   }
 
   @Test
   void testStartsWithSingleCharPrefixBothBoundsMatch() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "a"), stringFile());
     assertThat(shouldRead)
         .as("Should match: both bounds start with the single char prefix")
         .isTrue();
@@ -856,8 +840,7 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   void testStartsWithOnlyLowerBoundMatchesPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "abc")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "abc"), stringFile());
     assertThat(shouldRead)
         .as("Should not match: upper bound does not start with the prefix")
         .isFalse();
@@ -865,91 +848,76 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   void testStartsWithBoundsDoNotMatchPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "zzz")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "zzz"), stringFile());
     assertThat(shouldRead).as("Should not match: no bounds start with the prefix").isFalse();
   }
 
   @Test
   void testStartsWithWiderRange() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(STRING_FILE_2);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "a"), stringFile2());
     assertThat(shouldRead)
         .as("Should not match: upper bound does not start with the prefix")
         .isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "e")).eval(STRING_FILE_2);
+    shouldRead = shouldRead(SCHEMA, startsWith("required", "e"), stringFile2());
     assertThat(shouldRead).as("Should not match: no bounds start with the prefix").isFalse();
   }
 
   @Test
   void testStartsWithNoStats() {
-    boolean shouldRead = new StrictMetricsEvaluator(SCHEMA, startsWith("required", "a")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "a"), file());
     assertThat(shouldRead).as("Should not match: no bounds available for column").isFalse();
   }
 
   @Test
   public void testNotStartsWithSomeNullsBoundsOutsidePrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_2);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("some_nulls", "zzz"), file2());
     assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "aaa")).eval(FILE_2);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("some_nulls", "aaa"), file2());
     assertThat(shouldRead).as("Should match: all values are above the prefix").isTrue();
   }
 
   @Test
   public void testNotStartsWithPrefixLongerThanBounds() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "aaaaaaa")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", "aaaaaaa"), stringFile());
     assertThat(shouldRead).as("Should match: all values are above the long prefix").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "zzzzzzz")).eval(STRING_FILE);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("required", "zzzzzzz"), stringFile());
     assertThat(shouldRead).as("Should match: all values are below the long prefix").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "abcdef")).eval(STRING_FILE);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("required", "abcdef"), stringFile());
     assertThat(shouldRead).as("Should not match: prefix overlaps with bound range").isFalse();
   }
 
   @Test
   void testNotStartsWithEmptyPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("required", "")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("required", ""), stringFile());
     assertThat(shouldRead).as("Should not match: all strings start with empty prefix").isFalse();
   }
 
   @Test
   void testNotStartsWithExactBoundMatch() {
-    // FILE_3 has column 5 (some_nulls) with exact bounds ["bbb", "bbb"]
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "bbb")).eval(FILE_3);
+    // file3 has column 5 (some_nulls) with exact bounds ["bbb", "bbb"]
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("some_nulls", "bbb"), file3());
     assertThat(shouldRead).as("Should not match: bounds exactly equal the prefix").isFalse();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "zzz")).eval(FILE_3);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("some_nulls", "zzz"), file3());
     assertThat(shouldRead).as("Should match: all values are below the prefix").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("some_nulls", "aaa")).eval(FILE_3);
+    shouldRead = shouldRead(SCHEMA, notStartsWith("some_nulls", "aaa"), file3());
     assertThat(shouldRead).as("Should match: all values are above the prefix").isTrue();
   }
 
   @Test
   public void testNotStartsWithNestedColumn() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, notStartsWith("struct.nested_string_col", "a"))
-            .eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, notStartsWith("struct.nested_string_col", "a"), file());
     assertThat(shouldRead).as("notStartsWith nested column should not match").isFalse();
   }
 
   @Test
   void testStartsWithAllNulls() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("all_nulls", "a")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("all_nulls", "a"), file());
     assertThat(shouldRead)
         .as("Should not match: all null values do not satisfy startsWith")
         .isFalse();
@@ -957,8 +925,7 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   void testStartsWithSomeNulls() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("some_nulls", "b")).eval(FILE_2);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("some_nulls", "b"), file2());
     assertThat(shouldRead)
         .as("Should not match: some nulls means not all rows can satisfy startsWith")
         .isFalse();
@@ -966,35 +933,30 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   void testStartsWithPrefixLongerThanBounds() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "abcdef")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", "abcdef"), stringFile());
     assertThat(shouldRead).as("Should not match: prefix is longer than the bounds").isFalse();
   }
 
   @Test
   void testStartsWithEmptyPrefix() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("required", "")).eval(STRING_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("required", ""), stringFile());
     assertThat(shouldRead).as("Should match: all strings start with empty prefix").isTrue();
   }
 
   @Test
   void testStartsWithNestedColumn() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, startsWith("struct.nested_string_col", "a")).eval(FILE);
+    boolean shouldRead = shouldRead(SCHEMA, startsWith("struct.nested_string_col", "a"), file());
     assertThat(shouldRead).as("Should not match: nested column is not supported").isFalse();
   }
 
   @Test
   void missingNullCounts() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
-            .eval(MISSING_NULL_COUNTS_FILE);
+        shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE + 1), missingNullCountsFile());
     assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
 
     shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
-            .eval(MISSING_NULL_COUNTS_FILE);
+        shouldRead(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1), missingNullCountsFile());
     assertThat(shouldRead)
         .as("Should not match: optional column may contain nulls without a null count")
         .isFalse();
@@ -1003,13 +965,11 @@ public class TestStrictMetricsEvaluator {
   @Test
   void partialNullCounts() {
     boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("id", INT_MAX_VALUE + 1))
-            .eval(PARTIAL_NULL_COUNTS_FILE);
+        shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE + 1), partialNullCountsFile());
     assertThat(shouldRead).as("Should match: required column cannot contain nulls").isTrue();
 
     shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1))
-            .eval(PARTIAL_NULL_COUNTS_FILE);
+        shouldRead(SCHEMA, lessThan("no_stats", INT_MAX_VALUE + 1), partialNullCountsFile());
     assertThat(shouldRead)
         .as("Should not match: optional column may contain nulls without a null count")
         .isFalse();
@@ -1017,12 +977,10 @@ public class TestStrictMetricsEvaluator {
 
   @Test
   void missingNaNCounts() {
-    boolean shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nans", 10.0F)).eval(FLOAT_FILE);
+    boolean shouldRead = shouldRead(SCHEMA, lessThan("no_nans", 10.0F), floatFile());
     assertThat(shouldRead).as("Should match: float column has no nulls and no NaNs").isTrue();
 
-    shouldRead =
-        new StrictMetricsEvaluator(SCHEMA, lessThan("no_nan_stats", 10.0D)).eval(FLOAT_FILE);
+    shouldRead = shouldRead(SCHEMA, lessThan("no_nan_stats", 10.0D), floatFile());
     assertThat(shouldRead)
         .as("Should not match: float column may contain NaNs without a NaN count")
         .isFalse();

--- a/core/src/main/java/org/apache/iceberg/expressions/StrictStatsEvaluator.java
+++ b/core/src/main/java/org/apache/iceberg/expressions/StrictStatsEvaluator.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.expressions;
+
+import static org.apache.iceberg.expressions.Expressions.rewriteNot;
+
+import org.apache.iceberg.ContentStats;
+import org.apache.iceberg.FieldStats;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.types.Types;
+
+/**
+ * Evaluates an {@link Expression} on the {@link ContentStats} of a file to test whether all rows in
+ * the file match.
+ *
+ * <p>This evaluation is strict: it returns true if all rows in a file must match the expression.
+ * For example, if a file's ts column has min X and max Y, this evaluator will return true for ts
+ * &lt; Y+1 but not for ts &lt; Y-1.
+ *
+ * <p>Stats are passed to {@link #eval(ContentStats, long)}, which returns true if all rows in the
+ * file must contain matching rows and false if the file may contain rows that do not match.
+ *
+ * <p>Due to the comparison implementation of ORC stats, for float/double columns in ORC files, if
+ * the first value in a file is NaN, metrics of this file will report NaN for both upper and lower
+ * bound despite that the column could contain non-NaN data. Thus in some scenarios explicitly
+ * checks for NaN is necessary in order to not include files that may contain rows that don't match.
+ */
+public class StrictStatsEvaluator {
+  private final Types.StructType struct;
+  private final Expression expr;
+
+  public StrictStatsEvaluator(Schema schema, Expression unbound) {
+    this(schema, unbound, true);
+  }
+
+  public StrictStatsEvaluator(Schema schema, Expression unbound, boolean caseSensitive) {
+    this.struct = schema.asStruct();
+    this.expr = Binder.bind(struct, rewriteNot(unbound), caseSensitive);
+  }
+
+  /**
+   * Test whether all records within the file match the expression.
+   *
+   * @param stats the content stats of the file, or null if the file tracks no stats
+   * @param recordCount the number of records in the file
+   * @return false if the file may contain any row that doesn't match the expression, true
+   *     otherwise.
+   */
+  public boolean eval(ContentStats stats, long recordCount) {
+    return new StatsEvalVisitor(struct).eval(stats, recordCount);
+  }
+
+  private class StatsEvalVisitor extends StrictEvalVisitor {
+    private ContentStats stats = null;
+
+    private StatsEvalVisitor(Types.StructType struct) {
+      super(struct);
+    }
+
+    private boolean eval(ContentStats contentStats, long fileRecordCount) {
+      if (fileRecordCount == 0) {
+        return ROWS_MUST_MATCH;
+      }
+
+      if (fileRecordCount < 0) {
+        // imported Avro files may have an incorrect -1 row count
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      if (null == contentStats) {
+        return ROWS_MIGHT_NOT_MATCH;
+      }
+
+      this.stats = contentStats;
+
+      return ExpressionVisitors.visitEvaluator(expr, this);
+    }
+
+    @Override
+    protected boolean mayContainNull(int id) {
+      FieldStats<?> fieldStats = stats.statsFor(id);
+      return fieldStats == null
+          || !fieldStats.hasNullValueCount()
+          || fieldStats.nullValueCount() != 0;
+    }
+
+    @Override
+    protected boolean containsNullsOnly(int id) {
+      FieldStats<?> fieldStats = stats.statsFor(id);
+      return fieldStats != null
+          && fieldStats.hasValueCount()
+          && fieldStats.hasNullValueCount()
+          && fieldStats.valueCount() == fieldStats.nullValueCount();
+    }
+
+    @Override
+    protected boolean mayContainNaN(int id) {
+      FieldStats<?> fieldStats = stats.statsFor(id);
+      return fieldStats == null
+          || !fieldStats.hasNanValueCount()
+          || fieldStats.nanValueCount() != 0;
+    }
+
+    @Override
+    protected boolean containsNaNsOnly(int id) {
+      FieldStats<?> fieldStats = stats.statsFor(id);
+      return fieldStats != null
+          && fieldStats.hasValueCount()
+          && fieldStats.hasNanValueCount()
+          && fieldStats.valueCount() == fieldStats.nanValueCount();
+    }
+
+    @Override
+    protected <T> T lowerBound(BoundReference<T> ref) {
+      FieldStats<T> fieldStats = stats.statsFor(ref.fieldId());
+      return fieldStats != null ? fieldStats.lowerBound() : null;
+    }
+
+    @Override
+    protected <T> T upperBound(BoundReference<T> ref) {
+      FieldStats<T> fieldStats = stats.statsFor(ref.fieldId());
+      return fieldStats != null ? fieldStats.upperBound() : null;
+    }
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestStrictStatsEvaluator.java
+++ b/core/src/test/java/org/apache/iceberg/TestStrictStatsEvaluator.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.StatsTestUtil.contentStats;
+import static org.apache.iceberg.StatsTestUtil.fieldStats;
+import static org.apache.iceberg.StatsTestUtil.trackedFile;
+import static org.apache.iceberg.expressions.Expressions.lessThan;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.StrictStatsEvaluator;
+import org.apache.iceberg.expressions.TestStrictMetricsEvaluator;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+import org.junit.jupiter.api.Test;
+
+class TestStrictStatsEvaluator extends TestStrictMetricsEvaluator<TrackedFile> {
+  // stats are tracked for the leaf fields, not for the struct itself
+  private static final Types.StructType STATS_TYPE =
+      StatsUtil.statsReadSchema(
+          SCHEMA, ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18));
+
+  @Override
+  protected boolean shouldRead(Schema schema, Expression expr, TrackedFile testFile) {
+    return new StrictStatsEvaluator(schema, expr)
+        .eval(testFile.contentStats(), testFile.recordCount());
+  }
+
+  @Override
+  protected TrackedFile file() {
+    return trackedFile(
+        "file.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            // id is required, so its stats do not track a null count
+            stats(1, INT_MIN_VALUE, INT_MAX_VALUE, null, null, null),
+            stats(4, null, null, 50L, 50L, null),
+            stats(5, null, null, 50L, 10L, null),
+            stats(6, null, null, 50L, 0L, null),
+            stats(7, 5, 5, null, null, null),
+            stats(8, null, null, 50L, null, 50L),
+            stats(9, null, null, 50L, null, 10L),
+            stats(10, null, null, 50L, null, 0L),
+            stats(11, null, null, 50L, 50L, null),
+            stats(12, Float.NaN, Float.NaN, 50L, 0L, null),
+            stats(13, Double.NaN, Double.NaN, 50L, 1L, null),
+            stats(14, null, null, 50L, null, null),
+            stats(17, INT_MIN_VALUE, INT_MAX_VALUE, 50L, 0L, null)));
+  }
+
+  @Override
+  protected TrackedFile file2() {
+    return trackedFile(
+        "file_2.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            stats(4, null, null, 50L, 50L, null),
+            stats(5, "bbb", "eee", 50L, 10L, null),
+            stats(6, null, null, 50L, 0L, null),
+            stats(8, null, null, 50L, null, null)));
+  }
+
+  @Override
+  protected TrackedFile file3() {
+    return trackedFile(
+        "file_3.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            stats(4, null, null, 50L, 50L, null),
+            stats(5, "bbb", "bbb", 50L, 10L, null),
+            stats(6, null, null, 50L, 0L, null)));
+  }
+
+  @Override
+  protected TrackedFile stringFile() {
+    return trackedFile(
+        "string_file.avro", 50, contentStats(STATS_TYPE, stats(3, "abc", "abd", 50L, null, null)));
+  }
+
+  @Override
+  protected TrackedFile stringFile2() {
+    return trackedFile(
+        "string_file_2.avro", 50, contentStats(STATS_TYPE, stats(3, "aa", "dC", 50L, null, null)));
+  }
+
+  @Override
+  protected TrackedFile missingNullCountsFile() {
+    return trackedFile(
+        "missing_null_counts.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            stats(1, INT_MIN_VALUE, INT_MAX_VALUE, 50L, null, null),
+            stats(2, INT_MIN_VALUE, INT_MAX_VALUE, 50L, null, null)));
+  }
+
+  @Override
+  protected TrackedFile partialNullCountsFile() {
+    return trackedFile(
+        "partial_null_counts.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            stats(1, INT_MIN_VALUE, INT_MAX_VALUE, 50L, null, null),
+            stats(2, INT_MIN_VALUE, INT_MAX_VALUE, 50L, null, null),
+            // the null count is tracked only for all_nulls
+            stats(4, null, null, 50L, 0L, null)));
+  }
+
+  @Override
+  protected TrackedFile floatFile() {
+    return trackedFile(
+        "float_file.avro",
+        50,
+        contentStats(
+            STATS_TYPE, stats(10, 1.0F, 5.0F, 50L, 0L, 0L), stats(14, 1.0D, 5.0D, 50L, 0L, null)));
+  }
+
+  @Override
+  protected TrackedFile missingStats() {
+    return trackedFile("file.parquet", 50, contentStats(STATS_TYPE));
+  }
+
+  @Override
+  protected TrackedFile emptyFile() {
+    return trackedFile("file.parquet", 0, contentStats(STATS_TYPE));
+  }
+
+  @Test
+  void fileWithoutContentStats() {
+    TrackedFile file = trackedFile("file.avro", 50, null);
+
+    assertThat(shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE + 1), file))
+        .as("Should not match: file does not track content stats")
+        .isFalse();
+  }
+
+  @Test
+  void fileWithUnknownRecordCount() {
+    TrackedFile file =
+        trackedFile(
+            "file.avro",
+            -1,
+            contentStats(STATS_TYPE, stats(1, INT_MIN_VALUE, INT_MAX_VALUE, 50L, null, null)));
+
+    assertThat(shouldRead(SCHEMA, lessThan("id", INT_MAX_VALUE + 1), file))
+        .as("Should not match: record count is unknown")
+        .isFalse();
+  }
+
+  private static FieldStats<Object> stats(
+      int fieldId, Object lower, Object upper, Long valueCount, Long nullCount, Long nanCount) {
+    return fieldStats(STATS_TYPE, fieldId, lower, upper, valueCount, nullCount, nanCount);
+  }
+}

--- a/core/src/test/java/org/apache/iceberg/TestStrictStatsEvaluatorNaNHandling.java
+++ b/core/src/test/java/org/apache/iceberg/TestStrictStatsEvaluatorNaNHandling.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg;
+
+import static org.apache.iceberg.StatsTestUtil.contentStats;
+import static org.apache.iceberg.StatsTestUtil.fieldStats;
+import static org.apache.iceberg.StatsTestUtil.trackedFile;
+
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.StrictStatsEvaluator;
+import org.apache.iceberg.expressions.TestMetricsEvaluatorsNaNHandling;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
+import org.apache.iceberg.types.Types;
+
+class TestStrictStatsEvaluatorNaNHandling extends TestMetricsEvaluatorsNaNHandling<TrackedFile> {
+  private static final Types.StructType STATS_TYPE =
+      StatsUtil.statsReadSchema(SCHEMA, ImmutableList.of(1, 2, 3, 4, 5));
+
+  @Override
+  protected boolean allRowsMatch(Schema schema, Expression expr, TrackedFile testFile) {
+    return new StrictStatsEvaluator(schema, expr)
+        .eval(testFile.contentStats(), testFile.recordCount());
+  }
+
+  @Override
+  protected TrackedFile file() {
+    return trackedFile(
+        "file.avro",
+        50,
+        contentStats(
+            STATS_TYPE,
+            // all_nan, max_nan and all_nan_null_bounds are required, so their stats do not track a
+            // null count
+            stats(1, Double.NaN, Double.NaN, 10L, null, 10L),
+            stats(2, 7D, Double.NaN, 10L, null, null),
+            stats(3, Float.NaN, Float.NaN, 10L, 0L, null),
+            stats(4, null, null, 10L, null, 10L),
+            stats(5, 7F, 22F, 10L, 0L, 5L)));
+  }
+
+  private static FieldStats<Object> stats(
+      int fieldId, Object lower, Object upper, Long valueCount, Long nullCount, Long nanCount) {
+    return fieldStats(STATS_TYPE, fieldId, lower, upper, valueCount, nullCount, nanCount);
+  }
+}


### PR DESCRIPTION
This currently depends on https://github.com/apache/iceberg/pull/17648.

It adds the strict content stats evaluator (similar to #17413) and updates the strict metrics evaluator tests to make it possible to run them against the strict metrics & stats evaluators.