### PR TITLE
Spark: Read variant columns through the row reader to avoid a shredded vectorization failure

### DIFF
--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -18,23 +18,17 @@
  */
 package org.apache.iceberg.spark.source;
 
-import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.MetricsModes;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.spark.ImmutableOrcBatchReadConf;
 import org.apache.iceberg.spark.ImmutableParquetBatchReadConf;
@@ -43,7 +37,6 @@ import org.apache.iceberg.spark.ParquetBatchReadConf;
 import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.connector.read.Batch;
@@ -156,7 +149,7 @@ class SparkBatch implements Batch {
 
   // conditions for using Parquet batch reads:
   // - Parquet vectorization is enabled
-  // - only primitives, unshredded variant, or metadata columns are projected
+  // - only primitives or metadata columns are projected
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
     return readConf.parquetVectorizationEnabled()
@@ -171,18 +164,7 @@ class SparkBatch implements Batch {
 
     } else if (task.isFileScanTask() && !task.isDataTask()) {
       FileScanTask fileScanTask = task.asFileScanTask();
-      if (fileScanTask.file().format() != FileFormat.PARQUET) {
-        return false;
-      }
-      Map<Integer, ByteBuffer> lowerBounds = fileScanTask.file().lowerBounds();
-      if (lowerBounds != null) {
-        for (Types.NestedField field : expectedSchema.columns()) {
-          if (field.type().isVariantType() && lowerBounds.containsKey(field.fieldId())) {
-            return false;
-          }
-        }
-      }
-      return true;
+      return fileScanTask.file().format() == FileFormat.PARQUET;
 
     } else {
       return false;
@@ -190,27 +172,13 @@ class SparkBatch implements Batch {
   }
 
   private boolean supportsParquetBatchReads(Types.NestedField field) {
+    // Variant is read through the row reader: vectorized reads cannot reconstruct shredded
+    // variants, and shredding cannot be detected from plan-time metadata.
     if (field.type().isVariantType()) {
-      boolean shredVariants =
-          PropertyUtil.propertyAsBoolean(
-              table.properties(),
-              TableProperties.PARQUET_SHRED_VARIANTS,
-              TableProperties.PARQUET_SHRED_VARIANTS_DEFAULT);
-      if (shredVariants) {
-        return false;
-      }
-
-      MetricsConfig metricsConfig = MetricsConfig.forTable(table);
-      MetricsModes.MetricsMode mode =
-          MetricsUtil.metricsMode(table.schema(), metricsConfig, field.fieldId());
-      if (mode == MetricsModes.None.get() || mode == MetricsModes.Counts.get()) {
-        return false;
-      }
+      return false;
     }
 
-    return field.type().isPrimitiveType()
-        || field.type().isVariantType()
-        || MetadataColumns.isMetadataColumn(field.fieldId());
+    return field.type().isPrimitiveType() || MetadataColumns.isMetadataColumn(field.fieldId());
   }
 
   // conditions for using ORC batch reads:

--- a/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.0/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -479,7 +479,9 @@ public class SparkScanBuilder
             .project(expectedSchema)
             .metricsReporter(metricsReporter);
 
-    scan = includeStats(scan, expectedSchema, withStats);
+    if (withStats) {
+      scan = scan.includeColumnStats();
+    }
 
     if (snapshotId != null) {
       scan = scan.useSnapshot(snapshotId);
@@ -511,29 +513,15 @@ public class SparkScanBuilder
             .project(expectedSchema)
             .metricsReporter(metricsReporter);
 
-    scan = includeStats(scan, expectedSchema, withStats);
+    if (withStats) {
+      scan = scan.includeColumnStats();
+    }
 
     if (endSnapshotId != null) {
       scan = scan.toSnapshot(endSnapshotId);
     }
 
     return configureSplitPlanning(scan);
-  }
-
-  private <S extends org.apache.iceberg.Scan<S, ?, ?>> S includeStats(
-      S scan, Schema projection, boolean withStats) {
-    if (withStats) {
-      return scan.includeColumnStats();
-    }
-    List<String> variantColumns = variantColumnNames(projection);
-    return variantColumns.isEmpty() ? scan : scan.includeColumnStats(variantColumns);
-  }
-
-  private List<String> variantColumnNames(Schema projection) {
-    return projection.columns().stream()
-        .filter(field -> field.type().isVariantType())
-        .map(Types.NestedField::name)
-        .collect(Collectors.toList());
   }
 
   @SuppressWarnings("CyclomaticComplexity")

--- a/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
+++ b/spark/v4.0/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
@@ -509,6 +509,55 @@ public class TestSparkVariantRead extends TestBase {
     sql("DROP TABLE IF EXISTS %s", noStatsTable);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"none", "counts"})
+  public void testReadShreddedViaSessionConfWithoutTableProperty(String writeMetricsMode)
+      throws IOException, NoSuchTableException, ParseException {
+    // Shredding enabled through the session conf leaves the table property false, and metrics off
+    // leaves the file with no variant bound; the shredded file must still read correctly.
+    String sessionShredTable = CATALOG + ".default.var_session_shred";
+    sql("DROP TABLE IF EXISTS %s", sessionShredTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.metadata.metrics.default'='%s')",
+        sessionShredTable, writeMetricsMode);
+
+    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
+    try {
+      sql(
+          "INSERT INTO %s VALUES "
+              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+          sessionShredTable);
+    } finally {
+      spark.conf().unset("spark.sql.iceberg.shred-variants");
+    }
+
+    Table table = Spark3Util.loadIcebergTable(spark, sessionShredTable);
+    assertThat(table.properties()).doesNotContainKey("write.parquet.shred-variants");
+    assertHasTypedValueSubtree(table);
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('write.metadata.metrics.default'='full')",
+        sessionShredTable);
+    setVectorization(sessionShredTable, true);
+
+    List<Row> rows = spark.table(sessionShredTable).select("id", "v").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+    Variant v1 =
+        new Variant(
+            ((VariantVal) rows.get(0).get(1)).getValue(),
+            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
+    Variant v2 =
+        new Variant(
+            ((VariantVal) rows.get(1).get(1)).getValue(),
+            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
+
+    sql("DROP TABLE IF EXISTS %s", sessionShredTable);
+  }
+
   private void setVectorization(boolean on) {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('read.parquet.vectorization.enabled'='%s')",

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkBatch.java
@@ -18,23 +18,17 @@
  */
 package org.apache.iceberg.spark.source;
 
-import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.function.Supplier;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.FileScanTask;
 import org.apache.iceberg.MetadataColumns;
-import org.apache.iceberg.MetricsConfig;
-import org.apache.iceberg.MetricsModes;
-import org.apache.iceberg.MetricsUtil;
 import org.apache.iceberg.ScanTask;
 import org.apache.iceberg.ScanTaskGroup;
 import org.apache.iceberg.Schema;
 import org.apache.iceberg.SchemaParser;
 import org.apache.iceberg.Table;
-import org.apache.iceberg.TableProperties;
 import org.apache.iceberg.io.FileIO;
 import org.apache.iceberg.spark.ImmutableOrcBatchReadConf;
 import org.apache.iceberg.spark.ImmutableParquetBatchReadConf;
@@ -44,7 +38,6 @@ import org.apache.iceberg.spark.SparkReadConf;
 import org.apache.iceberg.spark.SparkUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
-import org.apache.iceberg.util.PropertyUtil;
 import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.broadcast.Broadcast;
 import org.apache.spark.sql.connector.read.Batch;
@@ -154,7 +147,7 @@ class SparkBatch implements Batch {
 
   // conditions for using Parquet batch reads:
   // - Parquet vectorization is enabled
-  // - only primitives, unshredded variant, or metadata columns are projected, excluding geometry
+  // - only primitives or metadata columns are projected, excluding geometry
   //   and geography which are primitives with no Arrow vector yet
   // - all tasks are of FileScanTask type and read only Parquet files
   private boolean useParquetBatchReads() {
@@ -170,18 +163,7 @@ class SparkBatch implements Batch {
 
     } else if (task.isFileScanTask() && !task.isDataTask()) {
       FileScanTask fileScanTask = task.asFileScanTask();
-      if (fileScanTask.file().format() != FileFormat.PARQUET) {
-        return false;
-      }
-      Map<Integer, ByteBuffer> lowerBounds = fileScanTask.file().lowerBounds();
-      if (lowerBounds != null) {
-        for (Types.NestedField field : projection.columns()) {
-          if (field.type().isVariantType() && lowerBounds.containsKey(field.fieldId())) {
-            return false;
-          }
-        }
-      }
-      return true;
+      return fileScanTask.file().format() == FileFormat.PARQUET;
 
     } else {
       return false;
@@ -200,25 +182,13 @@ class SparkBatch implements Batch {
       return false;
     }
 
+    // Variant is read through the row reader: vectorized reads cannot reconstruct shredded
+    // variants, and shredding cannot be detected from plan-time metadata.
     if (type.isVariantType()) {
-      boolean shredVariants =
-          PropertyUtil.propertyAsBoolean(
-              table.properties(),
-              TableProperties.PARQUET_SHRED_VARIANTS,
-              TableProperties.PARQUET_SHRED_VARIANTS_DEFAULT);
-      if (shredVariants) {
-        return false;
-      }
-
-      MetricsConfig metricsConfig = MetricsConfig.forTable(table);
-      MetricsModes.MetricsMode mode =
-          MetricsUtil.metricsMode(table.schema(), metricsConfig, field.fieldId());
-      if (mode == MetricsModes.None.get() || mode == MetricsModes.Counts.get()) {
-        return false;
-      }
+      return false;
     }
 
-    return type.isPrimitiveType() || type.isVariantType();
+    return type.isPrimitiveType();
   }
 
   // conditions for using ORC batch reads:

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/SparkScanBuilder.java
@@ -21,7 +21,6 @@ package org.apache.iceberg.spark.source;
 import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import org.apache.iceberg.BaseMetadataTable;
 import org.apache.iceberg.BaseTable;
 import org.apache.iceberg.BatchScan;
@@ -48,7 +47,6 @@ import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.spark.SparkTableUtil;
 import org.apache.iceberg.spark.TimeTravel;
 import org.apache.iceberg.types.Type;
-import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.Pair;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
@@ -327,7 +325,9 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
             .project(projection)
             .metricsReporter(metricsReporter());
 
-    scan = includeStats(scan, projection, withStats);
+    if (withStats) {
+      scan = scan.includeColumnStats();
+    }
 
     if (endSnapshotId != null) {
       scan = scan.toSnapshot(endSnapshotId);
@@ -363,25 +363,11 @@ public class SparkScanBuilder extends BaseSparkScanBuilder
       scan = scan.ignoreResiduals();
     }
 
-    scan = includeStats(scan, projection, withStats);
+    if (withStats) {
+      scan = scan.includeColumnStats();
+    }
 
     return configureSplitPlanning(scan);
-  }
-
-  private <S extends org.apache.iceberg.Scan<S, ?, ?>> S includeStats(
-      S scan, Schema projection, boolean withStats) {
-    if (withStats) {
-      return scan.includeColumnStats();
-    }
-    List<String> variantColumns = variantColumnNames(projection);
-    return variantColumns.isEmpty() ? scan : scan.includeColumnStats(variantColumns);
-  }
-
-  private List<String> variantColumnNames(Schema projection) {
-    return projection.columns().stream()
-        .filter(field -> field.type().isVariantType())
-        .map(Types.NestedField::name)
-        .collect(Collectors.toList());
   }
 
   private BatchScan newIcebergBatchScan() {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/sql/TestSparkVariantRead.java
@@ -509,6 +509,55 @@ public class TestSparkVariantRead extends TestBase {
     sql("DROP TABLE IF EXISTS %s", noStatsTable);
   }
 
+  @ParameterizedTest
+  @ValueSource(strings = {"none", "counts"})
+  public void testReadShreddedViaSessionConfWithoutTableProperty(String writeMetricsMode)
+      throws IOException, NoSuchTableException, ParseException {
+    // Shredding enabled through the session conf leaves the table property false, and metrics off
+    // leaves the file with no variant bound; the shredded file must still read correctly.
+    String sessionShredTable = CATALOG + ".default.var_session_shred";
+    sql("DROP TABLE IF EXISTS %s", sessionShredTable);
+    sql(
+        "CREATE TABLE %s (id BIGINT, v VARIANT) USING iceberg "
+            + "TBLPROPERTIES ('format-version'='3', 'write.metadata.metrics.default'='%s')",
+        sessionShredTable, writeMetricsMode);
+
+    spark.conf().set("spark.sql.iceberg.shred-variants", "true");
+    try {
+      sql(
+          "INSERT INTO %s VALUES "
+              + "(1, parse_json('{\"name\":\"alice\",\"age\":30}')), "
+              + "(2, parse_json('{\"name\":\"bob\",\"age\":25}'))",
+          sessionShredTable);
+    } finally {
+      spark.conf().unset("spark.sql.iceberg.shred-variants");
+    }
+
+    Table table = Spark3Util.loadIcebergTable(spark, sessionShredTable);
+    assertThat(table.properties()).doesNotContainKey("write.parquet.shred-variants");
+    assertHasTypedValueSubtree(table);
+
+    sql(
+        "ALTER TABLE %s SET TBLPROPERTIES ('write.metadata.metrics.default'='full')",
+        sessionShredTable);
+    setVectorization(sessionShredTable, true);
+
+    List<Row> rows = spark.table(sessionShredTable).select("id", "v").orderBy("id").collectAsList();
+    assertThat(rows).hasSize(2);
+    Variant v1 =
+        new Variant(
+            ((VariantVal) rows.get(0).get(1)).getValue(),
+            ((VariantVal) rows.get(0).get(1)).getMetadata());
+    assertThat(v1.getFieldByKey("name").getString()).isEqualTo("alice");
+    Variant v2 =
+        new Variant(
+            ((VariantVal) rows.get(1).get(1)).getValue(),
+            ((VariantVal) rows.get(1).get(1)).getMetadata());
+    assertThat(v2.getFieldByKey("name").getString()).isEqualTo("bob");
+
+    sql("DROP TABLE IF EXISTS %s", sessionShredTable);
+  }
+
   private void setVectorization(boolean on) {
     sql(
         "ALTER TABLE %s SET TBLPROPERTIES ('read.parquet.vectorization.enabled'='%s')",


### PR DESCRIPTION
## Rationale for this change

In my testing, I found that Vectorized Parquet reads throw `UnsupportedOperationException` when they hit a shredded variant column (`typed_value` subtree). `SparkBatch` tried to route shredded files away from the vectorized reader using the manifest variant bounds and the `write.parquet.shred-variants` property, but neither is sound. Bounds are optional (a file written with metrics `none`/`counts` carries none), and the property reflects writer intent, not how existing files were written. Shredding can also be enabled through the session conf or a write option with the table property left false. A shredded file can therefore reach the vectorized reader and crash, and it cannot be detected soundly at plan time, since shredding is a per-file Parquet-footer fact that is not recorded in the manifest.

After checking all possible options, this seemed like the easiest to do to avoid any edge cases. Follow up section has more.

## Changes

Spark 4.0 and 4.1: Route variant columns to the row reader in the batch path for now. `SparkBatch.supportsParquetBatchReads` now returns false for any variant column, and the unsound bounds and property/metrics checks are removed. A query that projects a variant column reads through the row reader, which reconstructs both shredded and unshredded variants correctly. Queries that do not project a variant column are unaffected and still vectorize.

Also, SparkScanBuilder no longer force-loads column stats for variant columns on read, since that plumbing existed only to feed the removed bounds check.

## Testing

Added `testReadShreddedViaSessionConfWithoutTableProperty` (v4.0 and v4.1). It enables shredding through the session conf with the table property left false and metrics disabled, then reads under vectorization and asserts the variant values are correct. On the previous routing the shredded file reached the vectorized reader and threw `UnsupportedOperationException`, so the test failed; with this change it reads through the row reader and passes. It guards against the crash returning: any routing that lets a shredded file reach the vectorized reader again fails the read, and the test.

## Follow up

This turns off vectorized reads for variant columns, including unshredded ones, since plan time cannot tell them apart. The follow-up is to write the vectorized reader to reconstruct shredded variants, which lets variant vectorize again for both shredded and unshredded data in a subsequent release. This is a more involved work that will take a while so disabling this for now until that can go in. I'll open the fix in parts soon.