### PR TITLE
API: Convert statement switches to arrow switches in expressions

### DIFF
--- a/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Aggregate.java
@@ -42,19 +42,13 @@ public abstract class Aggregate<C extends Term> implements Expression {
 
   @Override
   public String toString() {
-    switch (op()) {
-      case COUNT:
-        return "count(" + term() + ")";
-      case COUNT_NULL:
-        return "count_if(" + term() + " is null)";
-      case COUNT_STAR:
-        return "count(*)";
-      case MAX:
-        return "max(" + term() + ")";
-      case MIN:
-        return "min(" + term() + ")";
-      default:
-        throw new UnsupportedOperationException("Invalid aggregate: " + op());
-    }
+    return switch (op()) {
+      case COUNT -> "count(" + term() + ")";
+      case COUNT_NULL -> "count_if(" + term() + " is null)";
+      case COUNT_STAR -> "count(*)";
+      case MAX -> "max(" + term() + ")";
+      case MIN -> "min(" + term() + ")";
+      default -> throw new UnsupportedOperationException("Invalid aggregate: " + op());
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundAggregate.java
@@ -78,20 +78,14 @@ public class BoundAggregate<T, C> extends Aggregate<BoundTerm<T>> implements Bou
   }
 
   public String describe() {
-    switch (op()) {
-      case COUNT_STAR:
-        return "count(*)";
-      case COUNT:
-        return "count(" + ExpressionUtil.describe(term()) + ")";
-      case COUNT_NULL:
-        return "count_if(" + ExpressionUtil.describe(term()) + " is null)";
-      case MAX:
-        return "max(" + ExpressionUtil.describe(term()) + ")";
-      case MIN:
-        return "min(" + ExpressionUtil.describe(term()) + ")";
-      default:
-        throw new UnsupportedOperationException("Unsupported aggregate type: " + op());
-    }
+    return switch (op()) {
+      case COUNT_STAR -> "count(*)";
+      case COUNT -> "count(" + ExpressionUtil.describe(term()) + ")";
+      case COUNT_NULL -> "count_if(" + ExpressionUtil.describe(term()) + " is null)";
+      case MAX -> "max(" + ExpressionUtil.describe(term()) + ")";
+      case MIN -> "min(" + ExpressionUtil.describe(term()) + ")";
+      default -> throw new UnsupportedOperationException("Unsupported aggregate type: " + op());
+    };
   }
 
   <V> boolean safeContainsKey(Map<Integer, V> map, int key) {

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundLiteralPredicate.java
@@ -71,26 +71,18 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
   @Override
   public boolean test(T value) {
     Comparator<T> cmp = literal.comparator();
-    switch (op()) {
-      case LT:
-        return cmp.compare(value, literal.value()) < 0;
-      case LT_EQ:
-        return cmp.compare(value, literal.value()) <= 0;
-      case GT:
-        return cmp.compare(value, literal.value()) > 0;
-      case GT_EQ:
-        return cmp.compare(value, literal.value()) >= 0;
-      case EQ:
-        return cmp.compare(value, literal.value()) == 0;
-      case NOT_EQ:
-        return cmp.compare(value, literal.value()) != 0;
-      case STARTS_WITH:
-        return String.valueOf(value).startsWith((String) literal.value());
-      case NOT_STARTS_WITH:
-        return !String.valueOf(value).startsWith((String) literal.value());
-      default:
-        throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
-    }
+    return switch (op()) {
+      case LT -> cmp.compare(value, literal.value()) < 0;
+      case LT_EQ -> cmp.compare(value, literal.value()) <= 0;
+      case GT -> cmp.compare(value, literal.value()) > 0;
+      case GT_EQ -> cmp.compare(value, literal.value()) >= 0;
+      case EQ -> cmp.compare(value, literal.value()) == 0;
+      case NOT_EQ -> cmp.compare(value, literal.value()) != 0;
+      case STARTS_WITH -> String.valueOf(value).startsWith((String) literal.value());
+      case NOT_STARTS_WITH -> !String.valueOf(value).startsWith((String) literal.value());
+      default ->
+          throw new IllegalStateException("Invalid operation for BoundLiteralPredicate: " + op());
+    };
   }
 
   @Override
@@ -108,32 +100,21 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
     } else if (expr instanceof BoundLiteralPredicate) {
       BoundLiteralPredicate<?> other = (BoundLiteralPredicate<?>) expr;
       if (INTEGRAL_TYPES.contains(term().type().typeId()) && term().isEquivalentTo(other.term())) {
-        switch (op()) {
-          case LT:
-            if (other.op() == Operation.LT_EQ) {
+        return switch (op()) {
+          case LT ->
               // < 6 is equivalent to <= 5
-              return toLong(literal()) == toLong(other.literal()) + 1L;
-            }
-            break;
-          case LT_EQ:
-            if (other.op() == Operation.LT) {
+              other.op() == Operation.LT_EQ && toLong(literal()) == toLong(other.literal()) + 1L;
+          case LT_EQ ->
               // <= 5 is equivalent to < 6
-              return toLong(literal()) == toLong(other.literal()) - 1L;
-            }
-            break;
-          case GT:
-            if (other.op() == Operation.GT_EQ) {
+              other.op() == Operation.LT && toLong(literal()) == toLong(other.literal()) - 1L;
+          case GT ->
               // > 5 is equivalent to >= 6
-              return toLong(literal()) == toLong(other.literal()) - 1L;
-            }
-            break;
-          case GT_EQ:
-            if (other.op() == Operation.GT) {
+              other.op() == Operation.GT_EQ && toLong(literal()) == toLong(other.literal()) - 1L;
+          case GT_EQ ->
               // >= 5 is equivalent to > 4
-              return toLong(literal()) == toLong(other.literal()) + 1L;
-            }
-            break;
-        }
+              other.op() == Operation.GT && toLong(literal()) == toLong(other.literal()) + 1L;
+          default -> false;
+        };
       }
     }
 
@@ -142,29 +123,18 @@ public class BoundLiteralPredicate<T> extends BoundPredicate<T> {
 
   @Override
   public String toString() {
-    switch (op()) {
-      case LT:
-        return term() + " < " + literal;
-      case LT_EQ:
-        return term() + " <= " + literal;
-      case GT:
-        return term() + " > " + literal;
-      case GT_EQ:
-        return term() + " >= " + literal;
-      case EQ:
-        return term() + " == " + literal;
-      case NOT_EQ:
-        return term() + " != " + literal;
-      case STARTS_WITH:
-        return term() + " startsWith \"" + literal + "\"";
-      case NOT_STARTS_WITH:
-        return term() + " notStartsWith \"" + literal + "\"";
-      case IN:
-        return term() + " in { " + literal + " }";
-      case NOT_IN:
-        return term() + " not in { " + literal + " }";
-      default:
-        return "Invalid literal predicate: operation = " + op();
-    }
+    return switch (op()) {
+      case LT -> term() + " < " + literal;
+      case LT_EQ -> term() + " <= " + literal;
+      case GT -> term() + " > " + literal;
+      case GT_EQ -> term() + " >= " + literal;
+      case EQ -> term() + " == " + literal;
+      case NOT_EQ -> term() + " != " + literal;
+      case STARTS_WITH -> term() + " startsWith \"" + literal + "\"";
+      case NOT_STARTS_WITH -> term() + " notStartsWith \"" + literal + "\"";
+      case IN -> term() + " in { " + literal + " }";
+      case NOT_IN -> term() + " not in { " + literal + " }";
+      default -> "Invalid literal predicate: operation = " + op();
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundSetPredicate.java
@@ -56,14 +56,12 @@ public class BoundSetPredicate<T> extends BoundPredicate<T> {
 
   @Override
   public boolean test(T value) {
-    switch (op()) {
-      case IN:
-        return value != null && literalSet.contains(value);
-      case NOT_IN:
-        return value == null || !literalSet.contains(value);
-      default:
-        throw new IllegalStateException("Invalid operation for BoundSetPredicate: " + op());
-    }
+    return switch (op()) {
+      case IN -> value != null && literalSet.contains(value);
+      case NOT_IN -> value == null || !literalSet.contains(value);
+      default ->
+          throw new IllegalStateException("Invalid operation for BoundSetPredicate: " + op());
+    };
   }
 
   @Override
@@ -80,13 +78,10 @@ public class BoundSetPredicate<T> extends BoundPredicate<T> {
 
   @Override
   public String toString() {
-    switch (op()) {
-      case IN:
-        return term() + " in (" + COMMA.join(literalSet) + ")";
-      case NOT_IN:
-        return term() + " not in (" + COMMA.join(literalSet) + ")";
-      default:
-        return "Invalid unary predicate: operation = " + op();
-    }
+    return switch (op()) {
+      case IN -> term() + " in (" + COMMA.join(literalSet) + ")";
+      case NOT_IN -> term() + " not in (" + COMMA.join(literalSet) + ")";
+      default -> "Invalid unary predicate: operation = " + op();
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/BoundUnaryPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/BoundUnaryPredicate.java
@@ -42,18 +42,14 @@ public class BoundUnaryPredicate<T> extends BoundPredicate<T> {
 
   @Override
   public boolean test(T value) {
-    switch (op()) {
-      case IS_NULL:
-        return value == null;
-      case NOT_NULL:
-        return value != null;
-      case IS_NAN:
-        return NaNUtil.isNaN(value);
-      case NOT_NAN:
-        return !NaNUtil.isNaN(value);
-      default:
-        throw new IllegalStateException("Invalid operation for BoundUnaryPredicate: " + op());
-    }
+    return switch (op()) {
+      case IS_NULL -> value == null;
+      case NOT_NULL -> value != null;
+      case IS_NAN -> NaNUtil.isNaN(value);
+      case NOT_NAN -> !NaNUtil.isNaN(value);
+      default ->
+          throw new IllegalStateException("Invalid operation for BoundUnaryPredicate: " + op());
+    };
   }
 
   @Override
@@ -67,17 +63,12 @@ public class BoundUnaryPredicate<T> extends BoundPredicate<T> {
 
   @Override
   public String toString() {
-    switch (op()) {
-      case IS_NULL:
-        return "is_null(" + term() + ")";
-      case NOT_NULL:
-        return "not_null(" + term() + ")";
-      case IS_NAN:
-        return "is_nan(" + term() + ")";
-      case NOT_NAN:
-        return "not_nan(" + term() + ")";
-      default:
-        return "Invalid unary predicate: operation = " + op();
-    }
+    return switch (op()) {
+      case IS_NULL -> "is_null(" + term() + ")";
+      case NOT_NULL -> "not_null(" + term() + ")";
+      case IS_NAN -> "is_nan(" + term() + ")";
+      case NOT_NAN -> "not_nan(" + term() + ")";
+      default -> "Invalid unary predicate: operation = " + op();
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Expression.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Expression.java
@@ -62,64 +62,40 @@ public interface Expression extends Serializable {
 
     /** Returns the operation used when this is negated. */
     public Operation negate() {
-      switch (this) {
-        case IS_NULL:
-          return Operation.NOT_NULL;
-        case NOT_NULL:
-          return Operation.IS_NULL;
-        case IS_NAN:
-          return Operation.NOT_NAN;
-        case NOT_NAN:
-          return Operation.IS_NAN;
-        case LT:
-          return Operation.GT_EQ;
-        case LT_EQ:
-          return Operation.GT;
-        case GT:
-          return Operation.LT_EQ;
-        case GT_EQ:
-          return Operation.LT;
-        case EQ:
-          return Operation.NOT_EQ;
-        case NOT_EQ:
-          return Operation.EQ;
-        case IN:
-          return Operation.NOT_IN;
-        case NOT_IN:
-          return Operation.IN;
-        case STARTS_WITH:
-          return Operation.NOT_STARTS_WITH;
-        case NOT_STARTS_WITH:
-          return Operation.STARTS_WITH;
-        default:
-          throw new IllegalArgumentException("No negation for operation: " + this);
-      }
+      return switch (this) {
+        case IS_NULL -> Operation.NOT_NULL;
+        case NOT_NULL -> Operation.IS_NULL;
+        case IS_NAN -> Operation.NOT_NAN;
+        case NOT_NAN -> Operation.IS_NAN;
+        case LT -> Operation.GT_EQ;
+        case LT_EQ -> Operation.GT;
+        case GT -> Operation.LT_EQ;
+        case GT_EQ -> Operation.LT;
+        case EQ -> Operation.NOT_EQ;
+        case NOT_EQ -> Operation.EQ;
+        case IN -> Operation.NOT_IN;
+        case NOT_IN -> Operation.IN;
+        case STARTS_WITH -> Operation.NOT_STARTS_WITH;
+        case NOT_STARTS_WITH -> Operation.STARTS_WITH;
+        default -> throw new IllegalArgumentException("No negation for operation: " + this);
+      };
     }
 
     /** Returns the equivalent operation when the left and right operands are exchanged. */
     // Allow flipLR as a name because it's a public API
     @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
     public Operation flipLR() {
-      switch (this) {
-        case LT:
-          return Operation.GT;
-        case LT_EQ:
-          return Operation.GT_EQ;
-        case GT:
-          return Operation.LT;
-        case GT_EQ:
-          return Operation.LT_EQ;
-        case EQ:
-          return Operation.EQ;
-        case NOT_EQ:
-          return Operation.NOT_EQ;
-        case AND:
-          return Operation.AND;
-        case OR:
-          return Operation.OR;
-        default:
-          throw new IllegalArgumentException("No left-right flip for operation: " + this);
-      }
+      return switch (this) {
+        case LT -> Operation.GT;
+        case LT_EQ -> Operation.GT_EQ;
+        case GT -> Operation.LT;
+        case GT_EQ -> Operation.LT_EQ;
+        case EQ -> Operation.EQ;
+        case NOT_EQ -> Operation.NOT_EQ;
+        case AND -> Operation.AND;
+        case OR -> Operation.OR;
+        default -> throw new IllegalArgumentException("No left-right flip for operation: " + this);
+      };
     }
   }
 

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionUtil.java
@@ -388,32 +388,22 @@ public class ExpressionUtil {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Expression predicate(UnboundPredicate<T> pred) {
-      switch (pred.op()) {
-        case IS_NULL:
-        case NOT_NULL:
-        case IS_NAN:
-        case NOT_NAN:
-          // unary predicates don't need to be sanitized
-          return pred;
-        case LT:
-        case LT_EQ:
-        case GT:
-        case GT_EQ:
-        case EQ:
-        case NOT_EQ:
-        case STARTS_WITH:
-        case NOT_STARTS_WITH:
-          return new UnboundPredicate<>(
-              pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
-        case IN:
-        case NOT_IN:
+      return switch (pred.op()) {
+        case IS_NULL, NOT_NULL, IS_NAN, NOT_NAN ->
+            // unary predicates don't need to be sanitized
+            pred;
+        case LT, LT_EQ, GT, GT_EQ, EQ, NOT_EQ, STARTS_WITH, NOT_STARTS_WITH ->
+            new UnboundPredicate<>(
+                pred.op(), pred.term(), (T) sanitize(pred.literal(), now, today));
+        case IN, NOT_IN -> {
           Iterable<T> iter =
               () -> pred.literals().stream().map(lit -> (T) sanitize(lit, now, today)).iterator();
-          return new UnboundPredicate<>(pred.op(), pred.term(), iter);
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot sanitize unsupported predicate type: " + pred.op());
-      }
+          yield new UnboundPredicate<>(pred.op(), pred.term(), iter);
+        }
+        default ->
+            throw new UnsupportedOperationException(
+                "Cannot sanitize unsupported predicate type: " + pred.op());
+      };
     }
   }
 
@@ -460,105 +450,82 @@ public class ExpressionUtil {
     @Override
     public <T> String predicate(BoundPredicate<T> pred) {
       String term = describe(pred.term());
-      switch (pred.op()) {
-        case IS_NULL:
-          return term + " IS NULL";
-        case NOT_NULL:
-          return term + " IS NOT NULL";
-        case IS_NAN:
-          return "is_nan(" + term + ")";
-        case NOT_NAN:
-          return "not_nan(" + term + ")";
-        case LT:
-          return term + " < " + value((BoundLiteralPredicate<?>) pred);
-        case LT_EQ:
-          return term + " <= " + value((BoundLiteralPredicate<?>) pred);
-        case GT:
-          return term + " > " + value((BoundLiteralPredicate<?>) pred);
-        case GT_EQ:
-          return term + " >= " + value((BoundLiteralPredicate<?>) pred);
-        case EQ:
-          return term + " = " + value((BoundLiteralPredicate<?>) pred);
-        case NOT_EQ:
-          return term + " != " + value((BoundLiteralPredicate<?>) pred);
-        case IN:
-          return term
-              + " IN "
-              + abbreviateValues(
-                      pred.asSetPredicate().literalSet().stream()
-                          .map(lit -> sanitize((Literal<?>) lit, nowMicros, today))
-                          .collect(Collectors.toList()))
-                  .stream()
-                  .collect(Collectors.joining(", ", "(", ")"));
-        case NOT_IN:
-          return term
-              + " NOT IN "
-              + abbreviateValues(
-                      pred.asSetPredicate().literalSet().stream()
-                          .map(lit -> sanitize((Literal<?>) lit, nowMicros, today))
-                          .collect(Collectors.toList()))
-                  .stream()
-                  .collect(Collectors.joining(", ", "(", ")"));
-        case STARTS_WITH:
-          return term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
-        case NOT_STARTS_WITH:
-          return term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot sanitize unsupported predicate type: " + pred.op());
-      }
+      return switch (pred.op()) {
+        case IS_NULL -> term + " IS NULL";
+        case NOT_NULL -> term + " IS NOT NULL";
+        case IS_NAN -> "is_nan(" + term + ")";
+        case NOT_NAN -> "not_nan(" + term + ")";
+        case LT -> term + " < " + value((BoundLiteralPredicate<?>) pred);
+        case LT_EQ -> term + " <= " + value((BoundLiteralPredicate<?>) pred);
+        case GT -> term + " > " + value((BoundLiteralPredicate<?>) pred);
+        case GT_EQ -> term + " >= " + value((BoundLiteralPredicate<?>) pred);
+        case EQ -> term + " = " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_EQ -> term + " != " + value((BoundLiteralPredicate<?>) pred);
+        case IN ->
+            term
+                + " IN "
+                + abbreviateValues(
+                        pred.asSetPredicate().literalSet().stream()
+                            .map(lit -> sanitize((Literal<?>) lit, nowMicros, today))
+                            .collect(Collectors.toList()))
+                    .stream()
+                    .collect(Collectors.joining(", ", "(", ")"));
+        case NOT_IN ->
+            term
+                + " NOT IN "
+                + abbreviateValues(
+                        pred.asSetPredicate().literalSet().stream()
+                            .map(lit -> sanitize((Literal<?>) lit, nowMicros, today))
+                            .collect(Collectors.toList()))
+                    .stream()
+                    .collect(Collectors.joining(", ", "(", ")"));
+        case STARTS_WITH -> term + " STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        case NOT_STARTS_WITH -> term + " NOT STARTS WITH " + value((BoundLiteralPredicate<?>) pred);
+        default ->
+            throw new UnsupportedOperationException(
+                "Cannot sanitize unsupported predicate type: " + pred.op());
+      };
     }
 
     @Override
     public <T> String predicate(UnboundPredicate<T> pred) {
       String term = describe(pred.term());
-      switch (pred.op()) {
-        case IS_NULL:
-          return term + " IS NULL";
-        case NOT_NULL:
-          return term + " IS NOT NULL";
-        case IS_NAN:
-          return "is_nan(" + term + ")";
-        case NOT_NAN:
-          return "not_nan(" + term + ")";
-        case LT:
-          return term + " < " + sanitize(pred.literal(), nowMicros, today);
-        case LT_EQ:
-          return term + " <= " + sanitize(pred.literal(), nowMicros, today);
-        case GT:
-          return term + " > " + sanitize(pred.literal(), nowMicros, today);
-        case GT_EQ:
-          return term + " >= " + sanitize(pred.literal(), nowMicros, today);
-        case EQ:
-          return term + " = " + sanitize(pred.literal(), nowMicros, today);
-        case NOT_EQ:
-          return term + " != " + sanitize(pred.literal(), nowMicros, today);
-        case IN:
-          return term
-              + " IN "
-              + abbreviateValues(
-                      pred.literals().stream()
-                          .map(lit -> sanitize(lit, nowMicros, today))
-                          .collect(Collectors.toList()))
-                  .stream()
-                  .collect(Collectors.joining(", ", "(", ")"));
-        case NOT_IN:
-          return term
-              + " NOT IN "
-              + abbreviateValues(
-                      pred.literals().stream()
-                          .map(lit -> sanitize(lit, nowMicros, today))
-                          .collect(Collectors.toList()))
-                  .stream()
-                  .collect(Collectors.joining(", ", "(", ")"));
-        case STARTS_WITH:
-          return term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
-        case NOT_STARTS_WITH:
-          return term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
-        default:
-          throw new UnsupportedOperationException(
-              "Cannot sanitize unsupported predicate type: " + pred.op());
-      }
+      return switch (pred.op()) {
+        case IS_NULL -> term + " IS NULL";
+        case NOT_NULL -> term + " IS NOT NULL";
+        case IS_NAN -> "is_nan(" + term + ")";
+        case NOT_NAN -> "not_nan(" + term + ")";
+        case LT -> term + " < " + sanitize(pred.literal(), nowMicros, today);
+        case LT_EQ -> term + " <= " + sanitize(pred.literal(), nowMicros, today);
+        case GT -> term + " > " + sanitize(pred.literal(), nowMicros, today);
+        case GT_EQ -> term + " >= " + sanitize(pred.literal(), nowMicros, today);
+        case EQ -> term + " = " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_EQ -> term + " != " + sanitize(pred.literal(), nowMicros, today);
+        case IN ->
+            term
+                + " IN "
+                + abbreviateValues(
+                        pred.literals().stream()
+                            .map(lit -> sanitize(lit, nowMicros, today))
+                            .collect(Collectors.toList()))
+                    .stream()
+                    .collect(Collectors.joining(", ", "(", ")"));
+        case NOT_IN ->
+            term
+                + " NOT IN "
+                + abbreviateValues(
+                        pred.literals().stream()
+                            .map(lit -> sanitize(lit, nowMicros, today))
+                            .collect(Collectors.toList()))
+                    .stream()
+                    .collect(Collectors.joining(", ", "(", ")"));
+        case STARTS_WITH -> term + " STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        case NOT_STARTS_WITH ->
+            term + " NOT STARTS WITH " + sanitize(pred.literal(), nowMicros, today);
+        default ->
+            throw new UnsupportedOperationException(
+                "Cannot sanitize unsupported predicate type: " + pred.op());
+      };
     }
   }
 
@@ -725,38 +692,19 @@ public class ExpressionUtil {
       VariantValue fieldValue, PhysicalType fieldType, long now, int today) {
     StringBuilder builder = new StringBuilder();
     switch (fieldType) {
-      case INT8:
-      case INT16:
-      case INT32:
-      case INT64:
-      case FLOAT:
-      case DOUBLE:
-      case DECIMAL4:
-      case DECIMAL8:
-      case DECIMAL16:
-        builder.append(sanitizeNumber((Number) fieldValue.asPrimitive().get(), fieldType.name()));
-        break;
-      case DATE:
-        builder.append(sanitizeDate(((Number) fieldValue.asPrimitive().get()).intValue(), today));
-        break;
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-        builder.append(
-            sanitizeTimestamp(((Number) fieldValue.asPrimitive().get()).longValue(), now));
-        break;
-      case TIME:
+      case INT8, INT16, INT32, INT64, FLOAT, DOUBLE, DECIMAL4, DECIMAL8, DECIMAL16 ->
+          builder.append(sanitizeNumber((Number) fieldValue.asPrimitive().get(), fieldType.name()));
+      case DATE ->
+          builder.append(sanitizeDate(((Number) fieldValue.asPrimitive().get()).intValue(), today));
+      case TIMESTAMPTZ, TIMESTAMPNTZ, TIMESTAMPTZ_NANOS, TIMESTAMPNTZ_NANOS ->
+          builder.append(
+              sanitizeTimestamp(((Number) fieldValue.asPrimitive().get()).longValue(), now));
+      case TIME -> {
         return "(time)";
-      case ARRAY:
-        builder.append(sanitizeVariantArray((VariantArray) fieldValue, now, today));
-        break;
-      case OBJECT:
-        builder.append(sanitizeVariantObject((VariantObject) fieldValue, now, today));
-        break;
-      default:
-        builder.append(sanitizeSimpleString(fieldValue.toString()));
-        break;
+      }
+      case ARRAY -> builder.append(sanitizeVariantArray((VariantArray) fieldValue, now, today));
+      case OBJECT -> builder.append(sanitizeVariantObject((VariantObject) fieldValue, now, today));
+      default -> builder.append(sanitizeSimpleString(fieldValue.toString()));
     }
     return builder.toString();
   }

--- a/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/ExpressionVisitors.java
@@ -149,53 +149,40 @@ public class ExpressionVisitors {
 
       if (pred.isLiteralPredicate()) {
         BoundLiteralPredicate<T> literalPred = pred.asLiteralPredicate();
-        switch (pred.op()) {
-          case LT:
-            return lt((BoundReference<T>) pred.term(), literalPred.literal());
-          case LT_EQ:
-            return ltEq((BoundReference<T>) pred.term(), literalPred.literal());
-          case GT:
-            return gt((BoundReference<T>) pred.term(), literalPred.literal());
-          case GT_EQ:
-            return gtEq((BoundReference<T>) pred.term(), literalPred.literal());
-          case EQ:
-            return eq((BoundReference<T>) pred.term(), literalPred.literal());
-          case NOT_EQ:
-            return notEq((BoundReference<T>) pred.term(), literalPred.literal());
-          case STARTS_WITH:
-            return startsWith((BoundReference<T>) pred.term(), literalPred.literal());
-          case NOT_STARTS_WITH:
-            return notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundLiteralPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case LT -> lt((BoundReference<T>) pred.term(), literalPred.literal());
+          case LT_EQ -> ltEq((BoundReference<T>) pred.term(), literalPred.literal());
+          case GT -> gt((BoundReference<T>) pred.term(), literalPred.literal());
+          case GT_EQ -> gtEq((BoundReference<T>) pred.term(), literalPred.literal());
+          case EQ -> eq((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_EQ -> notEq((BoundReference<T>) pred.term(), literalPred.literal());
+          case STARTS_WITH -> startsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          case NOT_STARTS_WITH ->
+              notStartsWith((BoundReference<T>) pred.term(), literalPred.literal());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundLiteralPredicate: " + pred.op());
+        };
 
       } else if (pred.isUnaryPredicate()) {
-        switch (pred.op()) {
-          case IS_NULL:
-            return isNull((BoundReference<T>) pred.term());
-          case NOT_NULL:
-            return notNull((BoundReference<T>) pred.term());
-          case IS_NAN:
-            return isNaN((BoundReference<T>) pred.term());
-          case NOT_NAN:
-            return notNaN((BoundReference<T>) pred.term());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundUnaryPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IS_NULL -> isNull((BoundReference<T>) pred.term());
+          case NOT_NULL -> notNull((BoundReference<T>) pred.term());
+          case IS_NAN -> isNaN((BoundReference<T>) pred.term());
+          case NOT_NAN -> notNaN((BoundReference<T>) pred.term());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundUnaryPredicate: " + pred.op());
+        };
 
       } else if (pred.isSetPredicate()) {
-        switch (pred.op()) {
-          case IN:
-            return in((BoundReference<T>) pred.term(), pred.asSetPredicate().literalSet());
-          case NOT_IN:
-            return notIn((BoundReference<T>) pred.term(), pred.asSetPredicate().literalSet());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundSetPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IN -> in((BoundReference<T>) pred.term(), pred.asSetPredicate().literalSet());
+          case NOT_IN -> notIn((BoundReference<T>) pred.term(), pred.asSetPredicate().literalSet());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundSetPredicate: " + pred.op());
+        };
       }
 
       throw new IllegalStateException("Unsupported bound predicate: " + pred.getClass().getName());
@@ -270,53 +257,39 @@ public class ExpressionVisitors {
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
         BoundLiteralPredicate<T> literalPred = pred.asLiteralPredicate();
-        switch (pred.op()) {
-          case LT:
-            return lt(pred.term(), literalPred.literal());
-          case LT_EQ:
-            return ltEq(pred.term(), literalPred.literal());
-          case GT:
-            return gt(pred.term(), literalPred.literal());
-          case GT_EQ:
-            return gtEq(pred.term(), literalPred.literal());
-          case EQ:
-            return eq(pred.term(), literalPred.literal());
-          case NOT_EQ:
-            return notEq(pred.term(), literalPred.literal());
-          case STARTS_WITH:
-            return startsWith(pred.term(), literalPred.literal());
-          case NOT_STARTS_WITH:
-            return notStartsWith(pred.term(), literalPred.literal());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundLiteralPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case LT -> lt(pred.term(), literalPred.literal());
+          case LT_EQ -> ltEq(pred.term(), literalPred.literal());
+          case GT -> gt(pred.term(), literalPred.literal());
+          case GT_EQ -> gtEq(pred.term(), literalPred.literal());
+          case EQ -> eq(pred.term(), literalPred.literal());
+          case NOT_EQ -> notEq(pred.term(), literalPred.literal());
+          case STARTS_WITH -> startsWith(pred.term(), literalPred.literal());
+          case NOT_STARTS_WITH -> notStartsWith(pred.term(), literalPred.literal());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundLiteralPredicate: " + pred.op());
+        };
 
       } else if (pred.isUnaryPredicate()) {
-        switch (pred.op()) {
-          case IS_NULL:
-            return isNull(pred.term());
-          case NOT_NULL:
-            return notNull(pred.term());
-          case IS_NAN:
-            return isNaN(pred.term());
-          case NOT_NAN:
-            return notNaN(pred.term());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundUnaryPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IS_NULL -> isNull(pred.term());
+          case NOT_NULL -> notNull(pred.term());
+          case IS_NAN -> isNaN(pred.term());
+          case NOT_NAN -> notNaN(pred.term());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundUnaryPredicate: " + pred.op());
+        };
 
       } else if (pred.isSetPredicate()) {
-        switch (pred.op()) {
-          case IN:
-            return in(pred.term(), pred.asSetPredicate().literalSet());
-          case NOT_IN:
-            return notIn(pred.term(), pred.asSetPredicate().literalSet());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundSetPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IN -> in(pred.term(), pred.asSetPredicate().literalSet());
+          case NOT_IN -> notIn(pred.term(), pred.asSetPredicate().literalSet());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundSetPredicate: " + pred.op());
+        };
       }
 
       throw new IllegalStateException("Unsupported bound predicate: " + pred.getClass().getName());
@@ -353,23 +326,23 @@ public class ExpressionVisitors {
         return visitor.aggregate((UnboundAggregate<?>) expr);
       }
     } else {
-      switch (expr.op()) {
-        case TRUE:
-          return visitor.alwaysTrue();
-        case FALSE:
-          return visitor.alwaysFalse();
-        case NOT:
+      return switch (expr.op()) {
+        case TRUE -> visitor.alwaysTrue();
+        case FALSE -> visitor.alwaysFalse();
+        case NOT -> {
           Not not = (Not) expr;
-          return visitor.not(visit(not.child(), visitor));
-        case AND:
+          yield visitor.not(visit(not.child(), visitor));
+        }
+        case AND -> {
           And and = (And) expr;
-          return visitor.and(visit(and.left(), visitor), visit(and.right(), visitor));
-        case OR:
+          yield visitor.and(visit(and.left(), visitor), visit(and.right(), visitor));
+        }
+        case OR -> {
           Or or = (Or) expr;
-          return visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
-        default:
-          throw new UnsupportedOperationException("Unknown operation: " + expr.op());
-      }
+          yield visitor.or(visit(or.left(), visitor), visit(or.right(), visitor));
+        }
+        default -> throw new UnsupportedOperationException("Unknown operation: " + expr.op());
+      };
     }
   }
 
@@ -392,31 +365,31 @@ public class ExpressionVisitors {
         return visitor.predicate((UnboundPredicate<?>) expr);
       }
     } else {
-      switch (expr.op()) {
-        case TRUE:
-          return visitor.alwaysTrue();
-        case FALSE:
-          return visitor.alwaysFalse();
-        case NOT:
+      return switch (expr.op()) {
+        case TRUE -> visitor.alwaysTrue();
+        case FALSE -> visitor.alwaysFalse();
+        case NOT -> {
           Not not = (Not) expr;
-          return visitor.not(visitEvaluator(not.child(), visitor));
-        case AND:
+          yield visitor.not(visitEvaluator(not.child(), visitor));
+        }
+        case AND -> {
           And and = (And) expr;
           Boolean andLeftOperand = visitEvaluator(and.left(), visitor);
           if (!andLeftOperand) {
-            return visitor.alwaysFalse();
+            yield visitor.alwaysFalse();
           }
-          return visitor.and(Boolean.TRUE, visitEvaluator(and.right(), visitor));
-        case OR:
+          yield visitor.and(Boolean.TRUE, visitEvaluator(and.right(), visitor));
+        }
+        case OR -> {
           Or or = (Or) expr;
           Boolean orLeftOperand = visitEvaluator(or.left(), visitor);
           if (orLeftOperand) {
-            return visitor.alwaysTrue();
+            yield visitor.alwaysTrue();
           }
-          return visitor.or(Boolean.FALSE, visitEvaluator(or.right(), visitor));
-        default:
-          throw new UnsupportedOperationException("Unknown operation: " + expr.op());
-      }
+          yield visitor.or(Boolean.FALSE, visitEvaluator(or.right(), visitor));
+        }
+        default -> throw new UnsupportedOperationException("Unknown operation: " + expr.op());
+      };
     }
   }
 
@@ -448,53 +421,39 @@ public class ExpressionVisitors {
     public <T> R predicate(BoundPredicate<T> pred) {
       if (pred.isLiteralPredicate()) {
         BoundLiteralPredicate<T> literalPred = pred.asLiteralPredicate();
-        switch (pred.op()) {
-          case LT:
-            return lt(pred.term(), literalPred.literal());
-          case LT_EQ:
-            return ltEq(pred.term(), literalPred.literal());
-          case GT:
-            return gt(pred.term(), literalPred.literal());
-          case GT_EQ:
-            return gtEq(pred.term(), literalPred.literal());
-          case EQ:
-            return eq(pred.term(), literalPred.literal());
-          case NOT_EQ:
-            return notEq(pred.term(), literalPred.literal());
-          case STARTS_WITH:
-            return startsWith(pred.term(), literalPred.literal());
-          case NOT_STARTS_WITH:
-            return notStartsWith(pred.term(), literalPred.literal());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundLiteralPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case LT -> lt(pred.term(), literalPred.literal());
+          case LT_EQ -> ltEq(pred.term(), literalPred.literal());
+          case GT -> gt(pred.term(), literalPred.literal());
+          case GT_EQ -> gtEq(pred.term(), literalPred.literal());
+          case EQ -> eq(pred.term(), literalPred.literal());
+          case NOT_EQ -> notEq(pred.term(), literalPred.literal());
+          case STARTS_WITH -> startsWith(pred.term(), literalPred.literal());
+          case NOT_STARTS_WITH -> notStartsWith(pred.term(), literalPred.literal());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundLiteralPredicate: " + pred.op());
+        };
 
       } else if (pred.isUnaryPredicate()) {
-        switch (pred.op()) {
-          case IS_NULL:
-            return isNull(pred.term());
-          case NOT_NULL:
-            return notNull(pred.term());
-          case IS_NAN:
-            return isNaN(pred.term());
-          case NOT_NAN:
-            return notNaN(pred.term());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundUnaryPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IS_NULL -> isNull(pred.term());
+          case NOT_NULL -> notNull(pred.term());
+          case IS_NAN -> isNaN(pred.term());
+          case NOT_NAN -> notNaN(pred.term());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundUnaryPredicate: " + pred.op());
+        };
 
       } else if (pred.isSetPredicate()) {
-        switch (pred.op()) {
-          case IN:
-            return in(pred.term(), pred.asSetPredicate().literalSet());
-          case NOT_IN:
-            return notIn(pred.term(), pred.asSetPredicate().literalSet());
-          default:
-            throw new IllegalStateException(
-                "Invalid operation for BoundSetPredicate: " + pred.op());
-        }
+        return switch (pred.op()) {
+          case IN -> in(pred.term(), pred.asSetPredicate().literalSet());
+          case NOT_IN -> notIn(pred.term(), pred.asSetPredicate().literalSet());
+          default ->
+              throw new IllegalStateException(
+                  "Invalid operation for BoundSetPredicate: " + pred.op());
+        };
       }
 
       throw new IllegalStateException("Unsupported bound predicate: " + pred.getClass().getName());
@@ -583,23 +542,23 @@ public class ExpressionVisitors {
         return () -> visitor.predicate((UnboundPredicate<?>) expr);
       }
     } else {
-      switch (expr.op()) {
-        case TRUE:
-          return visitor::alwaysTrue;
-        case FALSE:
-          return visitor::alwaysFalse;
-        case NOT:
+      return switch (expr.op()) {
+        case TRUE -> visitor::alwaysTrue;
+        case FALSE -> visitor::alwaysFalse;
+        case NOT -> {
           Not not = (Not) expr;
-          return () -> visitor.not(visitExpr(not.child(), visitor));
-        case AND:
+          yield () -> visitor.not(visitExpr(not.child(), visitor));
+        }
+        case AND -> {
           And and = (And) expr;
-          return () -> visitor.and(visitExpr(and.left(), visitor), visitExpr(and.right(), visitor));
-        case OR:
+          yield () -> visitor.and(visitExpr(and.left(), visitor), visitExpr(and.right(), visitor));
+        }
+        case OR -> {
           Or or = (Or) expr;
-          return () -> visitor.or(visitExpr(or.left(), visitor), visitExpr(or.right(), visitor));
-        default:
-          throw new UnsupportedOperationException("Unknown operation: " + expr.op());
-      }
+          yield () -> visitor.or(visitExpr(or.left(), visitor), visitExpr(or.right(), visitor));
+        }
+        default -> throw new UnsupportedOperationException("Unknown operation: " + expr.op());
+      };
     }
   }
 }

--- a/api/src/main/java/org/apache/iceberg/expressions/Literals.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/Literals.java
@@ -253,25 +253,20 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case INTEGER:
-          return (Literal<T>) this;
-        case LONG:
-          return (Literal<T>) new LongLiteral(value().longValue());
-        case FLOAT:
-          return (Literal<T>) new FloatLiteral(value().floatValue());
-        case DOUBLE:
-          return (Literal<T>) new DoubleLiteral(value().doubleValue());
-        case DATE:
-          return (Literal<T>) new DateLiteral(value());
-        case DECIMAL:
+      return switch (type.typeId()) {
+        case INTEGER -> (Literal<T>) this;
+        case LONG -> (Literal<T>) new LongLiteral(value().longValue());
+        case FLOAT -> (Literal<T>) new FloatLiteral(value().floatValue());
+        case DOUBLE -> (Literal<T>) new DoubleLiteral(value().doubleValue());
+        case DATE -> (Literal<T>) new DateLiteral(value());
+        case DECIMAL -> {
           int scale = ((Types.DecimalType) type).scale();
           // rounding mode isn't necessary, but pass one to avoid warnings
-          return (Literal<T>)
+          yield (Literal<T>)
               new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
-        default:
-          return null;
-      }
+        }
+        default -> null;
+      };
     }
 
     @Override
@@ -288,42 +283,39 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case INTEGER:
+      return switch (type.typeId()) {
+        case INTEGER -> {
           if ((long) Integer.MAX_VALUE < value()) {
-            return aboveMax();
+            yield aboveMax();
           } else if ((long) Integer.MIN_VALUE > value()) {
-            return belowMin();
+            yield belowMin();
           }
-          return (Literal<T>) new IntegerLiteral(value().intValue());
-        case LONG:
-          return (Literal<T>) this;
-        case FLOAT:
-          return (Literal<T>) new FloatLiteral(value().floatValue());
-        case DOUBLE:
-          return (Literal<T>) new DoubleLiteral(value().doubleValue());
-        case TIME:
-          return (Literal<T>) new TimeLiteral(value());
-        case TIMESTAMP:
-          return (Literal<T>) new TimestampLiteral(value());
-        case TIMESTAMP_NANO:
-          // assume micros and convert to nanos to match the behavior in the timestamp case above
-          return new TimestampLiteral(value()).to(type);
-        case DATE:
+          yield (Literal<T>) new IntegerLiteral(value().intValue());
+        }
+        case LONG -> (Literal<T>) this;
+        case FLOAT -> (Literal<T>) new FloatLiteral(value().floatValue());
+        case DOUBLE -> (Literal<T>) new DoubleLiteral(value().doubleValue());
+        case TIME -> (Literal<T>) new TimeLiteral(value());
+        case TIMESTAMP -> (Literal<T>) new TimestampLiteral(value());
+        case TIMESTAMP_NANO ->
+            // assume micros and convert to nanos to match the behavior in the timestamp case above
+            new TimestampLiteral(value()).to(type);
+        case DATE -> {
           if ((long) Integer.MAX_VALUE < value()) {
-            return aboveMax();
+            yield aboveMax();
           } else if ((long) Integer.MIN_VALUE > value()) {
-            return belowMin();
+            yield belowMin();
           }
-          return (Literal<T>) new DateLiteral(value().intValue());
-        case DECIMAL:
+          yield (Literal<T>) new DateLiteral(value().intValue());
+        }
+        case DECIMAL -> {
           int scale = ((Types.DecimalType) type).scale();
           // rounding mode isn't necessary, but pass one to avoid warnings
-          return (Literal<T>)
+          yield (Literal<T>)
               new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
-        default:
-          return null;
-      }
+        }
+        default -> null;
+      };
     }
 
     @Override
@@ -340,18 +332,16 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case FLOAT:
-          return (Literal<T>) this;
-        case DOUBLE:
-          return (Literal<T>) new DoubleLiteral(value().doubleValue());
-        case DECIMAL:
+      return switch (type.typeId()) {
+        case FLOAT -> (Literal<T>) this;
+        case DOUBLE -> (Literal<T>) new DoubleLiteral(value().doubleValue());
+        case DECIMAL -> {
           int scale = ((Types.DecimalType) type).scale();
-          return (Literal<T>)
+          yield (Literal<T>)
               new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
-        default:
-          return null;
-      }
+        }
+        default -> null;
+      };
     }
 
     @Override
@@ -368,25 +358,25 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case FLOAT:
+      return switch (type.typeId()) {
+        case FLOAT -> {
           if ((double) Float.MAX_VALUE < value()) {
-            return aboveMax();
+            yield aboveMax();
           } else if ((double) -Float.MAX_VALUE > value()) {
             // Compare with -Float.MAX_VALUE because it is the most negative float value.
             // Float.MIN_VALUE is the smallest non-negative floating point value.
-            return belowMin();
+            yield belowMin();
           }
-          return (Literal<T>) new FloatLiteral(value().floatValue());
-        case DOUBLE:
-          return (Literal<T>) this;
-        case DECIMAL:
+          yield (Literal<T>) new FloatLiteral(value().floatValue());
+        }
+        case DOUBLE -> (Literal<T>) this;
+        case DECIMAL -> {
           int scale = ((Types.DecimalType) type).scale();
-          return (Literal<T>)
+          yield (Literal<T>)
               new DecimalLiteral(BigDecimal.valueOf(value()).setScale(scale, RoundingMode.HALF_UP));
-        default:
-          return null;
-      }
+        }
+        default -> null;
+      };
     }
 
     @Override
@@ -443,16 +433,13 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case TIMESTAMP:
-          return (Literal<T>) this;
-        case DATE:
-          return (Literal<T>) new DateLiteral(DateTimeUtil.microsToDays(value()));
-        case TIMESTAMP_NANO:
-          return (Literal<T>) new TimestampNanoLiteral(DateTimeUtil.microsToNanos(value()));
-        default:
-      }
-      return null;
+      return switch (type.typeId()) {
+        case TIMESTAMP -> (Literal<T>) this;
+        case DATE -> (Literal<T>) new DateLiteral(DateTimeUtil.microsToDays(value()));
+        case TIMESTAMP_NANO ->
+            (Literal<T>) new TimestampNanoLiteral(DateTimeUtil.microsToNanos(value()));
+        default -> null;
+      };
     }
 
     @Override
@@ -469,16 +456,12 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case DATE:
-          return (Literal<T>) new DateLiteral(DateTimeUtil.nanosToDays(value()));
-        case TIMESTAMP:
-          return (Literal<T>) new TimestampLiteral(DateTimeUtil.nanosToMicros(value()));
-        case TIMESTAMP_NANO:
-          return (Literal<T>) this;
-        default:
-      }
-      return null;
+      return switch (type.typeId()) {
+        case DATE -> (Literal<T>) new DateLiteral(DateTimeUtil.nanosToDays(value()));
+        case TIMESTAMP -> (Literal<T>) new TimestampLiteral(DateTimeUtil.nanosToMicros(value()));
+        case TIMESTAMP_NANO -> (Literal<T>) this;
+        default -> null;
+      };
     }
 
     @Override
@@ -495,13 +478,12 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case DECIMAL:
-          // do not change decimal scale
-          return (Literal<T>) this;
-        default:
-          return null;
-      }
+      return switch (type.typeId()) {
+        case DECIMAL ->
+            // do not change decimal scale
+            (Literal<T>) this;
+        default -> null;
+      };
     }
 
     @Override
@@ -518,12 +500,10 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case VARIANT:
-          return (Literal<T>) this;
-        default:
-          return null;
-      }
+      return switch (type.typeId()) {
+        case VARIANT -> (Literal<T>) this;
+        default -> null;
+      };
     }
 
     @Override
@@ -548,76 +528,71 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case DATE:
+      return switch (type.typeId()) {
+        case DATE -> {
           int date =
               (int)
                   ChronoUnit.DAYS.between(
                       EPOCH_DAY, LocalDate.parse(value(), DateTimeFormatter.ISO_LOCAL_DATE));
-          return (Literal<T>) new DateLiteral(date);
-
-        case TIME:
+          yield (Literal<T>) new DateLiteral(date);
+        }
+        case TIME -> {
           long timeMicros =
               LocalTime.parse(value(), DateTimeFormatter.ISO_LOCAL_TIME).toNanoOfDay() / 1000;
-          return (Literal<T>) new TimeLiteral(timeMicros);
-
-        case TIMESTAMP:
+          yield (Literal<T>) new TimeLiteral(timeMicros);
+        }
+        case TIMESTAMP -> {
           if (((Types.TimestampType) type).shouldAdjustToUTC()) {
             long timestampMicros = DateTimeUtil.isoTimestamptzToMicros(value().toString());
-            return (Literal<T>) new TimestampLiteral(timestampMicros);
+            yield (Literal<T>) new TimestampLiteral(timestampMicros);
           } else {
             long timestampMicros = DateTimeUtil.isoTimestampToMicros(value().toString());
-            return (Literal<T>) new TimestampLiteral(timestampMicros);
+            yield (Literal<T>) new TimestampLiteral(timestampMicros);
           }
-
-        case TIMESTAMP_NANO:
+        }
+        case TIMESTAMP_NANO -> {
           if (((Types.TimestampNanoType) type).shouldAdjustToUTC()) {
-            return (Literal<T>)
+            yield (Literal<T>)
                 new TimestampNanoLiteral(DateTimeUtil.isoTimestamptzToNanos(value()));
           } else {
-            return (Literal<T>) new TimestampNanoLiteral(DateTimeUtil.isoTimestampToNanos(value()));
+            yield (Literal<T>) new TimestampNanoLiteral(DateTimeUtil.isoTimestampToNanos(value()));
           }
-
-        case STRING:
-          return (Literal<T>) this;
-
-        case UUID:
-          return (Literal<T>) new UUIDLiteral(UUID.fromString(value().toString()));
-
-        case DECIMAL:
+        }
+        case STRING -> (Literal<T>) this;
+        case UUID -> (Literal<T>) new UUIDLiteral(UUID.fromString(value().toString()));
+        case DECIMAL -> {
           // do not change decimal scale
           BigDecimal decimal = new BigDecimal(value().toString());
-          return (Literal<T>) new DecimalLiteral(decimal);
-
-        case FIXED:
+          yield (Literal<T>) new DecimalLiteral(decimal);
+        }
+        case FIXED -> {
           try {
             ByteBuffer buffer =
                 ByteBuffer.wrap(
                     BASE16_ENCODING.decode(value().toString().toUpperCase(Locale.ROOT)));
             Types.FixedType fixed = (Types.FixedType) type;
             if (buffer.remaining() == fixed.length()) {
-              return (Literal<T>) new FixedLiteral(buffer);
+              yield (Literal<T>) new FixedLiteral(buffer);
             }
-            return null;
+            yield null;
           } catch (IllegalArgumentException e) {
             // Invalid hex string
-            return null;
+            yield null;
           }
-
-        case BINARY:
+        }
+        case BINARY -> {
           try {
-            return (Literal<T>)
+            yield (Literal<T>)
                 new BinaryLiteral(
                     ByteBuffer.wrap(
                         BASE16_ENCODING.decode(value().toString().toUpperCase(Locale.ROOT))));
           } catch (IllegalArgumentException e) {
             // Invalid hex string
-            return null;
+            yield null;
           }
-
-        default:
-          return null;
-      }
+        }
+        default -> null;
+      };
     }
 
     @Override
@@ -667,18 +642,17 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case FIXED:
+      return switch (type.typeId()) {
+        case FIXED -> {
           Types.FixedType fixed = (Types.FixedType) type;
           if (value().remaining() == fixed.length()) {
-            return (Literal<T>) this;
+            yield (Literal<T>) this;
           }
-          return null;
-        case BINARY:
-          return (Literal<T>) new BinaryLiteral(value());
-        default:
-          return null;
-      }
+          yield null;
+        }
+        case BINARY -> (Literal<T>) new BinaryLiteral(value());
+        default -> null;
+      };
     }
 
     @Override
@@ -713,18 +687,17 @@ class Literals {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Literal<T> to(Type type) {
-      switch (type.typeId()) {
-        case FIXED:
+      return switch (type.typeId()) {
+        case FIXED -> {
           Types.FixedType fixed = (Types.FixedType) type;
           if (value().remaining() == fixed.length()) {
-            return (Literal<T>) new FixedLiteral(value());
+            yield (Literal<T>) new FixedLiteral(value());
           }
-          return null;
-        case BINARY:
-          return (Literal<T>) this;
-        default:
-          return null;
-      }
+          yield null;
+        }
+        case BINARY -> (Literal<T>) this;
+        default -> null;
+      };
     }
 
     @Override

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundAggregate.java
@@ -46,20 +46,14 @@ public class UnboundAggregate<T> extends Aggregate<UnboundTerm<T>>
    */
   @Override
   public Expression bind(Types.StructType struct, boolean caseSensitive) {
-    switch (op()) {
-      case COUNT_STAR:
-        return new CountStar<>(null);
-      case COUNT:
-        return new CountNonNull<>(boundTerm(struct, caseSensitive));
-      case COUNT_NULL:
-        return new CountNull<>(boundTerm(struct, caseSensitive));
-      case MAX:
-        return new MaxAggregate<>(boundTerm(struct, caseSensitive));
-      case MIN:
-        return new MinAggregate<>(boundTerm(struct, caseSensitive));
-      default:
-        throw new UnsupportedOperationException("Unsupported aggregate type: " + op());
-    }
+    return switch (op()) {
+      case COUNT_STAR -> new CountStar<>(null);
+      case COUNT -> new CountNonNull<>(boundTerm(struct, caseSensitive));
+      case COUNT_NULL -> new CountNull<>(boundTerm(struct, caseSensitive));
+      case MAX -> new MaxAggregate<>(boundTerm(struct, caseSensitive));
+      case MIN -> new MinAggregate<>(boundTerm(struct, caseSensitive));
+      default -> throw new UnsupportedOperationException("Unsupported aggregate type: " + op());
+    };
   }
 
   private BoundTerm<T> boundTerm(Types.StructType struct, boolean caseSensitive) {

--- a/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/UnboundPredicate.java
@@ -124,38 +124,42 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
   }
 
   private Expression bindUnaryOperation(StructType struct, BoundTerm<T> boundTerm) {
-    switch (op()) {
-      case IS_NULL:
+    return switch (op()) {
+      case IS_NULL -> {
         if (!boundTerm.producesNull()
             && allAncestorFieldsAreRequired(struct, boundTerm.ref().fieldId())) {
-          return Expressions.alwaysFalse();
+          yield Expressions.alwaysFalse();
         } else if (boundTerm.type().equals(Types.UnknownType.get())) {
-          return Expressions.alwaysTrue();
+          yield Expressions.alwaysTrue();
         }
-        return new BoundUnaryPredicate<>(Operation.IS_NULL, boundTerm);
-      case NOT_NULL:
+        yield new BoundUnaryPredicate<>(Operation.IS_NULL, boundTerm);
+      }
+      case NOT_NULL -> {
         if (!boundTerm.producesNull()
             && allAncestorFieldsAreRequired(struct, boundTerm.ref().fieldId())) {
-          return Expressions.alwaysTrue();
+          yield Expressions.alwaysTrue();
         } else if (boundTerm.type().equals(Types.UnknownType.get())) {
-          return Expressions.alwaysFalse();
+          yield Expressions.alwaysFalse();
         }
-        return new BoundUnaryPredicate<>(Operation.NOT_NULL, boundTerm);
-      case IS_NAN:
+        yield new BoundUnaryPredicate<>(Operation.NOT_NULL, boundTerm);
+      }
+      case IS_NAN -> {
         if (floatingType(boundTerm.type().typeId())) {
-          return new BoundUnaryPredicate<>(Operation.IS_NAN, boundTerm);
+          yield new BoundUnaryPredicate<>(Operation.IS_NAN, boundTerm);
         } else {
           throw new ValidationException("IsNaN cannot be used with a non-floating-point column");
         }
-      case NOT_NAN:
+      }
+      case NOT_NAN -> {
         if (floatingType(boundTerm.type().typeId())) {
-          return new BoundUnaryPredicate<>(Operation.NOT_NAN, boundTerm);
+          yield new BoundUnaryPredicate<>(Operation.NOT_NAN, boundTerm);
         } else {
           throw new ValidationException("NotNaN cannot be used with a non-floating-point column");
         }
-      default:
-        throw new ValidationException("Operation must be IS_NULL, NOT_NULL, IS_NAN, or NOT_NAN");
-    }
+      }
+      default ->
+          throw new ValidationException("Operation must be IS_NULL, NOT_NULL, IS_NAN, or NOT_NAN");
+    };
   }
 
   private boolean allAncestorFieldsAreRequired(StructType struct, int fieldId) {
@@ -185,25 +189,21 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
 
     } else if (lit == Literals.aboveMax()) {
       switch (op()) {
-        case LT:
-        case LT_EQ:
-        case NOT_EQ:
+        case LT, LT_EQ, NOT_EQ -> {
           return Expressions.alwaysTrue();
-        case GT:
-        case GT_EQ:
-        case EQ:
+        }
+        case GT, GT_EQ, EQ -> {
           return Expressions.alwaysFalse();
+        }
       }
     } else if (lit == Literals.belowMin()) {
       switch (op()) {
-        case GT:
-        case GT_EQ:
-        case NOT_EQ:
+        case GT, GT_EQ, NOT_EQ -> {
           return Expressions.alwaysTrue();
-        case LT:
-        case LT_EQ:
-        case EQ:
+        }
+        case LT, LT_EQ, EQ -> {
           return Expressions.alwaysFalse();
+        }
       }
     }
 
@@ -230,28 +230,24 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
                 lit -> lit != Literals.aboveMax() && lit != Literals.belowMin()));
 
     if (convertedLiterals.isEmpty()) {
-      switch (op()) {
-        case IN:
-          return Expressions.alwaysFalse();
-        case NOT_IN:
-          return Expressions.alwaysTrue();
-        default:
-          throw new ValidationException("Operation must be IN or NOT_IN");
-      }
+      return switch (op()) {
+        case IN -> Expressions.alwaysFalse();
+        case NOT_IN -> Expressions.alwaysTrue();
+        default -> throw new ValidationException("Operation must be IN or NOT_IN");
+      };
     }
 
     Set<T> literalSet = setOf(convertedLiterals);
     if (literalSet.size() == 1) {
-      switch (op()) {
-        case IN:
-          return new BoundLiteralPredicate<>(
-              Operation.EQ, boundTerm, Iterables.get(convertedLiterals, 0));
-        case NOT_IN:
-          return new BoundLiteralPredicate<>(
-              Operation.NOT_EQ, boundTerm, Iterables.get(convertedLiterals, 0));
-        default:
-          throw new ValidationException("Operation must be IN or NOT_IN");
-      }
+      return switch (op()) {
+        case IN ->
+            new BoundLiteralPredicate<>(
+                Operation.EQ, boundTerm, Iterables.get(convertedLiterals, 0));
+        case NOT_IN ->
+            new BoundLiteralPredicate<>(
+                Operation.NOT_EQ, boundTerm, Iterables.get(convertedLiterals, 0));
+        default -> throw new ValidationException("Operation must be IN or NOT_IN");
+      };
     }
 
     return new BoundSetPredicate<>(op(), boundTerm, literalSet);
@@ -259,38 +255,23 @@ public class UnboundPredicate<T> extends Predicate<T, UnboundTerm<T>>
 
   @Override
   public String toString() {
-    switch (op()) {
-      case IS_NULL:
-        return "is_null(" + term() + ")";
-      case NOT_NULL:
-        return "not_null(" + term() + ")";
-      case IS_NAN:
-        return "is_nan(" + term() + ")";
-      case NOT_NAN:
-        return "not_nan(" + term() + ")";
-      case LT:
-        return term() + " < " + literal();
-      case LT_EQ:
-        return term() + " <= " + literal();
-      case GT:
-        return term() + " > " + literal();
-      case GT_EQ:
-        return term() + " >= " + literal();
-      case EQ:
-        return term() + " == " + literal();
-      case NOT_EQ:
-        return term() + " != " + literal();
-      case STARTS_WITH:
-        return term() + " startsWith \"" + literal() + "\"";
-      case NOT_STARTS_WITH:
-        return term() + " notStartsWith \"" + literal() + "\"";
-      case IN:
-        return term() + " in (" + COMMA.join(literals()) + ")";
-      case NOT_IN:
-        return term() + " not in (" + COMMA.join(literals()) + ")";
-      default:
-        return "Invalid predicate: operation = " + op();
-    }
+    return switch (op()) {
+      case IS_NULL -> "is_null(" + term() + ")";
+      case NOT_NULL -> "not_null(" + term() + ")";
+      case IS_NAN -> "is_nan(" + term() + ")";
+      case NOT_NAN -> "not_nan(" + term() + ")";
+      case LT -> term() + " < " + literal();
+      case LT_EQ -> term() + " <= " + literal();
+      case GT -> term() + " > " + literal();
+      case GT_EQ -> term() + " >= " + literal();
+      case EQ -> term() + " == " + literal();
+      case NOT_EQ -> term() + " != " + literal();
+      case STARTS_WITH -> term() + " startsWith \"" + literal() + "\"";
+      case NOT_STARTS_WITH -> term() + " notStartsWith \"" + literal() + "\"";
+      case IN -> term() + " in (" + COMMA.join(literals()) + ")";
+      case NOT_IN -> term() + " not in (" + COMMA.join(literals()) + ")";
+      default -> "Invalid predicate: operation = " + op();
+    };
   }
 
   @SuppressWarnings("unchecked")

--- a/api/src/main/java/org/apache/iceberg/expressions/VariantExpressionUtil.java
+++ b/api/src/main/java/org/apache/iceberg/expressions/VariantExpressionUtil.java
@@ -57,98 +57,91 @@ class VariantExpressionUtil {
       return (T) value.asPrimitive().get();
     }
 
-    switch (type.typeId()) {
-      case INTEGER:
-        switch (value.type()) {
-          case INT8:
-          case INT16:
-            return (T) (Integer) ((Number) value.asPrimitive().get()).intValue();
-        }
-
-        break;
-      case LONG:
-        switch (value.type()) {
-          case INT8:
-          case INT16:
-          case INT32:
-            return (T) (Long) ((Number) value.asPrimitive().get()).longValue();
-        }
-
-        break;
-      case DOUBLE:
+    return switch (type.typeId()) {
+      case INTEGER ->
+          switch (value.type()) {
+            case INT8, INT16 -> (T) (Integer) ((Number) value.asPrimitive().get()).intValue();
+            default -> null;
+          };
+      case LONG ->
+          switch (value.type()) {
+            case INT8, INT16, INT32 -> (T) (Long) ((Number) value.asPrimitive().get()).longValue();
+            default -> null;
+          };
+      case DOUBLE -> {
         if (value.type() == PhysicalType.FLOAT) {
-          return (T) (Double) ((Number) value.asPrimitive().get()).doubleValue();
+          yield (T) (Double) ((Number) value.asPrimitive().get()).doubleValue();
         }
-
-        break;
-      case FIXED:
+        yield null;
+      }
+      case FIXED -> {
         Types.FixedType fixedType = (Types.FixedType) type;
         if (value.type() == PhysicalType.BINARY) {
           ByteBuffer buffer = (ByteBuffer) value.asPrimitive().get();
           if (buffer.remaining() == fixedType.length()) {
-            return (T) buffer;
+            yield (T) buffer;
           }
         }
-
-        break;
-      case DECIMAL:
+        yield null;
+      }
+      case DECIMAL -> {
         Types.DecimalType decimalType = (Types.DecimalType) type;
-        switch (value.type()) {
-          case DECIMAL4:
-          case DECIMAL8:
-          case DECIMAL16:
+        yield switch (value.type()) {
+          case DECIMAL4, DECIMAL8, DECIMAL16 -> {
             BigDecimal decimalValue = (BigDecimal) value.asPrimitive().get();
             if (decimalValue.scale() == decimalType.scale()) {
-              return (T) decimalValue;
+              yield (T) decimalValue;
             }
-        }
-
-        break;
-      case BOOLEAN:
-        switch (value.type()) {
-          case BOOLEAN_FALSE:
-            return (T) Boolean.FALSE;
-          case BOOLEAN_TRUE:
-            return (T) Boolean.TRUE;
-        }
-
-        break;
-      case TIMESTAMP:
+            yield null;
+          }
+          default -> null;
+        };
+      }
+      case BOOLEAN ->
+          switch (value.type()) {
+            case BOOLEAN_FALSE -> (T) Boolean.FALSE;
+            case BOOLEAN_TRUE -> (T) Boolean.TRUE;
+            default -> null;
+          };
+      case TIMESTAMP -> {
         if (value.type() == PhysicalType.TIMESTAMPTZ_NANOS
             || value.type() == PhysicalType.TIMESTAMPNTZ_NANOS) {
-          return (T)
+          yield (T)
               (Long) DateTimeUtil.nanosToMicros(((Number) value.asPrimitive().get()).longValue());
         } else if (value.type() == PhysicalType.DATE) {
-          return (T)
+          yield (T)
               (Long)
                   DateTimeUtil.microsFromTimestamp(
                       DateTimeUtil.dateFromDays(((Number) value.asPrimitive().get()).intValue())
                           .atStartOfDay());
         }
-        break;
-      case TIMESTAMP_NANO:
+        yield null;
+      }
+      case TIMESTAMP_NANO -> {
         if (value.type() == PhysicalType.TIMESTAMPTZ || value.type() == PhysicalType.TIMESTAMPNTZ) {
-          return (T)
+          yield (T)
               (Long) DateTimeUtil.microsToNanos(((Number) value.asPrimitive().get()).longValue());
         } else if (value.type() == PhysicalType.DATE) {
-          return (T)
+          yield (T)
               (Long)
                   DateTimeUtil.nanosFromTimestamp(
                       DateTimeUtil.dateFromDays(((Number) value.asPrimitive().get()).intValue())
                           .atStartOfDay());
         }
-        break;
-      case DATE:
+        yield null;
+      }
+      case DATE -> {
         if (value.type() == PhysicalType.TIMESTAMPTZ || value.type() == PhysicalType.TIMESTAMPNTZ) {
-          return (T)
+          yield (T)
               (Integer) DateTimeUtil.microsToDays(((Number) value.asPrimitive().get()).longValue());
         } else if (value.type() == PhysicalType.TIMESTAMPTZ_NANOS
             || value.type() == PhysicalType.TIMESTAMPNTZ_NANOS) {
-          return (T)
+          yield (T)
               (Integer) DateTimeUtil.nanosToDays(((Number) value.asPrimitive().get()).longValue());
         }
-    }
-
-    return null;
+        yield null;
+      }
+      default -> null;
+    };
   }
 }


### PR DESCRIPTION
Converts the statement-form `switch` blocks in `expressions` to expression form, clearing the corresponding `StatementSwitchToExpressionSwitch` ErrorProne warnings the module emits and removing the risk of accidental fall-through in the converted code. Note: this is one of a series of per-package PRs splitting the `iceberg-api` switch conversion (https://github.com/apache/iceberg/pull/17534), following the discussion on https://github.com/apache/iceberg/pull/17534#issuecomment-5347030476 to land it as individual reviewable PRs rather than one sweep.