### PR TITLE
Docs: Fix spec formatting of geospatial CRS examples

### DIFF
--- a/format/spec.md
+++ b/format/spec.md
@@ -304,8 +304,9 @@ The default CRS value `OGC:CRS84` means that the objects must be stored in longi
 
 Non-default CRS values are specified by any string that uniquely identifies a coordinate reference system associated with this type.
 To maximize interoperability, suggested formats for CRS include, but are not limited to:
+
 * `<context>:<identifier>`: Identifies a CRS by name or other identifier in some well-documented context. Examples: `OGC:CRS84`, `EPSG:4326`, `IGNF:ATI` and `SRID:0`
-* `projjson:<property-name>` - where <property-name> refers to a table property where CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) format is stored.
+* `projjson:<property-name>` - where `<property-name>` refers to a table property where CRS definition in [PROJJSON](https://proj.org/en/stable/specifications/projjson.html) format is stored.
 
 CRS value must not contain inlined PROJJSON definitions and implementations must not parse the contents of the CRS as PROJJSON. PROJJSON definitions are very verbose, hence inlining them as part of schema would cause significant performance degradation. If the intention is for a PROJJSON definition to be part of the table metadata, then it must be stored in a table property and referenced from the CRS field using the `projjson:<property-name>` form described above.
 


### PR DESCRIPTION
This fixes two small formatting issues in the specification around geospatial CRS examples.

Before (current state of https://iceberg.apache.org/spec/#crs):

<img width="777" height="130" alt="image" src="https://github.com/user-attachments/assets/69ffdc75-9239-4780-8031-b5c77da18d92" />

After (rebuilt locally):

<img width="763" height="226" alt="image" src="https://github.com/user-attachments/assets/61c7b6f4-df4d-4bba-bd57-8eb801ea376c" />
