### PR TITLE
Core: Expose Iceberg-managed view properties

### DIFF
--- a/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
+++ b/core/src/main/java/org/apache/iceberg/view/ViewProperties.java
@@ -18,6 +18,9 @@
  */
 package org.apache.iceberg.view;
 
+import java.util.Set;
+import org.apache.iceberg.relocated.com.google.common.collect.ImmutableSet;
+
 /** View properties that can be set during CREATE/REPLACE view or using updateProperties API. */
 public class ViewProperties {
   public static final String VERSION_HISTORY_SIZE = "version.history.num-entries";
@@ -31,6 +34,19 @@ public class ViewProperties {
   public static final String COMMENT = "comment";
   public static final String REPLACE_DROP_DIALECT_ALLOWED = "replace.drop-dialect.allowed";
   public static final boolean REPLACE_DROP_DIALECT_ALLOWED_DEFAULT = false;
+
+  /**
+   * View properties that are managed by Iceberg and should be preserved by engines when replacing a
+   * view.
+   *
+   * <p>Engine-managed properties, such as {@link #COMMENT}, are intentionally excluded.
+   */
+  public static final Set<String> ICEBERG_MANAGED_PROPERTIES =
+      ImmutableSet.of(
+          VERSION_HISTORY_SIZE,
+          METADATA_COMPRESSION,
+          WRITE_METADATA_LOCATION,
+          REPLACE_DROP_DIALECT_ALLOWED);
 
   private ViewProperties() {}
 }

--- a/core/src/test/java/org/apache/iceberg/view/TestViewProperties.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewProperties.java
@@ -36,6 +36,7 @@ public class TestViewProperties {
         .doesNotContain(ViewProperties.COMMENT);
 
     assertThatThrownBy(() -> ViewProperties.ICEBERG_MANAGED_PROPERTIES.add("new.managed.property"))
-        .isInstanceOf(UnsupportedOperationException.class);
+        .isInstanceOf(UnsupportedOperationException.class)
+        .hasMessage(null);
   }
 }

--- a/core/src/test/java/org/apache/iceberg/view/TestViewProperties.java
+++ b/core/src/test/java/org/apache/iceberg/view/TestViewProperties.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.view;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+public class TestViewProperties {
+
+  @Test
+  public void icebergManagedProperties() {
+    assertThat(ViewProperties.ICEBERG_MANAGED_PROPERTIES)
+        .containsExactlyInAnyOrder(
+            ViewProperties.VERSION_HISTORY_SIZE,
+            ViewProperties.METADATA_COMPRESSION,
+            ViewProperties.WRITE_METADATA_LOCATION,
+            ViewProperties.REPLACE_DROP_DIALECT_ALLOWED)
+        .doesNotContain(ViewProperties.COMMENT);
+
+    assertThatThrownBy(() -> ViewProperties.ICEBERG_MANAGED_PROPERTIES.add("new.managed.property"))
+        .isInstanceOf(UnsupportedOperationException.class);
+  }
+}


### PR DESCRIPTION
Closes #17719

## What changed
- Add `ICEBERG_MANAGED_PROPERTIES` in `ViewProperties` listing properties managed by Iceberg that should be preserved during view replacement.
- Add `TestViewProperties` coverage validating the set and confirming `COMMENT` is intentionally excluded.

## Testing
- `./gradlew --no-parallel --max-workers=2 :iceberg-core:test --tests org.apache.iceberg.view.TestViewProperties`
- `./gradlew --no-parallel --max-workers=2 :iceberg-core:spotlessCheck`

## Notes
- This PR addresses issue #17719 by surfacing managed view properties as an explicit set for downstream engines.

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: Codex
- Human Oversight: fully reviewed
- Prompt Summary: Evaluate Iceberg issue #17719 and implement a minimal core API exposing Iceberg-managed view properties, explicitly distinguish them from engine-managed properties, add focused membership and immutability tests, and validate the relevant project checks.
