### PR TITLE
API: Convert statement switches to arrow switches in types

### DIFF
--- a/api/src/main/java/org/apache/iceberg/types/Conversions.java
+++ b/api/src/main/java/org/apache/iceberg/types/Conversions.java
@@ -48,34 +48,25 @@ public class Conversions {
       return null;
     }
 
-    switch (type.typeId()) {
-      case BOOLEAN:
-        return Boolean.valueOf(asString);
-      case INTEGER:
-        return Integer.valueOf(asString);
-      case LONG:
-        return Long.valueOf(asString);
-      case FLOAT:
-        return Float.valueOf(asString);
-      case DOUBLE:
-        return Double.valueOf(asString);
-      case STRING:
-        return asString;
-      case UUID:
-        return UUID.fromString(asString);
-      case FIXED:
+    return switch (type.typeId()) {
+      case BOOLEAN -> Boolean.valueOf(asString);
+      case INTEGER -> Integer.valueOf(asString);
+      case LONG -> Long.valueOf(asString);
+      case FLOAT -> Float.valueOf(asString);
+      case DOUBLE -> Double.valueOf(asString);
+      case STRING -> asString;
+      case UUID -> UUID.fromString(asString);
+      case FIXED -> {
         Types.FixedType fixed = (Types.FixedType) type;
-        return Arrays.copyOf(asString.getBytes(StandardCharsets.UTF_8), fixed.length());
-      case BINARY:
-        return asString.getBytes(StandardCharsets.UTF_8);
-      case DECIMAL:
-        return new BigDecimal(asString);
-      case DATE:
-        return Literal.of(asString).to(Types.DateType.get()).value();
-      default:
-        throw new UnsupportedOperationException(
-            "Unsupported type for fromPartitionString: " + type);
-    }
+        yield Arrays.copyOf(asString.getBytes(StandardCharsets.UTF_8), fixed.length());
+      }
+      case BINARY -> asString.getBytes(StandardCharsets.UTF_8);
+      case DECIMAL -> new BigDecimal(asString);
+      case DATE -> Literal.of(asString).to(Types.DateType.get()).value();
+      default ->
+          throw new UnsupportedOperationException(
+              "Unsupported type for fromPartitionString: " + type);
+    };
   }
 
   private static final ThreadLocal<CharsetEncoder> ENCODER =
@@ -92,36 +83,28 @@ public class Conversions {
       return null;
     }
 
-    switch (typeId) {
-      case BOOLEAN:
-        return ByteBuffer.allocate(1).put(0, (Boolean) value ? (byte) 0x01 : (byte) 0x00);
-      case INTEGER:
-      case DATE:
-        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(0, (int) value);
-      case LONG:
-      case TIME:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, (long) value);
-      case FLOAT:
-        return ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(0, (float) value);
-      case DOUBLE:
-        return ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(0, (double) value);
-      case STRING:
+    return switch (typeId) {
+      case BOOLEAN -> ByteBuffer.allocate(1).put(0, (Boolean) value ? (byte) 0x01 : (byte) 0x00);
+      case INTEGER, DATE ->
+          ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putInt(0, (int) value);
+      case LONG, TIME, TIMESTAMP, TIMESTAMP_NANO ->
+          ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(0, (long) value);
+      case FLOAT ->
+          ByteBuffer.allocate(4).order(ByteOrder.LITTLE_ENDIAN).putFloat(0, (float) value);
+      case DOUBLE ->
+          ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putDouble(0, (double) value);
+      case STRING -> {
         CharBuffer buffer = CharBuffer.wrap((CharSequence) value);
         try {
-          return ENCODER.get().encode(buffer);
+          yield ENCODER.get().encode(buffer);
         } catch (CharacterCodingException e) {
           throw new RuntimeIOException(e, "Failed to encode value as UTF-8: %s", value);
         }
-      case UUID:
-        return UUIDUtil.convertToByteBuffer((UUID) value);
-      case FIXED:
-      case BINARY:
-        return (ByteBuffer) value;
-      case DECIMAL:
-        return ByteBuffer.wrap(((BigDecimal) value).unscaledValue().toByteArray());
-      case VARIANT:
+      }
+      case UUID -> UUIDUtil.convertToByteBuffer((UUID) value);
+      case FIXED, BINARY -> (ByteBuffer) value;
+      case DECIMAL -> ByteBuffer.wrap(((BigDecimal) value).unscaledValue().toByteArray());
+      case VARIANT -> {
         // Produce a concatenated buffer of metadata and value
         Variant variant = (Variant) value;
         VariantMetadata variantMetadata = variant.metadata();
@@ -131,19 +114,16 @@ public class Conversions {
                 .order(ByteOrder.LITTLE_ENDIAN);
         variantMetadata.writeTo(variantBuffer, 0);
         variantValue.writeTo(variantBuffer, variantMetadata.sizeInBytes());
-        return variantBuffer;
-      case GEOMETRY:
-      case GEOGRAPHY:
+        yield variantBuffer;
+      }
         // Geometry and geography lower/upper bounds are single points encoded as an
         // x:y:z:m concatenation of 8-byte little-endian IEEE 754 doubles. See the
         // Bound Serialization section of the Iceberg spec.
-        return ((GeospatialBound) value).toByteBuffer();
-      case UNKNOWN:
+      case GEOMETRY, GEOGRAPHY -> ((GeospatialBound) value).toByteBuffer();
         // underlying type not known
-        return null;
-      default:
-        throw new UnsupportedOperationException("Cannot serialize type: " + typeId);
-    }
+      case UNKNOWN -> null;
+      default -> throw new UnsupportedOperationException("Cannot serialize type: " + typeId);
+    };
   }
 
   @SuppressWarnings("unchecked")
@@ -162,55 +142,44 @@ public class Conversions {
     } else {
       tmp.order(ByteOrder.LITTLE_ENDIAN);
     }
-    switch (type.typeId()) {
-      case BOOLEAN:
-        return tmp.get() != 0x00;
-      case INTEGER:
-      case DATE:
-        return tmp.getInt();
-      case LONG:
-      case TIME:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
+    return switch (type.typeId()) {
+      case BOOLEAN -> tmp.get() != 0x00;
+      case INTEGER, DATE -> tmp.getInt();
+      case LONG, TIME, TIMESTAMP, TIMESTAMP_NANO -> {
         if (tmp.remaining() < 8) {
           // type was later promoted to long
-          return (long) tmp.getInt();
+          yield (long) tmp.getInt();
         }
-        return tmp.getLong();
-      case FLOAT:
-        return tmp.getFloat();
-      case DOUBLE:
+        yield tmp.getLong();
+      }
+      case FLOAT -> tmp.getFloat();
+      case DOUBLE -> {
         if (tmp.remaining() < 8) {
           // type was later promoted to long
-          return (double) tmp.getFloat();
+          yield (double) tmp.getFloat();
         }
-        return tmp.getDouble();
-      case STRING:
+        yield tmp.getDouble();
+      }
+      case STRING -> {
         try {
-          return DECODER.get().decode(tmp);
+          yield DECODER.get().decode(tmp);
         } catch (CharacterCodingException e) {
           throw new RuntimeIOException(e, "Failed to decode value as UTF-8: %s", buffer);
         }
-      case UUID:
-        return UUIDUtil.convert(tmp);
-      case FIXED:
-      case BINARY:
-        return tmp;
-      case DECIMAL:
+      }
+      case UUID -> UUIDUtil.convert(tmp);
+      case FIXED, BINARY -> tmp;
+      case DECIMAL -> {
         Types.DecimalType decimal = (Types.DecimalType) type;
         byte[] unscaledBytes = new byte[buffer.remaining()];
         tmp.get(unscaledBytes);
-        return new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
-      case VARIANT:
-        return Variant.from(tmp);
-      case GEOMETRY:
-      case GEOGRAPHY:
-        return GeospatialBound.fromByteBuffer(tmp);
-      case UNKNOWN:
+        yield new BigDecimal(new BigInteger(unscaledBytes), decimal.scale());
+      }
+      case VARIANT -> Variant.from(tmp);
+      case GEOMETRY, GEOGRAPHY -> GeospatialBound.fromByteBuffer(tmp);
         // underlying type not known
-        return null;
-      default:
-        throw new UnsupportedOperationException("Cannot deserialize type: " + type);
-    }
+      case UNKNOWN -> null;
+      default -> throw new UnsupportedOperationException("Cannot deserialize type: " + type);
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/JavaHash.java
+++ b/api/src/main/java/org/apache/iceberg/types/JavaHash.java
@@ -26,15 +26,11 @@ public interface JavaHash<T> {
 
   @SuppressWarnings("unchecked")
   static <T> JavaHash<T> forType(Type type) {
-    switch (type.typeId()) {
-      case STRING:
-        return (JavaHash<T>) JavaHashes.strings();
-      case STRUCT:
-        return (JavaHash<T>) JavaHashes.struct(type.asStructType());
-      case LIST:
-        return (JavaHash<T>) JavaHashes.list(type.asListType());
-      default:
-        return Objects::hashCode;
-    }
+    return switch (type.typeId()) {
+      case STRING -> (JavaHash<T>) JavaHashes.strings();
+      case STRUCT -> (JavaHash<T>) JavaHashes.struct(type.asStructType());
+      case LIST -> (JavaHash<T>) JavaHashes.list(type.asListType());
+      default -> Objects::hashCode;
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
+++ b/api/src/main/java/org/apache/iceberg/types/TypeUtil.java
@@ -475,25 +475,21 @@ public class TypeUtil {
       return true;
     }
 
-    switch (from.typeId()) {
-      case INTEGER:
-        return to.typeId() == Type.TypeID.LONG;
-
-      case FLOAT:
-        return to.typeId() == Type.TypeID.DOUBLE;
-
-      case DECIMAL:
+    return switch (from.typeId()) {
+      case INTEGER -> to.typeId() == Type.TypeID.LONG;
+      case FLOAT -> to.typeId() == Type.TypeID.DOUBLE;
+      case DECIMAL -> {
         Types.DecimalType fromDecimal = (Types.DecimalType) from;
         if (to.typeId() != Type.TypeID.DECIMAL) {
-          return false;
+          yield false;
         }
 
         Types.DecimalType toDecimal = (Types.DecimalType) to;
-        return fromDecimal.scale() == toDecimal.scale()
+        yield fromDecimal.scale() == toDecimal.scale()
             && fromDecimal.precision() <= toDecimal.precision();
-    }
-
-    return false;
+      }
+      default -> false;
+    };
   }
 
   /**
@@ -579,61 +575,45 @@ public class TypeUtil {
   }
 
   private static int estimateSize(Type type) {
-    switch (type.typeId()) {
-      case BOOLEAN:
+    return switch (type.typeId()) {
         // the size of a boolean variable is virtual machine dependent
         // it is common to believe booleans occupy 1 byte in most JVMs
-        return 1;
-      case INTEGER:
-      case FLOAT:
-      case DATE:
+      case BOOLEAN -> 1;
         // ints and floats occupy 4 bytes
         // dates are internally represented as ints
-        return 4;
-      case LONG:
-      case DOUBLE:
-      case TIME:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
+      case INTEGER, FLOAT, DATE -> 4;
         // longs and doubles occupy 8 bytes
         // times and timestamps are internally represented as longs
-        return 8;
-      case STRING:
+      case LONG, DOUBLE, TIME, TIMESTAMP, TIMESTAMP_NANO -> 8;
         // 12 (header) + 6 (fields) + 16 (array overhead) + 20 (10 chars, 2 bytes each) = 54 bytes
-        return 54;
-      case UUID:
+      case STRING -> 54;
         // 12 (header) + 16 (two long variables) = 28 bytes
-        return 28;
-      case FIXED:
-        return ((Types.FixedType) type).length();
-      case BINARY:
-      case VARIANT:
-        return 80;
-      case GEOMETRY:
-      case GEOGRAPHY:
+      case UUID -> 28;
+      case FIXED -> ((Types.FixedType) type).length();
+      case BINARY, VARIANT -> 80;
         // 80 bytes is an approximate size for a polygon or linestring with 4 to 5 coordinates.
         // This is a reasonable estimate for the size of a geometry or geography object without
         // additional details.
-        return 80;
-      case UNKNOWN:
+      case GEOMETRY, GEOGRAPHY -> 80;
         // Consider Unknown as null
-        return 0;
-      case DECIMAL:
+      case UNKNOWN -> 0;
         // 12 (header) + (12 + 12 + 4) (BigInteger) + 4 (scale) = 44 bytes
-        return 44;
-      case STRUCT:
+      case DECIMAL -> 44;
+      case STRUCT -> {
         Types.StructType struct = (Types.StructType) type;
-        return HEADER_SIZE + struct.fields().stream().mapToInt(TypeUtil::estimateSize).sum();
-      case LIST:
+        yield HEADER_SIZE + struct.fields().stream().mapToInt(TypeUtil::estimateSize).sum();
+      }
+      case LIST -> {
         Types.ListType list = (Types.ListType) type;
-        return HEADER_SIZE + 5 * estimateSize(list.elementType());
-      case MAP:
+        yield HEADER_SIZE + 5 * estimateSize(list.elementType());
+      }
+      case MAP -> {
         Types.MapType map = (Types.MapType) type;
         int entrySize = HEADER_SIZE + estimateSize(map.keyType()) + estimateSize(map.valueType());
-        return HEADER_SIZE + 5 * entrySize;
-      default:
-        return 16;
-    }
+        yield HEADER_SIZE + 5 * entrySize;
+      }
+      default -> 16;
+    };
   }
 
   /** Interface for passing a function that assigns column IDs. */
@@ -763,8 +743,8 @@ public class TypeUtil {
   }
 
   public static <T> T visit(Type type, SchemaVisitor<T> visitor) {
-    switch (type.typeId()) {
-      case STRUCT:
+    return switch (type.typeId()) {
+      case STRUCT -> {
         Types.StructType struct = type.asNestedType().asStructType();
         List<T> results = Lists.newArrayListWithExpectedSize(struct.fields().size());
         for (Types.NestedField field : struct.fields()) {
@@ -777,9 +757,9 @@ public class TypeUtil {
           }
           results.add(visitor.field(field, result));
         }
-        return visitor.struct(struct, results);
-
-      case LIST:
+        yield visitor.struct(struct, results);
+      }
+      case LIST -> {
         Types.ListType list = type.asNestedType().asListType();
         T elementResult;
 
@@ -791,9 +771,9 @@ public class TypeUtil {
           visitor.afterListElement(elementField);
         }
 
-        return visitor.list(list, elementResult);
-
-      case MAP:
+        yield visitor.list(list, elementResult);
+      }
+      case MAP -> {
         Types.MapType map = type.asNestedType().asMapType();
         T keyResult;
         T valueResult;
@@ -814,14 +794,11 @@ public class TypeUtil {
           visitor.afterMapValue(valueField);
         }
 
-        return visitor.map(map, keyResult, valueResult);
-
-      case VARIANT:
-        return visitor.variant(type.asVariantType());
-
-      default:
-        return visitor.primitive(type.asPrimitiveType());
-    }
+        yield visitor.map(map, keyResult, valueResult);
+      }
+      case VARIANT -> visitor.variant(type.asVariantType());
+      default -> visitor.primitive(type.asPrimitiveType());
+    };
   }
 
   public static class CustomOrderSchemaVisitor<T> {
@@ -903,8 +880,8 @@ public class TypeUtil {
    * @return the result of traversing the given type with the visitor
    */
   public static <T> T visit(Type type, CustomOrderSchemaVisitor<T> visitor) {
-    switch (type.typeId()) {
-      case STRUCT:
+    return switch (type.typeId()) {
+      case STRUCT -> {
         Types.StructType struct = type.asNestedType().asStructType();
         List<VisitFieldFuture<T>> results =
             Lists.newArrayListWithExpectedSize(struct.fields().size());
@@ -912,25 +889,22 @@ public class TypeUtil {
           results.add(new VisitFieldFuture<>(field, visitor));
         }
 
-        return visitor.struct(struct, Iterables.transform(results, VisitFieldFuture::get));
-
-      case LIST:
+        yield visitor.struct(struct, Iterables.transform(results, VisitFieldFuture::get));
+      }
+      case LIST -> {
         Types.ListType list = type.asNestedType().asListType();
-        return visitor.list(list, new VisitFuture<>(list.elementType(), visitor));
-
-      case MAP:
+        yield visitor.list(list, new VisitFuture<>(list.elementType(), visitor));
+      }
+      case MAP -> {
         Types.MapType map = type.asNestedType().asMapType();
-        return visitor.map(
+        yield visitor.map(
             map,
             new VisitFuture<>(map.keyType(), visitor),
             new VisitFuture<>(map.valueType(), visitor));
-
-      case VARIANT:
-        return visitor.variant(type.asVariantType());
-
-      default:
-        return visitor.primitive(type.asPrimitiveType());
-    }
+      }
+      case VARIANT -> visitor.variant(type.asVariantType());
+      default -> visitor.primitive(type.asPrimitiveType());
+    };
   }
 
   static int decimalMaxPrecision(int numBytes) {


### PR DESCRIPTION
Converts the statement-form `switch` blocks in `types` to expression form, clearing the corresponding `StatementSwitchToExpressionSwitch` ErrorProne warnings the module emits and removing the risk of accidental fall-through in the converted code. Note: this is one of a series of per-package PRs splitting the `iceberg-api` switch conversion (https://github.com/apache/iceberg/pull/17534), following the discussion on https://github.com/apache/iceberg/pull/17534#issuecomment-5347030476 to land it as individual reviewable PRs rather than one sweep.