### PR TITLE
API: Convert statement switches to arrow switches in util and top-level enums

### DIFF
--- a/api/src/main/java/org/apache/iceberg/ManifestContent.java
+++ b/api/src/main/java/org/apache/iceberg/ManifestContent.java
@@ -34,12 +34,10 @@ public enum ManifestContent {
   }
 
   public static ManifestContent fromId(int id) {
-    switch (id) {
-      case 0:
-        return DATA;
-      case 1:
-        return DELETES;
-    }
-    throw new IllegalArgumentException("Unknown manifest content: " + id);
+    return switch (id) {
+      case 0 -> DATA;
+      case 1 -> DELETES;
+      default -> throw new IllegalArgumentException("Unknown manifest content: " + id);
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/NullOrder.java
+++ b/api/src/main/java/org/apache/iceberg/NullOrder.java
@@ -24,13 +24,10 @@ public enum NullOrder {
 
   @Override
   public String toString() {
-    switch (this) {
-      case NULLS_FIRST:
-        return "NULLS FIRST";
-      case NULLS_LAST:
-        return "NULLS LAST";
-      default:
-        throw new IllegalArgumentException("Unexpected null order: " + this);
-    }
+    return switch (this) {
+      case NULLS_FIRST -> "NULLS FIRST";
+      case NULLS_LAST -> "NULLS LAST";
+      default -> throw new IllegalArgumentException("Unexpected null order: " + this);
+    };
   }
 }

--- a/api/src/main/java/org/apache/iceberg/geospatial/GeospatialPredicateEvaluators.java
+++ b/api/src/main/java/org/apache/iceberg/geospatial/GeospatialPredicateEvaluators.java
@@ -42,14 +42,12 @@ public class GeospatialPredicateEvaluators {
    * @return the evaluator
    */
   public static GeospatialPredicateEvaluator create(Type type) {
-    switch (type.typeId()) {
-      case GEOMETRY:
-        return new GeometryEvaluator();
-      case GEOGRAPHY:
-        return new GeographyEvaluator();
-      default:
-        throw new UnsupportedOperationException("Unsupported type for BoundingBox: " + type);
-    }
+    return switch (type.typeId()) {
+      case GEOMETRY -> new GeometryEvaluator();
+      case GEOGRAPHY -> new GeographyEvaluator();
+      default ->
+          throw new UnsupportedOperationException("Unsupported type for BoundingBox: " + type);
+    };
   }
 
   public static class GeometryEvaluator implements GeospatialPredicateEvaluator {

--- a/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
+++ b/api/src/main/java/org/apache/iceberg/util/ByteBuffers.java
@@ -82,22 +82,15 @@ public class ByteBuffers {
   public static void writeLittleEndianUnsigned(ByteBuffer buffer, int value, int offset, int size) {
     int base = buffer.position() + offset;
     switch (size) {
-      case 4:
-        buffer.putInt(base, value);
-        return;
-      case 3:
+      case 4 -> buffer.putInt(base, value);
+      case 3 -> {
         buffer.putShort(base, (short) (value & 0xFFFF));
         buffer.put(base + 2, (byte) ((value >> 16) & 0xFF));
-        return;
-      case 2:
-        buffer.putShort(base, (short) (value & 0xFFFF));
-        return;
-      case 1:
-        buffer.put(base, (byte) (value & 0xFF));
-        return;
+      }
+      case 2 -> buffer.putShort(base, (short) (value & 0xFFFF));
+      case 1 -> buffer.put(base, (byte) (value & 0xFF));
+      default -> throw new IllegalArgumentException("Invalid size: " + size);
     }
-
-    throw new IllegalArgumentException("Invalid size: " + size);
   }
 
   public static byte readLittleEndianInt8(ByteBuffer buffer, int offset) {
@@ -114,18 +107,13 @@ public class ByteBuffers {
 
   public static int readLittleEndianUnsigned(ByteBuffer buffer, int offset, int size) {
     int base = buffer.position() + offset;
-    switch (size) {
-      case 4:
-        return buffer.getInt(base);
-      case 3:
-        return (((int) buffer.getShort(base)) & 0xFFFF) | ((buffer.get(base + 2) & 0xFF) << 16);
-      case 2:
-        return ((int) buffer.getShort(base)) & 0xFFFF;
-      case 1:
-        return buffer.get(base) & 0xFF;
-    }
-
-    throw new IllegalArgumentException("Invalid size: " + size);
+    return switch (size) {
+      case 4 -> buffer.getInt(base);
+      case 3 -> (((int) buffer.getShort(base)) & 0xFFFF) | ((buffer.get(base + 2) & 0xFF) << 16);
+      case 2 -> ((int) buffer.getShort(base)) & 0xFFFF;
+      case 1 -> buffer.get(base) & 0xFF;
+      default -> throw new IllegalArgumentException("Invalid size: " + size);
+    };
   }
 
   public static int readLittleEndianInt32(ByteBuffer buffer, int offset) {

--- a/api/src/main/java/org/apache/iceberg/util/StructProjection.java
+++ b/api/src/main/java/org/apache/iceberg/util/StructProjection.java
@@ -120,14 +120,13 @@ public class StructProjection implements StructLike {
           found = true;
           positionMap[pos] = i;
           switch (projectedField.type().typeId()) {
-            case STRUCT:
-              nestedProjections[pos] =
-                  new StructProjection(
-                      dataField.type().asStructType(),
-                      projectedField.type().asStructType(),
-                      allowMissing);
-              break;
-            case MAP:
+            case STRUCT ->
+                nestedProjections[pos] =
+                    new StructProjection(
+                        dataField.type().asStructType(),
+                        projectedField.type().asStructType(),
+                        allowMissing);
+            case MAP -> {
               MapType projectedMap = projectedField.type().asMapType();
               MapType originalMap = dataField.type().asMapType();
 
@@ -144,8 +143,8 @@ public class StructProjection implements StructLike {
                   dataField);
 
               nestedProjections[pos] = null;
-              break;
-            case LIST:
+            }
+            case LIST -> {
               ListType projectedList = projectedField.type().asListType();
               ListType originalList = dataField.type().asListType();
 
@@ -159,9 +158,8 @@ public class StructProjection implements StructLike {
                   dataField);
 
               nestedProjections[pos] = null;
-              break;
-            default:
-              nestedProjections[pos] = null;
+            }
+            default -> nestedProjections[pos] = null;
           }
         }
       }


### PR DESCRIPTION
Converts the statement-form `switch` blocks in `util` and top-level enums to expression form, clearing the corresponding `StatementSwitchToExpressionSwitch` ErrorProne warnings the module emits and removing the risk of accidental fall-through in the converted code. Note: this is one of a series of per-package PRs splitting the `iceberg-api` switch conversion (https://github.com/apache/iceberg/pull/17534), following the discussion on https://github.com/apache/iceberg/pull/17534#issuecomment-5347030476 to land it as individual reviewable PRs rather than one sweep.