### PR TITLE
Spark: Support nested geospatial values in StructInternalRow

### DIFF
--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
@@ -34,6 +34,7 @@ import java.util.function.Function;
 import org.apache.iceberg.StructLike;
 import org.apache.iceberg.relocated.com.google.common.collect.ImmutableList;
 import org.apache.iceberg.relocated.com.google.common.collect.Lists;
+import org.apache.iceberg.spark.SparkSchemaUtil;
 import org.apache.iceberg.types.Type;
 import org.apache.iceberg.types.Types;
 import org.apache.iceberg.util.ByteBuffers;
@@ -43,6 +44,7 @@ import org.apache.spark.sql.catalyst.util.ArrayBasedMapData;
 import org.apache.spark.sql.catalyst.util.ArrayData;
 import org.apache.spark.sql.catalyst.util.GenericArrayData;
 import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
 import org.apache.spark.sql.types.ArrayType;
 import org.apache.spark.sql.types.BinaryType;
 import org.apache.spark.sql.types.BooleanType;
@@ -53,6 +55,7 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
 import org.apache.spark.sql.types.MapType;
@@ -190,9 +193,10 @@ class StructInternalRow extends InternalRow {
   }
 
   private byte[] getBinaryInternal(int ordinal) {
-    Object bytes = struct.get(ordinal, Object.class);
+    return toByteArray(struct.get(ordinal, Object.class));
+  }
 
-    // should only be either ByteBuffer or byte[]
+  private static byte[] toByteArray(Object bytes) {
     if (bytes instanceof ByteBuffer) {
       return ByteBuffers.toByteArray((ByteBuffer) bytes);
     } else if (bytes instanceof byte[]) {
@@ -251,12 +255,14 @@ class StructInternalRow extends InternalRow {
 
   @Override
   public GeographyVal getGeography(int ordinal) {
-    return isNullAt(ordinal) ? null : GeographyVal.fromBytes(getBinaryInternal(ordinal));
+    return isNullAt(ordinal) ? null : STUtils.stGeogFromWKB(getBinaryInternal(ordinal));
   }
 
   @Override
   public GeometryVal getGeometry(int ordinal) {
-    return isNullAt(ordinal) ? null : GeometryVal.fromBytes(getBinaryInternal(ordinal));
+    return isNullAt(ordinal)
+        ? null
+        : toGeometryVal(type.fields().get(ordinal).type(), getBinaryInternal(ordinal));
   }
 
   @Override
@@ -339,6 +345,18 @@ class StructInternalRow extends InternalRow {
             values,
             array ->
                 (BiConsumer<Integer, BigDecimal>) (pos, dec) -> array[pos] = Decimal.apply(dec));
+      case GEOMETRY:
+        return fillArray(
+            values,
+            array ->
+                (BiConsumer<Integer, Object>)
+                    (pos, value) -> array[pos] = toGeometryVal(elementType, value));
+      case GEOGRAPHY:
+        return fillArray(
+            values,
+            array ->
+                (BiConsumer<Integer, Object>)
+                    (pos, value) -> array[pos] = STUtils.stGeogFromWKB(toByteArray(value)));
       case STRUCT:
         return fillArray(
             values,
@@ -367,6 +385,11 @@ class StructInternalRow extends InternalRow {
       default:
         throw new UnsupportedOperationException("Unsupported array element type: " + elementType);
     }
+  }
+
+  private static GeometryVal toGeometryVal(Type type, Object value) {
+    GeometryType sparkType = (GeometryType) SparkSchemaUtil.convert(type);
+    return STUtils.stGeomFromWKB(toByteArray(value), sparkType.srid());
   }
 
   private static VariantVal toVariantVal(Object value) {

--- a/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
+++ b/spark/v4.1/spark/src/main/java/org/apache/iceberg/spark/source/StructInternalRow.java
@@ -55,6 +55,7 @@ import org.apache.spark.sql.types.Decimal;
 import org.apache.spark.sql.types.DecimalType;
 import org.apache.spark.sql.types.DoubleType;
 import org.apache.spark.sql.types.FloatType;
+import org.apache.spark.sql.types.GeographyType;
 import org.apache.spark.sql.types.GeometryType;
 import org.apache.spark.sql.types.IntegerType;
 import org.apache.spark.sql.types.LongType;
@@ -255,14 +256,22 @@ class StructInternalRow extends InternalRow {
 
   @Override
   public GeographyVal getGeography(int ordinal) {
-    return isNullAt(ordinal) ? null : STUtils.stGeogFromWKB(getBinaryInternal(ordinal));
+    return isNullAt(ordinal) ? null : getGeographyInternal(ordinal);
+  }
+
+  private GeographyVal getGeographyInternal(int ordinal) {
+    return STUtils.stGeogFromWKB(getBinaryInternal(ordinal));
   }
 
   @Override
   public GeometryVal getGeometry(int ordinal) {
-    return isNullAt(ordinal)
-        ? null
-        : toGeometryVal(type.fields().get(ordinal).type(), getBinaryInternal(ordinal));
+    return isNullAt(ordinal) ? null : getGeometryInternal(ordinal);
+  }
+
+  private GeometryVal getGeometryInternal(int ordinal) {
+    GeometryType sparkType =
+        (GeometryType) SparkSchemaUtil.convert(type.fields().get(ordinal).type());
+    return toGeometryVal(sparkType.srid(), getBinaryInternal(ordinal));
   }
 
   @Override
@@ -304,6 +313,10 @@ class StructInternalRow extends InternalRow {
       return getLong(ordinal);
     } else if (dataType instanceof VariantType) {
       return getVariantInternal(ordinal);
+    } else if (dataType instanceof GeometryType) {
+      return getGeometryInternal(ordinal);
+    } else if (dataType instanceof GeographyType) {
+      return getGeographyInternal(ordinal);
     }
     return null;
   }
@@ -346,11 +359,12 @@ class StructInternalRow extends InternalRow {
             array ->
                 (BiConsumer<Integer, BigDecimal>) (pos, dec) -> array[pos] = Decimal.apply(dec));
       case GEOMETRY:
+        int srid = ((GeometryType) SparkSchemaUtil.convert(elementType)).srid();
         return fillArray(
             values,
             array ->
                 (BiConsumer<Integer, Object>)
-                    (pos, value) -> array[pos] = toGeometryVal(elementType, value));
+                    (pos, value) -> array[pos] = toGeometryVal(srid, value));
       case GEOGRAPHY:
         return fillArray(
             values,
@@ -387,9 +401,8 @@ class StructInternalRow extends InternalRow {
     }
   }
 
-  private static GeometryVal toGeometryVal(Type type, Object value) {
-    GeometryType sparkType = (GeometryType) SparkSchemaUtil.convert(type);
-    return STUtils.stGeomFromWKB(toByteArray(value), sparkType.srid());
+  private static GeometryVal toGeometryVal(int srid, Object value) {
+    return STUtils.stGeomFromWKB(toByteArray(value), srid);
   }
 
   private static VariantVal toVariantVal(Object value) {

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructInternalRowGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructInternalRowGeospatial.java
@@ -1,0 +1,160 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.iceberg.spark.source;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.iceberg.data.GenericRecord;
+import org.apache.iceberg.spark.SparkSchemaUtil;
+import org.apache.iceberg.types.Types;
+import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.catalyst.util.ArrayData;
+import org.apache.spark.sql.catalyst.util.MapData;
+import org.apache.spark.sql.catalyst.util.STUtils;
+import org.apache.spark.sql.types.DataType;
+import org.apache.spark.unsafe.types.GeographyVal;
+import org.apache.spark.unsafe.types.GeometryVal;
+import org.junit.jupiter.api.Test;
+
+public class TestStructInternalRowGeospatial {
+
+  @Test
+  public void convertsGeospatialArrays() {
+    Types.GeometryType geometryType = Types.GeometryType.of("EPSG:3857");
+    Types.GeographyType geographyType = Types.GeographyType.crs84();
+    Types.StructType structType =
+        Types.StructType.of(
+            Types.NestedField.required(1, "geometries", Types.ListType.ofOptional(2, geometryType)),
+            Types.NestedField.required(
+                3, "geographies", Types.ListType.ofOptional(4, geographyType)));
+
+    byte[] point = pointWkb(30.0, 10.0);
+    byte[] lineString = lineStringWkb(30.0, 10.0, 40.0, 20.0);
+    GenericRecord record = GenericRecord.create(structType);
+    record.set(0, Arrays.asList(ByteBuffer.wrap(point), lineString, null));
+    record.set(1, Arrays.asList(lineString, ByteBuffer.wrap(point), null));
+
+    InternalRow row = new StructInternalRow(structType).setStruct(record);
+    DataType sparkGeometryType = SparkSchemaUtil.convert(geometryType);
+    DataType sparkGeographyType = SparkSchemaUtil.convert(geographyType);
+
+    ArrayData geometries = row.getArray(0);
+    assertGeometry((GeometryVal) geometries.get(0, sparkGeometryType), 3857, point);
+    assertGeometry((GeometryVal) geometries.get(1, sparkGeometryType), 3857, lineString);
+    assertThat(geometries.isNullAt(2)).isTrue();
+
+    ArrayData geographies = row.getArray(1);
+    assertGeography((GeographyVal) geographies.get(0, sparkGeographyType), lineString);
+    assertGeography((GeographyVal) geographies.get(1, sparkGeographyType), point);
+    assertThat(geographies.isNullAt(2)).isTrue();
+  }
+
+  @Test
+  public void convertsGeospatialMapKeysAndValues() {
+    Types.GeometryType geometryType = Types.GeometryType.of("EPSG:3857");
+    Types.GeographyType geographyType = Types.GeographyType.crs84();
+    Types.MapType mapType = Types.MapType.ofOptional(2, 3, geometryType, geographyType);
+    Types.StructType structType =
+        Types.StructType.of(Types.NestedField.required(1, "locations", mapType));
+
+    byte[] firstGeometry = pointWkb(30.0, 10.0);
+    byte[] secondGeometry = lineStringWkb(30.0, 10.0, 40.0, 20.0);
+    byte[] geography = pointWkb(-71.0, 42.0);
+    Map<Object, Object> locations = new LinkedHashMap<>();
+    locations.put(ByteBuffer.wrap(firstGeometry), geography);
+    locations.put(secondGeometry, null);
+
+    GenericRecord record = GenericRecord.create(structType);
+    record.set(0, locations);
+
+    MapData map = new StructInternalRow(structType).setStruct(record).getMap(0);
+    DataType sparkGeometryType = SparkSchemaUtil.convert(geometryType);
+    DataType sparkGeographyType = SparkSchemaUtil.convert(geographyType);
+    assertGeometry((GeometryVal) map.keyArray().get(0, sparkGeometryType), 3857, firstGeometry);
+    assertGeometry((GeometryVal) map.keyArray().get(1, sparkGeometryType), 3857, secondGeometry);
+    assertGeography((GeographyVal) map.valueArray().get(0, sparkGeographyType), geography);
+    assertThat(map.valueArray().isNullAt(1)).isTrue();
+  }
+
+  @Test
+  public void convertsGeospatialValuesInStructList() {
+    Types.GeometryType geometryType = Types.GeometryType.of("EPSG:3857");
+    Types.GeographyType geographyType = Types.GeographyType.crs84();
+    Types.StructType locationType =
+        Types.StructType.of(
+            Types.NestedField.required(3, "geometry", geometryType),
+            Types.NestedField.required(4, "geography", geographyType));
+    Types.StructType structType =
+        Types.StructType.of(
+            Types.NestedField.required(1, "locations", Types.ListType.ofOptional(2, locationType)));
+
+    byte[] geometry = lineStringWkb(30.0, 10.0, 40.0, 20.0);
+    byte[] geography = pointWkb(-71.0, 42.0);
+    GenericRecord location = GenericRecord.create(locationType);
+    location.set(0, ByteBuffer.wrap(geometry));
+    location.set(1, geography);
+    GenericRecord record = GenericRecord.create(structType);
+    record.set(0, Arrays.asList(location, null));
+
+    ArrayData locations = new StructInternalRow(structType).setStruct(record).getArray(0);
+    InternalRow converted = locations.getStruct(0, locationType.fields().size());
+    assertGeometry(converted.getGeometry(0), 3857, geometry);
+    assertGeography(converted.getGeography(1), geography);
+    assertThat(locations.isNullAt(1)).isTrue();
+  }
+
+  private static void assertGeometry(GeometryVal geometry, int srid, byte[] wkb) {
+    assertThat(STUtils.stSrid(geometry)).isEqualTo(srid);
+    assertThat(STUtils.stAsBinary(geometry)).isEqualTo(wkb);
+  }
+
+  private static void assertGeography(GeographyVal geography, byte[] wkb) {
+    assertThat(STUtils.stSrid(geography)).isEqualTo(4326);
+    assertThat(STUtils.stAsBinary(geography)).isEqualTo(wkb);
+  }
+
+  private static byte[] pointWkb(double xCoordinate, double yCoordinate) {
+    return ByteBuffer.allocate(21)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put((byte) 1)
+        .putInt(1)
+        .putDouble(xCoordinate)
+        .putDouble(yCoordinate)
+        .array();
+  }
+
+  private static byte[] lineStringWkb(
+      double firstX, double firstY, double secondX, double secondY) {
+    return ByteBuffer.allocate(41)
+        .order(ByteOrder.LITTLE_ENDIAN)
+        .put((byte) 1)
+        .putInt(2)
+        .putInt(2)
+        .putDouble(firstX)
+        .putDouble(firstY)
+        .putDouble(secondX)
+        .putDouble(secondY)
+        .array();
+  }
+}

--- a/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructInternalRowGeospatial.java
+++ b/spark/v4.1/spark/src/test/java/org/apache/iceberg/spark/source/TestStructInternalRowGeospatial.java
@@ -121,15 +121,37 @@ public class TestStructInternalRowGeospatial {
     InternalRow converted = locations.getStruct(0, locationType.fields().size());
     assertGeometry(converted.getGeometry(0), 3857, geometry);
     assertGeography(converted.getGeography(1), geography);
+    DataType sparkGeometryType = SparkSchemaUtil.convert(geometryType);
+    DataType sparkGeographyType = SparkSchemaUtil.convert(geographyType);
+    assertGeometry((GeometryVal) converted.get(0, sparkGeometryType), 3857, geometry);
+    assertGeography((GeographyVal) converted.get(1, sparkGeographyType), geography);
     assertThat(locations.isNullAt(1)).isTrue();
   }
 
+  @Test
+  public void returnsNullForGeospatialFields() {
+    Types.GeometryType geometryType = Types.GeometryType.of("EPSG:3857");
+    Types.GeographyType geographyType = Types.GeographyType.crs84();
+    Types.StructType structType =
+        Types.StructType.of(
+            Types.NestedField.optional(1, "geometry", geometryType),
+            Types.NestedField.optional(2, "geography", geographyType));
+    InternalRow row = new StructInternalRow(structType).setStruct(GenericRecord.create(structType));
+
+    assertThat(row.getGeometry(0)).isNull();
+    assertThat(row.getGeography(1)).isNull();
+    assertThat(row.get(0, SparkSchemaUtil.convert(geometryType))).isNull();
+    assertThat(row.get(1, SparkSchemaUtil.convert(geographyType))).isNull();
+  }
+
   private static void assertGeometry(GeometryVal geometry, int srid, byte[] wkb) {
+    assertThat(geometry).isNotNull();
     assertThat(STUtils.stSrid(geometry)).isEqualTo(srid);
     assertThat(STUtils.stAsBinary(geometry)).isEqualTo(wkb);
   }
 
   private static void assertGeography(GeographyVal geography, byte[] wkb) {
+    assertThat(geography).isNotNull();
     assertThat(STUtils.stSrid(geography)).isEqualTo(4326);
     assertThat(STUtils.stAsBinary(geography)).isEqualTo(wkb);
   }


### PR DESCRIPTION
Closes #17720

Support nested `GEOMETRY` and `GEOGRAPHY` values in Spark 4.1 `StructInternalRow`, including list elements, map keys and values, and nested structs. Conversion accepts both `byte[]` and `ByteBuffer` WKB inputs and preserves geometry SRIDs.

Typed getters and generic `get(int, DataType)` now both handle geospatial values. Geometry SRIDs are resolved once before filling each collection array, rather than once per element.

Regression tests cover nested conversions, mixed WKB representations, SRID preservation, and both typed and generic access including null fields. The generic-access regression failed before the follow-up implementation and passes with the fix.

## Validation

- `./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:test --tests 'org.apache.iceberg.spark.source.TestStructInternalRow*'`
- `./gradlew :iceberg-spark:iceberg-spark-4.1_2.13:spotlessCheck :iceberg-spark:iceberg-spark-4.1_2.13:checkstyleMain :iceberg-spark:iceberg-spark-4.1_2.13:checkstyleTest`

---
**AI Disclosure**
- Model: GPT-5
- Platform/Tool: OpenAI Codex
- Human Oversight: partially reviewed (earlier revision reviewed by a contributor; follow-up changes awaiting review)
- Prompt Summary: Use Iceberg issue #17720 and specific reviewer feedback to implement nested geospatial conversion in Spark 4.1, support generic row access, avoid repeated collection SRID resolution, reproduce the missing-access regression, and verify affected row tests and style checks.
