### PR TITLE
API: Convert statement switches to arrow switches in variants

### DIFF
--- a/api/src/main/java/org/apache/iceberg/variants/PhysicalType.java
+++ b/api/src/main/java/org/apache/iceberg/variants/PhysicalType.java
@@ -65,51 +65,31 @@ public enum PhysicalType {
   }
 
   public static PhysicalType from(int primitiveType) {
-    switch (primitiveType) {
-      case Primitives.TYPE_NULL:
-        return NULL;
-      case Primitives.TYPE_TRUE:
-        return BOOLEAN_TRUE;
-      case Primitives.TYPE_FALSE:
-        return BOOLEAN_FALSE;
-      case Primitives.TYPE_INT8:
-        return INT8;
-      case Primitives.TYPE_INT16:
-        return INT16;
-      case Primitives.TYPE_INT32:
-        return INT32;
-      case Primitives.TYPE_INT64:
-        return INT64;
-      case Primitives.TYPE_DATE:
-        return DATE;
-      case Primitives.TYPE_TIMESTAMPTZ:
-        return TIMESTAMPTZ;
-      case Primitives.TYPE_TIMESTAMPNTZ:
-        return TIMESTAMPNTZ;
-      case Primitives.TYPE_FLOAT:
-        return FLOAT;
-      case Primitives.TYPE_DOUBLE:
-        return DOUBLE;
-      case Primitives.TYPE_DECIMAL4:
-        return DECIMAL4;
-      case Primitives.TYPE_DECIMAL8:
-        return DECIMAL8;
-      case Primitives.TYPE_DECIMAL16:
-        return DECIMAL16;
-      case Primitives.TYPE_BINARY:
-        return BINARY;
-      case Primitives.TYPE_STRING:
-        return STRING;
-      case Primitives.TYPE_TIME:
-        return TIME;
-      case Primitives.TYPE_TIMESTAMPTZ_NANOS:
-        return TIMESTAMPTZ_NANOS;
-      case Primitives.TYPE_TIMESTAMPNTZ_NANOS:
-        return TIMESTAMPNTZ_NANOS;
-      case Primitives.TYPE_UUID:
-        return UUID;
-    }
-
-    throw new UnsupportedOperationException("Unknown primitive physical type: " + primitiveType);
+    return switch (primitiveType) {
+      case Primitives.TYPE_NULL -> NULL;
+      case Primitives.TYPE_TRUE -> BOOLEAN_TRUE;
+      case Primitives.TYPE_FALSE -> BOOLEAN_FALSE;
+      case Primitives.TYPE_INT8 -> INT8;
+      case Primitives.TYPE_INT16 -> INT16;
+      case Primitives.TYPE_INT32 -> INT32;
+      case Primitives.TYPE_INT64 -> INT64;
+      case Primitives.TYPE_DATE -> DATE;
+      case Primitives.TYPE_TIMESTAMPTZ -> TIMESTAMPTZ;
+      case Primitives.TYPE_TIMESTAMPNTZ -> TIMESTAMPNTZ;
+      case Primitives.TYPE_FLOAT -> FLOAT;
+      case Primitives.TYPE_DOUBLE -> DOUBLE;
+      case Primitives.TYPE_DECIMAL4 -> DECIMAL4;
+      case Primitives.TYPE_DECIMAL8 -> DECIMAL8;
+      case Primitives.TYPE_DECIMAL16 -> DECIMAL16;
+      case Primitives.TYPE_BINARY -> BINARY;
+      case Primitives.TYPE_STRING -> STRING;
+      case Primitives.TYPE_TIME -> TIME;
+      case Primitives.TYPE_TIMESTAMPTZ_NANOS -> TIMESTAMPTZ_NANOS;
+      case Primitives.TYPE_TIMESTAMPNTZ_NANOS -> TIMESTAMPNTZ_NANOS;
+      case Primitives.TYPE_UUID -> UUID;
+      default ->
+          throw new UnsupportedOperationException(
+              "Unknown primitive physical type: " + primitiveType);
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/SerializedPrimitive.java
@@ -60,37 +60,18 @@ class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue, 
   }
 
   private static long payloadSize(PhysicalType type, ByteBuffer value) {
-    switch (type) {
-      case NULL:
-      case BOOLEAN_TRUE:
-      case BOOLEAN_FALSE:
-        return 0;
-      case INT8:
-        return 1;
-      case INT16:
-        return 2;
-      case INT32:
-      case DATE:
-      case FLOAT:
-        return 4;
-      case INT64:
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-      case TIME:
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-      case DOUBLE:
-        return 8;
-      case DECIMAL4:
-        return 5;
-      case DECIMAL8:
-        return 9;
-      case DECIMAL16:
-        return 17;
-      case UUID:
-        return 16;
-      case BINARY:
-      case STRING:
+    return switch (type) {
+      case NULL, BOOLEAN_TRUE, BOOLEAN_FALSE -> 0;
+      case INT8 -> 1;
+      case INT16 -> 2;
+      case INT32, DATE, FLOAT -> 4;
+      case INT64, TIMESTAMPTZ, TIMESTAMPNTZ, TIME, TIMESTAMPTZ_NANOS, TIMESTAMPNTZ_NANOS, DOUBLE ->
+          8;
+      case DECIMAL4 -> 5;
+      case DECIMAL8 -> 9;
+      case DECIMAL16 -> 17;
+      case UUID -> 16;
+      case BINARY, STRING -> {
         Preconditions.checkArgument(
             PRIMITIVE_OFFSET + 4 <= value.remaining(),
             "Invalid variant primitive: %s size field extends past buffer",
@@ -98,75 +79,55 @@ class SerializedPrimitive implements VariantPrimitive<Object>, SerializedValue, 
         int size = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
         Preconditions.checkArgument(
             size >= 0, "Invalid variant primitive: negative %s size %s", type, size);
-        return 4L + size;
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type);
+        yield 4L + size;
+      }
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type);
+    };
   }
 
   private Object read() {
-    switch (type) {
-      case NULL:
-        return null;
-      case BOOLEAN_TRUE:
-        return true;
-      case BOOLEAN_FALSE:
-        return false;
-      case INT8:
-        return ByteBuffers.readLittleEndianInt8(value, PRIMITIVE_OFFSET);
-      case INT16:
-        return ByteBuffers.readLittleEndianInt16(value, PRIMITIVE_OFFSET);
-      case INT32:
-      case DATE:
-        return ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
-      case INT64:
-      case TIMESTAMPTZ:
-      case TIMESTAMPNTZ:
-      case TIME:
-      case TIMESTAMPTZ_NANOS:
-      case TIMESTAMPNTZ_NANOS:
-        return ByteBuffers.readLittleEndianInt64(value, PRIMITIVE_OFFSET);
-      case FLOAT:
-        return VariantUtil.readFloat(value, PRIMITIVE_OFFSET);
-      case DOUBLE:
-        return VariantUtil.readDouble(value, PRIMITIVE_OFFSET);
-      case DECIMAL4:
-        {
-          int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
-          int unscaled = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET + 1);
-          return new BigDecimal(BigInteger.valueOf(unscaled), scale);
+    return switch (type) {
+      case NULL -> null;
+      case BOOLEAN_TRUE -> true;
+      case BOOLEAN_FALSE -> false;
+      case INT8 -> ByteBuffers.readLittleEndianInt8(value, PRIMITIVE_OFFSET);
+      case INT16 -> ByteBuffers.readLittleEndianInt16(value, PRIMITIVE_OFFSET);
+      case INT32, DATE -> ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
+      case INT64, TIMESTAMPTZ, TIMESTAMPNTZ, TIME, TIMESTAMPTZ_NANOS, TIMESTAMPNTZ_NANOS ->
+          ByteBuffers.readLittleEndianInt64(value, PRIMITIVE_OFFSET);
+      case FLOAT -> VariantUtil.readFloat(value, PRIMITIVE_OFFSET);
+      case DOUBLE -> VariantUtil.readDouble(value, PRIMITIVE_OFFSET);
+      case DECIMAL4 -> {
+        int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
+        int unscaled = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET + 1);
+        yield new BigDecimal(BigInteger.valueOf(unscaled), scale);
+      }
+      case DECIMAL8 -> {
+        int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
+        long unscaled = ByteBuffers.readLittleEndianInt64(value, PRIMITIVE_OFFSET + 1);
+        yield new BigDecimal(BigInteger.valueOf(unscaled), scale);
+      }
+      case DECIMAL16 -> {
+        int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
+        byte[] unscaled = new byte[16];
+        for (int i = 0; i < 16; i += 1) {
+          unscaled[i] = (byte) ByteBuffers.readByte(value, PRIMITIVE_OFFSET + 16 - i);
         }
-      case DECIMAL8:
-        {
-          int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
-          long unscaled = ByteBuffers.readLittleEndianInt64(value, PRIMITIVE_OFFSET + 1);
-          return new BigDecimal(BigInteger.valueOf(unscaled), scale);
-        }
-      case DECIMAL16:
-        {
-          int scale = ByteBuffers.readByte(value, PRIMITIVE_OFFSET);
-          byte[] unscaled = new byte[16];
-          for (int i = 0; i < 16; i += 1) {
-            unscaled[i] = (byte) ByteBuffers.readByte(value, PRIMITIVE_OFFSET + 16 - i);
-          }
-          return new BigDecimal(new BigInteger(unscaled), scale);
-        }
-      case BINARY:
-        {
-          int size = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
-          return VariantUtil.slice(value, PRIMITIVE_OFFSET + 4, size);
-        }
-      case STRING:
-        {
-          int size = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
-          return VariantUtil.readString(value, PRIMITIVE_OFFSET + 4, size);
-        }
-      case UUID:
-        return UUIDUtil.convert(
-            VariantUtil.slice(value, PRIMITIVE_OFFSET, 16).order(ByteOrder.BIG_ENDIAN));
-    }
-
-    throw new UnsupportedOperationException("Unsupported primitive type: " + type);
+        yield new BigDecimal(new BigInteger(unscaled), scale);
+      }
+      case BINARY -> {
+        int size = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
+        yield VariantUtil.slice(value, PRIMITIVE_OFFSET + 4, size);
+      }
+      case STRING -> {
+        int size = ByteBuffers.readLittleEndianInt32(value, PRIMITIVE_OFFSET);
+        yield VariantUtil.readString(value, PRIMITIVE_OFFSET + 4, size);
+      }
+      case UUID ->
+          UUIDUtil.convert(
+              VariantUtil.slice(value, PRIMITIVE_OFFSET, 16).order(ByteOrder.BIG_ENDIAN));
+      default -> throw new UnsupportedOperationException("Unsupported primitive type: " + type);
+    };
   }
 
   @Override

--- a/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantPrimitive.java
@@ -34,24 +34,16 @@ public interface VariantPrimitive<T> extends VariantValue {
   }
 
   private String valueAsString() {
-    switch (type()) {
-      case DATE:
-        return DateTimeUtil.daysToIsoDate((Integer) get());
-      case TIME:
-        return DateTimeUtil.microsToIsoTime((Long) get());
-      case TIMESTAMPTZ:
-        return DateTimeUtil.microsToIsoTimestamptz((Long) get());
-      case TIMESTAMPNTZ:
-        return DateTimeUtil.microsToIsoTimestamp((Long) get());
-      case TIMESTAMPTZ_NANOS:
-        return DateTimeUtil.nanosToIsoTimestamptz((Long) get());
-      case TIMESTAMPNTZ_NANOS:
-        return DateTimeUtil.nanosToIsoTimestamp((Long) get());
-      case BINARY:
-        return BaseEncoding.base16().encode(ByteBuffers.toByteArray((ByteBuffer) get()));
-      default:
-        return String.valueOf(get());
-    }
+    return switch (type()) {
+      case DATE -> DateTimeUtil.daysToIsoDate((Integer) get());
+      case TIME -> DateTimeUtil.microsToIsoTime((Long) get());
+      case TIMESTAMPTZ -> DateTimeUtil.microsToIsoTimestamptz((Long) get());
+      case TIMESTAMPNTZ -> DateTimeUtil.microsToIsoTimestamp((Long) get());
+      case TIMESTAMPTZ_NANOS -> DateTimeUtil.nanosToIsoTimestamptz((Long) get());
+      case TIMESTAMPNTZ_NANOS -> DateTimeUtil.nanosToIsoTimestamp((Long) get());
+      case BINARY -> BaseEncoding.base16().encode(ByteBuffers.toByteArray((ByteBuffer) get()));
+      default -> String.valueOf(get());
+    };
   }
 
   static String asString(VariantPrimitive<?> primitive) {

--- a/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
+++ b/api/src/main/java/org/apache/iceberg/variants/VariantUtil.java
@@ -57,18 +57,12 @@ class VariantUtil {
     Preconditions.checkArgument(value.remaining() >= 1, "Invalid variant: empty value buffer");
     int header = ByteBuffers.readByte(value, 0);
     BasicType basicType = basicType(header);
-    switch (basicType) {
-      case PRIMITIVE:
-        return SerializedPrimitive.from(value, header);
-      case SHORT_STRING:
-        return SerializedShortString.from(value, header);
-      case OBJECT:
-        return SerializedObject.from(metadata, value, header, depth);
-      case ARRAY:
-        return SerializedArray.from(metadata, value, header, depth);
-    }
-
-    throw new UnsupportedOperationException("Unsupported basic type: " + basicType);
+    return switch (basicType) {
+      case PRIMITIVE -> SerializedPrimitive.from(value, header);
+      case SHORT_STRING -> SerializedShortString.from(value, header);
+      case OBJECT -> SerializedObject.from(metadata, value, header, depth);
+      case ARRAY -> SerializedArray.from(metadata, value, header, depth);
+    };
   }
 
   static float readFloat(ByteBuffer buffer, int offset) {
@@ -153,17 +147,12 @@ class VariantUtil {
 
   static BasicType basicType(int header) {
     int basicType = header & BASIC_TYPE_MASK;
-    switch (basicType) {
-      case BASIC_TYPE_PRIMITIVE:
-        return BasicType.PRIMITIVE;
-      case BASIC_TYPE_SHORT_STRING:
-        return BasicType.SHORT_STRING;
-      case BASIC_TYPE_OBJECT:
-        return BasicType.OBJECT;
-      case BASIC_TYPE_ARRAY:
-        return BasicType.ARRAY;
-    }
-
-    throw new UnsupportedOperationException("Unsupported basic type: " + basicType);
+    return switch (basicType) {
+      case BASIC_TYPE_PRIMITIVE -> BasicType.PRIMITIVE;
+      case BASIC_TYPE_SHORT_STRING -> BasicType.SHORT_STRING;
+      case BASIC_TYPE_OBJECT -> BasicType.OBJECT;
+      case BASIC_TYPE_ARRAY -> BasicType.ARRAY;
+      default -> throw new UnsupportedOperationException("Unsupported basic type: " + basicType);
+    };
   }
 }


### PR DESCRIPTION
Converts the statement-form `switch` blocks in `variants` to expression form, clearing the corresponding `StatementSwitchToExpressionSwitch` ErrorProne warnings the module emits and removing the risk of accidental fall-through in the converted code. Note: this is one of a series of per-package PRs splitting the `iceberg-api` switch conversion (https://github.com/apache/iceberg/pull/17534), following the discussion on https://github.com/apache/iceberg/pull/17534#issuecomment-5347030476 to land it as individual reviewable PRs rather than one sweep.