### PR TITLE
API: Convert statement switches to arrow switches in transforms

### DIFF
--- a/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Bucket.java
@@ -55,28 +55,16 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
     Preconditions.checkArgument(
         numBuckets > 0, "Invalid number of buckets: %s (must be > 0)", numBuckets);
 
-    switch (type.typeId()) {
-      case DATE:
-      case INTEGER:
-        return (B) new BucketInteger(numBuckets);
-      case TIME:
-      case TIMESTAMP:
-      case LONG:
-        return (B) new BucketLong(numBuckets);
-      case DECIMAL:
-        return (B) new BucketDecimal(numBuckets);
-      case STRING:
-        return (B) new BucketString(numBuckets);
-      case FIXED:
-      case BINARY:
-        return (B) new BucketByteBuffer(numBuckets);
-      case TIMESTAMP_NANO:
-        return (B) new BucketTimestampNano(numBuckets);
-      case UUID:
-        return (B) new BucketUUID(numBuckets);
-      default:
-        throw new IllegalArgumentException("Cannot bucket by type: " + type);
-    }
+    return switch (type.typeId()) {
+      case DATE, INTEGER -> (B) new BucketInteger(numBuckets);
+      case TIME, TIMESTAMP, LONG -> (B) new BucketLong(numBuckets);
+      case DECIMAL -> (B) new BucketDecimal(numBuckets);
+      case STRING -> (B) new BucketString(numBuckets);
+      case FIXED, BINARY -> (B) new BucketByteBuffer(numBuckets);
+      case TIMESTAMP_NANO -> (B) new BucketTimestampNano(numBuckets);
+      case UUID -> (B) new BucketUUID(numBuckets);
+      default -> throw new IllegalArgumentException("Cannot bucket by type: " + type);
+    };
   }
 
   private final int numBuckets;
@@ -118,21 +106,21 @@ class Bucket<T> implements Transform<T, Integer>, Serializable {
 
   @Override
   public boolean canTransform(Type type) {
-    switch (type.typeId()) {
-      case INTEGER:
-      case LONG:
-      case DATE:
-      case TIME:
-      case TIMESTAMP:
-      case TIMESTAMP_NANO:
-      case STRING:
-      case BINARY:
-      case FIXED:
-      case DECIMAL:
-      case UUID:
-        return true;
-    }
-    return false;
+    return switch (type.typeId()) {
+      case INTEGER,
+              LONG,
+              DATE,
+              TIME,
+              TIMESTAMP,
+              TIMESTAMP_NANO,
+              STRING,
+              BINARY,
+              FIXED,
+              DECIMAL,
+              UUID ->
+          true;
+      default -> false;
+    };
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Dates.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Dates.java
@@ -50,16 +50,12 @@ enum Dates implements Transform<Integer, Integer> {
         return null;
       }
 
-      switch (granularity) {
-        case YEARS:
-          return DateTimeUtil.daysToYears(days);
-        case MONTHS:
-          return DateTimeUtil.daysToMonths(days);
-        case DAYS:
-          return days;
-        default:
-          throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
-      }
+      return switch (granularity) {
+        case YEARS -> DateTimeUtil.daysToYears(days);
+        case MONTHS -> DateTimeUtil.daysToMonths(days);
+        case DAYS -> days;
+        default -> throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+      };
     }
   }
 
@@ -199,16 +195,12 @@ enum Dates implements Transform<Integer, Integer> {
       return "null";
     }
 
-    switch (granularity) {
-      case YEARS:
-        return TransformUtil.humanYear(value);
-      case MONTHS:
-        return TransformUtil.humanMonth(value);
-      case DAYS:
-        return TransformUtil.humanDay(value);
-      default:
-        throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
-    }
+    return switch (granularity) {
+      case YEARS -> TransformUtil.humanYear(value);
+      case MONTHS -> TransformUtil.humanMonth(value);
+      case DAYS -> TransformUtil.humanDay(value);
+      default -> throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+    };
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/ProjectionUtil.java
@@ -42,114 +42,92 @@ class ProjectionUtil {
   static <T> UnboundPredicate<T> truncateInteger(
       String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
     int boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-        // adjust closed and then transform ltEq
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
-      case GT:
-        // adjust closed and then transform gtEq
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
-      case EQ:
-        return predicate(pred.op(), name, transform.apply(boundary));
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT ->
+          // adjust closed and then transform ltEq
+          predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1));
+      case LT_EQ -> predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+      case GT ->
+          // adjust closed and then transform gtEq
+          predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1));
+      case GT_EQ -> predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+      case EQ -> predicate(pred.op(), name, transform.apply(boundary));
+      default -> null;
+    };
   }
 
   static <T> UnboundPredicate<T> truncateIntegerStrict(
       String name, BoundLiteralPredicate<Integer> pred, Function<Integer, T> transform) {
     int boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary + 1));
-      case GT:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary - 1));
-      case NOT_EQ:
-        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
-      case EQ:
-        // there is no predicate that guarantees equality because adjacent ints transform to the
-        // same value
-        return null;
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT -> predicate(Expression.Operation.LT, name, transform.apply(boundary));
+      case LT_EQ -> predicate(Expression.Operation.LT, name, transform.apply(boundary + 1));
+      case GT -> predicate(Expression.Operation.GT, name, transform.apply(boundary));
+      case GT_EQ -> predicate(Expression.Operation.GT, name, transform.apply(boundary - 1));
+      case NOT_EQ -> predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ ->
+          // there is no predicate that guarantees equality because adjacent ints transform to the
+          // same value
+          null;
+      default -> null;
+    };
   }
 
   static <T> UnboundPredicate<T> truncateLongStrict(
       String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
     long boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary + 1L));
-      case GT:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary - 1L));
-      case NOT_EQ:
-        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
-      case EQ:
-        // there is no predicate that guarantees equality because adjacent longs transform to the
-        // same value
-        return null;
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT -> predicate(Expression.Operation.LT, name, transform.apply(boundary));
+      case LT_EQ -> predicate(Expression.Operation.LT, name, transform.apply(boundary + 1L));
+      case GT -> predicate(Expression.Operation.GT, name, transform.apply(boundary));
+      case GT_EQ -> predicate(Expression.Operation.GT, name, transform.apply(boundary - 1L));
+      case NOT_EQ -> predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ ->
+          // there is no predicate that guarantees equality because adjacent longs transform to the
+          // same value
+          null;
+      default -> null;
+    };
   }
 
   static <T> UnboundPredicate<T> truncateLong(
       String name, BoundLiteralPredicate<Long> pred, Function<Long, T> transform) {
     long boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-        // adjust closed and then transform ltEq
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
-      case GT:
-        // adjust closed and then transform gtEq
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
-      case EQ:
-        return predicate(pred.op(), name, transform.apply(boundary));
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT ->
+          // adjust closed and then transform ltEq
+          predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary - 1L));
+      case LT_EQ -> predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+      case GT ->
+          // adjust closed and then transform gtEq
+          predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary + 1L));
+      case GT_EQ -> predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+      case EQ -> predicate(pred.op(), name, transform.apply(boundary));
+      default -> null;
+    };
   }
 
   static <T> UnboundPredicate<T> truncateDecimal(
       String name, BoundLiteralPredicate<BigDecimal> pred, Function<BigDecimal, T> transform) {
     BigDecimal boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
+    return switch (pred.op()) {
+      case LT -> {
         // adjust closed and then transform ltEq
         BigDecimal minusOne =
             new BigDecimal(boundary.unscaledValue().subtract(BigInteger.ONE), boundary.scale());
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(minusOne));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
-      case GT:
+        yield predicate(Expression.Operation.LT_EQ, name, transform.apply(minusOne));
+      }
+      case LT_EQ -> predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+      case GT -> {
         // adjust closed and then transform gtEq
         BigDecimal plusOne =
             new BigDecimal(boundary.unscaledValue().add(BigInteger.ONE), boundary.scale());
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(plusOne));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
-      case EQ:
-        return predicate(pred.op(), name, transform.apply(boundary));
-      default:
-        return null;
-    }
+        yield predicate(Expression.Operation.GT_EQ, name, transform.apply(plusOne));
+      }
+      case GT_EQ -> predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+      case EQ -> predicate(pred.op(), name, transform.apply(boundary));
+      default -> null;
+    };
   }
 
   static <T> UnboundPredicate<T> truncateDecimalStrict(
@@ -162,66 +140,49 @@ class ProjectionUtil {
     BigDecimal plusOne =
         new BigDecimal(boundary.unscaledValue().add(BigInteger.ONE), boundary.scale());
 
-    switch (pred.op()) {
-      case LT:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary));
-      case LT_EQ:
-        return predicate(Expression.Operation.LT, name, transform.apply(plusOne));
-      case GT:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary));
-      case GT_EQ:
-        return predicate(Expression.Operation.GT, name, transform.apply(minusOne));
-      case NOT_EQ:
-        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
-      case EQ:
-        // there is no predicate that guarantees equality because adjacent decimals transform to the
-        // same value
-        return null;
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT -> predicate(Expression.Operation.LT, name, transform.apply(boundary));
+      case LT_EQ -> predicate(Expression.Operation.LT, name, transform.apply(plusOne));
+      case GT -> predicate(Expression.Operation.GT, name, transform.apply(boundary));
+      case GT_EQ -> predicate(Expression.Operation.GT, name, transform.apply(minusOne));
+      case NOT_EQ -> predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ ->
+          // there is no predicate that guarantees equality because adjacent decimals transform to
+          // the
+          // same value
+          null;
+      default -> null;
+    };
   }
 
   static <S, T> UnboundPredicate<T> truncateArray(
       String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
     S boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-      case LT_EQ:
-        return predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
-      case GT:
-      case GT_EQ:
-        return predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
-      case EQ:
-        return predicate(Expression.Operation.EQ, name, transform.apply(boundary));
-      case STARTS_WITH:
-        return predicate(Expression.Operation.STARTS_WITH, name, transform.apply(boundary));
+    return switch (pred.op()) {
+      case LT, LT_EQ -> predicate(Expression.Operation.LT_EQ, name, transform.apply(boundary));
+      case GT, GT_EQ -> predicate(Expression.Operation.GT_EQ, name, transform.apply(boundary));
+      case EQ -> predicate(Expression.Operation.EQ, name, transform.apply(boundary));
+      case STARTS_WITH ->
+          predicate(Expression.Operation.STARTS_WITH, name, transform.apply(boundary));
         //        case IN: // TODO
         //          return Expressions.predicate(Operation.IN, name, transform.apply(boundary));
-      default:
-        return null;
-    }
+      default -> null;
+    };
   }
 
   static <S, T> UnboundPredicate<T> truncateArrayStrict(
       String name, BoundLiteralPredicate<S> pred, Function<S, T> transform) {
     S boundary = pred.literal().value();
-    switch (pred.op()) {
-      case LT:
-      case LT_EQ:
-        return predicate(Expression.Operation.LT, name, transform.apply(boundary));
-      case GT:
-      case GT_EQ:
-        return predicate(Expression.Operation.GT, name, transform.apply(boundary));
-      case NOT_EQ:
-        return predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
-      case EQ:
-        // there is no predicate that guarantees equality because adjacent values transform to the
-        // same partition
-        return null;
-      default:
-        return null;
-    }
+    return switch (pred.op()) {
+      case LT, LT_EQ -> predicate(Expression.Operation.LT, name, transform.apply(boundary));
+      case GT, GT_EQ -> predicate(Expression.Operation.GT, name, transform.apply(boundary));
+      case NOT_EQ -> predicate(Expression.Operation.NOT_EQ, name, transform.apply(boundary));
+      case EQ ->
+          // there is no predicate that guarantees equality because adjacent values transform to the
+          // same partition
+          null;
+      default -> null;
+    };
   }
 
   /**
@@ -278,37 +239,35 @@ class ProjectionUtil {
     }
 
     // adjust the predicate for values that were 1 larger than the correct transformed value
-    switch (projected.op()) {
-      case LT:
+    return switch (projected.op()) {
+      case LT -> {
         if (projected.literal().value() < 0) {
-          return Expressions.lessThan(projected.term(), projected.literal().value() + 1);
+          yield Expressions.lessThan(projected.term(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case LT_EQ:
+        yield projected;
+      }
+      case LT_EQ -> {
         if (projected.literal().value() < 0) {
-          return Expressions.lessThanOrEqual(projected.term(), projected.literal().value() + 1);
+          yield Expressions.lessThanOrEqual(projected.term(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case GT:
-      case GT_EQ:
-        // incorrect projected values are already greater than the bound for GT, GT_EQ
-        return projected;
-
-      case EQ:
+        yield projected;
+      }
+      case GT, GT_EQ ->
+          // incorrect projected values are already greater than the bound for GT, GT_EQ
+          projected;
+      case EQ -> {
         if (projected.literal().value() < 0) {
           // match either the incorrect value (projectedValue + 1) or the correct value
           // (projectedValue)
-          return Expressions.in(
+          yield Expressions.in(
               projected.term(), projected.literal().value(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case IN:
+        yield projected;
+      }
+      case IN -> {
         Set<Integer> fixedSet = Sets.newHashSet();
         boolean hasNegativeValue = false;
         for (Literal<Integer> lit : projected.literals()) {
@@ -321,19 +280,16 @@ class ProjectionUtil {
         }
 
         if (hasNegativeValue) {
-          return Expressions.in(projected.term(), fixedSet);
+          yield Expressions.in(projected.term(), fixedSet);
         }
 
-        return projected;
-
-      case NOT_IN:
-      case NOT_EQ:
-        // there is no inclusive projection for NOT_EQ and NOT_IN
-        return null;
-
-      default:
-        return projected;
-    }
+        yield projected;
+      }
+      case NOT_IN, NOT_EQ ->
+          // there is no inclusive projection for NOT_EQ and NOT_IN
+          null;
+      default -> projected;
+    };
   }
 
   /**
@@ -349,13 +305,12 @@ class ProjectionUtil {
       return null;
     }
 
-    switch (projected.op()) {
-      case LT:
-      case LT_EQ:
-        // the correct bound is a correct strict projection for the incorrectly transformed values.
-        return projected;
-
-      case GT:
+    return switch (projected.op()) {
+      case LT, LT_EQ ->
+          // the correct bound is a correct strict projection for the incorrectly transformed
+          // values.
+          projected;
+      case GT -> {
         // GT and GT_EQ need to be adjusted because values that do not match the predicate may have
         // been transformed
         // into partition values that match the projected predicate. For example, >=
@@ -363,32 +318,30 @@ class ProjectionUtil {
         // 1969-10-31 was previously transformed to month -2 instead of -3. This must use the more
         // strict value.
         if (projected.literal().value() <= 0) {
-          return Expressions.greaterThan(projected.term(), projected.literal().value() + 1);
+          yield Expressions.greaterThan(projected.term(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case GT_EQ:
+        yield projected;
+      }
+      case GT_EQ -> {
         if (projected.literal().value() <= 0) {
-          return Expressions.greaterThanOrEqual(projected.term(), projected.literal().value() + 1);
+          yield Expressions.greaterThanOrEqual(projected.term(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case EQ:
-      case IN:
-        // there is no strict projection for EQ and IN
-        return null;
-
-      case NOT_EQ:
+        yield projected;
+      }
+      case EQ, IN ->
+          // there is no strict projection for EQ and IN
+          null;
+      case NOT_EQ -> {
         if (projected.literal().value() < 0) {
-          return Expressions.notIn(
+          yield Expressions.notIn(
               projected.term(), projected.literal().value(), projected.literal().value() + 1);
         }
 
-        return projected;
-
-      case NOT_IN:
+        yield projected;
+      }
+      case NOT_IN -> {
         Set<Integer> fixedSet = Sets.newHashSet();
         boolean hasNegativeValue = false;
         for (Literal<Integer> lit : projected.literals()) {
@@ -401,13 +354,12 @@ class ProjectionUtil {
         }
 
         if (hasNegativeValue) {
-          return Expressions.notIn(projected.term(), fixedSet);
+          yield Expressions.notIn(projected.term(), fixedSet);
         }
 
-        return projected;
-
-      default:
-        return null;
-    }
+        yield projected;
+      }
+      default -> null;
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/TimeTransform.java
@@ -27,19 +27,18 @@ import org.apache.iceberg.util.SerializableFunction;
 
 abstract class TimeTransform<S> implements Transform<S, Integer> {
   protected static <R> R fromSourceType(Type type, R dateResult, R microsResult, R nanosResult) {
-    switch (type.typeId()) {
-      case DATE:
+    return switch (type.typeId()) {
+      case DATE -> {
         if (dateResult != null) {
-          return dateResult;
+          yield dateResult;
         }
-        break;
-      case TIMESTAMP:
-        return microsResult;
-      case TIMESTAMP_NANO:
-        return nanosResult;
-    }
 
-    throw new IllegalArgumentException("Unsupported type: " + type);
+        throw new IllegalArgumentException("Unsupported type: " + type);
+      }
+      case TIMESTAMP -> microsResult;
+      case TIMESTAMP_NANO -> nanosResult;
+      default -> throw new IllegalArgumentException("Unsupported type: " + type);
+    };
   }
 
   protected abstract ChronoUnit granularity();

--- a/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Timestamps.java
@@ -63,36 +63,28 @@ enum Timestamps implements Transform<Long, Integer> {
         return null;
       }
 
-      switch (timestampUnit) {
-        case MICROS:
-          switch (granularity) {
-            case YEARS:
-              return DateTimeUtil.microsToYears(timestamp);
-            case MONTHS:
-              return DateTimeUtil.microsToMonths(timestamp);
-            case DAYS:
-              return DateTimeUtil.microsToDays(timestamp);
-            case HOURS:
-              return DateTimeUtil.microsToHours(timestamp);
-            default:
-              throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
-          }
-        case NANOS:
-          switch (granularity) {
-            case YEARS:
-              return DateTimeUtil.nanosToYears(timestamp);
-            case MONTHS:
-              return DateTimeUtil.nanosToMonths(timestamp);
-            case DAYS:
-              return DateTimeUtil.nanosToDays(timestamp);
-            case HOURS:
-              return DateTimeUtil.nanosToHours(timestamp);
-            default:
-              throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
-          }
-        default:
-          throw new UnsupportedOperationException("Unsupported time unit: " + timestampUnit);
-      }
+      return switch (timestampUnit) {
+        case MICROS ->
+            switch (granularity) {
+              case YEARS -> DateTimeUtil.microsToYears(timestamp);
+              case MONTHS -> DateTimeUtil.microsToMonths(timestamp);
+              case DAYS -> DateTimeUtil.microsToDays(timestamp);
+              case HOURS -> DateTimeUtil.microsToHours(timestamp);
+              default ->
+                  throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+            };
+        case NANOS ->
+            switch (granularity) {
+              case YEARS -> DateTimeUtil.nanosToYears(timestamp);
+              case MONTHS -> DateTimeUtil.nanosToMonths(timestamp);
+              case DAYS -> DateTimeUtil.nanosToDays(timestamp);
+              case HOURS -> DateTimeUtil.nanosToHours(timestamp);
+              default ->
+                  throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+            };
+        default ->
+            throw new UnsupportedOperationException("Unsupported time unit: " + timestampUnit);
+      };
     }
   }
 
@@ -216,18 +208,13 @@ enum Timestamps implements Transform<Long, Integer> {
       return "null";
     }
 
-    switch (granularity) {
-      case YEARS:
-        return TransformUtil.humanYear(value);
-      case MONTHS:
-        return TransformUtil.humanMonth(value);
-      case DAYS:
-        return TransformUtil.humanDay(value);
-      case HOURS:
-        return TransformUtil.humanHour(value);
-      default:
-        throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
-    }
+    return switch (granularity) {
+      case YEARS -> TransformUtil.humanYear(value);
+      case MONTHS -> TransformUtil.humanMonth(value);
+      case DAYS -> TransformUtil.humanDay(value);
+      case HOURS -> TransformUtil.humanHour(value);
+      default -> throw new UnsupportedOperationException("Unsupported time unit: " + granularity);
+    };
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/transforms/Transform.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transform.java
@@ -170,35 +170,28 @@ public interface Transform<S, T> extends Serializable {
       return "null";
     }
 
-    switch (type.typeId()) {
-      case DATE:
-        return TransformUtil.humanDay((Integer) value);
-      case TIME:
-        return TransformUtil.humanTime((Long) value);
-      case TIMESTAMP:
-        if (((Types.TimestampType) type).shouldAdjustToUTC()) {
-          return TransformUtil.humanTimestampWithZone((Long) value);
-        } else {
-          return TransformUtil.humanTimestampWithoutZone((Long) value);
-        }
-      case TIMESTAMP_NANO:
-        if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
-          return TransformUtil.humanTimestampNanoWithZone((Long) value);
-        } else {
-          return TransformUtil.humanTimestampNanoWithoutZone((Long) value);
-        }
-      case FIXED:
-      case BINARY:
+    return switch (type.typeId()) {
+      case DATE -> TransformUtil.humanDay((Integer) value);
+      case TIME -> TransformUtil.humanTime((Long) value);
+      case TIMESTAMP ->
+          ((Types.TimestampType) type).shouldAdjustToUTC()
+              ? TransformUtil.humanTimestampWithZone((Long) value)
+              : TransformUtil.humanTimestampWithoutZone((Long) value);
+      case TIMESTAMP_NANO ->
+          ((Types.TimestampNanoType) type).shouldAdjustToUTC()
+              ? TransformUtil.humanTimestampNanoWithZone((Long) value)
+              : TransformUtil.humanTimestampNanoWithoutZone((Long) value);
+      case FIXED, BINARY -> {
         if (value instanceof ByteBuffer) {
-          return TransformUtil.base64encode(((ByteBuffer) value).duplicate());
+          yield TransformUtil.base64encode(((ByteBuffer) value).duplicate());
         } else if (value instanceof byte[]) {
-          return TransformUtil.base64encode(ByteBuffer.wrap((byte[]) value));
+          yield TransformUtil.base64encode(ByteBuffer.wrap((byte[]) value));
         } else {
           throw new UnsupportedOperationException("Unsupported binary type: " + value.getClass());
         }
-      default:
-        return value.toString();
-    }
+      }
+      default -> value.toString();
+    };
   }
 
   /**

--- a/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
+++ b/api/src/main/java/org/apache/iceberg/transforms/Transforms.java
@@ -84,22 +84,15 @@ public class Transforms {
     }
 
     String lowerTransform = transform.toLowerCase(Locale.ROOT);
-    switch (lowerTransform) {
-      case "identity":
-        return Identity.get(type);
-      case "year":
-        return Years.get().toEnum(type);
-      case "month":
-        return Months.get().toEnum(type);
-      case "day":
-        return Days.get().toEnum(type);
-      case "hour":
-        return Hours.get().toEnum(type);
-      case "void":
-        return VoidTransform.get();
-    }
-
-    return new UnknownTransform<>(transform);
+    return switch (lowerTransform) {
+      case "identity" -> Identity.get(type);
+      case "year" -> Years.get().toEnum(type);
+      case "month" -> Months.get().toEnum(type);
+      case "day" -> Days.get().toEnum(type);
+      case "hour" -> Hours.get().toEnum(type);
+      case "void" -> VoidTransform.get();
+      default -> new UnknownTransform<>(transform);
+    };
   }
 
   /**


### PR DESCRIPTION
Converts the statement-form `switch` blocks in `arrow` to expression form, clearing the corresponding `StatementSwitchToExpressionSwitch` ErrorProne warnings the module emits and removing the risk of accidental fall-through in the converted code. Note: this is one of a series of per-package PRs splitting the `iceberg-api` switch conversion (https://github.com/apache/iceberg/pull/17534), following the discussion on https://github.com/apache/iceberg/pull/17534#issuecomment-5347030476 to land it as individual reviewable PRs rather than one sweep.