### PR TITLE
Flink: Support variant for Avro readers and writers

### DIFF
--- a/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
+++ b/data/src/test/java/org/apache/iceberg/data/ReadFormatModelTests.java
@@ -189,8 +189,7 @@ public abstract class ReadFormatModelTests<T> {
             FEATURE_SPLIT,
             FEATURE_COLUMN_LEVEL_METRICS,
             FEATURE_COLUMN_METRICS_TRUNCATE_BINARY,
-            FEATURE_NATIVE_ENCRYPTION,
-            FEATURE_VARIANT
+            FEATURE_NATIVE_ENCRYPTION
           },
           FileFormat.ORC,
           new String[] {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/AvroWithFlinkSchemaVisitor.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/AvroWithFlinkSchemaVisitor.java
@@ -24,12 +24,18 @@ import org.apache.flink.table.types.logical.LogicalTypeFamily;
 import org.apache.flink.table.types.logical.MapType;
 import org.apache.flink.table.types.logical.NullType;
 import org.apache.flink.table.types.logical.RowType;
+import org.apache.flink.table.types.logical.VariantType;
 import org.apache.iceberg.avro.AvroWithPartnerByStructureVisitor;
 import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.util.Pair;
 
 public abstract class AvroWithFlinkSchemaVisitor<T>
     extends AvroWithPartnerByStructureVisitor<LogicalType, T> {
+
+  @Override
+  protected boolean isVariantType(LogicalType logicalType) {
+    return logicalType instanceof VariantType;
+  }
 
   @Override
   protected boolean isStringType(LogicalType logicalType) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkAvroWriter.java
@@ -111,6 +111,12 @@ public class FlinkAvroWriter implements MetricsAwareDatumWriter<RowData> {
     }
 
     @Override
+    public ValueWriter<?> variant(
+        LogicalType variant, ValueWriter<?> metadataWriter, ValueWriter<?> valueWriter) {
+      return FlinkValueWriters.variants();
+    }
+
+    @Override
     public ValueWriter<?> primitive(LogicalType type, Schema primitive) {
       org.apache.avro.LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkPlannedAvroReader.java
@@ -126,6 +126,12 @@ public class FlinkPlannedAvroReader implements DatumReader<RowData>, SupportsRow
     }
 
     @Override
+    public ValueReader<?> variant(
+        Type partner, ValueReader<?> metadataReader, ValueReader<?> valueReader) {
+      return FlinkValueReaders.variants();
+    }
+
+    @Override
     public ValueReader<?> primitive(Type partner, Schema primitive) {
       LogicalType logicalType = primitive.getLogicalType();
       if (logicalType != null) {

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueReaders.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueReaders.java
@@ -35,6 +35,7 @@ import org.apache.flink.table.data.MapData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.variant.BinaryVariant;
 import org.apache.iceberg.avro.ValueReader;
 import org.apache.iceberg.avro.ValueReaders;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
@@ -77,6 +78,10 @@ public class FlinkValueReaders {
   static ValueReader<DecimalData> decimal(
       ValueReader<byte[]> unscaledReader, int precision, int scale) {
     return new DecimalReader(unscaledReader, precision, scale);
+  }
+
+  static ValueReader<BinaryVariant> variants() {
+    return VariantReader.INSTANCE;
   }
 
   static ValueReader<ArrayData> array(ValueReader<?> elementReader) {
@@ -151,6 +156,32 @@ public class FlinkValueReaders {
       byte[] bytes = bytesReader.read(decoder, null);
       return DecimalData.fromBigDecimal(
           new BigDecimal(new BigInteger(bytes), scale), precision, scale);
+    }
+  }
+
+  /** Variant reader reads the metadata and value bytes into a Flink {@link BinaryVariant}. */
+  private static class VariantReader implements ValueReader<BinaryVariant> {
+    private static final VariantReader INSTANCE = new VariantReader();
+
+    private final ValueReader<byte[]> metadataReader;
+    private final ValueReader<byte[]> valueReader;
+
+    private VariantReader() {
+      this.metadataReader = ValueReaders.bytes();
+      this.valueReader = ValueReaders.bytes();
+    }
+
+    @Override
+    public BinaryVariant read(Decoder decoder, Object reuse) throws IOException {
+      byte[] metadata = metadataReader.read(decoder, null);
+      byte[] value = valueReader.read(decoder, null);
+      return new BinaryVariant(value, metadata);
+    }
+
+    @Override
+    public void skip(Decoder decoder) throws IOException {
+      metadataReader.skip(decoder);
+      valueReader.skip(decoder);
     }
   }
 

--- a/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
+++ b/flink/v2.1/flink/src/main/java/org/apache/iceberg/flink/data/FlinkValueWriters.java
@@ -30,8 +30,12 @@ import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
 import org.apache.flink.table.types.logical.LogicalType;
+import org.apache.flink.types.variant.BinaryVariant;
+import org.apache.flink.types.variant.Variant;
 import org.apache.iceberg.avro.ValueWriter;
+import org.apache.iceberg.avro.ValueWriters;
 import org.apache.iceberg.flink.FlinkRowData;
+import org.apache.iceberg.relocated.com.google.common.base.Preconditions;
 import org.apache.iceberg.types.TypeUtil;
 import org.apache.iceberg.util.DecimalUtil;
 
@@ -41,6 +45,10 @@ public class FlinkValueWriters {
 
   static ValueWriter<StringData> strings() {
     return StringWriter.INSTANCE;
+  }
+
+  static ValueWriter<Variant> variants() {
+    return VariantWriter.INSTANCE;
   }
 
   static ValueWriter<Integer> timeMicros() {
@@ -155,6 +163,30 @@ public class FlinkValueWriters {
     @Override
     public void write(byte[] bytes, Encoder encoder) throws IOException {
       encoder.writeFixed(bytes);
+    }
+  }
+
+  /** Variant writer writes the metadata and value bytes of a Flink {@link BinaryVariant}. */
+  private static class VariantWriter implements ValueWriter<Variant> {
+    private static final VariantWriter INSTANCE = new VariantWriter();
+
+    private final ValueWriter<byte[]> metadataWriter;
+    private final ValueWriter<byte[]> valueWriter;
+
+    private VariantWriter() {
+      this.metadataWriter = ValueWriters.bytes();
+      this.valueWriter = ValueWriters.bytes();
+    }
+
+    @Override
+    public void write(Variant datum, Encoder encoder) throws IOException {
+      Preconditions.checkArgument(
+          datum instanceof BinaryVariant,
+          "Expected BinaryVariant but got: %s",
+          datum.getClass().getSimpleName());
+      BinaryVariant variant = (BinaryVariant) datum;
+      metadataWriter.write(variant.getMetadata(), encoder);
+      valueWriter.write(variant.getValue(), encoder);
     }
   }
 

--- a/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroReaderWriter.java
+++ b/flink/v2.1/flink/src/test/java/org/apache/iceberg/flink/data/TestFlinkAvroReaderWriter.java
@@ -59,6 +59,11 @@ public class TestFlinkAvroReaderWriter extends DataTestBase {
   }
 
   @Override
+  protected boolean supportsVariant() {
+    return true;
+  }
+
+  @Override
   protected void writeAndValidate(Schema schema) throws IOException {
     List<Record> expectedRecords = RandomGenericData.generate(schema, NUM_RECORDS, 1991L);
     writeAndValidate(schema, expectedRecords);


### PR DESCRIPTION
Iceberg v3 defines the Avro encoding for variant: a record with `metadata` and `value` binary fields (shredding is not supported in Avro). The core avro layer (`ValueWriters.variants()` / `ValueReaders.variants()`) and the Spark bridges (`SparkAvroWriter` / `SparkPlannedAvroReader`) already implement this encoding, and the Flink Parquet bridges also support variant. 

However, the Flink Avro bridges do not: `FlinkAvroWriter` and `FlinkPlannedAvroReader` do not override `variant()`, so any read or write of an Avro data file containing a variant column fails with:

```
java.lang.UnsupportedOperationException: Visitor does not support variant
```

This pr aim to add support variant for Avro readers and writers.


`TestFlinkAvroReaderWriter` passes with the variant round-trip cases enabled (write records / read RowData, and write RowData via `FlinkAvroWriter` / read back via `FlinkPlannedAvroReader`).

Remove the Miss Feature variant from Avro, and use the file format TCK to test this feature as well.