### PR TITLE
Core: Remove deprecated HadoopFileIO(SerializableSupplier) constructor

### DIFF
--- a/.palantir/revapi.yml
+++ b/.palantir/revapi.yml
@@ -730,6 +730,10 @@ acceptedBreaks:
         \ int, org.apache.iceberg.encryption.KeyManagementClient)"
       justification: "Removing deprecated API scheduled for removal in 1.12.0"
     - code: "java.method.removed"
+      old: "method void org.apache.iceberg.hadoop.HadoopFileIO::<init>(org.apache.iceberg.util.SerializableSupplier<org.apache.hadoop.conf.Configuration>)"
+      justification: "Removing deprecated HadoopFileIO constructor scheduled for removal\
+        \ in 1.12.0"
+    - code: "java.method.removed"
       old: "method void org.apache.iceberg.io.ContentCache::invalidateAll()"
       justification: "Removing deprecated API scheduled for removal in 1.12.0"
     org.apache.iceberg:iceberg-data:

--- a/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
+++ b/core/src/main/java/org/apache/iceberg/hadoop/HadoopFileIO.java
@@ -66,16 +66,7 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
   public HadoopFileIO() {}
 
   public HadoopFileIO(Configuration hadoopConf) {
-    this(new SerializableConfiguration(hadoopConf));
-  }
-
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0; use {@link
-   *     HadoopFileIO#HadoopFileIO(Configuration)} instead.
-   */
-  @Deprecated
-  public HadoopFileIO(SerializableSupplier<Configuration> hadoopConf) {
-    this.hadoopConf = hadoopConf;
+    this.hadoopConf = new SerializableConfiguration(hadoopConf);
   }
 
   public Configuration conf() {
@@ -138,10 +129,6 @@ public class HadoopFileIO implements HadoopConfigurable, DelegateFileIO {
     return hadoopConf.get();
   }
 
-  /**
-   * @deprecated since 1.11.0, will be removed in 1.12.0.
-   */
-  @Deprecated
   @Override
   public void serializeConfWith(
       Function<Configuration, SerializableSupplier<Configuration>> confSerializer) {


### PR DESCRIPTION
Removes `HadoopFileIO(SerializableSupplier<Configuration>)`, deprecated for removal in 1.12.0 in favor of `HadoopFileIO(Configuration)` from #15583 

## AI Disclosure

Model: Claude Opus 5 (1M context)
Platform/Tool: Claude Code
Human Oversight: reviewed
Prompt Summary: split #16449 into smaller self-contained PRs; verify each group compiles and tests green standalone