### PR TITLE
Core: Validate format version compatibility client-side on REST table create

### DIFF
--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -84,6 +84,14 @@ public class TableMetadata implements Serializable {
     return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties);
   }
 
+  public static void checkFormatVersionCompatibility(
+      Schema schema, Map<String, String> properties) {
+    int formatVersion =
+        PropertyUtil.propertyAsInt(
+            properties, TableProperties.FORMAT_VERSION, DEFAULT_TABLE_FORMAT_VERSION);
+    Schema.checkCompatibility(schema, formatVersion);
+  }
+
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {
     return rawProperties.entrySet().stream()
         .filter(e -> !TableProperties.RESERVED_PROPERTIES.contains(e.getKey()))

--- a/core/src/main/java/org/apache/iceberg/TableMetadata.java
+++ b/core/src/main/java/org/apache/iceberg/TableMetadata.java
@@ -84,14 +84,6 @@ public class TableMetadata implements Serializable {
     return newTableMetadata(schema, spec, SortOrder.unsorted(), location, properties);
   }
 
-  public static void checkFormatVersionCompatibility(
-      Schema schema, Map<String, String> properties) {
-    int formatVersion =
-        PropertyUtil.propertyAsInt(
-            properties, TableProperties.FORMAT_VERSION, DEFAULT_TABLE_FORMAT_VERSION);
-    Schema.checkCompatibility(schema, formatVersion);
-  }
-
   private static Map<String, String> unreservedProperties(Map<String, String> rawProperties) {
     return rawProperties.entrySet().stream()
         .filter(e -> !TableProperties.RESERVED_PROPERTIES.contains(e.getKey()))

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -45,6 +45,7 @@ import org.apache.iceberg.SortOrder;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
 import org.apache.iceberg.TableOperations;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.Transactions;
 import org.apache.iceberg.catalog.BaseViewSessionCatalog;
@@ -974,7 +975,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
       Endpoint.check(endpoints, Endpoint.V1_CREATE_TABLE);
       propertiesBuilder.putAll(tableOverrideProperties());
       Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
-      TableMetadata.checkFormatVersionCompatibility(schema, tableProperties);
+      checkFormatVersion(schema, tableProperties);
       CreateTableRequest request =
           CreateTableRequest.builder()
               .withName(ident.name())
@@ -1133,7 +1134,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     private LoadTableResponse stageCreate() {
       propertiesBuilder.putAll(tableOverrideProperties());
       Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
-      TableMetadata.checkFormatVersionCompatibility(schema, tableProperties);
+      checkFormatVersion(schema, tableProperties);
 
       CreateTableRequest request =
           CreateTableRequest.builder()
@@ -1155,6 +1156,14 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               LoadTableResponse.class,
               mutationHeaders,
               ErrorHandlers.tableErrorHandler());
+    }
+  }
+
+  private static void checkFormatVersion(Schema schema, Map<String, String> properties) {
+    Integer formatVersion =
+        PropertyUtil.propertyAsNullableInt(properties, TableProperties.FORMAT_VERSION);
+    if (formatVersion != null) {
+      Schema.checkCompatibility(schema, formatVersion);
     }
   }
 

--- a/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
+++ b/core/src/main/java/org/apache/iceberg/rest/RESTSessionCatalog.java
@@ -973,6 +973,8 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     public Table create() {
       Endpoint.check(endpoints, Endpoint.V1_CREATE_TABLE);
       propertiesBuilder.putAll(tableOverrideProperties());
+      Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
+      TableMetadata.checkFormatVersionCompatibility(schema, tableProperties);
       CreateTableRequest request =
           CreateTableRequest.builder()
               .withName(ident.name())
@@ -980,7 +982,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
               .withPartitionSpec(spec)
               .withWriteOrder(writeOrder)
               .withLocation(location)
-              .setProperties(propertiesBuilder.buildKeepingLast())
+              .setProperties(tableProperties)
               .build();
 
       AuthSession contextualSession = authManager.contextualSession(context, catalogAuth);
@@ -1131,6 +1133,7 @@ public class RESTSessionCatalog extends BaseViewSessionCatalog
     private LoadTableResponse stageCreate() {
       propertiesBuilder.putAll(tableOverrideProperties());
       Map<String, String> tableProperties = propertiesBuilder.buildKeepingLast();
+      TableMetadata.checkFormatVersionCompatibility(schema, tableProperties);
 
       CreateTableRequest request =
           CreateTableRequest.builder()

--- a/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
+++ b/core/src/test/java/org/apache/iceberg/rest/TestRESTCatalog.java
@@ -20,6 +20,7 @@ package org.apache.iceberg.rest;
 
 import static org.apache.iceberg.rest.RequestMatcher.containsHeaders;
 import static org.apache.iceberg.rest.RequestMatcher.matches;
+import static org.apache.iceberg.types.Types.NestedField.optional;
 import static org.apache.iceberg.types.Types.NestedField.required;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -30,6 +31,7 @@ import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,6 +72,7 @@ import org.apache.iceberg.Schema;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.TableMetadata;
+import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.TestCatalogUtil;
 import org.apache.iceberg.Transaction;
 import org.apache.iceberg.UpdatePartitionSpec;
@@ -439,6 +442,30 @@ public class TestRESTCatalog extends CatalogTests<RESTCatalog> {
   }
 
   /* RESTCatalog specific tests */
+
+  @Test
+  public void testCreateV2TableWithVariantColumnFailsClientSide() {
+    if (requiresNamespaceCreate()) {
+      restCatalog.createNamespace(TBL.namespace());
+    }
+
+    Schema variantSchema =
+        new Schema(
+            required(1, "id", Types.LongType.get()), optional(2, "data", Types.VariantType.get()));
+
+    assertThatThrownBy(
+            () ->
+                restCatalog
+                    .buildTable(TBL, variantSchema)
+                    .withProperty(TableProperties.FORMAT_VERSION, "2")
+                    .create())
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("variant is not supported until v3");
+
+    verify(adapterForRESTServer, never())
+        .execute(
+            matches(HTTPMethod.POST, RESOURCE_PATHS.tables(TBL.namespace())), any(), any(), any());
+  }
 
   @Test
   public void testConfigRoute() throws IOException {


### PR DESCRIPTION
## Rationale for the change

[#17500](https://github.com/apache/iceberg/pull/17500) added RCK coverage for variant columns, following up with the client-side change here.

The REST client previously forwarded the `CreateTableRequest` to the server without validating the schema against the requested format version. So the rejection of a v3-only type (variant, timestamp_ns, geometry/geography, unknown, non-null defaults) on a lower format version depended entirely on the server, and the server's error message is not spec-defined. That is why the RCK cannot assert on it.

Non-REST catalogs already run this check locally via `TableMetadata.newTableMetadata` -> `Builder.build()` -> `Schema.checkCompatibility`. This change makes the REST client run the same check before the request is sent, so the failure and its message are the client's.

## Changes

- `RESTSessionCatalog.create()` and `stageCreate()`: before building the `CreateTableRequest`, read `format-version` from the resolved table properties and, when it is set, run the existing `Schema.checkCompatibility` (via a small private `checkFormatVersion` helper). An incompatible schema is rejected client-side with the well-defined `"... is not supported until v3"` message and no request is issued.
- `TestRESTCatalog.testCreateV2TableWithVariantColumnFailsClientSide`: creates a v2 variant table and asserts the `IllegalStateException` message AND that no create-table `POST` reaches the server (the assertion that fails if the client-side check is removed).

## Notes

- The check runs only when `format-version` is explicitly set on the create. When it is absent, the client does not presume a default and the server remains the authority. This is deliberate: it keeps the change minimal, avoids widening `TableMetadata.DEFAULT_TABLE_FORMAT_VERSION` into public API or hardcoding the default in the REST client, and avoids diverging from a server whose default format version differs. Non-REST catalogs assume the v2 default and reject an unset-version variant create locally; the REST client instead defers that case to the server (which still rejects it), so correctness is preserved.
- Replace paths (`replaceTransaction`) already build `TableMetadata` client-side and are unaffected.
- The existing `CatalogTests.testCreateV2TableWithVariantColumnFails` continues to cover the message/behavior; the new REST-specific test pins the client-side behavior (client rejects and sends no request) for the explicit `format-version` case.
