### PR TITLE
Build: Bump httpcore5 and httpcore5-h2 dependencies to 5.4.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -207,6 +207,8 @@ subprojects {
           substitute module("org.lz4:lz4-java") using module(libs.lz4Java.get().toString()) because("Enforce lz4-java that contains CVE-2025-12183 and CVE-2025-66566 fixes")
           substitute module("io.airlift:aircompressor") using module(libs.aircompressor.get().toString()) because("Enforce aircompressor that contains CVE-2025-67721 fix")
           substitute module("org.bouncycastle:bcprov-jdk18on") using module(libs.bouncycastle.bcprov.get().toString()) because("Enforce BouncyCastle that contains CVE-2026-5598 fix")
+          substitute module("org.apache.httpcomponents.core5:httpcore5") using module(libs.httpcomponents.httpcore5.get().toString()) because("Enforce httpcore5 that contains CVE-2026-54399 fix")
+          substitute module("org.apache.httpcomponents.core5:httpcore5-h2") using module(libs.httpcomponents.httpcore5h2.get().toString()) because("Enforce httpcore5-h2 that contains CVE-2026-54428 fix")
         }
         eachDependency { details ->
           if (details.requested.group == 'io.netty'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@ gcs-analytics-core = "1.5.0"
 guava = "33.6.0-jre"
 hadoop3 = "3.4.3"
 httpcomponents-httpclient5 = "5.6.4"
+httpcomponents-httpcore5 = "5.4.3"
 hive2 = { strictly = "2.3.10"} # see rich version usage explanation above
 immutables-value = "2.12.2"
 jackson-annotations = "2.22"
@@ -152,6 +153,8 @@ hive2-exec = { module = "org.apache.hive:hive-exec", version.ref = "hive2" }
 hive2-metastore = { module = "org.apache.hive:hive-metastore", version.ref = "hive2" }
 hive2-service = { module = "org.apache.hive:hive-service", version.ref = "hive2" }
 httpcomponents-httpclient5 = { module = "org.apache.httpcomponents.client5:httpclient5", version.ref = "httpcomponents-httpclient5" }
+httpcomponents-httpcore5 = { module = "org.apache.httpcomponents.core5:httpcore5", version.ref = "httpcomponents-httpcore5" }
+httpcomponents-httpcore5h2 = { module = "org.apache.httpcomponents.core5:httpcore5-h2", version.ref = "httpcomponents-httpcore5" }
 immutables-value = { module = "org.immutables:value", version.ref = "immutables-value" }
 jackson-bom = { module = "com.fasterxml.jackson:jackson-bom", version.ref = "jackson-bom" }
 jackson-core = { module = "com.fasterxml.jackson.core:jackson-core", version.ref = "jackson-bom" }


### PR DESCRIPTION
Build: Bump httpcore5 and httpcore5-h2 to 5.4.3

Enforces httpcore5 5.4.3 and httpcore5-h2 5.4.3 across all subprojects via dependency substitution to patch two CVEs:

- [CVE-2026-54399](https://github.com/advisories/GHSA-hf6x-8p5f-cgmf) fixed in org.apache.httpcomponents.core5:httpcore5 5.4.3
- [CVE-2026-54428](https://github.com/advisories/GHSA-v3jc-474w-2wm6) fixed in org.apache.httpcomponents.core5:httpcore5-h2 5.4.3

Changes:
- Added httpcomponents-httpcore5 = "5.4.3" version entry to gradle/libs.versions.toml
- Added httpcomponents-httpcore5 and httpcomponents-httpcore5h2 library aliases to gradle/libs.versions.toml
- Added substitution rules in build.gradle to force the patched version across all transitive dependencies