### PR TITLE
Docs: Add max-file-group-input-files to rewrite options tables in spark-procedures.md

### DIFF
--- a/docs/docs/spark-procedures.md
+++ b/docs/docs/spark-procedures.md
@@ -410,6 +410,7 @@ Iceberg can compact data files in parallel using Spark with the `rewriteDataFile
 | `min-input-files` | 5 | Any file group with this number of files or more will be rewritten regardless of other criteria (the file group should have at least two files) |
 | `rewrite-all` | false | Force rewriting of all provided files overriding other options |
 | `max-file-group-size-bytes` | 107374182400 (100GB) | Largest amount of data that should be rewritten in a single file group. The entire rewrite operation is broken down into pieces based on partitioning and within partitions based on size into file-groups.  This helps with breaking down the rewriting of very large partitions which may not be rewritable otherwise due to the resource constraints of the cluster. |
+| `max-file-group-input-files` | 9223372036854775807 | Largest number of input files that should be rewritten in a single file group. When `rewrite-all` is false, if set below `min-input-files`, no group can reach `min-input-files`, so the file-count rewrite trigger never fires; groups are then rewritten only when they meet the size thresholds or contain files exceeding the delete-file/delete-ratio thresholds. |
 | `delete-file-threshold` | 2147483647 | Minimum number of deletes that needs to be associated with a data file for it to be considered for rewriting |
 | `delete-ratio-threshold` | 0.3 | Minimum deletion ratio that needs to be associated with a data file for it to be considered for rewriting |
 | `output-spec-id` | current partition spec id | Identifier of the output partition spec. Data will be reorganized during the rewrite to align with the output partitioning. |
@@ -549,6 +550,7 @@ Dangling deletes are always filtered out during rewriting.
 | `min-input-files` | 5 | Any file group exceeding this number of files will be rewritten regardless of other criteria |
 | `rewrite-all` | false | Force rewriting of all provided files overriding other options |
 | `max-file-group-size-bytes` | 107374182400 (100GB) | Largest amount of data that should be rewritten in a single file group. The entire rewrite operation is broken down into pieces based on partitioning and within partitions based on size into file-groups.  This helps with breaking down the rewriting of very large partitions which may not be rewritable otherwise due to the resource constraints of the cluster. |
+| `max-file-group-input-files` | 9223372036854775807 | Largest number of input files that should be rewritten in a single file group. When `rewrite-all` is false, if set below `min-input-files`, no group can reach `min-input-files`, so the file-count rewrite trigger never fires and groups are rewritten only when they meet the size thresholds. |
 | `max-files-to-rewrite` | null | This option sets an upper limit on the number of eligible files that will be rewritten. If this option is not specified, all eligible files will be rewritten. |
 
 #### Output


### PR DESCRIPTION
Add `max-file-group-input-files` to the options tables in `spark-procedures.md` for both `rewrite_data_files` and `rewrite_delete_files` procedures.

This option was added to `validOptions()` in #17544 but was not documented. The reviewer noted this gap during that review.