### PR TITLE
Core: Fix branch snapshot scans when main is empty

### DIFF
--- a/core/src/main/java/org/apache/iceberg/SnapshotScan.java
+++ b/core/src/main/java/org/apache/iceberg/SnapshotScan.java
@@ -83,10 +83,12 @@ public abstract class SnapshotScan<ThisT, T extends ScanTask, G extends ScanTask
   protected Map<Integer, PartitionSpec> specs() {
     Map<Integer, PartitionSpec> specs = table().specs();
     // requires latest schema
-    if (!useSnapshotSchema()
-        || snapshotId() == null
-        || table().currentSnapshot() == null
-        || snapshotId().equals(table().currentSnapshot().snapshotId())) {
+    if (!useSnapshotSchema() || snapshotId() == null) {
+      return specs;
+    }
+
+    Snapshot currentSnapshot = table().currentSnapshot();
+    if (currentSnapshot != null && snapshotId().equals(currentSnapshot.snapshotId())) {
       return specs;
     }
 

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -35,6 +35,7 @@ import org.apache.iceberg.avro.RandomAvroData;
 import org.apache.iceberg.expressions.Expressions;
 import org.apache.iceberg.expressions.Literal;
 import org.apache.iceberg.inmemory.InMemoryOutputFile;
+import org.apache.iceberg.io.CloseableIterable;
 import org.apache.iceberg.io.FileAppender;
 import org.apache.iceberg.io.OutputFile;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -315,6 +316,26 @@ public class TestScansAndSchemaEvolution {
                 .filter(Expressions.equal("data", "xyz"))
                 .planFiles());
     assertThat(tasks).hasSize(2);
+  }
+
+  @TestTemplate
+  void plansBranchSnapshotWhenMainIsEmptyAfterSchemaEvolution() throws IOException {
+    Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
+
+    table.newAppend().appendFile(createDataFile("one")).toBranch("branch").commit();
+    long snapshotId = table.snapshot("branch").snapshotId();
+    assertThat(table.currentSnapshot()).isNull();
+
+    table.updateSchema().deleteColumn("data").commit();
+
+    try (CloseableIterable<FileScanTask> tasks =
+        table
+            .newScan()
+            .useSnapshot(snapshotId)
+            .filter(Expressions.equal("data", "xyz"))
+            .planFiles()) {
+      assertThat(tasks).hasSize(1);
+    }
   }
 
   @TestTemplate

--- a/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
+++ b/core/src/test/java/org/apache/iceberg/TestScansAndSchemaEvolution.java
@@ -323,7 +323,7 @@ public class TestScansAndSchemaEvolution {
     Table table = TestTables.create(temp, "test", SCHEMA, SPEC, formatVersion);
 
     table.newAppend().appendFile(createDataFile("one")).toBranch("branch").commit();
-    long snapshotId = table.snapshot("branch").snapshotId();
+    long branchSnapshotId = table.snapshot("branch").snapshotId();
     assertThat(table.currentSnapshot()).isNull();
 
     table.updateSchema().deleteColumn("data").commit();
@@ -331,7 +331,7 @@ public class TestScansAndSchemaEvolution {
     try (CloseableIterable<FileScanTask> tasks =
         table
             .newScan()
-            .useSnapshot(snapshotId)
+            .useSnapshot(branchSnapshotId)
             .filter(Expressions.equal("data", "xyz"))
             .planFiles()) {
       assertThat(tasks).hasSize(1);


### PR DESCRIPTION
Closes https://github.com/apache/iceberg/issues/17734.

This PR removes the `currentSnapshot() == null` shortcut introduced in https://github.com/apache/iceberg/pull/13301, so that a snapshot rebinds partition specs to its own schema even when main is empty.

See the PR for a test that fails on `main`, demonstrating the filed issue.