### PR TITLE
arrow: Fix memory leak in ColumnVector by caching decoded vector

### DIFF
--- a/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
+++ b/arrow/src/main/java/org/apache/iceberg/arrow/vectorized/ColumnVector.java
@@ -67,13 +67,21 @@ public class ColumnVector implements AutoCloseable {
     return vectorHolder.vector();
   }
 
+  private FieldVector arrowVector;
+
   /**
    * Decodes a dict-encoded vector and returns the actual arrow vector.
+   * The decoded vector is cached per batch so that repeated calls within
+   * the same batch do not leak memory. The cached vector is released in
+   * {@link #close()}.
    *
    * @return instance of {@link FieldVector}
    */
   public FieldVector getArrowVector() {
-    return DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
+    if (arrowVector == null) {
+      arrowVector = DictEncodedArrowConverter.toArrowVector(vectorHolder, accessor);
+    }
+    return arrowVector;
   }
 
   public boolean hasNull() {
@@ -86,6 +94,10 @@ public class ColumnVector implements AutoCloseable {
 
   @Override
   public void close() {
+    if (arrowVector != null) {
+      arrowVector.close();
+      arrowVector = null;
+    }
     accessor.close();
   }
 


### PR DESCRIPTION
Every call to `ColumnVector.getArrowVector()` on a dictionary-encoded column allocates a new decoded `FieldVector` that is never released. Since `ColumnarBatch.createVectorSchemaRootFromVectors()` calls it for every column of every batch, a scan over dict-encoded data leaks one vector per batch per dict-encoded column, and the memory survives a fully drained and fully closed scan.

**Root cause**

`ColumnVector.getArrowVector()` routes dict-encoded columns through `DictEncodedArrowConverter.toArrowVector()` which allocates and populates a new vector from the reader's allocator on each call. `ColumnVector.close()` only closes the accessor, never the decoded vector.

**Fix**

Cache the decoded vector in a private field, materializing it once per batch instead of on every `getArrowVector()` call, and release it in `close()`. Repeated calls within the same batch return the same cached vector. This matches the documented contract ("the arrow vectors are owned by the reader").

Closes #17722